### PR TITLE
fix: a harness pty host must not outlive the run that made it

### DIFF
--- a/.changeset/orphan-pty-hosts.md
+++ b/.changeset/orphan-pty-hosts.md
@@ -1,0 +1,25 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Stop test and harness PTY hosts outliving the run that created them.
+
+A PTY host stays alive while it owns a live session, and the daemon's
+`PtyLiveHold` chains off the same fact. When a harness run died between
+`dev:sandbox:reset` and its `rm -rf`, the socket and pidfile went with the
+fixture home while the host kept idle shells running — leaving a process with
+no address anyone could reach it on. Twenty-five accumulated on one machine,
+the oldest over two days.
+
+Two fixes. The host now watches its own pidfile and exits when it no longer
+names it: deleted, or claimed by a successor. Possession of its address, not
+age and not the process table, so `rove daemon restart` and an attached
+`dev:sandbox` are untouched. And `stopDaemonProcess` no longer unlinks a
+socket and pidfile belonging to a process that is still alive — the race that
+erased a live host's address in the first place.
+
+Visual-fixture teardown now records the daemon and PTY-host pids before it
+deletes their home and fails loudly if either survives, instead of deleting
+the evidence. Fixture hosts also carry a 30-minute lifetime ceiling
+(`ROVE_PTY_MAX_LIFETIME_MS`) for the run that never reaches teardown at all;
+it is deliberately unset in production.

--- a/packages/kobe-daemon/src/daemon/lifecycle.ts
+++ b/packages/kobe-daemon/src/daemon/lifecycle.ts
@@ -119,6 +119,18 @@ export async function stopDaemonProcess(socketPath: string, pidPath: string): Pr
   // The daemon's own `serverApi.close` unlinks both files on its way out,
   // but if we had to SIGKILL it they linger and a respawn would hit
   // EADDRINUSE on the socket. Best-effort cleanup of both.
+  //
+  // EXCEPT when the pid we were given is still alive. `wasAlive` is false
+  // for a pidfile naming a dead process — and also for a pidfile written by
+  // a process that outran our read, which is how a still-running PTY host
+  // lost its address: unlinking here left it with no socket to be reached
+  // on and no pidfile to be recognized by, so nothing could ever stop it
+  // again (25 stranded hosts, up to two days old). Re-read before deleting;
+  // a live owner keeps its own files.
+  const survivor = await readPidFile(pidPath)
+  if (survivor !== null && survivor !== process.pid && isProcessAlive(survivor)) {
+    return { pid: oldPid, method }
+  }
   await unlink(socketPath).catch(() => {})
   await unlink(pidPath).catch(() => {})
   return { pid: oldPid, method }

--- a/packages/kobe-daemon/src/daemon/pty-server.ts
+++ b/packages/kobe-daemon/src/daemon/pty-server.ts
@@ -5,8 +5,8 @@
  * socket, deliberately OUTSIDE the daemon: the daemon restarts routinely
  * (it holds the fast-moving code), while this process is tiny, stable,
  * and must keep embedded-terminal children alive across both TUI exits
- * and daemon restarts. Only `kobe reset` (or idle-exit at zero live
- * sessions) ends it.
+ * and daemon restarts. Only `kobe reset`, idle-exit at zero live sessions,
+ * or losing its own address (see the watchdog below) ends it.
  *
  * Wire: the same JSON-lines frame grammar as the daemon socket
  * (`protocol.ts`), so `KobeDaemonClient` speaks it unchanged. Every
@@ -22,6 +22,7 @@
  * graceful path).
  */
 
+import { readFileSync } from "node:fs"
 import { mkdir, unlink, writeFile } from "node:fs/promises"
 import { type Server, type Socket, createServer } from "node:net"
 import { dirname } from "node:path"
@@ -54,6 +55,25 @@ import { parseTerminalDefaultColors } from "./terminal-colors.ts"
  */
 const DEFAULT_IDLE_EXIT_MS = 60_000
 
