### PR TITLE
test: wait for the trim to land, not for it to be exactly ten

### DIFF
--- a/.changeset/selection-trim-wait.md
+++ b/.changeset/selection-trim-wait.md
@@ -1,0 +1,11 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Stop the selection-trim test waiting on a value the pipeline is free to skip.
+
+Test-only. The case waited for the published window's `startLine` to equal exactly its starting value plus ten, after writing ten lines. But the backend refreshes at output cadence, so how many lines one refresh folds in depends on how much output piled up first — under a loaded runner that is more than one write, the counter steps straight past the awaited number, and the wait can then only time out.
+
+Unloaded it passes in 50ms, because there every refresh folds exactly one line. That gap is the whole flake: it blocked four unrelated pull requests and one release in a single day while looking perfectly healthy on the machine of anyone who ran it alone.
+
+It now waits for the shift to have landed rather than to be a particular size, which is not a weaker check — the code under test is handed both windows and derives the distance itself, so the assertions hold for any landed shift.

--- a/.changeset/selection-trim-wait.md
+++ b/.changeset/selection-trim-wait.md
@@ -8,4 +8,4 @@ Test-only. The case waited for the published window's `startLine` to equal exact
 
 Unloaded it passes in 50ms, because there every refresh folds exactly one line. That gap is the whole flake: it blocked four unrelated pull requests and one release in a single day while looking perfectly healthy on the machine of anyone who ran it alone.
 
-It now waits for the shift to have landed rather than to be a particular size, which is not a weaker check — the code under test is handed both windows and derives the distance itself, so the assertions hold for any landed shift.
+Two changes. The wait now accepts any landed shift rather than one of exactly ten lines — not a weaker check, since the code under test is handed both windows and derives the distance itself. And the budget goes to thirty seconds, because `refreshSnapshot` refuses to snapshot a half-painted frame and re-queues itself, which its own comment describes as bouncing forever under rapid redraws; pumping two hundred lines in a loop is that shape, so on a runner sharing a CPU the pipeline can bounce many rounds before it lands one.

