### PR TITLE
test: fix the two flakes that gated the v0.9.72 publish

### DIFF
--- a/.changeset/fix-two-publish-gating-flakes.md
+++ b/.changeset/fix-two-publish-gating-flakes.md
@@ -1,0 +1,23 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Fix the two flaky tests that blocked the v0.9.72 npm publish twice.
+
+Both were fixed-budget bets on async work, and both lost the bet on a loaded
+CI runner rather than on any code change:
+
+- `test/render/new-chat-flow.test.tsx` asserted on a frame 60ms after
+  `requestNewChat()`, but every open is gated on an async engine probe
+  (`availableEngineIds()` — a `which` + `stat` per vendor) that runs before the
+  dialog mounts. That took 38ms of the 60ms budget on an idle Mac, so a slower
+  runner read the pre-dialog frame, which is blank. All five call sites now wait
+  for the dialog's own text with `waitForFrameText`.
+- `test/daemon/attention-inbox.test.ts` drove its retention-cap fixture through
+  510 `record()` calls, each rewriting the whole store file — ~17.7MB of I/O
+  against a 5s timeout. The timeout then abandoned the loop mid-write, so the
+  `afterEach` cleanup hit `ENOTEMPTY` on a directory that loop was still writing
+  into; one defect, two symptoms. The fixture is now seeded through the store
+  file, and only the episodes that actually cross the cap are recorded.
+
+No retries, no bumped timeouts, no skips — tests only.

