### PR TITLE
fix: recover the rows of an alt-screen paint before counting lines

### DIFF
--- a/.changeset/alt-screen-row-recovery.md
+++ b/.changeset/alt-screen-row-recovery.md
@@ -1,0 +1,14 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Keep the whole screen a stuck engine was showing, not just its last line
+
+A task waiting on a dialog recorded one readable line of its death record —
+the `Enter to confirm · Esc to cancel` footer — with the question, its
+options, and the reason all missing. The tail budget was 40 lines and it kept
+1: an engine painting a full screen moves the cursor instead of writing
+newlines, and stripping the escapes first collapsed every row into one line.
+Vertical cursor motion now becomes a row break before the escapes are
+stripped, so `rove api read-output` and a dead tab's recorded tail both show
+the screen the engine was actually on.

--- a/packages/kobe-daemon/package.json
+++ b/packages/kobe-daemon/package.json
@@ -84,7 +84,8 @@
     "./plugins/task-diff": "./src/plugins/task-diff.ts",
     "./daemon/quota-resume": "./src/daemon/quota-resume.ts",
     "./prompts/issue-prompts": "./src/prompts/issue-prompts.ts",
-    "./prompts/observed-language": "./src/prompts/observed-language.ts"
+    "./prompts/observed-language": "./src/prompts/observed-language.ts",
+    "./daemon/terminal-rows": "./src/daemon/terminal-rows.ts"
   },
   "scripts": {
     "typecheck": "tsc --noEmit"

--- a/packages/kobe-daemon/src/daemon/pty-exit-store.ts
+++ b/packages/kobe-daemon/src/daemon/pty-exit-store.ts
@@ -27,6 +27,7 @@ import { mkdirSync, readFileSync, writeFileSync } from "node:fs"
 import { dirname } from "node:path"
 import { defaultPtyExitsPath } from "./paths.ts"
 import type { PtySessionEndInfo } from "./pty-observability.ts"
+import { terminalRows } from "./terminal-rows.ts"
 
 /**
  * Which process died. `pty` is the session's own child (the shell wrapper);
@@ -60,15 +61,11 @@ const MAX_RECORDS = 50
 const TAIL_LINES = 40
 const TAIL_LINE_CHARS = 500
 
-// Same escape grammar the read-output verb strips (CSI / OSC / single-char).
-// biome-ignore lint/suspicious/noControlCharactersInRegex: stripping raw ANSI escapes is the point
-const ANSI_RE = /\x1b\[[0-9;?]*[ -/]*[@-~]|\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)?|\x1b[@-_]/g
-
-/** Raw PTY tail → readable last lines: strip ANSI, honor CR overwrites,
- *  drop trailing blanks, keep the last {@link TAIL_LINES}. */
+/** Raw PTY tail → readable last lines: recover rows (see `terminal-rows.ts` —
+ *  an engine's alt-screen paint has no newlines to split on), drop trailing
+ *  blanks, keep the last {@link TAIL_LINES}. */
 export function plainTail(raw: string): string[] {
-  const plain = raw.replace(ANSI_RE, "").replace(/\r\n/g, "\n")
-  const lines = plain.split("\n").map((line) => (line.split("\r").pop() ?? "").slice(0, TAIL_LINE_CHARS))
+  const lines = terminalRows(raw, TAIL_LINE_CHARS)
   while (lines.length > 0 && (lines[lines.length - 1] ?? "").trim() === "") lines.pop()
   return lines.slice(-TAIL_LINES)
 }

--- a/packages/kobe-daemon/src/daemon/terminal-rows.ts
+++ b/packages/kobe-daemon/src/daemon/terminal-rows.ts
@@ -1,0 +1,60 @@
+/**
+ * Raw PTY bytes → readable rows. The one definition, shared by every reader
+ * that turns a captured terminal stream back into lines: the durable death
+ * record's tail (`pty-exit-store.ts`) and the `read-output` verb
+ * (`kobe/src/cli/api/read-output-page.ts`).
+ *
+ * The subtlety is that a full-screen TUI does not write newlines. A shell
+ * ends every row with `\n`, so splitting on it recovers the screen — but an
+ * engine in the alternate screen positions its cursor with CSI instead
+ * (`ESC[1B` down a row, `ESC[H` home), and emits no `\n` at all for a screen
+ * it is painting. Strip the escapes first, as a plain `replace(ANSI_RE, "")`
+ * does, and every row of that screen concatenates into ONE line — then the
+ * caller's "keep the last N lines" budget keeps 1 line where it meant to keep
+ * 40, and what survives is whatever the engine painted LAST (a footer, a
+ * `Enter to confirm · Esc to cancel`) with the question it belongs to
+ * discarded.
+ *
+ * So vertical cursor motion becomes a row break BEFORE the escapes are
+ * stripped. This is not a terminal emulator and does not try to be: absolute
+ * positioning is treated as "some other row", not as the row it names, so a
+ * screen repainted out of order reads out of order. It recovers the ROWS,
+ * which is what a tail budget needs to count.
+ */
+
+/** CSI cursor-down (`B`) / next-line (`E`), with an optional repeat count. */
+// biome-ignore lint/suspicious/noControlCharactersInRegex: matching raw ANSI escapes is the point
+const CURSOR_DOWN_RE = /\x1b\[(\d*)[BE]/g
+/** CSI absolute cursor position (`H` / `f`) — a move to some other row. */
+// biome-ignore lint/suspicious/noControlCharactersInRegex: matching raw ANSI escapes is the point
+const CURSOR_POSITION_RE = /\x1b\[[\d;]*[Hf]/g
+/** Bound the rows one escape can synthesize, so a hostile `ESC[999999B`
+ *  cannot turn a short capture into a huge array. A real screen is ~50 rows. */
+const MAX_ROWS_PER_ESCAPE = 200
+
+// Same escape grammar every reader here strips (CSI / OSC / single-char).
+// biome-ignore lint/suspicious/noControlCharactersInRegex: stripping raw ANSI escapes is the point
+const ANSI_RE = /\x1b\[[0-9;?]*[ -/]*[@-~]|\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)?|\x1b[@-_]/g
+
+/** Turn vertical cursor motion into newlines, so an alt-screen paint has rows
+ *  to be split on. Must run BEFORE {@link ANSI_RE} deletes the escapes. */
+function breakRowsOnCursorMotion(raw: string): string {
+  return raw
+    .replace(CURSOR_DOWN_RE, (_m, count: string) =>
+      "\n".repeat(Math.min(MAX_ROWS_PER_ESCAPE, Math.max(1, Number.parseInt(count, 10) || 1))),
+    )
+    .replace(CURSOR_POSITION_RE, "\n")
+}
+
+/**
+ * Raw PTY bytes → readable rows: recover alt-screen rows, strip ANSI, honor
+ * CR overwrites. `maxLineChars` clips each row when the caller has a per-line
+ * budget (the death record does; `read-output` does not).
+ */
+export function terminalRows(raw: string, maxLineChars?: number): string[] {
+  const plain = breakRowsOnCursorMotion(raw).replace(ANSI_RE, "").replace(/\r\n/g, "\n")
+  return plain.split("\n").map((line) => {
+    const overwritten = line.split("\r").pop() ?? ""
+    return maxLineChars === undefined ? overwritten : overwritten.slice(0, maxLineChars)
+  })
+}

--- a/packages/kobe/src/cli/api/read-output-page.ts
+++ b/packages/kobe/src/cli/api/read-output-page.ts
@@ -11,6 +11,7 @@
  */
 
 import type { PtySessionExit } from "@sma1lboy/kobe-daemon/daemon/protocol"
+import { terminalRows } from "@sma1lboy/kobe-daemon/daemon/terminal-rows"
 import type { Message } from "../../types/engine.ts"
 import { ApiError } from "./types.ts"
 
@@ -152,13 +153,12 @@ export function buildHistoryPage(messages: readonly Message[], startIdx: number,
 
 // ── Terminal text shaping (pure) ─────────────────────────────────────────────
 
-// biome-ignore lint/suspicious/noControlCharactersInRegex: stripping raw ANSI escapes is the point
-const ANSI_RE = /\x1b\[[0-9;?]*[ -/]*[@-~]|\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)?|\x1b[@-_]/g
-
-/** Raw PTY bytes → readable lines: strip ANSI, honor CR overwrites. */
+/** Raw PTY bytes → readable lines. Thin alias over the shared row recovery
+ *  (`kobe-daemon/daemon/terminal-rows`), which the death record's tail uses
+ *  too — an engine's alt-screen paint writes no newlines, so the escapes have
+ *  to become rows before anything counts lines. */
 export function terminalLines(text: string): string[] {
-  const plain = text.replace(ANSI_RE, "").replace(/\r\n/g, "\n")
-  return plain.split("\n").map((line) => line.split("\r").pop() ?? "")
+  return terminalRows(text)
 }
 
 export interface TerminalTail {

--- a/packages/kobe/test/daemon/terminal-rows.test.ts
+++ b/packages/kobe/test/daemon/terminal-rows.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Alt-screen row recovery (issue #97).
+ *
+ * The incident: a task whose engine put up a "you've hit your weekly limit"
+ * dialog and waited. Its durable death record kept ONE readable line —
+ * `Enter to confirm · Esc to cancel` — so the question, its three options,
+ * and the reason were all gone, and the tab was indistinguishable from a
+ * crash. The tail budget was 40 lines and it kept 1, because a full-screen
+ * engine paints with cursor motion and writes no newline for the screen: the
+ * old `replace(ANSI_RE, "")` deleted the row breaks along with the colors and
+ * concatenated the whole screen into a single line.
+ *
+ * The fixture is that screen, reduced to the shape that matters: CSI row
+ * motion, and not one `\n` in the whole capture.
+ */
+
+import { plainTail } from "@sma1lboy/kobe-daemon/daemon/pty-exit-store"
+import { terminalRows } from "@sma1lboy/kobe-daemon/daemon/terminal-rows"
+import { describe, expect, it } from "vitest"
+
+/** A rate-limit dialog as claude actually paints it: every row reached with
+ *  `ESC[nB` cursor motion, never a newline. */
+const ALT_SCREEN_DIALOG =
+  "\x1b[38;2;153;153;153m  ⎿ \x1b[38;2;255;107;128mYou've hit your weekly limit · resets Sep 2 at 3am" +
+  "\r\x1b[2B\x1b[38;2;153;153;153m✻\x1b[3GChurned for 0s · done 1:19 AM" +
+  "\r\x1b[1B\x1b[3C\x1b[1mWhat do you want to do?" +
+  "\r\x1b[3C\x1b[2B\x1b[22m❯\x1b[6G\x1b[38;2;153;153;153m1. \x1b[39mStop and wait for limit to reset" +
+  "\r\x1b[5C\x1b[1B\x1b[38;2;153;153;153m2. \x1b[39mWait here, then continue automatically" +
+  "\r\x1b[5C\x1b[1B\x1b[38;2;153;153;153m3. \x1b[39mUpgrade your plan" +
+  "\r\x1b[3C\x1b[2B\x1b[3mEnter to confirm · Esc to cancel\x1b[23m\x1b[39m"
+
+describe("terminalRows", () => {
+  it("recovers the rows of an alt-screen paint that contains no newline", () => {
+    expect(ALT_SCREEN_DIALOG).not.toContain("\n") // the premise: nothing to split on
+
+    const rows = terminalRows(ALT_SCREEN_DIALOG).filter((line) => line.trim() !== "")
+
+    // The question and every option survive — not just the last footer line.
+    expect(rows.length).toBeGreaterThan(1)
+    expect(rows.some((l) => l.includes("What do you want to do?"))).toBe(true)
+    expect(rows.some((l) => l.includes("Stop and wait for limit to reset"))).toBe(true)
+    expect(rows.some((l) => l.includes("Upgrade your plan"))).toBe(true)
+    // And the WHY, which is what made this dialog answerable at all.
+    expect(rows.some((l) => l.includes("hit your weekly limit"))).toBe(true)
+  })
+
+  it("keeps each row separate rather than concatenating the screen", () => {
+    const rows = terminalRows(ALT_SCREEN_DIALOG).filter((line) => line.trim() !== "")
+    // The bug's signature: one line carrying both the question and the footer.
+    const merged = rows.find((l) => l.includes("What do you want to do?") && l.includes("Esc to cancel"))
+    expect(merged).toBeUndefined()
+  })
+
+  it("breaks a row on absolute cursor positioning too", () => {
+    // The real capture ended `...Esc to cancel\x1b[44;1H\x1b[40;4H` — a status
+    // line jumped to with ESC[row;colH rather than stepped down to. Treated as
+    // "some other row", not as the row it names: this is not an emulator.
+    expect(terminalRows("footer\x1b[44;1Hstatus")).toEqual(["footer", "status"])
+  })
+
+  it("still splits ordinary newline-terminated shell output, and honors CR overwrites", () => {
+    expect(terminalRows("one\ntwo\r\nthree")).toEqual(["one", "two", "three"])
+    // A progress line rewritten in place reports only its final state.
+    expect(terminalRows("Installing [1/9]\rInstalling [9/9]")).toEqual(["Installing [9/9]"])
+  })
+
+  it("clips to maxLineChars only when the caller asks", () => {
+    expect(terminalRows("abcdef", 3)).toEqual(["abc"])
+    expect(terminalRows("abcdef")).toEqual(["abcdef"])
+  })
+
+  it("bounds the rows one escape can synthesize", () => {
+    // `ESC[999999B` must not turn a 20-byte capture into a million-row array.
+    expect(terminalRows("a\x1b[999999Bb").length).toBeLessThanOrEqual(202)
+  })
+})
+
+describe("plainTail (the death record's tail)", () => {
+  it("keeps the dialog's question, not just its last painted line", () => {
+    const tail = plainTail(ALT_SCREEN_DIALOG)
+    // Before the fix this was exactly ["Enter to confirm · Esc to cancel"].
+    expect(tail.length).toBeGreaterThan(1)
+    expect(tail.join("\n")).toContain("What do you want to do?")
+    expect(tail[tail.length - 1]).toContain("Enter to confirm")
+  })
+})


### PR DESCRIPTION
Part of #97 — the "state doesn't tell the truth" half (direction **a**).

## What was actually wrong

The brief predicted the stuck task would report `error` because a 120s
watchdog killed it. That is not what happened, and the real cause is a
different bug that direction (a) named correctly anyway.

Task `01M1E0T2A228RC0KTV210ZPFTB`'s tab-1 hit claude's **weekly rate-limit
dialog**, which waits on a 3-way choice. Its durable death record kept
exactly one readable line:

```
Enter to confirm · Esc to cancel
```

The tail budget is 40 lines. It kept **1** — and the one it kept was the
footer, with the question, the three options, and the reason all gone. That
is what made a waiting tab indistinguishable from a crashed one: not a
mislabelled state, but a record with the evidence removed.

## Root cause

`plainTail()` stripped ANSI and then split on `\n`. A full-screen engine
paints by **moving the cursor** (`ESC[1B`, `ESC[44;1H`) and emits no newline
for the screen it is drawing — the last 4KB of the real capture contains **0
newlines and 27 carriage returns**. Stripping the escapes first deleted the
row breaks along with the colors, so the whole screen concatenated into one
line; the "last 40 lines" budget then had a single line to keep.

Both readers that reconstruct a captured terminal had the same defect, from
copy-pasted code:

- `kobe-daemon/src/daemon/pty-exit-store.ts` — the death record's tail
- `kobe/src/cli/api/read-output-page.ts` — the `read-output` verb

So `read-output` was blind the same way, which is issue #97's symptom B
("`read-output` only gives tail... can't get back what was scrolled away").
Fixing it in one place fixes both.

## The change

Vertical cursor motion becomes a row break **before** the escapes are
stripped, in one shared `terminal-rows.ts` both callers use.

Deliberately **not** a terminal emulator: absolute positioning is treated as
"some other row", not as the row it names, so an out-of-order repaint reads
out of order. It recovers the ROWS, which is all a tail budget needs to
count. Row synthesis is bounded (`ESC[999999B` cannot blow up the array).

## Verification

Against the **real capture** from the incident, `plainTail()` goes from 1
readable line to 30 — the dialog's question, all three options, and the
`You've hit your weekly limit` reason are all back.

Mutation-verified at two different sites: disabling row-breaking fails 2
tests; degrading only the absolute-positioning branch initially **survived**,
which exposed an untested branch the real capture did exercise — test
widened, that mutant now fails too.

## Test gates

- root `bun run lint` — clean
- root `bun run typecheck` — clean
- `bun run test` — 4069 passed; the only 2 failing files are
  `open-dir-cmd` / `project-eligibility`, which judge by path shape and fail
  for any worktree under `~/.rove/worktrees`. **Proven unrelated**: a clean
  `origin/main` worktree outside that path passes all 30 of those tests, and
  this diff touches neither file.
- render track: 361 pass / 0 fail
- socket track: 689 passed (baseline 682 + the 7 added here)

## Scope

Direction (a) only, as briefed. **b** (read the current screen) and **c**
(send keys / forward clicks) are unstarted — they carry the two owner
decisions issue #97 flags, and the plan for them comes back for sign-off
rather than being implemented here.

Worth noting for (b): this fix removes a chunk of what made (b) look
necessary. The screen was being captured all along — it was the reader that
threw it away. `read-output` on a stuck engine is now considerably more
useful than when the issue was written.