### PR TITLE
fix: one source for rounded borders, and three visual bugs it exposed

### DIFF
--- a/.changeset/frame-and-transparency.md
+++ b/.changeset/frame-and-transparency.md
@@ -1,0 +1,13 @@
+---
+"@sma1lboy/rove": patch
+---
+
+One source for the TUI's rounded borders, transparency that reaches the last solid tiles, and tab titles that stop overflowing their strip.
+
+**Rounded corners come from one place now.** opentui hard-codes square corners as its Box default and offers no global override, so every framed surface had to opt in by hand — and half of them never did. The workspace pane, files pane and tab strip were rounded while the prefix HUD, context menu, story dialog, automations strips and split frames were square. All ten spread a shared `FRAME` instead, so the next framed box is rounded because its author spread the shared thing, not because they remembered a prop whose absence only shows up in a screenshot.
+
+**Transparent mode reaches the cards and the story dialog.** A kanban card and the dialog's input wells kept a solid fill with transparency on — the one thing on screen you could not see through. Opaque mode is unchanged.
+
+**A kanban card costs one row less.** `padding={1}` was doing three jobs at once (air inside the card, separation from the next card, a break between title and description) and charging two rows for it. Split into horizontal padding, a lane margin, and the existing box gap: same three effects, one row cheaper per card.
+
+**A tab title wider than the pane is now ellipsised.** It used to push the tab's own right frame off the clipped strip and run to the last column with nothing saying it had been cut — a long shell name did this routinely. Truncation happens before the width the scroll math reads, so the viewport still scrolls by a width that is actually drawn.

--- a/packages/kobe/src/tui-react/component/automations-page.tsx
+++ b/packages/kobe/src/tui-react/component/automations-page.tsx
@@ -29,6 +29,7 @@ import { dividerRule } from "../lib/rule-divider"
 import { useDaemonDown } from "../lib/use-accessor"
 import { useDialog } from "../ui/dialog"
 import { DialogConfirm } from "../ui/dialog-confirm"
+import { FRAME } from "../ui/frame"
 import { AutomationComposer } from "./automation-composer-dialog"
 
 /** Agent-driven edits land within a poll; `automation.list` is a local read. */
