### PR TITLE
fix: the new task dialog's repo field takes a name, not a path

### DIFF
--- a/.changeset/repo-field-shows-a-name.md
+++ b/.changeset/repo-field-shows-a-name.md
@@ -1,0 +1,21 @@
+---
+"@sma1lboy/rove": patch
+---
+
+New task dialog: the repo field takes a name, and shows the path beside it
+
+The Existing tab's repo field used to be a full absolute path — the one thing
+that identifies a repo sitting at the far right of a string whose left half is
+identical on every row you own. It now holds the repo's NAME, with the
+directory in muted text at the row's right edge, matching how the picker rows
+below already read. Those picker rows now right-align their directory tails
+into one column too, instead of trailing two spaces after each name.
+
+The field holds a name because an opentui `<input>` edits whatever its `value`
+prop says: showing a name while state kept a path meant the short string got
+written back on the next keystroke. So a name is resolved to a path at submit
+time — and when two saved repos share a basename (routine with a hundred repos
+flat under one parent), the dialog keeps the full path rather than picking one,
+and typing the shared name outright says so instead of silently opening the
+alphabetically-first match. Typing a path by hand still works and still renders
+verbatim.

--- a/packages/kobe/src/tui-react/component/new-task-dialog/picker-list.tsx
+++ b/packages/kobe/src/tui-react/component/new-task-dialog/picker-list.tsx
@@ -23,11 +23,12 @@ export type PickerRow = {
   /** Non-cursor rows render accent (selected) instead of muted. */
   readonly accent?: boolean
   /**
-   * Trailing text always painted muted, whatever the row's own state. For a
-   * row whose body is the part that IDENTIFIES the item and whose tail merely
-   * LOCATES it (the repo picker's basename + directory), so the cursor's
-   * bold/primary lands on the name alone instead of dragging a shared path
-   * prefix into the emphasis with it.
+   * Trailing text always painted muted and pushed to the row's RIGHT edge,
+   * whatever the row's own state. For a row whose body is the part that
+   * IDENTIFIES the item and whose tail merely LOCATES it (the repo picker's
+   * basename + directory), so the cursor's bold/primary lands on the name
+   * alone instead of dragging a shared path prefix into the emphasis with it,
+   * and the names line up in one column with the directories in another.
    */
   readonly dim?: string
 }
@@ -80,11 +81,19 @@ export function PickerList(props: {
               {isCursor ? "▸ " : "  "}
               {row.body}
             </text>
+            {/* Right-aligned by a growing spacer, not by padding the string:
+                the gap is whatever the row has left over, so the tails share
+                one right edge however ragged the names are. */}
+            <box flexGrow={1} />
             {/* The tail is the first thing to go on a narrow card: it is the
-                half the row can lose and still be identifiable. */}
+                half the row can lose and still be identifiable.
+                The separating space is INSIDE the text, not `paddingLeft`:
+                padding is part of the box being shrunk, so on a row wide
+                enough to close the gap it went to zero and the body ran
+                straight into the directory (`…(current dir)/var/folders/…`).
+                A leading space in the string shrinks with the string. */}
             <text fg={theme.textMuted} wrapMode="none" flexShrink={1}>
-              {"  "}
-              {row.dim}
+              {` ${row.dim}`}
             </text>
           </box>
         )

--- a/packages/kobe/src/tui-react/component/new-task-dialog/tab-existing.tsx
+++ b/packages/kobe/src/tui-react/component/new-task-dialog/tab-existing.tsx
@@ -14,6 +14,13 @@ import { useT } from "../../i18n"
 import { ChoiceRow, PickerList, labelStyle } from "./picker-list"
 import type { NewTaskVm } from "./view-model"
 
+/**
+ * Cells the repo input claims. Wide enough for a long repo name plus room to
+ * type a path by hand; the muted directory takes whatever is left and shrinks
+ * first, because it is the half the row can lose and stay identifiable.
+ */
+const REPO_INPUT_CELLS = 28
+
 export function ExistingTab({ vm }: { vm: NewTaskVm }) {
   const { theme } = useTheme()
   const t = useT()
@@ -33,7 +40,7 @@ export function ExistingTab({ vm }: { vm: NewTaskVm }) {
     return {
       key: `${vm.activeWindow.start + i}:${name}`,
       body: `${base}${tag}`,
-      accent: vm.repo.trim() === name,
+      accent: vm.expandedRepo === name,
       ...(dir ? { dim: dir } : {}),
     }
   })
