### PR TITLE
feat: let a routine keep one standing session, folded behind a sidebar count row

### DIFF
--- a/.changeset/routine-standing-session.md
+++ b/.changeset/routine-standing-session.md
@@ -1,0 +1,11 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Give a routine the option of one standing session, and fold its tasks behind a count row in the sidebar.
+
+`rove api routine-create --persistent-session` re-delivers each firing into ONE task instead of creating a fresh worktree and branch every time, so a daily check can build on what it said yesterday. It stays off by default and is per-routine: a routine that edits code still wants a clean branch per run, since a week of runs piled onto one branch is a branch nobody can land. Seven daily routines were otherwise 49 sidebar rows a week.
+
+Those tasks now rest behind a per-project `N routine sessions` row — `enter` opens it, `enter` again closes it. This is the one fold in a tree that has none by design, and it is scoped to match: it hides only what a schedule created, never a task you opened. A folded task is still found by `/`, still opens from the Routines page, and still raises an Inbox entry when its turn ends — which is how last night's report reaches you.
+
+Two run statuses come with it, because the degraded paths must not read as a clean run. `revived` means the engine had exited and was respawned in the same worktree: the files carried over, the conversation did not. `deferred` means the composer was busy, so the prompt is queued in your Inbox rather than dropped — a routine's report going missing is indistinguishable from one that never ran. A standing task that gets deleted is rebuilt on the next firing instead of wedging the routine forever.

--- a/docs/API.md
+++ b/docs/API.md
@@ -423,9 +423,10 @@ missing (`gh-missing` / `auth` / `no-remote`) rather than a generic error.
 
 ## routine
 
-Scheduled agent tasks (Routines): a cron rule + a prompt + a repo. Every firing creates a
-**fresh task** (worktree + branch + engine session) with the prompt as its
-first message. A run is an ordinary task you can open and keep talking to.
+Scheduled agent tasks (Routines): a cron rule + a prompt + a repo. By default
+every firing creates a **fresh task** (worktree + branch + engine session) with
+the prompt as its first message; `--persistent-session` instead re-delivers into
+ONE standing task. A run is an ordinary task you can open and keep talking to.
 An enabled routine keeps the daemon alive so schedules fire with no TUI
 attached. Walkthrough: [Routines](ROUTINES.md). Mechanics:
 [design/automations.md](./design/automations.md).
@@ -433,16 +434,26 @@ attached. Walkthrough: [Routines](ROUTINES.md). Mechanics:
 - `routine-list`: every routine with its next run time.
 - `routine-create --repo PATH --name N --prompt TEXT --schedule CRON
   [--vendor V] [--base-branch B] [--precheck CMD] [--precheck-timeout SEC]
-  [--grace MIN] [--disabled]`: schedule a prompt. `--schedule` is five-field
+  [--grace MIN] [--persistent-session] [--disabled]`: schedule a prompt. `--schedule` is five-field
   cron in the daemon host's local time (`"0 9 * * MON-FRI"`).
 - `routine-update --id ID [...]`: change any field. A new `--schedule`
   re-anchors the next run; `--precheck ''` clears the precheck.
 - `routine-set-enabled --id ID --enabled BOOL`: pause / resume.
 - `routine-run-now --id ID`: run immediately, skipping the precheck. Does
   not shift the schedule.
-- `routine-runs --id ID`: run history, newest first.
+- `routine-runs --id ID`: run history, newest first. `revived` and `deferred`
+  are standing-session outcomes — see below.
 - `routine-delete --id ID`: delete it and its history (tasks it already
   created are untouched).
+
+**`--persistent-session`** keeps ONE task per routine and delivers each firing
+into it, so a daily check can build on yesterday. Its task is folded behind the
+sidebar's `N routine sessions` count row (still findable by search, still
+Inbox-reachable). Leave it off for a routine that edits code: a week of runs on
+one branch is a branch nobody can land. Two extra run statuses come with it —
+`revived` (the engine had exited, so it was respawned in the same worktree; the
+files carried over, the conversation did not) and `deferred` (the composer was
+busy, so the prompt is queued in the Inbox rather than lost — a success).
 
 **`--precheck`** runs a shell command in the repo before the engine starts;
 a non-zero exit skips the run *without* creating a task. Use it so a schedule

--- a/docs/ROUTINES.md
+++ b/docs/ROUTINES.md
@@ -1,9 +1,10 @@
 # Routines
 
 Work that runs without you. A **Routine** is a cron rule + a prompt + a repo,
-owned by the daemon. Every firing creates a fresh [task](CONCEPTS.md) with its own
-worktree, its own branch, and its own engine session, carrying the prompt as that
-session's first message.
+owned by the daemon. By default every firing creates a fresh [task](CONCEPTS.md)
+with its own worktree, its own branch, and its own engine session, carrying the
+prompt as that session's first message. A routine that needs to remember what it
+said yesterday can instead keep [one standing session](#one-standing-session-instead-of-a-task-per-run).
 
 That last part is the design, not an implementation detail. A run is not a
 hidden background job with a log file somewhere; it is an ordinary task in your
@@ -137,7 +138,9 @@ needed:
 
 | Status | Meaning |
 |---|---|
-| `dispatched` | Task created, engine started with the prompt |
+| `dispatched` | Task created (or delivered into the standing session), engine started with the prompt |
+| `revived` | Standing session only: its engine had died, so it was respawned in the same worktree. The files carried over, the **conversation did not** |
+| `deferred` | Standing session only: the composer was busy, so the prompt is queued in your Inbox. **Not lost** — release it there |
 | `skipped_precheck` | The precheck said there was nothing to do. **Healthy** |
 | `skipped_missed` | The occurrence was older than the grace window |
 | `skipped_unavailable` | The repo or worktree could not be resolved |
@@ -145,6 +148,49 @@ needed:
 
 `skipped_precheck` and `dispatch_failed` are opposite signals; they never share
 a label.
+
+## One standing session instead of a task per run
+
+A routine that asks the same question every day — *is CI slower than last week?*
+— is worthless starting from zero each morning. Give it a standing session and
+every firing lands in the **same** task, as another turn in one conversation:
+
+```bash
+rove api routine-create --repo . \
+  --name "CI trend" \
+  --prompt "How do this week's CI times compare with last week?" \
+  --schedule "0 9 * * MON-FRI" \
+  --persistent-session
+```
+
+**Leave it off for a routine that edits code.** A fresh worktree per run is what
+makes each result a branch you can review and land; a week of runs piled onto
+one branch is a branch nobody can merge.
+
+### Where its output goes
+
+The standing task does not sit in your sidebar as another row. It rests behind a
+**`N routine sessions`** count row under its project — press `enter` on that row
+to open it and see them, `enter` again to close. Seven daily routines would
+otherwise be forty-nine rows a week competing with the handful of tasks you
+opened yourself.
+
+Hidden at rest is not hidden: the task is still found by `/` search, still opens
+from the Routines page (`enter` on the routine), and still raises an **Inbox**
+entry when its turn finishes or it needs you. That entry is how you learn what
+last night's routine said — you do not go looking for it.
+
+### When the engine has exited
+
+Continuity comes from the engine's own live conversation, which the PTY host
+keeps alive across daemon restarts. When that process is gone — an overnight gap
+usually means it is — the next firing respawns it **in the same worktree**. The
+files and the branch carry over; the transcript does not, and that run is
+recorded as `revived` rather than `dispatched` so a run that started over never
+reads like one that had yesterday in front of it.
+
+If the standing task is deleted, the routine simply builds a new one on its next
+firing rather than failing forever.
 
 ## Restarts, and runs you missed
 
@@ -175,7 +221,8 @@ lifetime rules.
 
 Known and deliberate, as of today:
 
-- Every firing creates a new task; a routine cannot reuse an existing one.
+- A standing session's engine, once it has exited, comes back without the
+  previous transcript (see below).
 - No timezone field; schedules are the daemon host's local time.
 - No per-run cost attribution, and no remote/SSH execution target.
 

--- a/docs/ROUTINES.md
+++ b/docs/ROUTINES.md
@@ -180,6 +180,11 @@ from the Routines page (`enter` on the routine), and still raises an **Inbox**
 entry when its turn finishes or it needs you. That entry is how you learn what
 last night's routine said — you do not go looking for it.
 
+It also never wins the "which task should I open?" fallback on a cold start. A
+routine that fired at 03:00 is genuinely the most recently touched task in the
+install and the least likely one you meant; opening Rove lands on your own work
+instead.
+
 ### When the engine has exited
 
 Continuity comes from the engine's own live conversation, which the PTY host

--- a/docs/ROUTINES.md
+++ b/docs/ROUTINES.md
@@ -84,6 +84,19 @@ closes the page.
 Deleting removes the routine and its run history. **Tasks it already created are
 untouched.** They are ordinary tasks and outlive the schedule that made them.
 
+To find them — a routine that has been firing for weeks has a task per run —
+read the ids off its history before deleting it, since deleting takes the
+history with it:
+
+```bash
+rove api routine-runs --id <id> | jq -r '.runs[].taskId | select(.)'
+```
+
+Then delete the ones you want with `rove api delete --task-id <id>`. Rove does
+not sweep them for you: they are ordinary tasks, some may hold work you want,
+and a schedule deleting tasks in the background is not a thing you should have
+to expect.
+
 ## The schedule
 
 Five-field cron, in the **daemon host's local time** (there is no timezone

--- a/docs/design/automations.md
+++ b/docs/design/automations.md
@@ -5,13 +5,15 @@
 > migration of `~/.rove/automations.json`.
 
 > Daemon-owned cron. A schedule + a prompt + a repo; every firing creates a
-> fresh task and starts its engine with that prompt.
+> fresh task and starts its engine with that prompt — or, with
+> `persistentSession`, re-delivers into one standing task.
 
 ## What it is
 
 ```text
 Automation = cron rule + prompt + repo
 Firing     = a new Task (worktree + branch + engine session)
