### PR TITLE
fix: kv set(key, undefined) deletes the key from the in-memory snapshot

### DIFF
--- a/.changeset/kv-undefined-delete-loop.md
+++ b/.changeset/kv-undefined-delete-loop.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Deleting a KV key (`set(key, undefined)`) now removes it from the in-memory snapshot instead of leaving it enumerable. A stale `terminalTabs.*` snapshot left the orphan sweep re-"deleting" the same key on every task-list change — each pass a new snapshot identity, which re-armed the sweep effect into an infinite setState loop and crashed the workspace with React #185.

--- a/packages/kobe/src/tui-react/context/kv-core.ts
+++ b/packages/kobe/src/tui-react/context/kv-core.ts
@@ -91,7 +91,20 @@ export function createKvCore(): KvCore {
       return store.get()[key] ?? defaultValue
     },
     set(key, value) {
-      store.update((s) => ({ ...s, [key]: value }))
+      // `undefined` DELETES: the key must leave the snapshot, not sit in it
+      // as an enumerable `undefined` — `sweepOrphanTabsSnapshots` walks
+      // `Object.keys` and re-deletes anything still present, and its effect
+      // re-runs on every kv identity change, so a spread-back key turned one
+      // sweep into an infinite setState loop (React #185, 2026-09-01). Disk
+      // already had delete semantics (patchStateFile drops explicit-undefined
+      // entries); this aligns the in-memory snapshot with it.
+      store.update((s) => {
+        if (value !== undefined) return { ...s, [key]: value }
+        if (!(key in s)) return s // already absent — no snapshot churn
+        const next = { ...s }
+        delete next[key]
+        return next
+      })
       dirtyKeys.add(key)
       scheduleWrite()
     },

--- a/packages/kobe/test/tui-react/kv-core.test.ts
+++ b/packages/kobe/test/tui-react/kv-core.test.ts
@@ -86,6 +86,25 @@ describe("createKvCore", () => {
     expect(readState(home)).toEqual({ kept: 2 })
   })
 
+  it("set(key, undefined) removes the key from the in-memory snapshot", () => {
+    // React #185 (2026-09-01): the spread `{ ...s, [key]: undefined }` kept
+    // the deleted key ENUMERABLE in the snapshot, so the orphan sweep
+    // (`sweepOrphanTabsSnapshots`, which walks Object.keys and re-deletes)
+    // re-set it on every task-list change — each set a new snapshot identity,
+    // each identity a re-run of the sweep effect: an infinite setState loop
+    // that crashed the workspace whenever a stale `terminalTabs.*` key
+    // existed. Deletion must actually shrink Object.keys.
+    isolatedHome({ "terminalTabs.dead": { tabs: [] }, kept: 1 })
+    const kv = createKvCore()
+    kv.set("terminalTabs.dead", undefined)
+    expect(Object.keys(kv.snapshot())).toEqual(["kept"])
+    // Idempotent: deleting an absent key must not mint a new snapshot
+    // identity (that identity churn is what re-armed the sweep effect).
+    const before = kv.snapshot()
+    kv.set("terminalTabs.dead", undefined)
+    expect(kv.snapshot()).toBe(before)
+  })
+
   it("seed() is visible in memory but never persisted", () => {
     const home = isolatedHome({ existing: "x" })
     const kv = createKvCore()


### PR DESCRIPTION
## 症状

Owner 报告 (2026-09-01):TUI 反复崩溃,`client.log` 里成对出现:

- `dropped attention.inbox event: malformed item`(items 里带 `state: "dead"` — 老版本客户端不认识这个 state,drop 是正确防御,只是日志噪音)
- `pane-crash … Minified React error #185`(Maximum update depth exceeded)

崩溃栈解出来是:`kv.set`(kv-core)→ `dl`(= `sweepOrphanTabsSnapshots`)→ `use-workspace-selection` 的 sweep effect。

## 根因

`kv-core.set(key, undefined)` 用 `{ ...s, [key]: undefined }` 写快照——key 仍然**可枚举**地留在快照里。而 `sweepOrphanTabsSnapshots` 走 `Object.keys(kv.store)` 找孤儿 `terminalTabs.*` 并逐个 `kv.set(key, undefined)`,它的 effect 依赖 `[tasks, kv]`,`kv` context value 又按快照身份重建。于是:

1. sweep 删孤儿 key → 快照换身份(key 还在)
2. KVProvider 重建 context → effect 依赖变 → sweep 再跑
3. `Object.keys` 里那个 key 还在 → 再 set → 回到 1

React 数到 50 层就抛 #185。磁盘侧本来就是删除语义(`patchStateFile` 丢 explicit-undefined),只有内存快照不一致。

#678 把 sweep 从「每 session 一次」改成「每次 task 列表变都跑」之后,任何一个陈旧 `terminalTabs.*` key(比如另一个 client 删了 task)都会点着这个环——这也解释了为什么和 dir/main task 指到同一路径的场景一起出现:那个操作制造了 task 列表变更 + 孤儿快照。

## 修复

`set(key, undefined)` 真删 key(`delete next[key]`),且删除已缺席的 key 不再更换快照身份(`Object.is` 短路,effect 不再被重新武装)。

## 验证

- 新增回归测试锁 `Object.keys` 收缩 + 幂等身份;对未修复代码跑,正好死在该测试(变异验证)
- `bun run lint` / typecheck / `test:fast` 4044 pass / `bun test test/render` 357 pass

Closes #88 的实证一半:issue 里「仍然未知——崩溃那一刻究竟是哪个值在震荡」的答案就是这个可枚举的 undefined key。