### PR TITLE
feat: let the composer delivery check be turned off

### DIFF
--- a/.changeset/composer-gate-setting.md
+++ b/.changeset/composer-gate-setting.md
@@ -1,0 +1,11 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Add a switch that turns off the composer check before prompt delivery (Settings → Dev).
+
+Before pasting a peer or API prompt into a running engine, Rove renders that session's screen and holds the message when the composer already has text in it. That check reads the engine's current on-screen layout, so a vendor redesign can make it confidently wrong — as one did, holding every message to every Claude task while their composers sat empty.
+
+The detector was fixed, but the failure mode returns whenever an engine moves its UI, and until now there was no way to say "I can see it's empty, send it". Turning the switch off drops the screen read only: the recent-keystroke guard stays on, so a composer someone is actively typing into is still protected — that one measures time rather than parsing a layout, and cannot go stale.
+
+On by default. Documented under Troubleshooting for the symptom that leads to it.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -281,6 +281,31 @@ A bare `send` (no `--task-id`) targets the dispatcher's tab when run from a
 task another Rove session spawned, and otherwise the active task — it never
 silently spawns an engine on a guess.
 
+## `rove api send` reports `deferred` over a composer that is empty
+
+A `deferred` result is a success, not an error: the delivery gate found the
+target busy, so the daemon took ownership of the text and queued a
+`prompt_deferred` episode for you to release from the Inbox. Retrying stacks a
+duplicate — the daemon already has the message.
+
+Two gates can defer, and the `layer` in the response says which:
+
+- **`recent-human-write`** — someone typed into that session within the last
+  10 seconds. Wait it out.
+- **`composer-not-empty`** — Rove rendered the session's screen and read text
+  in its composer.
+
+The second one reads the engine's CURRENT on-screen layout, so a vendor
+redesign can make it wrong: it holds every message while reporting a composer
+you can see is empty. If that happens, turn the check off in **Settings → Dev
+→ Check the composer before delivering**. Delivery then skips the screen read
+and relies on the keystroke-recency guard alone, which measures time instead
+of parsing a layout and so cannot go stale — a composer you are typing into
+right now stays protected either way.
+
+Leave it on otherwise. It is what stops an agent's message landing in the
+middle of a half-typed sentence.
+
 ## `rove api set-branch` fails, but the branch was renamed anyway
 
 The call exits non-zero with git's own complaint, stamped with the path of the

--- a/packages/kobe/src/engine/hosted-session.ts
+++ b/packages/kobe/src/engine/hosted-session.ts
@@ -6,6 +6,7 @@ import { defaultPtyHostSocketPath } from "@sma1lboy/kobe-daemon/daemon/paths"
 import type { PtyOpenResult, PtyPeekResult } from "@sma1lboy/kobe-daemon/daemon/protocol"
 import type { PtySessionInfo } from "@sma1lboy/kobe-daemon/daemon/pty-host"
 import type { TerminalDefaultColors } from "@sma1lboy/kobe-daemon/daemon/terminal-colors"
+import { composerGateEnabled } from "../state/composer-gate.ts"
 import { readPersistedTerminalDefaultColors } from "../tui/lib/terminal-colors.ts"
 import { BUILTIN_VENDORS } from "../types/vendor.ts"
 import { isComposerEmpty } from "./composer-state.ts"