+           | a delivery into the ONE standing Task (persistentSession)
 ```
 
 The unit of work is an ordinary Rove task, not a hidden background job. A run
@@ -29,7 +31,9 @@ writer). Types in [`contracts.ts`](../../packages/kobe-daemon/src/daemon/contrac
 
 - **`Automation`** — the rule. `schedule` (five-field cron), `prompt`, `repo`,
   optional `vendor` / `baseRef` / `precheck`, `enabled`, `nextRunAt`,
-  `missedRunGraceMinutes`.
+  `missedRunGraceMinutes`, and the standing-session pair `persistentSession` /
+  `sessionTaskId` (issue #91). Types in
+  [`automation-contracts.ts`](../../packages/kobe-daemon/src/daemon/automation-contracts.ts).
 - **`AutomationRun`** — one firing. `scheduledFor` (when it *should* have run),
   `status`, `trigger`, and the `taskId` it produced. Capped at 100 per
   automation.
@@ -38,16 +42,74 @@ writer). Types in [`contracts.ts`](../../packages/kobe-daemon/src/daemon/contrac
 
 | Status | Meaning |
 |---|---|
-| `dispatched` | Task created, engine started with the prompt |
+| `dispatched` | Task created (or delivered into the standing session), engine started with the prompt |
+| `revived` | Standing session whose engine had died, respawned in the same worktree — files kept, transcript not |
+| `deferred` | Standing session's composer was busy; the daemon owns the prompt and queued an Inbox episode |
 | `skipped_precheck` | The precheck said there was nothing to do — **healthy** |
 | `skipped_missed` | The occurrence was older than the grace window |
 | `skipped_unavailable` | The repo/worktree could not be resolved |
 | `dispatch_failed` | Task created but its engine did not start |
 
-The four "didn't run" reasons are deliberately distinct. Unattended automation
+The "didn't run" reasons are deliberately distinct. Unattended automation
 is only trustworthy if a glance tells you whether a human is needed;
 `skipped_precheck` and `dispatch_failed` are opposite signals and must not
 share a label.
+
+## Standing sessions (issue #91)
+
+`persistentSession` swaps "a task per firing" for one task the schedule keeps
+delivering into. It exists because an inspection routine (*is CI worse than last
+week?*) is worthless without the previous answer in the same transcript, while a
+routine that EDITS code needs the opposite — a fresh branch per run, since a
+week of runs on one branch is a branch nobody can land. Hence per-routine, and
+off by default.
+
+The four paths one firing can take live in
+[`automation-dispatch.ts`](../../packages/kobe-daemon/src/daemon/automation-dispatch.ts):
+
+```text
+fire → persistentSession?
+       ├─ no  → createTask + startTaskSessionWithPrompt        → dispatched
+       └─ yes → sessionTaskId resolves to a live, undeleted task?
+                ├─ no  → createTask (marked routine) + spawn,
+                │        relink sessionTaskId                   → dispatched
+                └─ yes → deliverPromptToLiveEngineDetailed
+                         ├─ delivered → dispatched
+                         ├─ busy      → defer + Inbox episode   → deferred
+                         └─ no-session→ respawn same worktree   → revived
+```
+
+**What continuity actually rests on.** The engine's own conversation, kept alive
+by the PTY host — which lives outside the daemon on purpose
+([`pty-server.ts`](../../packages/kobe-daemon/src/daemon/pty-server.ts)), so it
+survives `rove daemon restart`. When that process is gone, the respawn does NOT
+inherit the transcript: the daemon's spawn path (`buildEngineSessionLaunch`) has
+no resume verb wired into it — `engineResumeArgv` is the TUI's tab-restart path.
+Hence `revived` as its own status: a run that started over must not read like
+one that had context.
+
+**Why a busy composer cannot be dropped.** `quota-resume` drops a blocked prompt
+deliberately — it is a nudge, and the next rate-limit arms another. A routine's
+report has no second chance, and a dropped one is indistinguishable from a
+routine that never ran. So it files a deferral and an Inbox episode, the same
+accepted-but-deferred contract `rove api send` gives agents, and the run records
+`deferred` (a success). Because `ComposerBusyError` lives in the `rove` package,
+which depends on this one, the outcome crosses the runtime adapter as DATA
+(`deliverPromptToLiveEngineDetailed`) rather than as a catchable error type.
+
+**Self-healing.** A `sessionTaskId` whose task was deleted, is mid-deletion, or
+lost its worktree resolves to null, and the firing rebuilds and relinks. Without
+that, one deleted task would wedge the routine forever — and a wedged schedule
+looks exactly like a quiet one.
+
+**In the sidebar.** A standing task carries `Task.routine`, which folds it behind
+a per-project `N routine sessions` count row
+([`tree-core.ts`](../../packages/kobe/src/tui/panes/sidebar/tree-core.ts)). This
+is the one fold in a tree that otherwise has none (owner call 2026-08-01, round
+5), scoped so the rule it bends still holds: it hides only what a SCHEDULE
+created, never a task a human opened. A folded task stays findable by `/` (the
+search builds the tree fully expanded), openable from the Routines page, and
+reachable from the Inbox — hiding a ROW, not a task.
 
 ## Scheduling
 

--- a/packages/kobe-daemon/src/daemon/automation-contracts.ts
+++ b/packages/kobe-daemon/src/daemon/automation-contracts.ts
@@ -1,0 +1,139 @@
+/**
+ * Scheduled automations ("routines") — the schedule record, its run history,
+ * and the patch shape edits take.
+ *
+ * Split from `contracts.ts` at the file-size cap, along the seam that was
+ * already there: nothing else in the daemon's contracts refers to these, and
+ * they are the one group with their own store, runner, and RPC family.
+ */
+
+import type { VendorId } from "./contracts.ts"
+
+/** Back-pointer from a routine's standing session task to its schedule.
+ *  Lives here rather than beside the task types because the id it carries is
+ *  an {@link Automation}'s. */
+export interface TaskRoutineLink {
+  readonly automationId: string
+}
+
+/** A shell command run BEFORE an automation's engine starts. A non-zero exit
+ *  means "nothing to do" and the run is skipped without spawning an engine —
+ *  the cheap way to stop a schedule burning a turn when nothing changed. */
+export interface AutomationPrecheck {
+  readonly command: string
+  readonly timeoutSeconds: number
+}
+
+/**
+ * One scheduled agent task: a cron rule + a prompt + a repo. By default every
+ * firing creates a FRESH task (worktree + branch + engine session), so an
+ * automation run is an ordinary task you can open and keep talking to.
+ * {@link persistentSession} swaps that for one standing task the schedule
+ * re-delivers into, which is what lets a daily routine build on yesterday.
+ *
+ * `nextRunAt` is the whole scheduling story: an absolute timestamp on disk,
+ * never an in-memory timer. A daemon restart needs no re-arm pass — the first
+ * sweep after boot re-reads it (same shape as `Task.quotaResume`).
+ */
+export interface Automation {
+  readonly id: string
+  readonly name: string
+  /** Absolute repo root; resolved once at create time. */
+  readonly repo: string
+  /** Delivered as the engine's launch-time first message. */
+  readonly prompt: string
+  readonly vendor?: VendorId
+  /** Five-field cron, evaluated in the daemon host's local time. */
+  readonly schedule: string
+  readonly precheck?: AutomationPrecheck
+  readonly baseRef?: string
+  /**
+   * Re-deliver into ONE standing task instead of creating a fresh worktree
+   * per firing (issue #91). Off by default, and deliberately per-routine:
+   * an inspection routine wants yesterday's context, while a routine that
+   * EDITS code wants a clean branch it can land — piling a week of runs onto
+   * one branch makes it unlandable.
+   */
+  readonly persistentSession?: boolean
+  /**
+   * The standing task {@link persistentSession} delivers into. Set on the
+   * first firing, cleared when that task is gone (deleted, or its worktree
+   * removed) so the next firing rebuilds rather than failing forever.
+   */
+  readonly sessionTaskId?: string
+  readonly enabled: boolean
+  /** ISO-8601. The single source of truth for when this fires next. */
+  readonly nextRunAt: string
+  /** How late a missed occurrence may still run. Older ones are skipped. */
+  readonly missedRunGraceMinutes: number
+  readonly lastRunAt?: string
+  readonly createdAt: string
+  readonly updatedAt: string
+}
+
+/**
+ * Why a run did or did not produce work. The "didn't run" reasons are
+ * deliberately distinct: unattended automation is only trustworthy if the user
+ * can tell "nothing to do" (`skipped_precheck`, healthy) from "it broke"
+ * (`dispatch_failed`, needs a human) at a glance. The same rule is why a
+ * standing session's degraded paths (`revived`, `deferred`) are not folded
+ * into `dispatched`.
+ */
+export type AutomationRunStatus =
+  | "dispatched"
+  /**
+   * A standing session (issue #91) whose engine had died was respawned in the
+   * same worktree. Distinct from `dispatched` because the files carried over
+   * but the CONVERSATION did not — a run that answered without yesterday's
+   * context in front of it should not read as one that had it.
+   */
+  | "revived"
+  /**
+   * The standing session's composer was busy, so the daemon took ownership of
+   * the prompt and queued it for a human to release from the Inbox. A SUCCESS
+   * (the report is not lost), and deliberately not `dispatch_failed`.
+   */
+  | "deferred"
+  | "skipped_precheck"
+  | "skipped_missed"
+  | "skipped_unavailable"
+  | "dispatch_failed"
+
+export interface AutomationPrecheckResult {
+  readonly exitCode: number | null
+  readonly timedOut: boolean
+  readonly stdout: string
+  readonly stderr: string
+  readonly durationMs: number
+}
+
+export interface AutomationRun {
+  readonly id: string
+  readonly automationId: string
+  /** Monotonic per automation; survives retention pruning. */
+  readonly runNumber: number
+  /** When this occurrence was SUPPOSED to run — not when it actually did. */
+  readonly scheduledFor: string
+  readonly status: AutomationRunStatus
+  readonly trigger: "scheduled" | "manual"
+  readonly taskId?: string
+  readonly precheckResult?: AutomationPrecheckResult
+  readonly error?: string
+  /** ISO-8601 event time. */
+  readonly at: string
+}
+
+/** Mutable fields of an automation. `schedule` changes recompute `nextRunAt`. */
+export interface AutomationPatch {
+  readonly name?: string
+  readonly prompt?: string
+  readonly vendor?: VendorId
+  readonly schedule?: string
+  readonly precheck?: AutomationPrecheck | null
+  readonly baseRef?: string | null
+  readonly enabled?: boolean
+  readonly missedRunGraceMinutes?: number
+  readonly persistentSession?: boolean
+  /** `null` clears the standing session link; absent leaves it untouched. */
+  readonly sessionTaskId?: string | null
+}

--- a/packages/kobe-daemon/src/daemon/automation-dispatch.ts
+++ b/packages/kobe-daemon/src/daemon/automation-dispatch.ts
@@ -1,0 +1,213 @@
+/**
+ * How ONE automation firing reaches an engine (issue #91).
+ *
+ * Split from `automation-runner.ts` (file-size cap) along a real seam: the
+ * runner owns WHEN a schedule fires, this owns WHERE the prompt lands. Both
+ * stay well under the cap, and the four delivery paths below are testable
+ * without a clock.
+ *
+ * Two shapes, chosen per routine by `Automation.persistentSession`:
+ *
+ *  - **Fresh** (default, and what every routine did before this): create a
+ *    task, spawn its engine with the prompt on the argv. One worktree and one
+ *    branch per firing — what a routine that EDITS code needs, since a week of
+ *    runs piled onto one branch is a branch nobody can land.
+ *
+ *  - **Standing**: create the task once, then re-deliver into it every firing.
+ *    An inspection routine ("is CI worse than yesterday?") is worthless
+ *    without the previous answer in the same transcript.
+ *
+ * ## What "continuity" actually rests on
+ *
+ * The engine's own conversation, kept alive by the PTY host — which lives
+ * OUTSIDE the daemon on purpose (`pty-server.ts`), so it survives
+ * `rove daemon restart` and every sweep in between. While that PTY is alive,
+ * a firing is another turn in one conversation.
+ *
+ * When it is NOT alive, the standing task is revived by spawning a fresh
+ * engine in the same worktree. That engine does NOT inherit the transcript:
+ * the daemon's spawn path (`buildEngineSessionLaunch`) has no resume verb
+ * wired into it — `engineResumeArgv` is the TUI's tab-restart path, not this
+ * one. The worktree and its files carry over; the conversation does not. That
+ * is recorded as `revived` on the run rather than reported as a plain
+ * `dispatched`, because "it answered with yesterday in mind" and "it started
+ * over" must not look identical in the run history.
+ *
+ * ## Why composer-busy cannot be dropped here
+ *
+ * `quota-resume` drops a blocked prompt on purpose — it is a nudge, and the
+ * next rate-limit arms a new one. A routine's report has no such second
+ * chance: dropped, it is indistinguishable from a routine that never ran. So
+ * a busy composer files a deferral and an Inbox episode, and the run is
+ * recorded as `deferred` — the same accepted-but-deferred contract
+ * `rove api send` already gives agents.
+ */
+
+import type { Automation, AutomationRunStatus, DaemonOrchestrator, DaemonTask } from "./contracts.ts"
+import { logDaemonInfo } from "./crash-log.ts"
+import type { DeferredPromptsStore } from "./deferred-prompts-store.ts"
+import type { DaemonRuntimeAdapter } from "./runtime.ts"
+
+/** The orchestrator slice a firing needs. */
+export type DispatchOrchestrator = Pick<DaemonOrchestrator, "createTask" | "getTask">
+
+export type DispatchRuntime = Pick<
+  DaemonRuntimeAdapter,
+  "startTaskSessionWithPrompt" | "deliverPromptToLiveEngineDetailed"
+>
+
+/** The Inbox slice a deferral needs (`attention-inbox.ts`). */
+export interface DispatchInbox {
+  recordPromptDeferred(
+    taskId: string,
+    tabId: string,
+    deferredId: string,
+    layer: "recent-human-write" | "composer-not-empty",
+  ): Promise<void>
+}
+
+export interface DispatchDeps {
+  readonly orch: DispatchOrchestrator
+  readonly runtime: DispatchRuntime
+  /** Resolved lazily for the same construction-order reason as the runner's. */
+  readonly link: () => import("../client/rpc.ts").DaemonRpcClient
+  /** Absent in a daemon booted without one; a busy composer then falls back
+   *  to reporting the failure rather than silently dropping the report. */
+  readonly deferred?: DeferredPromptsStore
+  readonly inbox?: DispatchInbox
+  readonly now?: () => number
+}
+
+/**
+ * Outcome of one firing. `taskId` is carried even on failure: the task may
+ * exist while its engine did not start, and the run record is the only place
+ * that id survives for a human to open by hand.
+ */
+export interface DispatchOutcome {
+  readonly status: AutomationRunStatus
+  readonly taskId?: string
+  readonly error?: string
+  /** Set when the standing session was rebuilt — see `clearSessionTaskId`. */
+  readonly sessionTaskIdToClear?: boolean
+  /** Set on the firing that established a standing session. */
+  readonly sessionTaskIdToSet?: string
+}
+
+/**
+ * The standing task this automation should deliver into, or null when it must
+ * be (re)built.
+ *
+ * A task that was deleted, is BEING deleted, or lost its worktree is not a
+ * session — returning null here is what stops one deleted task from wedging a
+ * routine into failing forever, which is the failure mode a bare stored id
+ * would otherwise have.
+ */
+export function resolveStandingTask(
+  orch: DispatchOrchestrator,
+  automation: Automation,
+): { task: DaemonTask } | { task: null; hadStaleLink: boolean } {
+  const id = automation.sessionTaskId
+  if (!id) return { task: null, hadStaleLink: false }
+  const task = orch.getTask(id)
+  if (!task || task.deletion || !task.worktreePath) return { task: null, hadStaleLink: true }
+  return { task }
+}
+
+/** Create the task a firing runs in, marked as the routine's when standing. */
+async function createRunTask(deps: DispatchDeps, automation: Automation): Promise<DaemonTask> {
+  return await deps.orch.createTask({
+    repo: automation.repo,
+    title: automation.name,
+    ...(automation.vendor ? { vendor: automation.vendor } : {}),
+    ...(automation.baseRef ? { baseRef: automation.baseRef } : {}),
+    // The marker is what folds this task behind the sidebar's routine count
+    // row. Only standing sessions get it: a fresh-per-run routine produces
+    // ordinary tasks, and hiding those would hide work the user must land.
+    ...(automation.persistentSession ? { routine: { automationId: automation.id } } : {}),
+  })
+}
+
+/** Spawn a task's engine with the prompt on its argv. Shared by both shapes. */
+async function spawnWithPrompt(
+  deps: DispatchDeps,
+  automation: Automation,
+  taskId: string,
+  status: AutomationRunStatus,
+): Promise<DispatchOutcome> {
+  const started = await deps.runtime.startTaskSessionWithPrompt(deps.link(), taskId, automation.prompt)
+  if (!started) return { status: "dispatch_failed", taskId, error: "engine session did not start" }
+  return { status, taskId }
+}
+
+/**
+ * File a blocked prompt for a human to release from the Inbox. Returns the
+ * outcome to record — `deferred` when the daemon took ownership of the text,
+ * and a failure when it could not, so a report is never lost quietly.
+ */
+async function deferBlockedPrompt(
+  deps: DispatchDeps,
+  automation: Automation,
+  taskId: string,
+  tabId: string,
+  layer: "recent-human-write" | "composer-not-empty",
+): Promise<DispatchOutcome> {
+  if (!deps.deferred || !deps.inbox) {
+    return { status: "dispatch_failed", taskId, error: `composer busy (${layer}) and no deferred-prompt store` }
+  }
+  const record = await deps.deferred.file({
+    taskId,
+    tabId,
+    prompt: automation.prompt,
+    layer,
+    senderLabel: `routine: ${automation.name}`,
+    at: (deps.now ?? Date.now)(),
+  })
+  await deps.inbox.recordPromptDeferred(taskId, tabId, record.id, layer)
+  logDaemonInfo("automation", `deferred ${automation.name} task=${taskId} tab=${tabId} layer=${layer}`)
+  return { status: "deferred", taskId }
+}
+
+/**
+ * Run one firing to the point where an engine has the prompt (or a human owns
+ * it). Pure of scheduling and of run-recording — the runner does both.
+ */
+export async function dispatchAutomation(deps: DispatchDeps, automation: Automation): Promise<DispatchOutcome> {
+  if (!automation.persistentSession) {
+    const task = await createRunTask(deps, automation)
+    return await spawnWithPrompt(deps, automation, task.id, "dispatched")
+  }
+
+  const standing = resolveStandingTask(deps.orch, automation)
+  if (standing.task === null) {
+    // No session yet, or the one we had is gone. Build one and remember it —
+    // clearing the stale link in the same breath, so a deleted task cannot
+    // strand this routine on an id that will never resolve again.
+    const task = await createRunTask(deps, automation)
+    const outcome = await spawnWithPrompt(deps, automation, task.id, "dispatched")
+    return {
+      ...outcome,
+      // Remember the task even when its engine failed to start: the worktree
+      // exists, and the next firing should revive THAT session rather than
+      // stack a second standing task beside it.
+      sessionTaskIdToSet: task.id,
+      ...(standing.hadStaleLink ? { sessionTaskIdToClear: true } : {}),
+    }
+  }
+
+  const task = standing.task
+  const result = await deps.runtime.deliverPromptToLiveEngineDetailed(
+    { id: task.id, vendor: task.vendor, command: task.command, worktreePath: task.worktreePath },
+    automation.prompt,
+  )
+  if (result.outcome === "delivered") {
+    logDaemonInfo("automation", `delivered ${automation.name} task=${task.id} tab=${result.tabId}`)
+    return { status: "dispatched", taskId: task.id }
+  }
+  if (result.outcome === "busy") {
+    return await deferBlockedPrompt(deps, automation, task.id, result.tabId, result.layer)
+  }
+  // The engine died between firings (an overnight gap is the normal case).
+  // Respawn it in the SAME worktree: the files carry over, the transcript
+  // does not — recorded as `revived` so the run history says which it was.
+  return await spawnWithPrompt(deps, automation, task.id, "revived")
+}

--- a/packages/kobe-daemon/src/daemon/automation-runner.ts
+++ b/packages/kobe-daemon/src/daemon/automation-runner.ts
@@ -1,5 +1,9 @@
 /**
- * Automation sweep: fire due schedules, one fresh task per run.
+ * Automation sweep: fire due schedules.
+ *
+ * WHERE a firing's prompt lands is `automation-dispatch.ts` (fresh task per
+ * run, or one standing session re-delivered into — issue #91). This module
+ * owns only WHEN, and recording what happened.
  *
  * Shape copied wholesale from {@link startQuotaResumeRunner} — same stateless
  * tick, same re-entrancy latch, same unref'd timer, and the same deliberate
@@ -21,11 +25,13 @@
  */
 
 import type { DaemonRpcClient } from "../client/rpc.ts"
+import { type DispatchInbox, dispatchAutomation } from "./automation-dispatch.ts"
 import { formatPrecheckSkip, precheckPassed, runAutomationPrecheck } from "./automation-precheck.ts"
 import type { AutomationsStore } from "./automations-store.ts"
 import type { Automation, AutomationRunStatus, DaemonOrchestrator } from "./contracts.ts"
 import { logDaemonError, logDaemonInfo } from "./crash-log.ts"
 import { latestCronAtOrBefore } from "./cron.ts"
+import type { DeferredPromptsStore } from "./deferred-prompts-store.ts"
 import type { DaemonRuntimeAdapter } from "./runtime.ts"
 
 /** How often the sweep looks for due schedules. Cron's own resolution is one
@@ -63,10 +69,14 @@ export function resolveDueOccurrence(
   return { scheduledFor, missed: nowMs - scheduledFor > graceMs }
 }
 
-/** The slice of the orchestrator this runner needs. */
-export type AutomationOrchestrator = Pick<DaemonOrchestrator, "createTask">
+/** The slice of the orchestrator this runner needs. `getTask` resolves a
+ *  standing session's task before re-delivering into it (issue #91). */
+export type AutomationOrchestrator = Pick<DaemonOrchestrator, "createTask" | "getTask">
 
-export type AutomationRuntime = Pick<DaemonRuntimeAdapter, "startTaskSessionWithPrompt">
+export type AutomationRuntime = Pick<
+  DaemonRuntimeAdapter,
+  "startTaskSessionWithPrompt" | "deliverPromptToLiveEngineDetailed"
+>
 
 interface RunnerDeps {
   readonly store: AutomationsStore
@@ -79,6 +89,11 @@ interface RunnerDeps {
   /** Plugin event sink (getter for the same construction-order reason as
    *  `link`). Every recorded run fires one automation.* plugin event. */
   readonly plugins?: () => { handleUiReport(report: PluginRunReport): void } | null
+  /** Ownership of a prompt a busy composer refused (standing sessions only).
+   *  Absent in a daemon booted without the stores; the firing then records a
+   *  failure rather than dropping the report silently. */
+  readonly deferred?: DeferredPromptsStore
+  readonly inbox?: DispatchInbox
   readonly now?: () => number
 }
 
@@ -88,9 +103,12 @@ type PluginRunReport = {
   readonly detail?: Record<string, unknown>
 }
 
-/** Run outcome → plugin event name (docs/design/plugin-events.md). */
+/** Run outcome → plugin event name (docs/design/plugin-events.md).
+ *  `revived` and `deferred` both delivered the prompt somewhere it will be
+ *  read, so they report as dispatched rather than minting event names every
+ *  existing plugin would ignore. */
 function runEventFor(status: AutomationRunStatus): PluginRunReport["kind"] {
-  if (status === "dispatched") return "automation.dispatched"
+  if (status === "dispatched" || status === "revived" || status === "deferred") return "automation.dispatched"
   if (status === "dispatch_failed") return "automation.failed"
   return "automation.skipped"
 }
@@ -159,36 +177,47 @@ export async function runAutomationOnce(
     }
   }
 
-  let taskId: string
+  let outcome: Awaited<ReturnType<typeof dispatchAutomation>>
   try {
-    const task = await deps.orch.createTask({
-      repo: automation.repo,
-      title: automation.name,
-      ...(automation.vendor ? { vendor: automation.vendor } : {}),
-      ...(automation.baseRef ? { baseRef: automation.baseRef } : {}),
-    })
-    taskId = task.id
+    outcome = await dispatchAutomation(
+      {
+        orch: deps.orch,
+        runtime: deps.runtime,
+        link: () => resolveLink(deps.link),
+        ...(deps.deferred ? { deferred: deps.deferred } : {}),
+        ...(deps.inbox ? { inbox: deps.inbox } : {}),
+        ...(deps.now ? { now: deps.now } : {}),
+      },
+      automation,
+    )
   } catch (err) {
     // A repo that moved or was forgotten lands here — the schedule is fine,
     // its target is not, so this is `unavailable` rather than a failure.
     const error = err instanceof Error ? err.message : String(err)
-    logDaemonError("automation-create-task", err)
+    logDaemonError("automation-dispatch", err)
     return await record("skipped_unavailable", { error })
   }
 
-  try {
-    const started = await deps.runtime.startTaskSessionWithPrompt(resolveLink(deps.link), taskId, automation.prompt)
-    if (!started) {
-      // The task EXISTS even though its engine did not start, so the id is
-      // carried on the run record — the user can open it and retry by hand.
-      return await record("dispatch_failed", { taskId, error: "engine session did not start" })
-    }
-    logDaemonInfo("automation", `dispatched ${automation.name} task=${taskId}`)
-    return await record("dispatched", { taskId })
-  } catch (err) {
-    logDaemonError("automation-dispatch", err)
-    return await record("dispatch_failed", { taskId, error: err instanceof Error ? err.message : String(err) })
+  // Persist the standing-session link BEFORE recording the run: a crash
+  // between the two costs one run record, while the reverse would leave the
+  // routine building a second standing task on its next firing.
+  if (outcome.sessionTaskIdToSet) {
+    await deps.store
+      .update(automation.id, { sessionTaskId: outcome.sessionTaskIdToSet })
+      .catch((err) => logDaemonError("automation-session-link", err))
+  } else if (outcome.sessionTaskIdToClear) {
+    await deps.store
+      .update(automation.id, { sessionTaskId: null })
+      .catch((err) => logDaemonError("automation-session-unlink", err))
   }
+
+  if (outcome.status === "dispatched" || outcome.status === "revived") {
+    logDaemonInfo("automation", `${outcome.status} ${automation.name} task=${outcome.taskId}`)
+  }
+  return await record(outcome.status, {
+    ...(outcome.taskId ? { taskId: outcome.taskId } : {}),
+    ...(outcome.error ? { error: outcome.error } : {}),
+  })
 }
 
 /** One sweep pass. Exported so tests can drive it without a timer. */

--- a/packages/kobe-daemon/src/daemon/automations-store.ts
+++ b/packages/kobe-daemon/src/daemon/automations-store.ts
@@ -77,6 +77,8 @@ function normalizeAutomation(value: unknown): Automation | null {
         }
       : {}),
     ...(str(raw.baseRef) ? { baseRef: raw.baseRef } : {}),
+    ...(raw.persistentSession === true ? { persistentSession: true } : {}),
+    ...(str(raw.sessionTaskId) ? { sessionTaskId: raw.sessionTaskId } : {}),
     ...(str(raw.lastRunAt) ? { lastRunAt: raw.lastRunAt } : {}),
     createdAt: str(raw.createdAt) ?? now,
     updatedAt: str(raw.updatedAt) ?? now,
@@ -93,6 +95,8 @@ function normalizeRun(value: unknown): AutomationRun | null {
   if (!id || !automationId || !scheduledFor || !at) return null
   if (
     raw.status !== "dispatched" &&
+    raw.status !== "revived" &&
+    raw.status !== "deferred" &&
     raw.status !== "skipped_precheck" &&
     raw.status !== "skipped_missed" &&
     raw.status !== "skipped_unavailable" &&
@@ -259,6 +263,14 @@ export class AutomationsStore {
           ? { baseRef: undefined }
           : patch.baseRef !== undefined
             ? { baseRef: patch.baseRef }
+            : {}),
+        ...(patch.persistentSession !== undefined ? { persistentSession: patch.persistentSession } : {}),
+        // `null` clears the standing-session link outright: a stored null
+        // would read as "linked to nothing" on the next firing's lookup.
+        ...(patch.sessionTaskId === null
+          ? { sessionTaskId: undefined }
+          : patch.sessionTaskId !== undefined
+            ? { sessionTaskId: patch.sessionTaskId }
             : {}),
         // Re-anchor the schedule whenever the expression changes, else the old
         // nextRunAt would fire on a rule the user just replaced.

--- a/packages/kobe-daemon/src/daemon/collectors.ts
+++ b/packages/kobe-daemon/src/daemon/collectors.ts
@@ -56,6 +56,10 @@ export interface AutomationCollectorDeps {
   readonly link: DaemonRpcClient | (() => DaemonRpcClient)
   /** Plugin host getter (constructed after the collectors start, like `link`). */
   readonly plugins?: () => import("../plugins/runtime.ts").PluginHost | null
+  /** Where a standing session's blocked report goes (issue #91) instead of
+   *  being dropped. Optional so tests that don't exercise it keep working. */
+  readonly deferred?: import("./deferred-prompts-store.ts").DeferredPromptsStore
+  readonly inbox?: import("./automation-dispatch.ts").DispatchInbox
 }
 
 /**
@@ -236,6 +240,8 @@ export function startDaemonCollectors(
           runtime,
           link: automations.link,
           ...(automations.plugins ? { plugins: automations.plugins } : {}),
+          ...(automations.deferred ? { deferred: automations.deferred } : {}),
+          ...(automations.inbox ? { inbox: automations.inbox } : {}),
         },
         options.automationTickMs ?? DEFAULT_AUTOMATION_TICK_MS,
       )

--- a/packages/kobe-daemon/src/daemon/contracts.ts
+++ b/packages/kobe-daemon/src/daemon/contracts.ts
@@ -1,6 +1,20 @@
 /** Framework-free product contracts consumed by the daemon package. */
 
 import type { ObservedLanguage } from "../prompts/observed-language.ts"
+import type { TaskRoutineLink } from "./automation-contracts.ts"
+
+// Automation ("routine") contracts live in their own module (file-size cap)
+// and are re-exported here: every existing importer names them through
+// `contracts.ts`, and the split is a file boundary, not an API change.
+export type {
+  Automation,
+  AutomationPatch,
+  AutomationPrecheck,
+  AutomationPrecheckResult,
+  AutomationRun,
+  AutomationRunStatus,
+  TaskRoutineLink,
+} from "./automation-contracts.ts"
 
 /** Engine id (kobe `VendorId`). Deliberately plain `string`: the daemon
  *  treats vendor ids as opaque pass-through values and never narrows on
@@ -88,6 +102,10 @@ export interface DaemonTask {
   /** Scratch shell task (issue #33): a dir task with no settled cwd, living
    *  in the sidebar's Scratch section; cleared when named or adopted. */
   readonly scratch?: boolean
+  /** Standing session for a routine (issue #91): the one task a
+   *  `persistentSession` automation re-delivers into, folded behind a count
+   *  row in the sidebar instead of a loose task row. */
+  readonly routine?: TaskRoutineLink
   readonly status: TaskStatus
   readonly pinned?: boolean
   readonly vendor?: VendorId
@@ -168,6 +186,8 @@ export interface DaemonOrchestrator {
     modelEffort?: string
     groupId?: string
     dispatcher?: TaskDispatcher
+    /** Mark this the standing session task of a routine (issue #91). */
+    routine?: TaskRoutineLink
   }): Promise<DaemonTask>
   ensureMainTask(repo: string): Promise<DaemonTask>
   /** Open an existing directory as a standalone `kind:"dir"` task (`kobe .`).
@@ -370,94 +390,6 @@ export interface AttentionInboxItem {
   readonly unread: boolean
   /** Event time, epoch milliseconds. Stable across daemon/TUI restarts. */
   readonly at: number
-}
-
-/** A shell command run BEFORE an automation's engine starts. A non-zero exit
- *  means "nothing to do" and the run is skipped without spawning an engine —
- *  the cheap way to stop a schedule burning a turn when nothing changed. */
-export interface AutomationPrecheck {
-  readonly command: string
-  readonly timeoutSeconds: number
-}
-
-/**
- * One scheduled agent task: a cron rule + a prompt + a repo. Every firing
- * creates a FRESH task (worktree + branch + engine session), so an automation
- * run is an ordinary task you can open and keep talking to.
- *
- * `nextRunAt` is the whole scheduling story: an absolute timestamp on disk,
- * never an in-memory timer. A daemon restart needs no re-arm pass — the first
- * sweep after boot re-reads it (same shape as `Task.quotaResume`).
- */
-export interface Automation {
-  readonly id: string
-  readonly name: string
-  /** Absolute repo root; resolved once at create time. */
-  readonly repo: string
-  /** Delivered as the engine's launch-time first message. */
-  readonly prompt: string
-  readonly vendor?: VendorId
-  /** Five-field cron, evaluated in the daemon host's local time. */
-  readonly schedule: string
-  readonly precheck?: AutomationPrecheck
-  readonly baseRef?: string
-  readonly enabled: boolean
-  /** ISO-8601. The single source of truth for when this fires next. */
-  readonly nextRunAt: string
-  /** How late a missed occurrence may still run. Older ones are skipped. */
-  readonly missedRunGraceMinutes: number
-  readonly lastRunAt?: string
-  readonly createdAt: string
-  readonly updatedAt: string
-}
-
-/**
- * Why a run did or did not produce work. The four "didn't run" reasons are
- * deliberately distinct: unattended automation is only trustworthy if the user
- * can tell "nothing to do" (`skipped_precheck`, healthy) from "it broke"
- * (`dispatch_failed`, needs a human) at a glance.
- */
-export type AutomationRunStatus =
-  | "dispatched"
-  | "skipped_precheck"
-  | "skipped_missed"
-  | "skipped_unavailable"
-  | "dispatch_failed"
-
-export interface AutomationPrecheckResult {
-  readonly exitCode: number | null
-  readonly timedOut: boolean
-  readonly stdout: string
-  readonly stderr: string
-  readonly durationMs: number
-}
-
-export interface AutomationRun {
-  readonly id: string
-  readonly automationId: string
-  /** Monotonic per automation; survives retention pruning. */
-  readonly runNumber: number
-  /** When this occurrence was SUPPOSED to run — not when it actually did. */
-  readonly scheduledFor: string
-  readonly status: AutomationRunStatus
-  readonly trigger: "scheduled" | "manual"
-  readonly taskId?: string
-  readonly precheckResult?: AutomationPrecheckResult
-  readonly error?: string
-  /** ISO-8601 event time. */
-  readonly at: string
-}
-
-/** Mutable fields of an automation. `schedule` changes recompute `nextRunAt`. */
-export interface AutomationPatch {
-  readonly name?: string
-  readonly prompt?: string
-  readonly vendor?: VendorId
-  readonly schedule?: string
-  readonly precheck?: AutomationPrecheck | null
-  readonly baseRef?: string | null
-  readonly enabled?: boolean
-  readonly missedRunGraceMinutes?: number
 }
 
 export interface UpdateInfo {

--- a/packages/kobe-daemon/src/daemon/handlers-automations.ts
+++ b/packages/kobe-daemon/src/daemon/handlers-automations.ts
@@ -51,6 +51,7 @@ export const AUTOMATION_HANDLERS: readonly DaemonRequestHandler[] = [
         ...(optionalVendor(payload, "vendor") ? { vendor: optionalVendor(payload, "vendor") } : {}),
         ...(precheck ? { precheck } : {}),
         ...(optionalString(payload, "baseRef") ? { baseRef: optionalString(payload, "baseRef") } : {}),
+        ...(optionalBoolean(payload, "persistentSession") === true ? { persistentSession: true } : {}),
         ...(optionalBoolean(payload, "enabled") !== undefined ? { enabled: optionalBoolean(payload, "enabled") } : {}),
       })
       // A new enabled schedule may be the daemon's only reason to stay up.
@@ -72,6 +73,9 @@ export const AUTOMATION_HANDLERS: readonly DaemonRequestHandler[] = [
         ...(optionalBoolean(payload, "enabled") !== undefined ? { enabled: optionalBoolean(payload, "enabled") } : {}),
         ...(optionalNumber(payload, "missedRunGraceMinutes") !== undefined
           ? { missedRunGraceMinutes: optionalNumber(payload, "missedRunGraceMinutes") }
+          : {}),
+        ...(optionalBoolean(payload, "persistentSession") !== undefined
+          ? { persistentSession: optionalBoolean(payload, "persistentSession") }
           : {}),
       }
       const automation = await ctx.automations.update(id, patch)

--- a/packages/kobe-daemon/src/daemon/protocol.ts
+++ b/packages/kobe-daemon/src/daemon/protocol.ts
@@ -353,6 +353,9 @@ export interface SerializedTask {
   readonly kind: "main" | "task" | "dir"
   /** Scratch shell task (issue #33) — Scratch-section row, cleared on adopt/rename. */
   readonly scratch?: boolean
+  /** Standing session of a routine (issue #91) — folded behind the sidebar's
+   *  routine count row instead of rendering as a loose task. */
+  readonly routine?: DaemonTask["routine"]
   readonly status: DaemonTask["status"]
   readonly pinned: boolean
   readonly vendor?: DaemonTask["vendor"]
@@ -404,6 +407,7 @@ export function serializeTask(task: DaemonTask): SerializedTask {
     worktreePath: task.worktreePath,
     kind: task.kind ?? "task",
     ...(task.scratch ? { scratch: true } : {}),
+    ...(task.routine ? { routine: task.routine } : {}),
     status: task.status,
     pinned: task.pinned ?? false,
     vendor: task.vendor,

--- a/packages/kobe-daemon/src/daemon/runtime.ts
+++ b/packages/kobe-daemon/src/daemon/runtime.ts
@@ -137,6 +137,34 @@ export interface DaemonRuntimeAdapter {
     },
     prompt: string,
   ): Promise<boolean>
+  /**
+   * {@link deliverPromptToLiveEngine} with the composer-busy outcome as DATA
+   * rather than a thrown `ComposerBusyError` — the error class lives in the
+   * `rove` package, which depends on this one, so the daemon cannot catch it
+   * by type. A caller that must not drop the prompt (a routine's daily report
+   * — issue #91) reads `busy` and files a deferral; quota-resume keeps using
+   * the boolean form, where dropping is the right answer.
+   *
+   * `tabId` names which tab the live engine was found on, so the deferral and
+   * its Inbox episode point at the tab a human will actually open.
+   */
+  deliverPromptToLiveEngineDetailed(
+    task: {
+      readonly id: string
+      readonly vendor?: VendorId
+      readonly command?: string
+      readonly worktreePath: string
+    },
+    prompt: string,
+  ): Promise<
+    | { readonly outcome: "delivered"; readonly tabId: string }
+    | { readonly outcome: "no-session" }
+    | {
+        readonly outcome: "busy"
+        readonly tabId: string
+        readonly layer: "recent-human-write" | "composer-not-empty"
+      }
+  >
   settingsSnapshot(): Response
   settingsPatch(request: Request): Promise<Response>
   handleDiffRequest(request: Request, url: URL): Promise<Response | null>

--- a/packages/kobe-daemon/src/daemon/server.ts
+++ b/packages/kobe-daemon/src/daemon/server.ts
@@ -248,6 +248,10 @@ export async function startDaemonServer(orch: DaemonOrchestrator, options: Daemo
       // Same construction-order deferral: the plugin host starts right after
       // the collectors, and the sweep only reads it on a tick.
       plugins: () => pluginHost,
+      // A standing routine session whose composer is busy hands its report to
+      // these instead of dropping it (issue #91).
+      ...(deferredPrompts ? { deferred: deferredPrompts } : {}),
+      inbox,
     },
     activity,
   )

--- a/packages/kobe/src/cli/api/verbs-automations.ts
+++ b/packages/kobe/src/cli/api/verbs-automations.ts
@@ -3,9 +3,11 @@
  * of `verbs.ts` (file-size cap); spread back into the {@link VERBS} table
  * there, so schema/help/validation see one canonical list.
  *
- * Every firing creates a FRESH task (worktree + branch + engine session) with
- * the automation's prompt as its first message. Mechanics live in
- * `docs/design/automations.md`.
+ * By default every firing creates a FRESH task (worktree + branch + engine
+ * session) with the automation's prompt as its first message.
+ * `--persistent-session` swaps that for ONE standing task the schedule
+ * re-delivers into, so a daily routine can build on yesterday. Mechanics live
+ * in `docs/design/automations.md`.
  */
 
 import { F } from "./flags.ts"
@@ -43,6 +45,13 @@ const GRACE_FLAG = {
     "How late a missed occurrence may still run when the daemon was down (default 60). Only the most recent missed occurrence is ever run.",
 } as const
 
+const PERSISTENT_FLAG = {
+  name: "persistent-session",
+  type: "bool",
+  description:
+    "Re-deliver into ONE standing task instead of a fresh worktree per run — for a routine that needs yesterday's context (a trend check). Its task is folded behind the sidebar's routine count row. Leave off for a routine that EDITS code: a week of runs on one branch is a branch nobody can land.",
+} as const
+
 /** Shared `--precheck` → payload shape. `--precheck ''` clears it on update. */
 function precheckPayload(ctx: Parameters<VerbSpec["handler"]>[0]): Record<string, unknown> {
   const command = ctx.args.str("precheck")
@@ -76,6 +85,7 @@ export const ROUTINE_VERBS: readonly VerbSpec[] = [
       },
       ...PRECHECK_FLAGS,
       GRACE_FLAG,
+      PERSISTENT_FLAG,
       { name: "disabled", type: "bool", description: "Create it paused instead of active." },
     ],
     handler: (ctx) =>
@@ -88,6 +98,7 @@ export const ROUTINE_VERBS: readonly VerbSpec[] = [
         ...(ctx.args.str("base-branch") ? { baseRef: ctx.args.str("base-branch") } : {}),
         ...precheckPayload(ctx),
         ...(ctx.args.int("grace") !== undefined ? { missedRunGraceMinutes: ctx.args.int("grace") } : {}),
+        ...(ctx.args.bool("persistent-session") ? { persistentSession: true } : {}),
         ...(ctx.args.bool("disabled") ? { enabled: false } : {}),
       }),
   },
@@ -103,6 +114,7 @@ export const ROUTINE_VERBS: readonly VerbSpec[] = [
       { name: "base-branch", type: "string", placeholder: "B", description: "New base ref ('' to clear)." },
       ...PRECHECK_FLAGS,
       GRACE_FLAG,
+      PERSISTENT_FLAG,
     ],
     handler: (ctx) =>
       simpleRpc(ctx, "automation.update", {
@@ -114,6 +126,7 @@ export const ROUTINE_VERBS: readonly VerbSpec[] = [
         ...(ctx.args.str("base-branch") !== undefined ? { baseRef: ctx.args.str("base-branch") } : {}),
         ...precheckPayload(ctx),
         ...(ctx.args.int("grace") !== undefined ? { missedRunGraceMinutes: ctx.args.int("grace") } : {}),
+        ...(ctx.args.bool("persistent-session") ? { persistentSession: true } : {}),
       }),
   },
   {
@@ -142,7 +155,7 @@ export const ROUTINE_VERBS: readonly VerbSpec[] = [
   {
     name: "routine-runs",
     summary:
-      "Run history, newest first. Statuses: dispatched, skipped_precheck (nothing to do), skipped_missed, skipped_unavailable, dispatch_failed.",
+      "Run history, newest first. Statuses: dispatched, revived (standing session respawned — files kept, conversation did not), deferred (composer busy; the prompt is queued in the Inbox, NOT lost), skipped_precheck (nothing to do), skipped_missed, skipped_unavailable, dispatch_failed.",
     flags: [{ name: "id", type: "string", required: true, placeholder: "ID", description: "Routine id." }],
     handler: (ctx) => simpleRpc(ctx, "automation.runs", { id: ctx.args.require("id") }),
   },

--- a/packages/kobe/src/client/remote-orchestrator-payloads.ts
+++ b/packages/kobe/src/client/remote-orchestrator-payloads.ts
@@ -384,6 +384,7 @@ export function deserializeTask(s: SerializedTask): Task {
     worktreePath: s.worktreePath,
     kind: s.kind,
     ...(s.scratch ? { scratch: true } : {}),
+    ...(s.routine ? { routine: s.routine } : {}),
     status: s.status,
     pinned: s.pinned,
     vendor: s.vendor,

--- a/packages/kobe/src/core/daemon-runtime.ts
+++ b/packages/kobe/src/core/daemon-runtime.ts
@@ -27,6 +27,7 @@ import { handleNotesRequest } from "../web/notes.ts"
 import { handleThemesRequest } from "../web/themes.ts"
 import {
   deliverPromptToLiveEngineAdapter,
+  deliverPromptToLiveEngineDetailedAdapter,
   engineSpecAdapter,
   ensureTaskSessionAdapter,
   startTaskSessionWithPromptAdapter,
@@ -93,6 +94,7 @@ export const daemonRuntime: DaemonRuntimeAdapter = {
   quotaUsage: (vendor) => engineEntry(vendor).quotaUsage?.() ?? Promise.resolve(null),
   vendorsWithQuotaProbe,
   deliverPromptToLiveEngine: deliverPromptToLiveEngineAdapter,
+  deliverPromptToLiveEngineDetailed: deliverPromptToLiveEngineDetailedAdapter,
   settingsSnapshot: daemonSettingsSnapshot,
   settingsPatch: daemonSettingsPatch,
   handleDiffRequest,

--- a/packages/kobe/src/core/daemon-session-adapter.ts
+++ b/packages/kobe/src/core/daemon-session-adapter.ts
@@ -161,6 +161,54 @@ export async function deliverPromptToLiveEngineAdapter(
   }
 }
 
+/** The tab a hosted session key names (`<taskId>::<tabId>`), default tab-1. */
+function tabIdFromHostedKey(key: string): string {
+  return key.split("::")[1] ?? "tab-1"
+}
+
+/**
+ * {@link deliverPromptToLiveEngineAdapter} reporting composer-busy as a VALUE.
+ *
+ * The routine runner (issue #91) must not drop a daily report the way
+ * quota-resume drops a continue nudge: a dropped report and a routine that
+ * never ran look identical to the user. It needs the busy layer and the tab
+ * to file a deferral, and the daemon cannot catch `ComposerBusyError` by type
+ * across the package boundary — so the outcome crosses as data.
+ */
+export async function deliverPromptToLiveEngineDetailedAdapter(
+  task: { readonly id: string; readonly vendor?: VendorId; readonly command?: string; readonly worktreePath: string },
+  prompt: string,
+): Promise<
+  | { outcome: "delivered"; tabId: string }
+  | { outcome: "no-session" }
+  | { outcome: "busy"; tabId: string; layer: "recent-human-write" | "composer-not-empty" }
+> {
+  const host = await openHostedSessionHost()
+  if (!host) return { outcome: "no-session" }
+  try {
+    const sessions = await listHostedSessions(host.rpc)
+    const engineBin = engineLaunchArgv({ command: task.command, vendor: task.vendor })[0]
+    const key = findHostedEngineKey(sessions, task.id, engineBin)
+    if (!key) return { outcome: "no-session" }
+    const manifest = task.vendor ? engineEntry(task.vendor).screenManifest : undefined
+    try {
+      const delivered = await deliverToHostedKey(host.rpc, key, prompt, { screenManifest: manifest })
+      return delivered === null ? { outcome: "no-session" } : { outcome: "delivered", tabId: tabIdFromHostedKey(key) }
+    } catch (err) {
+      if (err instanceof ComposerBusyError) {
+        return { outcome: "busy", tabId: tabIdFromHostedKey(key), layer: err.layer }
+      }
+      throw err
+    }
+  } catch {
+    // A host that went away mid-delivery is indistinguishable from one that
+    // was never there — both mean "revive it", which is the caller's fallback.
+    return { outcome: "no-session" }
+  } finally {
+    host.close()
+  }
+}
+
 export async function tearDownTaskSessionAdapter(taskId: string): Promise<void> {
   const host = await openHostedSessionHost()
   if (!host) return

--- a/packages/kobe/src/orchestrator/core.ts
+++ b/packages/kobe/src/orchestrator/core.ts
@@ -6,13 +6,21 @@
 
 import { type ReadableState, type StateCell, createStateCell } from "../lib/external-store.ts"
 import { readLastActiveTaskId, writeLastActiveTaskId } from "../state/last-active.ts"
-import type { ProjectIntent } from "../state/project-eligibility.ts"
 import { getRemoteRepoConfig, getSavedRepos, removeSavedRepo } from "../state/repos.ts"
 import { resolvePreferredVendor } from "../state/vendor-prefs.ts"
-import type { Task, TaskDispatcher, TaskId, TaskPRStatus, TaskStatus, VendorId } from "../types/task.ts"
+import type {
+  Task,
+  TaskDispatcher,
+  TaskId,
+  TaskPRStatus,
+  TaskRoutineLink,
+  TaskStatus,
+  VendorId,
+} from "../types/task.ts"
 import { DEFAULT_TASK_VENDOR } from "../types/task.ts"
 import type { AdoptableWorktree } from "../types/worktree.ts"
 import { canonPath, normalizeMainRepo, randomDirTaskSuffix, repoWorkingDir, titleFromRepo } from "./core-helpers.ts"
+import type { CreateTaskInput } from "./create-task-input.ts"
 import { DirtyWorktreeError, TaskDeletingError, TaskNotFoundError, WorktreeRemoveFailedError } from "./errors.ts"
 import type { TaskIndexStore, TaskIndexUnsubscribe } from "./index/store.ts"
 import { type LandResult, type LandTaskOpts, landTaskWithCleanup } from "./land.ts"
@@ -23,36 +31,10 @@ import { PLACEHOLDER_TASK_TITLE } from "./title.ts"
 import { WorktreeCoordinator } from "./worktree-coordinator.ts"
 import type { GitWorktreeManager } from "./worktree/manager.ts"
 
-/** Input to {@link Orchestrator.createTask}. */
-export interface CreateTaskInput {
-  readonly repo: string
-  /** Title for the sidebar row. Defaults to `(new task)` when omitted. */
-  readonly title?: string
-  /** Branch override; otherwise an auto branch is generated lazily. */
-  readonly branch?: string
-  /** Optional base ref for the new lazy worktree branch. */
-  readonly baseRef?: string
-  /** Engine PROTOCOL for the monitor's history-reader hint (derived from
-   *  {@link command} when the caller passed one). */
-  readonly vendor?: VendorId
-  /** Raw engine launch command (`add --command`), recorded verbatim. */
-  readonly command?: string
-  /** Reasoning/effort level for the engine, when the vendor supports one. */
-  readonly modelEffort?: string
-  /** Fan-out round marker shared by all siblings of one fan-out call. */
-  readonly groupId?: string
-  /** The kobe session (task + tab) dispatching this create, when one is. */
-  readonly dispatcher?: TaskDispatcher
-  /**
-   * How the repo was chosen, for the project-admission gate
-   * (state/project-eligibility.ts). Defaults to `"explicit"`: every caller
-   * today reaches here from a user naming the repo — the new-task dialog,
-   * `rove api add`, a quick-fork of the row you are on. A caller that
-   * INFERRED the repo (a script walking directories, a fixture harness)
-   * should pass `"derived"` to get the stricter gate.
-   */
-  readonly projectIntent?: ProjectIntent
-}
+// The create-task input type lives in its own module (file-size cap) and is
+// re-exported here: callers name it through the orchestrator, and the split
+// is a file boundary, not an API change.
+export type { CreateTaskInput } from "./create-task-input.ts"
 
 export type Unsubscribe = () => void
 export type TaskListListener = (snapshot: readonly Task[]) => void
@@ -264,6 +246,7 @@ export class Orchestrator {
       ...(input.modelEffort ? { modelEffort: input.modelEffort } : {}),
       ...(input.groupId ? { groupId: input.groupId } : {}),
       ...(input.dispatcher ? { dispatcher: input.dispatcher } : {}),
+      ...(input.routine ? { routine: input.routine } : {}),
       // Persisted ON the task (not a one-shot side-map): `ensureWorktree`
       // reads it whenever the worktree materialises — including after a
       // daemon restart between create and first enter — and `collect`'s

--- a/packages/kobe/src/orchestrator/create-task-input.ts
+++ b/packages/kobe/src/orchestrator/create-task-input.ts
@@ -1,0 +1,44 @@
+/**
+ * The shape of a `createTask` call.
+ *
+ * Split from `core.ts` at the file-size cap. A pure input type with no
+ * dependency on the Orchestrator class, so it moves cleanly and gives every
+ * caller a smaller thing to read than the whole orchestrator.
+ */
+
+import type { ProjectIntent } from "../state/project-eligibility.ts"
+import type { TaskDispatcher, TaskRoutineLink, VendorId } from "../types/task.ts"
+
+/** Input to {@link Orchestrator.createTask}. */
+export interface CreateTaskInput {
+  readonly repo: string
+  /** Title for the sidebar row. Defaults to `(new task)` when omitted. */
+  readonly title?: string
+  /** Branch override; otherwise an auto branch is generated lazily. */
+  readonly branch?: string
+  /** Optional base ref for the new lazy worktree branch. */
+  readonly baseRef?: string
+  /** Engine PROTOCOL for the monitor's history-reader hint (derived from
+   *  {@link command} when the caller passed one). */
+  readonly vendor?: VendorId
+  /** Raw engine launch command (`add --command`), recorded verbatim. */
+  readonly command?: string
+  /** Reasoning/effort level for the engine, when the vendor supports one. */
+  readonly modelEffort?: string
+  /** Fan-out round marker shared by all siblings of one fan-out call. */
+  readonly groupId?: string
+  /** The kobe session (task + tab) dispatching this create, when one is. */
+  readonly dispatcher?: TaskDispatcher
+  /** Marks this the standing session task of a routine (issue #91): the
+   *  sidebar folds it behind a count row instead of a loose task row. */
+  readonly routine?: TaskRoutineLink
+  /**
+   * How the repo was chosen, for the project-admission gate
+   * (state/project-eligibility.ts). Defaults to `"explicit"`: every caller
+   * today reaches here from a user naming the repo — the new-task dialog,
+   * `rove api add`, a quick-fork of the row you are on. A caller that
+   * INFERRED the repo (a script walking directories, a fixture harness)
+   * should pass `"derived"` to get the stricter gate.
+   */
+  readonly projectIntent?: ProjectIntent
+}

--- a/packages/kobe/src/orchestrator/index/store-codec.ts
+++ b/packages/kobe/src/orchestrator/index/store-codec.ts
@@ -33,6 +33,7 @@ import type {
   TaskLinkedWorkItem,
   TaskPRStatus,
   TaskQuotaResumeState,
+  TaskRoutineLink,
   TaskStatus,
   TaskTombstone,
 } from "../../types/task.ts"
@@ -330,6 +331,7 @@ function coerceTask(value: unknown): Task | null {
   const quotaResume = coerceQuotaResume(v.quotaResume)
   const linkedWorkItem = coerceLinkedWorkItem(v.linkedWorkItem)
   const dispatcher = coerceDispatcher(v.dispatcher)
+  const routine = coerceRoutine(v.routine)
 
   return {
     id: toTaskId(v.id),
@@ -341,6 +343,7 @@ function coerceTask(value: unknown): Task | null {
     pinned: typeof v.pinned === "boolean" ? v.pinned : false,
     kind,
     ...(scratch ? { scratch: true } : {}),
+    ...(routine ? { routine } : {}),
     vendor: coerceVendorId(typeof v.vendor === "string" ? v.vendor : undefined),
     // Raw launch command (`add --command` / `set-command`) — must survive
     // the load coercion or the task falls back to its protocol's preset on
@@ -393,6 +396,16 @@ function coerceDispatcher(value: unknown): TaskDispatcher | undefined {
   if (typeof v.taskId !== "string" || v.taskId.length === 0) return undefined
   if (typeof v.tabId !== "string" || v.tabId.length === 0) return undefined
   return { taskId: v.taskId, tabId: v.tabId }
+}
+
+/** Routine back-pointer (issue #91). A link with no automation id is junk —
+ *  dropped, so the task reads as an ordinary one rather than folding itself
+ *  behind a routine section that can never be resolved back to a schedule. */
+function coerceRoutine(value: unknown): TaskRoutineLink | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined
+  const v = value as Record<string, unknown>
+  if (typeof v.automationId !== "string" || v.automationId.length === 0) return undefined
+  return { automationId: v.automationId }
 }
 
 function coerceQuotaResume(value: unknown): TaskQuotaResumeState | undefined {

--- a/packages/kobe/src/tui-react/panes/sidebar/SidebarTree.tsx
+++ b/packages/kobe/src/tui-react/panes/sidebar/SidebarTree.tsx
@@ -161,8 +161,13 @@ export function SidebarTree(props: SidebarTreeProps) {
    * and the tab state all move together.
    */
   const recentTaskRef = useLatest(props.recentTask ?? null)
+  const toggleRoutinesRow = tree.toggleRoutinesRow
   const activateRow = useCallback(
     (rowId: string): void => {
+      // The routine count row (issue #91) opens and closes instead of
+      // activating: it names no task, so `parseRowId` below would hand a
+      // sentinel id to `onSelect` and land on nothing.
+      if (toggleRoutinesRow(rowId)) return
       // The "↩ recent" jump row IS its task — ⏎ re-enters that workspace.
       const recent = rowId === RECENT_ROW_ID ? recentTaskRef.current : null
       const { taskId, tabId } = recent ? { taskId: recent.id, tabId: null } : parseRowId(rowId)
@@ -174,7 +179,7 @@ export function SidebarTree(props: SidebarTreeProps) {
       props.onSelectTab?.(taskId, tabId)
       props.onActivate?.(taskId)
     },
-    [props.onSelect, props.onActivate, props.onSelectTab],
+    [props.onSelect, props.onActivate, props.onSelectTab, toggleRoutinesRow],
   )
   const activateRowRef = useLatest(activateRow)
 

--- a/packages/kobe/src/tui-react/panes/sidebar/tree-panel.tsx
+++ b/packages/kobe/src/tui-react/panes/sidebar/tree-panel.tsx
@@ -7,8 +7,10 @@
  * two-line card to one line, and tab rows start at the same column with the
  * state glyph carrying the hierarchy (issue #41).
  *
- * No fold anywhere (owner round 5): every project and worktree always shows
- * everything under it, so there are no twisties and no collapse state.
+ * No fold anywhere (owner round 5) with ONE scoped exception: a project's
+ * routine count row (issue #91), which folds only the standing sessions a
+ * SCHEDULE created. Every project and every task a human opened still shows
+ * everything under it — the promise that rule protects is intact.
  *
  * One scrollbox, not the flat sidebar's two: a tree's whole point is that a
  * project and its worktrees scroll together, and the cursor indexes one flat
@@ -21,7 +23,7 @@ import { sidebarEmptyStateKey } from "../../../tui/panes/sidebar/view-core"
 import { useTheme } from "../../context/theme"
 import { useT } from "../../i18n"
 import { SectionHeader } from "./chrome"
-import { RecentJumpRow, TabTreeRow, type TreeRowShared, WorktreeTreeRow } from "./tree-rows"
+import { RecentJumpRow, RoutinesTreeRow, TabTreeRow, type TreeRowShared, WorktreeTreeRow } from "./tree-rows"
 
 export function SidebarTreeBody(props: {
   readonly rows: readonly TreeRow[]
@@ -76,6 +78,18 @@ export function SidebarTreeBody(props: {
                 rowId={row.id}
                 flatIndex={props.flatIndexOf.get(row.id) ?? -1}
                 task={row.task}
+                shared={props.shared}
+              />
+            )
+          }
+          if (row.kind === "routines") {
+            return (
+              <RoutinesTreeRow
+                key={row.id}
+                rowId={row.id}
+                flatIndex={props.flatIndexOf.get(row.id) ?? -1}
+                count={row.count}
+                expanded={row.expanded}
                 shared={props.shared}
               />
             )

--- a/packages/kobe/src/tui-react/panes/sidebar/tree-rows.tsx
+++ b/packages/kobe/src/tui-react/panes/sidebar/tree-rows.tsx
@@ -404,6 +404,39 @@ export function TabTreeRow(props: {
 }
 
 /**
+ * A project's routine count row (issue #91) — the one fold in this tree.
+ *
+ * Standing routine sessions rest behind it because a schedule's output is
+ * background noise beside the tasks the user opened themselves. ⏎ (or a
+ * click) toggles it open, and the tasks then render as ordinary worktree
+ * rows: the fold hides them, it never turns them into a different kind of
+ * thing. They stay selectable from the Inbox and the Routines page while
+ * closed, so this hides a ROW, not a task.
+ */
+export function RoutinesTreeRow(props: {
+  readonly rowId: string
+  readonly flatIndex: number
+  readonly count: number
+  readonly expanded: boolean
+  readonly shared: TreeRowShared
+}) {
+  const { theme } = useTheme()
+  const t = useT()
+  return (
+    <RowShell rowId={props.rowId} flatIndex={props.flatIndex} depth={1} shared={props.shared}>
+      {/* A 2-cell twisty is terminal grammar for "this opens", the same
+          fixed-glyph exception the diff gutter takes. */}
+      <text fg={theme.textMuted} wrapMode="none" width={2} flexShrink={0}>
+        {props.expanded ? "▾ " : "▸ "}
+      </text>
+      <text fg={theme.textMuted} wrapMode="none" flexShrink={1}>
+        {t("tasks.routinesRow", { count: String(props.count) })}
+      </text>
+    </RowShell>
+  )
+}
+
+/**
  * Narrow mode's "↩ Recent: <task>" jump row (issue #14, 2A) — the first
  * navigable row of the narrow sidebar. ⏎ re-enters the named task's
  * workspace; it answers to nothing else (no menu, no per-task verbs).

--- a/packages/kobe/src/tui-react/panes/sidebar/use-tree-menu.ts
+++ b/packages/kobe/src/tui-react/panes/sidebar/use-tree-menu.ts
@@ -83,8 +83,9 @@ export function useTreeMenu(deps: TreeMenuDeps): TreeMenu {
   const openForRow = useCallback(
     (flatIndex: number, rowId: string, x: number, y: number): void => {
       const row = tree.rows.find((candidate) => candidate.id === rowId)
-      // The "↩ recent" jump row has no menu — it's a shortcut, not a task row.
-      if (!row || row.kind === "project" || row.kind === "recent") return
+      // Neither the "↩ recent" jump row nor the routine count row has a menu:
+      // both are shortcuts, not task rows, so there is no task to act on.
+      if (!row || row.kind === "project" || row.kind === "recent" || row.kind === "routines") return
       // Move the cursor too: the menu and the highlight must agree about which
       // row the next action lands on.
       setCursorIndex(flatIndex)
@@ -146,6 +147,9 @@ export function useTreeMenu(deps: TreeMenuDeps): TreeMenu {
         }
         return
       }
+      // A routine count row never opens a menu (see the guard above), so it
+      // can only arrive here through a stale `menu` — nothing to act on.
+      if (row.kind === "routines") return
       const taskId = row.task.id
       switch (action) {
         case "open":

--- a/packages/kobe/src/tui-react/panes/sidebar/use-tree-state.ts
+++ b/packages/kobe/src/tui-react/panes/sidebar/use-tree-state.ts
@@ -6,9 +6,17 @@
  * because that module is framework-free (vitest loads it in Node) while this
  * one is React state.
  *
- * There is NO fold anywhere (owner call 2026-08-01, round 5): every project
- * and every worktree always shows everything under it. The tree is a map,
- * not a filing cabinet — hiding rows just made the map lie.
+ * There is NO fold anywhere (owner call 2026-08-01, round 5) except one: a
+ * project's routine count row (issue #91), which folds ONLY the standing
+ * sessions a schedule created. Every project and every task a human opened
+ * still shows everything under it. The tree is a map, not a filing cabinet —
+ * hiding rows made the map lie, and the exception is scoped so it can't: a
+ * folded routine stays findable by search, and openable from the Inbox and
+ * the Routines page.
+ *
+ * The expansion set is deliberately NOT persisted: it resets closed each
+ * session, because the resting state that keeps the sidebar readable is the
+ * closed one.
  *
  * The tab projection reads through `knownTaskTabs`, which answers for tasks
  * whose TerminalTabs is not mounted — the whole point of the tree is that
@@ -27,6 +35,8 @@ import {
   filterTreeRows,
   mainTaskIdOfProject,
   parseRowId,
+  projectKeyOfRoutinesRow,
+  projectKeysOf,
   rowLiveBranchPath,
   tabRowId,
   treeFlatIds,
@@ -78,12 +88,27 @@ export interface TreeState {
   readonly projectIdOfTask: (taskId: string) => string | null
   /** The task whose move reorders this project (its `main` checkout). */
   readonly mainTaskIdOfProject: (projectId: string) => string | null
+  /** Toggle a project's routine count row (issue #91). True when `rowId` was
+   *  one — the press is then consumed, and no task activation follows. */
+  readonly toggleRoutinesRow: (rowId: string) => boolean
 }
 
 export function useTreeState(opts: TreeStateOpts): TreeState {
   const { tasks, kv, selectedTaskId, selectedTabId } = opts
   const query = opts.query ?? ""
   const searching = query.trim() !== ""
+
+  // Which projects' routine count rows are OPEN (issue #91). Session-scoped
+  // on purpose: closed is the resting state worth returning to, so this
+  // never reaches a store.
+  const [expandedRoutines, setExpandedRoutines] = useState<ReadonlySet<string>>(() => new Set())
+  const toggleRoutines = useCallback((projectKey: string): void => {
+    setExpandedRoutines((current) => {
+      const next = new Set(current)
+      if (!next.delete(projectKey)) next.add(projectKey)
+      return next
+    })
+  }, [])
 
   // Live process identity (the `ps`-walk store): a user-typed `claude` in a
   // shell tab IS an agent while that process lives, and stops being one the
@@ -225,7 +250,13 @@ export function useTreeState(opts: TreeStateOpts): TreeState {
   const recentTask = opts.recentTask ?? null
   const sortMode = opts.sortMode ?? "default"
   const { rows, totalCount } = useMemo(() => {
-    const all = buildTreeRows({ tasks, tabsByTask, sortMode })
+    // A SEARCH builds the tree fully expanded (issue #91): folding the routine
+    // sessions away at rest must not make them unfindable, and search is how
+    // you reach one without opening the fold first. `filterTreeRows` then
+    // drops the (now empty) count row itself.
+    const all = searching
+      ? buildTreeRows({ tasks, tabsByTask, sortMode, expandedRoutines: new Set(projectKeysOf(tasks)) })
+      : buildTreeRows({ tasks, tabsByTask, sortMode, expandedRoutines })
     const total = treeFlatIds(all).length
     // Dependency-only invalidation key: re-run the search when the poll tick
     // moves, so a `main` row becomes findable by its branch as soon as the
@@ -245,7 +276,7 @@ export function useTreeState(opts: TreeStateOpts): TreeState {
       rows: searching ? filterTreeRows(all, query, liveBranch) : withRecentRow(all, recentTask),
       totalCount: total,
     }
-  }, [tasks, tabsByTask, searching, query, recentTask, sortMode, opts.branchTick])
+  }, [tasks, tabsByTask, searching, query, recentTask, sortMode, expandedRoutines, opts.branchTick])
   const flatIds = useMemo(() => treeFlatIds(rows), [rows])
 
   // The active row is the selected task's ACTIVE TAB, else the worktree row
@@ -279,6 +310,18 @@ export function useTreeState(opts: TreeStateOpts): TreeState {
     activeRowId,
     projectIdOfTask,
     mainTaskIdOfProject: mainTaskOfProject,
+    /** Open/close a project's routine count row (issue #91). Returns true when
+     *  `rowId` WAS a routine row, so the caller knows the press was consumed
+     *  and must not also try to activate a task by that id. */
+    toggleRoutinesRow: useCallback(
+      (rowId: string): boolean => {
+        const projectKey = projectKeyOfRoutinesRow(rowId)
+        if (projectKey === null) return false
+        toggleRoutines(projectKey)
+        return true
+      },
+      [toggleRoutines],
+    ),
   }
 }
 

--- a/packages/kobe/src/tui-react/workspace/use-task-selection.ts
+++ b/packages/kobe/src/tui-react/workspace/use-task-selection.ts
@@ -74,6 +74,14 @@ export async function activateWorkspaceTask(opts: ActivateWorkspaceTaskOptions, 
  * never used as a tiebreak — tasks.json leads with the oldest saved repo's
  * main task, which is how every SSH reconnect used to land on an untouched
  * project instead of the one being worked on.
+ *
+ * The recency fallback SKIPS a routine's standing session (issue #91): a
+ * schedule that fired at 03:00 makes it the most recently updated task in the
+ * install, but it is the least likely thing you meant to open — and its
+ * sidebar row is folded away, so booting onto it would leave the cursor on a
+ * session with no visible row. It stays reachable by every deliberate route
+ * (search, the Routines page, the Inbox); it just never wins by default.
+ * An explicit active/lastActive id still selects it — that was a real choice.
  */
 export function firstSelectableTask(
   tasks: readonly Task[],
@@ -85,6 +93,11 @@ export function firstSelectableTask(
   const active = alive(activeId) ?? alive(lastActiveId)
   if (active) return active
   const live = tasks.filter((task) => !task.deletion)
-  if (live.length > 0) return live.reduce((newest, task) => (task.updatedAt > newest.updatedAt ? task : newest))
-  return tasks.find((task) => !task.deletion)
+  const newest = (pool: readonly Task[]): Task | undefined =>
+    pool.length > 0 ? pool.reduce((best, task) => (task.updatedAt > best.updatedAt ? task : best)) : undefined
+  // Routine sessions are the fallback of last resort, never the default: an
+  // overnight firing would otherwise win every cold boot on recency alone.
+  return (
+    newest(live.filter((task) => task.routine === undefined)) ?? newest(live) ?? tasks.find((task) => !task.deletion)
+  )
 }

--- a/packages/kobe/src/tui/i18n/messages/tasks.ts
+++ b/packages/kobe/src/tui/i18n/messages/tasks.ts
@@ -43,6 +43,8 @@ export const en = {
   moveChip: " move",
   /** Narrow mode's top-of-sidebar jump row back into the last-entered task */
   recentJump: "Recent: {title}",
+  /** The fold row standing in for a project's routine sessions (issue #91) */
+  routinesRow: "{count} routine sessions",
   /** Empty-state messages */
   empty: {
     noMatchSearch: "No matching tasks — esc to clear.",
@@ -141,6 +143,7 @@ export const zh: typeof en = {
   },
   moveChip: " 移动",
   recentJump: "最近:{title}",
+  routinesRow: "{count} 个 routine 会话",
   empty: {
     noMatchSearch: "无匹配任务——按 esc 清除。",
     noActiveProject: "该项目暂无活跃任务。",

--- a/packages/kobe/src/tui/panes/sidebar/tab-row-activity.ts
+++ b/packages/kobe/src/tui/panes/sidebar/tab-row-activity.ts
@@ -1,0 +1,36 @@
+/**
+ * Which activity entry names a sidebar TAB row's state glyph.
+ *
+ * Split from `tree-core.ts` at the file-size cap, and a real seam: everything
+ * in `tree-core` answers "what rows exist"; this answers "which of the
+ * daemon's two activity levels speaks for this row" — no row shapes, no tree.
+ */
+
+/**
+ * Which activity entry names a TAB row's state glyph.
+ *
+ * The daemon publishes activity at two levels. Tab-level is the precise
+ * answer. Task-level is a last-event-wins rollup across every tab, so it may
+ * only stand in for a task whose engine reports NO tab identity at all — a
+ * `claude` the user typed into a shell, which has no `KOBE_TAB_ID` to tag its
+ * hook events with.
+ *
+ * Once ANY tab of the task has reported, the rollup means "whichever tab
+ * moved last", and lending it to whichever tab happens to be active made a
+ * switch inside a busy worktree light the tab you switched TO with its
+ * sibling's spinner until its own state landed (owner report 2026-08-10).
+ */
+export function tabRowActivity<T>(args: {
+  /** This tab's own entry, when the daemon has one. */
+  readonly tabActivity: T | undefined
+  /** How many tabs of this task have reported at all. */
+  readonly reportedTabCount: number
+  /** The task-level rollup. */
+  readonly taskActivity: T | undefined
+  /** Whether this row is the task's active tab. */
+  readonly active: boolean
+}): T | undefined {
+  if (args.tabActivity !== undefined) return args.tabActivity
+  if (!args.active || args.reportedTabCount > 0) return undefined
+  return args.taskActivity
+}

--- a/packages/kobe/src/tui/panes/sidebar/tree-core.ts
+++ b/packages/kobe/src/tui/panes/sidebar/tree-core.ts
@@ -60,6 +60,21 @@ export type TreeRow =
       readonly depth: 2
     }
   | { readonly kind: "recent"; readonly id: typeof RECENT_ROW_ID; readonly task: Task; readonly depth: 1 }
+  /**
+   * The routine count row (issue #91): one row standing in for a project's
+   * routine session tasks, which are background noise beside the handful of
+   * tasks the user opened themselves — 7 daily routines are 49 rows a week.
+   * Opening it reveals those tasks; they are never removed from the data.
+   */
+  | {
+      readonly kind: "routines"
+      readonly id: string
+      /** Project key these routines belong to — the row sits under it. */
+      readonly projectKey: string
+      readonly count: number
+      readonly expanded: boolean
+      readonly depth: 1
+    }
 
 /**
  * Navigation id of the narrow-mode "↩ recent" jump row (issue #14, 2A).
@@ -76,6 +91,31 @@ export const RECENT_ROW_ID = "~recent"
  * miss — a Scratch header has no main task to move and no repo to file into.
  */
 export const SCRATCH_SECTION_ID = "~scratch"
+
+/**
+ * Navigation id of a project's routine count row (issue #91). Prefixed like
+ * the other sentinels so it can never collide with a ULID, and carrying the
+ * project key so two projects' rows stay distinct.
+ *
+ * This row is the ONE fold in a tree that otherwise has none (owner call
+ * 2026-08-01, round 5 — see `tree-panel.tsx`). It is scoped deliberately: it
+ * folds only tasks a SCHEDULE created, never a task a human opened, so the
+ * "everything under a project is always visible" promise still holds for
+ * everything the user made themselves.
+ */
+export function routinesRowId(projectKey: string): string {
+  return `~routines:${projectKey}`
+}
+
+/** The project key a routines row id names, or null for any other id. */
+export function projectKeyOfRoutinesRow(id: string): string | null {
+  return id.startsWith("~routines:") ? id.slice("~routines:".length) : null
+}
+
+/** True for a task the sidebar folds behind a routine count row. */
+export function isRoutineTask(task: Task): boolean {
+  return task.routine !== undefined
+}
 
 /**
  * Prepend the "↩ recent: <task>" jump row (narrow mode only — the caller
@@ -167,6 +207,9 @@ export interface TreeInput {
   readonly tabsByTask: ReadonlyMap<string, readonly TreeTab[]>
   /** Task sort applied within each project group. Defaults to input order. */
   readonly sortMode?: import("./groups").TaskSortMode
+  /** Project keys whose routine count row is open (issue #91). Absent = all
+   *  closed, which is the resting state a fresh session starts in. */
+  readonly expandedRoutines?: ReadonlySet<string>
 }
 
 /**
@@ -336,7 +379,27 @@ export function buildTreeRows(input: TreeInput): TreeRow[] {
       label: sidebarProjectLabel(entry.repo, projectRepos),
       depth: 0,
     })
-    for (const task of entry.tasks) pushWorktree(rows, task, tabsByTask)
+    // Routine sessions (issue #91) sort to the END of their project, behind
+    // one count row: they are a schedule's output, so they must never push
+    // the tasks the user opened themselves down the pane.
+    const routineTasks = entry.tasks.filter(isRoutineTask)
+    for (const task of entry.tasks) {
+      if (!isRoutineTask(task)) pushWorktree(rows, task, tabsByTask)
+    }
+    if (routineTasks.length > 0) {
+      const expanded = input.expandedRoutines?.has(key) === true
+      rows.push({
+        kind: "routines",
+        id: routinesRowId(key),
+        projectKey: key,
+        count: routineTasks.length,
+        expanded,
+        depth: 1,
+      })
+      // Opened, the folded tasks render as ordinary worktree rows — the fold
+      // hides them at rest, it does not make them a different kind of thing.
+      if (expanded) for (const task of routineTasks) pushWorktree(rows, task, tabsByTask)
+    }
   }
   return rows
 }
@@ -360,6 +423,8 @@ function pushWorktree(rows: TreeRow[], task: Task, tabsByTask: ReadonlyMap<strin
 export function treeFlatIds(rows: readonly TreeRow[]): string[] {
   const ids: string[] = []
   for (const row of rows) {
+    // The routines count row IS navigable, unlike a project header: opening
+    // it is the whole point, so the cursor has to be able to land on it.
     if (row.kind !== "project") ids.push(row.id)
   }
   return ids
@@ -411,31 +476,7 @@ export function mainTaskIdOfProject(tasks: readonly Task[], projectKey: string):
   return null
 }
 
-/**
- * Which activity entry names a TAB row's state glyph.
- *
- * The daemon publishes activity at two levels. Tab-level is the precise
- * answer. Task-level is a last-event-wins rollup across every tab, so it may
- * only stand in for a task whose engine reports NO tab identity at all — a
- * `claude` the user typed into a shell, which has no `KOBE_TAB_ID` to tag its
- * hook events with.
- *
- * Once ANY tab of the task has reported, the rollup means "whichever tab
- * moved last", and lending it to whichever tab happens to be active made a
- * switch inside a busy worktree light the tab you switched TO with its
- * sibling's spinner until its own state landed (owner report 2026-08-10).
- */
-export function tabRowActivity<T>(args: {
-  /** This tab's own entry, when the daemon has one. */
-  readonly tabActivity: T | undefined
-  /** How many tabs of this task have reported at all. */
-  readonly reportedTabCount: number
-  /** The task-level rollup. */
-  readonly taskActivity: T | undefined
-  /** Whether this row is the task's active tab. */
-  readonly active: boolean
-}): T | undefined {
-  if (args.tabActivity !== undefined) return args.tabActivity
-  if (!args.active || args.reportedTabCount > 0) return undefined
-  return args.taskActivity
-}
+// Tab-row activity resolution lives in its own module (file-size cap) and is
+// re-exported here: callers name it through the tree's vocabulary, and the
+// split is a file boundary, not an API change.
+export { tabRowActivity } from "./tab-row-activity"

--- a/packages/kobe/src/tui/panes/sidebar/tree-menu.ts
+++ b/packages/kobe/src/tui/panes/sidebar/tree-menu.ts
@@ -92,6 +92,10 @@ export function treeMenuItems(row: TreeRow, ctx: TreeMenuContext = {}): TreeMenu
       ...taskVerbs(row.task.pinned === true, row.task.kind),
     ]
   }
+  // The routine count row (issue #91) is a fold toggle, not a task — there is
+  // no task for any verb here to act on, and an entry that does nothing is
+  // worse than no entry (the same rule `closeTab` follows above).
+  if (row.kind === "routines") return []
   const tabItems: TreeMenuItem[] = [{ action: "open", labelKey: "tasks.menu.openTab" }]
   if ((ctx.tabCount ?? 0) > 0) tabItems.push({ action: "closeTab", labelKey: "tasks.menu.closeTab" })
   return [...tabItems, ...newTabVerbs(), ...taskVerbs(row.task.pinned === true, row.task.kind)]

--- a/packages/kobe/src/tui/panes/sidebar/tree-search.ts
+++ b/packages/kobe/src/tui/panes/sidebar/tree-search.ts
@@ -38,6 +38,11 @@ import { type TreeRow, ownerProjectKey, worktreeRowLabel } from "./tree-core"
  */
 function rowHaystacks(row: TreeRow, liveBranch?: (task: Task) => string): readonly string[] {
   if (row.kind === "project") return [row.label]
+  // The routine count row carries a translated count, not a name worth
+  // matching. It is dropped from a search entirely (see `filterTreeRows`):
+  // while searching, the routine tasks it folds are shown DIRECTLY, so the
+  // toggle would be a fold with nothing left under it.
+  if (row.kind === "routines") return []
   if (row.kind === "tab") return [row.tab.label]
   const task = row.task
   // A `dir` task's stored title is the noise the row refuses to show; it must
@@ -88,7 +93,7 @@ export function filterTreeRows(
     if (!matchesRow(q, row, liveBranch)) continue
     selfMatch.add(row.id)
     keep.add(row.id)
-    if (row.kind === "project") continue
+    if (row.kind === "project" || row.kind === "routines") continue
     if (row.kind === "tab") keep.add(row.task.id)
     const project = ownerProjectKey(row.task)
     if (project !== null) keep.add(project)
@@ -102,6 +107,11 @@ export function filterTreeRows(
       if (keep.has(row.id)) out.push(row)
       continue
     }
+    // A search shows every matching routine session directly, so the fold
+    // toggle itself never survives one. Hiding a row at rest must not make it
+    // unfindable — search is precisely how you reach a folded row without
+    // opening the fold first.
+    if (row.kind === "routines") continue
     const project = ownerProjectKey(row.task)
     const underMatchedProject = project !== null && selfMatch.has(project)
     if (row.kind === "worktree") {

--- a/packages/kobe/src/types/task.ts
+++ b/packages/kobe/src/types/task.ts
@@ -121,6 +121,12 @@ export interface TaskDispatcher {
   readonly tabId: string
 }
 
+/** Back-pointer from a routine's standing session task to its schedule. */
+export interface TaskRoutineLink {
+  /** `Automation.id`. Survives the routine being renamed or rescheduled. */
+  readonly automationId: string
+}
+
 /**
  * One task. Stored in `~/.rove/tasks.json` as part of {@link TaskIndex}.
  *
@@ -163,6 +169,22 @@ export interface Task {
    * (`adoptScratchRepo`) — after which it is an ordinary directory task.
    */
   readonly scratch?: boolean
+  /**
+   * The routine (`Automation`) this task is the standing session for
+   * (issue #91). A routine with `persistentSession` creates ONE task and
+   * re-delivers into it on every firing, instead of a fresh worktree per
+   * run — so a daily check can read what it said yesterday.
+   *
+   * The sidebar renders these behind a per-project count row rather than as
+   * loose task rows: 7 daily routines are 49 rows a week of background noise
+   * competing with the handful of tasks the user opened themselves. The task
+   * is ordinary in every other layer — selectable, Inbox-reachable, and
+   * addressable by `rove api` — only its resting sidebar row is folded away.
+   *
+   * Absent on tasks created before the field, which is what keeps the
+   * already-created routine tasks rendering exactly as they do today.
+   */
+  readonly routine?: TaskRoutineLink
   readonly status: TaskStatus
   /**
    * User-pinned regular tasks float to the top of the sidebar's

--- a/packages/kobe/test/daemon/automation-runner.test.ts
+++ b/packages/kobe/test/daemon/automation-runner.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { describe, expect, it, vi } from "vitest"
 import type { DaemonRpcClient } from "../../../kobe-daemon/src/client/rpc.ts"
+import type { DispatchRuntime } from "../../../kobe-daemon/src/daemon/automation-dispatch.ts"
 import {
   dueAutomations,
   resolveDueOccurrence,
@@ -47,12 +48,17 @@ function fakeDeps(args: {
   store: AutomationsStore
   createTask?: (input: unknown) => Promise<DaemonTask>
   start?: (link: DaemonRpcClient, taskId: string, prompt: string) => Promise<boolean>
+  /** Tasks `resolveStandingTask` can find, keyed by id (issue #91). */
+  tasks?: Record<string, DaemonTask>
+  deliver?: DispatchRuntime["deliverPromptToLiveEngineDetailed"]
 }) {
   const created: unknown[] = []
   const prompts: string[] = []
+  const delivered: string[] = []
   return {
     created,
     prompts,
+    delivered,
     deps: {
       store: args.store,
       orch: {
@@ -62,6 +68,7 @@ function fakeDeps(args: {
             created.push(input)
             return { id: "task-1" } as DaemonTask
           }),
+        getTask: (id: string) => args.tasks?.[id],
       },
       runtime: {
         startTaskSessionWithPrompt:
@@ -69,6 +76,12 @@ function fakeDeps(args: {
           (async (_l: DaemonRpcClient, _id: string, prompt: string) => {
             prompts.push(prompt)
             return true
+          }),
+        deliverPromptToLiveEngineDetailed:
+          args.deliver ??
+          (async (_task: unknown, prompt: string) => {
+            delivered.push(prompt)
+            return { outcome: "delivered" as const, tabId: "tab-1" }
           }),
       },
       link,

--- a/packages/kobe/test/daemon/automation-standing-session.test.ts
+++ b/packages/kobe/test/daemon/automation-standing-session.test.ts
@@ -1,0 +1,295 @@
+/**
+ * A routine's STANDING session (issue #91): one task re-delivered into every
+ * firing, instead of a fresh worktree + branch per run.
+ *
+ * The four paths a firing can take are here because they are the ones that
+ * fail silently in production, and each fails DIFFERENTLY:
+ *
+ *   1. first firing      — build the task, mark it, remember its id
+ *   2. live engine       — deliver into it (no second task, no second branch)
+ *   3. dead engine       — respawn in the SAME worktree, recorded as `revived`
+ *   4. task deleted      — self-heal by rebuilding, rather than failing forever
+ *
+ * (4) is the one worth the most: a stored task id whose task is gone would
+ * otherwise wedge the routine permanently, and a wedged schedule looks exactly
+ * like a schedule that is merely quiet.
+ *
+ * The composer-busy case is here for the same reason: dropping a routine's
+ * daily report and never running at all are indistinguishable to the user, so
+ * the prompt must end up owned by the deferred store, not on the floor.
+ */
+
+import { mkdtempSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { describe, expect, it } from "vitest"
+import type { DaemonRpcClient } from "../../../kobe-daemon/src/client/rpc.ts"
+import { type DispatchDeps, dispatchAutomation } from "../../../kobe-daemon/src/daemon/automation-dispatch.ts"
+import { runAutomationOnce } from "../../../kobe-daemon/src/daemon/automation-runner.ts"
+import { AutomationsStore } from "../../../kobe-daemon/src/daemon/automations-store.ts"
+import type { Automation, DaemonTask } from "../../../kobe-daemon/src/daemon/contracts.ts"
+import { DeferredPromptsStore } from "../../../kobe-daemon/src/daemon/deferred-prompts-store.ts"
+
+const NOW = new Date(2026, 6, 31, 10, 0, 0).getTime()
+const REPO = process.cwd()
+const link = {} as DaemonRpcClient
+
+function automation(over: Partial<Automation> = {}): Automation {
+  return {
+    id: "auto-1",
+    name: "daily audit",
+    repo: REPO,
+    prompt: "what changed since yesterday?",
+    schedule: "0 9 * * *",
+    enabled: true,
+    persistentSession: true,
+    nextRunAt: new Date(NOW).toISOString(),
+    missedRunGraceMinutes: 60,
+    createdAt: new Date(NOW - 86_400_000).toISOString(),
+    updatedAt: new Date(NOW - 86_400_000).toISOString(),
+    ...over,
+  }
+}
+
+function task(over: Partial<DaemonTask> = {}): DaemonTask {
+  return {
+    id: "task-1",
+    title: "daily audit",
+    repo: REPO,
+    branch: "routine/daily-audit",
+    worktreePath: "/wt/daily-audit",
+    status: "in_progress",
+    createdAt: new Date(NOW).toISOString(),
+    updatedAt: new Date(NOW).toISOString(),
+    ...over,
+  } as DaemonTask
+}
+
+/** Records every call so a test can prove which path a firing actually took. */
+function harness(
+  args: {
+    tasks?: Record<string, DaemonTask>
+    deliver?: DispatchDeps["runtime"]["deliverPromptToLiveEngineDetailed"]
+    startOk?: boolean
+  } = {},
+) {
+  const created: unknown[] = []
+  const spawned: Array<{ taskId: string; prompt: string }> = []
+  const delivered: Array<{ taskId: string; prompt: string }> = []
+  const deps: DispatchDeps = {
+    orch: {
+      createTask: async (input: never) => {
+        created.push(input)
+        return task({ id: `task-${created.length}` })
+      },
+      getTask: (id: string) => args.tasks?.[id],
+    },
+    runtime: {
+      startTaskSessionWithPrompt: async (_l: DaemonRpcClient, taskId: string, prompt: string) => {
+        spawned.push({ taskId, prompt })
+        return args.startOk !== false
+      },
+      deliverPromptToLiveEngineDetailed:
+        args.deliver ??
+        (async (t: { id: string }, prompt: string) => {
+          delivered.push({ taskId: t.id, prompt })
+          return { outcome: "delivered" as const, tabId: "tab-1" }
+        }),
+    },
+    link: () => link,
+    now: () => NOW,
+  }
+  return { created, spawned, delivered, deps }
+}
+
+describe("standing session — first firing", () => {
+  it("creates ONE task, marks it as the routine's, and reports its id back", async () => {
+    const { created, spawned, deps } = harness()
+
+    const outcome = await dispatchAutomation(deps, automation())
+
+    expect(created).toHaveLength(1)
+    // The marker is what folds the task behind the sidebar's count row. Without
+    // it the routine's task renders as an ordinary loose row — the exact noise
+    // this issue exists to remove.
+    expect(created[0]).toMatchObject({ repo: REPO, routine: { automationId: "auto-1" } })
+    expect(spawned).toEqual([{ taskId: "task-1", prompt: "what changed since yesterday?" }])
+    expect(outcome).toMatchObject({ status: "dispatched", taskId: "task-1", sessionTaskIdToSet: "task-1" })
+  })
+
+  it("does NOT mark a task when the routine is not persistent", async () => {
+    const { created, deps } = harness()
+
+    await dispatchAutomation(deps, automation({ persistentSession: false }))
+
+    // A fresh-per-run routine makes ordinary tasks: its output is a branch the
+    // user has to review and land, so hiding it would hide real work.
+    expect(created[0]).not.toHaveProperty("routine")
+  })
+
+  it("remembers the task even when its engine failed to start", async () => {
+    const { deps } = harness({ startOk: false })
+
+    const outcome = await dispatchAutomation(deps, automation())
+
+    // The worktree exists either way, so the NEXT firing must revive this task
+    // rather than stack a second standing task beside it.
+    expect(outcome).toMatchObject({ status: "dispatch_failed", taskId: "task-1", sessionTaskIdToSet: "task-1" })
+  })
+})
+
+describe("standing session — later firings", () => {
+  it("delivers into the live engine instead of creating a second task", async () => {
+    const { created, delivered, spawned, deps } = harness({ tasks: { "task-1": task() } })
+
+    const outcome = await dispatchAutomation(deps, automation({ sessionTaskId: "task-1" }))
+
+    expect(created).toHaveLength(0)
+    expect(spawned).toHaveLength(0)
+    expect(delivered).toEqual([{ taskId: "task-1", prompt: "what changed since yesterday?" }])
+    expect(outcome).toMatchObject({ status: "dispatched", taskId: "task-1" })
+    expect(outcome.sessionTaskIdToSet).toBeUndefined()
+  })
+
+  it("respawns the same worktree when the engine died, recorded as revived", async () => {
+    const { created, spawned, deps } = harness({
+      tasks: { "task-1": task() },
+      deliver: async () => ({ outcome: "no-session" as const }),
+    })
+
+    const outcome = await dispatchAutomation(deps, automation({ sessionTaskId: "task-1" }))
+
+    expect(created).toHaveLength(0)
+    expect(spawned).toEqual([{ taskId: "task-1", prompt: "what changed since yesterday?" }])
+    // NOT `dispatched`: the files carried over but the conversation did not,
+    // and a run that started over must not read like one that had context.
+    expect(outcome).toMatchObject({ status: "revived", taskId: "task-1" })
+  })
+
+  it("rebuilds and relinks when the standing task was deleted", async () => {
+    const { created, deps } = harness({ tasks: {} })
+
+    const outcome = await dispatchAutomation(deps, automation({ sessionTaskId: "gone" }))
+
+    expect(created).toHaveLength(1)
+    expect(outcome).toMatchObject({
+      status: "dispatched",
+      taskId: "task-1",
+      sessionTaskIdToSet: "task-1",
+      sessionTaskIdToClear: true,
+    })
+  })
+
+  it("rebuilds when the standing task is mid-deletion or lost its worktree", async () => {
+    for (const broken of [task({ deletion: { at: NOW } as never }), task({ worktreePath: "" })]) {
+      const { created, deps } = harness({ tasks: { "task-1": broken } })
+
+      const outcome = await dispatchAutomation(deps, automation({ sessionTaskId: "task-1" }))
+
+      expect(created).toHaveLength(1)
+      expect(outcome.sessionTaskIdToSet).toBe("task-1")
+    }
+  })
+})
+
+describe("standing session — busy composer", () => {
+  it("hands the report to the deferred store instead of dropping it", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "kobe-routine-defer-"))
+    const deferred = new DeferredPromptsStore(join(dir, "deferred.json"))
+    const episodes: Array<{ taskId: string; tabId: string; layer: string }> = []
+    const { deps } = harness({
+      tasks: { "task-1": task() },
+      deliver: async () => ({ outcome: "busy" as const, tabId: "tab-2", layer: "composer-not-empty" as const }),
+    })
+
+    const outcome = await dispatchAutomation(
+      {
+        ...deps,
+        deferred,
+        inbox: {
+          recordPromptDeferred: async (taskId, tabId, _id, layer) => {
+            episodes.push({ taskId, tabId, layer })
+          },
+        },
+      },
+      automation({ sessionTaskId: "task-1" }),
+    )
+
+    // A SUCCESS: the daemon owns the text now. Reporting this as a failure
+    // would send a human hunting for a broken routine that is working.
+    expect(outcome).toMatchObject({ status: "deferred", taskId: "task-1" })
+    const stored = await deferred.listForTask("task-1")
+    expect(stored).toHaveLength(1)
+    expect(stored[0]).toMatchObject({ prompt: "what changed since yesterday?", tabId: "tab-2" })
+    // The episode points at the tab the engine was actually found on, so
+    // releasing it lands on the session that holds the conversation.
+    expect(episodes).toEqual([{ taskId: "task-1", tabId: "tab-2", layer: "composer-not-empty" }])
+  })
+
+  it("reports a failure rather than losing the report when no store is wired", async () => {
+    const { deps } = harness({
+      tasks: { "task-1": task() },
+      deliver: async () => ({ outcome: "busy" as const, tabId: "tab-1", layer: "recent-human-write" as const }),
+    })
+
+    const outcome = await dispatchAutomation(deps, automation({ sessionTaskId: "task-1" }))
+
+    expect(outcome.status).toBe("dispatch_failed")
+    expect(outcome.error).toContain("composer busy")
+  })
+})
+
+describe("runAutomationOnce persists the standing link", () => {
+  it("writes sessionTaskId on the first firing so the next one reuses it", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "kobe-routine-link-"))
+    const store = new AutomationsStore(join(dir, "automations.json"), () => NOW)
+    await store.init()
+    const created = await store.create({
+      name: "daily audit",
+      repo: REPO,
+      prompt: "what changed since yesterday?",
+      schedule: "0 9 * * *",
+      missedRunGraceMinutes: 60,
+      persistentSession: true,
+    })
+    const { deps } = harness()
+
+    const status = await runAutomationOnce(
+      { store, orch: deps.orch, runtime: deps.runtime, link, now: () => NOW },
+      created,
+      { scheduledFor: NOW, trigger: "scheduled" },
+    )
+
+    expect(status).toBe("dispatched")
+    expect(store.get(created.id)?.sessionTaskId).toBe("task-1")
+    expect(store.runsFor(created.id)[0]).toMatchObject({ status: "dispatched", taskId: "task-1" })
+  })
+
+  it("clears a stale link so a deleted task cannot wedge the routine forever", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "kobe-routine-stale-"))
+    const store = new AutomationsStore(join(dir, "automations.json"), () => NOW)
+    await store.init()
+    const created = await store.create({
+      name: "daily audit",
+      repo: REPO,
+      prompt: "p",
+      schedule: "0 9 * * *",
+      missedRunGraceMinutes: 60,
+      persistentSession: true,
+    })
+    await store.update(created.id, { sessionTaskId: "deleted-task" })
+    const { deps } = harness({ tasks: {} })
+
+    await runAutomationOnce(
+      { store, orch: deps.orch, runtime: deps.runtime, link, now: () => NOW },
+      store.get(created.id) as Automation,
+      {
+        scheduledFor: NOW,
+        trigger: "scheduled",
+      },
+    )
+
+    // Relinked to the REBUILT task, not left pointing at the corpse.
+    expect(store.get(created.id)?.sessionTaskId).toBe("task-1")
+  })
+})

--- a/packages/kobe/test/daemon/serialize-task-fields.test.ts
+++ b/packages/kobe/test/daemon/serialize-task-fields.test.ts
@@ -38,6 +38,7 @@ const FULL: DeepRequired<SerializedTask> = {
   worktreePath: "/repo/.worktrees/wire",
   kind: "task",
   scratch: true,
+  routine: { automationId: "auto-1" },
   status: "in_review",
   pinned: true,
   vendor: "claude",

--- a/packages/kobe/test/orchestrator/store-codec-roundtrip.test.ts
+++ b/packages/kobe/test/orchestrator/store-codec-roundtrip.test.ts
@@ -46,6 +46,7 @@ const FULL_TASK: DeepRequired<Task> = {
   worktreePath: "/repo/.worktrees/round-trip",
   kind: "dir",
   scratch: true,
+  routine: { automationId: "auto-1" },
   status: "in_review",
   pinned: true,
   vendor: "claude",

--- a/packages/kobe/test/render/sidebar-routine-fold.test.tsx
+++ b/packages/kobe/test/render/sidebar-routine-fold.test.tsx
@@ -1,0 +1,143 @@
+/** @jsxImportSource @opentui/react */
+/**
+ * The sidebar's routine fold (issue #91), against real captured frames.
+ *
+ * Asserted on the FRAME, not on `buildTreeRows`' output: the thing that has to
+ * be true is that a routine session's row is not on screen at rest, and a pure
+ * function returning the right array proves nothing about what the pane paints.
+ *
+ * The keypress cases exist for the same reason `sidebar-tree.test.tsx` has
+ * them: a fold whose ⏎ does nothing renders identically to one that is simply
+ * closed, and a frame-only test would stay green through a dead toggle.
+ */
+import { expect, test } from "bun:test"
+import { SidebarTree } from "../../src/tui-react/panes/sidebar/SidebarTree"
+import { tabsByTask } from "../../src/tui-react/workspace/terminal-tabs-shared"
+import type { Task } from "../../src/types/task"
+import { toTaskId } from "../../src/types/task"
+import { renderComponent } from "./harness"
+
+function task(id: string, over: Partial<Task> = {}): Task {
+  return {
+    id: toTaskId(id),
+    title: id,
+    repo: "/repos/rove",
+    branch: `feat/${id}`,
+    worktreePath: `/wt/${id}`,
+    kind: "task",
+    status: "in_progress",
+    createdAt: "2026-08-01T00:00:00.000Z",
+    updatedAt: "2026-08-01T00:00:00.000Z",
+    ...over,
+  }
+}
+
+const MAIN = task("m", { kind: "main", branch: "", worktreePath: "/repos/rove" })
+const MINE = task("mine-task")
+const ROUTINES = [
+  task("nightly-audit", { routine: { automationId: "auto-1" } }),
+  task("dep-check", { routine: { automationId: "auto-2" } }),
+  task("ci-trend", { routine: { automationId: "auto-3" } }),
+]
+const SETTLE = 80
+
+function tree(over: Partial<Parameters<typeof SidebarTree>[0]> = {}) {
+  return (
+    <SidebarTree
+      tasks={[MAIN, MINE, ...ROUTINES]}
+      selectedId="mine-task"
+      selectedTabId={null}
+      onSelect={() => {}}
+      focused={true}
+      width={34}
+      {...over}
+    />
+  )
+}
+
+test("routine sessions rest behind a count row instead of loose rows", async () => {
+  tabsByTask.clear()
+  const { frame } = await renderComponent(tree(), { width: 34, height: 20 })
+  await new Promise((r) => setTimeout(r, SETTLE))
+  const painted = await frame()
+
+  // The task the user opened is on screen…
+  expect(painted).toContain("mine-task")
+  // …and the three the SCHEDULE opened are not — that is the whole point:
+  // 7 daily routines would otherwise be 49 rows a week of background noise.
+  expect(painted).not.toContain("nightly-audit")
+  expect(painted).not.toContain("dep-check")
+  expect(painted).not.toContain("ci-trend")
+  // One row stands in for them, and it says how many there are.
+  expect(painted).toContain("3 routine sessions")
+})
+
+test("enter on the count row reveals the sessions, and closes them again", async () => {
+  tabsByTask.clear()
+  const { frame, mockInput } = await renderComponent(tree(), { width: 34, height: 20 })
+  await new Promise((r) => setTimeout(r, SETTLE))
+
+  // Cursor starts on the selected `mine-task`; j steps onto the count row,
+  // which sorts after every task the user opened.
+  mockInput.typeText("j")
+  await new Promise((r) => setTimeout(r, SETTLE))
+  mockInput.pressEnter()
+  await new Promise((r) => setTimeout(r, SETTLE))
+
+  const opened = await frame()
+  expect(opened).toContain("nightly-audit")
+  expect(opened).toContain("ci-trend")
+
+  // Toggling shut restores the resting state — the fold is not one-way.
+  mockInput.pressEnter()
+  await new Promise((r) => setTimeout(r, SETTLE))
+  expect(await frame()).not.toContain("nightly-audit")
+})
+
+test("opening the fold does not activate a task", async () => {
+  tabsByTask.clear()
+  const activated: string[] = []
+  const selected: string[] = []
+  const { mockInput } = await renderComponent(
+    tree({ onActivate: (id) => activated.push(id), onSelect: (id) => selected.push(id) }),
+    { width: 34, height: 20 },
+  )
+  await new Promise((r) => setTimeout(r, SETTLE))
+
+  mockInput.typeText("j")
+  await new Promise((r) => setTimeout(r, SETTLE))
+  mockInput.pressEnter()
+  await new Promise((r) => setTimeout(r, SETTLE))
+
+  // The row names no task: passing its sentinel id to onSelect/onActivate
+  // would land the workspace on nothing at all.
+  expect(activated).toEqual([])
+  expect(selected).toEqual([])
+})
+
+test("a folded routine session is still findable by search", async () => {
+  tabsByTask.clear()
+  // Hiding a row at rest must not make it unreachable — search is how you get
+  // to one without opening the fold first. Driven through the real `/` chord,
+  // since the query is the sidebar's own state, not a prop.
+  const { frame, mockInput } = await renderComponent(tree(), { width: 34, height: 20 })
+  await new Promise((r) => setTimeout(r, SETTLE))
+  mockInput.typeText("/")
+  await new Promise((r) => setTimeout(r, SETTLE))
+  mockInput.typeText("nightly")
+  await new Promise((r) => setTimeout(r, SETTLE))
+  const painted = await frame()
+
+  expect(painted).toContain("nightly-audit")
+  // The fold toggle itself does not survive a search: its rows are shown
+  // directly, so there would be nothing left underneath it.
+  expect(painted).not.toContain("routine sessions")
+})
+
+test("a project with no routines shows no count row", async () => {
+  tabsByTask.clear()
+  const { frame } = await renderComponent(tree({ tasks: [MAIN, MINE] }), { width: 34, height: 20 })
+  await new Promise((r) => setTimeout(r, SETTLE))
+
+  expect(await frame()).not.toContain("routine sessions")
+})

--- a/packages/kobe/test/tui/workspace-task-selection.test.ts
+++ b/packages/kobe/test/tui/workspace-task-selection.test.ts
@@ -193,6 +193,26 @@ describe("pure-TUI workspace task activation", () => {
     expect(firstSelectableTask([deleting], null)).toBeUndefined()
     expect(firstSelectableTask([], null)).toBeUndefined()
   })
+
+  test("a routine's standing session never wins the recency fallback (issue #91)", () => {
+    const mine = { ...task("mine", "/worktrees/mine"), updatedAt: "2026-07-01T00:00:00.000Z" }
+    // Fired at 03:00, so it is genuinely the most recently updated task in the
+    // install — and the least likely thing the user meant to open. Its sidebar
+    // row is folded away too, so booting onto it would put the cursor on a
+    // session with no visible row.
+    const routine = {
+      ...task("nightly", "/worktrees/nightly"),
+      updatedAt: "2026-07-02T03:00:00.000Z",
+      routine: { automationId: "auto-1" },
+    }
+
+    expect(firstSelectableTask([mine, routine], null)).toBe(mine)
+    // Naming it explicitly still selects it — that was a real choice.
+    expect(firstSelectableTask([mine, routine], "nightly")).toBe(routine)
+    expect(firstSelectableTask([mine, routine], null, "nightly")).toBe(routine)
+    // And it is still better than nothing when it is all there is.
+    expect(firstSelectableTask([routine], null)).toBe(routine)
+  })
 })
 
 /**


### PR DESCRIPTION
Closes #91.

## What

Two independent problems in the issue, addressed together because the second is what makes the first usable.

**1. A routine could not remember anything.** Every firing called `createTask` — new worktree, new branch, new row. An inspection routine ("is CI worse than last week?") started from zero every morning. `Automation` now carries `persistentSession` + `sessionTaskId`: with the flag on, the first firing creates one task and every later firing delivers into it.

**2. Routine tasks crowded out the ones you opened.** 7 daily routines = 49 sidebar rows a week. A standing task now carries `Task.routine` and rests behind a per-project `N routine sessions` count row.

## The four paths one firing can take

```
fire → persistentSession?
       ├─ no  → createTask + spawn                          → dispatched
       └─ yes → sessionTaskId resolves to a live task?
                ├─ no  → createTask (marked) + spawn, relink → dispatched
                └─ yes → deliverPromptToLiveEngineDetailed
                         ├─ delivered → dispatched
                         ├─ busy      → defer + Inbox        → deferred
                         └─ no-session→ respawn same worktree→ revived
