### PR TITLE
docs: name the seam a split found, not the line count

### DIFF
--- a/.changeset/seam-not-line-count.md
+++ b/.changeset/seam-not-line-count.md
@@ -1,0 +1,11 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Module comments now name the seam a split found, not the line count that
+prompted it. 96 comments across 80 files said a module existed "for the
+file-size cap"; each was rewritten to state what the two halves each own —
+pure decision vs. side-effecting execution, local cache vs. network, data vs.
+behavior — or, where the split really was mechanical (the keybinding tables,
+the RPC handler registry grouped by wire-name prefix), to say so plainly
+rather than invent a boundary. Comments only; no code changed.

--- a/packages/kobe-daemon/src/daemon/activity-debug-dump.ts
+++ b/packages/kobe-daemon/src/daemon/activity-debug-dump.ts
@@ -1,6 +1,8 @@
 /**
- * `kobe api inspect`'s raw view of the activity registry — a pure projection,
- * split out of `activity-registry.ts` (file-size cap).
+ * `kobe api inspect`'s raw view of the activity registry — a pure projection
+ * of registry state, in its own module because it is a DIAGNOSTIC surface
+ * rather than part of the registry's job. Nothing in the daemon's behavior
+ * depends on it, and it may show fields the wire payload deliberately hides.
  *
  * Deliberately NOT the wire payload: a production bug report needs the fields
  * `engine-state` omits — the probe vendor, whether a lapse watchdog is armed,

--- a/packages/kobe-daemon/src/daemon/activity-reduce.ts
+++ b/packages/kobe-daemon/src/daemon/activity-reduce.ts
@@ -1,7 +1,11 @@
 /**
- * The engine-activity reducer + its policy constants/types — the pure half
- * of the daemon activity registry, split out of `activity-registry.ts`
- * (file-size cap). `activity-registry.ts` re-exports the public names so
+ * The engine-activity reducer + its policy constants/types — the pure half of
+ * the daemon activity registry. The seam is state: this file is
+ * `(state, event) → state` with nothing to mount, while `activity-registry.ts`
+ * holds the live map, the timers and the subscribers. That is what lets the
+ * state machine below be driven through every transition as plain values, and
+ * it is why the reducer can be shared across both packages at all — a stateful
+ * registry could not be. `activity-registry.ts` re-exports the public names so
  * existing importers keep one entry point.
  *
  * {@link reduceActivity} is the single definition of the activity state

--- a/packages/kobe-daemon/src/daemon/automation-contracts.ts
+++ b/packages/kobe-daemon/src/daemon/automation-contracts.ts
@@ -2,9 +2,9 @@
  * Scheduled automations ("routines") — the schedule record, its run history,
  * and the patch shape edits take.
  *
- * Split from `contracts.ts` at the file-size cap, along the seam that was
- * already there: nothing else in the daemon's contracts refers to these, and
- * they are the one group with their own store, runner, and RPC family.
+ * Their own module along a seam that was already there: nothing else in the
+ * daemon's contracts refers to these, and they are the one group with their
+ * own store, runner, and RPC family.
  */
 
 import type { VendorId } from "./contracts.ts"

--- a/packages/kobe-daemon/src/daemon/automation-dispatch.ts
+++ b/packages/kobe-daemon/src/daemon/automation-dispatch.ts
@@ -1,10 +1,10 @@
 /**
  * How ONE automation firing reaches an engine (issue #91).
  *
- * Split from `automation-runner.ts` (file-size cap) along a real seam: the
- * runner owns WHEN a schedule fires, this owns WHERE the prompt lands. Both
- * stay well under the cap, and the four delivery paths below are testable
- * without a clock.
+ * Its own module along a real seam: the runner owns WHEN a schedule fires,
+ * this owns WHERE the prompt lands. That is also what makes the four delivery
+ * paths below testable without a clock — none of them needs to know a schedule
+ * exists.
  *
  * Two shapes, chosen per routine by `Automation.persistentSession`:
  *

--- a/packages/kobe-daemon/src/daemon/contracts.ts
+++ b/packages/kobe-daemon/src/daemon/contracts.ts
@@ -3,9 +3,10 @@
 import type { ObservedLanguage } from "../prompts/observed-language.ts"
 import type { TaskRoutineLink } from "./automation-contracts.ts"
 
-// Automation ("routine") contracts live in their own module (file-size cap)
-// and are re-exported here: every existing importer names them through
-// `contracts.ts`, and the split is a file boundary, not an API change.
+// Automation ("routine") contracts live in their own module — nothing else in
+// this file refers to them, and they are the one group with their own store,
+// runner, and RPC family. Re-exported here so every existing importer still
+// names them through `contracts.ts`.
 export type {
   Automation,
   AutomationPatch,

--- a/packages/kobe-daemon/src/daemon/handlers-task.ts
+++ b/packages/kobe-daemon/src/daemon/handlers-task.ts
@@ -1,10 +1,15 @@
 /**
- * `task.*` (+ `project.forget`) daemon RPC handlers — split out of
- * `handlers.ts` (which was over the repo's 500-line file-size cap) purely
- * mechanically: same entries, same behavior, moved verbatim. See
- * `handlers.ts`'s doc comment for the registry's wire-compatibility
- * contract (byte-equivalent payloads, key order load-bearing) — unchanged
- * here.
+ * `task.*` (+ `project.forget`) daemon RPC handlers — the `task.` slice of the
+ * one registry, spread back into it by `handlers.ts`.
+ *
+ * The cut follows the RPC name prefix and nothing deeper: which file a handler
+ * lives in is decided by its wire name, so this is a long registry grouped by
+ * namespace rather than a responsibility boundary. Adding a `task.*` handler
+ * here and a `ui.*` one in `handlers-ui.ts` are the same edit.
+ *
+ * What the split does NOT relax: see `handlers.ts`'s doc comment for the
+ * registry's wire-compatibility contract (byte-equivalent payloads, key order
+ * load-bearing). Moving a handler between files must never change either.
  */
 
 import { logDaemonError } from "./crash-log.ts"

--- a/packages/kobe-daemon/src/daemon/handlers-ui.ts
+++ b/packages/kobe-daemon/src/daemon/handlers-ui.ts
@@ -2,10 +2,12 @@
  * UI-facing daemon RPC handlers — the broadcast/report family the TUI and
  * plugin CLI drive (`session.deliver`, `ui.reportEvent`, `tab.open`,
  * `notice.send`, `note.file`) plus the host-dialog prompt pair
- * (`ui.prompt` / `ui.promptReply`). Split out of `handlers.ts` for the
- * repo's 500-line file-size cap; see its doc comment for the registry's
- * wire-compatibility contract (byte-equivalent payloads, key order
- * load-bearing) — unchanged here.
+ * (`ui.prompt` / `ui.promptReply`). Like `handlers-task.ts`, this is the slice
+ * of the one registry that shares an RPC-name prefix — grouped by wire
+ * namespace, not by a responsibility boundary — spread back in by
+ * `handlers.ts`. See its doc comment for the registry's wire-compatibility
+ * contract (byte-equivalent payloads, key order load-bearing), which moving a
+ * handler between files must never change.
  */
 
 import { randomUUID } from "node:crypto"

--- a/packages/kobe-daemon/src/daemon/handlers-worktree.ts
+++ b/packages/kobe-daemon/src/daemon/handlers-worktree.ts
@@ -1,9 +1,10 @@
 /**
  * `worktree.*` daemon RPC handlers.
  *
- * The first entries (`discoverAdoptable`/`adopt`) are
- * split out of `handlers.ts` (which was over the repo's 500-line file-size
- * cap). `worktree.reconcile` (adopt-on-`git worktree add`) was REMOVED
+ * The `worktree.` slice of the one registry, grouped by RPC-name prefix like
+ * `handlers-task.ts` / `handlers-ui.ts` and spread back in by `handlers.ts`.
+ *
+ * `worktree.reconcile` (adopt-on-`git worktree add`) was REMOVED
  * 2026-08-24: creation is mechanical, not intent — adoption now needs an
  * engine session-start in a managed root or an explicit `rove add .`/adopt.
  *

--- a/packages/kobe-daemon/src/daemon/handlers.ts
+++ b/packages/kobe-daemon/src/daemon/handlers.ts
@@ -304,10 +304,10 @@ export function createDaemonHandlerRegistry(): ReadonlyMap<DaemonRequestName, Da
       },
     },
     // `task.*` (+ `project.forget`) and `worktree.*` live in their own files
-    // (handlers-task.ts / handlers-worktree.ts) — split out to stay under
-    // the repo's 500-line file-size cap. Entry ORDER here doesn't affect any
-    // individual response's byte shape (only within-object key order is
-    // wire-load-bearing), so grouping them via spread is safe.
+    // (handlers-task.ts / handlers-worktree.ts), grouped by RPC-name prefix —
+    // a file boundary, not a responsibility one. Entry ORDER here doesn't
+    // affect any individual response's byte shape (only within-object key
+    // order is wire-load-bearing), so grouping them via spread is safe.
     ...TASK_HANDLERS,
     ...WORKTREE_HANDLERS,
     ...ATTENTION_HANDLERS,

--- a/packages/kobe-daemon/src/daemon/pty-child-controller.ts
+++ b/packages/kobe-daemon/src/daemon/pty-child-controller.ts
@@ -1,11 +1,12 @@
 /**
  * PtyChildController — owns one hosted session's child process lifecycle.
  *
- * Split from `pty-host.ts` for the file-size cap. This module is responsible
- * for starting a PTY child, feeding its output bytes into the session's ring
- * buffer + narrow OSC scans, observing its exit, and tearing it down. It does NOT
- * know about the host's session map, client sinks, or freeze policy — those
- * stay in `PtyHost`.
+ * The seam is ONE session versus ALL of them. This module starts a PTY child,
+ * feeds its output bytes into that session's ring buffer + narrow OSC scans,
+ * observes its exit and tears it down — and deliberately knows nothing of the
+ * host's session map, client sinks, or freeze policy, which are all questions
+ * about the set. Keeping the per-child work free of that means a bug here can
+ * only damage one session.
  */
 
 import { resolveLoginShell } from "./platform-shell.js"

--- a/packages/kobe-daemon/src/daemon/pty-host-types.ts
+++ b/packages/kobe-daemon/src/daemon/pty-host-types.ts
@@ -1,5 +1,6 @@
-/** PtyHost's public contract types — split from `pty-host.ts` for the
- *  file-size cap; behavior and ownership stay with the host. */
+/** PtyHost's public contract types. Their own module so a caller can name what
+ *  it sends the host without importing the host itself — behavior and
+ *  ownership stay there; this is only the vocabulary. */
 
 import { StringDecoder } from "node:string_decoder"
 import type { DaemonFrame, PtySessionExit } from "./protocol.ts"

--- a/packages/kobe-daemon/src/daemon/pty-host.ts
+++ b/packages/kobe-daemon/src/daemon/pty-host.ts
@@ -85,7 +85,8 @@ export class PtyHost {
   private readonly humanWriteQuietMs: number
   private parkRestoreDeltas = 0
   private parkRestoreFallbacks = 0
-  /** One session's child-process lifecycle (split out for the file-size cap). */
+  /** One session's child-process lifecycle — `pty-child-controller.ts` owns a
+   *  SINGLE child; this class owns the set of them. */
   private readonly childController: PtyChildController
   /** The one warm-spare shell slot (see `pty-warm.ts`). */
   private readonly warmSpare: WarmSpare

--- a/packages/kobe-daemon/src/daemon/pty-protocol.ts
+++ b/packages/kobe-daemon/src/daemon/pty-protocol.ts
@@ -1,7 +1,9 @@
 /**
- * PTY protocol payloads — split out of `protocol.ts` to keep that file under
- * the ~500 line cap. These types travel on the standalone PTY host socket
- * (v4 protocol) and are re-exported from `protocol.ts` for existing callers.
+ * PTY protocol payloads. Their own module because they travel on a DIFFERENT
+ * socket than the rest of `protocol.ts`: the standalone PTY host's v4
+ * protocol, which is versioned and restarted independently of the daemon. A
+ * change here is a compatibility question about that socket alone.
+ * Re-exported from `protocol.ts` for existing callers.
  */
 
 /** How a session's child ended — recorded at exit time by the PTY host.

--- a/packages/kobe-daemon/src/daemon/pty-termination.ts
+++ b/packages/kobe-daemon/src/daemon/pty-termination.ts
@@ -1,10 +1,10 @@
 /**
  * Ending a PTY child — the escalation, and the bounded waits around it.
  *
- * Split from `pty-host.ts` (file-size cap), and a separate concern besides:
- * nothing here knows what a session is, only how to make a process stop and
- * how long to wait for proof. Both helpers are pure over their arguments,
- * which is what makes the platform behaviour below testable without spawning.
+ * A separate concern from the host: nothing here knows what a session is, only
+ * how to make a process stop and how long to wait for proof. Both helpers are
+ * pure over their arguments, which is what makes the platform behaviour below
+ * testable without spawning.
  */
 
 import type { PtyChild } from "./pty-driver.ts"

--- a/packages/kobe-daemon/src/daemon/pty-warm.ts
+++ b/packages/kobe-daemon/src/daemon/pty-warm.ts
@@ -1,5 +1,9 @@
 /**
- * The warm-spare shell — split from `pty-host.ts` for the file-size cap.
+ * The warm-spare shell — a latency optimization, in its own file because it is
+ * an optional one: nothing in the host's correctness depends on the spare
+ * existing, and deleting this class would only make `open` slower. Isolating
+ * it keeps that true, and keeps a purely-for-speed policy from tangling into
+ * the session bookkeeping it must stay invisible to.
  *
  * One pre-initialized spare shell (`pty.warm`) is kept OUTSIDE the host's
  * session map — invisible to `list`/`sweepTasks`/`liveCount` (it must not

--- a/packages/kobe-daemon/src/daemon/server-options.ts
+++ b/packages/kobe-daemon/src/daemon/server-options.ts
@@ -1,9 +1,10 @@
 /**
  * Construction options + the handle `startDaemonServer` returns.
  *
- * Split out of `server.ts` (which was over the repo's 500-line file-size cap)
- * with no behavior change — both interfaces are re-exported from
- * `daemon/server` so every existing import path keeps working.
+ * Their own module so a caller can describe the server it wants without
+ * importing the server — these are the options `startDaemonServer` accepts and
+ * the handle it returns, no behavior. Both interfaces are re-exported from
+ * `daemon/server`, so every existing import path keeps working.
  */
 
 import type { DaemonClientConnection } from "./client-connection.ts"

--- a/packages/kobe-daemon/src/daemon/server.ts
+++ b/packages/kobe-daemon/src/daemon/server.ts
@@ -133,8 +133,8 @@ export async function startDaemonServer(orch: DaemonOrchestrator, options: Daemo
     broadcast(clients, { type: "event", name: event.channel, payload: event.payload })
   })
 
