### PR TITLE
fix: derive verb groups from one declaration so none can orphan

### DIFF
--- a/.changeset/verb-groups-single-source.md
+++ b/.changeset/verb-groups-single-source.md
@@ -1,0 +1,11 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Fix `rove api schema`: the `prompt` verb was in no browsable group. A verb's
+group used to be declared twice — once by which `verbs-*.ts` file held it, once
+in a hand-written table — and `prompt` was missing from the table, so it
+reported group `other`, which `--group` then rejected as unknown. Groups are
+now derived from a required `group` field on each verb, so an ungrouped verb is
+a compile error instead of a silent orphan. Within a group, `--group` lists
+verbs in the same canonical order as the index and `--all`.

--- a/docs/API.md
+++ b/docs/API.md
@@ -366,6 +366,10 @@ placeholder branch to a descriptive name. Prompts into existing sessions
   a toast in every attached Rove UI. `done` / `needs_input` / `error` get
   severity styling; any other kind renders neutrally. The result's `clients`
   is the reach signal: `0` = no attached UI showed the toast (headless).
+- `prompt --title TEXT [--placeholder T] [--initial T] [--timeout MS]`:
+  ask the human for a line of text through the attached TUI's input dialog;
+  blocks until answered/cancelled/timeout (default 120000 ms, max 600000)
+  and returns `{ value }` or `{ cancelled, reason }`.
 - `engine-report --kind KIND [--task-id ID] [--engine ID] [--tab TAB]
   [--detail JSON]`: report a normalized engine-activity verb for a task,
   the public face of the `engine.reportEvent` RPC the built-in hook adapters
@@ -519,11 +523,7 @@ nothing to do), `skipped_missed`, `skipped_unavailable`, and
 - `adopt --repo PATH --worktree PATH [--branch B] [--command CMD] [--title T]`:
   import an existing git worktree as a Rove task.
 
-## feedback + other
+## feedback
 
 - `feedback --title T --body TEXT [--category SLUG]` *(offline)*: create a
   GitHub Discussion in the Rove repository's Feedback category via `gh`.
-- `prompt --title TEXT [--placeholder T] [--initial T] [--timeout MS]`:
-  ask the human for a line of text through the attached TUI's input dialog;
-  blocks until answered/cancelled/timeout (default 120000 ms, max 600000)
-  and returns `{ value }` or `{ cancelled, reason }`.

