### PR TITLE
fix: carry peer provenance into a dispatched task's opening brief

### DIFF
--- a/.changeset/add-peer-provenance.md
+++ b/.changeset/add-peer-provenance.md
@@ -1,0 +1,9 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Give a dispatched task the reply address in its opening brief.
+
+`rove api send` prefixes a cross-task prompt with who sent it and the exact command to answer. `rove api add --prompt` — which is how one agent starts another — did not, so a task began its work with no idea who dispatched it or how to report back. The sender was recorded as `dispatcher` on the task row, but that is data a receiver has to think to go read, and has no reason to suspect exists.
+
+A task's opening brief is where the reply address matters most: every report it will ever send flows back through it. Both delivery verbs now carry the same prefix, from one shared implementation. A create from a plain shell is unchanged — the prefix only appears when the caller is a verified Rove session, and never when a task addresses itself.

--- a/packages/kobe/src/cli/api/dispatcher.ts
+++ b/packages/kobe/src/cli/api/dispatcher.ts
@@ -13,6 +13,7 @@
  */
 
 import type { SerializedTask } from "@sma1lboy/kobe-daemon/daemon/protocol"
+import { kobeApiInvocation } from "../../engine/interactive-command.ts"
 import type { DaemonRpc } from "../daemon-session.ts"
 import { activeCliName } from "../rename-compat.ts"
 import { ApiError, type ApiRuntime } from "./types.ts"
@@ -203,4 +204,57 @@ export async function resolveDispatcherTab(runtime: ApiRuntime, dispatcher: Disp
       nextCommandArgs: ["api", "pty-list"],
     },
   )
+}
+
+/**
+ * Peer provenance: a prompt issued from INSIDE another kobe task is one agent
+ * messaging another, and the receiver needs what a bare paste never carries —
+ * who is talking and how to answer.
+ *
+ * Both delivery verbs wear it. `send` always did; `add --prompt` did not, and
+ * that gap is why a dispatched task finished its work and then sat waiting:
+ * `add` records the sender as `dispatcher` on the task ROW, which a receiver
+ * would have to think to go read (`rove api get-task`) and has no reason to
+ * suspect exists. A task's opening brief is exactly the moment the reply
+ * address matters, since every report it will ever send flows back through
+ * it (2026-09-01: issue #92's survey completed and was never delivered). Same convention as field
+ * notes (`[ROVE FIELD NOTE] from "<label>" (task <id>)`), plus the reply
+ * command so a peer conversation is symmetric without any coordinator.
+ * Sender identity is the VERIFIED $KOBE_TASK_ID/$KOBE_TAB_ID pair, not the
+ * raw env: an unverified one names a stranger's session as the sender and
+ * bakes their tab into the reply command (issue #24). A send from a plain
+ * shell, an unverified process, or to yourself stays untouched.
+ */
+export async function withPeerProvenance(daemon: DaemonRpc, targetTaskId: string, prompt: string): Promise<string> {
+  const self = await verifiedSelfSession()
+  const senderId = self?.taskId
+  if (!senderId || senderId === targetTaskId) return prompt
+  let label = senderId
+  try {
+    const res = await daemon.request<{ task: SerializedTask }>("task.get", { taskId: senderId })
+    label = res.task.title || res.task.branch || senderId
+  } catch {
+    /* stale env id — keep id-only provenance rather than dropping it */
+  }
+  const api = kobeApiInvocation()
+  // The baked-in reply command carries the sender's TAB, not just its task
+  // (issue #21): task-granular replies land on canonical-tab resolution,
+  // which is exactly the link that breaks (#19) — tab-precise addressing is
+  // the loop's durable route home. $KOBE_TAB_ID is exported into every
+  // engine tab alongside $KOBE_TASK_ID (session-launch.ts).
+  const replyTarget = `--task-id ${senderId} --tab ${self.tabId}`
+  // The trailing pointer closes the loop for a receiver that has never seen
+  // kobe: reply command baked in, and where to learn the rest (the herdr
+  // "--skill first" trick) — a pointer, not a curriculum, since every peer
+  // message pays for this prefix in context. Loading the skill is REQUIRED,
+  // not suggested: a receiver that replies from the raw prefix alone
+  // improvises verbs and side-channels (2026-08-10: a peer coordination
+  // round-trip fell back to a human relay because neither side had the
+  // skill's contract in context).
+  // The sender's text goes LAST, whole, after a blank line — never as the
+  // object of this English sentence. A model generates in the language of
+  // the tokens nearest its turn, so wrapping a Chinese prompt in an English
+  // clause pulled replies into English; ending on the sender's own words
+  // removes that pull without changing what the prefix says.
+  return `[ROVE PEER] from "${label}" (task ${senderId} — load the Rove agent skill FIRST (registered as /rove; legacy /kobe installs still work), then reply: \`${api} send ${replyTarget} --prompt "<text>"\`; verb reference: \`${api} schema\`)\n\n${prompt}`
 }