```

## Design decisions worth reviewing

**Per-routine, default off.** An inspection routine wants yesterday's context; a routine that *edits* code wants a clean branch it can land. A week of runs piled onto one branch is unlandable, so this could not be a global switch.

**`revived` and `deferred` are their own statuses.** Continuity rests on the engine's live conversation, kept alive by the PTY host (which lives outside the daemon on purpose, so it survives `daemon restart`). When that process is gone, the respawn does **not** inherit the transcript — the daemon's spawn path has no resume verb wired into it (`engineResumeArgv` is the TUI's tab-restart path). Files carry over, conversation does not, and that must not report as a clean `dispatched`.

**A busy composer cannot be dropped.** `quota-resume` drops a blocked prompt deliberately — it is a nudge and the next rate-limit arms another. A routine's daily report has no second chance, and a dropped one is indistinguishable from a routine that never ran. So it files a deferral + Inbox episode (the same accepted-but-deferred contract `rove api send` gives agents) and records `deferred`, a success. `ComposerBusyError` lives in the `rove` package which depends on the daemon, so the outcome crosses the runtime adapter as **data**, not a catchable type.

**Self-healing.** A `sessionTaskId` whose task was deleted / is mid-deletion / lost its worktree resolves to null and the firing rebuilds + relinks. Without it one deleted task wedges the routine forever, and a wedged schedule looks exactly like a quiet one.

**The fold is the one exception to "no fold anywhere"** (`tree-panel.tsx:10`, owner round 5). Scoped so the rule it bends still holds: it hides only what a *schedule* created, never a task a human opened. Hidden at rest ≠ hidden — the task stays findable by `/` (search builds the tree fully expanded), openable from the Routines page, and Inbox-reachable. That Inbox entry is the fan-in answer to "how do I know what last night's routine said" (#66 family) — no new panel nobody reads.

## Found while building

`firstSelectableTask` falls back to the most recently updated task — and a routine that fired at 03:00 is exactly that. A cold start with no active/lastActive record would have landed the workspace on a session whose sidebar row is folded away, putting the cursor on a row that isn't there. The recency fallback now prefers a non-routine task; an explicit id still selects one, and it stays the fallback of last resort when it is the only live task. (Second commit, mutation-verified.)

## Not done, deliberately

Existing routine tasks are untouched: they have no `routine` marker, so they render exactly as today. Per the issue, **no deletion**.

For issue item 4 (what to do with the historical tasks) I did not add a verb: `routine-runs` already returns every run with its `taskId`, so the read is `rove api routine-runs --id <id> | jq -r '.runs[].taskId | select(.)'` — now documented in ROUTINES.md, along with the fact that deleting a routine takes its history with it, so the ids must be read first. A new verb would have duplicated an existing read.

## Tests

- `test/daemon/automation-standing-session.test.ts` — 11 cases covering all four paths + both busy-composer branches.
- `test/render/sidebar-routine-fold.test.tsx` — 5 cases against **real captured frames**, driving real keypresses (a fold whose enter does nothing renders identically to a closed one).

Mutation-verified at 5 distinct sites (drop the marker / ignore a deleted task / silently drop a busy report / never fold / dead toggle) — each caught by the test that names it.

The 4 `open-dir-cmd` + `project-eligibility` vitest failures are pre-existing: pristine `origin/main` fails the same 4 when run from inside `~/.rove/worktrees` (path-shape based project eligibility). Verified against a baseline worktree.

## Gates

typecheck ✅ · root lint ✅ · i18n ✅ (719 keys × 2) · daemon 675 ✅ · render 354 ✅ · vitest 4036 ✅ · changeset (patch) ✅

File-size cap: my change pushed `contracts.ts`, `tree-core.ts` and `orchestrator/core.ts` over 500, so all three were split along real seams (`automation-contracts.ts`, `tab-row-activity.ts`, `create-task-input.ts`) with re-exports — no import path changed.