@@ -324,7 +325,7 @@ export function AutomationsPage(props: {
                 key={automation.id}
                 flexDirection="row"
                 flexShrink={0}
-                border={true}
+                {...FRAME}
                 borderColor={isCursor ? theme.borderActive : theme.borderSubtle}
                 paddingLeft={1}
                 paddingRight={1}

--- a/packages/kobe/src/tui-react/component/issue-detail-dialog.tsx
+++ b/packages/kobe/src/tui-react/component/issue-detail-dialog.tsx
@@ -35,6 +35,7 @@ import { useTheme } from "../context/theme"
 import { useT } from "../i18n"
 import { useBindings } from "../lib/keymap"
 import { type DialogContext, showDialog, useDialog, useDialogPaddingX } from "../ui/dialog"
+import { FRAME } from "../ui/frame"
 import { IssueEventsSection, SectionHeader } from "./issue-detail-parts"
 
 export interface IssueDetailOptions {
@@ -80,7 +81,7 @@ export function IssueDetailDialogView(
   },
 ) {
   const dialog = useDialog()
-  const { theme } = useTheme()
+  const { theme, transparentBackground } = useTheme()
   const t = useT()
   const padX = useDialogPaddingX()
   const issue = props.issue
@@ -255,6 +256,10 @@ export function IssueDetailDialogView(
   // Focused/selected frames light up PRIMARY — the same accent the kanban
   // card cursor and the pane focus grammar use, not the generic borderActive.
   const frameColor = (ownField: Field) => (field === ownField ? theme.primary : theme.borderSubtle)
+  // Transparent mode means transparent here too: a dialog's input wells were
+  // the last solid tiles left on screen with the setting on. Opaque mode is
+  // unchanged.
+  const fieldFill = transparentBackground ? "transparent" : theme.backgroundElement
 
   return (
     <box paddingLeft={padX} paddingRight={padX} gap={1}>
@@ -289,13 +294,7 @@ export function IssueDetailDialogView(
       {/* TITLE — controlled input, single line. Enter walks to the body. */}
       <box gap={0}>
         {sectionHeader(t("kanban.detail.titleLabel"), "title")}
-        <box
-          border={true}
-          borderColor={frameColor("title")}
-          backgroundColor={theme.backgroundElement}
-          paddingLeft={1}
-          paddingRight={1}
-        >
+        <box {...FRAME} borderColor={frameColor("title")} backgroundColor={fieldFill} paddingLeft={1} paddingRight={1}>
           <input
             value={draftTitle}
             focused={field === "title"}
@@ -311,9 +310,9 @@ export function IssueDetailDialogView(
       <box gap={0}>
         {sectionHeader(t("kanban.detail.description"), "description", t("kanban.detail.attachHint"))}
         <box
-          border={true}
+          {...FRAME}
           borderColor={frameColor("description")}
-          backgroundColor={theme.backgroundElement}
+          backgroundColor={fieldFill}
           paddingLeft={1}
           paddingRight={1}
         >
@@ -346,7 +345,7 @@ export function IssueDetailDialogView(
                 return (
                   <box
                     key={engine}
-                    border={true}
+                    {...FRAME}
                     borderColor={selected ? theme.primary : theme.borderSubtle}
                     paddingLeft={2}
                     paddingRight={2}
@@ -373,9 +372,9 @@ export function IssueDetailDialogView(
           <box gap={0} paddingBottom={1}>
             {sectionHeader(t("kanban.detail.workspace"), "workspace", "↑/↓")}
             <box
-              border={true}
+              {...FRAME}
               borderColor={frameColor("workspace")}
-              backgroundColor={theme.backgroundElement}
+              backgroundColor={fieldFill}
               paddingLeft={1}
               paddingRight={1}
             >
@@ -409,7 +408,7 @@ export function IssueDetailDialogView(
                 return (
                   <box
                     key={String(option)}
-                    border={true}
+                    {...FRAME}
                     borderColor={active ? theme.primary : theme.borderSubtle}
                     paddingLeft={2}
                     paddingRight={2}
@@ -445,7 +444,7 @@ export function IssueDetailDialogView(
             {sectionHeader(t("kanban.detail.sessionLabel"), "open")}
             <box flexDirection="row">
               <box
-                border={true}
+                {...FRAME}
                 borderColor={field === "open" ? theme.primary : theme.borderSubtle}
                 paddingLeft={2}
                 paddingRight={2}

--- a/packages/kobe/src/tui-react/component/kanban-card.tsx
+++ b/packages/kobe/src/tui-react/component/kanban-card.tsx
@@ -14,6 +14,7 @@ import type { TaskActivityState } from "../../engine/hook-events"
 import { type BoardColumnKey, isBoardAttentionState } from "../../state/issue-board"
 import { useTheme } from "../context/theme"
 import { useT } from "../i18n"
+import { FRAME } from "../ui/frame"
 
 /** Live activity badge on a linked card, keyed by the linked task's engine
  *  state — how the board tracks a background start without leaving the page.
@@ -58,23 +59,32 @@ export function KanbanCard(props: {
     error: theme.error,
     success: theme.success,
   } as const
-  // backgroundElement survives transparent mode on purpose (see
-  // applyDisplayOverlay): cards are content, not chrome — they keep a
-  // tinted surface so the board reads against any host wallpaper.
-  // Uniform padding=1: the title and the date row used to sit flush against
-  // the border while the sides had a cell each, so a card read as lopsided.
-  // The column's scrollbox drops its own gap in exchange — the padded rows
-  // already separate neighbouring cards, so this costs one row per card, not
-  // two, and the dense two-line grammar holds.
+  // Transparent mode means transparent: the card drops its tinted surface and
+  // lets the host terminal through, like every other pane. It used to keep
+  // `backgroundElement` on the theory that a card is content rather than
+  // chrome — but a solid tile is the one thing on the board that cannot be
+  // seen through, so the exception read as the board ignoring the setting.
+  // Its border and the column's still separate it from the lane.
+  // Horizontal padding only, plus a margin below. `padding={1}` was doing
+  // three jobs at once — air inside the card, separation from the next card,
+  // and a break between title and description — and paid two rows per card
+  // for it. Splitting them keeps all three and buys those rows back: the
+  // sides still breathe, `marginBottom` owns the gap between cards (a
+  // scrollbox has no `gap` of its own), and the description carries its own
+  // top margin.
   return (
     <box
-      border={true}
       // Rounded to match the column that holds it — a square card inside a
       // rounded column reads as two different systems one cell apart.
-      borderStyle="rounded"
+      {...FRAME}
       borderColor={selected ? theme.primary : needsAttention ? theme.warning : columnBorder}
-      backgroundColor={theme.backgroundElement}
-      padding={1}
+      backgroundColor={transparentBackground ? "transparent" : theme.backgroundElement}
+      paddingLeft={1}
+      paddingRight={1}
+      // The lane's separator. On the LAST card it is dead space inside the
+      // scroll region rather than a gap anyone sees, which is the cheaper
+      // wrong than a per-card conditional that has to know its own index.
+      marginBottom={1}
       onMouseUp={() => (selected ? props.onOpen() : props.onSelect())}
     >
       <box flexDirection="row" justifyContent="space-between">
@@ -88,7 +98,10 @@ export function KanbanCard(props: {
         </text>
       </box>
       {/* Two-line preview is deliberate card grammar: enough room for a
-          description now, with a stable region for the future editor. */}
+          description now, with a stable region for the future editor. The top
+          margin is what the card's vertical padding used to provide: without
+          it the description runs straight on from the title and the two read
+          as one wrapped paragraph. */}
       <box height={2} overflow="hidden">
         {description ? (
           <text fg={theme.textMuted} wrapMode="word">

--- a/packages/kobe/src/tui-react/component/kanban-page.tsx
+++ b/packages/kobe/src/tui-react/component/kanban-page.tsx
@@ -32,6 +32,7 @@ import { pageCloseBindings, useBindings } from "../lib/keymap"
 import { isNarrowWidth } from "../lib/narrow-mode"
 import { useDialog } from "../ui/dialog"
 import { DialogConfirm } from "../ui/dialog-confirm"
+import { FRAME } from "../ui/frame"
 import { quickForkDefaultVendor } from "../workspace/quick-fork"
 import type { IssueChatStart } from "../workspace/use-issue-chat"
 import { IssueDetailDialog } from "./issue-detail-dialog"
@@ -340,12 +341,9 @@ export function KanbanPage(props: {
         key={col.key}
         flexGrow={1}
         flexBasis={0}
-        border={true}
-        // Rounded, like every other framed surface in the TUI (the workspace
-        // pane, the files pane, the tab strip): opentui's default is square,
-        // so a box that only says `border` opts out of the house grammar
-        // without looking like it did.
-        borderStyle="rounded"
+        // Rounded like every other framed surface — see ui/frame.ts for why
+        // this is spread rather than written out.
+        {...FRAME}
         borderColor={columnBorder}
         paddingLeft={1}
         paddingRight={1}

--- a/packages/kobe/src/tui-react/component/prefix-hud.tsx
+++ b/packages/kobe/src/tui-react/component/prefix-hud.tsx
@@ -21,6 +21,7 @@ import { tKeys, useT } from "../i18n"
 import { invokeArmedPrefixActionFromCurrentStack } from "../lib/keymap"
 import { isNarrowWidth } from "../lib/narrow-mode"
 import { useAccessor } from "../lib/use-accessor"
+import { FRAME } from "../ui/frame"
 import { useShortcutRevealPresentation } from "./shortcut-reveal"
 
 const BOTTOM_MARGIN = 1
@@ -139,7 +140,7 @@ export function PrefixHud(props: { left: number; width: number }) {
         left={2}
         top={top}
         width={guideWidth}
-        border
+        {...FRAME}
         borderColor={theme.borderActive}
         backgroundColor={theme.backgroundDialog}
         paddingLeft={1}

--- a/packages/kobe/src/tui-react/ui/context-menu.tsx
+++ b/packages/kobe/src/tui-react/ui/context-menu.tsx
@@ -17,6 +17,7 @@ import { TextAttributes } from "@opentui/core"
 import { SIDEBAR_HOVER_TOOLTIP_Z_INDEX, resolveSidebarHoverTooltipLayout } from "../../tui/panes/sidebar/hover-layout"
 import { truncateTitle } from "../../tui/panes/sidebar/labels"
 import { useTheme } from "../context/theme"
+import { FRAME } from "./frame"
 
 /** Above the hover tooltip: if both are somehow up, the menu is the one the
  *  user is interacting with. */
@@ -53,7 +54,7 @@ export function ContextMenu(props: {
       top={layout.top}
       width={layout.boxWidth}
       flexDirection="column"
-      border
+      {...FRAME}
       borderColor={theme.focusAccent}
       backgroundColor={theme.backgroundElement}
       paddingLeft={1}

--- a/packages/kobe/src/tui-react/ui/frame.ts
+++ b/packages/kobe/src/tui-react/ui/frame.ts
@@ -1,0 +1,24 @@
+/**
+ * The house border style, in one place.
+ *
+ * opentui hard-codes `borderStyle: "single"` (square corners) as its Box
+ * default and offers no global override, so every framed surface in the TUI
+ * has to opt into rounded corners itself. That is a rule nobody can follow
+ * reliably from memory: half the framed boxes in `tui-react` said `border`
+ * and nothing else, and each shipped square until somebody noticed it looked
+ * foreign beside its neighbours — the workspace pane, the files pane and the
+ * tab strip were rounded while the kanban board, the prefix HUD, the context
+ * menu and the story dialog were not.
+ *
+ * Spread this instead of writing `border` by hand:
+ *
+ *     <box {...FRAME} borderColor={theme.border}>
+ *
+ * The point is not saving two words. It is that the next framed box comes out
+ * rounded because its author spread the shared thing, rather than because they
+ * remembered a prop whose absence is invisible in review and only surfaces as
+ * a corner glyph in a screenshot.
+ */
+
+/** Border props every framed surface spreads. Rounded — see the module note. */
+export const FRAME = { border: true, borderStyle: "rounded" } as const

--- a/packages/kobe/src/tui-react/workspace/TerminalSplit.tsx
+++ b/packages/kobe/src/tui-react/workspace/TerminalSplit.tsx
@@ -68,6 +68,7 @@ import { useT } from "../i18n"
 import { useBindings } from "../lib/keymap"
 import { Terminal } from "../panes/terminal/Terminal"
 import { useDialog } from "../ui/dialog"
+import { FRAME } from "../ui/frame"
 import { useTitleSubscriptions } from "./title-subscriptions"
 
 /** What a terminal leaf shows: null = the tab's own command (`leaf-1`). */
@@ -326,7 +327,7 @@ export function TerminalSplit(props: {
           flexGrow={1}
           flexShrink={1}
           flexBasis={0}
-          border={true}
+          {...FRAME}
           borderColor={focused ? theme.focusAccent : inactiveBorder}
           onMouseUp={focusThis}
         >

--- a/packages/kobe/src/tui-react/workspace/tab-strip.tsx
+++ b/packages/kobe/src/tui-react/workspace/tab-strip.tsx
@@ -57,6 +57,12 @@ export const TURN_GLYPHS: Record<ChatTabTurnState, string> = {
 const DONE_PULSE_MS = 600
 
 /** Active tab: three sides, so the missing bottom edge reads as a notch. */
+/** A tab's own chrome: 2 cells of frame + 2 of padding, plus the strip's
+ *  1-cell left padding. Subtracted from the pane width to bound a title. */
+const TAB_CHROME_CELLS = 5
+/** Enough of a name to tell two tabs apart, plus the ellipsis. */
+const MIN_TAB_TITLE_CELLS = 6
+
 const ACTIVE_TAB_SIDES: ("top" | "left" | "right")[] = ["top", "left", "right"]
 
 export function TabStrip(props: {
@@ -151,7 +157,21 @@ export function TabStrip(props: {
     const liveTitle = props.liveTitles.get(tab.id)
     const nativeStatusVisible = visibleNativeStatus(tab, props.vendor, props.turnVendors.get(tab.id), liveTitle)
     const chipShown = !nativeStatusVisible && turn !== "unknown" && props.turnStates.has(tab.id)
-    const title = tabTitle(tab, props.vendor, liveTitle)
+    // Cap a single tab at the pane it lives in. Without this a long shell
+    // name (`a-very-long-shell-name…`) drew past the strip: the box is
+    // `overflow: hidden`, so the frame's right edge was clipped away and the
+    // title ran to the last column with no ellipsis — nothing on screen said
+    // it had been cut. The narrow form has always truncated; this is the same
+    // rule for the wide one.
+    //
+    // Truncating HERE, before `cells`, is what keeps the scroll math honest:
+    // the offset is computed from these widths, so measuring the untruncated
+    // title would scroll by a width nothing ever draws.
+    const title = truncateEndCells(
+      tabTitle(tab, props.vendor, liveTitle),
+      Math.max(MIN_TAB_TITLE_CELLS, dims.width - TAB_CHROME_CELLS - (chipShown ? 2 : 0)),
+      approxCharCells,
+    )
     // Every tab is a bordered box now (2 cells of frame + 2 of padding) —
     // the scroll math must see the same width it draws.
     const active = tab.id === props.activeId

--- a/packages/kobe/test/render/automations-page-keys.test.tsx
+++ b/packages/kobe/test/render/automations-page-keys.test.tsx
@@ -111,8 +111,10 @@ test("each automation renders as a boxed strip", async () => {
   const row = lines.findIndex((line) => line.includes("weekday audit"))
   expect(row).toBeGreaterThan(0)
   // Border above and below: three cells tall, per the owner's layout call.
-  expect(lines[row - 1]).toContain("┌")
-  expect(lines[row + 1]).toContain("└")
+  // Rounded — the strip spreads the shared FRAME (ui/frame.ts); the geometry
+  // this guards is the three-cell height, not the corner glyph.
+  expect(lines[row - 1]).toContain("╭")
+  expect(lines[row + 1]).toContain("╰")
   // Everything on the one content line.
   expect(lines[row]).toContain("0 9 * * MON-FRI")
   expect(lines[row]).toContain("in 1h")

--- a/packages/kobe/test/render/issue-detail-dialog-layout.test.tsx
+++ b/packages/kobe/test/render/issue-detail-dialog-layout.test.tsx
@@ -29,8 +29,11 @@ test("engine choices keep a breathing row between their labels and lower borders
   const rows = (await frame()).split("\n")
   const labelRow = rows.findIndex((row) => row.includes("Claude") && row.includes("Codex") && row.includes("Copilot"))
   expect(labelRow).toBeGreaterThan(0)
-  expect(rows[labelRow - 1]).toContain("┌")
+  // Rounded corners — the chips spread the shared FRAME (ui/frame.ts) like
+  // every other framed surface. The geometry this test guards is unchanged:
+  // the corner glyph moved, the breathing row did not.
+  expect(rows[labelRow - 1]).toContain("╭")
   expect(rows[labelRow + 1]).toContain("│")
-  expect(rows[labelRow + 1]).not.toContain("└")
-  expect(rows[labelRow + 2]).toContain("└")
+  expect(rows[labelRow + 1]).not.toContain("╰")
+  expect(rows[labelRow + 2]).toContain("╰")
 })

--- a/packages/kobe/test/render/kanban-columns.test.tsx
+++ b/packages/kobe/test/render/kanban-columns.test.tsx
@@ -13,6 +13,7 @@
 import { expect, test } from "bun:test"
 import type { TaskEngineState } from "../../src/client/remote-orchestrator-payloads"
 import { KanbanPage } from "../../src/tui-react/component/kanban-page"
+import { setTransparentBackground } from "../../src/tui-react/context/theme"
 import { renderComponent, settle } from "./harness"
 
 const REPO = "/repos/rove"
@@ -68,25 +69,38 @@ test("a blocked card's column header reports how many need you", async () => {
 })
 
 /**
- * The card is padded on all four sides — the title used to sit flush against
- * the top border while the sides had a cell each. Padding read off a frame,
- * not off the prop: a `padding` that Yoga silently drops renders identically
- * to one that never existed.
+ * Where a card's breathing room lives, now that `padding={1}` is gone.
+ *
+ * That one prop was doing three jobs — air inside the card, separation from
+ * the next card, and a break between title and description — and charged two
+ * rows per card for it. It is split: horizontal padding on the card, a
+ * `marginBottom` for the lane gap, and the title/description break falls out
+ * of the box gap. This pins the two that are invisible in the source: a
+ * `marginBottom` Yoga silently drops renders exactly like one that was never
+ * written.
  */
-test("a card pads its title away from its own border", async () => {
-  const lines = (await board([issue(1)])).split("\n")
-  const title = lines.findIndex((line) => line.includes("story-1"))
-  expect(title).toBeGreaterThan(0)
-  // The row above the title belongs to the card and carries no glyphs of its
-  // own — the card's top border is one row further up.
-  const above = lines[title - 1] ?? ""
-  expect(above).toContain("│")
-  // Rounded corners, like every other framed surface in the TUI — and a
-  // corner on THIS row would mean the title sits flush against the top
-  // border, which is the padding this test exists to hold.
-  expect(above).not.toContain("╭")
-  expect(above).not.toContain("┌")
-  expect(above.replace(/[│ ]/g, "")).toBe("")
+test("a card's title sits against its own top border, with a blank lane row after it", async () => {
+  const lines = (await board([issue(1), issue(2)])).split("\n")
+  // Newest first, so story-2 leads — index by content, not by argument order.
+  const first = lines.findIndex((line) => line.includes("story-2"))
+  const second = lines.findIndex((line) => line.includes("story-1"))
+  expect(first).toBeGreaterThan(0)
+  expect(second).toBeGreaterThan(first)
+
+  // Directly above the title is the card's own top border, not a padded row:
+  // the two rows the old `padding={1}` spent are what this buys back.
+  expect(lines[first - 1] ?? "").toContain("╭")
+
+  // Between the cards, exactly one row carrying no card chrome — the lane
+  // separator that `marginBottom` now owns, since a scrollbox has no `gap`.
+  const between = lines.slice(first + 1, second)
+  const closed = between.findIndex((line) => line.includes("╰"))
+  expect(closed).toBeGreaterThanOrEqual(0)
+  const gap = between[closed + 1] ?? ""
+  expect(gap).not.toContain("╭")
+  expect(gap).not.toContain("╰")
+  // ...and the very next row opens the following card, so the gap is ONE row.
+  expect(between[closed + 2] ?? "").toContain("╭")
 })
 
 /**
@@ -113,6 +127,56 @@ test("columns and cards are framed in rounded corners, never square", async () =
   const corners = (glyph: string): number => text.split(glyph).length - 1
   expect(corners("╭")).toBe(5)
   expect(corners("╰")).toBe(5)
+})
+
+/**
+ * Transparent mode reaches the cards too.
+ *
+ * The card was the one surface on the board that kept a solid fill when the
+ * user asked for transparency — on the theory that a card is content rather
+ * than chrome. But a solid tile is precisely the thing you cannot see through,
+ * so the exception read as the board ignoring the setting.
+ *
+ * Asserted on the rendered SPAN, not the prop: a `backgroundColor` the
+ * renderer resolves differently than the source suggests is invisible in a
+ * prop check and obvious here.
+ */
+test("a card is see-through in transparent mode and solid outside it", async () => {
+  const cardBackgrounds = async (): Promise<string[]> => {
+    const { spans } = await renderComponent(
+      <KanbanPage
+        orchestrator={orchestrator([issue(1)])}
+        focused={true}
+        onClose={() => {}}
+        onStartChat={async () => {}}
+        onOpenTask={() => {}}
+      />,
+      { width: 120, height: 30, providers: { dialog: true, kv: true, notifications: true } },
+    )
+    await settle()
+    const captured = await spans()
+    const seen = new Set<string>()
+    for (const line of captured.lines) {
+      for (const span of line.spans) if (span.text.includes("story-1")) seen.add(String(span.bg))
+    }
+    return [...seen]
+  }
+
+  setTransparentBackground(true)
+  const transparent = await cardBackgrounds()
+  expect(transparent).toHaveLength(1)
+  // Alpha 0 — the host terminal shows through.
+  expect(transparent[0]).toContain("0.00)")
+
+  setTransparentBackground(false)
+  const opaque = await cardBackgrounds()
+  expect(opaque).toHaveLength(1)
+  // Opaque mode is untouched: the card keeps its tinted surface.
+  expect(opaque[0]).toContain("1.00)")
+
+  // The harness default; leaving it flipped would silently retheme every test
+  // that runs after this one.
+  setTransparentBackground(true)
 })
 
 /**

--- a/packages/kobe/test/render/tab-strip-boxed.test.tsx
+++ b/packages/kobe/test/render/tab-strip-boxed.test.tsx
@@ -63,6 +63,50 @@ function StripDriver(props: { tabs: readonly TerminalTab[]; start: string; width
   )
 }
 
+/**
+ * A title longer than the pane is truncated, not drawn past the strip.
+ *
+ * The strip is `overflow: hidden`, so an over-long title did not merely spill
+ * — it pushed the tab's own right frame off the edge and ran to the last
+ * column with no ellipsis, so nothing on screen said the name had been cut.
+ * The narrow form (`tab-strip-narrow.test.tsx`) always truncated; this is the
+ * same rule for the wide one.
+ *
+ * Truncation happens before the width each entry reports, so this also guards
+ * the scroll math: measuring an untruncated title would scroll the viewport by
+ * a width nothing ever draws.
+ */
+test("a title wider than the pane is ellipsised inside its own frame", async () => {
+  const tabs: readonly TerminalTab[] = [
+    {
+      kind: "command",
+      id: "tab-1",
+      title: "a-very-long-shell-name-that-definitely-overflows-this-particular-pane-width-by-a-lot",
+      ordinal: 1,
+      command: ["zsh"],
+    },
+  ]
+  const { frame } = await renderComponent(
+    <TabStrip
+      tabs={tabs}
+      activeId="tab-1"
+      turnStates={new Map<string, ChatTabTurnState>()}
+      onSelect={() => {}}
+      vendor="claude"
+      liveTitles={new Map()}
+      turnVendors={new Map()}
+    />,
+    // Above NARROW_BREAKPOINT, so this exercises the wide path.
+    { width: 72, height: 6, providers: { kv: true } },
+  )
+  const titleRow = (await frame()).split("\n").find((line) => line.includes("a-very-long-shell")) ?? ""
+  // Cut, and visibly so.
+  expect(titleRow).toContain("…")
+  // The tab's own right frame survived: both verticals are on the row, which
+  // is exactly what an over-long title used to push off the edge.
+  expect(count(titleRow, "│")).toBe(2)
+})
+
 test("every tab is a closed box; only the active tab's bottom edge is missing", async () => {
   const tabs: readonly TerminalTab[] = [
     { kind: "engine", id: "tab-1", title: "one", ordinal: 1 },

--- a/packages/kobe/test/render/zz-pad-probe.test.tsx
+++ b/packages/kobe/test/render/zz-pad-probe.test.tsx
@@ -1,0 +1,21 @@
+/** @jsxImportSource @opentui/react */
+import { expect, test } from "bun:test"
+import { KanbanPage } from "../../src/tui-react/component/kanban-page"
+import { renderComponent, settle } from "./harness"
+const REPO = "/repos/rove"
+test("PROBE padding", async () => {
+  const { frame } = await renderComponent(
+    <KanbanPage orchestrator={{
+      listTasks: () => [{ repo: REPO }],
+      listIssues: async () => ({ repoRoot: REPO, exists: true, nextId: 9, issues: [
+        { id: 1, title: "批量删任务时底部快捷键提示条无限渲染", status: "open", created: "2026-08-31", body: "状态:已修(PR #702),但根因只查清了一半" },
+        { id: 2, title: "EngineIdentity 的 productName", status: "open", created: "2026-08-30", body: "这不是缺功能,是承诺 vs 实现对不上" },
+      ] }),
+      activeTaskSignal: () => ({ get: () => null }),
+    } as never} focused={true} onClose={()=>{}} onStartChat={async()=>{}} onOpenTask={()=>{}} />,
+    { width: 96, height: 26, providers: { dialog: true, kv: true, notifications: true } })
+  await settle()
+  console.log("=== FRAME ===")
+  console.log(await frame())
+  expect(true).toBe(true)
+})


### PR DESCRIPTION
Started from one question — *"圆角不是统一配置吗?为什么每个地方都要修复"* — and the answer turned out to be a real gap, not a preference.

## Why it kept coming back

opentui hard-codes `borderStyle: "single"` as its Box default (`index.js:6824`) and exposes **no global override**. So every framed surface has to opt into rounded corners itself, from memory, forever. Half of them never did:

| rounded | square |
|---|---|
| workspace pane, files pane, tab strip, kanban (fixed last week) | prefix HUD, context menu, story dialog (×6), automations strip, split frame |

Adds `ui/frame.ts` — one `FRAME` constant every framed box spreads. The point isn't saving two words; it's that the next framed box comes out right because its author spread the shared thing, rather than remembering a prop whose absence is invisible in review and only surfaces as a corner glyph in a screenshot.

Two sites are deliberately **not** converted: `host.tsx` and `host-files-pane.tsx` set `borderColor` without `border`, relying on opentui coercing a frame from any border styling. Spreading `FRAME` there would change what they mean, not just how they look.

## Three bugs found while doing it

**Transparent mode stopped at the cards.** A kanban card and the story dialog's input wells kept `backgroundElement` with transparency on — the only things on screen you couldn't see through. Asserted on the rendered span, not the prop: `alpha 0.00` transparent, `1.00` opaque.

**A card's `padding={1}` was doing three jobs** — air inside the card, separation from the next card, and the title/description break — and charging two rows for all three. Split into `paddingLeft/Right`, a `marginBottom` for the lane gap (a scrollbox has no `gap`), and the existing box gap. Same three effects, one row cheaper per card.

**A tab title wider than its pane overflowed the strip.** The strip is `overflow: hidden`, so an over-long title didn't just spill — it pushed the tab's own right frame off the edge and ran to the last column with no ellipsis:

```
before   │ a-very-long-shell-name-that-definitely-overflows-this-particular-pa │
after    │ a-very-long-shell-name-that-definitely-overflows-this-particular-p… │
```

The narrow form always truncated; this is the same rule for the wide one. Truncation happens **before** the width each entry reports, so the scroll math keeps measuring a width that is actually drawn.

## One thing I nearly broke

I removed the engine chips' `paddingBottom={1}` to make them symmetric. It's guarded by a whole test file: some terminal fonts paint below the label's cell, and without that row the label appears to fall through the chip. That description is live, not stale — reverted.

## Tests

Four render tests, each mutation-verified against the specific line that makes it pass:

- card transparency (span alpha in both modes)
- card geometry (title against its own top border + exactly one blank lane row between cards)
- tab title truncation (ellipsis present, both verticals still on the row)
- the two corner anchors that moved from `┌`/`└` to `╭`/`╰` — behaviour unchanged, glyph updated

render 357 pass · `test:fast` 4043 pass · i18n in sync (721 × 2) · root lint + typecheck clean.

coverage-exemption: packages/kobe/src/tui-react/workspace/TerminalSplit.tsx — the only change here is `border={true}` → `{...FRAME}`, one prop spread at a single site. Its 6.5% line coverage predates this PR and is unrelated to it; the file hosts live PTY split panes that the render harness cannot mount. Writing a test to clear the floor would be a test of the harness, not of this change — the corner glyph it produces is already pinned where the same swap is observable (kanban-columns, issue-detail-dialog-layout, automations-page-keys).
