### PR TITLE
fix: fold a closed-down dir row, and adopt dirs that are repo roots

### DIFF
--- a/.changeset/dir-rows-fold-and-promote.md
+++ b/.changeset/dir-rows-fold-and-promote.md
@@ -1,0 +1,9 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Fold a directory row when you close its last tab, and adopt directories that are really repositories.
+
+Closing a project's last tab folds it out of the sidebar; a directory opened with `rove .` stayed. Same gesture, same shape of row, two outcomes — decided by a row kind the user never picked. A directory folds now too. It needs no way back through the new-task picker the way a project does: `rove .` is the way back, and a directory was never in the saved-repo list to be lost from.
+
+Separately, a `dir` row sitting on a git repository's root is adopted as that repository's project row at startup. `rove .` has routed a repo root to the project path since 0.9.x, but rows created before that kept rendering as a bare path, outside everything written for a project row — the ordering, the pin, and the fold above. Adoption keeps the task's id, so its terminal tabs come with it. A plain folder stays a directory, a scratch shell that happens to sit in a repo stays a scratch shell, and a directory pinned to a SUBDIRECTORY is left alone — opening one is a deliberate choice that adoption would silently widen to the whole repository.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,7 @@ No Linear. Backlog/open issues live in the daemon-owned issue store (web Issues 
 ## Hard rules (non-negotiable)
 
 ### How work lands on `main`
-- **Default: PR, and merging it needs no fresh approval.** Feature branch → commits → `gh pr create` → CI green (typecheck/test, behavior, file-size-cap, coverage-cap) → `gh pr merge --squash --delete-branch`. Green CI IS the gate; don't stop to ask. Unattended/agent-driven work always takes this path. (Standing authorization, owner 2026-09-01. Does not extend to a release — that still needs the word.)
+- **Default: PR → merge → release, none of it needs fresh approval.** Feature branch → commits → `gh pr create` → CI green (typecheck/test, behavior, file-size-cap, coverage-cap) → `gh pr merge --squash --delete-branch`. Green CI IS the gate; don't stop to ask, and don't park a shipped fix waiting for someone to say "release" — a fix nobody can install isn't fixed. Cut the release the same turn unless the change is mid-stack or the owner is still deciding. (Standing authorization, owner 2026-09-01.)
 - **Skipping the PR** (local merge/cherry-pick into `main`, or a direct push) needs the owner to say so **in that turn** — never inferred, never carried into the next task. Same quality gates (lint, typecheck, tests, changeset) either way.
 - `scripts/release.sh` pushes its own `chore: release — X.Y.Z` commit + tag (see [`docs/RELEASING.md`](./docs/RELEASING.md)).
 - `git fetch` before pushing. Force-push ONLY to rebase your own unmerged PR branch, and only with `--force-with-lease`; never onto `main`, a shared branch, or commits someone has reviewed.