@@ -164,6 +165,13 @@ export interface HostedPromptDeliveryOpts {
   readonly now?: () => number
   /** Override for the paste-readiness wait (ms). Tests shorten it. */
   readonly pasteReadyTimeoutMs?: number
+  /**
+   * Run the screen-based composer check. Defaults to the persisted setting
+   * (`state/composer-gate.ts`, on unless the user turned it off); an explicit
+   * value is the test seam, so a suite never depends on the machine's
+   * state.json.
+   */
+  readonly composerGate?: boolean
 }
 
 function recentHumanWriteBlocks(peek: PtyPeekResult, opts: HostedPromptDeliveryOpts, now: number): boolean {
@@ -184,6 +192,12 @@ async function assertComposerClear(peek: PtyPeekResult, key: string, opts?: Host
   if (recentHumanWriteBlocks(peek, opts ?? {}, now)) {
     throw new ComposerBusyError("recent-human-write", key)
   }
+  // The A layer above measures TIME and cannot be disabled: someone typing
+  // right now is protected whatever this setting says. Only the screen read
+  // below is switchable, because only it depends on a vendor's current
+  // layout — see state/composer-gate.ts. Read per delivery, so flipping the
+  // switch takes effect without a restart.
+  if (!(opts?.composerGate ?? composerGateEnabled())) return
   if (await composerNonEmpty(peek, opts?.screenManifest)) {
     throw new ComposerBusyError("composer-not-empty", key)
   }

--- a/packages/kobe/src/state/composer-gate.ts
+++ b/packages/kobe/src/state/composer-gate.ts
@@ -1,0 +1,35 @@
+/**
+ * The composer-empty delivery gate's off switch.
+ *
+ * Before pasting a peer/API prompt into a running engine, Rove renders that
+ * session's screen and refuses when the composer already holds text — so a
+ * message never lands in the middle of what someone is typing. That check
+ * reads the engine's CURRENT layout through an `EngineScreenManifest`, which
+ * is a rule about pixels an upstream vendor is free to change without telling
+ * anyone. When Claude moved its composer behind three rows of status
+ * furniture, the rule stopped matching and every delivery to every Claude task
+ * was held (2026-09-01).
+ *
+ * The detector is now conservative in the right direction — an unmatched
+ * anchor answers "I can't see it" rather than "there is text" — but the
+ * failure mode this switch exists for is the one that comes back: a vendor
+ * moves, the gate is confidently wrong, and the user watches messages queue up
+ * with no way to say "I know, send it anyway". Turning this off drops the
+ * SCREEN check only; the recent-keystroke window still protects a composer
+ * someone is actively typing into, because that one measures time rather than
+ * reading a layout.
+ *
+ * Lives in shared state.json (the Settings dialog's KV writes the same file)
+ * and is read fresh at each delivery, so toggling needs no restart — the
+ * dispatcher-flag precedent. ON by default: this is an escape hatch, not a
+ * preference.
+ */
+
+import { getPersistedBool } from "./store.ts"
+
+export const COMPOSER_GATE_KEY = "delivery.composerGate"
+
+/** Whether the screen-based composer check runs. Default true. */
+export function composerGateEnabled(): boolean {
+  return getPersistedBool(COMPOSER_GATE_KEY, true)
+}

--- a/packages/kobe/src/tui-react/component/settings-dialog/index.tsx
+++ b/packages/kobe/src/tui-react/component/settings-dialog/index.tsx
@@ -248,6 +248,7 @@ export function SettingsDialog(props: SettingsDialogProps) {
     devRemoteProjects: () => prefs.toggleRemoteProjects(),
     devAutoStatus: () => prefs.toggleAutoStatus(),
     devDispatcher: () => prefs.toggleDispatcher(),
+    devComposerGate: () => prefs.toggleComposerGate(),
   }
 
   function activateBodyRow(): void {

--- a/packages/kobe/src/tui-react/component/settings-dialog/sections-misc.tsx
+++ b/packages/kobe/src/tui-react/component/settings-dialog/sections-misc.tsx
@@ -230,6 +230,13 @@ export function DevSettingsSection(
           "settings.dev.dispatcher",
           prefs.toggleDispatcher,
         )}
+        {toggleRow(
+          "composer-gate",
+          prefs.composerGateOn(),
+          "settings.dev.composerGateHint",
+          "settings.dev.composerGate",
+          prefs.toggleComposerGate,
+        )}
       </box>
     </box>
   )

--- a/packages/kobe/src/tui-react/component/settings-dialog/use-settings-prefs.ts
+++ b/packages/kobe/src/tui-react/component/settings-dialog/use-settings-prefs.ts
@@ -10,6 +10,7 @@
 import { accessSync, constants as fsConstants, mkdirSync } from "node:fs"
 import { errorMessage } from "@/lib/error-message"
 import { AUTO_STATUS_KEY } from "../../../state/auto-status"
+import { COMPOSER_GATE_KEY } from "../../../state/composer-gate"
 import { DISPATCHER_KEY } from "../../../state/dispatcher"
 import { DEFAULT_SCROLLBACK_ROWS, SCROLLBACK_ROWS_KEY, normalizeScrollbackRows } from "../../../state/scrollback"
 import { SPLIT_STYLE_KEY, type SplitStyle, normalizeSplitStyle } from "../../../state/split-style"
@@ -136,6 +137,14 @@ export function useSettingsPrefs(kv: KVContext, dialog: DialogContext) {
   }
   function toggleDispatcher(): void {
     kv.set(DISPATCHER_KEY, !dispatcherOn())
+  }
+  // ON by default (the only default-on switch here) — it is an escape hatch
+  // for a gate that reads a vendor's screen layout, not a feature to opt into.
+  function composerGateOn(): boolean {
+    return kv.get(COMPOSER_GATE_KEY, true) !== false
+  }
+  function toggleComposerGate(): void {
+    kv.set(COMPOSER_GATE_KEY, !composerGateOn())
   }
 
   // Editor preference: which editor the file tree's `e` key launches.
@@ -286,6 +295,8 @@ export function useSettingsPrefs(kv: KVContext, dialog: DialogContext) {
     toggleAutoStatus,
     dispatcherOn,
     toggleDispatcher,
+    composerGateOn,
+    toggleComposerGate,
     editorKind,
     cycleEditorKind,
     editorCustomCommand,

--- a/packages/kobe/src/tui/component/settings-dialog/model.ts
+++ b/packages/kobe/src/tui/component/settings-dialog/model.ts
@@ -76,6 +76,7 @@ export type SettingsRow =
   | { id: "remote-projects"; kind: "devRemoteProjects" }
   | { id: "auto-status"; kind: "devAutoStatus" }
   | { id: "dispatcher"; kind: "devDispatcher" }
+  | { id: "composer-gate"; kind: "devComposerGate" }
 
 /** Stable row ids for payload-bearing rows (shared by builders + views). */
 export function themeRowId(name: string): string {
@@ -206,9 +207,9 @@ export function keybindingRows(keybindingsFileExists: boolean): SettingsRow[] {
 }
 
 /**
- * Dev section: Reset (always), Restart (daemon only), then the
- * Experimental remote-projects toggle — kept last so its presence never
- * shifts the rows above it.
+ * Dev section: Reset (always), Restart (daemon only), then the Experimental
+ * toggles — kept last so their presence never shifts the rows above them, and
+ * appended in order so an added switch never renumbers an existing one.
  */
 export function devRows(hasDaemon: boolean): SettingsRow[] {
   return [
@@ -217,6 +218,7 @@ export function devRows(hasDaemon: boolean): SettingsRow[] {
     { id: "remote-projects", kind: "devRemoteProjects" },
     { id: "auto-status", kind: "devAutoStatus" },
     { id: "dispatcher", kind: "devDispatcher" },
+    { id: "composer-gate", kind: "devComposerGate" },
   ]
 }
 

--- a/packages/kobe/src/tui/i18n/messages/settings.ts
+++ b/packages/kobe/src/tui/i18n/messages/settings.ts
@@ -186,6 +186,9 @@ export const en = {
     dispatcherHint:
       "Field-notes dispatcher: task sessions file one-line gotchas (`rove api note`), the daemon forwards each to the repo's main session, and that session relays them to the in-flight tasks that benefit (`rove api dispatch`). Web-hosted sessions receive the relays today.",
     dispatcher: "Field-notes dispatcher",
+    composerGateHint:
+      "Before pasting a peer/API prompt into a running engine, Rove reads that session's screen and holds the message if the composer already has text in it. The check knows each engine's CURRENT layout, so a vendor redesign can make it wrong — turn it off if messages are being held over composers you can see are empty. The separate recent-keystroke guard stays on either way, so a composer you are typing into now is still protected.",
+    composerGate: "Check the composer before delivering",
   },
 }
 
@@ -361,5 +364,8 @@ export const zh: typeof en = {
     dispatcherHint:
       "现场笔记调度器：任务会话提交一行经验（`rove api note`），daemon 将每条转发给仓库的主会话，主会话再把它们转达给能受益的进行中任务（`rove api dispatch`）。目前由 Web 托管的会话会收到转达。",
     dispatcher: "现场笔记调度器",
+    composerGateHint:
+      "把 peer/API 的消息粘进运行中的引擎之前,Rove 会读一遍那个会话的屏幕,发现输入框里已经有字就先扣住不发。这个判断依赖引擎当前的界面布局,所以厂商改版可能让它失准——如果你看着输入框明明是空的、消息却一直被扣住,就关掉它。另一道「刚刚有人在打字」的保护始终生效,正在输入的输入框仍然受保护。",
+    composerGate: "投递前检查输入框",
   },
 }

--- a/packages/kobe/test/engine/hosted-session.test.ts
+++ b/packages/kobe/test/engine/hosted-session.test.ts
@@ -272,12 +272,46 @@ describe("deliverToHostedKey A+C gates (issue #78)", () => {
     const rpc = rpcWith({ alive: true, data: Buffer.from("❯ hello", "utf8").toString("base64") })
     const err = await deliverToHostedKey(rpc as HostedSessionRpc, "t1::tab-1", "go", {
       screenManifest: manifest,
+      // Pinned, not defaulted: the gate now falls back to the persisted
+      // setting, so leaving this out made the assertion depend on whether the
+      // machine running the suite had turned the switch off.
+      composerGate: true,
     }).then(
       () => null,
       (e) => e,
     )
     expect(err).toBeInstanceOf(ComposerBusyError)
     expect((err as ComposerBusyError).layer).toBe("composer-not-empty")
+  })
+
+  it("skips the screen check when the composer gate is off, but keeps the timing one", async () => {
+    // The escape hatch (state/composer-gate.ts) for a screen rule an engine
+    // redesign has outrun. It drops the LAYOUT read only: the A layer measures
+    // keystroke recency, so a composer someone is typing into right now stays
+    // protected however this is set — otherwise turning it off would trade a
+    // stuck queue for messages landing mid-sentence.
+    const busyScreen = { alive: true, data: Buffer.from("❯ hello", "utf8").toString("base64") }
+
+    const cOff = await deliverToHostedKey(rpcWith(busyScreen) as HostedSessionRpc, "t1::tab-1", "go", {
+      screenManifest: manifest,
+      composerGate: false,
+    }).then(
+      () => "delivered",
+      (e) => e,
+    )
+    expect(cOff).toBe("delivered")
+
+    const aStillOn = await deliverToHostedKey(
+      rpcWith({ ...busyScreen, lastHumanWriteMs: 1_000, humanWriteQuietMs: 10_000 }) as HostedSessionRpc,
+      "t1::tab-1",
+      "go",
+      { screenManifest: manifest, composerGate: false, now: () => 5_000 },
+    ).then(
+      () => null,
+      (e) => e,
+    )
+    expect(aStillOn).toBeInstanceOf(ComposerBusyError)
+    expect((aStillOn as ComposerBusyError).layer).toBe("recent-human-write")
   })
 
   it("delivers when both gates pass", async () => {

--- a/packages/kobe/test/tui/settings-rows.test.ts
+++ b/packages/kobe/test/tui/settings-rows.test.ts
@@ -125,7 +125,7 @@ describe("engineRows", () => {
 })
 
 describe("devRows", () => {
-  it("with a daemon: reset, restart, remote-projects, auto-status, dispatcher", () => {
+  it("with a daemon: reset, restart, then the experimental toggles in order", () => {
     const rows = devRows(true)
     expect(rows.map((r) => r.kind)).toEqual([
       "devReset",
@@ -133,18 +133,27 @@ describe("devRows", () => {
       "devRemoteProjects",
       "devAutoStatus",
       "devDispatcher",
+      "devComposerGate",
     ])
     expect(rowIndex(rows, "remote-projects")).toBe(2)
     expect(rowIndex(rows, "auto-status")).toBe(3)
     expect(rowIndex(rows, "dispatcher")).toBe(4)
+    expect(rowIndex(rows, "composer-gate")).toBe(5)
   })
 
-  it("without a daemon: reset, remote-projects, auto-status, dispatcher", () => {
+  it("without a daemon: the same list, one row shorter, indices shifted by one", () => {
     const rows = devRows(false)
-    expect(rows.map((r) => r.kind)).toEqual(["devReset", "devRemoteProjects", "devAutoStatus", "devDispatcher"])
+    expect(rows.map((r) => r.kind)).toEqual([
+      "devReset",
+      "devRemoteProjects",
+      "devAutoStatus",
+      "devDispatcher",
+      "devComposerGate",
+    ])
     expect(rowIndex(rows, "remote-projects")).toBe(1)
     expect(rowIndex(rows, "auto-status")).toBe(2)
     expect(rowIndex(rows, "dispatcher")).toBe(3)
+    expect(rowIndex(rows, "composer-gate")).toBe(4)
   })
 })
 
@@ -198,8 +207,9 @@ describe("sectionRows / bodyRowCount", () => {
     expect(bodyRowCount("engines", inp)).toBe(ALL_VENDORS.length + 2 + 1) // 6
     expect(bodyRowCount("keys", inp)).toBe(2)
     expect(bodyRowCount("feedback", inp)).toBe(3)
-    expect(bodyRowCount("dev", inp)).toBe(5)
-    expect(bodyRowCount("dev", { ...inp, hasDaemon: false })).toBe(4)
+    // reset + restart + 4 experimental toggles; one fewer without a daemon.
+    expect(bodyRowCount("dev", inp)).toBe(6)
+    expect(bodyRowCount("dev", { ...inp, hasDaemon: false })).toBe(5)
   })
 
   it("row ids are unique within every section", () => {


### PR DESCRIPTION
The escape hatch you asked for after the delivery outage — the switch itself, not a workaround for that specific bug (#714 fixed the detector).

## Why a switch, when the detector is fixed

The C-layer gate reads the engine's **current on-screen layout** through an `EngineScreenManifest`. That is a rule about a vendor's pixels, and vendors move them without telling anyone: when Claude put its composer behind three rows of status furniture, the rule stopped matching and every delivery to every Claude task was held.

#714 made the detector conservative in the right direction (an unmatched anchor now answers "I can't see it" rather than "there is text"). But the shape of the failure returns whenever an engine redesigns, and until now the user had no way to say *"I can see it's empty — send it."* They just watched messages queue.

## What the switch does

`delivery.composerGate` in `state.json` (on by default), toggled at **Settings → Dev → Check the composer before delivering**. Read fresh on each delivery, so flipping it needs no restart.

It drops the **screen read only**. The A-layer keystroke-recency window stays on whatever the setting says:

| gate | measures | switchable |
|---|---|---|
| A: recent-human-write | time since the last keystroke | no |
| C: composer-not-empty | the engine's rendered layout | **yes** |

That split is the point. A layer that measures elapsed time cannot go stale, and it is the one that actually protects a composer someone is typing into *right now*. Making the whole gate switchable would trade a stuck queue for messages landing mid-sentence.

## A machine-state dependency this surfaced

Wiring the default to the persisted setting made an existing assertion read the real `~/.config/rove/state.json`. Proved it, rather than assuming:

```
KOBE_HOME_DIR=<fake home with the flag off> vitest run test/engine/hosted-session.test.ts
  → 1 failed   ("throws ComposerBusyError when the composer is not empty")
```

Anyone who turned the switch off on their own machine would have had a red suite that is green in CI. That test now pins `composerGate: true` explicitly; green under both homes.

## Test

- new: the gate off skips the screen check **and** still throws on `recent-human-write` — one test, both halves, so "turned it off" can't quietly mean "turned both off"
- `settings-rows` row-order and count assertions updated (the count guard caught the new row, as designed)

Mutation-verified: removing the flag check fails the new test.

`test/engine` + `test/tui` 2147 pass, `test:fast` 4041 pass, i18n in sync (720 keys × 2), root lint + typecheck clean. Troubleshooting entry added under the symptom that leads here (`send` reports `deferred` over an empty composer).