--- a/packages/kobe/src/cli/api/handlers-add.ts
+++ b/packages/kobe/src/cli/api/handlers-add.ts
@@ -18,7 +18,7 @@ import { resolveCommandProtocol } from "../../engine/engine-presets.ts"
 import { ulid } from "../../orchestrator/index/ulid.ts"
 import type { TaskStatus } from "../../types/task.ts"
 import type { VendorId } from "../../types/vendor.ts"
-import { dispatcherEnvPayload } from "./dispatcher.ts"
+import { dispatcherEnvPayload, withPeerProvenance } from "./dispatcher.ts"
 import { FANOUT_CAP, buildCountPlan, parseAgentsSpec } from "./flags.ts"
 import { daemonOf } from "./handler-helpers.ts"
 import { ApiError, type VerbContext, helpStep } from "./types.ts"
@@ -94,6 +94,14 @@ async function addOne(ctx: VerbContext, repo: string): Promise<unknown> {
 
   const prompt = args.str("prompt")
   if (!prompt) return { taskId, task, started: false }
+  // Same provenance prefix `send` carries: a task created from inside another
+  // kobe session is agent-to-agent, and its opening brief is where the reply
+  // address matters most — every report this task ever sends goes back through
+  // it. `add` already records the sender as `dispatcher` on the task row, but
+  // that is data a receiver has to think to go read; this puts it in the
+  // message. No-ops for a create from a plain shell, so a human's `rove add`
+  // is unchanged.
+  const brief = await withPeerProvenance(daemon, taskId, prompt)
   const delivered = await ctx.runtime.deliverPrompt(
     daemon,
     {
@@ -106,7 +114,7 @@ async function addOne(ctx: VerbContext, repo: string): Promise<unknown> {
       repo: task.repo,
       newTask: true,
     },
-    prompt,
+    brief,
   )
   // A prompt that never confirmed AND was not deferred is a failure — but the
   // task IS created, so carry the taskId in the error so a script can find it.

--- a/packages/kobe/src/cli/api/handlers-tasks.ts
+++ b/packages/kobe/src/cli/api/handlers-tasks.ts
@@ -12,7 +12,7 @@ import { kobeApiInvocation } from "../../engine/interactive-command.ts"
 import { EMPTY_BRANCH_DIRTY_WORKTREE_CODE } from "../../orchestrator/errors.ts"
 import type { VendorId } from "../../types/vendor.ts"
 import type { DaemonRpc } from "../daemon-session.ts"
-import { readOwnDispatcher, resolveDispatcherTab, verifiedSelfSession } from "./dispatcher.ts"
+import { readOwnDispatcher, resolveDispatcherTab, verifiedSelfSession, withPeerProvenance } from "./dispatcher.ts"
 import { F } from "./flags.ts"
 import { daemonOf, simpleRpc } from "./handler-helpers.ts"
 import { resolveActiveTaskId } from "./runtime.ts"
@@ -23,51 +23,6 @@ import { ApiError, type VerbContext, type VerbSpec, helpStep } from "./types.ts"
  *  deadline the deletion itself respects. */
 const DELETE_WAIT_TIMEOUT_MS = 60_000
 const DELETE_POLL_INTERVAL_MS = 250
-
-/**
- * Peer provenance: a `send` issued from INSIDE another kobe task is one
- * agent messaging another, and the receiver needs what a bare paste never
- * carries — who is talking and how to answer. Same convention as field
- * notes (`[ROVE FIELD NOTE] from "<label>" (task <id>)`), plus the reply
- * command so a peer conversation is symmetric without any coordinator.
- * Sender identity is the VERIFIED $KOBE_TASK_ID/$KOBE_TAB_ID pair, not the
- * raw env: an unverified one names a stranger's session as the sender and
- * bakes their tab into the reply command (issue #24). A send from a plain
- * shell, an unverified process, or to yourself stays untouched.
- */
-async function withPeerProvenance(daemon: DaemonRpc, targetTaskId: string, prompt: string): Promise<string> {
-  const self = await verifiedSelfSession()
-  const senderId = self?.taskId
-  if (!senderId || senderId === targetTaskId) return prompt
-  let label = senderId
-  try {
-    const res = await daemon.request<{ task: SerializedTask }>("task.get", { taskId: senderId })
-    label = res.task.title || res.task.branch || senderId
-  } catch {
-    /* stale env id — keep id-only provenance rather than dropping it */
-  }
-  const api = kobeApiInvocation()
-  // The baked-in reply command carries the sender's TAB, not just its task
-  // (issue #21): task-granular replies land on canonical-tab resolution,
-  // which is exactly the link that breaks (#19) — tab-precise addressing is
-  // the loop's durable route home. $KOBE_TAB_ID is exported into every
-  // engine tab alongside $KOBE_TASK_ID (session-launch.ts).
-  const replyTarget = `--task-id ${senderId} --tab ${self.tabId}`
-  // The trailing pointer closes the loop for a receiver that has never seen
-  // kobe: reply command baked in, and where to learn the rest (the herdr
-  // "--skill first" trick) — a pointer, not a curriculum, since every peer
-  // message pays for this prefix in context. Loading the skill is REQUIRED,
-  // not suggested: a receiver that replies from the raw prefix alone
-  // improvises verbs and side-channels (2026-08-10: a peer coordination
-  // round-trip fell back to a human relay because neither side had the
-  // skill's contract in context).
-  // The sender's text goes LAST, whole, after a blank line — never as the
-  // object of this English sentence. A model generates in the language of
-  // the tokens nearest its turn, so wrapping a Chinese prompt in an English
-  // clause pulled replies into English; ending on the sender's own words
-  // removes that pull without changing what the prefix says.
-  return `[ROVE PEER] from "${label}" (task ${senderId} — load the Rove agent skill FIRST (registered as /rove; legacy /kobe installs still work), then reply: \`${api} send ${replyTarget} --prompt "<text>"\`; verb reference: \`${api} schema\`)\n\n${prompt}`
-}
 
 export async function issueUpdate(ctx: VerbContext): Promise<unknown> {
   const title = ctx.args.str("title")

--- a/packages/kobe/test/cli/api-handlers.test.ts
+++ b/packages/kobe/test/cli/api-handlers.test.ts
@@ -331,6 +331,30 @@ describe("send handler", () => {
       expect(provenance).not.toContain("帮我重构登录模块")
     })
 
+    it("gives a dispatched task the same reply address in its opening brief", async () => {
+      // `add --prompt` from inside a kobe session is agent-to-agent too, and
+      // its brief is where the reply address matters most: every report that
+      // task ever sends flows back through it. Before this, `add` recorded the
+      // sender only as `dispatcher` on the task ROW — data a receiver has to
+      // think to go read — so a dispatched survey finished and sat waiting
+      // (2026-09-01, issue #92).
+      const { calls, deliver } = recordingDelivery()
+      await invokeVerb("add", ["--repo", "/repo/x", "--prompt", "研究一下 X"], {
+        client: new FakeClient({
+          "task.create": () => ({ taskId: "child-1", task: taskFixture({ id: "child-1" }) }),
+          "task.get": (payload) => {
+            const id = (payload as { taskId: string }).taskId
+            return { task: taskFixture({ id, title: id === "sender-1" ? "Auth attempt" : "T" }) }
+          },
+        }),
+        runtime: stubRuntime({ deliverPrompt: deliver }),
+      })
+      expect(calls[0].prompt).toContain('[ROVE PEER] from "Auth attempt" (task sender-1')
+      expect(calls[0].prompt).toContain("send --task-id sender-1 --tab tab-1")
+      // Same shape as `send`: the brief is last and whole.
+      expect(calls[0].prompt.endsWith("研究一下 X")).toBe(true)
+    })
+
     it("--plain sends verbatim", async () => {
       const { calls, deliver } = recordingDelivery()
       await invokeVerb("send", ["--task-id", "abc", "--prompt", "hi", "--plain"], {


### PR DESCRIPTION
## The gap

`rove api send` prefixes a cross-task prompt with provenance:

```
[ROVE PEER] from "Auth attempt" (task sender-1 — load the Rove agent skill FIRST,
then reply: `rove api send --task-id sender-1 --tab tab-1 --prompt "<text>"`)

<the sender's text>
```

`rove api add --prompt` did not. But `add` is **how one agent starts another** — the prompt it delivers is that task's entire opening context. So a dispatched task began work not knowing who sent it or how to answer.

`add` does record the sender as `dispatcher` on the task row, and a bare `send` routes back through it. But that is data the receiver has to *think to go read* (`rove api get-task`) and has no reason to suspect exists. Neither fact is derivable from the brief.

## What it cost

Issue #92's survey task completed its research and **sat waiting**. The brief said "send the conclusions back" and gave it no address. The dispatching session meanwhile reported "#92 still researching" in a status summary — the delivery gap became a wrong read of project state, and it took the owner noticing the task's screen to catch it.

Its sibling (#71) was briefed the same way and would have done the same thing.

## Change

`withPeerProvenance` moves from `handlers-tasks.ts` to `dispatcher.ts` — both call sites already import that module, so no cycle and no new dependency — and `add` applies it to the delivered brief.

Its existing guards do the rest: no prefix when the caller is not a verified Rove session (so a human's `rove add` is untouched), and none when a task addresses itself.

`--plain` remains send-only. `add` has no such flag today and this PR does not invent one; if a caller ever needs a verbatim brief, that is a flag to add deliberately rather than a default to leave broken.

## Test

One case in the existing peer-provenance block (same verified-session harness as `send`): a dispatched `add` carries the sender's identity and a **tab-precise** reply command, with the brief last and whole.

Mutation-verified: delivering the bare prompt again fails it.

`test/cli` 755 pass · `test:fast` 4043 pass · root lint + typecheck clean.