### PR TITLE
docs: a dispatched task is finished when it is gone, not when it says so

### DIFF
--- a/.agents/skills/kobe/SKILL.md
+++ b/.agents/skills/kobe/SKILL.md
@@ -291,7 +291,10 @@ rove api list --pretty
 ```
 
 `.running` means any hosted engine tab on the task is alive; a live shell,
-command, or content tab alone does not count.
+command, or content tab alone does not count. It is process truth, not
+progress: a task whose work is merged and whose worker has signed off still
+reads `true` until somebody deletes it (see "A task is finished when it is
+GONE").
 Omitting BOTH `--task-id` and `--tab` inside a task that has a dispatcher
 targets that dispatcher's tab (see the reply rule above); otherwise the
 target is the active task. Omitting only `--tab` targets a live engine tab
@@ -501,6 +504,43 @@ verify the winner's actual diff before landing. Silence never proves a
 worker died (it may be mid-turn or stuck on a permission prompt): peek with
 `collect`/`get-task`, nudge with `send`, and never mark a silent task failed
 or auto-retry it.
+
+### A task is finished when it is GONE
+
+The dispatcher closes tasks. A worker cannot delete itself, so when it reports
+"done" the round is not over — its engine is still running, its Worktree still
+holds a branch, and its row is still in the sidebar.
+
+None of these mean a task is finished:
+
+| Looks final | What it actually is |
+|---|---|
+| the worker said "done" | a message; it has no verb to remove itself |
+| its PR is MERGED | the code landed; the task did not move |
+| its issue is `status done` | a field in a different store |
+| `set-status canceled` | a label — see Lifecycle above |
+
+**The only evidence is that `rove api list` no longer shows it.** Check the
+task, not the paperwork:
+
+```bash
+rove api get-task --task-id <id>   # .running true = its engine is still alive
+rove api delete --task-id <id> --wait
+```
+
+`--wait` is what turns "queued" into an answer; without it the call returns
+before the Worktree is gone.
+
+Before ending a round, sweep for both halves — they drift apart:
+
+```bash
+rove api list          # tasks whose work is done but which are still here
+git worktree list      # directories no task claims (delete finds tasks by id,
+                       # so a stray one is only reachable via git)
+```
+
+A worker that has taken over `main` in its Worktree will block the dispatcher's
+own checkout — a release cannot even start until that task is closed.
 
 ### Closing a round
 

--- a/.changeset/skill-task-closed-is-the-evidence.md
+++ b/.changeset/skill-task-closed-is-the-evidence.md
@@ -1,0 +1,9 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Teach the agent skill that a dispatched task is finished only when it is gone.
+
+A worker has no verb that removes itself, so "done" from a worker is a message, not a state change — its engine keeps running, its worktree keeps holding a branch, and its row stays in the sidebar. The skill covered closing a parallel round (land the winner, delete the losers) but said nothing about the ordinary case of one task doing one job, so a dispatcher would take the worker's report, or a merged PR, or an issue moved to `done`, as evidence the task had ended. None of those touch the task.
+
+The skill now names the only evidence — `rove api list` no longer shows it — with the sweep for the other half, since tasks and worktrees drift apart: `delete` finds tasks by id, so a stray worktree is reachable only through git. It also warns about the case that makes this expensive rather than untidy: a worker holding `main` in its worktree blocks the dispatcher's own checkout, and a release cannot start until that task is closed.

--- a/claude-plugin/skills/rove/SKILL.md
+++ b/claude-plugin/skills/rove/SKILL.md
@@ -291,7 +291,10 @@ rove api list --pretty
 ```
 
 `.running` means any hosted engine tab on the task is alive; a live shell,
-command, or content tab alone does not count.
+command, or content tab alone does not count. It is process truth, not
+progress: a task whose work is merged and whose worker has signed off still
+reads `true` until somebody deletes it (see "A task is finished when it is
+GONE").
 Omitting BOTH `--task-id` and `--tab` inside a task that has a dispatcher
 targets that dispatcher's tab (see the reply rule above); otherwise the
 target is the active task. Omitting only `--tab` targets a live engine tab
@@ -501,6 +504,43 @@ verify the winner's actual diff before landing. Silence never proves a
 worker died (it may be mid-turn or stuck on a permission prompt): peek with
 `collect`/`get-task`, nudge with `send`, and never mark a silent task failed
 or auto-retry it.
+
+### A task is finished when it is GONE
+
+The dispatcher closes tasks. A worker cannot delete itself, so when it reports
+"done" the round is not over — its engine is still running, its Worktree still
+holds a branch, and its row is still in the sidebar.
+
+None of these mean a task is finished:
+
+| Looks final | What it actually is |
+|---|---|
+| the worker said "done" | a message; it has no verb to remove itself |
+| its PR is MERGED | the code landed; the task did not move |
+| its issue is `status done` | a field in a different store |
+| `set-status canceled` | a label — see Lifecycle above |
+
+**The only evidence is that `rove api list` no longer shows it.** Check the
+task, not the paperwork:
+
+```bash
+rove api get-task --task-id <id>   # .running true = its engine is still alive
+rove api delete --task-id <id> --wait
+```
+
+`--wait` is what turns "queued" into an answer; without it the call returns
+before the Worktree is gone.
+
+Before ending a round, sweep for both halves — they drift apart:
+
+```bash
+rove api list          # tasks whose work is done but which are still here
+git worktree list      # directories no task claims (delete finds tasks by id,
+                       # so a stray one is only reachable via git)
+```
+
+A worker that has taken over `main` in its Worktree will block the dispatcher's
+own checkout — a release cannot even start until that task is closed.
 
 ### Closing a round
 


### PR DESCRIPTION
I closed a round today on the strength of "the worker reported done, its PR merged, its issue is `status done`". All three were true. The task was still running, and its worktree had taken over the `main` branch — which I found out when `git checkout main` in the primary checkout failed and the release could not start.

## What the skill was missing

`### Closing a round` covers the parallel case: land the winner, delete the losers. Nothing covered the ordinary case — **one task, one job** — which is most of what a dispatcher does. So the completion signals a dispatcher naturally reaches for all read as final:

| Looks final | What it actually is |
|---|---|
| the worker said "done" | a message; **a worker has no verb that removes itself** |
| its PR is MERGED | the code landed; the task did not move |
| its issue is `status done` | a field in a different store |
| `set-status canceled` | a label (#729 just documented this one) |

That last row is the same mistake twice in one day: I shipped the fix saying `set-status canceled` closes nothing, then took a different status field as proof a task had closed.

## Change

Adds `### A task is finished when it is GONE` before the round-closing section, naming the one piece of evidence (`rove api list` no longer shows it), the `--wait` that turns "queued" into an answer, and the sweep for the other half:

```bash
rove api list          # tasks whose work is done but which are still here
git worktree list      # directories no task claims — delete finds tasks by id,
                       # so a stray one is only reachable via git
```

Both are needed because the two records drift: deleting a task takes its worktree, but a worktree whose task is already gone is invisible to `rove api delete`.

Also flags the failure that makes this expensive rather than untidy — a worker holding `main` blocks the dispatcher's own checkout — and clarifies `.running` where it is explained: it is process truth, not progress, and stays `true` long after the work is merged.

## Scope

Docs only. Both shipped copies of the skill (`.agents/skills/kobe/` for the npm tarball, `claude-plugin/skills/rove/` for the Claude Code plugin) updated together; `claude-plugin.test.ts` pins them byte-identical and passes.

`test:fast` 4056 pass, lint + typecheck clean.