### PR TITLE
docs: set-status is a label; delete is what closes a task

### DIFF
--- a/.agents/skills/kobe/SKILL.md
+++ b/.agents/skills/kobe/SKILL.md
@@ -344,7 +344,7 @@ logs, dashboards), don't scatter panes for work `add` should own.
 | `rename --task-id ID --title T` | Rename a task |
 | `set-branch --task-id ID --branch B` | Rename its branch |
 | `set-command --task-id ID --command CMD` | Change the engine launch command for the next launch |
-| `set-status --task-id ID --status S` | Set lifecycle status |
+| `set-status --task-id ID --status S` | Set the lifecycle LABEL (`backlog`/`in_progress`/`in_review`/`done`/`canceled`/`error`). Cosmetic: the row, its Worktree, its branch and its engine all stay. `canceled` does NOT close or clean up anything |
 | `pin --task-id ID [--pinned=false]` | Pin/unpin |
 | `set-active --task-id ID` / `--none` | Change shared active task |
 | `ensure-worktree --task-id ID` | Materialize without starting an engine |
@@ -353,12 +353,21 @@ logs, dashboards), don't scatter panes for work `add` should own.
 | `discover-adoptable --repo PATH` | Find untracked Worktrees |
 | `adopt --repo PATH --worktree PATH` | Import a Worktree |
 
-Once a task's work is merged, `delete` is the normal cleanup — the branch is
-git's durable record and survives. There is no "hide the row without
-deleting" verb anymore (`archive` was removed); a merged task you want out of
-the way is a `delete`, and its branch is still there if you need the history
-back. `--delete-branch` (or a dirty-worktree `--force`) still needs
-explicit user authorization.
+### "Close this task" means `delete`
+
+`delete` is the ONLY verb that ends a task: it removes the row and its
+Worktree, and the git branch survives as the durable record. `set-status
+canceled` is a label — the row, Worktree, branch and engine all stay, so a
+"close" done that way changes nothing the user can see. Reach for `delete`
+whether or not the work merged; an unmerged branch is still on disk
+afterwards, which is what makes this recoverable.
+
+There is no "hide the row without deleting" verb (`archive` was removed).
+
+**Deleting still needs the user to ask for it in that turn** — say what you
+would remove and wait. `--delete-branch` (or `--force` on a dirty Worktree)
+destroys the recoverable half and needs its own explicit authorization; the
+two flags are never implied by one another.
 
 ## Issue tracker
 

--- a/.changeset/skill-closing-a-task.md
+++ b/.changeset/skill-closing-a-task.md
@@ -1,0 +1,9 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Say plainly that `set-status canceled` closes nothing, and that `delete` is what ends a task.
+
+An agent asked to "close the finished tasks in this repo" set all six to `canceled` and reported them closed. Nothing had happened: the rows, worktrees, branches and engine sessions were all still there, and the sidebar looked exactly the same. The skill described that verb as "Set lifecycle status" and the API summary as "Set a task's lifecycle status" — neither said the status is a label with no effect on anything, so the verb whose value literally reads `canceled` was the obvious pick.
+
+Both now say what the verb does and does not do, and the skill's lifecycle section leads with the question an agent actually has: closing a task means `delete`, whether or not the work merged, and the git branch survives either way.

--- a/claude-plugin/skills/rove/SKILL.md
+++ b/claude-plugin/skills/rove/SKILL.md
@@ -344,7 +344,7 @@ logs, dashboards), don't scatter panes for work `add` should own.
 | `rename --task-id ID --title T` | Rename a task |
 | `set-branch --task-id ID --branch B` | Rename its branch |
 | `set-command --task-id ID --command CMD` | Change the engine launch command for the next launch |
-| `set-status --task-id ID --status S` | Set lifecycle status |
+| `set-status --task-id ID --status S` | Set the lifecycle LABEL (`backlog`/`in_progress`/`in_review`/`done`/`canceled`/`error`). Cosmetic: the row, its Worktree, its branch and its engine all stay. `canceled` does NOT close or clean up anything |
 | `pin --task-id ID [--pinned=false]` | Pin/unpin |
 | `set-active --task-id ID` / `--none` | Change shared active task |
 | `ensure-worktree --task-id ID` | Materialize without starting an engine |