-  // Daemon-owned durable stores + the per-task teardown runner — created in
-  // stores.ts (split out of this file at the ~500-line cap); see initDaemonStores.
+  // Daemon-owned durable stores + the per-task teardown runner — CREATED in
+  // stores.ts, wired together here; see initDaemonStores.
   const {
     activity,
     inbox,

--- a/packages/kobe-daemon/src/daemon/stores.ts
+++ b/packages/kobe-daemon/src/daemon/stores.ts
@@ -1,8 +1,10 @@
 /**
- * Daemon-owned durable store wiring — split out of `server.ts` (which was at
- * the ~500-line cap) by responsibility: this module owns CREATING every
- * daemon-owned store plus the per-task teardown chain, so the composition root
- * only destructures the bag. Behavior is unchanged; the split is layout only.
+ * Daemon-owned durable store wiring, split from `server.ts` by responsibility:
+ * this module owns CONSTRUCTING every daemon-owned store plus the per-task
+ * teardown chain, and `server.ts` owns wiring them to the socket and its
+ * lifecycle. That keeps the composition root a place you can read the daemon's
+ * shape from, instead of a page of paths and constructor arguments — and it
+ * means adding a store is one edit here plus one name in the destructure.
  */
 
 import { readActivityLiveness } from "./activity-liveness.ts"

--- a/packages/kobe-daemon/src/daemon/subscribe.ts
+++ b/packages/kobe-daemon/src/daemon/subscribe.ts
@@ -5,8 +5,7 @@
  * (`subscribed`, `holdsLifetime`, `channels`), drives the gui-refcount
  * idle-grace timer, and writes event frames out-of-band during channel replay.
  * None of that fits the registry's payload→result shape, so it lives here
- * beside its own machinery instead (extracted from `server.ts` for the
- * file-size cap; behavior is unchanged).
+ * beside its own machinery instead of pretending to be a handler.
  */
 
 import type { DaemonActivityRegistry } from "./activity-registry.ts"

--- a/packages/kobe-daemon/src/daemon/web-server.ts
+++ b/packages/kobe-daemon/src/daemon/web-server.ts
@@ -135,8 +135,9 @@ function sseResponse(register: (send: SseSend) => () => void, signal?: AbortSign
 // Exposure policy comes FROM the handler registry (`web: true` per entry) —
 // no separately maintained allowlist to drift. Registry construction is
 // stateless/cheap, so deriving the set once at module load is fine.
-// Re-exported: this module is the web-exposure seam, and `server.ts` (the
-// usual re-export spot) is over the file-size cap.
+// Re-exported from here rather than the usual `server.ts`: this module IS the
+// web-exposure boundary, so the name every caller asks "is this reachable from
+// a browser?" through should come from the file that enforces it.
 export { webExposedRpcNames } from "./handlers.ts"
 export { requiresWebToken } from "./web-token.ts"
 const WEB_EXPOSED_RPCS = webExposedRpcNames(createDaemonHandlerRegistry())

--- a/packages/kobe/src/cli/api-cmd.ts
+++ b/packages/kobe/src/cli/api-cmd.ts
@@ -43,7 +43,7 @@
  * script does not have to babysit it (read-only verbs like `schema` skip
  * the daemon entirely).
  *
- * ## Module map (kept ≤500 lines each, this file is the dispatcher + barrel)
+ * ## Module map (one concern each; this file is the dispatcher + barrel)
  *   - `./api/types.ts`            — shared types (FlagSpec, VerbContext, ApiRuntime, ...) + ApiError
  *   - `./api/flags.ts`            — flag parsing/validation + VerbArgs + fan-out plan helpers
  *   - `./api/schema.ts`           — `schema` verb + `--help` rendering

--- a/packages/kobe/src/cli/api/handlers-add.ts
+++ b/packages/kobe/src/cli/api/handlers-add.ts
@@ -9,8 +9,12 @@
  * whole parallel contract (shared `groupId`, `#i/N` titles, per-sibling
  * failure rows, PARTIAL_FANOUT) applies unchanged from N=2 up.
  *
- * Split out of `handlers-tasks.ts` (file-size cap) rather than living beside
- * `send`: create-with-fleet is its own concern now.
+ * Its own module rather than living beside `send` in `handlers-tasks.ts`: the
+ * handlers there act on a task that already exists, while everything here is
+ * the create path and its parallel contract. That is also where the failure
+ * modes diverge — a `send` either lands or does not, whereas an `add --count`
+ * can half-succeed (PARTIAL_FANOUT), and that per-sibling bookkeeping is what
+ * this file exists to hold.
  */
 
 import type { SerializedTask } from "@sma1lboy/kobe-daemon/daemon/protocol"

--- a/packages/kobe/src/cli/api/handlers-engines.ts
+++ b/packages/kobe/src/cli/api/handlers-engines.ts
@@ -9,8 +9,11 @@
  * write twin: it resolves the command's protocol here (the preset registry
  * lives in kobe's state.json, which the daemon cannot read) and sends both.
  *
- * Spec + handler live together (the PANE_VERB pattern) so `verbs.ts` stays
- * under the file-size cap.
+ * Spec + handler live together (the PANE_VERB pattern) rather than the spec
+ * sitting in a `verbs-*.ts` group: these two read the engine preset registry,
+ * so keeping the flag list next to the code that consumes it is what stops the
+ * documented values and the accepted values drifting apart. `verbs.ts` imports
+ * the finished specs.
  */
 
 import { pluginEngineIds } from "../../engine/contrib-engines.ts"

--- a/packages/kobe/src/cli/api/handlers-tasks.ts
+++ b/packages/kobe/src/cli/api/handlers-tasks.ts
@@ -230,8 +230,9 @@ export async function dispatch(ctx: VerbContext): Promise<unknown> {
   }
 }
 
-/** The verb spec lives beside its handler (PANE_VERB pattern) so verbs.ts
- *  stays under the file-size cap. */
+/** The verb spec lives beside its handler (PANE_VERB pattern): the flag list
+ *  and the code that reads those flags change together, so they stay in one
+ *  file and `verbs.ts` imports the finished spec. */
 export const DISPATCH_VERB: VerbSpec = {
   name: "dispatch",
   summary:

--- a/packages/kobe/src/cli/api/read-output-page.ts
+++ b/packages/kobe/src/cli/api/read-output-page.ts
@@ -1,9 +1,13 @@
 /**
- * Pure paging/shaping half of `kobe api read-output` (split for the 500-line
- * cap): the envelope + cursor types, the deterministic page builders, and
- * the terminal-text shaping. No daemon, no PTY host, no vendor imports —
- * the read logic and the verb live in `read-output.ts`, which re-exports
- * this module so `@/cli/api/read-output` stays the one import site.
+ * Pure paging/shaping half of `kobe api read-output`: the envelope + cursor
+ * types, the deterministic page builders, and the terminal-text shaping.
+ *
+ * The seam is I/O. Nothing here talks to a daemon, a PTY host, or a vendor —
+ * it is messages in, page out — which is what makes the cursor round-trip and
+ * every byte/line boundary checkable against plain arrays, with no live
+ * session to stand up. Fetching those messages, and the verb itself, live in
+ * `read-output.ts`, which re-exports this module so `@/cli/api/read-output`
+ * stays the one import site.
  */
 
 import type { PtySessionExit } from "@sma1lboy/kobe-daemon/daemon/protocol"

--- a/packages/kobe/src/cli/api/read-output.ts
+++ b/packages/kobe/src/cli/api/read-output.ts
@@ -59,8 +59,10 @@ import {
 import { resolveActiveTaskId } from "./runtime.ts"
 import { ApiError, type VerbContext, type VerbSpec } from "./types.ts"
 
-// The paging/shaping half lives in `read-output-page.ts` (file-size cap);
-// re-exported so `@/cli/api/read-output` stays the one import site.
+// The paging/shaping half lives in `read-output-page.ts` — pure functions with
+// no daemon and no PTY host, so cursor and page-boundary behavior is testable
+// on plain arrays; this file keeps the reads that need a live daemon.
+// Re-exported so `@/cli/api/read-output` stays the one import site.
 export {
   boundedTail,
   buildHistoryPage,

--- a/packages/kobe/src/cli/api/verbs-automations.ts
+++ b/packages/kobe/src/cli/api/verbs-automations.ts
@@ -1,7 +1,10 @@
 /**
- * The `routine` verb group — daemon-owned scheduled agent tasks. Split out
- * of `verbs.ts` (file-size cap); spread back into the {@link VERBS} table
- * there, so schema/help/validation see one canonical list.
+ * The `routine` verb group — daemon-owned scheduled agent tasks: the schedule
+ * that CREATES tasks, which is a different object from the tasks themselves.
+ * One file per `VERB_GROUPS` entry in `verbs.ts`, the taxonomy
+ * `rove api schema --group routine` prints; a verb missing from that table
+ * reports as group "other". Specs spread back into the {@link VERBS} table, so
+ * schema/help/validation see one canonical list.
  *
  * By default every firing creates a FRESH task (worktree + branch + engine
  * session) with the automation's prompt as its first message.

--- a/packages/kobe/src/cli/api/verbs-create.ts
+++ b/packages/kobe/src/cli/api/verbs-create.ts
@@ -1,7 +1,9 @@
 /**
- * The `create` verb group — spawning new Rove tasks. Split out of `verbs.ts`
- * (file-size cap); spread back into the {@link VERBS} table there, so
- * schema/help/validation see one canonical list.
+ * The `create` verb group — spawning new Rove tasks. One file per
+ * `VERB_GROUPS` entry in `verbs.ts`, because that taxonomy is what
+ * `rove api schema --group create` prints; a verb declared here but missing
+ * from that table reports as group "other". Specs spread back into the
+ * {@link VERBS} table, so schema/help/validation see one canonical list.
  */
 
 import { F, FANOUT_CAP } from "./flags.ts"

--- a/packages/kobe/src/cli/api/verbs-drive.ts
+++ b/packages/kobe/src/cli/api/verbs-drive.ts
@@ -1,7 +1,11 @@
 /**
  * The `drive` verb group — sending prompts, notes, panes, and UI notices to
- * tasks. Split out of `verbs.ts` (file-size cap); spread back into the
- * {@link VERBS} table there, so schema/help/validation see one canonical list.
+ * tasks: everything that acts on a RUNNING task without changing what the task
+ * is (that's `edit`) or whether it exists (`lifecycle`). One file per
+ * `VERB_GROUPS` entry in `verbs.ts` — that taxonomy is what
+ * `rove api schema --group drive` prints, so a verb declared here and left out
+ * of that table reports as group "other". Specs spread back into the
+ * {@link VERBS} table, so schema/help/validation see one canonical list.
  */
 
 import { F } from "./flags.ts"

--- a/packages/kobe/src/cli/api/verbs-edit.ts
+++ b/packages/kobe/src/cli/api/verbs-edit.ts
@@ -1,6 +1,9 @@
 /**
- * The `edit` verb group — mutating task metadata. Split out of `verbs.ts`
- * (file-size cap); spread back into the {@link VERBS} table there, so
+ * The `edit` verb group — mutating task METADATA (title, branch, command,
+ * status), as opposed to driving the running session (`drive`) or ending it
+ * (`lifecycle`). One file per `VERB_GROUPS` entry in `verbs.ts`, the taxonomy
+ * `rove api schema --group edit` prints; a verb missing from that table
+ * reports as group "other". Specs spread back into the {@link VERBS} table, so
  * schema/help/validation see one canonical list.
  */
 

--- a/packages/kobe/src/cli/api/verbs-feedback.ts
+++ b/packages/kobe/src/cli/api/verbs-feedback.ts
@@ -1,7 +1,10 @@
 /**
- * The `feedback` verb group — GitHub Discussions integration. Split out of
- * `verbs.ts` (file-size cap); spread back into the {@link VERBS} table there,
- * so schema/help/validation see one canonical list.
+ * The `feedback` verb group — GitHub Discussions integration, the one group
+ * that reaches an EXTERNAL service rather than the daemon. One file per
+ * `VERB_GROUPS` entry in `verbs.ts`, the taxonomy
+ * `rove api schema --group feedback` prints; a verb missing from that table
+ * reports as group "other". Specs spread back into the {@link VERBS} table, so
+ * schema/help/validation see one canonical list.
  */
 
 import { DEFAULT_FEEDBACK_CATEGORY_SLUG } from "../../lib/feedback.ts"

--- a/packages/kobe/src/cli/api/verbs-issues.ts
+++ b/packages/kobe/src/cli/api/verbs-issues.ts
@@ -1,7 +1,10 @@
 /**
- * The `issues` verb group — daemon-owned issue-store CRUD. Split out of
- * `verbs.ts` (file-size cap); spread back into the {@link VERBS} table
- * there, so schema/help/validation see one canonical list.
+ * The `issues` verb group — daemon-owned issue-store CRUD. Operates on the
+ * issue store, not on tasks, which is the whole reason it is its own group.
+ * One file per `VERB_GROUPS` entry in `verbs.ts`, the taxonomy
+ * `rove api schema --group issues` prints; a verb missing from that table
+ * reports as group "other". Specs spread back into the {@link VERBS} table, so
+ * schema/help/validation see one canonical list.
  */
 
 import { F } from "./flags.ts"

--- a/packages/kobe/src/cli/api/verbs-lifecycle.ts
+++ b/packages/kobe/src/cli/api/verbs-lifecycle.ts
@@ -1,7 +1,10 @@
 /**
- * The `lifecycle` verb group — pin, land, delete. Split out of `verbs.ts`
- * (file-size cap); spread back into the {@link VERBS} table there, so
- * schema/help/validation see one canonical list.
+ * The `lifecycle` verb group — pin, land, delete: the verbs that end a task's
+ * life or decide it survives, which is why they are worth naming apart from
+ * the metadata edits next door. One file per `VERB_GROUPS` entry in
+ * `verbs.ts`, the taxonomy `rove api schema --group lifecycle` prints; a verb
+ * missing from that table reports as group "other". Specs spread back into the
+ * {@link VERBS} table, so schema/help/validation see one canonical list.
  */
 
 import { F } from "./flags.ts"

--- a/packages/kobe/src/cli/api/verbs-read.ts
+++ b/packages/kobe/src/cli/api/verbs-read.ts
@@ -1,7 +1,17 @@
 /**
  * The `read` verb group — non-mutating queries over tasks, PTYs, and
- * diagnostics. Split out of `verbs.ts` (file-size cap); spread back into the
- * {@link VERBS} table there, so schema/help/validation see one canonical list.
+ * diagnostics.
+ *
+ * These files follow the `VERB_GROUPS` taxonomy in `verbs.ts`, which is not an
+ * internal detail: it's what `rove api schema --group read` prints. So a
+ * verb's group is stated TWICE — by which file declares it, and by its entry
+ * in `VERB_GROUPS` — and only the second one is what agents discover. Declare
+ * a verb here and forget the table and it silently reports as group "other".
+ *
+ * "Non-mutating" is the group's actual invariant, not just its label: a verb
+ * that writes anything belongs in `drive`/`edit`/`lifecycle`, because agents
+ * are told this group is safe to call for orientation. Specs spread back into
+ * {@link VERBS}, so schema/help/validation see one canonical list.
  */
 
 import { F } from "./flags.ts"

--- a/packages/kobe/src/cli/api/verbs-worktree.ts
+++ b/packages/kobe/src/cli/api/verbs-worktree.ts
@@ -1,7 +1,10 @@
 /**
- * The `worktree` verb group — materializing and adopting worktrees. Split out
- * of `verbs.ts` (file-size cap); spread back into the {@link VERBS} table
- * there, so schema/help/validation see one canonical list.
+ * The `worktree` verb group — materializing and adopting worktrees: the verbs
+ * that touch git rather than the task index. One file per `VERB_GROUPS` entry
+ * in `verbs.ts`, the taxonomy `rove api schema --group worktree` prints; a
+ * verb missing from that table reports as group "other". Specs spread back
+ * into the {@link VERBS} table, so schema/help/validation see one canonical
+ * list.
  */
 
 import { F } from "./flags.ts"

--- a/packages/kobe/src/cli/index-commands.ts
+++ b/packages/kobe/src/cli/index-commands.ts
@@ -2,10 +2,13 @@
  * Dynamic command dispatch entries for `src/cli/index.ts`.
  *
  * Heavy or rarely-used subcommands are dynamically imported so a bare
- * `kobe add` does not pull in the TUI, opentui, or plugin machinery. The
- * table is split out here to keep `index.ts` under the file-size cap; the
- * three inline handlers (`add`, `remove`, `adopt`) stay in `index.ts` and are
- * merged into the final table there.
+ * `kobe add` does not pull in the TUI, opentui, or plugin machinery. That is
+ * the seam this file draws, and the reason it holds only `import()` thunks:
+ * anything eagerly imported here is paid for on EVERY CLI invocation, so
+ * keeping the table apart from `index.ts` makes an accidental static import
+ * visible instead of buried in the entry point. The three cheap inline
+ * handlers (`add`, `remove`, `adopt`) stay in `index.ts` and are merged into
+ * the final table there.
  */
 
 export type CommandHandler = (args: string[]) => Promise<void>

--- a/packages/kobe/src/client/remote-orchestrator-connect.ts
+++ b/packages/kobe/src/client/remote-orchestrator-connect.ts
@@ -1,10 +1,14 @@
 /**
- * The daemon handshake for `RemoteOrchestrator.init()` — split out of
- * `remote-orchestrator.ts` (which was over the repo's 500-line file-size
- * cap) into its own file. Same behavior, moved verbatim: `performInit` is
- * the exact body of the old `RemoteOrchestrator.init`, now taking the
- * client + subscribe options + an explicit {@link OrchestratorSignals}
- * deps bag instead of closing over `this`.
+ * The daemon handshake for `RemoteOrchestrator.init()`, plus the reconnect
+ * loop below — the CONNECTION half of the class, apart from what it does once
+ * connected (`-reads.ts` / `-writes.ts` / `-events.ts`). This is the only code
+ * that runs while there may be no daemon at all.
+ *
+ * Taking the client + subscribe options + an explicit
+ * {@link OrchestratorSignals} deps bag instead of closing over `this` is what
+ * makes that testable: drive a handshake or a retry policy with fakes, no
+ * socket and no real backoff. Same behavior, moved verbatim — `performInit` is
+ * the exact body of the old `RemoteOrchestrator.init`.
  */
 
 import type { KobeDaemonClient } from "@sma1lboy/kobe-daemon/client"
@@ -30,8 +34,10 @@ export interface PerformInitOptions {
 
 /**
  * The reconnect loop body — moved verbatim from
- * `RemoteOrchestrator.runReconnectLoop` (file-size cap), taking an explicit
- * deps bag instead of closing over `this`. A GUI (`spawnDaemon`) may spawn
+ * `RemoteOrchestrator.runReconnectLoop`, taking an explicit deps bag instead
+ * of closing over `this` so the retry policy can be driven with fake clocks
+ * and a fake `init` — no daemon, and no waiting out real backoff. A GUI
+ * (`spawnDaemon`) may spawn
  * the daemon via `ensureReachable`; a pane only retries the existing socket
  * so helper panes never defeat daemon lazy-shutdown. Failures stay silent in
  * the UI with the caller-supplied bounded forensic logging policy.

--- a/packages/kobe/src/client/remote-orchestrator-events.ts
+++ b/packages/kobe/src/client/remote-orchestrator-events.ts
@@ -1,10 +1,15 @@
 /**
- * Daemon push-channel event handling for `RemoteOrchestrator` — split out
- * of `remote-orchestrator.ts` (which was over the repo's 500-line
- * file-size cap) into its own file. Same behavior, moved verbatim:
- * `handleOrchestratorEvent` is the exact body of the old
- * `RemoteOrchestrator.handleEvent`, now taking an explicit
- * {@link OrchestratorSignals} deps bag instead of closing over `this`.
+ * Daemon push-channel event handling for `RemoteOrchestrator` — the INBOUND
+ * direction, the one place the daemon drives us rather than the other way
+ * round. It is the third side of the same split: `-reads.ts` answers from the
+ * local cache, `-writes.ts` pushes RPCs out, and this is what keeps that cache
+ * true as the daemon reports changes.
+ *
+ * Taking an explicit {@link OrchestratorSignals} deps bag instead of closing
+ * over `this` is what makes that testable: hand it plain closures and drive
+ * event payloads through with no daemon and no class. Same behavior, moved
+ * verbatim — `handleOrchestratorEvent` is the exact body of the old
+ * `RemoteOrchestrator.handleEvent`.
  */
 
 import { logClientError } from "@sma1lboy/kobe-daemon/client/client-log"

--- a/packages/kobe/src/client/remote-orchestrator-payloads.ts
+++ b/packages/kobe/src/client/remote-orchestrator-payloads.ts
@@ -1,7 +1,11 @@
 /**
  * Wire-payload types + pure parse/decode/compare helpers for
- * `RemoteOrchestrator` — split out of `remote-orchestrator.ts` (which was
- * over the repo's 500-line file-size cap) purely mechanically: same
+ * `RemoteOrchestrator`.
+ *
+ * The seam is the wire: this file knows the daemon's payload SHAPES and
+ * nothing about the connection, so decoding a task or comparing two snapshots
+ * is checkable against literals with no socket in play. That also makes it the
+ * file the other three can all depend on without depending on each other. Same
  * types/functions, moved verbatim, re-exported from `remote-orchestrator.ts`
  * so existing importers (tests, `deserializeTask` callers) keep their path.
  *

--- a/packages/kobe/src/client/remote-orchestrator-reads.ts
+++ b/packages/kobe/src/client/remote-orchestrator-reads.ts
@@ -1,7 +1,12 @@
 /**
- * `RemoteOrchestrator`'s read surface — split out of `remote-orchestrator.ts`
- * (which was over the repo's 500-line file-size cap) into its own file; same
- * behavior/docs, moved verbatim (mirrors the `-writes.ts` split). The class
+ * `RemoteOrchestrator`'s read surface — and the seam against `-writes.ts` is
+ * the network: not one function in this file touches the daemon client. Every
+ * read is served from the locally replayed signal cache, so it is synchronous
+ * and cannot fail, while its `-writes.ts` twin is all RPC — async, and every
+ * call a place the socket can drop. Keeping them apart is what makes that
+ * property checkable by looking at the imports.
+ *
+ * Same behavior/docs, moved verbatim. The class
  * keeps its public method names/signatures — each is now a 1-line delegate
  * to the matching function here, operating on the {@link ReadSignals} bag
  * (a superset of `OrchestratorSignals` — the extra fields are the

--- a/packages/kobe/src/client/remote-orchestrator-writes.ts
+++ b/packages/kobe/src/client/remote-orchestrator-writes.ts
@@ -1,9 +1,13 @@
 /**
  * `RemoteOrchestrator`'s write surface — each function forwards one daemon
- * RPC. Split out of `remote-orchestrator.ts` (which was over the repo's
- * 500-line file-size cap) into its own file; same behavior, moved
- * verbatim. The class keeps its public method names/signatures — each is
- * now a 1-line delegate to the matching function here.
+ * RPC. Every mutation the client can make crosses the socket here, which is
+ * the seam against `-reads.ts`: those are synchronous reads of the replayed
+ * local cache and cannot fail, these are all async and every one of them is a
+ * place the daemon can be gone.
+ *
+ * Same behavior, moved verbatim. The class keeps its public method
+ * names/signatures — each is now a 1-line delegate to the matching function
+ * here.
  */
 
 import type { KobeDaemonClient } from "@sma1lboy/kobe-daemon/client"

--- a/packages/kobe/src/client/remote-orchestrator.ts
+++ b/packages/kobe/src/client/remote-orchestrator.ts
@@ -261,10 +261,11 @@ export class RemoteOrchestrator {
   }
 
   /**
-   * Start or join the role-appropriate reconnect loop (body in
-   * `remote-orchestrator-connect.ts` `runReconnectLoop` — file-size cap).
-   * On success subscribe replay rehydrates every signal, including the
-   * current task snapshot.
+   * Start or join the role-appropriate reconnect loop. The body lives in
+   * `remote-orchestrator-connect.ts` `runReconnectLoop`, over an explicit deps
+   * bag, so the retry policy is testable without a daemon; this method only
+   * supplies this instance's dependencies. On success subscribe replay
+   * rehydrates every signal, including the current task snapshot.
    */
   private reconnectLoop(spawnDaemon: boolean): Promise<void> {
     if (this.reconnectTask) return this.reconnectTask

--- a/packages/kobe/src/engine/builtin-engines.ts
+++ b/packages/kobe/src/engine/builtin-engines.ts
@@ -1,8 +1,9 @@
 /**
  * The BUILT-IN engine table — the four first-party adapters' wiring, as
- * data. Split out of `registry.ts` (the ~500-line cap); the module doc
- * there explains what an entry means and why neutral layers must go
- * through `engineEntry` instead of reaching in here.
+ * data — the DATA half of `registry.ts`, which owns the entry type and the
+ * lookup. That is what makes adding an engine a data edit rather than a code
+ * one. The module doc there explains what an entry means and why neutral
+ * layers must go through `engineEntry` instead of reaching in here.
  *
  * Adding a built-in engine = one entry here plus its `*-local/` modules.
  * The entry TYPE stays in `registry.ts` (imported type-only, so the pair is

--- a/packages/kobe/src/engine/history-readers.ts
+++ b/packages/kobe/src/engine/history-readers.ts
@@ -1,6 +1,11 @@
 /**
- * The per-vendor {@link EngineHistoryReader} implementations, split out of
- * `registry.ts` (file-size cap). Each is a thin adapter over its vendor's
+ * The per-vendor {@link EngineHistoryReader} implementations.
+ *
+ * Their own module because `registry.ts` declares the CONTRACT every engine
+ * must satisfy while this file holds the vendor-specific mess of satisfying
+ * it — and only this half grows when a vendor changes its on-disk transcript
+ * format. Adding an engine touches the registry's table; a vendor rearranging
+ * its store touches only here. Each is a thin adapter over its vendor's
  * `*-local/history.ts` module, normalizing store quirks to the registry's
  * contract — nothing else in the tree should import these directly; go
  * through `engineEntry(vendor).history`.

--- a/packages/kobe/src/engine/registry.ts
+++ b/packages/kobe/src/engine/registry.ts
@@ -231,9 +231,11 @@ export interface EngineRegistryEntry {
   readonly screenManifest?: EngineScreenManifest
 }
 
-// The per-vendor readers live in `history-readers.ts` (file-size cap);
-// EMPTY_HISTORY is re-exported so `@/engine/registry` stays the one
-// import site for the whole registry surface.
+// The per-vendor readers live in `history-readers.ts` — this file declares the
+// contract, that one holds the vendor-specific work of meeting it, so a
+// vendor's transcript format changing never edits the table below.
+// EMPTY_HISTORY is re-exported so `@/engine/registry` stays the one import
+// site for the whole registry surface.
 export { EMPTY_HISTORY }
 
 /** See module doc: the explicit empty entry for a user-registered engine id. */

--- a/packages/kobe/src/engine/session-identity.ts
+++ b/packages/kobe/src/engine/session-identity.ts
@@ -1,7 +1,8 @@
 /**
  * Session-identity policy — how an engine answers "what is my current
- * session id" and "how do I resume it", split out of `registry.ts` (the
- * ~500-line cap) alongside its sibling `terminal-title.ts`.
+ * session id" and "how do I resume it". Like its sibling `terminal-title.ts`,
+ * held apart from `registry.ts` so the POLICY can be written without naming a
+ * vendor while the registry keeps the vendor→entry resolution.
  *
  * Pure on purpose: every function here takes the engine's declared
  * {@link EngineSessionIdentity} rather than a vendor id, so nothing in this

--- a/packages/kobe/src/engine/terminal-title.ts
+++ b/packages/kobe/src/engine/terminal-title.ts
@@ -1,6 +1,8 @@
 /**
  * Terminal-title policy — the rules for reading an engine's OWN OSC 0/2
- * title, split out of `registry.ts` (the ~500-line cap).
+ * title, held apart from `registry.ts` so the rules never learn a vendor's
+ * name (see the next paragraph — that is the seam, and the imports keep it
+ * honest).
  *
  * Pure on purpose: every function here takes the engine's declared
  * {@link EngineTerminalTitle} rather than a vendor id, so `registry.ts` keeps

--- a/packages/kobe/src/engine/worktree-protocol.ts
+++ b/packages/kobe/src/engine/worktree-protocol.ts
@@ -3,11 +3,12 @@
  * status self-report (`experimental.autoStatus`), field-note filing +
  * recall, and the repo main session's dispatcher brief.
  *
- * Split out of `interactive-command.ts` (the ~500-line cap) so the protocol
- * text and its injection gates sit together, and so this module may import
- * `engine-presets.ts` for protocol resolution — `engine-presets.ts` imports
- * `interactive-command.ts`, so asking that file to resolve a protocol would
- * close an import cycle.
+ * Its own module for two reasons, the second load-bearing: the protocol text
+ * and its injection gates belong together, and this file may import
+ * `engine-presets.ts` for protocol resolution while `interactive-command.ts`
+ * may not — `engine-presets.ts` imports IT, so asking that file to resolve a
+ * protocol would close an import cycle. Moving this code back would break the
+ * build, not just crowd a file.
  *
  * Injection rides `--append-system-prompt`, per-invocation and scoped
  * exactly to Rove-spawned sessions. Why a flag and not a file: a dropped

--- a/packages/kobe/src/orchestrator/core-helpers.ts
+++ b/packages/kobe/src/orchestrator/core-helpers.ts
@@ -1,8 +1,11 @@
 /**
  * Pure, `this`-independent helpers for the {@link Orchestrator} (`core.ts`).
  *
- * Path / repo-key normalisation with no orchestrator state — split out so the
- * class stays under the file-size cap. Moved verbatim from `core.ts`.
+ * The seam is `this`: everything here is path / repo-key normalisation that
+ * reads no orchestrator state, so it is testable as plain input → output and
+ * can be called from anywhere without an Orchestrator to hand. Keeping it out
+ * of the class is what stops these from quietly growing a dependency on it.
+ * Moved verbatim from `core.ts`.
  */
 
 import { realpathSync } from "node:fs"

--- a/packages/kobe/src/orchestrator/core.ts
+++ b/packages/kobe/src/orchestrator/core.ts
@@ -33,9 +33,9 @@ import { PLACEHOLDER_TASK_TITLE } from "./title.ts"
 import { WorktreeCoordinator } from "./worktree-coordinator.ts"
 import type { GitWorktreeManager } from "./worktree/manager.ts"
 
-// The create-task input type lives in its own module (file-size cap) and is
-// re-exported here: callers name it through the orchestrator, and the split
-// is a file boundary, not an API change.
+// The create-task input type lives in its own module so it can be imported
+// without importing this class. Re-exported here so callers still name it
+// through the orchestrator.
 export type { CreateTaskInput } from "./create-task-input.ts"
 
 export type Unsubscribe = () => void
@@ -373,9 +373,9 @@ export class Orchestrator {
 
   // In-place task-field edits (title / branch / engine / pinned / status /
   // PR-status / move / reorder) live in the TaskEditor collaborator.
-  // Terse one-liners below on purpose: they are PURE forwarding (the rules,
-  // guards, and doc comments all live on TaskEditor's own methods), and this
-  // file sits at the 500-line cap — same shape `remote-orchestrator.ts` uses
+  // Terse one-liners below on purpose: they are PURE forwarding, so anything
+  // written here would be a second copy of a rule that lives on TaskEditor's
+  // own methods — read them there. Same shape `remote-orchestrator.ts` uses
   // for its own write delegates.
 
   setTitle = (id: TaskId | string, title: string): Promise<void> => this.editor.setTitle(id, title)

--- a/packages/kobe/src/orchestrator/create-task-input.ts
+++ b/packages/kobe/src/orchestrator/create-task-input.ts
@@ -1,9 +1,11 @@
 /**
  * The shape of a `createTask` call.
  *
- * Split from `core.ts` at the file-size cap. A pure input type with no
- * dependency on the Orchestrator class, so it moves cleanly and gives every
- * caller a smaller thing to read than the whole orchestrator.
+ * Its own module because the direction of dependency should only go one way:
+ * this type names what a caller must supply, and it imports nothing from the
+ * Orchestrator class. Callers building a `createTask` argument read one small
+ * file instead of pulling the whole orchestrator into view, and nothing about
+ * the class's internals can leak into the shape of its own input.
  */
 
 import type { ProjectIntent } from "../state/project-eligibility.ts"

--- a/packages/kobe/src/orchestrator/index/store-codec.ts
+++ b/packages/kobe/src/orchestrator/index/store-codec.ts
@@ -18,8 +18,10 @@
  *     the store class focuses on the mutable cache / dirty tracking /
  *     persistence orchestration.
  *
- * All functions here are `this`-independent — moved out verbatim so the
- * store class stays under the file-size cap.
+ * The seam is `this`: every function here is stateless, so the versions the
+ * codec must tolerate can be fed in as plain values and the merge protocol
+ * checked without a store, a lock, or a real manifest on disk. The store keeps
+ * the mutable half — cache, dirty tracking, when to persist.
  */
 
 import { copyFile, readFile } from "node:fs/promises"

--- a/packages/kobe/src/orchestrator/worktree/manager-branch.ts
+++ b/packages/kobe/src/orchestrator/worktree/manager-branch.ts
@@ -1,9 +1,10 @@
 /**
- * The BRANCH operations, split out of `manager.ts` (file-size cap).
+ * The BRANCH operations of `manager.ts`.
  *
  * Existence probes, upstream lookup, delete and rename — the git-branch verbs
- * the manager exposes. They're orthogonal to worktree lifecycle (create /
- * remove / list) and share only the run-git primitive, so they live here as
+ * the manager exposes. A branch and a worktree are two different git objects;
+ * these verbs are orthogonal to worktree lifecycle (create / remove / list)
+ * and share only the run-git primitive, so they live here as
  * free functions over a small {@link BranchDeps}, and the class methods stay
  * thin delegators. Same shape as `manager-list.ts`; no behaviour change.
  */

--- a/packages/kobe/src/orchestrator/worktree/manager-list.ts
+++ b/packages/kobe/src/orchestrator/worktree/manager-list.ts
@@ -1,5 +1,7 @@
 /**
- * The worktree LISTING operations, split out of `manager.ts` (file-size cap).
+ * The worktree LISTING operations of `manager.ts` — the read-only half, which
+ * is why they are safe to hold apart from create/remove: nothing here can
+ * change the repo, and a bug is a wrong answer rather than a lost worktree.
  *
  * `listManaged` / `listAllAdoptable` / `adoptablePaths` are the porcelain-parse
  * + filter + concurrent-probe logic behind `GitWorktreeManager.list` /

--- a/packages/kobe/src/orchestrator/worktree/manager-remove.ts
+++ b/packages/kobe/src/orchestrator/worktree/manager-remove.ts
@@ -1,5 +1,6 @@
 /**
- * `remove()`, split out of `manager.ts` (file-size cap).
+ * `remove()` — the manager's one destructive verb, alone in its own file
+ * precisely because it is the one that can lose a user's work.
  *
  * Worktree removal is the module's one destructive verb, and every safety
  * decision it makes — the dirty gate, the salvage snapshot, the orphaned-repo

--- a/packages/kobe/src/orchestrator/worktree/manager.ts
+++ b/packages/kobe/src/orchestrator/worktree/manager.ts
@@ -192,9 +192,10 @@ export class GitWorktreeManager implements WorktreeManager {
     return this.create(args.repo, args.branch, target, args.baseRef)
   }
 
-  /** Remove a worktree — body in `manager-remove.ts` (file-size cap). Refuses
-   *  a dirty worktree unless `opts.force`; a forced removal salvages first and
-   *  can also clear a worktree whose upstream repo is gone. */
+  /** Remove a worktree — body in `manager-remove.ts`, the destructive verb kept
+   *  in its own file. Refuses a dirty worktree unless `opts.force`; a forced
+   *  removal salvages first and can also clear a worktree whose upstream repo
+   *  is gone. */
   async remove(worktreePath: string, opts?: RemoveOpts): Promise<void> {
     await removeWorktree(
       {

--- a/packages/kobe/src/tui-react/component/kanban-card.tsx
+++ b/packages/kobe/src/tui-react/component/kanban-card.tsx
@@ -1,7 +1,9 @@
 /** @jsxImportSource @opentui/react */
 /**
- * KanbanCard — one issue card on the board (extracted from kanban-page.tsx
- * for the file-size cap). Selection border > attention border > column
+ * KanbanCard — one issue card on the board. Its own component because it
+ * renders ONE card from props and holds no board state: everything about which
+ * cards exist, the cursor and the mutations stays in `kanban-page.tsx`.
+ * Selection border > attention border > column
  * border; a live activity badge tracks the linked task's engine on both the
  * In-progress and Parked columns (a parked card keeps its badge as passive
  * signal — it just never floats or counts toward "N need you").

--- a/packages/kobe/src/tui-react/component/settings-dialog/use-engine-settings.ts
+++ b/packages/kobe/src/tui-react/component/settings-dialog/use-engine-settings.ts
@@ -1,6 +1,9 @@
 /**
- * Engines-section state for the React settings dialog (issue #15, G3) —
- * split out of `./index.tsx` for the file-size cap. Same kv keys and flows
+ * Engines-section state for the React settings dialog (issue #15, G3) — one
+ * section's state in its own file, like `use-settings-prefs` / `use-section-data`,
+ * so `./index.tsx` owns only the dialog's structure. This is the section with
+ * real logic behind it: a custom-engine registry and the global default. Same
+ * kv keys and flows
  * as the Solid `src/tui/component/settings-dialog.tsx`: per-vendor launch
  * command + display-name overrides (engineCommand.<id> / engineName.<id>),
  * the customEngineIds registry, and the GLOBAL default engine (the ●

--- a/packages/kobe/src/tui-react/component/settings-dialog/use-section-data.ts
+++ b/packages/kobe/src/tui-react/component/settings-dialog/use-section-data.ts
@@ -3,8 +3,9 @@
  * engine detection probes (fs/env) and the plugin registry (`~/.kobe/
  * plugins.json`). Both are lazy: nothing is read until the owning section
  * is first opened, so a settings open that never visits them pays nothing.
- * Split out of `index.tsx` for the file-size cap, like `use-settings-prefs`
- * / `use-engine-settings`.
+ * The seam is where the data COMES FROM: `use-settings-prefs` reads kv, this
+ * reads the filesystem and environment, so the probes that can be slow or fail
+ * are all on one side of the line and easy to keep lazy.
  */
 
 import { useEffect, useState } from "react"

--- a/packages/kobe/src/tui-react/component/settings-dialog/use-settings-prefs.ts
+++ b/packages/kobe/src/tui-react/component/settings-dialog/use-settings-prefs.ts
@@ -1,7 +1,9 @@
 /**
  * kv-backed preference helpers for the settings dialog (issue #15, G3) —
- * the General/Dev getter+toggle closures split out of `./index.tsx` to
- * keep it under the file-size cap. All reads are plain `kv.get` — the
+ * the General/Dev getter+toggle closures, kept apart from `./index.tsx` so the
+ * dialog's structure (which sections, which is open) never mixes with the
+ * per-preference kv keys and their normalizers. Adding a preference edits only
+ * this file. All reads are plain `kv.get` — the
  * KVProvider re-renders the tree on every `kv.set`, so the values are
  * recomputed per render. Sections receive the whole bundle as a single
  * `prefs: SettingsPrefs` prop and call the getters directly.

--- a/packages/kobe/src/tui-react/component/use-kanban-boards.ts
+++ b/packages/kobe/src/tui-react/component/use-kanban-boards.ts
@@ -1,8 +1,11 @@
 /**
- * Kanban board loading — extracted from kanban-page.tsx (file-size cap split).
- * Owns only the data concern: fetch every saved repo's issue file, poll it
- * while the page is open, and land the initial project/card cursor. Rendering,
- * key handling, and mutations stay in the page.
+ * Kanban board loading — the data half of `kanban-page.tsx`: fetch every saved
+ * repo's issue file, poll it while the page is open, and land the initial
+ * project/card cursor. Rendering, key handling, and mutations stay in the
+ * page.
+ *
+ * The seam is IO: this is the only part that talks to the orchestrator, so the
+ * page's own logic never has to reason about a poll landing mid-interaction.
  */
 
 import type { RepoIssues } from "@sma1lboy/kobe-daemon/daemon/issues-store"

--- a/packages/kobe/src/tui-react/panes/sidebar/use-tree-menu.ts
+++ b/packages/kobe/src/tui-react/panes/sidebar/use-tree-menu.ts
@@ -2,8 +2,9 @@
  * The tree sidebar's right-click menu: which row was clicked, the entries it
  * offers, the highlight, and what each entry does.
  *
- * Split from `SidebarTree.tsx` for the file-size cap. What the menu OFFERS is
- * the framework-free `tree-menu.ts`; this hook is the state in between, plus
+ * The seam here is a three-way one, and this hook is the middle: what the menu
+ * OFFERS is the framework-free `tree-menu.ts`, what each entry DOES is the
+ * host's callbacks, and this holds only the React state between them, plus
  * the `t()` pass that turns label keys into text so the menu follows a language
  * switch, plus the dispatch that routes an entry to the host callback the tree
  * was already holding.

--- a/packages/kobe/src/tui-react/panes/sidebar/use-tree-search.ts
+++ b/packages/kobe/src/tui-react/panes/sidebar/use-tree-search.ts
@@ -2,8 +2,9 @@
  * Tree-sidebar search state — the `/` query, its keystroke capture, and the
  * enter/exit transitions.
  *
- * Split out of `SidebarTree.tsx` for the file-size cap. The mechanics are the
- * flat sidebar's (`Sidebar.tsx`) verbatim: a raw renderer keypress listener
+ * Its own hook because it does something the rest of the tree does not: bypass
+ * the component's normal key handling entirely. The mechanics are the flat
+ * sidebar's (`Sidebar.tsx`) verbatim — a raw renderer keypress listener
  * rather than an opentui `<input>` (which misbehaved in the Solid original),
  * registered after the keymap dispatcher so chords that already
  * preventDefault'd never leak into the query.

--- a/packages/kobe/src/tui-react/panes/sidebar/use-tree-state.ts
+++ b/packages/kobe/src/tui-react/panes/sidebar/use-tree-state.ts
@@ -2,9 +2,9 @@
  * Sidebar tree state — the flat row list and the cursor's translation
  * between row ids and the terminal's (taskId, tabId) pair.
  *
- * Kept out of `Sidebar.tsx` for the file-size cap, and out of `tree-core.ts`
- * because that module is framework-free (vitest loads it in Node) while this
- * one is React state.
+ * Kept out of `tree-core.ts` because that module is framework-free — vitest
+ * loads it in Node — while this one is React state; the fold and expansion
+ * rules below need that separation to stay testable as plain data.
  *
  * There is NO fold anywhere (owner call 2026-08-01, round 5) except one: a
  * project's routine count row (issue #91), which folds ONLY the standing

--- a/packages/kobe/src/tui-react/panes/terminal/use-terminal-geometry.ts
+++ b/packages/kobe/src/tui-react/panes/terminal/use-terminal-geometry.ts
@@ -1,10 +1,13 @@
 /**
- * Body-box geometry measurement for the embedded terminal pane — split out
- * of `Terminal.tsx` (React port of the measurement half of the Solid
- * original) purely to keep the component under the file-size cap; the
+ * Body-box geometry measurement for the embedded terminal pane (React port of
+ * the measurement half of the Solid original).
+ *
+ * The seam is ordering, and the import graph pins it: this hook measures
+ * BEFORE the PTY exists, so its `bodyGeometry` can feed `useTerminalPty`. The
  * resize-push-to-pty and host-cursor-anchor effects stay in `Terminal.tsx`
  * because they need the PTY handle and the computed viewport cursor, which
- * only exist after this hook's `bodyGeometry` has fed `useTerminalPty`.
+ * only exist afterwards — nothing here may depend on either, or the pane
+ * cannot boot at its real size.
  *
  * Measures the rendered body box (before spawning the PTY) so a fresh pane
  * boots at its real size instead of the 80x24 default — booting small

--- a/packages/kobe/src/tui-react/panes/terminal/use-terminal-host-cursor.ts
+++ b/packages/kobe/src/tui-react/panes/terminal/use-terminal-host-cursor.ts
@@ -2,10 +2,11 @@
  * Host-side terminal output effects: push geometry changes to the PTY and
  * anchor the native host cursor to the visible terminal cell for macOS IME.
  *
- * Split out of `Terminal.tsx` to keep the component under the file-size cap.
- * The caller still supplies the computed viewport cursor (`visibleImeCursor`);
- * this hook only owns the imperative renderer/PTY side-effects and the
- * retention objects that survive across output frames.
+ * Its own hook because everything here is IMPERATIVE: renderer and PTY side
+ * effects plus the retention objects that survive across output frames, none
+ * of which belongs in a render path. The caller still supplies the computed
+ * viewport cursor (`visibleImeCursor`) — deciding where the cursor is stays
+ * declarative in the component; only telling the host about it lives here.
  */
 
 import type { BoxRenderable } from "@opentui/core"

--- a/packages/kobe/src/tui-react/panes/terminal/use-terminal-reset.ts
+++ b/packages/kobe/src/tui-react/panes/terminal/use-terminal-reset.ts
@@ -1,6 +1,8 @@
 /**
- * The terminal pane's F5 reset — extracted from Terminal.tsx (file-size cap
- * split). Owns the confirm gate and the two ways a reset can be reached:
+ * The terminal pane's F5 reset. Its own hook because the two paths below are
+ * one policy that must be decided together — the pre-split code got this wrong
+ * (see the second bullet), which is exactly the failure a scattered gate
+ * invites. Owns the confirm gate and the two ways a reset can be reached:
  *
  *  - a LIVE pty: confirm first (a running shell and its in-flight vim/htop
  *    are about to die), then reacquire, guarding against a task switch that

--- a/packages/kobe/src/tui-react/panes/terminal/use-terminal-selection.ts
+++ b/packages/kobe/src/tui-react/panes/terminal/use-terminal-selection.ts
@@ -2,8 +2,10 @@
  * Copy-on-select, GRID-based selection for the embedded terminal pane —
  * React port of the selection half of `tui/panes/terminal/Terminal.tsx`
  * (tmux convention; see `terminal-selection.ts` for why opentui's text-flow
- * selection can't work over this pane). Split out purely to keep
- * `Terminal.tsx` under the file-size cap.
+ * selection can't work over this pane). Its own hook because selection is
+ * self-contained mouse state that the rest of the pane never reads — and,
+ * per the two notes below, it is the part with the most non-obvious
+ * re-render rules, which are easier to hold correct in one file.
  *
  * Anchor and head live in ABSOLUTE snapshot coordinates so the highlight
  * survives every frame refresh and scrollback move. A ZERO-WIDTH selection

--- a/packages/kobe/src/tui-react/workspace/TerminalTabs.tsx
+++ b/packages/kobe/src/tui-react/workspace/TerminalTabs.tsx
@@ -260,10 +260,10 @@ export function TerminalTabs(props: TerminalTabsProps): ReactNode {
   /* --------- restart resume verification (issue #22) — mount-only ------- */
   const hydrating = useTabHydration(rehydratedRef.current, { stateRef, propsRef, update })
 
-  // Parent handoffs — mount-once effects, extracted to use-tab-handoffs.ts
-  // (file-size cap split). The quick-fork initial prompt needs no delivery
-  // effect: it rides the first spawn (argv, or firstMessage paste for
-  // paste-delivery vendors — engineTabSpawn).
+  // Parent handoffs — the once-per-mount work, in use-tab-handoffs.ts apart
+  // from the per-render hooks below. The quick-fork initial prompt needs no
+  // delivery effect: it rides the first spawn (argv, or firstMessage paste
+  // for paste-delivery vendors — engineTabSpawn).
   const { sendToEngine } = useTabHandoffs({
     stateRef,
     propsRef,
@@ -333,7 +333,7 @@ export function TerminalTabs(props: TerminalTabsProps): ReactNode {
   const resumeTriedRef = useRef(new Set<string>())
 
   // Tab teardown — ctrl+w, close-from-the-tree, process exit, and the exit
-  // policy above them (use-tab-close.ts, file-size cap split).
+  // policy above them: one hook (use-tab-close.ts) so the four stay one rule.
   const tabClose = useTabClose({
     stateRef,
     propsRef,
@@ -350,8 +350,8 @@ export function TerminalTabs(props: TerminalTabsProps): ReactNode {
   // through a ref rather than the one from its first render.
   const tabCloseRef = useLatest(tabClose)
 
-  // Rename + the unified new-conversation dialog (issue #7) — extracted
-  // (file-size cap split); recreated per render for state freshness.
+  // Rename + the unified new-conversation dialog (issue #7) — the flows that
+  // ASK the user something (use-tab-dialogs.ts); per render for freshness.
   const { requestRename, requestNewChat } = useTabDialogs({
     dialog,
     t,

--- a/packages/kobe/src/tui-react/workspace/fork-chat-tab.ts
+++ b/packages/kobe/src/tui-react/workspace/fork-chat-tab.ts
@@ -3,9 +3,10 @@
  * opens on the active tab's conversation and then diverges — the sibling of
  * `quick-fork.ts`, which forks the WORKTREE into a child task.
  *
- * Split out of `TerminalTabs.tsx` for the file-size cap; the vendor-specific
- * launch flags live in the engine layer (`engineForkArgv`), the tab-state
- * transition in `terminal-tabs-core`, so this is just the join.
+ * Its own module because it is only the JOIN: the vendor-specific launch
+ * flags live in the engine layer (`engineForkArgv`) and the tab-state
+ * transition in `terminal-tabs-core`, so the fork gesture owns neither, and
+ * keeping it thin is what stops either of them leaking into the component.
  */
 
 import { engineCanFork } from "@/engine/engine-presets"

--- a/packages/kobe/src/tui-react/workspace/host-files-pane.tsx
+++ b/packages/kobe/src/tui-react/workspace/host-files-pane.tsx
@@ -2,9 +2,10 @@
 /**
  * The workspace host's right rail — the FileTree pane and its width math.
  *
- * Extracted from `host.tsx` when it crossed the file-size cap (same reason
- * as `host-sidebar.tsx`). Width: a third of what's left beside the sidebar,
- * clamped to the documented worktree-tools convention [22, 34].
+ * A region that owns its own layout, like `host-sidebar.tsx`: the width math
+ * below is this rail's business, not the host's. Width: a third of what's left
+ * beside the sidebar, clamped to the documented worktree-tools convention
+ * [22, 34].
  */
 
 import { useTerminalDimensions } from "@opentui/react"

--- a/packages/kobe/src/tui-react/workspace/host-footer.tsx
+++ b/packages/kobe/src/tui-react/workspace/host-footer.tsx
@@ -17,8 +17,9 @@
  * explicit cell budget (usage-core's buildFooterChips), so an 80-col
  * terminal degrades to compact chips instead of colliding with the hint bar.
  *
- * `WorkspaceFrame` owns the column wrapper so `host.tsx` stays under the
- * file-size cap — same extraction reason as `host-sidebar.tsx`.
+ * `WorkspaceFrame` owns the column wrapper, for the same reason as
+ * `host-sidebar.tsx`: the host composes the workspace's regions and each
+ * region owns how it renders itself.
  */
 
 import { useTerminalDimensions } from "@opentui/react"

--- a/packages/kobe/src/tui-react/workspace/host-pages.tsx
+++ b/packages/kobe/src/tui-react/workspace/host-pages.tsx
@@ -3,9 +3,10 @@
  * The workspace host's full-page swaps, in one place.
  *
  * Each of these replaces the whole workspace rather than layering over it, so
- * they were a run of early-returns at the top of `host.tsx`'s render. Six of
- * them is enough to be its own thing — and `host.tsx` is at the repo's file
- * size cap, so a seventh has to land here rather than there.
+ * they were a run of early-returns at the top of `host.tsx`'s render. That is
+ * the seam: "which surface occupies the window" is one decision, and it is a
+ * different question from how the normal workspace lays out its rails. Six of
+ * them is enough to be its own thing, and a seventh belongs here too.
  *
  * Order is the precedence order: the first open page wins. That matters only
  * in theory (the keybinding gate stops a second page opening over a first),
@@ -231,10 +232,9 @@ export interface UseHostPagesRenderResult {
 /**
  * Page-render + layout decisions for the workspace host.
  *
- * Pulled out of `host.tsx` (file-size cap) because `pageDeps`, the
- * full-window/content-page render calls, the narrow-mode surface decision,
- * and the settings standalone page all serve the same concern: deciding
- * which surface occupies the workspace. Keeping them together means
+ * `pageDeps`, the full-window/content-page render calls, the narrow-mode
+ * surface decision, and the settings standalone page all serve one concern:
+ * deciding which surface occupies the workspace. Keeping them together means
  * `host.tsx` no longer has to thread every dependency through `pageDeps`.
  */
 export function useHostPagesRender(opts: UseHostPagesRenderOpts): UseHostPagesRenderResult {

--- a/packages/kobe/src/tui-react/workspace/host-sidebar.tsx
+++ b/packages/kobe/src/tui-react/workspace/host-sidebar.tsx
@@ -2,8 +2,10 @@
 /**
  * The workspace host's left rail — which sidebar renders, and its wiring.
  *
- * Extracted from `host.tsx` when it hit the file-size cap: ~30 props of
- * sidebar wiring did not fit in a file that was already at the limit.
+ * Its own component because `host.tsx` should compose the workspace, not know
+ * how one rail is wired. The ~30 props below are that wiring made explicit —
+ * having to pass them is the honest cost of the boundary, and it is why a new
+ * sidebar concern lands here instead of accreting on the host.
  */
 
 import type { TaskEngineState, TaskJobState } from "@/client/remote-orchestrator"

--- a/packages/kobe/src/tui-react/workspace/host.tsx
+++ b/packages/kobe/src/tui-react/workspace/host.tsx
@@ -79,8 +79,9 @@ export function WorkspaceRoot(props: { orchestrator: RemoteOrchestrator }) {
   // mode / toasts live in useSidebarHostState below.
   const [searchActive, setSearchActive] = useState(false)
 
-  // Selection + adopt-first-focus + the deleting-task PTY sweep — extracted
-  // verbatim to use-workspace-selection.ts (file-size cap split).
+  // Selection + adopt-first-focus + the deleting-task PTY sweep — one hook in
+  // use-workspace-selection.ts, because those three all answer "which task is
+  // the user on" and get it wrong together if they drift apart.
   const t = useT()
 
   // Declared before useWorkspaceSelection so its worktree-gone callback can
@@ -168,8 +169,9 @@ export function WorkspaceRoot(props: { orchestrator: RemoteOrchestrator }) {
 
   // Quick-fork (issue #17, ctrl+f): composer → create+enter → hand the
   // prompt to the new task's TerminalTabs mount (phase 2). Wiring lives in
-  // `quick-fork.ts` — the create/enter/pending-prompt shape is identical
-  // regardless of host, and this component is already near the file-size cap.
+  // `quick-fork.ts` because the create/enter/pending-prompt shape is identical
+  // regardless of host — the other caller is TerminalTabs, and both must stay
+  // one implementation.
   const quickFork = useQuickFork(orch, { selectTask: setSelectedId, enterTask: activateTask, notifyError })
 
   // Scratch temp shell tasks (issue #33) — open gesture, exit deletion, and
@@ -217,7 +219,9 @@ export function WorkspaceRoot(props: { orchestrator: RemoteOrchestrator }) {
   })
 
   // Page-render + layout decisions (full-window swaps, rail pages, narrow
-  // surface, settings standalone) — extracted to host-pages.tsx (file-size cap).
+  // surface, settings standalone) live in host-pages.tsx: "which surface
+  // occupies the window" is one decision, separate from how the normal
+  // workspace lays out its rails.
   const pageRender = useHostPagesRender({
     orchestrator: orch,
     pages,

--- a/packages/kobe/src/tui-react/workspace/inbox-item-view.ts
+++ b/packages/kobe/src/tui-react/workspace/inbox-item-view.ts
@@ -1,8 +1,8 @@
 /**
  * Attention-Inbox item → its presentation (glyph, tone, state word, and the
- * rate-limit resume note). Pure and framework-free, split out of
- * `AttentionInboxPane.tsx` (file-size cap) so the mapping is unit-testable
- * without mounting the pane.
+ * rate-limit resume note). Pure and framework-free, kept out of
+ * `AttentionInboxPane.tsx` so the mapping is unit-testable without mounting
+ * the pane — which matters more here than usual, because of the rule below.
  *
  * One rule holds the four together: the Inbox's vocabulary must MATCH the
  * sidebar rail's (`row-view.ts`) and the tab strip's (`tab-strip.tsx`). Three

--- a/packages/kobe/src/tui-react/workspace/quick-fork.ts
+++ b/packages/kobe/src/tui-react/workspace/quick-fork.ts
@@ -8,8 +8,9 @@
  * SOURCE task's TerminalTabs mount, but the prompt has to reach the
  * NEW task's mount, so the pending prompt is held here, keyed by task id.
  *
- * Split out of `TerminalTabs.tsx`/`host.tsx` purely for the file-size cap —
- * both hosts sit close to the 500-line limit already.
+ * Its own module because BOTH `TerminalTabs.tsx` and `host.tsx` drive this
+ * gesture: the create/enter/pending-prompt shape must not exist twice, or the
+ * two entry points diverge on the tmux-parity side effects above.
  */
 
 import { errorMessage } from "@/lib/error-message"

--- a/packages/kobe/src/tui-react/workspace/show-workspace.tsx
+++ b/packages/kobe/src/tui-react/workspace/show-workspace.tsx
@@ -3,7 +3,8 @@
  * The workspace center column — the terminal-in-the-middle seam (issue #16):
  * either the empty "select a task" placeholder or the selected worktree's
  * TerminalTabs (keyed per task so tasks sharing a directory never share
- * component state). Split from host.tsx (file-size cap).
+ * component state) — the host composes the workspace's regions, and this
+ * region owns the empty-versus-loaded decision.
  */
 
 import type { ReactNode } from "react"

--- a/packages/kobe/src/tui-react/workspace/terminal-tabs-shared.ts
+++ b/packages/kobe/src/tui-react/workspace/terminal-tabs-shared.ts
@@ -1,10 +1,10 @@
 /**
  * Cross-component tab state shared between the mounted `TerminalTabs`
  * component and the host-side flows that need it while the component may
- * not be mounted — extracted from `TerminalTabs.tsx` for the file-size cap.
- * Module-level on purpose (framework-agnostic process state): per-task tab
- * snapshots survive task switches, and the F7 attention jump can request a
- * tab activation before the target task's tabs ever mount.
+ * not be mounted. That is the seam, and why it CANNOT live in the component:
+ * module-level, framework-agnostic process state outlives any mount, so
+ * per-task tab snapshots survive task switches and the F7 attention jump can
+ * request a tab activation before the target task's tabs ever exist.
  */
 
 import { engineLaunchArgv, withPinnedSessionId } from "../../engine/engine-presets"

--- a/packages/kobe/src/tui-react/workspace/use-create-pr.ts
+++ b/packages/kobe/src/tui-react/workspace/use-create-pr.ts
@@ -1,10 +1,11 @@
 /**
  * Create-PR action (FileTree `pr` chip + prefix+p) — a PTY paste+submit of
- * the PR prompt into the selected task's engine session. Split out of
- * `host.tsx` (file-size cap); the identity guard is the same as the other
- * imperative-ref actions there: after an await, the selected task (and the
- * TerminalTabs mount behind the ref) may have changed, and a stale
- * continuation must not deliver into the new task.
+ * the PR prompt into the selected task's engine session. Its own module
+ * because of the guard below, which is the whole hazard: after an await, the
+ * selected task (and the TerminalTabs mount behind the ref) may have changed,
+ * and a stale continuation must not deliver into the new task. Same guard as
+ * the other imperative-ref actions in `host.tsx`, kept where it can be read in
+ * one screen.
  *
  * `createPRAction` is the React-free core (git IO injectable) so vitest can
  * pin the target-branch toast and both identity guards without a repo;

--- a/packages/kobe/src/tui-react/workspace/use-daemon-state.tsx
+++ b/packages/kobe/src/tui-react/workspace/use-daemon-state.tsx
@@ -1,7 +1,7 @@
 /** React subscriptions to the workspace host's daemon signals.
  *
- * Pulled out of `host.tsx` (file-size cap) because this block is pure
- * plumbing: one `useAccessor` per signal, plus the two derived overlays
+ * Its own hook because this block is pure plumbing with no decisions in it:
+ * one `useAccessor` per signal, plus the two derived overlays
  * (`engineTabState` and `sidebarEngineState`) that are consumed by the
  * Sidebar and attention hooks. Grouping them keeps the orchestration layer
  * from being buried under ten signal reads before it wires any behavior. */

--- a/packages/kobe/src/tui-react/workspace/use-editor-handles.tsx
+++ b/packages/kobe/src/tui-react/workspace/use-editor-handles.tsx
@@ -75,7 +75,8 @@ export function useEditorHandles(opts: UseEditorHandlesOpts): UseEditorHandlesRe
   // have changed — a stale continuation must not deliver into the new task.
   const selectedWorktreeRef = useLatest(worktree)
 
-  // FileTree `pr` chip + prefix+p — split out for the file-size cap.
+  // FileTree `pr` chip + prefix+p — own module for the guard above, which its
+  // awaits also need.
   const createPR = useCreatePR({ worktree, sendToEngineFn, selectedWorktreeRef, notifyError })
 
   // FileTree's Enter (editor/plugin/OS) and `d` (read-only diff tab).

--- a/packages/kobe/src/tui-react/workspace/use-optimistic-engine-state.ts
+++ b/packages/kobe/src/tui-react/workspace/use-optimistic-engine-state.ts
@@ -1,5 +1,5 @@
 /**
- * Sidebar-only optimistic overlay (host extraction, file-size cap): local
+ * Sidebar-only optimistic overlay: local
  * enter/esc keypresses flip the row icon immediately; authoritative daemon
  * events always win, and a superseded mark is dropped so the overlay never
  * becomes a second source of truth. Store + merge rules live in

--- a/packages/kobe/src/tui-react/workspace/use-tab-close.ts
+++ b/packages/kobe/src/tui-react/workspace/use-tab-close.ts
@@ -1,8 +1,10 @@
 /**
- * Everything about a tab going away — extracted from `TerminalTabs.tsx` for
- * the file-size cap, joining `use-tab-dialogs` / `use-tab-handoffs` /
- * `use-tab-lifecycle` as a per-render hook (state freshness comes from being
- * rebuilt each render, plus refs for the mount-only callers).
+ * Everything about a tab going away, in one hook so the four exits below stay
+ * one policy — they differ in ways that are easy to get subtly wrong, and
+ * scattering them across the component is how two of them drift. Joins
+ * `use-tab-dialogs` / `use-tab-handoffs` / `use-tab-lifecycle` as a per-render
+ * hook (state freshness comes from being rebuilt each render, plus refs for
+ * the mount-only callers).
  *
  * The four exits a tab has, and why they differ:
  *

--- a/packages/kobe/src/tui-react/workspace/use-tab-dialogs.ts
+++ b/packages/kobe/src/tui-react/workspace/use-tab-dialogs.ts
@@ -1,7 +1,8 @@
 /**
- * Tab-strip dialog flows extracted from `TerminalTabs.tsx` (file-size cap):
- * rename (F2) and the unified new-conversation dialog (issue #7). Pure
- * composition over the injected deps — every closure reads the CURRENT
+ * Tab-strip dialog flows: rename (F2) and the unified new-conversation dialog
+ * (issue #7) — the places the component ASKS the user something, kept apart
+ * from the places it acts. Pure composition over the injected deps: no state
+ * of its own, so every closure reads the CURRENT
  * render's `state`/`active` (the caller re-creates this hook's return every
  * render, same freshness contract as the inline originals).
  *

--- a/packages/kobe/src/tui-react/workspace/use-tab-handoffs.ts
+++ b/packages/kobe/src/tui-react/workspace/use-tab-handoffs.ts
@@ -1,7 +1,9 @@
 /**
- * Mount-once parent-handoff effects extracted from `TerminalTabs.tsx` (the
- * ~500-line cap), sibling of `use-tab-lifecycle.ts`: the imperative
- * editor-tab / engine-send handles handed to the parent. Both are
+ * Mount-once parent-handoff effects, sibling of `use-tab-lifecycle.ts`: the
+ * imperative editor-tab / engine-send handles handed to the parent. The seam
+ * against the per-render hooks is lifetime — these run ONCE per mount and live
+ * forever, so grouping them keeps that distinction visible instead of buried
+ * among effects that rebuild every render. Both are
  * mount-only, forever-lived effects — everything they read comes through
  * the caller's `stateRef`/`propsRef` latest-render mirrors, and every write
  * goes through the caller's `update` (which refreshes `stateRef`

--- a/packages/kobe/src/tui-react/workspace/use-tab-lifecycle.ts
+++ b/packages/kobe/src/tui-react/workspace/use-tab-lifecycle.ts
@@ -1,7 +1,8 @@
 /**
- * Mount-once tab-lifecycle effects extracted from `TerminalTabs.tsx` (the
- * ~500-line cap): restart-resume verification (issue #22) and the tab
- * auto-naming poll (the tmux naming pass). Both are mount-only, forever-
+ * Mount-once tab-lifecycle effects: restart-resume verification (issue #22)
+ * and the tab auto-naming poll (the tmux naming pass) — grouped with
+ * `use-tab-handoffs.ts` by lifetime, not by topic: what these have in common
+ * is running once per mount and living forever. Both are mount-only, forever-
  * lived effects — everything they read comes through the caller's
  * `stateRef`/`propsRef` latest-render mirrors, and every write goes
  * through the caller's `update` (which refreshes `stateRef`

--- a/packages/kobe/src/tui-react/workspace/use-tab-requests.ts
+++ b/packages/kobe/src/tui-react/workspace/use-tab-requests.ts
@@ -1,7 +1,8 @@
 /**
- * Consume the cross-component tab REQUESTS aimed at this task — extracted
- * from `TerminalTabs.tsx` (the ~500-line cap), sibling of
- * `use-tab-handoffs.ts`.
+ * Consume the cross-component tab REQUESTS aimed at this task — a third
+ * mount-once listener, sibling of `use-tab-handoffs.ts`, and its own file
+ * because consuming a request is what CLAIMS it (see below): that ownership
+ * rule is easier to keep true when there is exactly one place doing it.
  *
  * All requests (`terminal-tabs-shared.ts`) share one mount-once listener:
  * activation (F7 attention jump), plugin-pane open/close (`tab.open` /

--- a/packages/kobe/src/tui-react/workspace/use-workspace-selection.ts
+++ b/packages/kobe/src/tui-react/workspace/use-workspace-selection.ts
@@ -1,9 +1,12 @@
 /**
- * Workspace task selection — extracted verbatim from WorkspaceRoot
- * (file-size cap split): the selected-task state, the adopt-first-focus
+ * Workspace task selection: the selected-task state, the adopt-first-focus
  * rule, the deleting-task PTY sweep, and the select/activate actions.
- * The framework-free activation policy stays in use-task-selection.ts; this
- * hook owns only the React reactivity.
+ *
+ * These four belong together because they all answer "which task is the user
+ * on" and go wrong together when they drift. The seam against
+ * `use-task-selection.ts` is React: the activation POLICY there is
+ * framework-free and testable on plain values, and this hook owns only the
+ * reactivity that drives it.
  */
 
 import { useEffect, useRef, useState } from "react"

--- a/packages/kobe/src/tui/context/keybindings-files.ts
+++ b/packages/kobe/src/tui/context/keybindings-files.ts
@@ -1,9 +1,13 @@
 /**
- * `files.*` keybinding rows — split out of `keybindings.ts` (which was
- * over the repo's 500-line file-size cap) purely mechanically: same
- * entries, same order, moved verbatim. See `keybindings.ts`'s doc comment
- * for the full contract (id stability, scope semantics, hint display
- * rules).
+ * `files.*` keybinding rows — the `scope: "files"` slice of the one binding
+ * table, spread back into `keybindings-table.ts`.
+ *
+ * Same kind of cut as `keybindings-sidebar.ts` and `keybindings-chat.ts`:
+ * a long array literal sliced at the scope headers it already carried as
+ * comments. No responsibility boundary — which file a row lives in is
+ * decided by its `scope` field and nothing else. See `keybindings-table.ts`
+ * for the contract these rows must satisfy (stable `id`, spread order is
+ * display order, `hint` vs `keys`).
  */
 
 import type { KobeBinding } from "./keybindings-table.ts"

--- a/packages/kobe/src/tui/context/keybindings-sidebar.ts
+++ b/packages/kobe/src/tui/context/keybindings-sidebar.ts
@@ -1,9 +1,18 @@
 /**
- * `sidebar.*` / `tasks.*` keybinding rows — split out of `keybindings.ts`
- * (which was over the repo's 500-line file-size cap) purely mechanically:
- * same entries, same order, moved verbatim. See `keybindings.ts`'s doc
- * comment for the full contract (id stability, scope semantics, hint
- * display rules).
+ * `sidebar.*` / `tasks.*` keybinding rows. These are data, not behavior:
+ * plain {@link KobeBinding} literals spread back into the one table in
+ * `keybindings-table.ts`, which stays the single source of truth.
+ *
+ * There is no responsibility boundary here. The cut follows the `─── Sidebar
+ * ───` section header that was already a comment in the table — one long
+ * literal split at its existing seams, so a row's file is decided by its
+ * `scope`, nothing else. Adding a sidebar row here and a files row in
+ * `keybindings-files.ts` are the same edit.
+ *
+ * What the split does NOT change, and what you must preserve: spread order
+ * in `keybindings-table.ts` is the display order, and id stability is what
+ * `bindByIds` and user overrides key off. See `keybindings-table.ts`'s doc
+ * comment for that full contract.
  */
 
 import { TASK_JUMP_CHORDS } from "../panes/sidebar/jump-digits.ts"

--- a/packages/kobe/src/tui/context/keybindings-table.ts
+++ b/packages/kobe/src/tui/context/keybindings-table.ts
@@ -336,17 +336,19 @@ export const KobeKeymap: readonly KobeBinding[] = [
     description: "Interrupt current turn (esc while streaming)",
   },
   // ─── Sidebar + Tasks pane ─────────────────────────────────────────────
-  // Moved to keybindings-sidebar.ts (file-size cap) — same entries, same
-  // order, same live-binding contract (`kobe tasks` consumes these via
-  // `bindByIds`, following user overrides).
+  // The rows below this header live in keybindings-sidebar.ts — a long
+  // literal cut at its scope headers, not a responsibility boundary. Order
+  // here is the order they display in, and `kobe tasks` still consumes them
+  // through `bindByIds` after user overrides, exactly as when they were
+  // inline.
   ...SIDEBAR_BINDINGS,
 
   // ─── Workspace (chat) ────────────────────────────────────────────────
-  // Moved to keybindings-chat.ts (file-size cap) — same entries, same order.
+  // In keybindings-chat.ts — same entries, same order, spread back in place.
   ...CHAT_BINDINGS,
 
   // ─── Files ────────────────────────────────────────────────────────────
-  // Moved to keybindings-files.ts (file-size cap) — same entries, same order.
+  // In keybindings-files.ts — same entries, same order, spread back in place.
   ...FILES_BINDINGS,
 
   // ─── Attention Inbox ─────────────────────────────────────────────────

--- a/packages/kobe/src/tui/panes/sidebar/tab-row-activity.ts
+++ b/packages/kobe/src/tui/panes/sidebar/tab-row-activity.ts
@@ -1,9 +1,11 @@
 /**
  * Which activity entry names a sidebar TAB row's state glyph.
  *
- * Split from `tree-core.ts` at the file-size cap, and a real seam: everything
- * in `tree-core` answers "what rows exist"; this answers "which of the
- * daemon's two activity levels speaks for this row" — no row shapes, no tree.
+ * Its own module along a real seam: everything in `tree-core` answers "what
+ * rows exist"; this answers "which of the daemon's two activity levels speaks
+ * for this row". It touches no row shapes and no tree — the whole file is one
+ * generic function over the daemon's activity contract, which is why the
+ * precedence rule below can be tested with two plain values.
  */
 
 /**

--- a/packages/kobe/src/tui/panes/sidebar/tree-core.ts
+++ b/packages/kobe/src/tui/panes/sidebar/tree-core.ts
@@ -26,8 +26,9 @@ import { truncateStart } from "../../lib/truncate"
 import { fuzzyMatch } from "./fuzzy"
 import { compareRecent, repoBasename, sidebarProjectKey, sidebarProjectLabel } from "./groups"
 
-// Search lives in its own module (file-size cap) but stays part of tree-core's
-// public surface — every caller imports the tree's vocabulary from one place.
+// Search lives in its own module — this file decides what rows EXIST, that one
+// decides which survive a query — but stays part of tree-core's public surface,
+// so every caller imports the tree's vocabulary from one place.
 export { filterTreeRows } from "./tree-search"
 
 /** Separator between a task id and a tab id in a tab row's id. Matches the
@@ -484,7 +485,8 @@ export function mainTaskIdOfProject(tasks: readonly Task[], projectKey: string):
   return null
 }
 
-// Tab-row activity resolution lives in its own module (file-size cap) and is
-// re-exported here: callers name it through the tree's vocabulary, and the
-// split is a file boundary, not an API change.
+// Tab-row activity resolution lives in its own module: it answers which of the
+// daemon's two activity levels speaks for a row, which is not a question about
+// rows existing and needs none of this file's shapes. Re-exported here so
+// callers still name it through the tree's vocabulary.
 export { tabRowActivity } from "./tab-row-activity"

--- a/packages/kobe/src/tui/panes/sidebar/tree-search.ts
+++ b/packages/kobe/src/tui/panes/sidebar/tree-search.ts
@@ -1,9 +1,10 @@
 /**
  * Searching the sidebar tree — pruning `buildTreeRows`' output to a query.
  *
- * Split from `tree-core.ts` at the file-size cap. It is a genuinely separate
- * concern: `tree-core` decides what rows EXIST, this decides which of them
- * survive a query, and the two share only the row shape. `filterTreeRows` is
+ * Its own module because `tree-core` decides what rows EXIST and this decides
+ * which of them survive a query — the two share only the row shape, and the
+ * matching rule below is worth reading without the tree around it.
+ * `filterTreeRows` is
  * re-exported from `tree-core` so callers still import the tree's vocabulary
  * from one place.
  *

--- a/packages/kobe/src/tui/workspace/terminal-tab-argv.ts
+++ b/packages/kobe/src/tui/workspace/terminal-tab-argv.ts
@@ -1,9 +1,18 @@
 /**
  * Spawn composition for an engine tab: argv (session pin / resume / fork)
- * plus the shell-wrapped launch, split out of `terminal-tabs-core.ts` (the
- * tab-list transitions) for the 500-line file-size cap. Re-exported from
- * core, so importers keep one entry point. Tab shapes come back from core
- * as TYPE-only imports — erased at build time, so the cycle is cosmetic.
+ * plus the shell-wrapped launch.
+ *
+ * Separate from `terminal-tabs-core.ts` because the two fail for different
+ * reasons and change on different schedules. Core's transitions are closed
+ * over the tab list — a bug there is a wrong active tab. Everything here
+ * reads the ENGINE contract (`engine-presets`, `session-launch`,
+ * `trust-worktree`), so a bug is a wrong command line, and the thing that
+ * moves it is a vendor changing its resume/fork flags, not anything about
+ * tabs. Vendor knowledge stays on this side of the line.
+ *
+ * Re-exported from core, so importers keep one entry point. Tab shapes come
+ * back from core as TYPE-only imports — erased at build time, so the cycle
+ * is cosmetic.
  */
 
 import {

--- a/packages/kobe/src/tui/workspace/terminal-tab-shapes.ts
+++ b/packages/kobe/src/tui/workspace/terminal-tab-shapes.ts
@@ -1,9 +1,13 @@
 /**
  * The tab SHAPES — `TabBase` and the three `kind`-discriminated variants
- * that make up {@link TerminalTab}. Split out of `terminal-tabs-core.ts`
- * (which owns the pure state transitions) for the file-size cap, the same
- * way the split-tree and argv helpers already were; core re-exports these
- * so existing importers keep one entry point.
+ * that make up {@link TerminalTab}.
+ *
+ * The seam is data vs. behavior: this file declares what a tab IS,
+ * `terminal-tabs-core.ts` declares what happens TO the list of them. That
+ * makes it the file everything else can depend on without depending on the
+ * transitions — the split tree, argv composition and the component all need
+ * the shapes, and none of them should be pulling in tab-list logic to get
+ * them. Core re-exports these so importers still have one entry point.
  *
  * Types only — no runtime code, so the core↔shapes pair is erased at build
  * time and can never become an import cycle.

--- a/packages/kobe/src/tui/workspace/terminal-tab-spawn.ts
+++ b/packages/kobe/src/tui/workspace/terminal-tab-spawn.ts
@@ -1,10 +1,14 @@
 /**
  * Shell-wrapping helpers for a terminal tab's PTY spawn — the argv → typed
- * shell command line translation, split out of `terminal-tabs-core.ts` (the
- * tab-list transitions) purely for the 500-line file-size cap. Self-contained:
- * no tab-shape imports, just string → `TabSpawn`. Kept as its own module so
- * both the core transitions and the component read one source for the
- * shell-quoting rule.
+ * shell command line translation.
+ *
+ * The leaf of this corner of the tree, and deliberately so: it imports
+ * nothing. Not the tab shapes, not the engine registry, not core — just
+ * `string[] → TabSpawn`. That is what makes the shell-quoting rule testable
+ * as pure string work and lets the core transitions, the component and
+ * `terminal-tab-argv.ts` all read ONE source for it. Anything that needs to
+ * know what a tab is does not belong here; that knowledge would make this
+ * file impossible to reason about in isolation, which is its whole value.
  */
 
 /** What a tab's PTY should spawn: an argv, plus optional bytes typed into

--- a/packages/kobe/src/tui/workspace/terminal-tab-split.ts
+++ b/packages/kobe/src/tui/workspace/terminal-tab-split.ts
@@ -1,14 +1,20 @@
 /**
  * Split-tree + naming policy for a terminal tab — the terminal-flavored
- * layer over the content-agnostic `split-core.ts` tree, split out of
- * `terminal-tabs-core.ts` (the tab-list transitions) purely for the
- * 500-line file-size cap. Owns the persisted leaf payload shape
+ * layer over the content-agnostic `split-core.ts` tree.
+ *
+ * Its own module because it answers a different question than
+ * `terminal-tabs-core.ts`: core owns WHICH tabs exist and which one is
+ * active; this owns what is INSIDE one tab and what that tab is called.
+ * The import graph enforces the direction — nothing here ever reads
+ * `TabsState`, so no naming or split rule can start depending on the tab
+ * list, and the one tab-shape reference ({@link TerminalTab}) is type-only
+ * and erased at build time.
+ *
+ * Owns the persisted leaf payload shape
  * ({@link PersistedSplit}), the collapse/is-split/has-engine predicates,
  * leaf PTY keying, leaf display naming, and the tab-level display naming
  * ({@link tabTitle} — framework-free so both the strip and non-render
- * callers share one rule). Never imports `TabsState`; the one tab-shape
- * dependency is the type-only {@link TerminalTab} (erased at runtime, so
- * no cycle with `terminal-tabs-core`).
+ * callers share one rule).
  */
 
 import type { VendorId } from "@/types/vendor"

--- a/packages/kobe/src/tui/workspace/terminal-tabs-core.ts
+++ b/packages/kobe/src/tui/workspace/terminal-tabs-core.ts
@@ -15,8 +15,9 @@ import type { VendorId } from "@/types/vendor"
 import type { PersistedSplit } from "./terminal-tab-split"
 
 // Split-tree + naming policy (PersistedSplit + the leaf predicates/keying/
-// naming + tab display naming) moved to `./terminal-tab-split` for the
-// file-size cap; re-exported here so existing importers keep one entry point.
+// naming + tab display naming) lives in `./terminal-tab-split`: what is
+// INSIDE one tab, versus this file's WHICH tabs exist. Re-exported here so
+// importers keep one entry point.
 export {
   type PersistedSplit,
   SHELL_LEAF_NAME,
@@ -31,8 +32,10 @@ export {
 } from "./terminal-tab-split"
 
 // Tab SHAPES (TabBase + EngineTab/CommandTab/ContentTab + the TerminalTab
-// union) moved to `./terminal-tab-shapes` for the file-size cap; re-exported
-// here so existing importers keep one entry point.
+// union) live in `./terminal-tab-shapes` — what a tab IS, so the split tree,
+// argv composition and the component can depend on the shapes without
+// depending on these transitions. Re-exported here so importers keep one
+// entry point.
 export type { CommandTab, ContentTab, EngineTab, TerminalTab } from "./terminal-tab-shapes"
 import type { CommandTab, ContentTab, TerminalTab } from "./terminal-tab-shapes"
 
@@ -338,9 +341,11 @@ export function markTabSpawned(state: TabsState, id: string): TabsState {
   return setTabSpawned(state, id, true)
 }
 
-// Engine-tab argv/spawn composition moved to `./terminal-tab-argv` for the
-// file-size cap; shell-wrapping helpers to `./terminal-tab-spawn`. Both are
-// re-exported here so existing importers keep one entry point.
+// Engine-tab argv/spawn composition lives in `./terminal-tab-argv` (it reads
+// the ENGINE contract — resume/fork flags, trust — so vendor knowledge stays
+// off the transitions); shell-quoting in `./terminal-tab-spawn` (imports
+// nothing, pure string work). Both re-exported here so importers keep one
+// entry point.
 export { type TabExitAction, engineTabArgv, engineTabSpawnFor, tabExitAction } from "./terminal-tab-argv"
 export { type TabSpawn, shellCommandLine, shellIdentityInput, shellSpawn } from "./terminal-tab-spawn"
 


### PR DESCRIPTION
Closes #93.

96 module comments across 80 files gave the repo's 500-line file-size cap as
the reason a module exists. A number is not a reason, and those comments were
teaching every next reader — and every agent — that splitting is driven by line
count. This replaces each one with the seam that split actually found.

**Comments only.** `git diff -U0` filtered to non-comment lines is empty.

## All 96 done in one pass

Every occurrence of `file-size cap` / `500-line cap` / `~500 line cap` /
`≤500 lines` in `packages/*/src` is gone. No `sed`, no template: each site was
read against the file it was split from before the comment was rewritten.

## What came out of the thinking

The seams turned out to be several distinct kinds, which is the point — a
batch replace would have flattened them into one phrase:

- **Pure decision vs. side-effecting execution** — `orchestrator/core-helpers`,
  `index/store-codec` (the seam is `this`: stateless halves are testable with
  no store, no lock, no manifest on disk).
- **Local cache vs. network** — `client/remote-orchestrator-reads` has zero
  `client.` references; `-writes` has 35. Reads are synchronous and cannot
  fail; writes are all async and every one is a place the socket can drop.
  That property is now stated, and it is checkable from the imports.
- **Data vs. behavior** — `terminal-tab-shapes` (what a tab IS) vs.
  `terminal-tabs-core` (what happens to the list of them); `activity-reduce`
  (`(state, event) → state`) vs. `activity-registry` (the live map and timers).
- **Ordering pinned by the import graph** — `use-terminal-geometry` must
  measure *before* the PTY exists, so its result can feed `useTerminalPty`.
- **A cycle that would actually break the build** — `worktree-protocol` may
  import `engine-presets`; `interactive-command` may not, because
  `engine-presets` imports *it*. Moving that code back is a compile error, not
  a crowded file. Worth saying out loud.
- **Blast radius** — `pty-child-controller` owns ONE child, `pty-host` owns the
  set; a bug in the former can only damage one session. `manager-remove` is
  alone because it is the one verb that can lose a user's work.
- **Contract vs. the mess of satisfying it** — `engine/registry` declares what
  an engine must do, `history-readers` holds the per-vendor adapters. Only the
  latter changes when a vendor rearranges its transcript store.

## Where there was no seam, it says so

Per the issue, inventing a boundary is worse than admitting there isn't one:

- **`keybindings-{sidebar,files,chat}.ts`** — one long array literal cut at the
  `─── Sidebar ───` section headers it already carried as comments. Which file
  a row lives in is decided by its `scope` field and nothing else.
- **`handlers-{task,ui,worktree}.ts`** — the daemon RPC registry grouped by
  wire-name prefix. A file boundary, not a responsibility one.

In both cases the comment now also states what the split must NOT relax
(spread order is display order; byte-equivalent payloads and key order stay
wire-load-bearing) — the thing an author moving an entry between files could
actually break.

## One thing found worth reporting separately, not fixed here

The `cli/api/verbs-*.ts` files mirror `VERB_GROUPS` in `verbs.ts`, and that
taxonomy is **user-visible** — it is what `rove api schema --group read`
prints. So a verb's group is declared twice: by which file holds it, and by its
entry in `VERB_GROUPS`. Declare a verb in `verbs-read.ts` and forget the table,
and it silently reports as group `"other"`. The comments now warn about this;
the duplication itself is a code change and out of scope for this PR.

## Verification

- Comment-only: `git diff -U0` with comment lines filtered out → empty.
- Root `bun run lint` — clean (1303 files).
- `typecheck` — clean in both `kobe` and `kobe-daemon`.
- `test:fast` 4056/4056 · `bun test test/render` 675/675 · `test:socket` 356/356.

The 4 failures this branch shows when run from `~/.rove/worktrees/...`
(`open-dir-cmd`, `project-eligibility`) are the known path-shape artifact: the
identical commit checked out under `~/i` passes 30/30, and clean `origin/main`
fails the same way from a worktree path.


coverage-exemption: packages/kobe/src/tui-react/workspace/TerminalTabs.tsx — comment-only change. `git diff -U0` on this PR contains no executable line; the gate counts a touched file regardless of what changed in it, and its 34% coverage predates this PR by every commit in its history.
coverage-exemption: packages/kobe/src/tui-react/workspace/use-tab-handoffs.ts — same: comment-only. Nothing here alters what runs, so no test could observe the change.


---

coverage-exemption: packages/kobe/src/tui-react/workspace/use-tab-handoffs.ts — comment-only change (the module doc-block); no behavior was touched, so there is no changed behavior to write a render test for. The file's 35% coverage predates this PR and is unchanged by it.