+/** How often a host re-checks that its own pidfile still names it. */
+const DEFAULT_ORPHAN_CHECK_MS = 30_000
+
+/**
+ * Optional wall-clock ceiling on this host's life, in ms — read from
+ * `KOBE_PTY_MAX_LIFETIME_MS`. Unset (production, and an interactive
+ * `dev:sandbox` a human is watching) means no ceiling at all: a host whose
+ * owner is still there must never be killed for being old. Test fixtures set
+ * it, because a fixture host that outlives its run has nobody left to serve
+ * and the pidfile signal below cannot see a run that was interrupted before
+ * it tore anything down.
+ */
+function resolveMaxLifetimeMs(): number | null {
+  const raw = process.env.KOBE_PTY_MAX_LIFETIME_MS
+  if (raw === undefined) return null
+  const n = Number(raw)
+  return Number.isFinite(n) && n > 0 ? n : null
+}
+
 function resolveIdleExitMs(): number {
   const raw = process.env.KOBE_PTY_IDLE_EXIT_MS
   if (raw === undefined) return DEFAULT_IDLE_EXIT_MS
@@ -66,6 +86,11 @@ export interface PtyHostServerOptions {
   readonly pidPath?: string
   /** Grace before a zero-live-session host exits; `0` uses the default. */
   readonly idleExitMs?: number
+  /** Cadence of the orphan watchdog (see below); `0` uses the default. */
+  readonly orphanCheckMs?: number
+  /** Wall-clock life ceiling; `null`/omitted uses `KOBE_PTY_MAX_LIFETIME_MS`,
+   *  which is itself normally unset. Only fixtures set either. */
+  readonly maxLifetimeMs?: number | null
   /** How PTY children get spawned. Defaults to Bun's; the node host passes node-pty's. */
   readonly driver?: PtyDriver
   /** Freeze-store directory (`pty-freeze-store.ts`). Defaults to the home's
@@ -93,6 +118,9 @@ export async function startPtyHostServer(options: PtyHostServerOptions = {}): Pr
   const pidPath = options.pidPath ?? defaultPtyHostPidPath()
   const freezeDir = options.freezeDir ?? defaultPtyFreezeDir()
   const idleExitMs = options.idleExitMs || resolveIdleExitMs()
+  const orphanCheckMs = options.orphanCheckMs || DEFAULT_ORPHAN_CHECK_MS
+  const maxLifetimeMs = options.maxLifetimeMs ?? resolveMaxLifetimeMs()
+  const bootedAtMs = Date.now()
   const log = options.log ?? (() => {})
   const clients = new Set<PtyClientState>()
   let stopping = false
@@ -120,6 +148,58 @@ export async function startPtyHostServer(options: PtyHostServerOptions = {}): Pr
       void stop()
     }, idleExitMs)
   }
+
+  /**
+   * Orphan watchdog — the ONLY keep-alive that survives losing every client.
+   *
+   * A live session keeps this host up indefinitely (`armIdle` above), and a
+   * `PtyLiveHold` in the daemon chains off the same fact. That pair is
+   * correct while somebody still owns the sessions, and it is exactly what
+   * stranded 25 hosts for up to two days: a harness run died between
+   * `stopDaemonProcess` and its `rm -rf`, the socket and pidfile went with
+   * the fixture home, and the host kept a handful of idle shells alive with
+   * no address left for anyone to reach it on.
+   *
+   * The signal is possession of our own ADDRESS, not age and not client
+   * count: re-read the pidfile and require it to still say `process.pid`.
+   *  - pidfile gone      → whatever owned this home tore it down (or deleted
+   *                        the home outright) while we kept running.
+   *  - pidfile is a peer → a second host bound our path and owns it now; we
+   *                        are the stranded one.
+   *  - pidfile is us     → still reachable. A daemon restart never touches
+   *                        it, which is what keeps `rove daemon restart`
+   *                        (and an attached `dev:sandbox` idling overnight)
+   *                        out of this branch entirely.
+   *
+   * Self-termination only, and only on evidence about THIS process: nothing
+   * here reads the process table or signals a pid it did not write itself,
+   * so it cannot reach another home's host — see the pty-sweep incident.
+   */
+  const orphaned = (): string | null => {
+    if (maxLifetimeMs !== null && Date.now() - bootedAtMs >= maxLifetimeMs) {
+      return `exceeded its ${maxLifetimeMs}ms lifetime ceiling`
+    }
+    let owner: string
+    try {
+      owner = readFileSync(pidPath, "utf8").trim()
+    } catch {
+      return `pidfile ${pidPath} is gone`
+    }
+    const pid = Number.parseInt(owner, 10)
+    if (pid === process.pid) return null
+    return Number.isInteger(pid) ? `pidfile ${pidPath} now names pid ${pid}` : `pidfile ${pidPath} is unreadable`
+  }
+
+  // unref'd, unlike the idle timer: this one must never be the reason the
+  // event loop stays alive, only the reason it stops.
+  const orphanTimer = setInterval(() => {
+    if (stopping) return
+    const reason = orphaned()
+    if (!reason) return
+    log("orphan", `${reason} — exiting rather than outliving my owner`)
+    void stop()
+  }, orphanCheckMs)
+  orphanTimer.unref?.()
 
   const ptys = new PtyHost({
     onSessionStart: cancelIdle,
@@ -188,6 +268,7 @@ export async function startPtyHostServer(options: PtyHostServerOptions = {}): Pr
       if (stopping) return
       stopping = true
       cancelIdle()
+      clearInterval(orphanTimer)
       // The host process IS the sessions' lifetime — ending it ends them.
       // shutdown() freezes first: the records outlive us, and the next
       // host incarnation restores the work scene. An explicit `daemon.stop`

--- a/packages/kobe-web/e2e/visual-fixture.ts
+++ b/packages/kobe-web/e2e/visual-fixture.ts
@@ -1,4 +1,5 @@
 import { chmod, mkdir, readFile, rm, writeFile } from "node:fs/promises"
+import { isProcessAlive } from "@sma1lboy/kobe-daemon/daemon/lifecycle"
 import { basename, join, relative, resolve, sep } from "node:path"
 import {
   assertFixtureIsolation,
@@ -40,6 +41,12 @@ const XDG_RUNTIME_DIR = join(VISUAL_HOME, ".runtime")
 // pin rides both VISUAL_ENV and the PTY command.
 const VISUAL_TODAY = "2026-07-15"
 
+/** Backstop life ceiling for fixture daemons and PTY hosts (`pty-server.ts`).
+ *  Generous next to a ~15s journey, short next to the two DAYS the stranded
+ *  hosts reached. Deliberately absent from production and the interactive
+ *  `dev:sandbox`, where a long-lived host is somebody's live environment. */
+const VISUAL_PTY_MAX_LIFETIME_MS = String(30 * 60 * 1000)
+
 export const VISUAL_ENV = buildFixtureEnv({
   root: VISUAL_ROOT,
   home: VISUAL_HOME,
@@ -48,6 +55,11 @@ export const VISUAL_ENV = buildFixtureEnv({
   extra: {
     ROVE_ISSUES_TODAY: VISUAL_TODAY,
     KOBE_ISSUES_TODAY: VISUAL_TODAY,
+    // A fixture host has no business outliving the run that made it. Teardown
+    // below is the primary reaper; this is the backstop for the run that never
+    // reaches teardown at all (a killed harness, an interrupted Playwright).
+    ROVE_PTY_MAX_LIFETIME_MS: VISUAL_PTY_MAX_LIFETIME_MS,
+    KOBE_PTY_MAX_LIFETIME_MS: VISUAL_PTY_MAX_LIFETIME_MS,
   },
 })
 
@@ -138,6 +150,40 @@ async function seedStartupState(): Promise<void> {
   await writeFile(join(stateDir, "state.json"), `${JSON.stringify(state, null, 2)}\n`)
 }
 
+/** Pid a runtime pidfile names right now, or null when absent/unreadable. */
+async function pidFromFile(path: string): Promise<number | null> {
+  try {
+    const pid = Number.parseInt((await readFile(path, "utf8")).trim(), 10)
+    return Number.isInteger(pid) && pid > 1 ? pid : null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Teardown must PROVE it cleaned up. `rm -rf VISUAL_ROOT` deletes the socket
+ * and pidfile that are the only handles anyone has on the fixture's daemon and
+ * PTY host, so a reset that quietly failed used to leave a running process
+ * nothing could ever address again — and the deletion erased the evidence
+ * that it had. Read the pids BEFORE the delete, check them after, and say so
+ * out loud when one survived.
+ */
+async function assertFixtureProcessesGone(pids: ReadonlyMap<string, number>): Promise<void> {
+  const survivors: string[] = []
+  for (const [role, pid] of pids) {
+    // A dying process can take a moment past its socket close.
+    for (let attempt = 0; attempt < 10 && isProcessAlive(pid); attempt += 1) {
+      await new Promise((resolve) => setTimeout(resolve, 200))
+    }
+    if (isProcessAlive(pid)) survivors.push(`${role} (pid ${pid})`)
+  }
+  if (survivors.length === 0) return
+  throw new Error(
+    `visual fixture teardown leaked ${survivors.join(", ")}: the process outlived its home ${VISUAL_ROOT}, ` +
+      "whose socket and pidfile are now deleted, so nothing can address it. Kill it by the pid above.",
+  )
+}
+
 export async function cleanupVisualFixture(): Promise<void> {
   assertSafeVisualRoot()
   assertFixtureIsolation(VISUAL_HOME, VISUAL_ROOT)
@@ -150,6 +196,15 @@ export async function cleanupVisualFixture(): Promise<void> {
     body: JSON.stringify({ tab: `visual-${VISUAL_RUN_ID}` }),
   }).catch(() => {})
   await new Promise((resolve) => setTimeout(resolve, 500))
+  // Read the addresses BEFORE reset or rm can remove them; verified after.
+  const owners = new Map<string, number>()
+  for (const [role, path] of [
+    ["daemon", PATHS.daemonPidPath],
+    ["pty host", PATHS.ptyPidPath],
+  ] as const) {
+    const pid = await pidFromFile(path)
+    if (pid !== null) owners.set(role, pid)
+  }
   try {
     run("bun", ["run", "dev:sandbox:reset"])
   } finally {
@@ -165,6 +220,7 @@ export async function cleanupVisualFixture(): Promise<void> {
       }
     }
   }
+  await assertFixtureProcessesGone(owners)
 }
 
 /** Warm-path probe: marker matches and the fixture daemon still answers. */

--- a/packages/kobe/test/daemon/pty-orphan-exit.test.ts
+++ b/packages/kobe/test/daemon/pty-orphan-exit.test.ts
@@ -1,0 +1,212 @@
+/**
+ * A harness PTY host must not outlive the run that created it — and an
+ * ATTACHED one must survive regardless of age.
+ *
+ * The leak this pins: 25 hosts stranded on the owner's machine for up to two
+ * days, each holding idle shells for a fixture home that was already deleted.
+ * A harness run tore down between `stopDaemonProcess` and its `rm -rf`, the
+ * socket and pidfile went with the home, and the live sessions kept both the
+ * host's idle-exit and the daemon's `PtyLiveHold` armed forever. Nothing could
+ * address the host afterwards, because its address was the thing deleted.
+ *
+ * Both halves have to hold, and only together: a host that exits when its
+ * owner is gone but ALSO exits while someone is watching would kill the
+ * owner's interactive `dev:sandbox`. The signal is possession of its own
+ * pidfile, never age and never the process table (see the pty-sweep incident,
+ * where a name-matching sweep killed live engines).
+ */
+
+import { spawn } from "node:child_process"
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { type Socket, createServer } from "node:net"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { KobeDaemonClient } from "@sma1lboy/kobe-daemon/client"
+import { stopDaemonProcess } from "@sma1lboy/kobe-daemon/daemon/lifecycle"
+import type { PtyChild, PtyDriver, PtyExit } from "@sma1lboy/kobe-daemon/daemon/pty-driver"
+import { type PtyHostServer, startPtyHostServer } from "@sma1lboy/kobe-daemon/daemon/pty-server"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+
+let dir: string
+let socketPath: string
+let pidPath: string
+let freezeDir: string
+let savedHome: string | undefined
+const servers: PtyHostServer[] = []
+const clients: KobeDaemonClient[] = []
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "kobe-pty-orphan-"))
+  socketPath = join(dir, "pty.sock")
+  pidPath = join(dir, "pty.pid")
+  freezeDir = join(dir, "pty-sessions")
+  savedHome = process.env.KOBE_HOME_DIR
+  process.env.KOBE_HOME_DIR = dir
+})
+
+afterEach(async () => {
+  for (const client of clients.splice(0)) client.close()
+  for (const server of servers.splice(0)) await server.close().catch(() => {})
+  if (savedHome === undefined) Reflect.deleteProperty(process.env, "KOBE_HOME_DIR")
+  else process.env.KOBE_HOME_DIR = savedHome
+  rmSync(dir, { recursive: true, force: true })
+})
+
+/** A child that never exits on its own — the idle shells the orphans held. */
+class IdleChild {
+  static nextPid = 4000
+  readonly pid = IdleChild.nextPid++
+  private settle!: (exit: PtyExit) => void
+  readonly exited = new Promise<PtyExit>((resolve) => {
+    this.settle = resolve
+  })
+  write(): void {}
+  resize(): void {}
+  close(): void {}
+  kill(signal: NodeJS.Signals): void {
+    this.settle({ code: null, signal })
+  }
+}
+
+const idleDriver: PtyDriver = () => new IdleChild() as unknown as PtyChild
+
+/** Fast watchdog so the test measures the RULE, not the production cadence. */
+async function bootHost(): Promise<PtyHostServer> {
+  const server = await startPtyHostServer({
+    socketPath,
+    pidPath,
+    freezeDir,
+    driver: idleDriver,
+    idleExitMs: 60_000,
+    orphanCheckMs: 50,
+    maxLifetimeMs: null,
+  })
+  servers.push(server)
+  return server
+}
+
+async function connect(): Promise<KobeDaemonClient> {
+  const client = new KobeDaemonClient(socketPath)
+  await client.connect()
+  clients.push(client)
+  return client
+}
+
+/** True once the host has stopped serving; false if it is still up at `ms`. */
+async function stoppedWithin(ms: number): Promise<boolean> {
+  const deadline = Date.now() + ms
+  while (Date.now() < deadline) {
+    const probe = new KobeDaemonClient(socketPath)
+    try {
+      await probe.connect()
+      await probe.request("hello")
+      probe.close()
+    } catch {
+      probe.close()
+      return true
+    }
+    await new Promise((resolve) => setTimeout(resolve, 25))
+  }
+  return false
+}
+
+describe("pty host self-termination when its owner is gone", () => {
+  it("exits when its pidfile is deleted, even holding live sessions", async () => {
+    await bootHost()
+    const client = await connect()
+    await client.request("pty.open", { key: "fixture::tab-1", cwd: dir, command: ["/bin/zsh"] })
+    const listed = await client.request<{ sessions: Array<{ alive: boolean }> }>("pty.list", {})
+    expect(listed.sessions.filter((s) => s.alive)).toHaveLength(1)
+
+    // The `rm -rf VISUAL_ROOT` half of the leak: the home, and with it every
+    // handle on this process, disappears while its sessions are live.
+    rmSync(pidPath, { force: true })
+
+    expect(await stoppedWithin(3000)).toBe(true)
+  })
+
+  it("exits when a second host takes over its pidfile", async () => {
+    await bootHost()
+    const client = await connect()
+    await client.request("pty.open", { key: "fixture::tab-1", cwd: dir, command: ["/bin/zsh"] })
+
+    // Somebody else now owns this address; we are the stranded one.
+    writeFileSync(pidPath, `${process.pid + 1}\n`, "utf8")
+
+    expect(await stoppedWithin(3000)).toBe(true)
+  })
+
+  it("STAYS UP for an attached sandbox: pidfile still ours, sessions live", async () => {
+    await bootHost()
+    const client = await connect()
+    await client.request("pty.open", { key: "sandbox::tab-1", cwd: dir, command: ["/bin/zsh"] })
+
+    // Many watchdog ticks (50ms cadence) with the pidfile untouched — the
+    // owner's long-lived `dev:sandbox` must not be killed for being old.
+    expect(await stoppedWithin(600)).toBe(false)
+    const alive = await client.request<{ sessions: Array<{ alive: boolean }> }>("pty.list", {})
+    expect(alive.sessions.filter((s) => s.alive)).toHaveLength(1)
+  })
+
+  it("honours a fixture lifetime ceiling, which production leaves unset", async () => {
+    const server = await startPtyHostServer({
+      socketPath,
+      pidPath,
+      freezeDir,
+      driver: idleDriver,
+      idleExitMs: 60_000,
+      orphanCheckMs: 25,
+      maxLifetimeMs: 1,
+    })
+    servers.push(server)
+    const client = await connect()
+    await client.request("pty.open", { key: "fixture::tab-1", cwd: dir, command: ["/bin/zsh"] })
+
+    expect(await stoppedWithin(3000)).toBe(true)
+  })
+})
+
+describe("stopDaemonProcess never erases a live host's address", () => {
+  it("keeps the pidfile a live process claimed while the stop was in flight", async () => {
+    // The race that strands a host: a reset reads a stale/dead pid, decides
+    // nothing is running, and unlinks — while `ensurePtyHostReachable` is
+    // concurrently spawning a host that writes its pid into that same file.
+    // The unlink then leaves the newborn with no address anyone can reach.
+    //
+    // A server that accepts and never answers holds `daemon.stop` open for its
+    // full 2s budget, which is the window the real race lives in.
+    const stallSocket = join(dir, "stall.sock")
+    // Hold every inbound socket so it can be destroyed at the end: `close()`
+    // only stops new connections and would otherwise wait on this one forever.
+    const accepted: Socket[] = []
+    const stalled = createServer((socket) => {
+      accepted.push(socket)
+    })
+    await new Promise<void>((resolve) => stalled.listen(stallSocket, () => resolve()))
+    writeFileSync(pidPath, "999999\n", "utf8") // stale: names a dead process
+
+    const claimant = spawn("sleep", ["30"], { stdio: "ignore" })
+    try {
+      const stopping = stopDaemonProcess(stallSocket, pidPath)
+      // Mid-flight: the live host claims the address.
+      await new Promise((resolve) => setTimeout(resolve, 200))
+      writeFileSync(pidPath, `${claimant.pid}\n`, "utf8")
+      const result = await stopping
+
+      expect(result.method).toBe("absent") // it saw only the stale pid
+      expect(existsSync(pidPath)).toBe(true) // ...and left the live claim alone
+      expect(readFileSync(pidPath, "utf8").trim()).toBe(String(claimant.pid))
+    } finally {
+      claimant.kill("SIGKILL")
+      for (const socket of accepted) socket.destroy()
+      await new Promise<void>((resolve) => stalled.close(() => resolve()))
+    }
+    // The stalled `daemon.stop` burns its full 2s budget by design.
+  }, 15_000)
+
+  it("still clears a pidfile whose process is genuinely dead", async () => {
+    writeFileSync(pidPath, "999999\n", "utf8")
+    await stopDaemonProcess(join(dir, "absent.sock"), pidPath)
+    expect(existsSync(pidPath)).toBe(false)
+  })
+})


### PR DESCRIPTION
## The leak

A PTY host stays alive while it owns a live session, and the daemon's `PtyLiveHold` chains off the same fact. That pair is correct while someone still owns the sessions — and it is exactly what stranded 25 hosts on the owner's machine, the oldest over two days old, each holding idle shells for a fixture home that no longer existed.

The sequence: a harness run dies between `dev:sandbox:reset` and its `rm -rf VISUAL_ROOT`. The socket and pidfile live *inside* the home being deleted, so they go with it. The host keeps running with live sessions, and the only handles anyone had on it are gone. Nothing can address it again.

`cleanupVisualFixture` made this worse than it looks: `reset` ran in `try`, `rm -rf` in `finally`. A reset that failed still deleted the evidence that it had.

## Field claim that did not reproduce

The brief reported SIGTERM not killing any of the 22 orphans, suspecting the opentui signal-swallowing defect. **I could not reproduce that on this build.** Two probes in an isolated home (`/tmp/rove-orphan-probe`, never production):

- host + one `/bin/sh` session → SIGTERM → exited in ~0.5s, child killed;
- host + five interactive `zsh -ilc` sessions, home `rm -rf`'d underneath first → SIGTERM → exited in ~0.5s, all five process groups escalated SIGTERM→SIGKILL and reaped.

So `pty-host-cmd.ts`'s handler is reached and `shutdown()` completes. The orphans were most likely started by an older build, or were already unaddressable by the time a signal was tried. Self-termination is therefore a viable shape — the process can end itself.

## The fix

**1. The host watches its own address** (`pty-server.ts`). Every 30s it re-reads its pidfile and exits unless it still names `process.pid`. Gone → its owner tore down (or deleted the home). Names a peer → a successor bound the path and we are the stranded one. Names us → still reachable.

The signal is *possession of its own address*, not age and not client count. A daemon restart never touches the pidfile, so `rove daemon restart` and an attached `dev:sandbox` idling overnight never enter this branch. Self-termination only, on evidence about this process: nothing reads the process table or signals a pid it did not write itself, so it cannot reach another home's host (the pty-sweep incident).

**2. `stopDaemonProcess` stops erasing live addresses** (`lifecycle.ts`). It unlinked the socket and pidfile whenever `wasAlive` was false — which is true for a stale pidfile *and* for one written by a process that outran the read. That is the race that leaves a live host with no address. It now re-reads before deleting and leaves a live owner's files alone.

**3. Teardown proves it cleaned up** (`visual-fixture.ts`). Pids captured *before* `rm -rf`, verified after, and a survivor throws with the pid to kill rather than vanishing silently. Fixture hosts also carry a 30-minute `ROVE_PTY_MAX_LIFETIME_MS` ceiling for the run that never reaches teardown at all — deliberately unset in production and in the interactive `dev:sandbox`, where a long-lived host is somebody's live environment.

## Tests

`test/daemon/pty-orphan-exit.test.ts` (6, `test:socket`) pins both halves — an orphan must exit, an attached sandbox must not.

Mutation-verified at three distinct sites:

| Mutation | Result |
| --- | --- |
| Watchdog never fires (revert fix 1) | 3 red |
| Live-owner guard removed (revert fix 2) | 1 red |
| Watchdog fires even when pidfile is ours | 1 red — the attached-sandbox half |

The third matters most: it proves the "must not kill an attached sandbox" test fails when the design is over-aggressive, rather than passing by accident.

## Verification

- `bun run lint` — clean (1304 files)
- `bun run typecheck` — clean
- `test:socket` — 80 files, 682 tests green
- `test:fast` — 4052 pass; the 4 failures are the known `project-eligibility` / `open-dir-cmd` path-shape artifact of running inside `~/.rove/worktrees`. Verified against a baseline in `/Users/jacksonc/i/kobe` at the same commit: all 30 pass there. Unrelated to this change.

No production process was touched at any point; every probe ran in an isolated `/tmp` home and was cleaned up.

## Scope note

`packages/kobe/scripts/dev-sandbox.ts` needed no change: its `stopSandbox()` calls `stopDaemonProcess`, which is where fix 2 landed. Untouched, and it inherits the fix. No coordination needed with the `client/**` sibling task — `pty-process.ts` is not modified.