--- a/packages/kobe/test/daemon/attention-inbox.test.ts
+++ b/packages/kobe/test/daemon/attention-inbox.test.ts
@@ -26,6 +26,33 @@ describe("daemon attention inbox", () => {
     return { store, path, bus }
   }
 
+  /**
+   * Seed `count` already-persisted episodes (task-0 … task-N, ascending `at`)
+   * straight into the store file, then load them with one `init()`.
+   *
+   * Driving the seed through `record()` instead costs one whole-file rewrite
+   * per episode — 510 rewrites of a file growing to 66KB, ~17.7MB of I/O.
+   * That fits vitest's 5s budget on a dev Mac (~160ms) and blew it on a
+   * loaded CI runner (v0.9.72 attempt 2: 5018ms and 5248ms). The timeout then
+   * abandoned the loop still mid-write, so `afterEach`'s rm hit ENOTEMPTY on a
+   * directory the orphaned loop was still writing into — one defect, two
+   * symptoms. The prune under test lives in `commit()`, which only the
+   * records made AFTER the seed reach, so nothing is lost by seeding cheaply.
+   */
+  async function seed(count: number, firstAt: number): Promise<string> {
+    dir = await mkdtemp(join(tmpdir(), "kobe-attention-inbox-"))
+    const path = join(dir, "attention-inbox.json")
+    const items = Array.from({ length: count }, (_, i) => ({
+      taskId: `task-${i}`,
+      tabId: "tab-1",
+      state: "turn_complete",
+      unread: true,
+      at: firstAt + i,
+    }))
+    await writeFile(path, JSON.stringify({ version: 1, items }), "utf8")
+    return path
+  }
+
   it("persists attention episodes and replays the full snapshot", async () => {
     const { store, path, bus } = await create(123)
     const snapshots: unknown[] = []
@@ -141,14 +168,18 @@ describe("daemon attention inbox", () => {
   })
 
   it("prunes the oldest episodes past the retention cap", async () => {
-    let now = 1000
-    const { store, path } = await create(() => now)
     // MAX_EPISODES + 10 distinct episodes, oldest first — the ten oldest
     // must fall off the tail-ward end and stay off after a reload. Without
     // the cap these would all persist: episodes of forgotten tasks leave
     // only on visit / turn-start / hard-delete, so this queue used to grow
     // without bound (one whole-file rewrite per recorded episode).
-    for (let i = 0; i < MAX_EPISODES + 10; i++) {
+    // The first MAX_EPISODES are seeded (see `seed`); the ten that cross the
+    // cap are recorded for real, so each one runs the prune in `commit()`.
+    const path = await seed(MAX_EPISODES, 1000)
+    let now = 1000 + MAX_EPISODES
+    const store = new AttentionInboxStore(path, new DaemonEventBus(), () => now)
+    await store.init()
+    for (let i = MAX_EPISODES; i < MAX_EPISODES + 10; i++) {
       await store.record(`task-${i}`, "turn-complete", undefined, "tab-1")
       now += 1
     }
@@ -164,12 +195,9 @@ describe("daemon attention inbox", () => {
   })
 
   it("a fresh episode on a capped task re-stamps it to the tail, not past the cap", async () => {
-    let now = 1000
-    const { store } = await create(() => now)
-    for (let i = 0; i < MAX_EPISODES; i++) {
-      await store.record(`task-${i}`, "turn-complete", undefined, "tab-1")
-      now += 1
-    }
+    const path = await seed(MAX_EPISODES, 1000)
+    const store = new AttentionInboxStore(path, new DaemonEventBus(), () => 1000 + MAX_EPISODES)
+    await store.init()
     // Re-recording a task already under the cap REPLACES its episode (dedupe
     // rule) — nothing is pruned yet, and the re-stamped episode sits at the
     // newest slot.

--- a/packages/kobe/test/render/new-chat-flow.test.tsx
+++ b/packages/kobe/test/render/new-chat-flow.test.tsx
@@ -10,6 +10,14 @@
  *   fork+continue → composer with the handoff brief leading the prompt;
  *                   refusal toast (no composer) without a session
  *
+ * Every `requestNewChat` open is gated on an ASYNC engine probe
+ * (`availableEngineIds()` → `findClaudeBinary()` &c., a `which` + `stat` per
+ * vendor) that runs before `NewChatDialog.show`. A fixed `settle()` is a bet
+ * that probe finishes inside 60ms; it took 38ms on an idle Mac, and lost that
+ * bet on a loaded CI runner (v0.9.72 attempt 1 — the assertion read the
+ * pre-dialog frame, which is blank because `Driver` renders `null`). Wait for
+ * the dialog's own text with `waitForFrameText` instead.
+ *
  * Engine history reads and kobe state writes are both sandboxed to a
  * tmpdir via their real env seams (`CLAUDE_CONFIG_DIR` / `CODEX_HOME` /
  * `KOBE_HOME_DIR`) — bun's `os.homedir()` ignores runtime `HOME` changes,
@@ -27,7 +35,7 @@ import { useT } from "../../src/tui-react/i18n"
 import { useDialog } from "../../src/tui-react/ui/dialog"
 import { type NewChatPreset, useTabDialogs } from "../../src/tui-react/workspace/use-tab-dialogs"
 import type { TabsState } from "../../src/tui/workspace/terminal-tabs-core"
-import { act, renderComponent, settle } from "./harness"
+import { act, renderComponent, settle, waitForFrameText } from "./harness"
 
 let root: string
 let repo: string
@@ -133,8 +141,7 @@ describe("requestNewChat dispatch", () => {
   test("default combo lands a sibling engine tab (old ctrl+e)", async () => {
     const { frame, mockInput, captured } = await mountFlow(tabs())
     act(() => captured.request())
-    await settle()
-    expect(await frame()).toContain("New conversation")
+    await waitForFrameText(frame, "New conversation")
     act(() => mockInput.pressEnter())
     await settle()
     await frame()
@@ -148,8 +155,7 @@ describe("requestNewChat dispatch", () => {
   test("tab+continue with no conversation → refusal toast, no tab", async () => {
     const { frame, mockInput, captured } = await mountFlow(tabs())
     act(() => captured.request({ context: "continue" }))
-    await settle()
-    expect(await frame()).toContain("continue this conversation")
+    await waitForFrameText(frame, "continue this conversation")
     act(() => mockInput.pressEnter())
     await settle()
     await frame()
@@ -160,11 +166,9 @@ describe("requestNewChat dispatch", () => {
   test("fork+fresh opens the QuickTaskComposer; submit reaches onQuickFork", async () => {
     const { frame, mockInput, captured } = await mountFlow(tabs())
     act(() => captured.request({ destination: "fork" }))
-    await settle()
-    expect(await frame()).toContain("fork a child task")
+    await waitForFrameText(frame, "fork a child task")
     act(() => mockInput.pressEnter())
-    await settle()
-    expect(await frame()).toContain("Quick task")
+    await waitForFrameText(frame, "Quick task")
     await act(async () => mockInput.typeText("ship the thing"))
     act(() => mockInput.pressEnter())
     await settle()
@@ -187,7 +191,7 @@ describe("requestNewChat dispatch", () => {
 
     const { frame, mockInput, captured } = await mountFlow(tabs("s1"))
     act(() => captured.request({ destination: "fork", context: "continue" }))
-    await settle()
+    await waitForFrameText(frame, "fork a child task")
     act(() => mockInput.pressEnter())
     // `forkChildTask` resolves the handoff plan asynchronously before opening
     // the QuickTaskComposer. Wait for the composer (or a refusal toast) instead
@@ -219,7 +223,7 @@ describe("requestNewChat dispatch", () => {
       nextOrdinal: 2,
     })
     act(() => captured.request({ destination: "fork", context: "continue" }))
-    await settle()
+    await waitForFrameText(frame, "fork a child task")
     act(() => mockInput.pressEnter())
     // Same async-plan race as the handoff test above: wait for the refusal
     // toast instead of assuming it has fired within the fixed settle window.


### PR DESCRIPTION
Two separate flaky tests blocked the same `npm publish` twice (release run 33486422766, tag v0.9.72). Both are fixed-budget bets on async work that lose on a loaded CI runner. Neither is a regression — both pass on `origin/main`, which is exactly what makes them dangerous: they surface at the moment the version is already tagged and burned.

They are **independent defects that share a shape**, not one root cause.

## Flake 1 — render-track, `new-chat-flow.test.tsx`

The failing assertion read an entirely blank 80x24 frame. That frame is *correct*: `Driver` renders `null`, so the screen is legitimately empty until the dialog mounts. The stray `act(...)` warnings in the same log are ambient noise from other files — only ONE test failed and every later test passed, so nothing was stranded.

Every `requestNewChat` open is gated on an async engine probe before `NewChatDialog.show`:

```
requestNewChat → await availableEngineIds() → findClaudeBinary() ×4 (which + stat)
               → listPaneLaunches() → NewChatDialog.show()
```

Measured: that chain makes the dialog visible at **38ms of the 60ms `settle()` budget** on an idle Mac. CI lost the remaining 22ms.

**Fix:** wait for the dialog's own text with `waitForFrameText` (already in the harness for exactly this). Applied at all five call sites — the other four had the same latent bug, two of them worse: they `pressEnter()` after a bare `settle()`, so a slow probe drops the keypress entirely.

## Flake 2 — publish job, `attention-inbox.test.ts`

The timeout and the dirty teardown are the same defect seen twice, as suspected — but the un-awaited operation is in the *test harness*, not the store. `AttentionInboxStore` awaits correctly throughout; `commit()` rewrites the **whole file** per record.

The fixture drove `MAX_EPISODES + 10` = 510 sequential `record()` calls. Measured: **17.7MB of I/O across ~1530 syscalls**, against a file growing to 66KB. 163ms on a dev Mac; 5018ms and 5248ms on CI. vitest's timeout then rejects the test's promise but **cannot cancel the running loop** — so `afterEach`'s `rm` raced a loop still writing into that directory, which is the `ENOTEMPTY`.

**Fix:** seed the pre-cap episodes through the store file and load them with one `init()`. Only the episodes that actually *cross* the cap are recorded, so every `commit()` prune the test asserts on still runs for real. 10508ms → **~290ms**.

## Proof

No retries, no bumped timeouts, no skips. Tests only — zero source changes.

**Flake 1** — instrumented `availableEngineIds` with an artificial delay (the exact CI condition), then ran the original file against the fixed one:

| | SLOW_PROBE=200ms |
|---|---|
| original | **0 pass / 5 fail** |
| fixed | 5 pass / 0 fail |

Fixed version also survives 800ms and 2000ms — 33× the old budget.

**Flake 2** — two different mutation sites, both caught:

- `slice(-MAX_EPISODES)` → `slice(0, MAX_EPISODES)` (prune the wrong end) → 2 failed
- cap removed entirely → 2 failed

Re-verified after the lint-driven `let`→`const` cleanup.

**Repetition:** render suite 5× (352 pass), inbox test 10× (13 pass, 258–388ms), full socket suite (79 files / 676 tests).

`test:fast` shows 4 failures in `open-dir-cmd` / `project-eligibility` — the documented path-shape artifact of running inside `~/.rove/worktrees`, in files this PR does not touch. (47 further failures were the `ROVE_INVOKED_AS` env artifact; `env -u` clears them.)