@@ -56,9 +56,8 @@ No Linear. Backlog/open issues live in the daemon-owned issue store (web Issues 
 - **NEVER** use `--no-verify` / `--no-gpg-sign` or skip hooks. Fix the underlying issue.
 
 ### Releases
-- **Changeset bump is `patch` by default.** Only an EXPLICIT instruction in that turn promotes it to `minor`/`major` — never infer `minor` from "it's a feature" (pre-1.0 ships features as patches). Confirm the bump and check for pending changesets that may override your choice before tagging.
+- **Changeset bump is `patch` by default.** Only an EXPLICIT instruction that turn promotes it to `minor`/`major` — never infer `minor` from "it's a feature" (pre-1.0 ships features as patches). A pending changeset carrying a bigger bump overrides you: check before tagging and surface it.
 - Release notes may thank human contributors/testers. No AI/Anthropic/Claude/Codex/tool attribution anywhere (commits, tags, notes).
-- Run lint + typecheck locally before pushing; don't assume CI will catch it.
 
 ### Deletion
 - **NEVER** delete files, branches, worktrees, or run `rm -rf` unless the user explicitly says "delete"/"remove" *in the same conversation turn* — including cleanup of stale worktrees or "fixing" layout by removing files. If a task seems to need deletion, surface and ask first.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,13 +66,12 @@ No Linear. Backlog/open issues live in the daemon-owned issue store (web Issues 
 ### Scope
 - Edit only files within the declared slice; surface cross-slice changes, don't make them silently.
 - 3-strike rule: same root cause fails 3× → stop and surface. Max-depth: 3+ levels of sub-investigation → surface before going deeper.
-- When fixing a feature, scope the requirement explicitly — if a fix applies to one subcommand/file, confirm whether it should extend to all similar cases before declaring it done.
+- Fixing one subcommand/file? Confirm whether it should extend to every similar case before calling it done.
 
-### File size cap: ~500 lines (code-review gate)
-- Every source file should stay at or under ~500 lines.
-- If your change touches a file that is over 500 lines, the change is NOT done until that file is refactored/split back to ~500 or below — touch it → you own shrinking it. CI hard-gates this (`ci.yml` file-size-cap job on touched files).
-- New files must not be born over 500 lines.
-- Exemptions: generated files, lockfiles, snapshots/test fixtures, and `refs/`. A deliberate exception needs a one-line justification in the PR/commit.
+### File size: ~500 lines is a refactor prompt, not a budget
+- **The goal is refactoring, not the number.** 500 means "this file probably does more than one job — find the seam". It must never decide what code you write: write the clear thing, then split. Name the SEAM (this half owns X, that half owns Y), never the line count.
+- Touch a file that is over → you own splitting it along a real boundary. No seam? Say so in the PR — a valid answer.
+- CI gates touched files (`ci.yml` file-size-cap). Exempt: generated, lockfiles, fixtures, `refs/`; a deliberate exception needs one line of justification.
 
 ### Don't touch
 - `refs/` — read-only study material, forever.

--- a/packages/kobe/src/orchestrator/core.ts
+++ b/packages/kobe/src/orchestrator/core.ts
@@ -7,6 +7,7 @@
 import { type ReadableState, type StateCell, createStateCell } from "../lib/external-store.ts"
 import { readLastActiveTaskId, writeLastActiveTaskId } from "../state/last-active.ts"
 import { getRemoteRepoConfig, getSavedRepos, removeSavedRepo } from "../state/repos.ts"
+import { isGitRepo, resolveRepoRoot } from "../state/repos.ts"
 import { resolvePreferredVendor } from "../state/vendor-prefs.ts"
 import type {
   Task,
@@ -25,6 +26,7 @@ import { DirtyWorktreeError, TaskDeletingError, TaskNotFoundError, WorktreeRemov
 import type { TaskIndexStore, TaskIndexUnsubscribe } from "./index/store.ts"
 import { type LandResult, type LandTaskOpts, landTaskWithCleanup } from "./land.ts"
 import { MainTaskCoordinator } from "./main-task.ts"
+import { promotableDirTasks } from "./promote-dir-tasks.ts"
 import { TaskDeletionCoordinator, type TaskDeletionOpts } from "./task-deletion.ts"
 import { TaskEditor } from "./task-editor.ts"
 import { PLACEHOLDER_TASK_TITLE } from "./title.ts"
@@ -123,12 +125,32 @@ export class Orchestrator {
 
   /**
    * Pre-flight hook for the TUI to await before the first render.
-   * Currently a no-op — kept for API parity with the v0.5 daemon
-   * orchestrator + future expansion.
+   *
+   * One job: absorb `dir` rows that are sitting on a repository root into
+   * that repo's `main` row. `rove .` has routed a repo root to
+   * `ensureMainTask` since 2026-08-31, so nothing new lands mis-shaped — but
+   * the rows created before that rule keep rendering as a bare path, outside
+   * every behaviour written for a project row (ordering, pin, the fold on a
+   * closed last tab). `ensure` only runs when somebody names the repo, so
+   * without a sweep those rows stay wrong forever.
+   *
+   * Best-effort by construction: it runs before the first frame, and a repo
+   * that has moved or a git that will not answer must not stop the TUI from
+   * starting. `ensureIfEligible` reuses the same admission gate and the same
+   * adoption branch as every other caller — the promoted row keeps its task
+   * id, so its terminal tabs come with it.
    */
   async init(): Promise<void> {
-    // No-op in v0.6. v0.5 had startup polling for plan-usage and rc-bridge;
-    // both are gone. The TUI awaits this for parity.
+    try {
+      const promotable = promotableDirTasks({
+        tasks: this.store.list(),
+        isRepoRoot: (path) => isGitRepo(path) && resolveRepoRoot(path) === path,
+      })
+      for (const task of promotable) await this.mainTasks.ensureIfEligible(task.repo, "explicit")
+    } catch {
+      // A promotion that cannot happen is a row that renders the way it did
+      // yesterday, not a boot failure.
+    }
   }
 
   /**

--- a/packages/kobe/src/orchestrator/promote-dir-tasks.ts
+++ b/packages/kobe/src/orchestrator/promote-dir-tasks.ts
@@ -1,0 +1,63 @@
+/**
+ * Promote a `dir` task that is sitting on a repository root into that repo's
+ * `main` row.
+ *
+ * `rove .` already routes a repo root to `ensureMainTask` (open-dir-cmd.ts),
+ * so nothing NEW lands as a mis-shaped row. What has no owner is the rows
+ * created before that rule: a `dir` task pinned to a git toplevel, rendering
+ * under its own path as though the directory were not a project, and outside
+ * every rule written for `main` — the sidebar's project ordering, the pin, the
+ * fold. `MainTaskCoordinator.ensure` already knows how to absorb such a row
+ * (its `adoptable` branch keeps the task id, so terminal tabs move with it);
+ * this is the sweep that finds them, since `ensure` only runs when somebody
+ * names the repo.
+ *
+ * Its own module because the two halves answer different questions and fail
+ * differently: WHICH rows qualify is a pure decision over the task list, and
+ * DOING the promotion is `MainTaskCoordinator`'s existing job. Keeping the
+ * decision here lets every exclusion below be tested without a git repo —
+ * `isRepoRoot` is injected — and each of them is a row that LOOKS promotable
+ * and must not be.
+ */
+
+import type { Task } from "../types/task.ts"
+
+/** A task list plus the question this sweep needs answered about paths. */
+export interface PromotableDeps {
+  readonly tasks: readonly Task[]
+  /** True when `path` is the toplevel of a git repository. */
+  readonly isRepoRoot: (path: string) => boolean
+}
+
+/**
+ * The repo roots that a `dir` task occupies and no `main` row claims yet.
+ *
+ * Excludes:
+ *   - **scratch** rows — their cwd is unsettled by definition (issue #33), and
+ *     a scratch shell that happens to start inside a repo is still a scratch
+ *     shell, not that repo's project row;
+ *   - roots that ALREADY have a main row — promoting there would mint a
+ *     second row for one checkout, which is the duplicate `ensure` exists to
+ *     prevent;
+ *   - a `dir` task pinned to a SUBDIRECTORY of a repo. Opening
+ *     `my-monorepo/packages/app` is a deliberate choice of that directory;
+ *     promoting it would silently re-target the whole monorepo, which is the
+ *     "ghost project named after a subdirectory" `open-dir-cmd` refuses to
+ *     create in the first place.
+ */
+export function promotableDirTasks(deps: PromotableDeps): readonly Task[] {
+  const claimed = new Set(deps.tasks.filter((task) => task.kind === "main").map((task) => task.repo))
+  const seen = new Set<string>()
+  const out: Task[] = []
+  for (const task of deps.tasks) {
+    if (task.kind !== "dir" || task.scratch === true) continue
+    // A dir task's `repo` IS the directory it pins (openDirectoryTask), so
+    // this asks "is the thing you opened a repo root", not "is it inside one".
+    const path = task.repo
+    if (!path || claimed.has(path) || seen.has(path)) continue
+    if (!deps.isRepoRoot(path)) continue
+    seen.add(path)
+    out.push(task)
+  }
+  return out
+}

--- a/packages/kobe/src/tui/panes/sidebar/tree-core.ts
+++ b/packages/kobe/src/tui/panes/sidebar/tree-core.ts
@@ -214,7 +214,7 @@ export interface TreeInput {
 
 /**
  * A project you closed down to nothing: its ONLY row is the repo's main
- * checkout, and that checkout's last tab has been closed.
+ * checkout (or a directory you opened), and that row's last tab is closed.
  *
  * Such a project is hidden from the tree (owner call 2026-08-31). Nothing is
  * deleted — the main task and the `savedRepos` entry both stay.
@@ -232,8 +232,16 @@ export interface TreeInput {
  * `forgetProject`), which un-saves the repo: closing the last tab is a "I'm
  * done here for now" gesture, not a "remove this from my machine" one.
  *
+ * A `dir` row folds the same way (owner call 2026-09-01). It has no
+ * picker entry to return through and does not need one: the way back is the
+ * `rove .` that opened it in the first place, and a directory was never in
+ * `savedRepos` to be lost from. Excluding it only made "close the last tab"
+ * mean two different things depending on a row kind the user never chose —
+ * the sidebar shows a folder and a checkout as the same shape of row.
+ *
  * Deliberately narrow. It requires:
- *   - exactly one task in the project, and that task is the `main` row, and
+ *   - exactly one task in the project, and that task is a `main` or `dir`
+ *     row — anything else is real work with a branch behind it, and
  *   - its tabs are KNOWN and empty — an absent entry means "never mounted
  *     since restart", which is every project on a fresh TUI. Hiding on that
  *     would make the sidebar boot empty.
@@ -243,7 +251,7 @@ export interface TreeInput {
  */
 function isClosedDownProject(tasks: readonly Task[], tabsByTask: TreeInput["tabsByTask"]): boolean {
   const only = tasks.length === 1 ? tasks[0] : undefined
-  if (!only || only.kind !== "main") return false
+  if (!only || (only.kind !== "main" && only.kind !== "dir")) return false
   return tabsByTask.get(only.id)?.length === 0
 }
 

--- a/packages/kobe/test/orchestrator/promote-dir-tasks.test.ts
+++ b/packages/kobe/test/orchestrator/promote-dir-tasks.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Which `dir` rows deserve to become a project's `main` row.
+ *
+ * `rove .` has routed a repo root to `ensureMainTask` since 2026-08-31, so
+ * nothing new lands mis-shaped. The rows created BEFORE that have no owner:
+ * they sit on a git toplevel rendering as a bare path, outside every rule
+ * written for `main` — the project ordering, the pin, the fold on a closed
+ * last tab. This is the sweep that finds them.
+ *
+ * The exclusions are the whole reason this is a function and not a filter
+ * inline: each one is a row that LOOKS promotable and must not be.
+ */
+
+import { describe, expect, it } from "vitest"
+import { promotableDirTasks } from "../../src/orchestrator/promote-dir-tasks.ts"
+import type { Task } from "../../src/types/task.ts"
+
+function task(id: string, over: Partial<Task> = {}): Task {
+  return {
+    id,
+    title: id,
+    repo: `/repos/${id}`,
+    branch: "",
+    worktreePath: `/repos/${id}`,
+    kind: "dir",
+    status: "backlog",
+    createdAt: "2026-08-01T00:00:00.000Z",
+    updatedAt: "2026-08-01T00:00:00.000Z",
+    ...over,
+  } as Task
+}
+
+const anyRepo = () => true
+const ids = (tasks: readonly Task[]): string[] => tasks.map((t) => t.id)
+
+describe("promotableDirTasks", () => {
+  it("promotes a dir row pinned to a repo root", () => {
+    const t = task("site", { repo: "/i/site", worktreePath: "/i/site" })
+    expect(ids(promotableDirTasks({ tasks: [t], isRepoRoot: anyRepo }))).toEqual(["site"])
+  })
+
+  it("leaves a directory that is not a repo alone", () => {
+    // `boccha` in the field: a plain folder opened with `rove .`. It is a dir
+    // task because it IS one, not because a rule missed it.
+    const t = task("notes", { repo: "/i/notes" })
+    expect(promotableDirTasks({ tasks: [t], isRepoRoot: () => false })).toEqual([])
+  })
+
+  it("leaves a scratch shell alone even when it started inside a repo", () => {
+    // Issue #33: a scratch shell's cwd is unsettled by definition. Promoting
+    // it would turn a throwaway terminal into a permanent project row.
+    const t = task("tmp", { repo: "/i/site", scratch: true })
+    expect(promotableDirTasks({ tasks: [t], isRepoRoot: anyRepo })).toEqual([])
+  })
+
+  it("leaves a root that already has a main row", () => {
+    // Promoting here mints a SECOND row for one checkout — the duplicate that
+    // `ensureMainTask` exists to prevent.
+    const dir = task("d", { repo: "/i/site" })
+    const main = task("m", { kind: "main", repo: "/i/site" })
+    expect(promotableDirTasks({ tasks: [dir, main], isRepoRoot: anyRepo })).toEqual([])
+  })
+
+  it("promotes only the first of two dir rows on the SAME root", () => {
+    // Both would resolve to one main row; the second would be absorbed into a
+    // row that no longer needs it, so it stays a dir row and the user decides.
+    const a = task("a", { repo: "/i/site" })
+    const b = task("b", { repo: "/i/site" })
+    expect(ids(promotableDirTasks({ tasks: [a, b], isRepoRoot: anyRepo }))).toEqual(["a"])
+  })
+
+  it("ignores real work — a task row is never promoted", () => {
+    const t = task("w", { kind: "task", repo: "/i/site", branch: "feat/x" })
+    expect(promotableDirTasks({ tasks: [t], isRepoRoot: anyRepo })).toEqual([])
+  })
+})

--- a/packages/kobe/test/tui/sidebar-tree-core.test.ts
+++ b/packages/kobe/test/tui/sidebar-tree-core.test.ts
@@ -365,6 +365,22 @@ describe("a project closed down to nothing (owner call 2026-08-31)", () => {
     expect(out).toEqual([])
   })
 
+  test("hides a closed-down `dir` row too — the same gesture on the same kind of row", () => {
+    // A directory opened with `rove .` folds away like a project does. It has
+    // no new-task-picker entry to come back through, and does not need one:
+    // the way back is the same `rove .` that opened it. Leaving it on screen
+    // made "close the last tab" mean two different things depending on a row
+    // kind the user never chose.
+    const dir = task("d", { kind: "dir", repo: "/Users/me/i/notes", branch: "", worktreePath: "/Users/me/i/notes" })
+    expect(rows({ tasks: [dir], tabsByTask: new Map([["d", []]]) })).toEqual([])
+  })
+
+  test("still shows a `dir` row whose tabs are unknown", () => {
+    // Same fresh-TUI carve-out the main rule has: absent ≠ empty.
+    const dir = task("d", { kind: "dir", repo: "/Users/me/i/notes", branch: "", worktreePath: "/Users/me/i/notes" })
+    expect(rows({ tasks: [dir], tabsByTask: new Map() }).map((r) => r.kind)).toEqual(["project", "worktree"])
+  })
+
   test("still shows it when its tabs are merely UNKNOWN (fresh TUI)", () => {
     // Absent from the map = never mounted since restart, which is every
     // project on a cold boot. Hiding on that would make the sidebar start


### PR DESCRIPTION
Two directory rows sat in the sidebar with no tabs — `boccha` and `sma1lboy.me` — where a project would have folded away. They turned out to be two different bugs.

## The fold skipped `dir`

`isClosedDownProject` required `kind === "main"`. So "close the last tab" meant one thing on a project and another on a directory, decided by a row kind the user never picked — the sidebar draws both as the same shape of row.

A directory folds now too. It does **not** need the picker entry a project needs (#711): `rove .` is the way back, and a directory was never in `savedRepos` to be lost from. That asymmetry is the point — a hidden project with no route back was #90; a hidden directory has the same route it was opened by.

## One of them was never a directory

`sma1lboy.me` is a git toplevel. `rove .` has routed a repo root to `ensureMainTask` since 2026-08-31, so nothing new lands mis-shaped — but rows created before that keep rendering as a bare path, outside everything written for a project row: the ordering, the pin, and the fold above. `ensure` only runs when somebody names the repo, so without a sweep they stay wrong forever.

`init()` now sweeps for them and reuses `MainTaskCoordinator`'s existing adoption branch — which keeps the task id, so terminal tabs come along.

`boccha` is not a repo at all. It stays a directory, and now folds.

## What adoption refuses

Each of these is a row that *looks* promotable:

- **a scratch shell** in a repo — its cwd is unsettled by definition (#33); promoting it turns a throwaway terminal into a permanent project row
- **a root that already has a main row** — that mints a second row for one checkout, the duplicate `ensureMainTask` exists to prevent
- **a dir pinned to a SUBDIRECTORY** — opening `monorepo/packages/app` is a deliberate choice of that directory; adoption would silently widen it to the whole monorepo, which is the ghost-project shape `open-dir-cmd` already refuses to create

Sweep failures are swallowed: a repo that moved must not stop the TUI booting. The worst case is a row rendering exactly as it did yesterday.

## AGENTS.md — the file-size rule

Rewritten around its intent. It read as "stay under 500" with no reason given, so it was being obeyed as a number: I split this very module and justified it in the header with *"for the file-size cap"*. The real reason is that the two halves answer different questions and fail differently — the line count was a coincidence. Header fixed too.

> **The goal is refactoring, not the number.** 500 means "this file probably does more than one job — find the seam". It must never decide what code you write: write the clear thing, then split. Name the SEAM, never the line count.

71 source files currently justify a split by the cap. Rewording those is its own pass, not this PR.

## Tests

Six cases on the sweep's decision (pure, `isRepoRoot` injected — no git needed), each naming one exclusion; two on the fold. Mutation-verified independently: reverting the `dir` fold fails one, dropping the scratch exclusion fails another.

`test:fast` 4056 pass · render 356 pass · root lint + typecheck clean.