### PR TITLE
fix: stop the daemon churn loop — socket guard now fails closed

### DIFF
--- a/.changeset/daemon-socket-guard-fail-closed.md
+++ b/.changeset/daemon-socket-guard-fail-closed.md
@@ -1,0 +1,9 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Stop the daemon disconnect/reconnect loop caused by a socket guard that deleted a healthy daemon's files.
+
+A daemon whose socket path was clobbered between bind and `arm()` never recorded an ownership stamp, and shutdown treated "never armed" as "still mine" — unlinking the socket **and pidfile** of whichever daemon owned the path by then (both node and Bun unlink a unix socket by path inside `server.close()`). The missing pidfile then blinded the busy-daemon grace in `ensureDaemonReachable`, which keys on `readPidFile`, so every client skipped the grace and went straight to stop+spawn. That fed itself: 293 autospawns and 23 takeovers in one window, cycling every 5-16 seconds with all attached clients dropping together.
+
+Ownership cleanup now fails closed — socket and pidfile are removed only on proven ownership (armed, and the inode still matches). The guard is also armed immediately after `listen`, so no `await` sits in the window where a usurper could unlink or rebind the path.

--- a/packages/kobe-daemon/package.json
+++ b/packages/kobe-daemon/package.json
@@ -62,6 +62,7 @@
     "./daemon/quota-usage-cache": "./src/daemon/quota-usage-cache.ts",
     "./daemon/runtime": "./src/daemon/runtime.ts",
     "./daemon/server": "./src/daemon/server.ts",
+    "./daemon/socket-guard": "./src/daemon/socket-guard.ts",
     "./daemon/status-disposition": "./src/daemon/status-disposition.ts",
     "./daemon/task-deletion-audit": "./src/daemon/task-deletion-audit.ts",
     "./daemon/terminal-colors": "./src/daemon/terminal-colors.ts",

--- a/packages/kobe-daemon/src/daemon/server.ts
+++ b/packages/kobe-daemon/src/daemon/server.ts
@@ -332,12 +332,15 @@ export async function startDaemonServer(orch: DaemonOrchestrator, options: Daemo
   }
 
   await listenOnUnixSocket(server, socketPath)
+  // Fingerprint FIRST, before any other await. Every await between bind and
+  // arm is a window in which a usurper can unlink+rebind the path; arming
+  // late meant either no stamp at all or a stamp of the usurper's inode.
+  await sockGuard.arm()
   await writeFile(pidPath, `${process.pid}\n`, "utf8")
   // A pre-rename binary only knows `.kobe`; without these it starts a second
   // daemon on the same task index. See compat-link.ts.
   await linkLegacyRuntimePath(socketPath, legacyDaemonSocketPath(homeDir))
   await linkLegacyRuntimePath(pidPath, legacyDaemonPidPath(homeDir))