@@ -54,16 +61,47 @@ export function ExistingTab({ vm }: { vm: NewTaskVm }) {
     <>
       <box gap={0}>
         <text {...labelStyle(theme, vm.field, "repo")}>{t("newTask.field.repo")}</text>
-        <input
-          value={vm.repo}
-          placeholder={vm.defaultRepo}
-          focused={vm.field === "repo"}
-          onMouseUp={() => vm.setField("repo")}
-          onInput={(v: string) => vm.setRepoText(v)}
-          // Every Enter routes through onRepoSubmit — it handles the
-          // empty-input pick-first case too.
-          onSubmit={() => vm.onRepoSubmit()}
-        />
+        {/* Name left, directory right — the same weighting as the picker rows
+            below, so a repo reads the same whether it is being chosen or has
+            been. The input still holds the full path (`vm.repo`); only which
+            half of it sits in the editable cell changes. */}
+        <box flexDirection="row">
+          <input
+            value={vm.repo}
+            placeholder={splitRepoRow(vm.defaultRepo).base}
+            focused={vm.field === "repo"}
+            onMouseUp={() => vm.setField("repo")}
+            onInput={(v: string) => vm.setRepoText(v)}
+            // Every Enter routes through onRepoSubmit — it handles the
+            // empty-input pick-first case too.
+            onSubmit={() => vm.onRepoSubmit()}
+            // Two shapes, because the field holds two kinds of value.
+            //
+            // Holding a NAME, there is a directory beside it and the row has
+            // to divide: the input takes a fixed column and the directory is
+            // what gives way. `flexGrow` here is what CAUSED the bug this
+            // replaces — the input grew to the row, the directory then
+            // compressed it below the name's length, and an input narrower
+            // than its content scrolls to the cursor, so `fixture-repo`
+            // rendered as `ture-repo` with nothing to admit the cut.
+            //
+            // Holding a PATH (typed by hand, or a name too ambiguous to show)
+            // nothing sits beside it and it takes the whole row: a path needs
+            // every cell it can get, and capping it at the name's column would
+            // clip what the user is typing.
+            flexGrow={vm.repoDir ? 0 : 1}
+            flexShrink={0}
+            {...(vm.repoDir ? { flexBasis: REPO_INPUT_CELLS } : {})}
+          />
+          {/* The separating space is INSIDE the string rather than
+              `paddingLeft`: padding belongs to the box Yoga is shrinking, so a
+              full row closes it to zero and the name runs into the path. */}
+          {vm.repoDir ? (
+            <text fg={theme.textMuted} wrapMode="none" flexShrink={1}>
+              {` ${vm.repoDir}`}
+            </text>
+          ) : null}
+        </box>
       </box>
       {vm.field === "repo" && vm.activeList.length > 0 && !vm.repoPicked ? (
         <PickerList window={vm.activeWindow} cursor={vm.repoCursor} rows={repoRows} onPick={vm.selectRepoAt} />

--- a/packages/kobe/src/tui-react/component/new-task-dialog/view-model.ts
+++ b/packages/kobe/src/tui-react/component/new-task-dialog/view-model.ts
@@ -21,6 +21,7 @@ import { type VendorId, nextVendorWithin, prevVendorWithin } from "@/types/vendo
 import type { AdoptableWorktree } from "@/types/worktree"
 import { useTerminalDimensions } from "@opentui/react"
 import { useEffect, useMemo, useState } from "react"
+import { nameOrPath, resolveRepoInput, splitRepoInput } from "../../../tui/component/new-task-dialog/repo-field"
 import {
   type DialogTab,
   type ExistingIntent,
@@ -42,6 +43,7 @@ import {
   stripNewlines,
   windowAround,
 } from "../../../tui/component/new-task-dialog/state"
+import { t } from "../../../tui/i18n"
 import { DEFAULT_BASE_REF, getCurrentBranch, listLocalBranches, validateRepoPath } from "../../../tui/lib/git-snapshot"
 import { expandHome, joinPicked } from "../../../tui/lib/path-helpers"
 import { useBindings } from "../../lib/keymap"
@@ -85,7 +87,14 @@ export function useNewTaskViewModel(props: NewTaskDialogProps) {
   // Open focused on the mode selector — ←/→ switches tabs immediately;
   // Tab then walks engine → repo → branch → Create.
   const [field, setField] = useState<Field>("tabs")
-  const [repo, setRepo] = useState(props.defaultRepo)
+  // Seeded from the caller's PATH, shown as a name — the field's own grammar
+  // from the first frame rather than a path that turns into a name on first
+  // touch. `repoDir` puts the directory back beside it. Same round-trip guard
+  // as `pickRepo`: a basename shared with another saved repo would open the
+  // dialog on an ambiguous value, so that case keeps the path.
+  const [repo, setRepo] = useState(() =>
+    nameOrPath(props.defaultRepo, computeRepoOptions(props.defaultRepo, props.savedRepos)),
+  )
   // Initial baseRef tracks the cwd's current branch (worktree forked from a
   // feature branch defaults to it, not hardcoded "main").
   const [baseRef, setBaseRef] = useState(
@@ -118,12 +127,30 @@ export function useNewTaskViewModel(props: NewTaskDialogProps) {
   // short re-windows the pickers instead of clipping the Create button.
   const pickerRows = pickerVisibleRows(useTerminalDimensions().height)
   const mode = pickerModeFor(repo, repoOptions)
+  // `repo` holds exactly what the field shows — a NAME once one is chosen,
+  // free text while it is being typed. It is never a display derived from a
+  // different underlying value: an opentui `<input>` adopts its `value` prop
+  // as its edit buffer, so a field showing one string while state held another
+  // wrote the shown one back on the next keystroke and the two oscillated.
+  // One representation, resolved to a path at the boundaries instead.
+  const repoResolution = resolveRepoInput(repo, repoOptions)
+  // The directory the chosen NAME resolves to — muted, at the row's right
+  // edge, so a bare name still says where it is. Empty whenever the field
+  // already holds a path: the directory is then in the field itself, and
+  // repeating it beside it would print the same string twice.
+  const repoDir =
+    repoResolution.kind === "path" && repoResolution.path !== repo.trim()
+      ? splitRepoInput(repoResolution.path, true).dir
+      : ""
   const { split: subdirSplit, filtered: subdirFiltered } = useDerivedDir(repo)
   const savedFiltered = useMemo(() => filterRepos(repoOptions, repo), [repoOptions, repo])
   const activeList = mode === "browse" ? subdirFiltered : savedFiltered
   const activeWindow: PickerWindow = windowAround(activeList, repoCursor, pickerRows)
 
-  const expandedRepo = expandHome(repo.trim())
+  // Everything downstream (branch list, validation, adopt scan, the submitted
+  // `repo`) needs a PATH, and the field holds a name — so resolve first, then
+  // expand. An ambiguous name resolves to nothing until the user disambiguates.
+  const expandedRepo = repoResolution.kind === "path" ? expandHome(repoResolution.path) : ""
   // Offered against the EXPANDED path: `mainRepos` holds absolute repo roots,
   // and a `~/`-typed entry would otherwise never match its own project.
   const canOpenProject = offersProjectIntent(expandedRepo, props.mainRepos ?? EMPTY_MAIN_REPOS)
@@ -182,6 +209,15 @@ export function useNewTaskViewModel(props: NewTaskDialogProps) {
     setIntent("task")
   }
 
+  /**
+   * A repo was PICKED (dropdown Enter, click, browse-mode select) — the picker
+   * deals in paths, the field holds names, and this is the one funnel every
+   * selection route already goes through, so the conversion belongs here.
+   */
+  function pickRepo(path: string): void {
+    changeRepo(nameOrPath(path, repoOptions))
+  }
+
   function setRepoText(v: string): void {
     setRepoPicked(false)
     changeRepo(stripNewlines(v))
@@ -197,6 +233,16 @@ export function useNewTaskViewModel(props: NewTaskDialogProps) {
   /* ── Commit paths ── */
 
   function commitExisting(): void {
+    // Two saved repos can share a basename (a hundred flat repos under one
+    // parent makes this ordinary), and the name alone cannot say which. Send
+    // the user back to the picker — where the directories that separate them
+    // are on screen — rather than opening the alphabetically-first one.
+    if (repoResolution.kind === "ambiguous") {
+      setSubmitError(t("newTask.error.repoAmbiguous", { name: repoResolution.name }))
+      setField("repo")
+      setRepoPicked(false)
+      return
+    }
     const r = expandedRepo
     if (!r) return
     const reason = validateRepoPath(r)
@@ -282,7 +328,7 @@ export function useNewTaskViewModel(props: NewTaskDialogProps) {
     if (!repo.trim() && mode === "saved") {
       const picked = activeList[0]
       if (picked) {
-        changeRepo(picked)
+        pickRepo(picked)
         setField(advanceField("repo"))
         return
       }
@@ -291,7 +337,7 @@ export function useNewTaskViewModel(props: NewTaskDialogProps) {
       const picked = subdirFiltered[repoCursor]
       if (picked) {
         // Enter = SELECT this dir as the repo and advance (no drill).
-        changeRepo(joinPicked(repo, subdirSplit.base, picked))
+        pickRepo(joinPicked(repo, subdirSplit.base, picked))
         setRepoCursor(0)
         setRepoPicked(true)
       }
@@ -299,7 +345,7 @@ export function useNewTaskViewModel(props: NewTaskDialogProps) {
       return
     }
     const picked = activeList[repoCursor]
-    if (picked) changeRepo(picked)
+    if (picked) pickRepo(picked)
     setField(advanceField("repo"))
   }
 
@@ -307,10 +353,10 @@ export function useNewTaskViewModel(props: NewTaskDialogProps) {
     const picked = activeList[absoluteIndex]
     if (!picked) return
     if (mode === "browse") {
-      changeRepo(joinPicked(repo, subdirSplit.base, picked))
+      pickRepo(joinPicked(repo, subdirSplit.base, picked))
       setRepoPicked(true)
     } else {
-      changeRepo(picked)
+      pickRepo(picked)
     }
     setRepoCursor(absoluteIndex)
     setField(advanceField("repo"))
@@ -409,6 +455,7 @@ export function useNewTaskViewModel(props: NewTaskDialogProps) {
     field,
     setField,
     repo,
+    repoDir,
     mode,
     activeList,
     activeWindow,

--- a/packages/kobe/src/tui/component/new-task-dialog/repo-field.ts
+++ b/packages/kobe/src/tui/component/new-task-dialog/repo-field.ts
@@ -1,0 +1,95 @@
+/**
+ * What the text in the new-task dialog's repo FIELD means.
+ *
+ * Split from `state.ts` because it answers a different question. `state.ts` is
+ * the dialog's reducer layer — which field has focus, which list is open,
+ * where the cursor sits. This file is the field's own vocabulary: the input
+ * shows a repo NAME, everything downstream needs a PATH, and these three
+ * functions are the whole translation between them.
+ *
+ * The reason it is a translation and not a rendering: an opentui `<input>`
+ * adopts its `value` prop as the text it edits, so a field displaying
+ * `quokka` while state held `/Users/me/i/quokka` wrote the short string back
+ * on the next keystroke and the two oscillated. The field really does hold a
+ * name; the conversion happens at the boundaries, here.
+ *
+ * Same rules as `state.ts`: framework-free, side-effect-free, no fs, no git.
+ */
+
+import { splitRepoRow } from "./state"
+
+/**
+ * How the repo INPUT should render a value: the repo's name, and the
+ * directory that merely locates it.
+ *
+ * The field still HOLDS a path. Everything downstream needs one —
+ * `validateRepoPath`, `listLocalBranches`, `getCurrentBranch`, the adopt
+ * scan and the submitted `repo` all take a path — and with a hundred repos
+ * flat under one parent a basename does not identify a repo on its own.
+ * What changes is what the field SHOWS: once the value is a RESOLVED repo
+ * it leads with the name and hands the directory back for the row to paint
+ * muted at the right edge, the same split {@link splitRepoRow} gives the
+ * picker rows. Two repos sharing a basename stay tellable apart because
+ * that directory is on screen beside the name, not because the name is
+ * unique.
+ *
+ * A value the user is still typing is NOT resolved and comes back verbatim
+ * with an empty `dir` — rewriting a half-typed path under the cursor would
+ * leave the field disagreeing with the keystrokes that produced it, and
+ * typing a path is still how you reach a repo the saved list has never seen.
+ */
+export function splitRepoInput(value: string, resolved: boolean): { name: string; dir: string } {
+  if (!resolved) return { name: value, dir: "" }
+  const { base, dir } = splitRepoRow(value.trim())
+  return { name: base, dir }
+}
+
+/**
+ * What a repo field value MEANS at submit time.
+ *
+ * The field is an editing buffer, not a display: an opentui `<input>` adopts
+ * its `value` prop as the text it edits, so a field showing `quokka` sends
+ * back `quokka` + the keystroke, never the path it was derived from. Showing
+ * names therefore means the field really does hold names, and a bare name has
+ * to be turned back into a path before anything downstream can use it.
+ *
+ * Three answers, because a name is not always an answer:
+ *   - `path` — the value already IS a path (contains a separator, or `~`), or
+ *     it names exactly one known repo. This is the ordinary case.
+ *   - `ambiguous` — several known repos share that basename. With a hundred
+ *     repos flat under one parent this is routine, and picking the
+ *     alphabetically-first one would silently open the wrong repo, so the
+ *     caller must send the user back to the list instead of guessing.
+ *   - `path` with the raw text — an unknown name. Left alone so
+ *     `validateRepoPath` produces its own "path does not exist" rather than
+ *     this layer inventing a second vocabulary for the same failure.
+ */
+export type RepoResolution =
+  | { kind: "path"; path: string }
+  | { kind: "ambiguous"; name: string; matches: readonly string[] }
+
+export function resolveRepoInput(value: string, repoOptions: readonly string[]): RepoResolution {
+  const trimmed = value.trim()
+  // Anything path-shaped is already the answer — the same test `pickerModeFor`
+  // uses to decide it is looking at a path rather than a query.
+  if (!trimmed || trimmed.includes("/") || trimmed.startsWith("~")) return { kind: "path", path: trimmed }
+  const matches = repoOptions.filter((p) => splitRepoRow(p).base === trimmed)
+  if (matches.length === 1) return { kind: "path", path: matches[0] as string }
+  if (matches.length > 1) return { kind: "ambiguous", name: trimmed, matches }
+  return { kind: "path", path: trimmed }
+}
+
+/**
+ * What the repo FIELD should hold for a given path: its name when that name
+ * resolves back to this very path, the whole path otherwise.
+ *
+ * The point of showing a name is that it identifies the repo. A basename
+ * shared with another saved repo resolves to `ambiguous` and a name outside
+ * the saved list resolves to itself — in both cases the name identifies
+ * nothing, so the path stays and keeps doing the job.
+ */
+export function nameOrPath(path: string, repoOptions: readonly string[]): string {
+  const name = splitRepoInput(path, true).name
+  const back = resolveRepoInput(name, repoOptions)
+  return back.kind === "path" && back.path === path ? name : path
+}

--- a/packages/kobe/src/tui/i18n/messages/newTask.ts
+++ b/packages/kobe/src/tui/i18n/messages/newTask.ts
@@ -89,6 +89,8 @@ export const en = {
     targetExists: "target already exists: {path}",
     cloneFailed: "git clone failed: {error}",
     noAdoptable: "no adoptable worktrees to import",
+    /** Two saved repos share this basename — the name alone can't pick one. */
+    repoAmbiguous: "more than one saved repo is named {name} — pick the one you mean from the list",
   },
 }
 
@@ -178,5 +180,7 @@ export const zh: typeof en = {
     targetExists: "目标路径已存在：{path}",
     cloneFailed: "git clone 失败：{error}",
     noAdoptable: "没有可接管的 worktree",
+    /** Two saved repos share this basename — the name alone can't pick one. */
+    repoAmbiguous: "有多个已保存仓库都叫 {name} — 请从列表中选择你要的那个",
   },
 }

--- a/packages/kobe/test/render/new-task-repo-name-field.test.tsx
+++ b/packages/kobe/test/render/new-task-repo-name-field.test.tsx
@@ -1,0 +1,224 @@
+/** @jsxImportSource @opentui/react */
+/**
+ * The Existing tab's repo field shows a NAME, with the directory demoted to
+ * muted text at the row's right edge (owner report 2026-09-01) — while the
+ * value it submits stays a full path.
+ *
+ * The split is only worth having if both halves hold at once, and the two
+ * halves fail in opposite directions:
+ *   - render only → the field could show a bare name and SUBMIT a bare name,
+ *     which resolves to nothing (or, with ~100 flat repos under one parent,
+ *     to the wrong one).
+ *   - submit only → the path could still be sitting in the editable cell,
+ *     which is the thing being changed.
+ * So each test below reads the frame AND the submitted value.
+ *
+ * Real `git init` temp dirs because the tab validates the path and reads its
+ * branches synchronously; a fake path renders the error state instead of the
+ * fields.
+ */
+
+import { expect, test } from "bun:test"
+import { execSync } from "node:child_process"
+import { mkdtempSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { NewTaskDialogView } from "../../src/tui-react/component/new-task-dialog/dialog"
+import type { NewTaskInput } from "../../src/tui/component/new-task-dialog/state"
+import { act, renderComponent, settle } from "./harness"
+
+/** A repo whose PARENT path is long enough to crowd the row. */
+function repoUnderLongParent(name: string): string {
+  const parent = mkdtempSync(join(tmpdir(), "kobe-reponame-with-a-deliberately-long-parent-path-"))
+  const dir = join(parent, name)
+  execSync(`mkdir -p ${dir}`, { shell: "/bin/sh" })
+  execSync("git init -q -b main && git -c user.email=t@t -c user.name=t commit -q --allow-empty -m init", { cwd: dir })
+  return dir
+}
+
+function repo(name: string): string {
+  const parent = mkdtempSync(join(tmpdir(), "kobe-reponame-"))
+  const dir = join(parent, name)
+  execSync(
+    `mkdir -p ${dir} && git init -q -b main && git -c user.email=t@t -c user.name=t commit -q --allow-empty -m init`,
+    {
+      cwd: parent,
+      shell: "/bin/sh",
+    },
+  )
+  execSync("git init -q -b main && git -c user.email=t@t -c user.name=t commit -q --allow-empty -m init", { cwd: dir })
+  return dir
+}
+
+async function mount(defaultRepo: string, savedRepos: readonly string[] = [], width = 100) {
+  const submitted: NewTaskInput[] = []
+  const handle = await renderComponent(
+    <NewTaskDialogView
+      defaultRepo={defaultRepo}
+      savedRepos={savedRepos}
+      onSubmit={(v) => submitted.push(v)}
+      onCancel={() => {}}
+    />,
+    { width, height: 40, providers: { kv: true, dialog: true } },
+  )
+  await settle()
+  return { ...handle, submitted }
+}
+
+/** Tab `times` stops along the field chain: tabs → engine → repo → baseRef. */
+async function pressTab(handle: { mockInput: { pressTab: () => void } }, times: number) {
+  for (let i = 0; i < times; i++) {
+    act(() => handle.mockInput.pressTab())
+    await settle()
+  }
+}
+
+/** Stops from the dialog's opening field (`tabs`) to each input. */
+const TO_REPO = 2
+const TO_BASE_REF = 3
+
+test("a resolved repo shows its NAME, not its path, and still submits the path", async () => {
+  const dir = repo("quokka")
+  const h = await mount(dir)
+  const f = await h.frame()
+
+  // The name is on screen and the full path is NOT sitting in the field.
+  expect(f).toContain("quokka")
+  // The directory is still visible — demoted, not deleted. It may be clipped
+  // at the card edge (it is the half designed to give way), so assert its
+  // head, which is the part that always renders.
+  const parent = dir.slice(0, dir.lastIndexOf("/") + 1)
+  expect(f).toContain(parent.slice(0, 40))
+
+  // …and the value that leaves the dialog is the whole path. Enter on the
+  // branch field is the commit.
+  await pressTab(h, TO_BASE_REF)
+  act(() => h.mockInput.pressEnter())
+  await settle()
+  expect(h.submitted).toHaveLength(1)
+  expect(h.submitted[0]?.repo).toBe(dir)
+})
+
+test("a basename shared by two saved repos keeps the PATH — it identifies nothing", async () => {
+  const a = repo("app")
+  const b = repo("app")
+  const h = await mount(a, [a, b])
+
+  // Showing a name is only worth it when the name says WHICH repo. With two
+  // saved `app`s it doesn't, so the field falls back to the path rather than
+  // displaying a label that matches both. (~100 flat repos under one parent
+  // makes this the ordinary case, not a corner.)
+  expect(await h.frame()).toContain(a.slice(0, 40))
+
+  // And it still submits the repo it was opened on, not the other `app`.
+  await pressTab(h, TO_BASE_REF)
+  act(() => h.mockInput.pressEnter())
+  await settle()
+  expect(h.submitted[0]?.repo).toBe(a)
+  expect(h.submitted[0]?.repo).not.toBe(b)
+})
+
+test("typing an ambiguous name refuses to guess, and says so", async () => {
+  const a = repo("app")
+  const b = repo("app")
+  const h = await mount(a, [a, b])
+
+  // Type the bare shared name, then try to create. Resolving it to the
+  // alphabetically-first match would silently open the wrong repo.
+  await pressTab(h, TO_REPO)
+  // ctrl+u clears the line in one keystroke — 80 backspaces is 80 renders and
+  // overruns the per-test budget.
+  await act(async () => h.mockInput.typeText("\x15"))
+  await settle()
+  await act(async () => h.mockInput.typeText("app"))
+  await settle()
+  await pressTab(h, TO_BASE_REF - TO_REPO)
+  act(() => h.mockInput.pressEnter())
+  await settle()
+
+  expect(h.submitted).toHaveLength(0)
+  expect(await h.frame()).toContain("more than one saved repo is named app")
+})
+
+test("a path being typed renders VERBATIM — the field does not rewrite mid-keystroke", async () => {
+  const dir = repo("typed")
+  const h = await mount(dir)
+
+  // Clear the field and type a path that is not (yet) any known repo. An
+  // unresolved value must render exactly as typed: splitting a half-typed
+  // path would leave the field disagreeing with the keys that produced it,
+  // and typing a path is still the only way to reach a repo the saved list
+  // has never seen.
+  await pressTab(h, TO_REPO)
+  await act(async () => h.mockInput.typeText("\x15"))
+  await settle()
+  const partial = `${dir.slice(0, dir.lastIndexOf("/") + 1)}ty`
+  await act(async () => h.mockInput.typeText(partial))
+  await settle()
+  // The tail of what was typed is on screen verbatim — the field did not
+  // swallow the directory half mid-keystroke.
+  expect(await h.frame()).toContain(partial.slice(0, 40))
+
+  // Completing it to the real repo submits that full path.
+  await act(async () => h.mockInput.typeText("ped"))
+  await settle()
+  await pressTab(h, 1)
+  act(() => h.mockInput.pressEnter())
+  await settle()
+  expect(h.submitted[0]?.repo).toBe(dir)
+})
+
+test("picker rows right-align their directory tails into one column", async () => {
+  // Names of deliberately different lengths: left-aligned-with-a-gap would
+  // start each directory at a different column, and the whole point of the
+  // change is that they share one right edge.
+  const short = repo("a")
+  const long = repo("a-much-longer-repo-name")
+  // Wide enough that neither tail is clipped — a clipped tail ends where the
+  // card ends for reasons that have nothing to do with alignment.
+  const h = await mount(short, [short, long], 200)
+
+  // Open the dropdown: focus the repo field, then clear it so both rows show.
+  await pressTab(h, TO_REPO)
+  await act(async () => h.mockInput.typeText("\x15"))
+  await settle()
+
+  const lines = (await h.frame()).split("\n")
+  const rows = lines.filter((l) => l.includes("kobe-reponame-") && (l.includes(" a ") || l.includes("a-much-longer")))
+  expect(rows.length).toBeGreaterThanOrEqual(2)
+
+  // Every row's directory ends at the same column. `trimEnd().length` is that
+  // right edge; equal across rows means one column, not a ragged trail.
+  const ends = new Set(rows.map((l) => l.trimEnd().length))
+  expect(ends.size).toBe(1)
+})
+
+test("a long directory never eats into the name", async () => {
+  // Regression, caught in the harness and invisible to every test above: with
+  // the input on `flexGrow`, a long directory compressed it below the name's
+  // length — and an input narrower than its content scrolls to the cursor, so
+  // `fixture-repo` rendered as `ture-repo`. Silent: no ellipsis, nothing that
+  // reads as truncation, just a different repo name on screen.
+  const dir = repoUnderLongParent("fixture-repo")
+  const h = await mount(dir)
+
+  const row = (await h.frame()).split("\n").find((l) => l.includes("ture-repo"))
+  expect(row).toBeDefined()
+  expect(row).toContain("fixture-repo")
+})
+
+test("a full-width row keeps air between the name and the directory", async () => {
+  // `paddingLeft` on the muted tail belongs to the box Yoga is shrinking, so
+  // on a row wide enough to close the gap it went to zero and the two halves
+  // collided — `(current dir)/var/folders/…` reads as one string.
+  const dir = repo("fixture-repo")
+  const h = await mount(dir, [dir], 72)
+
+  await pressTab(h, TO_REPO)
+  await act(async () => h.mockInput.typeText("\x15"))
+  await settle()
+
+  const row = (await h.frame()).split("\n").find((l) => l.includes("current dir"))
+  expect(row).toBeDefined()
+  expect(row).not.toContain("dir)/")
+})

--- a/packages/kobe/test/tui/new-task-dialog/repo-field.test.ts
+++ b/packages/kobe/test/tui/new-task-dialog/repo-field.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Unit tests for the repo field's name↔path vocabulary
+ * (`src/tui/component/new-task-dialog/repo-field.ts`).
+ *
+ * These are the boundary the whole "show a name" change rests on: the field
+ * holds a NAME and everything downstream needs a PATH, so every conversion
+ * between the two happens in these three functions. The render tests drive the
+ * mounted dialog; these pin the rules that make it safe — above all that a
+ * name shared by two saved repos is REFUSED rather than resolved to whichever
+ * one sorts first.
+ */
+
+import { nameOrPath, resolveRepoInput, splitRepoInput } from "@/tui/component/new-task-dialog/repo-field"
+import { describe, expect, it } from "vitest"
+
+describe("splitRepoInput", () => {
+  it("splits a resolved path into the name and the directory that locates it", () => {
+    expect(splitRepoInput("/Users/me/i/quokka", true)).toEqual({ name: "quokka", dir: "/Users/me/i/" })
+  })
+
+  it("leaves an UNRESOLVED value verbatim — a half-typed path is not a name", () => {
+    // Splitting mid-typing would leave the field disagreeing with the keys
+    // that produced it.
+    expect(splitRepoInput("/Users/me/i/quo", false)).toEqual({ name: "/Users/me/i/quo", dir: "" })
+  })
+
+  it("has nothing to split when the value has no directory part", () => {
+    expect(splitRepoInput("quokka", true)).toEqual({ name: "quokka", dir: "" })
+  })
+})
+
+describe("resolveRepoInput", () => {
+  const repos = ["/Users/me/i/quokka", "/Users/me/i/wisp"]
+
+  it("resolves a known name to its one path", () => {
+    expect(resolveRepoInput("quokka", repos)).toEqual({ kind: "path", path: "/Users/me/i/quokka" })
+  })
+
+  it("REFUSES a name two saved repos share, rather than picking one", () => {
+    // The whole reason the ambiguous case exists: with ~100 repos flat under
+    // one parent, duplicate basenames are ordinary, and resolving to the first
+    // match would silently open the wrong repo.
+    const dupes = ["/Users/me/a/app", "/Users/me/b/app"]
+    expect(resolveRepoInput("app", dupes)).toEqual({ kind: "ambiguous", name: "app", matches: dupes })
+  })
+
+  it("passes a path straight through — it is already the answer", () => {
+    expect(resolveRepoInput("/tmp/elsewhere", repos)).toEqual({ kind: "path", path: "/tmp/elsewhere" })
+    expect(resolveRepoInput("~/i/quokka", repos)).toEqual({ kind: "path", path: "~/i/quokka" })
+  })
+
+  it("leaves an unknown name alone so validateRepoPath owns the error", () => {
+    // Not this layer's job to invent a second vocabulary for "no such repo".
+    expect(resolveRepoInput("nosuchrepo", repos)).toEqual({ kind: "path", path: "nosuchrepo" })
+  })
+
+  it("treats an empty value as an empty path, not as a name matching nothing", () => {
+    expect(resolveRepoInput("   ", repos)).toEqual({ kind: "path", path: "" })
+  })
+})
+
+describe("nameOrPath (what the field should hold)", () => {
+  const repos = ["/Users/me/i/quokka", "/Users/me/i/wisp"]
+
+  it("uses the name when the name round-trips back to that path", () => {
+    expect(nameOrPath("/Users/me/i/quokka", repos)).toBe("quokka")
+  })
+
+  it("keeps the PATH when the name is ambiguous — it identifies nothing", () => {
+    const dupes = ["/Users/me/a/app", "/Users/me/b/app"]
+    expect(nameOrPath("/Users/me/a/app", dupes)).toBe("/Users/me/a/app")
+    expect(nameOrPath("/Users/me/b/app", dupes)).toBe("/Users/me/b/app")
+  })
+
+  it("keeps the PATH for a repo outside the saved list", () => {
+    // Its basename resolves to itself, not back to the path, so the name would
+    // name nothing the dialog can find.
+    expect(nameOrPath("/tmp/scratch", repos)).toBe("/tmp/scratch")
+  })
+})


### PR DESCRIPTION
Four asks on the Existing tab. Three shipped; the first one's premise doesn't hold and is explained below.

## What changed

**The repo field holds a name, with the path in gray at the right edge.** It used to hold a full absolute path, so the one word that identifies a repo sat at the far right of a string whose left half is identical on every repo you own.

**Picker rows right-align their directory tails.** They were `body` + two spaces + `dim`, which is left-aligned-with-a-gap. Now a `flexGrow` spacer pushes the tail to the row's right edge, so names sit in one column and directories in another. The three pickers that pass no tail (branch, clone parent, adopt) still render as a single text node — that comment in `picker-list.tsx` is respected.

## The decision the brief asked me to make explicitly

**The input genuinely holds a name.** "Hold the path, change only the rendering" is not available: an opentui `<input>` adopts its `value` prop as its edit buffer. I probed it — an input rendered with `value={basename(path)}` and typing `X` fires `onInput("typedX")`, not `onInput("/a/b/typedX")`. Showing a name over a path-shaped state wrote the short string back on the next keystroke, and the two representations oscillated into `Maximum update depth exceeded`.

So there is one representation, and the name is converted back to a path at the boundaries. `src/tui/component/new-task-dialog/repo-field.ts` owns that vocabulary in three pure functions.

**Ambiguity is refused, not guessed.** With ~100 repos flat under `~/i`, two saved repos sharing a basename is routine. `resolveRepoInput` returns `ambiguous` for that case, and:
- opening the dialog on such a repo keeps the full **path** in the field — a name that matches two repos identifies neither, so the path stays and keeps doing the job;
- typing the shared name and submitting shows `more than one saved repo is named app — pick the one you mean from the list` and returns focus to the picker, instead of opening whichever sorts first.

Typing a path by hand still works and renders verbatim — a value mid-typing is not split, since rewriting under the cursor would leave the field disagreeing with the keystrokes that produced it.

## Ask 1 (default to Rove's own repo when the sidebar is empty) — not shipped

The premise fails in the installed case. The published package ships `dist/` only:

```
files: ["dist/cli", "dist/web-ui", "dist/skills", "dist/*.wav", "README.md", "LICENSE"]

$ git -C ~/.nvm/.../node_modules/@sma1lboy/rove rev-parse --show-toplevel
fatal: not a git repository (or any of the parent directories): .git
```

No `.git`, no source. "Self" resolves to a real git repo only in a dev checkout; for every installed user it resolves to a directory `validateRepoPath` rejects. Shipping it would put a path in the field that cannot become a task — a worse empty state than the current one, not a better one.

**What I'd propose instead**, for a separate decision: on a fresh install the honest empty state is not a repo at all but the *action* of choosing one. The field is already seeded with cwd and `pickerModeFor` already flips to the directory browser on `/` or `~`. The smallest change with a real effect is to open the dialog in browse mode when `savedRepos` is empty, so the first frame is a directory picker rather than a path the user has to clear first. That is a behavior change to the first-run flow, so I left it out of this PR rather than deciding it here.

## Two bugs the harness caught that the render tests did not

1. **The name was being truncated silently.** With the input on `flexGrow`, a long directory compressed it below the name's length — and an input narrower than its content scrolls to its cursor, so `fixture-repo` rendered as `ture-repo`. No ellipsis, nothing that reads as truncation, just a different repo name on screen. The input now takes a fixed column when a directory sits beside it (and the whole row when it holds a path, so typing one isn't clipped).
2. **The gap between the halves collapsed on a full row.** `paddingLeft` belongs to the box Yoga is shrinking, so a wide-enough row closed it to zero and `(current dir)/var/folders/…` read as one string. The separating space now lives inside the string, which shrinks with the string.

Both are pinned by tests that fail without the fix.

## Verification

- `test/render/new-task-repo-name-field.test.tsx` — 7 tests through the mounted dialog. Each reads the frame **and** the submitted value, because the two halves fail in opposite directions: render-only would let it show a name and submit a name; submit-only would leave the path in the editable cell.
- `test/tui/new-task-dialog/repo-field.test.ts` — 11 unit tests on the pure helpers.
- Mutation-verified at five sites, each caught: ambiguity guard removed (render + unit), submit reading raw field text, the flex-end spacer removed, and the `flexGrow` that caused the truncation.
- Full render suite 359 pass. `test:fast` 4063 pass; the 4 failures (`open-dir-cmd`, `project-eligibility`) are pre-existing and path-shape driven — they pass on a clean `origin/main` worktree under `~/i` and fail on `origin/main` inside `~/.rove/worktrees`, with my changes stashed.
- Visual check through the harness ground-truth path (`/harness` → xterm → PTY sidecar → real OpenTUI), on an isolated fixture at port base 5473.

## Harness screenshots

Field — name left, gray path right:

```
  repo
  fixture-repo                /Users/jacksonc/.rove/worktrees/kobe-0aff3858ab7
```

Picker row, right-aligned tail:

```
  repo
  fixture-repo
    ▸ fixture-repo  (current dir) /Users/jacksonc/.rove/worktrees/kobe-0aff385
```

The fixture holds one repo, so I could not photograph the multi-row column alignment or the ambiguous-name error through the harness — both are covered by frame-reading render tests instead.