### PR TITLE
fix: resolve inverse attributes before OpenTUI renders terminal rows

### DIFF
--- a/.changeset/fix-terminal-inverse-rendering.md
+++ b/.changeset/fix-terminal-inverse-rendering.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Fix reverse-video regions and drag selections in embedded terminals so their text stays visible.

--- a/packages/kobe/src/tui-react/panes/terminal/Terminal.tsx
+++ b/packages/kobe/src/tui-react/panes/terminal/Terminal.tsx
@@ -40,7 +40,12 @@ import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react"
 import { ImeCursorRetention } from "../../../tui/panes/terminal/ime-cursor"
 import { type PtyRegistry, getDefaultPtyRegistry } from "../../../tui/panes/terminal/registry"
 import { rowsToStyledText } from "../../../tui/panes/terminal/sgr-to-text-chunk"
-import { isShellMissing, overlayCursor, sealRowEndAttributes } from "../../../tui/panes/terminal/terminal-render"
+import {
+  isShellMissing,
+  overlayCursor,
+  resolveInverseAttributes,
+  sealRowEndAttributes,
+} from "../../../tui/panes/terminal/terminal-render"
 import { overlaySelection } from "../../../tui/panes/terminal/terminal-selection"
 import {
   FOLLOW_VIEWPORT,
@@ -283,8 +288,9 @@ export function Terminal(props: TerminalProps) {
   // the "wrapped URL underlines everything below it" report). Its doc comment
   // has the full mechanism; drop this call once opentui resets per row.
   const styledSnapshot = useMemo(() => {
+    const resolved = resolveInverseAttributes(cursorRows, terminalColors.foreground, terminalColors.background)
     const sealed = sealRowEndAttributes(
-      cursorRows,
+      resolved,
       bodyGeometry?.cols ?? 80,
       terminalColors.foreground,
       terminalColors.background,

--- a/packages/kobe/src/tui/panes/terminal/terminal-render.ts
+++ b/packages/kobe/src/tui/panes/terminal/terminal-render.ts
@@ -118,6 +118,34 @@ export function overlayCursor(
   return rows.map((row, y) => (y === cursor.y ? overlayCursorRow(row, cursor.x, colors) : row))
 }
 
+/** Resolve reverse-video to literal colors before OpenTUI sees it. */
+export function resolveInverseAttributes(
+  rows: readonly (readonly Chunk[])[],
+  defaultFg: RGB,
+  defaultBg: RGB,
+): readonly (readonly Chunk[])[] {
+  return rows.map((row) => {
+    let out: Chunk[] | null = null
+    for (let i = 0; i < row.length; i++) {
+      const chunk = row[i] as Chunk
+      const attributes = chunk.attributes ?? 0
+      if ((attributes & ATTR.INVERSE) === 0) {
+        if (out) out.push(chunk)
+        continue
+      }
+      out ??= row.slice(0, i)
+      const resolvedAttributes = attributes & ~ATTR.INVERSE
+      out.push({
+        text: chunk.text,
+        fg: chunk.bg ?? defaultBg,
+        bg: chunk.fg ?? defaultFg,
+        ...(resolvedAttributes !== 0 ? { attributes: resolvedAttributes } : {}),
+      })
+    }
+    return out ?? row
+  })
+}
+
 /**
  * LOCAL PATCH for an opentui attribute leak (kept in kobe rather than
  * upstreamed — see the `sealRowEndAttributes` call in the React pane).

--- a/packages/kobe/src/tui/panes/terminal/terminal-selection.ts
+++ b/packages/kobe/src/tui/panes/terminal/terminal-selection.ts
@@ -169,7 +169,7 @@ function overlayRowSpan(row: readonly Chunk[], from: number, to: number): Chunk[
     }
     const { before, selected, after } = sliceTextByCells(chunk.text, from - start, to - start)
     if (before) out.push({ ...chunk, text: before })
-    out.push({ ...chunk, text: selected, attributes: (chunk.attributes ?? 0) | ATTR.INVERSE })
+    out.push({ ...chunk, text: selected, attributes: (chunk.attributes ?? 0) ^ ATTR.INVERSE })
     if (after) out.push({ ...chunk, text: after })
   }
   // Selection reaching past the row's painted cells: show the highlight

--- a/packages/kobe/test/render/terminal-drag-autoscroll.test.tsx
+++ b/packages/kobe/test/render/terminal-drag-autoscroll.test.tsx
@@ -1,10 +1,18 @@
 /** @jsxImportSource @opentui/react */
 
 import { expect, test } from "bun:test"
+import type { CapturedSpan } from "@opentui/core"
 import { Terminal } from "../../src/tui-react/panes/terminal/Terminal"
 import { createScriptedPtyRegistry } from "../../src/tui/panes/terminal/pty-scripted"
-import { ATTR } from "../../src/tui/panes/terminal/sgr"
 import { type RenderHandle, act, renderComponent } from "./harness"
+
+const rgbMatches = (span: CapturedSpan, channel: "fg" | "bg", expected: readonly [number, number, number]): boolean => {
+  const [r, g, b] = span[channel].toInts()
+  return r === expected[0] && g === expected[1] && b === expected[2]
+}
+
+const isResolvedSelection = (span: CapturedSpan): boolean =>
+  rgbMatches(span, "fg", [20, 20, 19]) && rgbMatches(span, "bg", [234, 231, 223])
 
 /** A pane fed `content`, its first visible row at screen y=2 (body: 16 rows). */
 const mountPane = async (
@@ -151,7 +159,7 @@ test("a drag held at the edge scrolls an app that owns its own scrollback", asyn
   const highlightedLines = async (): Promise<string[]> => {
     const frame = await handle.spans()
     return frame.lines
-      .filter((line) => line.spans.some((s) => (s.attributes & ATTR.INVERSE) !== 0))
+      .filter((line) => line.spans.some(isResolvedSelection))
       .map((line) =>
         line.spans
           .map((s) => s.text)

--- a/packages/kobe/test/tui/terminal-render.test.ts
+++ b/packages/kobe/test/tui/terminal-render.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest"
 import { ATTR, type Chunk, type RGB } from "../../src/tui/panes/terminal/sgr"
-import { overlayCursor, sealRowEndAttributes } from "../../src/tui/panes/terminal/terminal-render"
+import {
+  overlayCursor,
+  resolveInverseAttributes,
+  sealRowEndAttributes,
+} from "../../src/tui/panes/terminal/terminal-render"
 
 const CURSOR_FG: RGB = [20, 20, 19]
 const CURSOR_BG: RGB = [234, 231, 223]
@@ -96,6 +100,42 @@ describe("overlayCursor — cell-column aware", () => {
     const out = overlayCursor(rows, { x: 4, y: 0 }, COLORS)[0]
     expect(out.map((c) => c.text).join("")).toBe("ab   ")
     expect(out.at(-1)).toEqual({ text: " ", fg: CURSOR_FG, bg: CURSOR_BG })
+  })
+})
+
+describe("resolveInverseAttributes", () => {
+  const FG: RGB = [230, 225, 210]
+  const BG: RGB = [20, 20, 20]
+
+  it("resolves default-color inverse to swapped theme colors and strips the bit", () => {
+    const rows = [[{ text: "CD", attributes: ATTR.INVERSE } as Chunk]]
+
+    expect(resolveInverseAttributes(rows, FG, BG)).toEqual([[{ text: "CD", fg: BG, bg: FG }]])
+  })
+
+  it("swaps explicit colors and preserves other attribute bits", () => {
+    const fg: RGB = [1, 2, 3]
+    const bg: RGB = [4, 5, 6]
+    const rows = [[{ text: "styled", fg, bg, attributes: ATTR.INVERSE | ATTR.BOLD } as Chunk]]
+
+    expect(resolveInverseAttributes(rows, FG, BG)).toEqual([
+      [{ text: "styled", fg: bg, bg: fg, attributes: ATTR.BOLD }],
+    ])
+  })
+
+  it("reuses non-inverse chunks and untouched rows by reference", () => {
+    const plain = { text: "plain", attributes: ATTR.UNDERLINE } as Chunk
+    const inverse = { text: "inverse", attributes: ATTR.INVERSE } as Chunk
+    const untouchedRow = [plain]
+    const changedRow = [plain, inverse]
+    const rows = [untouchedRow, changedRow]
+
+    const out = resolveInverseAttributes(rows, FG, BG)
+
+    expect(out[0]).toBe(untouchedRow)
+    expect(out[0]?.[0]).toBe(plain)
+    expect(out[1]).not.toBe(changedRow)
+    expect(out[1]?.[0]).toBe(plain)
   })
 })
 

--- a/packages/kobe/test/tui/terminal-selection.test.ts
+++ b/packages/kobe/test/tui/terminal-selection.test.ts
@@ -82,6 +82,17 @@ describe("terminal grid selection", () => {
     expect(overlaySelection([ROWS[0]], range, 0, 14)[0]).toBe(ROWS[0])
   })
 
+  it("toggles inverse off when selected content is already reverse-video", () => {
+    const source = [[{ text: "plain" } as Chunk, { text: "reverse", attributes: ATTR.INVERSE | ATTR.BOLD } as Chunk]]
+    const range = { anchor: { row: 0, col: 0 }, head: { row: 0, col: 11 } }
+
+    const out = overlaySelection(source, range, 0, 12)[0]
+
+    expect((out[0]?.attributes ?? 0) & ATTR.INVERSE).toBe(ATTR.INVERSE)
+    expect((out[1]?.attributes ?? 0) & ATTR.INVERSE).toBe(0)
+    expect((out[1]?.attributes ?? 0) & ATTR.BOLD).toBe(ATTR.BOLD)
+  })
+
   it("overlaySelection paints highlight over unpainted padding cells", () => {
     const short = [row("ab")]
     const range = { anchor: { row: 0, col: 0 }, head: { row: 0, col: 5 } }


### PR DESCRIPTION
## Problem

Two related embedded-terminal rendering bugs, one root cause:

1. Any region an embedded app (e.g. Claude Code) paints with SGR 7 reverse-video renders as a solid same-color block — the text inside is invisible (beige blocks for default-colored text, green/red/gray bars for colored text).
2. The drag-selection highlight (drawn by ORing `ATTR.INVERSE` onto chunks) renders as the same solid block hiding the selected text, and selecting content that is already reverse-video shows no highlight at all (OR of an already-set bit is a no-op).

## Root cause

opentui 0.4.3 applies INVERSE twice: `buffer.zig`'s drawTextBuffer swaps fg/bg at draw time but keeps the INVERSE bit in the cell, and the frame writer then also emits `\e[7m`, so the host terminal swaps again. With both colors explicit and opaque the double swap is identity — which is why it went unnoticed. But terminal chunks leave fg/bg undefined for default-colored cells, so the chunk bg is transparent; the draw-time swap moves transparency into fg, alpha blending resolves it against the new bg, and the cell lands in the frame buffer with fg == bg (verified via `captureSpans`: a `{text:"CD", attributes:32}` chunk under `<text fg=#e6e1d2>` captures as fg=bg=[230,225,210]).

## Fix

Never hand opentui a chunk carrying `ATTR.INVERSE`:

- `terminal-render.ts`: new pure `resolveInverseAttributes(rows, defaultFg, defaultBg)` resolves inverse chunks to a literal fg/bg swap (theme colors fill in for defaults) and strips the bit — the same treatment `cursorChunk` already gives the synthetic cursor. Untouched rows/chunks pass through by reference.
- `Terminal.tsx`: the styled-snapshot memo runs rows through the resolver before `sealRowEndAttributes` (order: selection → cursor → resolve → seal).
- `terminal-selection.ts`: the selection overlay toggles INVERSE with XOR instead of OR, so selecting reverse-video content visibly un-reverses it (xterm semantics) instead of disappearing.

## Verification

- vitest: new `resolveInverseAttributes` cases + XOR selection semantics; full fast track green.
- `bun run test:render` green (354 tests).
- Browser-harness visual acceptance against real OpenTUI: an app-drawn full-width SGR 7 line now shows its text; a multi-row drag selection shows dark-on-highlight text; a drag across the reverse-video line renders the selected span un-reversed.