### PR TITLE
fix: name the stale install instead of retrying it forever

### DIFF
--- a/.changeset/stale-install-integrity.md
+++ b/.changeset/stale-install-integrity.md
@@ -1,0 +1,11 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Say so when Rove is running from an install that has been deleted
+
+A `bun`/`node` process holds its entry open by inode, so uninstalling Rove out from under a running one leaves it alive on a path that no longer exists. It keeps working until it needs to spawn a daemon, and then fails identically forever — one GUI on the owner's machine spent two days in a reconnect loop that could never succeed, showing nothing but "reconnecting".
+
+Three changes. The resolver now throws a distinguishable `StaleInstallError` instead of a generic message, so a permanent failure can be told apart from a transient one. The reconnect loop stops on it — retrying assumes the next attempt could differ, which it cannot here — and the workspace paints a banner naming the reinstall. And `rove doctor` gains an `install:` line that runs the spawn path's own resolver, so the two can never disagree.
+
+Also fixes an ordering bug found alongside it: `ensureDaemonReachable` killed the existing daemon *before* resolving the entry point to replace it, so a stale install removed a working daemon it could not put back.

--- a/packages/kobe-daemon/src/client/daemon-process.ts
+++ b/packages/kobe-daemon/src/client/daemon-process.ts
@@ -176,7 +176,11 @@ export function tryAcquireSpawnLock(lockPath: string, staleMs: number = SPAWN_LO
  * comes up — or, inside an engine session, when the daemon is wedged
  * (session helpers never kill/replace the shared daemon).
  */
-export async function ensureDaemonReachable(): Promise<string> {
+export async function ensureDaemonReachable(
+  /** Seam for tests: the spawn argv resolver. A stale install cannot be
+   *  reproduced otherwise without deleting the running source tree. */
+  resolveSpawn: (subcommand: readonly string[]) => string[] = resolveKobeSpawn,
+): Promise<string> {
   const socketPath = defaultDaemonSocketPath()
   const state = await probeDaemonSocket(socketPath)
   if (state === "alive") return socketPath
@@ -246,13 +250,20 @@ export async function ensureDaemonReachable(): Promise<string> {
       // (graceful → SIGTERM → SIGKILL) is the right tool.
     }
 
-    // Absent, or wedged outside a session: kill any wedged process FIRST —
-    // `stopDaemonProcess` is idempotent (just clears stale socket/pidfile
-    // when nothing is alive) and prevents a fresh spawn from racing a
-    // still-alive wedged daemon onto the same tasks.json (split-brain).
-    await stopDaemonProcess(socketPath, defaultDaemonPidPath()).catch(() => {})
+    // Resolve the replacement's argv BEFORE tearing anything down. These two
+    // steps were the other way round, and on a stale install that ordering
+    // was destructive: `stopDaemonProcess` killed the daemon and unlinked
+    // its socket + pidfile, and only THEN did `resolveKobeSpawn` discover it
+    // had no entry point to re-exec — so the client removed a working daemon
+    // and could not put one back. Resolving first makes a stale install
+    // INERT: it throws here, having touched nothing.
+    const [command, ...args] = resolveSpawn(DAEMON_START_ARGS)
 
-    const [command, ...args] = resolveKobeSpawn(DAEMON_START_ARGS)
+    // Kill any wedged process FIRST — `stopDaemonProcess` is idempotent (just
+    // clears stale socket/pidfile when nothing is alive) and prevents a fresh
+    // spawn from racing a still-alive wedged daemon onto the same tasks.json
+    // (split-brain).
+    await stopDaemonProcess(socketPath, defaultDaemonPidPath()).catch(() => {})
     spawnDetachedDaemon(command, args, autospawnDaemonEnv(), defaultDaemonLogPath())
 
     const deadline = Date.now() + 5000
@@ -375,6 +386,38 @@ export async function testDaemonResponds(
 }
 
 /**
+ * This process is running from an install that is no longer on disk.
+ *
+ * Not a spawn failure — a spawn failure is transient (a busy daemon, a lost
+ * race) and retrying is the right answer. This one is structural: the entry
+ * point {@link resolveKobeSpawn} would re-exec was unlinked out from under
+ * the running process, so every future attempt fails identically. The shape
+ * is ordinary rather than exotic: a brew copy uninstalled while its GUI kept
+ * running, leaving the process alive on an unlinked inode (the owner's
+ * machine, 2026-09-01 — one GUI 2 days into a reconnect loop that could
+ * never succeed).
+ *
+ * Callers that retry must treat it as terminal (see `runReconnectLoop`), and
+ * `rove doctor` names it, because the remedy is reinstalling, not waiting.
+ */
+export class StaleInstallError extends Error {
+  readonly candidates: readonly string[]
+  constructor(cliName: string, dir: string, candidates: readonly string[]) {
+    super(
+      `${cliName}: this process is running from an install that no longer exists on disk — no ${cliName} entry near ${dir} (checked ${candidates.join(", ")}). Reinstall (\`npm install -g @sma1lboy/rove\`) and relaunch Rove.`,
+    )
+    this.name = "StaleInstallError"
+    this.candidates = candidates
+  }
+}
+
+/** True for {@link StaleInstallError}, across the package boundary (an
+ *  `instanceof` over two copies of the module would miss). */
+export function isStaleInstallError(err: unknown): boolean {
+  return err instanceof Error && err.name === "StaleInstallError"
+}
+
+/**
  * Build the argv used to spawn a detached CLI child.
  * Returns `[command, ...args]`; callers pass to `child_process.spawn`
  * as `spawn(command, args, opts)`.
@@ -391,8 +434,15 @@ export async function testDaemonResponds(
  *    IS the kobe binary, so we re-exec it directly. After the kobed → kobe
  *    bin merge, no sibling lookup is needed.
  */
-export function resolveKobeSpawn(subcommand: readonly string[], env: NodeJS.ProcessEnv = process.env): string[] {
-  const here = fileURLToPath(import.meta.url)
+export function resolveKobeSpawn(
+  subcommand: readonly string[],
+  env: NodeJS.ProcessEnv = process.env,
+  /** The module's own path. Injectable so a test can point at a directory
+   *  that does not exist — the stale-install case cannot otherwise be
+   *  reproduced without deleting the running source tree. */
+  moduleFile: string = fileURLToPath(import.meta.url),
+): string[] {
+  const here = moduleFile
   if (here.startsWith("/$bunfs") || here.startsWith("B:\\~BUN")) {
     return [process.execPath, ...subcommand]
   }
@@ -408,5 +458,5 @@ export function resolveKobeSpawn(subcommand: readonly string[], env: NodeJS.Proc
   ]
   const entry = candidates.find((candidate) => existsSync(candidate))
   if (entry) return [process.execPath, entry, ...subcommand]
-  throw new Error(`${cliName}: could not locate ${cliName} entry near ${dir}; checked ${candidates.join(", ")}`)
+  throw new StaleInstallError(cliName, dir, candidates)
 }

--- a/packages/kobe/src/cli/doctor-cmd.ts
+++ b/packages/kobe/src/cli/doctor-cmd.ts
@@ -3,6 +3,7 @@
 import { existsSync, readFileSync, statSync } from "node:fs"
 import { join } from "node:path"
 import { KobeDaemonClient } from "@sma1lboy/kobe-daemon/client"
+import { isStaleInstallError, resolveKobeSpawn } from "@sma1lboy/kobe-daemon/client/daemon-process"
 import { resolveNodeBinary } from "@sma1lboy/kobe-daemon/client/pty-process"
 import {
   defaultDaemonLogPath,
@@ -25,6 +26,7 @@ import {
   defaultFixRuntime,
   engineTabsManualFix,
   humanOnlyFix,
+  reinstallManualFix,
   resetManualFix,
   skillInstallFix,
 } from "./doctor-fix.ts"
@@ -118,6 +120,30 @@ function tailFile(path: string, count: number): string {
   }
 }
 
+/**
+ * Is the entry point this process would re-exec still on disk? Runs the
+ * spawn path's own resolver rather than re-deriving the candidate list, so
+ * doctor cannot pass while the spawn path fails (or vice versa). Only a
+ * StaleInstallError is a finding: any other throw means the resolver itself
+ * had a problem, which is not a verdict about the install.
+ */
+function describeInstall(): { line: string; ok: boolean } {
+  try {
+    const [, entry] = resolveKobeSpawn([])
+    return { line: `install:  ✓ ${entry ?? process.execPath}`, ok: true }
+  } catch (err) {
+    if (!isStaleInstallError(err)) return { line: `install:  ? could not check (${String(err)})`, ok: true }
+    return {
+      line: [
+        "install:  ✗ GONE — this process is running from an install that no longer exists on disk",
+        "          it cannot start a daemon; every reconnect fails the same way until you reinstall",
+        "          → npm install -g @sma1lboy/rove   (then relaunch Rove)",
+      ].join("\n"),
+      ok: false,
+    }
+  }
+}
+
 async function appendUnavailableProcess(
   out: string[],
   label: string,
@@ -149,6 +175,14 @@ async function collectDoctor(): Promise<{ lines: string[]; fixes: DoctorFix[] }>
   if (!git.found) fixes.push(humanOnlyFix("git"))
   const engines = await probeEngines()
   if (!engines.anyUsable) fixes.push(humanOnlyFix("noEngine"))
+  // Can this process still re-exec itself? A `bun`/`node` process holds its
+  // entry open by inode, so uninstalling Rove out from under a running one
+  // leaves it alive on a path that is gone — it keeps working until it needs
+  // to spawn a daemon, then fails identically forever (issue #96). The check
+  // is exactly the resolution the spawn path performs, so the two can never
+  // disagree about whether this install is intact.
+  const install = describeInstall()
+  if (!install.ok) fixes.push(reinstallManualFix())
   const out = [
     "Rove doctor",
     `  build:  v${CURRENT_VERSION} (${process.platform} ${process.arch}, bun ${Bun.version})`,
@@ -158,6 +192,8 @@ async function collectDoctor(): Promise<{ lines: string[]; fixes: DoctorFix[] }>
     git.line,
     "",
     ...engines.lines,
+    "",
+    install.line,
     "",
   ]
 

--- a/packages/kobe/src/cli/doctor-fix.ts
+++ b/packages/kobe/src/cli/doctor-fix.ts
@@ -91,6 +91,21 @@ export function engineTabsManualFix(): DoctorFix {
   }
 }
 
+/**
+ * The install this process runs from was deleted (issue #96). Print-only,
+ * and not because it is dangerous: doctor cannot reinstall Rove over the
+ * running process, and the running process is the one asking.
+ */
+export function reinstallManualFix(): DoctorFix {
+  return {
+    kind: "manual",
+    id: "reinstall",
+    label: t("doctor.fix.staleInstall"),
+    action: t("doctor.fix.staleInstallAction"),
+    why: t("doctor.fix.staleInstallWhy"),
+  }
+}
+
 type HumanOnlyReason = "git" | "noEngine" | "windowsNode"
 
 /** Installs and logins: doctor can only point, a human has to act. */

--- a/packages/kobe/src/client/remote-orchestrator-connect.ts
+++ b/packages/kobe/src/client/remote-orchestrator-connect.ts
@@ -13,6 +13,7 @@
 
 import type { KobeDaemonClient } from "@sma1lboy/kobe-daemon/client"
 import { logClient, logClientError } from "@sma1lboy/kobe-daemon/client/client-log"
+import { isStaleInstallError } from "@sma1lboy/kobe-daemon/client/daemon-process"
 import {
   type ChannelName,
   DAEMON_PROTOCOL_VERSION,
@@ -41,6 +42,15 @@ export interface PerformInitOptions {
  * the daemon via `ensureReachable`; a pane only retries the existing socket
  * so helper panes never defeat daemon lazy-shutdown. Failures stay silent in
  * the UI with the caller-supplied bounded forensic logging policy.
+ *
+ * Retrying assumes the next attempt could differ from this one. Exactly one
+ * failure breaks that assumption: this process is running from an install
+ * that has been deleted, so `ensureReachable` cannot resolve an entry point
+ * to re-exec and fails identically forever. The loop gives up there and
+ * reports it once, via `onFatal`. Giving up is the SAFE direction — a client
+ * that cannot spawn is not a reason to keep pressure on a healthy daemon
+ * (PR #733), and the remedy is reinstalling, which no amount of waiting
+ * performs.
  */
 export async function runReconnectLoop(deps: {
   readonly isDisposed: () => boolean
@@ -48,6 +58,8 @@ export async function runReconnectLoop(deps: {
   readonly ensureReachable: () => Promise<unknown>
   readonly init: () => Promise<void>
   readonly shouldLogAttempt: (attempt: number) => boolean
+  /** Called once, then the loop stops, when retrying cannot ever succeed. */
+  readonly onFatal?: (err: unknown) => void
 }): Promise<void> {
   // A GUI used to retry with ZERO delay, which made every GUI in the process
   // wake at the same instant after a shared daemon drop and probe a daemon
@@ -67,6 +79,14 @@ export async function runReconnectLoop(deps: {
       logClient("orch", `reconnected and re-subscribed after ${attempt} attempt(s) — task list re-synced`)
       return
     } catch (err) {
+      // The one non-transient failure: our own install is gone. Retrying is
+      // not recovery here, it is two days of identical throws (the owner's
+      // pid 59121). Say it once and stop.
+      if (isStaleInstallError(err)) {
+        logClientError("orch-reconnect-fatal", err)
+        deps.onFatal?.(err)
+        return
+      }
       // Pane failures are expected while no GUI owns a daemon; GUI failures
       // mean ensure/start itself is temporarily failing.
       if (deps.shouldLogAttempt(attempt)) logClientError("orch-reconnect", err)

--- a/packages/kobe/src/client/remote-orchestrator.ts
+++ b/packages/kobe/src/client/remote-orchestrator.ts
@@ -159,8 +159,7 @@ export class RemoteOrchestrator {
   private readonly uiPrefsAcc = createStateCell<UiPrefsPayload | null>(null)
   private readonly keybindingsRevAcc = createStateCell<number | null>(null)
   private readonly connectionStateAcc = createStateCell<DaemonConnectionState>("online")
-  /** Set once when the reconnect loop gives up because this process's own
-   *  install is gone (see {@link staleInstallSignal}). */
+  /** Set once, by the reconnect loop giving up — see {@link staleInstallSignal}. */
   private readonly staleInstallAcc = createStateCell<string | null>(null)
   private readonly ensureReachable: () => Promise<unknown>
   private readonly role: SubscribeRole
@@ -301,13 +300,10 @@ export class RemoteOrchestrator {
     return this.connectionStateAcc
   }
 
-  /**
-   * The reconnect loop's one terminal failure, as a message — non-null once
-   * this process is confirmed to be running from an install that has been
-   * deleted, and never cleared, because nothing this process can do fixes it.
-   * Latched deliberately: it is the difference between "reconnecting" (which
-   * is what a stale install used to look like, forever) and "reinstall Rove".
-   */
+  /** The reconnect loop's one terminal failure, as a message: non-null once
+   *  this process is confirmed to be running from a deleted install. Latched,
+   *  never cleared — only a reinstall clears it, and the alternative is what
+   *  a stale install already looked like: "reconnecting", forever. */
   staleInstallSignal(): ReadableState<string | null> {
     return this.staleInstallAcc
   }

--- a/packages/kobe/src/client/remote-orchestrator.ts
+++ b/packages/kobe/src/client/remote-orchestrator.ts
@@ -159,6 +159,9 @@ export class RemoteOrchestrator {
   private readonly uiPrefsAcc = createStateCell<UiPrefsPayload | null>(null)
   private readonly keybindingsRevAcc = createStateCell<number | null>(null)
   private readonly connectionStateAcc = createStateCell<DaemonConnectionState>("online")
+  /** Set once when the reconnect loop gives up because this process's own
+   *  install is gone (see {@link staleInstallSignal}). */
+  private readonly staleInstallAcc = createStateCell<string | null>(null)
   private readonly ensureReachable: () => Promise<unknown>
   private readonly role: SubscribeRole
   /** Per-channel subscribe filter; `undefined` = subscribe to all channels. */
@@ -275,6 +278,7 @@ export class RemoteOrchestrator {
       ensureReachable: this.ensureReachable,
       init: () => this.init(),
       shouldLogAttempt: shouldLogReconnectAttempt,
+      onFatal: (err) => this.staleInstallAcc.set(err instanceof Error ? err.message : String(err)),
     })
     this.reconnectTask = task
     const clear = (): void => {
@@ -295,6 +299,17 @@ export class RemoteOrchestrator {
 
   connectionStateSignal(): ReadableState<DaemonConnectionState> {
     return this.connectionStateAcc
+  }
+
+  /**
+   * The reconnect loop's one terminal failure, as a message — non-null once
+   * this process is confirmed to be running from an install that has been
+   * deleted, and never cleared, because nothing this process can do fixes it.
+   * Latched deliberately: it is the difference between "reconnecting" (which
+   * is what a stale install used to look like, forever) and "reinstall Rove".
+   */
+  staleInstallSignal(): ReadableState<string | null> {
+    return this.staleInstallAcc
   }
 
   /** Explicitly force the same spawning recovery used by a GUI socket drop. */

--- a/packages/kobe/src/tui-react/component/version-skew-banner.tsx
+++ b/packages/kobe/src/tui-react/component/version-skew-banner.tsx
@@ -13,6 +13,12 @@
  * on. Skew is the opposite — it persists until someone restarts the daemon,
  * which is an action, which is why this one stayed.
  *
+ * {@link StaleInstallBanner} — red, the same strip, for the one condition
+ * that never clears on its own: this process is running from an install that
+ * has been deleted, so it can never start a daemon again. That earned a
+ * banner on the same test the skew banner passed and the disconnect banner
+ * failed — it persists until someone acts, and the action is reinstalling.
+ *
  * Theme tokens only, engine-neutral copy. React canon: props are plain
  * values, not Accessors.
  */
@@ -76,6 +82,27 @@ export function VersionSkewBanner(props: VersionSkewBannerProps) {
       tone={theme.warning}
       title={t("update.skew.title")}
       hint={t("update.skew.hint", { daemon, clientVersion: props.clientVersion })}
+      width={props.width}
+    />
+  )
+}
+
+export type StaleInstallBannerProps = {
+  /** The reconnect loop's terminal error message, or null while all is well. */
+  message: string | null
+  /** Available width (cells) so the accent rule fills the strip. */
+  width: number
+}
+
+export function StaleInstallBanner(props: StaleInstallBannerProps) {
+  const { theme } = useTheme()
+  const t = useT()
+  if (!props.message) return null
+  return (
+    <BannerStrip
+      tone={theme.error}
+      title={t("update.staleInstall.title")}
+      hint={t("update.staleInstall.hint")}
       width={props.width}
     />
   )

--- a/packages/kobe/src/tui-react/workspace/host.tsx
+++ b/packages/kobe/src/tui-react/workspace/host.tsx
@@ -15,7 +15,7 @@ import { getDefaultPtyRegistry } from "../../tui/panes/terminal/registry"
 import { CURRENT_VERSION } from "../../version.ts"
 import { PrefixHud } from "../component/prefix-hud"
 import { ToastOverlay } from "../component/toast-overlay"
-import { VersionSkewBanner } from "../component/version-skew-banner"
+import { StaleInstallBanner, VersionSkewBanner } from "../component/version-skew-banner"
 import { useFocus } from "../context/focus"
 import { useKV } from "../context/kv"
 import { useNotifications } from "../context/notifications"
@@ -294,7 +294,14 @@ export function WorkspaceRoot(props: { orchestrator: RemoteOrchestrator }) {
   // working through the ones it doesn't, so the alert interrupted to announce
   // something with nothing to act on. Skew is different: it persists until
   // someone restarts the daemon, which is why it kept its banner.
-  const banner = (
+  // The one condition that outranks skew: this process's install was deleted,
+  // so it cannot start a daemon at all. It used to be invisible — the client
+  // just looked like it was reconnecting, for two days (issue #96). Latched,
+  // never cleared: only a reinstall fixes it.
+  const staleInstall = useAccessor(orch.staleInstallSignal())
+  const banner = staleInstall ? (
+    <StaleInstallBanner message={staleInstall} width={dims.width} />
+  ) : (
     <VersionSkewBanner
       stale={daemonStale}
       daemonVersion={daemonVersion}

--- a/packages/kobe/src/tui/i18n/messages/doctor.ts
+++ b/packages/kobe/src/tui/i18n/messages/doctor.ts
@@ -62,6 +62,13 @@ export const en = {
     /** Why engine-tab restarts are print-only */
     engineTabsWhy: "kills that tab's live engine session — your call, not doctor's",
 
+    /** This process's entry point was deleted out from under it */
+    staleInstall: "the install this Rove runs from no longer exists on disk",
+    /** The manual action for {@link staleInstall} */
+    staleInstallAction: "npm install -g @sma1lboy/rove, then relaunch Rove",
+    /** Why {@link staleInstall} is print-only */
+    staleInstallWhy: "doctor cannot reinstall Rove over the running process — a human has to, then relaunch",
+
     /** Why installs/logins are print-only */
     humanOnlyWhy: "doctor does not install software or log in to accounts for you",
     /** git missing from PATH */
@@ -110,6 +117,10 @@ export const zh: typeof en = {
     engineTabs: "引擎 tab 可能持有过期的 daemon socket 路径",
     engineTabsAction: "在 TUI 里关闭并重开受影响的引擎 tab",
     engineTabsWhy: "会杀掉该 tab 的活动引擎会话 — 由你决定, doctor 不代劳",
+
+    staleInstall: "当前 Rove 所在的安装已从磁盘删除",
+    staleInstallAction: "npm install -g @sma1lboy/rove, 然后重新启动 Rove",
+    staleInstallWhy: "doctor 无法在运行中的进程上重装 Rove — 需要人工重装后重新启动",
 
     humanOnlyWhy: "doctor 不会替你安装软件或登录账号",
     git: "PATH 上找不到 git",

--- a/packages/kobe/src/tui/i18n/messages/update.ts
+++ b/packages/kobe/src/tui/i18n/messages/update.ts
@@ -33,6 +33,11 @@ export const en = {
     olderBuild: "an older build",
     hint: "daemon is {daemon} — you launched v{clientVersion}. Run `rove daemon restart`, then relaunch Rove",
   },
+  /** This process's own install was deleted — it can never start a daemon again. */
+  staleInstall: {
+    title: "✕ ROVE INSTALL IS GONE",
+    hint: "this Rove is running from an install that no longer exists on disk, so it cannot start a daemon. Reinstall (`npm install -g @sma1lboy/rove`) and relaunch Rove",
+  },
   versions: {
     pageTitle: "ROVE VERSIONS",
     loading: "Loading releases...",
@@ -71,6 +76,10 @@ export const zh: typeof en = {
     title: "⚠ DAEMON 版本不一致",
     olderBuild: "旧版本构建",
     hint: "daemon 运行的是 {daemon}，而你启动的是 v{clientVersion}。请运行 `rove daemon restart`，然后重新启动 Rove",
+  },
+  staleInstall: {
+    title: "✕ ROVE 安装已不存在",
+    hint: "当前 Rove 运行自一份已从磁盘删除的安装，因此无法启动 daemon。请重新安装（`npm install -g @sma1lboy/rove`）并重新启动 Rove",
   },
   versions: {
     pageTitle: "ROVE 版本列表",

--- a/packages/kobe/test/client/daemon-process.test.ts
+++ b/packages/kobe/test/client/daemon-process.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from "node:os"
 import { join } from "node:path"
 import {
   ensureDaemonReachable,
+  isStaleInstallError,
   probeDaemonSocket,
   resolveKobeSpawn,
   testDaemonResponds,
@@ -34,6 +35,31 @@ describe("resolveKobeSpawn", () => {
       "daemon",
       "start",
     ])
+  })
+
+  // Issue #96. `bun`/`node` hold an entry open by inode, so uninstalling
+  // Rove out from under a running process leaves it alive on a path that no
+  // longer exists — `/opt/homebrew/lib/node_modules/@sma1lboy/` was gone
+  // while a GUI kept running from it (owner's machine, 2026-09-01). The
+  // failure has to be DISTINGUISHABLE from an ordinary spawn failure,
+  // because the two want opposite handling: retry a transient one, stop on
+  // this one.
+  it("throws an identifiable StaleInstallError when its own install is gone", () => {
+    const gone = "/opt/homebrew/lib/node_modules/@sma1lboy/rove/dist/client/daemon-process.js"
+    let thrown: unknown
+    try {
+      resolveKobeSpawn(["daemon", "start"], { ROVE_INVOKED_AS: "rove" }, gone)
+    } catch (err) {
+      thrown = err
+    }
+    expect(isStaleInstallError(thrown)).toBe(true)
+    // And it names the remedy, since waiting is not one.
+    expect((thrown as Error).message).toContain("npm install -g @sma1lboy/rove")
+  })
+
+  it("does not mistake an intact install for a stale one", () => {
+    expect(isStaleInstallError(new Error("daemon did not start"))).toBe(false)
+    expect(isStaleInstallError(undefined)).toBe(false)
   })
 })
 
@@ -368,6 +394,82 @@ describe("ensureDaemonReachable when the daemon is busy, not dead", () => {
       expect(outcome.value).toBe(socketPath)
     } finally {
       busyDaemon.kill("SIGKILL")
+      restoreEnv()
+      rmSync(dir, { recursive: true, force: true })
+    }
+  }, 30_000)
+})
+
+/**
+ * Issue #96, the destructive half — and the one nobody reported, because its
+ * symptom is indistinguishable from the reported one.
+ *
+ * `ensureDaemonReachable` used to call `stopDaemonProcess` FIRST and
+ * `resolveKobeSpawn` second. On a stale install that ordering does damage:
+ * the client kills the daemon and unlinks its socket + pidfile, and only
+ * then discovers it has no entry point to re-exec — so it has removed a
+ * daemon it cannot replace. PR #733 established that a client which cannot
+ * spawn must not be a reason to take down a daemon; this is that rule
+ * applied to the one client that can NEVER spawn.
+ *
+ * The assertion is about EFFECTS, not the message: a stale install must
+ * leave the pidfile and the daemon process exactly as it found them.
+ * Asserting only "it threw" would stay green with the ordering restored,
+ * since it throws either way.
+ */
+describe("ensureDaemonReachable on a stale install", () => {
+  it("destroys nothing — it cannot replace what it would kill", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "kobe-stale-install-"))
+    const socketPath = join(SOCK_DIR, `kobe-dpr-stale-${process.pid}.sock`)
+    const pidPath = join(dir, "daemon.pid")
+    const restoreEnv = overrideRoveEnv({
+      DAEMON_SOCKET_PATH: socketPath,
+      DAEMON_PID_PATH: pidPath,
+      HOME_DIR: dir,
+      // Cleared, or `insideEngineSession` short-circuits on a wedged socket
+      // before the spawn path is ever reached.
+      TASK_ID: undefined,
+      TAB_ID: undefined,
+    })
+
+    // A live daemon process that is silent — the shape that sends the client
+    // down the stop+spawn path. A real child, because the question is what
+    // survives, and `stopDaemonProcess` skips a pidfile naming ourselves.
+    const daemon = spawn(process.execPath, ["-e", "setTimeout(() => {}, 60000)"], { stdio: "ignore" })
+    const daemonPid = daemon.pid as number
+    const seen: string[] = []
+    // Never answers hello: alive, unreachable, so the client must decide
+    // what to do about it — which on a stale install is "nothing".
+    await listenAt(socketPath, busyThenHealthy(Number.POSITIVE_INFINITY, seen))
+
+    // The resolver's verdict for an install that is gone. Built by the REAL
+    // resolver against a directory that does not exist, so this test cannot
+    // drift from what `resolveKobeSpawn` actually throws.
+    const staleDir = join(dir, "gone", "node_modules", "@sma1lboy", "rove", "dist", "client")
+    const resolveSpawn = (): string[] => {
+      resolveKobeSpawn([], { ROVE_INVOKED_AS: "rove" }, join(staleDir, "daemon-process.js"))
+      throw new Error("unreachable: the resolver was supposed to reject a missing install")
+    }
+
+    try {
+      writeFileSync(pidPath, String(daemonPid))
+      const err = await ensureDaemonReachable(resolveSpawn).then(
+        () => undefined,
+        (e: unknown) => e,
+      )
+
+      expect(isStaleInstallError(err)).toBe(true)
+      // THE invariant: nothing was taken down. `stopDaemonProcess` opens with
+      // a `daemon.stop` RPC and unlinks the pidfile on its way out, so these
+      // are three independent reads of "we touched nothing".
+      expect(seen).not.toContain("daemon.stop")
+      expect(isProcessAlive(daemonPid)).toBe(true)
+      expect(existsSync(pidPath)).toBe(true)
+      // And the spawn lock was released, so a client on a GOOD install can
+      // still recover this daemon after we bailed.
+      expect(existsSync(`${pidPath}.spawn-lock`)).toBe(false)
+    } finally {
+      daemon.kill("SIGKILL")
       restoreEnv()
       rmSync(dir, { recursive: true, force: true })
     }

--- a/packages/kobe/test/client/remote-orchestrator-reconnect.test.ts
+++ b/packages/kobe/test/client/remote-orchestrator-reconnect.test.ts
@@ -181,3 +181,83 @@ describe("RemoteOrchestrator auto-reconnect", () => {
     expect(h.helloCount()).toBe(0) // disposed → loop bails before any attempt
   })
 })
+
+/**
+ * Issue #96. A GUI whose own install has been deleted cannot ever bring a
+ * daemon up: `ensureReachable` fails identically on every attempt. The loop
+ * used to retry it forever — the owner had a GUI two days into that, logging
+ * the same resolution failure and looking, from the UI, exactly like a client
+ * that was about to reconnect.
+ *
+ * Stopping is also the SAFE direction. PR #733 established that a client
+ * which cannot spawn must not keep pressure on a healthy daemon; a client
+ * that can NEVER spawn is the extreme of that case.
+ */
+describe("RemoteOrchestrator on a stale install", () => {
+  // Same isolation as the suite above: the loop's error logging writes to
+  // client.log, which must never land in the real ~/.rove.
+  let home: string
+  const prev = process.env.KOBE_HOME_DIR
+
+  beforeEach(async () => {
+    home = await mkdtemp(join(tmpdir(), "kobe-orch-stale-"))
+    process.env.KOBE_HOME_DIR = home
+  })
+
+  afterEach(async () => {
+    // biome-ignore lint/performance/noDelete: env must fully unset when it was unset pre-test (assigning undefined leaves the string "undefined").
+    if (prev === undefined) delete process.env.KOBE_HOME_DIR
+    else process.env.KOBE_HOME_DIR = prev
+    await rm(home, { recursive: true, force: true })
+  })
+
+  /** Shaped like the real one: `isStaleInstallError` keys on `name`, so a
+   *  bare Error here would not be recognized — which is the point. */
+  function staleInstallError(): Error {
+    const err = new Error("rove: this process is running from an install that no longer exists on disk")
+    err.name = "StaleInstallError"
+    return err
+  }
+
+  it("stops retrying, and says so, instead of failing forever", async () => {
+    const h = fakeClient()
+    let ensureCalls = 0
+    const orch = new RemoteOrchestrator(h.client, {
+      role: "gui",
+      ensureReachable: async () => {
+        ensureCalls++
+        throw staleInstallError()
+      },
+    })
+    expect(orch.staleInstallSignal()()).toBe(null)
+
+    h.triggerClose()
+    // Long enough for several ordinary retries: jitter (≤400ms) plus the
+    // 500ms → 1000ms → 2000ms backoff would be at least four attempts.
+    await sleep(2500)
+
+    // Once. Not "fewer" — a second attempt would resolve the same missing
+    // path and is pure waste.
+    expect(ensureCalls).toBe(1)
+    expect(h.helloCount()).toBe(0)
+    // And it is now VISIBLE. Silence here is the actual bug: the client
+    // looked like it was reconnecting for two days.
+    expect(orch.staleInstallSignal()()).toContain("no longer exists on disk")
+  })
+
+  it("still retries an ordinary spawn failure — the two must not be conflated", async () => {
+    const h = fakeClient()
+    let ensureCalls = 0
+    const orch = new RemoteOrchestrator(h.client, {
+      role: "gui",
+      ensureReachable: async () => {
+        ensureCalls++
+        if (ensureCalls === 1) throw new Error("daemon did not start (or stayed wedged)")
+      },
+    })
+    h.triggerClose()
+    await sleep(1400)
+    expect(ensureCalls).toBe(2) // retried, recovered
+    expect(orch.staleInstallSignal()()).toBe(null) // and never flagged
+  })
+})

--- a/packages/kobe/test/render/host-version-skew-banner.test.tsx
+++ b/packages/kobe/test/render/host-version-skew-banner.test.tsx
@@ -66,8 +66,10 @@ function fakeOrchestrator() {
   const stale = createStateCell(false)
   const daemonVersion = createStateCell<string | null>(null)
   const connection = createStateCell<DaemonConnectionState>("online")
+  const staleInstall = createStateCell<string | null>(null)
   const orchestrator = {
     connectionStateSignal: () => connection,
+    staleInstallSignal: () => staleInstall,
     daemonStaleSignal: () => stale,
     daemonVersionSignal: () => daemonVersion,
     tasksSignal: () => EMPTY_ARR,
@@ -92,7 +94,7 @@ function fakeOrchestrator() {
     reportEngineInterrupt: () => {},
     listTasks: () => [],
   } as unknown as RemoteOrchestrator
-  return { orchestrator, stale, daemonVersion, connection }
+  return { orchestrator, stale, daemonVersion, connection, staleInstall }
 }
 
 async function mountHost(orchestrator: RemoteOrchestrator) {
@@ -153,4 +155,46 @@ test("a socket disconnect paints no banner of its own", async () => {
   const text = await frame()
   expect(text).not.toContain("DAEMON DISCONNECTED")
   expect(text).toContain("DAEMON OUT OF DATE")
+})
+
+/**
+ * Issue #96, the surfacing half. A GUI running from a deleted install can
+ * never start a daemon, and until now that state had no picture at all: the
+ * client looked like it was reconnecting, for two days on the owner's
+ * machine. Mounted through the real host and driven from the cell the
+ * reconnect loop writes, for the same reason as the skew test above — a
+ * banner fed a hand-set prop would pass with the wiring deleted.
+ */
+test("the host mounts the stale-install banner and drives it from the orchestrator", async () => {
+  const { orchestrator, staleInstall } = fakeOrchestrator()
+  const { frame } = await mountHost(orchestrator)
+  expect(await frame()).not.toContain("ROVE INSTALL IS GONE")
+
+  await act(async () => {
+    staleInstall.set("rove: this process is running from an install that no longer exists on disk")
+  })
+  await settle(60)
+  const text = await frame()
+  expect(text).toContain("ROVE INSTALL IS GONE")
+  // The remedy, not just the diagnosis — waiting is what the user was
+  // already doing, so the banner has to name the thing that actually works.
+  expect(text).toContain("npm install -g @sma1lboy/rove")
+})
+
+test("a gone install outranks a stale daemon build — only one banner shows", async () => {
+  // Both can be true at once (a deleted install leaves whatever daemon was
+  // already running, which then falls behind). They share the one banner
+  // slot, and only one of them is worth acting on: restarting a daemon this
+  // process cannot spawn is not a fix.
+  const { orchestrator, stale, daemonVersion, staleInstall } = fakeOrchestrator()
+  const { frame } = await mountHost(orchestrator)
+  await act(async () => {
+    daemonVersion.set("0.9.1")
+    stale.set(true)
+    staleInstall.set("rove: this process is running from an install that no longer exists on disk")
+  })
+  await settle(60)
+  const text = await frame()
+  expect(text).toContain("ROVE INSTALL IS GONE")
+  expect(text).not.toContain("DAEMON OUT OF DATE")
 })


### PR DESCRIPTION
Fixes #96.

## The bug, as observed

A GUI on the owner's machine had been running 2 days 9 hours as

    /usr/local/bin/bun /opt/homebrew/lib/node_modules/@sma1lboy/rove/dist/cli/kobe-run.js

with `/opt/homebrew/lib/node_modules/@sma1lboy/` no longer on disk — the whole scope uninstalled out from under it. `bun` and `node` hold their entry open by inode, so the process kept running from an unlinked file. It worked fine until it needed to spawn a daemon; then `resolveKobeSpawn` walked six candidates, found none, and threw. The reconnect loop caught it, backed off, retried, and threw in the same place. Forever.

## Why it was invisible

Nothing distinguished this from an ordinary spawn failure, so nothing could treat it differently. The client looked like it was reconnecting, because that is exactly what it was doing.

## The judgment call the issue asked for

**Should the reconnect loop degrade to a visible one-time error, or keep retrying silently?** It should stop, and here is the reasoning.

Retrying encodes a belief: that the next attempt could differ from this one. That belief is true for every other failure this loop sees — a busy daemon, a lost spawn race, a daemon mid-shutdown — and it is false here. The entry point is gone; resolution will fail identically until a human reinstalls. Retrying a fixed function of unchanged inputs is not recovery, it is just the same computation repeated 100k times.

Stopping is also the **safe** direction with respect to #733. That PR established that a client which cannot spawn must not be a reason to kill or replace a healthy daemon. This change adds no retries and no probes; it strictly removes them from the one client that can never succeed. Spawn pressure goes down, not up.

Silence, though, was never defensible — so giving up is paired with saying so, once.

## Three changes, plus one bug found along the way

1. **`StaleInstallError`** (`daemon-process.ts`) — a named, cross-package-identifiable error (keys on `.name`, so two copies of the module don't break `instanceof`). Permanent failure is now distinguishable from transient, which is the precondition for handling them differently.

2. **The reconnect loop stops on it** (`remote-orchestrator-connect.ts`) — logs once via `onFatal`, latches `staleInstallSignal()`, returns. Every other error keeps its existing backoff untouched.

3. **The workspace says so** (`version-skew-banner.tsx`, `host.tsx`) — a red strip reusing `BannerStrip`, whose doc already invited the next banner to reuse it. It passes the same test the skew banner passed and the removed disconnect banner failed: *it persists until someone acts, and there is an action*. It outranks skew, since restarting a daemon this process cannot spawn is not a fix.

4. **`rove doctor` names it** — an `install:` line that calls the spawn path's **own resolver** rather than re-deriving the candidate list, so doctor cannot pass while the spawn path fails. The remedy is print-only: doctor cannot reinstall Rove over the running process.

**The bug found alongside:** `ensureDaemonReachable` called `stopDaemonProcess` *before* `resolveKobeSpawn`. On a stale install that ordering is destructive — the client kills the daemon and unlinks its socket and pidfile, and only *then* discovers it has nothing to re-exec. It removed a working daemon it could not put back. Resolving first makes a stale install inert: it throws having touched nothing. This is #733's rule applied to the client that can never spawn.

## Verification

Every assertion was mutation-checked — the fix reverted at **three separate sites**, each caught by a different test on the invariant itself, not a proxy:

| mutation | test that failed | how |
|---|---|---|
| restore `stop` → `resolve` order | *destroys nothing* | `expected [...] to not include 'daemon.stop'` |
| generic `Error` instead of `StaleInstallError` | 2 tests | discriminator gone |
| drop the loop's fatal short-circuit | *stops retrying, and says so* | `expected 3 to be 1` — the pre-fix loop reproduced |

The ordering test asserts **effects** (`daemon.stop` never sent, process still alive, pidfile intact, spawn lock released), not the throw — asserting "it threw" would stay green with the ordering restored, since it throws either way.

Also checked live: driving the real resolver at the owner's exact `dist/cli` path produces the classified error naming the reinstall.

Suites: `test:fast` (4057 pass), `test:socket` (676 pass), `test/render` (354 pass, includes 3 new). The 4 `test:fast` failures in `project-eligibility` / `open-dir-cmd` are the documented `~/.rove/worktrees` path-shape artifact — verified at **30/30 passing** on an unmodified `origin/main` worktree outside `~/.rove`. Typecheck, lint, i18n (723 keys × 2 locales), and file-size gates all clean.