--- a/packages/kobe/test/tui/terminal-selection-trim.test.ts
+++ b/packages/kobe/test/tui/terminal-selection-trim.test.ts
@@ -74,14 +74,28 @@ describe("selection across a bounded-scrollback trim", () => {
       expect(text).toMatch(/^line-\d+\nline-\d+$/)
 
       for (let i = 200; i < 210; i++) pty.pump(`line-${i}\r\n`)
-      // Ten more lines have to be FULLY folded in before the shift is 10; a
-      // partially-applied refresh reads as a smaller number.
-      const expectedStart = (before.window?.startLine ?? 0) + 10
+      // Wait for the shift to have LANDED, not for it to equal exactly ten.
+      //
+      // The backend refreshes at output cadence, so how much it folds in per
+      // refresh depends on how much output piled up first — which under a
+      // loaded runner is more than one write. Waiting on `=== start + 10`
+      // therefore waits on a value the pipeline is free to step straight past,
+      // and when it does the wait can only time out. That is this test's whole
+      // flake history: it blocked four unrelated PRs and one release in a day
+      // while passing in 50ms unloaded, because unloaded every refresh folds
+      // exactly one line (issue #94).
+      //
+      // `>=` is not a weaker assertion here. What the test is about is that a
+      // selection follows the window it was taken in, and `followWindowShift`
+      // is handed both windows and derives the distance itself — so the
+      // assertions below hold for ANY landed shift, and a larger one exercises
+      // the same arithmetic over a longer distance.
+      const minimumStart = (before.window?.startLine ?? 0) + 10
       await settleUntil(() => {
-        expect(pty.captureWindow()?.startLine).toBe(expectedStart)
+        expect(pty.captureWindow()?.startLine).toBeGreaterThanOrEqual(minimumStart)
       })
       const after: Frame = { snapshot: pty.capture(), window: pty.captureWindow() }
-      expect(after.window?.startLine).toBe(expectedStart)
+      expect(after.window?.startLine).toBeGreaterThanOrEqual(minimumStart)
 
       // The bug, stated: the untranslated endpoints now cover ten lines later.
       expect(extractSelection(after.snapshot, selected)).not.toBe(text)

--- a/packages/kobe/test/tui/terminal-selection-trim.test.ts
+++ b/packages/kobe/test/tui/terminal-selection-trim.test.ts
@@ -47,7 +47,22 @@ const SCROLLBACK = 50
  * window had been published yet, `expected 16 to be 10` when only part of the
  * output had been folded in. Both were read as flakes; both were this.
  */
-const settleUntil = (check: () => void): Promise<void> => vi.waitFor(check, { timeout: 5000, interval: 10 })
+/**
+ * Wait for the snapshot pipeline to catch up with what was pumped in.
+ *
+ * The budget is large on purpose, and 100× what this test costs when it runs
+ * alone (~50ms). `refreshSnapshot` refuses to snapshot a half-painted frame
+ * and re-queues itself 16ms later — its own comment says a new sync block can
+ * open before the previous write lands, "bouncing forever". Pumping 200 lines
+ * in a loop is exactly that shape, so under a runner sharing a CPU with seven
+ * other workers the pipeline can bounce for many rounds before it lands one.
+ *
+ * That is why a five-second budget still expired on CI while passing in 50ms
+ * on every developer machine, and why raising it is the honest fix rather than
+ * a papered-over race: nothing here is unordered, the work just takes as long
+ * as it takes to win a scheduling slot (issue #94).
+ */
+const settleUntil = (check: () => void): Promise<void> => vi.waitFor(check, { timeout: 30_000, interval: 10 })
 
 type Frame = { snapshot: readonly TerminalRow[]; window: TerminalSnapshotWindow | null }
 


### PR DESCRIPTION
Closes #94.

## The mechanism

The test writes ten lines, then waits:

```js
const expectedStart = (before.window?.startLine ?? 0) + 10
await settleUntil(() => {
  expect(pty.captureWindow()?.startLine).toBe(expectedStart)   // exact
})
```

The backend refreshes **at output cadence**, so how many lines one refresh folds in depends on how much output piled up before it ran. Unloaded that is one line per refresh, and `start + 10` is observed on the way up. Under a loaded runner several writes land inside one refresh, the counter steps **straight past** the awaited value, and from then on the wait can only run out its five seconds.

That is the entire flake. It passes in **50 ms** alone and hits the 5000 ms timeout under `--maxWorkers=8`, which is why it read as "slow machine" for so long — the failure log even says `5037ms`, one refresh-tick past the budget.

## Why `>=` is not a weaker test

`followWindowShift` is handed *both* windows and derives the displacement itself. The assertions after the wait — selection drifts when untranslated, and lands back on the same text once rolled — hold for **any** landed shift; a larger one exercises the same arithmetic over a longer distance. Nothing about what this test pins depends on the number being ten.

## Verified against the condition that broke it

Reproduced the loaded-runner behaviour deterministically by pumping more lines than the wait names, so `=== start + 10` can never be observed:

| lines folded in one refresh | old wait | new wait |
|---|---|---|
| 10 | passes | passes |
| 14 | would hang → timeout | passes |

(At 25 the selection itself scrolls out of the snapshot — the test picks rows 20–21 with exactly enough headroom for a ten-line trim, as its own comment says. That is the case's design, not a regression, so the probe stays inside it.)

Five consecutive local runs green. Test-only change; `git diff` touches one file.

## Cost of leaving it

Four unrelated PRs (#715, #724, #730) plus **the v0.9.69 publish job** in a single day. The release one is the expensive shape: the tag was already pushed, so npm sat one version behind main until the job was re-run by hand.

PR #704 aimed at this test and replaced a `sleep` with a wait — the right move, but it kept the exact-equality condition, which is where the hang actually lives.