@@ -353,12 +353,21 @@ logs, dashboards), don't scatter panes for work `add` should own.
 | `discover-adoptable --repo PATH` | Find untracked Worktrees |
 | `adopt --repo PATH --worktree PATH` | Import a Worktree |
 
-Once a task's work is merged, `delete` is the normal cleanup — the branch is
-git's durable record and survives. There is no "hide the row without
-deleting" verb anymore (`archive` was removed); a merged task you want out of
-the way is a `delete`, and its branch is still there if you need the history
-back. `--delete-branch` (or a dirty-worktree `--force`) still needs
-explicit user authorization.
+### "Close this task" means `delete`
+
+`delete` is the ONLY verb that ends a task: it removes the row and its
+Worktree, and the git branch survives as the durable record. `set-status
+canceled` is a label — the row, Worktree, branch and engine all stay, so a
+"close" done that way changes nothing the user can see. Reach for `delete`
+whether or not the work merged; an unmerged branch is still on disk
+afterwards, which is what makes this recoverable.
+
+There is no "hide the row without deleting" verb (`archive` was removed).
+
+**Deleting still needs the user to ask for it in that turn** — say what you
+would remove and wait. `--delete-branch` (or `--force` on a dirty Worktree)
+destroys the recoverable half and needs its own explicit authorization; the
+two flags are never implied by one another.
 
 ## Issue tracker
 

--- a/packages/kobe/src/cli/api/verbs-edit.ts
+++ b/packages/kobe/src/cli/api/verbs-edit.ts
@@ -32,7 +32,8 @@ export const EDIT_VERBS: readonly VerbSpec[] = [
   SET_COMMAND_VERB,
   {
     name: "set-status",
-    summary: "Set a task's lifecycle status.",
+    summary:
+      "Set a task's lifecycle LABEL. Cosmetic — the task row, its worktree, its branch and its engine session all stay exactly as they are, so `--status canceled` does NOT close, stop, or clean up anything. To end a task use `delete` (which keeps the git branch).",
     flags: [
       F.taskId(),
       { name: "status", type: "enum", required: true, values: TASK_STATUSES, description: "New status." },


### PR DESCRIPTION
Asked to *"close the tasks in this repo that can be closed"*, an agent set all six to `canceled` and reported it done — noting, in its own words, that it had *"deleted nothing: the task rows, worktrees and branches are all still there."* Which is exactly right, and exactly why nothing was closed. The sidebar was unchanged.

## Why it picked that verb

Both surfaces an agent reads described `set-status` as a bare restatement of its own name:

```
skill table:   | set-status --task-id ID --status S | Set lifecycle status |
API summary:   "Set a task's lifecycle status."
```

Neither said the status is **cosmetic**. `TaskStatus` is one of six labels and nothing runtime reads it — `sidebar-row-view.test.ts` exists specifically to pin that "persisted lifecycle status never reaches the runtime row". So the verb whose value literally reads `canceled` was the obvious pick for "close", and nothing anywhere contradicted it.

The correct answer *was* in the skill, in prose under the table:

> Once a task's work is merged, `delete` is the normal cleanup…

Two problems with it. It is below a table an agent scans and stops at; and it is scoped to merged work, while all six of these were unmerged, PR-less and hundreds of commits behind main. Nothing in that sentence claims the unmerged case.

## Change

The table row now states the negative space, which is the part that was missing:

> Set the lifecycle LABEL (…). Cosmetic: the row, its Worktree, its branch and its engine all stay. `canceled` does NOT close or clean up anything

And the prose leads with the question rather than a caveat — `### "Close this task" means delete` — saying `delete` applies whether or not the work merged, and that the branch surviving is what makes it recoverable. The existing authorization requirements are kept and made explicit about the two flags not implying each other.

`rove api schema --verb set-status` gets the same correction, since an agent may reach that without the skill.

## Scope

`.agents/skills/kobe/SKILL.md` (npm tarball) and `claude-plugin/skills/rove/SKILL.md` (Claude Code plugin) are two shipped copies of one file, kept byte-identical by `claude-plugin.test.ts`. Both updated; that guard passes.

Docs + one summary string. `test:fast` 4056 pass, lint + typecheck clean.