--- a/packages/kobe/src/cli/api/handlers-agent-turns.ts
+++ b/packages/kobe/src/cli/api/handlers-agent-turns.ts
@@ -73,6 +73,7 @@ async function agentTurns(ctx: VerbContext): Promise<unknown> {
 
 export const AGENT_TURNS_VERB: VerbSpec = {
   name: "agent-turns",
+  group: "read",
   summary:
     "Per-turn agent telemetry: one record per completed engine turn (task/tab/vendor/model/timings/tokens), newest first, plus totals. Engine-produced, daemon-stored; read-only.",
   flags: [

--- a/packages/kobe/src/cli/api/handlers-digest.ts
+++ b/packages/kobe/src/cli/api/handlers-digest.ts
@@ -99,6 +99,7 @@ export async function digest(ctx: VerbContext): Promise<unknown> {
 /** Spec half of the digest verb — spread into {@link VERBS} in `verbs.ts`. */
 export const DIGEST_VERB: VerbSpec = {
   name: "digest",
+  group: "read",
   summary:
     "Aggregate a repo's recent agent work: tasks touched in the window plus routine run outcomes. Reads state Rove already persists — the measurement any workflow change has to move.",
   flags: [

--- a/packages/kobe/src/cli/api/handlers-engines.ts
+++ b/packages/kobe/src/cli/api/handlers-engines.ts
@@ -45,6 +45,7 @@ function listAllEnginePresets() {
 
 export const ENGINE_LIST_VERB: VerbSpec = {
   name: "engine-list",
+  group: "discover",
   summary:
     "List every engine Rove can launch — built-ins, registered presets, and engines contributed by enabled plugins — each with its RAW launch command, exactly as it runs. Copy one into `add --command` / `send --tab new --command` verbatim, or edit its flags first. `protocol` is the adapter Rove speaks to it (history, trust, delivery); `generic` = none, which still runs fine but loses transcript reads. Returns { engines }.",
   flags: [],
@@ -72,6 +73,7 @@ export async function setCommand(ctx: VerbContext): Promise<unknown> {
 
 export const SET_COMMAND_VERB: VerbSpec = {
   name: "set-command",
+  group: "edit",
   summary:
     "Set a task's engine launch command (takes effect on the next session rebuild). The protocol Rove speaks to it is derived from the command — the result reports which one, `generic` when the command names no engine Rove knows.",
   flags: [F.taskId(), { ...F.command(), required: true }],

--- a/packages/kobe/src/cli/api/handlers-inspect.ts
+++ b/packages/kobe/src/cli/api/handlers-inspect.ts
@@ -180,6 +180,7 @@ async function inspect(ctx: VerbContext): Promise<unknown> {
 /** Spec half — spread into {@link VERBS} in `verbs.ts`. */
 export const INSPECT_VERB: VerbSpec = {
   name: "inspect",
+  group: "read",
   summary:
     "Production diagnostics in one read: daemon activity registry (raw states, probe vendors, watchdogs), pty-host sessions joined with a live process-tree engine walk, durable session death records (exit code/signal/output tail), and the persisted tab snapshots the sidebar renders from. Read-only; missing daemon/host degrade to null.",
   flags: [F.taskId(false)],

--- a/packages/kobe/src/cli/api/handlers-pane.ts
+++ b/packages/kobe/src/cli/api/handlers-pane.ts
@@ -15,6 +15,7 @@ import { ApiError, type VerbSpec } from "./types.ts"
 
 export const PANE_VERB: VerbSpec = {
   name: "pane-open",
+  group: "drive",
   summary:
     "Open a terminal pane in a task's workspace: split the focused tab (default, or --tab's tab) or open a separate command tab, optionally running a command. Broadcast over the daemon's tab.open channel — an attached TUI showing the task performs the split. Task defaults to $ROVE_TASK_ID, then the active task. Returns the resolved `title` (the label `pane-close --title` must match — derived from the command's first word when --title is omitted) plus `clients` (attached connections; 0 = nobody performed the split).",
   flags: [
@@ -87,6 +88,7 @@ export const PANE_VERB: VerbSpec = {
 
 export const PANE_CLOSE_VERB: VerbSpec = {
   name: "pane-close",
+  group: "drive",
   summary:
     "Close panes opened by pane-open: every split pane / command tab in the task whose label matches --title. Broadcast over the daemon's tab.close channel — an attached TUI showing the task performs the close (headless no-op). Task defaults to $ROVE_TASK_ID, then the active task. Returns `clients` (attached connections; 0 = nobody performed the close).",
   flags: [

--- a/packages/kobe/src/cli/api/handlers-tasks.ts
+++ b/packages/kobe/src/cli/api/handlers-tasks.ts
@@ -235,6 +235,7 @@ export async function dispatch(ctx: VerbContext): Promise<unknown> {
  *  file and `verbs.ts` imports the finished spec. */
 export const DISPATCH_VERB: VerbSpec = {
   name: "dispatch",
+  group: "drive",
   summary:
     "Route text into a task's live session via the daemon's session.deliver channel. The dispatcher's messenger (docs/design/dispatcher.md); unlike `send`, it requires an already-hosted session.",
   flags: [

--- a/packages/kobe/src/cli/api/read-output.ts
+++ b/packages/kobe/src/cli/api/read-output.ts
@@ -380,6 +380,7 @@ async function handleReadOutput(ctx: VerbContext): Promise<unknown> {
 
 export const READ_OUTPUT_VERB: VerbSpec = {
   name: "read-output",
+  group: "read",
   summary:
     "Read a task's engine output as bounded, cursor-paged JSON: the engine's own structured history when available, else a labeled terminal tail (typed fallbackReason). --tab tab-N reads one exact terminal tab. Read-only; the cursor stays pinned to one source/session/tab (SOURCE_CHANGED when it moved).",
   flags: [

--- a/packages/kobe/src/cli/api/schema.ts
+++ b/packages/kobe/src/cli/api/schema.ts
@@ -13,17 +13,10 @@ import { getCustomEngineIds } from "../../state/repos.ts"
 import { CURRENT_VERSION } from "../../version.ts"
 import { activeCliName } from "../rename-compat.ts"
 import { ApiError, type FlagSpec, type VerbSpec } from "./types.ts"
-import { VERBS, VERB_ALIASES, VERB_GROUPS, findVerb } from "./verbs.ts"
+import { VERBS, VERB_ALIASES, VERB_GROUPS } from "./verbs.ts"
 
 /** Bumped when the verb/flag shape changes incompatibly. Agents can gate on it. */
 export const API_SCHEMA_VERSION = 2
-
-export function groupOf(verbName: string): string {
-  for (const [group, names] of Object.entries(VERB_GROUPS)) {
-    if (names.includes(verbName)) return group
-  }
-  return "other"
-}
 
 const GLOBAL_FLAGS = [
   { name: "pretty", type: "bool", description: "Pretty-print stdout JSON." },
@@ -63,7 +56,7 @@ function flagJson(f: FlagSpec): unknown {
 export function verbSchema(v: VerbSpec): unknown {
   return {
     name: v.name,
-    group: groupOf(v.name),
+    group: v.group,
     summary: v.summary,
     offline: v.offline ?? false,
     flags: v.flags.map(flagJson),
@@ -79,24 +72,25 @@ export function schemaIndex(): unknown {
     kobeVersion: CURRENT_VERSION,
     hint: `Compact index. Drill into ONE verb: \`${cliName} api schema --verb <name>\` (or \`${cliName} api <verb> --help\`). One group: \`--group <g>\`. Whole spec: \`--all\`.`,
     groups: VERB_GROUPS,
-    verbs: VERBS.map((v) => ({ name: v.name, group: groupOf(v.name), summary: v.summary })),
+    verbs: VERBS.map((v) => ({ name: v.name, group: v.group, summary: v.summary })),
     globalFlags: GLOBAL_FLAGS,
     aliases: VERB_ALIASES,
   }
 }
 
-/** The verbs in ONE group (compact). */
+/**
+ * The verbs in ONE group (compact). Every group here has verbs and every verb
+ * is in a group — both sides come from the same `VerbSpec.group` field, so the
+ * listing can no longer disagree with the `group` an agent read off the index.
+ */
 export function groupSchema(group: string): unknown {
-  const names = VERB_GROUPS[group]
-  if (!names) {
+  const verbs = VERBS.filter((v) => v.group === group)
+  if (verbs.length === 0) {
     throw new ApiError(`unknown group: ${group}. Groups: ${Object.keys(VERB_GROUPS).join(", ")}`, "BAD_FLAG")
   }
   return {
     group,
-    verbs: names.map((n) => {
-      const v = findVerb(n)
-      return { name: n, summary: v?.summary ?? "" }
-    }),
+    verbs: verbs.map((v) => ({ name: v.name, summary: v.summary })),
   }
 }
 

--- a/packages/kobe/src/cli/api/types.ts
+++ b/packages/kobe/src/cli/api/types.ts
@@ -81,8 +81,35 @@ export interface VerbContext {
 
 export type VerbHandler = (ctx: VerbContext) => Promise<unknown>
 
+/**
+ * The taxonomy `rove api schema` exposes for LEVELED exploration. Closed on
+ * purpose: a verb's group is a REQUIRED field on {@link VerbSpec}, so a new
+ * verb does not compile until it is grouped, and `VERB_GROUPS` is derived from
+ * the specs instead of being hand-maintained beside them. There is
+ * deliberately no `other`: the old fallback let an ungrouped verb report a
+ * group name that `--group` then rejected as unknown — invisible until an
+ * agent actually browsed by group.
+ */
+export const VERB_GROUP_IDS = [
+  "discover",
+  "read",
+  "create",
+  "drive",
+  "edit",
+  "issues",
+  "workitems",
+  "routine",
+  "lifecycle",
+  "worktree",
+  "feedback",
+] as const
+
+export type VerbGroup = (typeof VERB_GROUP_IDS)[number]
+
 export interface VerbSpec {
   readonly name: string
+  /** Which `rove api schema --group G` listing this verb appears under. */
+  readonly group: VerbGroup
   readonly summary: string
   readonly flags: readonly FlagSpec[]
   /** Verbs that don't need the daemon (e.g. `schema`). */

--- a/packages/kobe/src/cli/api/verbs-automations.ts
+++ b/packages/kobe/src/cli/api/verbs-automations.ts
@@ -1,9 +1,9 @@
 /**
  * The `routine` verb group — daemon-owned scheduled agent tasks: the schedule
  * that CREATES tasks, which is a different object from the tasks themselves.
- * One file per `VERB_GROUPS` entry in `verbs.ts`, the taxonomy
- * `rove api schema --group routine` prints; a verb missing from that table
- * reports as group "other". Specs spread back into the {@link VERBS} table, so
+ * One file per `VerbGroup`, mirroring the taxonomy
+ * `rove api schema --group routine` prints — though it is each spec's own
+ * `group` field, not this file, that decides where a verb lists. Specs spread back into the {@link VERBS} table, so
  * schema/help/validation see one canonical list.
  *
  * By default every firing creates a FRESH task (worktree + branch + engine
@@ -66,12 +66,14 @@ function precheckPayload(ctx: Parameters<VerbSpec["handler"]>[0]): Record<string
 export const ROUTINE_VERBS: readonly VerbSpec[] = [
   {
     name: "routine-list",
+    group: "routine",
     summary: "List scheduled routines with their next run time.",
     flags: [],
     handler: (ctx) => simpleRpc(ctx, "automation.list", {}),
   },
   {
     name: "routine-create",
+    group: "routine",
     summary:
       "Schedule a prompt. Each firing creates a fresh task (worktree + engine) and delivers it. An enabled routine keeps the daemon alive so it fires with no TUI attached.",
     flags: [
@@ -107,6 +109,7 @@ export const ROUTINE_VERBS: readonly VerbSpec[] = [
   },
   {
     name: "routine-update",
+    group: "routine",
     summary: "Change a routine. A new --schedule re-anchors its next run; --precheck '' clears the precheck.",
     flags: [
       { name: "id", type: "string", required: true, placeholder: "ID", description: "Routine id." },
@@ -134,6 +137,7 @@ export const ROUTINE_VERBS: readonly VerbSpec[] = [
   },
   {
     name: "routine-set-enabled",
+    group: "routine",
     summary: "Pause or resume a routine. Disabling the last active one releases the daemon's keep-alive hold.",
     flags: [
       { name: "id", type: "string", required: true, placeholder: "ID", description: "Routine id." },
@@ -144,12 +148,14 @@ export const ROUTINE_VERBS: readonly VerbSpec[] = [
   },
   {
     name: "routine-delete",
+    group: "routine",
     summary: "Delete a routine and its run history. Tasks it already created are untouched.",
     flags: [{ name: "id", type: "string", required: true, placeholder: "ID", description: "Routine id." }],
     handler: (ctx) => simpleRpc(ctx, "automation.delete", { id: ctx.args.require("id") }),
   },
   {
     name: "routine-run-now",
+    group: "routine",
     summary:
       "Run a routine immediately, skipping its precheck (asking for it IS the answer). Does not shift its schedule.",
     flags: [{ name: "id", type: "string", required: true, placeholder: "ID", description: "Routine id." }],
@@ -157,6 +163,7 @@ export const ROUTINE_VERBS: readonly VerbSpec[] = [
   },
   {
     name: "routine-runs",
+    group: "routine",
     summary:
       "Run history, newest first. Statuses: dispatched, revived (standing session respawned — files kept, conversation did not), deferred (composer busy; the prompt is queued in the Inbox, NOT lost), skipped_precheck (nothing to do), skipped_missed, skipped_unavailable, dispatch_failed.",
     flags: [{ name: "id", type: "string", required: true, placeholder: "ID", description: "Routine id." }],

--- a/packages/kobe/src/cli/api/verbs-create.ts
+++ b/packages/kobe/src/cli/api/verbs-create.ts
@@ -1,8 +1,8 @@
 /**
  * The `create` verb group — spawning new Rove tasks. One file per
- * `VERB_GROUPS` entry in `verbs.ts`, because that taxonomy is what
- * `rove api schema --group create` prints; a verb declared here but missing
- * from that table reports as group "other". Specs spread back into the
+ * `VerbGroup`, mirroring the taxonomy `rove api schema --group create` prints
+ * — though it is each spec's own `group` field, not this file, that decides
+ * where a verb lists. Specs spread back into the
  * {@link VERBS} table, so schema/help/validation see one canonical list.
  */
 
@@ -14,6 +14,7 @@ import type { VerbSpec } from "./types.ts"
 export const CREATE_VERBS: readonly VerbSpec[] = [
   {
     name: "add",
+    group: "create",
     summary: `Create a task (shows in the sidebar immediately). With --prompt it also starts the engine and delivers it. PARALLEL ATTEMPTS: --count N spawns N sibling tasks of the SAME prompt, each in its own worktree/branch (--agents claude:2,codex:1 for a mixed fleet); capped at ${FANOUT_CAP}, prefer 3-4. Does NOT steal focus — pass --activate to make it the active task. Alias: spawn-task.`,
     flags: [
       F.repo(),

--- a/packages/kobe/src/cli/api/verbs-drive.ts
+++ b/packages/kobe/src/cli/api/verbs-drive.ts
@@ -2,9 +2,9 @@
  * The `drive` verb group — sending prompts, notes, panes, and UI notices to
  * tasks: everything that acts on a RUNNING task without changing what the task
  * is (that's `edit`) or whether it exists (`lifecycle`). One file per
- * `VERB_GROUPS` entry in `verbs.ts` — that taxonomy is what
- * `rove api schema --group drive` prints, so a verb declared here and left out
- * of that table reports as group "other". Specs spread back into the
+ * `VerbGroup`, mirroring the taxonomy `rove api schema --group drive` prints —
+ * though it is each spec's own `group` field, not this file, that decides
+ * where a verb lists. Specs spread back into the
  * {@link VERBS} table, so schema/help/validation see one canonical list.
  */
 
@@ -17,6 +17,7 @@ import type { VerbSpec } from "./types.ts"
 export const DRIVE_VERBS: readonly VerbSpec[] = [
   {
     name: "send",
+    group: "drive",
     summary:
       "Paste a follow-up prompt into a task's running engine (one full turn). Without --task-id, a task spawned from another Rove session replies to its dispatcher's tab (then that task's live canonical engine; nothing alive = DISPATCHER_UNREACHABLE, never a silent spawn); otherwise the active task. Sent from inside another Rove task ($ROVE_TASK_ID), the prompt is prefixed with [ROVE PEER] provenance — who sent it and how to reply (tab-precise) — so agent-to-agent messaging needs no coordinator. When the target composer is busy (you'd paste into a half-typed message), the prompt is accepted-but-deferred: the daemon stores it and queues a `prompt_deferred` Inbox episode for a human to release — that outcome is a SUCCESS (exit 0, `deferred` in the JSON). Do NOT retry a deferred send: the daemon already owns the message, and resending stacks a duplicate in the queue. A `succeeded:` report sent from a managed task whose branch has 0 commits is REFUSED (EMPTY_SUCCESS_REPORT) — commit first, or pass --allow-empty when the task genuinely produced no commits.",
     flags: [
@@ -54,6 +55,7 @@ export const DRIVE_VERBS: readonly VerbSpec[] = [
   DISPATCH_VERB,
   {
     name: "note",
+    group: "drive",
     summary:
       "File a one-line field note — a resolved, repo-level gotcha worth sharing. Appended to the repo's durable note store (every future session on this repo starts with it) and forwarded to the dispatcher session for live relay (docs/design/dispatcher.md).",
     flags: [
@@ -70,6 +72,7 @@ export const DRIVE_VERBS: readonly VerbSpec[] = [
   },
   {
     name: "note-list",
+    group: "drive",
     summary: "Read a repo's accumulated field notes, newest first. Returns { notes }.",
     flags: [F.repo(true)],
     handler: (ctx) => simpleRpc(ctx, "note.list", { repo: ctx.args.requirePath("repo") }),
@@ -78,6 +81,7 @@ export const DRIVE_VERBS: readonly VerbSpec[] = [
   PANE_CLOSE_VERB,
   {
     name: "notify",
+    group: "drive",
     summary:
       "Show a toast in every attached Rove UI — broadcast over the daemon's notice.event channel. Agents/scripts use it to surface 'done / needs input / error' moments without touching the task's session. Returns `clients` (attached connections; 0 = no UI showed the toast).",
     flags: [
@@ -115,6 +119,7 @@ export const DRIVE_VERBS: readonly VerbSpec[] = [
   },
   {
     name: "prompt",
+    group: "drive",
     summary:
       "Ask the human for a line of text through the attached TUI's input dialog (plugins' host-provided prompt). Blocks until answered, cancelled, or timed out; returns { value } or { cancelled, reason }.",
     flags: [
@@ -147,6 +152,7 @@ export const DRIVE_VERBS: readonly VerbSpec[] = [
   },
   {
     name: "engine-report",
+    group: "drive",
     summary:
       "Report a normalized engine-activity verb for a task — the public face of the same engine.reportEvent RPC the built-in hook adapters use. Lets a plugin-contributed engine (or any wrapper script) drive the sidebar badge, attention inbox, and plugin event stream without a built-in hook adapter. Kinds: session-start|turn-start|turn-complete|turn-failed|turn-interrupted|awaiting-input|session-end (state kinds) plus tool-pre|tool-post|tool-failed|pre-compact|post-compact|subagent-start|subagent-stop (plugin-only).",
     flags: [
@@ -200,6 +206,7 @@ export const DRIVE_VERBS: readonly VerbSpec[] = [
   },
   {
     name: "set-active",
+    group: "drive",
     summary: "Set the shared active task (the focus every Tasks pane highlights). Pass --none to clear.",
     flags: [
       F.taskId(false),

--- a/packages/kobe/src/cli/api/verbs-edit.ts
+++ b/packages/kobe/src/cli/api/verbs-edit.ts
@@ -1,9 +1,9 @@
 /**
  * The `edit` verb group — mutating task METADATA (title, branch, command,
  * status), as opposed to driving the running session (`drive`) or ending it
- * (`lifecycle`). One file per `VERB_GROUPS` entry in `verbs.ts`, the taxonomy
- * `rove api schema --group edit` prints; a verb missing from that table
- * reports as group "other". Specs spread back into the {@link VERBS} table, so
+ * (`lifecycle`). One file per `VerbGroup`, mirroring the taxonomy
+ * `rove api schema --group edit` prints — though it is each spec's own `group`
+ * field, not this file, that decides where a verb lists. Specs spread back into the {@link VERBS} table, so
  * schema/help/validation see one canonical list.
  */
 
@@ -17,6 +17,7 @@ import type { VerbSpec } from "./types.ts"
 export const EDIT_VERBS: readonly VerbSpec[] = [
   {
     name: "rename",
+    group: "edit",
     summary: "Set a task's title.",
     flags: [F.taskId(), { name: "title", type: "string", required: true, placeholder: "T", description: "New title." }],
     handler: (ctx) =>
@@ -24,6 +25,7 @@ export const EDIT_VERBS: readonly VerbSpec[] = [
   },
   {
     name: "set-branch",
+    group: "edit",
     summary: "Rename a task's branch (git branch -m if materialized, else recorded).",
     flags: [
       F.taskId(),
@@ -35,6 +37,7 @@ export const EDIT_VERBS: readonly VerbSpec[] = [
   SET_COMMAND_VERB,
   {
     name: "set-status",
+    group: "edit",
     summary:
       "Set a task's lifecycle LABEL. Cosmetic — the task row, its worktree, its branch and its engine session all stay exactly as they are, so `--status canceled` does NOT close, stop, or clean up anything. To end a task use `delete` (which keeps the git branch).",
     flags: [

--- a/packages/kobe/src/cli/api/verbs-feedback.ts
+++ b/packages/kobe/src/cli/api/verbs-feedback.ts
@@ -1,9 +1,9 @@
 /**
  * The `feedback` verb group — GitHub Discussions integration, the one group
  * that reaches an EXTERNAL service rather than the daemon. One file per
- * `VERB_GROUPS` entry in `verbs.ts`, the taxonomy
- * `rove api schema --group feedback` prints; a verb missing from that table
- * reports as group "other". Specs spread back into the {@link VERBS} table, so
+ * `VerbGroup`, mirroring the taxonomy `rove api schema --group feedback`
+ * prints — though it is each spec's own `group` field, not this file, that
+ * decides where a verb lists. Specs spread back into the {@link VERBS} table, so
  * schema/help/validation see one canonical list.
  */
 
@@ -15,6 +15,7 @@ import type { VerbSpec } from "./types.ts"
 export const FEEDBACK_VERBS: readonly VerbSpec[] = [
   {
     name: "feedback",
+    group: "feedback",
     summary: "Create a GitHub Discussion in the Rove repo's Feedback category through `gh`.",
     flags: [
       { name: "title", type: "string", required: true, placeholder: "T", description: "Discussion title." },

--- a/packages/kobe/src/cli/api/verbs-issues.ts
+++ b/packages/kobe/src/cli/api/verbs-issues.ts
@@ -1,9 +1,9 @@
 /**
  * The `issues` verb group — daemon-owned issue-store CRUD. Operates on the
  * issue store, not on tasks, which is the whole reason it is its own group.
- * One file per `VERB_GROUPS` entry in `verbs.ts`, the taxonomy
- * `rove api schema --group issues` prints; a verb missing from that table
- * reports as group "other". Specs spread back into the {@link VERBS} table, so
+ * One file per `VerbGroup`, mirroring the taxonomy
+ * `rove api schema --group issues` prints — though it is each spec's own
+ * `group` field, not this file, that decides where a verb lists. Specs spread back into the {@link VERBS} table, so
  * schema/help/validation see one canonical list.
  */
 
@@ -18,12 +18,14 @@ type IssueStatus = (typeof ISSUE_STATUSES)[number]
 export const ISSUE_VERBS: readonly VerbSpec[] = [
   {
     name: "issue-list",
+    group: "issues",
     summary: "List daemon-owned issues for a repo.",
     flags: [F.repo()],
     handler: (ctx) => simpleRpc(ctx, "issue.list", { repoRoot: ctx.args.requirePath("repo") }),
   },
   {
     name: "issue-create",
+    group: "issues",
     summary: "Create a daemon-owned issue for a repo.",
     flags: [
       F.repo(),
@@ -38,6 +40,7 @@ export const ISSUE_VERBS: readonly VerbSpec[] = [
   },
   {
     name: "issue-set-status",
+    group: "issues",
     summary: "Set a daemon-owned issue's status.",
     flags: [
       F.repo(),
@@ -52,6 +55,7 @@ export const ISSUE_VERBS: readonly VerbSpec[] = [
   },
   {
     name: "issue-update",
+    group: "issues",
     summary: "Update a daemon-owned issue's title, body, and/or linked task.",
     flags: [
       F.repo(),

--- a/packages/kobe/src/cli/api/verbs-lifecycle.ts
+++ b/packages/kobe/src/cli/api/verbs-lifecycle.ts
@@ -1,9 +1,10 @@
 /**
  * The `lifecycle` verb group — pin, land, delete: the verbs that end a task's
  * life or decide it survives, which is why they are worth naming apart from
- * the metadata edits next door. One file per `VERB_GROUPS` entry in
- * `verbs.ts`, the taxonomy `rove api schema --group lifecycle` prints; a verb
- * missing from that table reports as group "other". Specs spread back into the
+ * the metadata edits next door. One file per `VerbGroup`, mirroring the
+ * taxonomy `rove api schema --group lifecycle` prints — though it is each
+ * spec's own `group` field, not this file, that decides where a verb lists.
+ * Specs spread back into the
  * {@link VERBS} table, so schema/help/validation see one canonical list.
  */
 
@@ -15,6 +16,7 @@ import type { VerbSpec } from "./types.ts"
 export const LIFECYCLE_VERBS: readonly VerbSpec[] = [
   {
     name: "pin",
+    group: "lifecycle",
     summary: "Pin (or with --pinned=false, unpin) a task to the top of the sidebar.",
     flags: [F.taskId(), { name: "pinned", type: "bool", default: "true", description: "true to pin, false to unpin." }],
     handler: (ctx) =>
@@ -25,6 +27,7 @@ export const LIFECYCLE_VERBS: readonly VerbSpec[] = [
   },
   {
     name: "land",
+    group: "lifecycle",
     summary:
       "Merge a task's branch back into its base repo's current branch. Refuses a dirty base checkout and refuses a branch with zero commits ahead of the base (EMPTY_BRANCH; EMPTY_BRANCH_DIRTY_WORKTREE with a send-back recovery path when the worktree still holds the uncommitted work). On conflict, aborts and returns the conflicted files (resolve by hand). Returns { landedOn, commit }.",
     flags: [
@@ -54,6 +57,7 @@ export const LIFECYCLE_VERBS: readonly VerbSpec[] = [
   },
   {
     name: "delete",
+    group: "lifecycle",
     summary:
       "Remove a task and its worktree; the git branch stays unless --delete-branch. Needs --force on a dirty worktree. Returns { queued } — removal itself runs in the background; add --wait for the resolved outcome.",
     flags: [

--- a/packages/kobe/src/cli/api/verbs-read.ts
+++ b/packages/kobe/src/cli/api/verbs-read.ts
@@ -2,11 +2,9 @@
  * The `read` verb group — non-mutating queries over tasks, PTYs, and
  * diagnostics.
  *
- * These files follow the `VERB_GROUPS` taxonomy in `verbs.ts`, which is not an
- * internal detail: it's what `rove api schema --group read` prints. So a
- * verb's group is stated TWICE — by which file declares it, and by its entry
- * in `VERB_GROUPS` — and only the second one is what agents discover. Declare
- * a verb here and forget the table and it silently reports as group "other".
+ * File layout mirrors the `VerbGroup` taxonomy, but only each spec's own
+ * `group` field decides what `rove api schema --group read` prints — a verb
+ * put in the wrong file still lists under the group it declares.
  *
  * "Non-mutating" is the group's actual invariant, not just its label: a verb
  * that writes anything belongs in `drive`/`edit`/`lifecycle`, because agents
@@ -27,6 +25,7 @@ import type { VerbSpec } from "./types.ts"
 export const READ_VERBS: readonly VerbSpec[] = [
   {
     name: "list",
+    group: "read",
     summary:
       "List all tasks. Returns { tasks, activeTaskId } — `activeTaskId` is the shared focus verbs default to when --task-id is omitted (null = no active task), the audit read for any implicit-target delivery.",
     flags: [],
@@ -34,6 +33,7 @@ export const READ_VERBS: readonly VerbSpec[] = [
   },
   {
     name: "get-task",
+    group: "read",
     summary:
       "Read one task's metadata + terminal tabs. `.running` = any hosted engine tab is live; `.tabs[]` (id/kind/vendor/liveVendor/lastTitle/alive) is the discovery read for `send --tab tab-N`; `.task.dispatcher` = the Rove session (task+tab) that created it, when one did; `.task.prStatus.checkState` (none|pending|passing|failing|unknown) is Rove's OWN CI truth for the branch's PR — `passing` is what \"CI is green\" means, never a local test run.",
     flags: [F.taskId()],
@@ -41,6 +41,7 @@ export const READ_VERBS: readonly VerbSpec[] = [
   },
   {
     name: "pty-list",
+    group: "read",
     summary:
       "List hosted PTY sessions (key, alive, pid, command, live OSC window title). Empty when no pty host runs. Returns { sessions }.",
     flags: [],
@@ -49,6 +50,7 @@ export const READ_VERBS: readonly VerbSpec[] = [
   },
   {
     name: "collect",
+    group: "read",
     summary:
       "Read-only health snapshot of a parallel round: identity, branch, lineage (.dispatcher, .groupId), .running (pty-host process truth, not a cached status), .activity (daemon engine state + how long it has been in it, null when unknowable), per-tab .tabs with a dead tab's exit cause AND output tail, uncommitted .changes (non-zero = it cannot land), and committed .base (ahead count + diffstat — ahead:0 is the `succeeded but committed nothing` tell). Select with --group (one fan-out round), --repo, or --task-ids.",
     flags: [

--- a/packages/kobe/src/cli/api/verbs-work-items.ts
+++ b/packages/kobe/src/cli/api/verbs-work-items.ts
@@ -15,6 +15,7 @@ const WORK_ITEM_STATES = ["open", "closed", "all"] as const
 export const WORK_ITEM_VERBS: readonly VerbSpec[] = [
   {
     name: "workitem-list",
+    group: "workitems",
     summary:
       "List a repo's GitHub issues through the `gh` CLI. Read-only — nothing is copied into Rove's own issue store.",
     flags: [
@@ -42,6 +43,7 @@ export const WORK_ITEM_VERBS: readonly VerbSpec[] = [
   },
   {
     name: "workitem-start",
+    group: "workitems",
     summary:
       "Start a task on one GitHub issue: creates a worktree + engine session whose first message carries the issue title, body, and URL. The task keeps a link back to the issue.",
     flags: [

--- a/packages/kobe/src/cli/api/verbs-worktree.ts
+++ b/packages/kobe/src/cli/api/verbs-worktree.ts
@@ -1,10 +1,10 @@
 /**
  * The `worktree` verb group — materializing and adopting worktrees: the verbs
- * that touch git rather than the task index. One file per `VERB_GROUPS` entry
- * in `verbs.ts`, the taxonomy `rove api schema --group worktree` prints; a
- * verb missing from that table reports as group "other". Specs spread back
- * into the {@link VERBS} table, so schema/help/validation see one canonical
- * list.
+ * that touch git rather than the task index. One file per `VerbGroup`,
+ * mirroring the taxonomy `rove api schema --group worktree` prints — though it
+ * is each spec's own `group` field, not this file, that decides where a verb
+ * lists. Specs spread back into the {@link VERBS} table, so
+ * schema/help/validation see one canonical list.
  */
 
 import { F } from "./flags.ts"
@@ -15,18 +15,21 @@ import type { VerbSpec } from "./types.ts"
 export const WORKTREE_VERBS: readonly VerbSpec[] = [
   {
     name: "ensure-worktree",
+    group: "worktree",
     summary: "Materialize a task's git worktree on disk now (without starting an engine). Returns { worktreePath }.",
     flags: [F.taskId()],
     handler: (ctx) => simpleRpc(ctx, "task.ensureWorktree", { taskId: ctx.args.require("task-id") }),
   },
   {
     name: "discover-adoptable",
+    group: "worktree",
     summary: "List existing git worktrees in a repo not yet tracked as Rove tasks. Returns { worktrees }.",
     flags: [F.repo()],
     handler: (ctx) => simpleRpc(ctx, "worktree.discoverAdoptable", { repo: ctx.args.requirePath("repo") }),
   },
   {
     name: "adopt",
+    group: "worktree",
     summary: "Import an existing git worktree as a Rove task. Returns { task }.",
     flags: [
       F.repo(),

--- a/packages/kobe/src/cli/api/verbs.ts
+++ b/packages/kobe/src/cli/api/verbs.ts
@@ -11,7 +11,7 @@
 
 import { ENGINE_LIST_VERB } from "./handlers-engines.ts"
 import { fullSchema, groupSchema, schemaIndex, verbSchema } from "./schema.ts"
-import { ApiError, type VerbContext, type VerbSpec } from "./types.ts"
+import { ApiError, VERB_GROUP_IDS, type VerbContext, type VerbGroup, type VerbSpec } from "./types.ts"
 import { ROUTINE_VERBS } from "./verbs-automations.ts"
 import { CREATE_VERBS } from "./verbs-create.ts"
 import { DRIVE_VERBS } from "./verbs-drive.ts"
@@ -83,36 +83,10 @@ export const RETIRED_VERBS: Readonly<Record<string, { hint: string; nextCommandA
   },
 }
 
-/**
- * Verb groups for LEVELED exploration. An agent reads the compact index
- * (groups + verb summaries), then drills into one verb or one group —
- * instead of slurping every flag of every verb and polluting its context.
- */
-export const VERB_GROUPS: Readonly<Record<string, readonly string[]>> = {
-  discover: ["schema", "engine-list"],
-  read: ["list", "get-task", "collect", "digest", "agent-turns", "pty-list", "read-output", "inspect"],
-  create: ["add"],
-  drive: ["send", "dispatch", "note", "note-list", "set-active", "pane-open", "pane-close", "notify", "engine-report"],
-  edit: ["rename", "set-branch", "set-command", "set-status"],
-  issues: ["issue-list", "issue-create", "issue-set-status", "issue-update"],
-  workitems: ["workitem-list", "workitem-start"],
-  routine: [
-    "routine-list",
-    "routine-create",
-    "routine-update",
-    "routine-set-enabled",
-    "routine-delete",
-    "routine-run-now",
-    "routine-runs",
-  ],
-  lifecycle: ["pin", "land", "delete"],
-  worktree: ["ensure-worktree", "adopt", "discover-adoptable"],
-  feedback: ["feedback"],
-}
-
 /** The `schema` verb spec — kept here because its handler references VERBS. */
 const SCHEMA_VERB: VerbSpec = {
   name: "schema",
+  group: "discover",
   summary:
     "Explore the API. Default = a COMPACT index (groups + verb summaries, no flags). Drill in with --verb / --group; --all for the full spec.",
   flags: [
@@ -147,6 +121,26 @@ export const VERBS: readonly VerbSpec[] = [
 
 /** Verb names in canonical order (schema/help/tests). */
 export const API_VERBS = VERBS.map((v) => v.name)
+
+/**
+ * Verb groups for LEVELED exploration. An agent reads the compact index
+ * (groups + verb summaries), then drills into one verb or one group — instead
+ * of slurping every flag of every verb and polluting its context.
+ *
+ * DERIVED from `VerbSpec.group`, not hand-written: a verb used to state its
+ * group twice (once by which `verbs-*.ts` declares it, once in a table here),
+ * and forgetting the table half silently produced a group `--group` then
+ * rejected as unknown (issue #95). One declaration, one source of truth —
+ * `VerbGroup` is a closed union, so an ungrouped verb is a type error.
+ *
+ * Group order follows {@link VERB_GROUP_IDS}; verbs within a group follow the
+ * canonical {@link VERBS} order, so every listing agrees.
+ */
+export const VERB_GROUPS: Readonly<Record<VerbGroup, readonly string[]>> = (() => {
+  const byGroup = Object.fromEntries(VERB_GROUP_IDS.map((g) => [g, [] as string[]])) as Record<VerbGroup, string[]>
+  for (const v of VERBS) byGroup[v.group].push(v.name)
+  return byGroup
+})()
 
 export function findVerb(name: string): VerbSpec | undefined {
   const canonical = VERB_ALIASES[name] ?? name

--- a/packages/kobe/test/cli/api-handlers-more.test.ts
+++ b/packages/kobe/test/cli/api-handlers-more.test.ts
@@ -13,6 +13,8 @@ import {
   API_SCHEMA_VERSION,
   ApiError,
   type ApiRuntime,
+  VERBS,
+  VERB_GROUPS,
   VerbArgs,
   findVerb,
   invokeVerb,
@@ -135,6 +137,12 @@ describe("schema drill-ins", () => {
     })
   })
 
+  // Hardcoded on purpose: the neighbouring "every advertised group" test
+  // compares the listing against `VERB_GROUPS`, and both now derive from
+  // `VerbSpec.group`, so they move together. This one is the independent pin —
+  // and it is in canonical VERBS order, which is the order the index, `--all`
+  // and `--help` already used, so a group listing can no longer disagree with
+  // them.
   it("--group lists that group's verbs compactly (name + summary only)", async () => {
     const result = (await invokeVerb("schema", ["--group", "read"], offline)) as {
       group: string
@@ -144,12 +152,12 @@ describe("schema drill-ins", () => {
     expect(result.verbs.map((v) => v.name)).toEqual([
       "list",
       "get-task",
+      "pty-list",
       "collect",
       "digest",
       "agent-turns",
-      "pty-list",
-      "read-output",
       "inspect",
+      "read-output",
     ])
     for (const v of result.verbs) expect(v.summary.length).toBeGreaterThan(0)
   })
@@ -164,11 +172,31 @@ describe("schema drill-ins", () => {
     expect(result.verbs.length).toBeGreaterThan(10)
   })
 
-  it("a verb outside every group is reported as group 'other'", async () => {
-    const schema = verbSchema({ name: "not-grouped", summary: "s", flags: [], handler: async () => null }) as {
-      group: string
+  // Regression for issue #95: `prompt` was declared in `verbs-drive.ts` but
+  // never added to the hand-written group table, so it reported group "other"
+  // — a name `--group` then rejected as unknown, leaving it in NO browsable
+  // group. Groups are now derived from `VerbSpec.group`, so this holds for
+  // every verb by construction; the assertion is what fails if someone
+  // reintroduces a fallback.
+  it("every verb is reachable through the group it reports", async () => {
+    for (const v of VERBS) {
+      const listing = (await invokeVerb("schema", ["--group", v.group], offline)) as {
+        verbs: Array<{ name: string }>
+      }
+      expect(listing.verbs.map((entry) => entry.name)).toContain(v.name)
     }
-    expect(schema.group).toBe("other")
+  })
+
+  it("every advertised group is browsable, and lists exactly its own verbs", async () => {
+    for (const [group, names] of Object.entries(VERB_GROUPS)) {
+      const listing = (await invokeVerb("schema", ["--group", group], offline)) as {
+        group: string
+        verbs: Array<{ name: string; summary: string }>
+      }
+      expect(listing.group).toBe(group)
+      expect(listing.verbs.map((v) => v.name)).toEqual([...names])
+      for (const v of listing.verbs) expect(v.summary.length).toBeGreaterThan(0)
+    }
   })
 })
 


### PR DESCRIPTION
Fixes #95.

## Root cause

A verb's group was declared **twice**, and the halves were never checked against each other:

1. which `verbs-*.ts` file declares it, and
2. its entry in the hand-written `VERB_GROUPS` table in `verbs.ts`.

Only the second is what agents see. `prompt` (declared in `verbs-drive.ts`, absent from the table) fell through `groupOf()`'s `return "other"` — and `"other"` is not a key of `VERB_GROUPS`, so `groupSchema()` rejected it as an unknown group. The verb showed a group name in the index that `--group` refused to open: browsable from nowhere, with no warning and no red test.

## Which direction, and why

The issue offered three: single source of truth, an assertion, or make the fallback throw. **I took the single source of truth**, because the other two only shorten the feedback loop on a mistake the design still invites:

- **An assertion** (`every VERBS entry appears in exactly one VERB_GROUPS group`) catches the omission at test time, but you still write the group twice and can still get it wrong — you just find out in CI instead of in production.
- **Throwing from the fallback** turns a silent orphan into a loud crash, which is better, but it fires at *runtime*, on whoever ran `schema` next.

Deriving it removes the second declaration entirely, so the failure mode has nowhere left to occur:

- `group` is now a **required** field on `VerbSpec`, typed as `VerbGroup` — a closed union of the eleven group ids.
- `VERB_GROUPS` is **computed from `VERBS`** instead of hand-written.
- `groupOf()` and its `"other"` fallback are **deleted** (`verbSchema`/`schemaIndex` read `v.group` directly).

A new verb without a group no longer compiles; a typo'd group no longer compiles either. That is strictly earlier than the assertion the issue proposed, and it needs no test to stay true. File layout is now what the issue predicted — pure organisation, load-bearing for nothing.

`prompt` lands in `drive`, where it was already declared.

## The docs had the same orphan

`docs/API.md` carried a `## feedback + other` heading that existed *only* because `prompt` reported group `"other"` and there was no group to file it under. Second commit puts `prompt` under `drive` (after `notify`, matching the order `schema --group drive` now prints) and drops the `+ other`. The page and the schema agree again.

## The failing test

The old test pinned the bug (`a verb outside every group is reported as group 'other'`). Replaced with two that fail if it comes back:

- **`every verb is reachable through the group it reports`** — for each verb, actually calls `schema --group <its group>` and asserts the verb is in that listing. This is the property #95 violated: `prompt` reported a group you could not open.
- **`every advertised group is browsable, and lists exactly its own verbs`** — every key of `VERB_GROUPS` opens and returns exactly its members.

Mutation-verified in both directions:

| mutation | result |
|---|---|
| widen `VerbGroup` to `string`, set `prompt`'s group to `"other"` (the literal #95 state) | ✗ suite fails to load — `VERB_GROUPS` construction throws on the unknown group |
| make `groupSchema` filter `prompt` out of its own group's listing | ✗ 2 tests fail, naming `prompt`: `expected [...] to include 'prompt'` |

## `API_SCHEMA_VERSION`: **not bumped** (stays 2)

The issue flagged this correctly — `VERB_GROUPS` shape change is agent-facing. But the version gates *incompatible* changes, and every observable change here moves the output **toward** the documented contract, not away from it:

- **`groups` keys/values:** identical. Same eleven groups, same membership — plus `prompt`, which is a bug fix (it was never reachable). Verified: 45 verbs, 0 orphans.
- **`verbs[].group`:** every value was already a valid group key except `prompt`'s `"other"` — and `"other"` was precisely the broken value, one no agent could act on. An agent that special-cased it degrades to the normal path.
- **`--group other`:** still `BAD_FLAG`, unchanged.
- **Within-group verb order:** the one real change. `--group read` now lists in canonical `VERBS` order rather than the table's arbitrary hand-written order. Order was never a documented contract for group listings; the index, `--all` and `--help` already used the canonical order, so this removes a disagreement between them.

Nothing an agent could correctly rely on changed shape or meaning. A bump would make every version-gating agent treat a strict repair as a breaking change and re-probe for nothing.

## Gates

- `bun run lint` ✓ · `bun run typecheck` ✓
- `env -u ROVE_INVOKED_AS bun run test` — 4053 passed; 4 pre-existing failures in `project-eligibility.test.ts` / `open-dir-cmd.test.ts`, untouched by this diff. They are the known path-shape artifact of running inside `~/.rove/worktrees` (the checkout classifies as `roveInternal`). Confirmed against a clean `origin/main` worktree outside that path: **all 4 pass unmodified there, and this branch's full `test/cli` + `test/state` is 1019/1019 green in the same location.**
- Changeset: `patch`.