-  await sockGuard.arm()
 
   async function stopSoon(): Promise<void> {
     if (lifetime.isStopping()) return

--- a/packages/kobe-daemon/src/daemon/socket-guard.ts
+++ b/packages/kobe-daemon/src/daemon/socket-guard.ts
@@ -16,10 +16,12 @@
  *     clients' reconnect loops then land on the new owner. A socketless
  *     daemon must never outlive its socket.
  *  2. Shutdown cleanup ({@link SocketOwnershipGuard.release}) unlinks the
- *     socket + pidfile ONLY while the socket is still owned. A superseded
- *     daemon exiting late must not delete the NEW owner's files — that was
- *     the whack-a-mole cascade where killing each stale daemon unlinked
- *     the live one's socket and triggered yet another autospawn.
+ *     socket + pidfile ONLY on PROVEN ownership — armed, and the inode
+ *     still matches. Unproven (superseded, or never armed) means hands off.
+ *     A superseded daemon exiting late must not delete the NEW owner's
+ *     files — that was the whack-a-mole cascade where killing each stale
+ *     daemon unlinked the live one's socket and triggered yet another
+ *     autospawn.
  */
 
 import { readFile, stat, unlink } from "node:fs/promises"
@@ -67,14 +69,23 @@ export interface SocketOwnershipGuard {
    *  Call once, right after listen + pidfile write. */
   arm(): Promise<void>
   /**
-   * Ownership-aware teardown. While the socket is still ours: close the
-   * listener and unlink socket + pidfile (a guard that never armed falls
-   * back to this historical behavior). Once the path belongs to someone
-   * else: only UNREF the listener — both node and Bun unlink the socket
-   * path BY NAME inside `server.close()`, so a superseded daemon closing
-   * gracefully would delete the new owner's socket (the prod whack-a-mole
-   * cascade). The unref'd listener sits on an unlinked inode, can never
-   * accept another connection, and dies with the process.
+   * Ownership-aware teardown, and it FAILS CLOSED. Unlink socket + pidfile
+   * only while ownership is PROVEN — the guard armed, and the path still
+   * carries the inode it stamped. Otherwise (superseded, or never armed at
+   * all) only UNREF the listener: both node and Bun unlink the socket path
+   * BY NAME inside `server.close()`, so closing gracefully would delete
+   * whoever owns the path now. The unref'd listener sits on an unlinked
+   * inode, can never accept another connection, and dies with the process.
+   *
+   * "Never armed" used to fall back to unconditional cleanup, which is how
+   * the cascade came back (2026-09-01, 293 autospawns / 23 takeovers in one
+   * window): a daemon that lost the path between bind and arm deleted the
+   * live owner's socket AND pidfile. The missing pidfile then blinded
+   * `ensureDaemonReachable`'s busy-daemon grace, which keys on
+   * `readPidFile` — so every client skipped the grace and went straight to
+   * stop+spawn, feeding the loop. The cost of failing closed is a stale
+   * socket/pidfile, which the boot probe and `stopDaemonProcess` already
+   * clear; the cost of failing open is killing a healthy daemon.
    */
   release(server: Server): Promise<void>
 }
@@ -129,6 +140,11 @@ export function createSocketOwnershipGuard(options: {
 
   return {
     async arm() {
+      // Call this IMMEDIATELY after listen: every await between bind and
+      // fingerprint is a window in which the path can be unlinked (stamp
+      // stays null) or rebound by a usurper (we would stamp THEIR inode and
+      // later delete their socket). A null stamp means ownership was never
+      // proven, and release() treats that as not-ours.
       const now = await currentStamp()
       if (now === null || now === "error") return
       stamp = now
@@ -142,7 +158,7 @@ export function createSocketOwnershipGuard(options: {
       // Final ownership read — a takeover between watch ticks (or with the
       // watch disabled) must still be honored here.
       await verify()
-      if (stamp !== null && lost) {
+      if (stamp === null || lost) {
         server.unref()
         return
       }

--- a/packages/kobe/test/daemon/socket-takeover.test.ts
+++ b/packages/kobe/test/daemon/socket-takeover.test.ts
@@ -9,12 +9,14 @@
  * leftover file is still cleared like before.
  */
 
-import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
 import { unlink } from "node:fs/promises"
+import type { Server } from "node:net"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { KobeDaemonClient } from "@sma1lboy/kobe-daemon/client"
 import { type DaemonServerOptions, startDaemonServer } from "@sma1lboy/kobe-daemon/daemon/server"
+import { createSocketOwnershipGuard } from "@sma1lboy/kobe-daemon/daemon/socket-guard"
 import { describe, expect, it } from "vitest"
 import { daemonRuntime } from "../../src/core/daemon-runtime.ts"
 import { bootDaemonHarness, fakeOrchestrator, waitFor } from "./harness.ts"
@@ -129,6 +131,60 @@ describe("daemon socket takeover guard", () => {
       expect(existsSync(pidPath)).toBe(false)
     } finally {
       cleanup()
+    }
+  })
+
+  it("a guard that never armed unlinks NOTHING on release — the self-feeding-cascade regression", async () => {
+    // The 2026-09-01 field cascade (293 autospawns / 23 takeovers in one
+    // window). `arm()` returns without stamping when the initial stat sees
+    // ENOENT — the path was already clobbered between bind and arm. release()
+    // used to treat "never armed" as "still mine" and unlink socket + pidfile
+    // BY PATH (both node and Bun do that inside server.close() too), deleting
+    // the LIVE owner's files. Deleting the pidfile is the half that made it
+    // self-feeding: `ensureDaemonReachable`'s busy-daemon grace keys on
+    // readPidFile, so with it gone every client skipped the grace and went
+    // straight to stop+spawn.
+    const dir = mkdtempSync(join(tmpdir(), "kobe-sock-unarmed-"))
+    try {
+      const socketPath = join(dir, "daemon.sock")
+      const pidPath = join(dir, "daemon.pid")
+      // Stand in for the live owner's files; the never-armed guard must not
+      // touch either. Plain files, so a stray unlink is unambiguous.
+      writeFileSync(socketPath, "live-owner-socket")
+      writeFileSync(pidPath, "4242\n")
+
+      let lost = false
+      const guard = createSocketOwnershipGuard({
+        socketPath: join(dir, "absent.sock"), // never existed → arm() cannot stamp
+        pidPath,
+        watchMs: 0,
+        onLost: () => {
+          lost = true
+        },
+      })
+      await guard.arm()
+
+      let unrefs = 0
+      let closes = 0
+      const server = {
+        unref: () => {
+          unrefs += 1
+        },
+        close: (cb: () => void) => {
+          closes += 1
+          cb()
+        },
+      } as unknown as Server
+      await guard.release(server)
+
+      expect(readFileSync(socketPath, "utf8")).toBe("live-owner-socket")
+      expect(readFileSync(pidPath, "utf8")).toBe("4242\n")
+      // Unref, never close: close() itself unlinks the path by name.
+      expect(unrefs).toBe(1)
+      expect(closes).toBe(0)
+      expect(lost).toBe(false)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
     }
   })
 

--- a/packages/kobe/test/daemon/socket-takeover.test.ts
+++ b/packages/kobe/test/daemon/socket-takeover.test.ts
@@ -148,21 +148,24 @@ describe("daemon socket takeover guard", () => {
     try {
       const socketPath = join(dir, "daemon.sock")
       const pidPath = join(dir, "daemon.pid")
-      // Stand in for the live owner's files; the never-armed guard must not
-      // touch either. Plain files, so a stray unlink is unambiguous.
-      writeFileSync(socketPath, "live-owner-socket")
-      writeFileSync(pidPath, "4242\n")
 
       let lost = false
       const guard = createSocketOwnershipGuard({
-        socketPath: join(dir, "absent.sock"), // never existed → arm() cannot stamp
+        socketPath,
         pidPath,
         watchMs: 0,
         onLost: () => {
           lost = true
         },
       })
+      // Arm while the path is ABSENT — the incumbent's socket was already
+      // clobbered in its bind→arm window, so no stamp is recorded.
       await guard.arm()
+      // ...and only THEN does the new owner bind the path and write its pid.
+      // Both files belong to a live daemon now. Plain files, so a stray
+      // unlink is unambiguous.
+      writeFileSync(socketPath, "live-owner-socket")
+      writeFileSync(pidPath, "4242\n")
 
       let unrefs = 0
       let closes = 0


### PR DESCRIPTION
## Symptom

On the owner's machine, `~/.rove/daemon.log` carries 293 `autospawned — arming 60000ms first-gui grace` lines and 23 `socket path was taken over or removed`. The dense window 07:19:26–07:20:28 on 2026-09-01 cycles every 5–16 seconds: daemon binds → ~5s later declares takeover and self-stops → all 6 clients (3 gui + 3 pane) drop in the same instant → each reconnects → autospawn → repeat. `client.log` shows `connect ENOENT ...daemon.sock` right after each takeover: the socket **file** was deleted, not merely rebound.

## Root cause

`createSocketOwnershipGuard` failed **open** on the never-armed path.

- `arm()` returns early without setting `stamp` when the initial `stat` gives ENOENT — the path was clobbered in the window between `listen` and `arm`.
- `release()` then read `stamp === null` as "still mine", skipped the unref branch, and ran `server.close()` + `unlink(socket)` + `unlink(pid)`.

Both node and Bun unlink a unix socket **by path** inside `close()`, verified directly:

```
bound, ino: 250417429
second owner bound, ino: 250417430 (differs: true)
after superseded server.close() -> second owner socket exists: false
```

So a daemon that failed to arm deleted whoever owned the path by then. The file header claims this cascade was fixed; the fix covered the armed case and left the never-armed case open.

**Why it self-fed** (the half that turns one bad shutdown into 293): `release()` also unlinks the **pidfile**. `ensureDaemonReachable`'s busy-daemon grace keys on `readPidFile` — with the pidfile gone, `livePid` is `null`, every client skips the 15s grace and goes straight to `stopDaemonProcess` + spawn. That answers the brief's second question: the ENOENT probe path *does* still reach the grace; the deleted pidfile is what bypassed it. No separate change needed there — this fix restores it.

## Fix

1. `release()` fails closed: unlink only on **proven** ownership (armed, and the inode still matches). Unproven — superseded or never armed — unrefs and leaves the files alone. The cost of failing closed is a stale socket/pidfile, which the boot probe and `stopDaemonProcess` already clear; the cost of failing open is killing a healthy daemon.
2. `arm()` moved to immediately after `listen`, before the pidfile write and the two `linkLegacyRuntimePath` awaits. Each of those was a window where a usurper could unlink+rebind — leaving either no stamp or, worse, a stamp of the *usurper's* inode.

## Verification

- **Regression test** (`socket-takeover.test.ts`): a guard whose `arm()` saw no socket must not unlink on release. Mutation-verified — reverting the `release()` condition fails it; re-verified after rebasing onto fresh main.
- **Live daemons** from this source, real `startDaemonServer` under Bun: superseded daemon's late close leaves the owner's socket **and** pidfile intact, pid unchanged.
- `bun run test:socket` — 676 passed / 79 files.
- `bun run test:fast` — 4052 passed; the 4 failures are the documented `project-eligibility` / `open-dir-cmd` path-shape false failures from running inside `~/.rove/worktrees`, confirmed green in a checkout under `~/i`.
- Root `bun run lint` + `typecheck` clean.

## Note, not fixed here

One of the owner's GUIs (pid 59121) logs `could not locate kobe entry near /opt/homebrew/lib/node_modules/@sma1lboy/rove/dist/cli` — a stale brew install path that no longer exists, so `resolveKobeSpawn` throws and that client can never spawn a daemon; it just retries forever. It is a **contributing amplifier**, not the cause (the cycle reproduces without it), and the fix belongs in install-path resolution or `rove doctor`, outside this slice. Worth its own issue.