### PR TITLE
fix: make routine-update clear the precheck and base ref on an empty flag

### DIFF
--- a/.changeset/routine-clear-by-empty.md
+++ b/.changeset/routine-clear-by-empty.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Fix `rove api routine-update --precheck ''` and `--base-branch ''` so they actually clear the field instead of silently leaving it in place. Both flags are documented as "'' clears it", and the daemon already treats an empty value as a clear, but the CLI folded the empty string into "not passed" and dropped it before it reached the daemon — so the old value stayed. Passing an empty value now sends an explicit clear.

--- a/packages/kobe/src/cli/api/flags.ts
+++ b/packages/kobe/src/cli/api/flags.ts
@@ -192,6 +192,18 @@ export class VerbArgs {
     return v && v.length > 0 ? v : undefined
   }
 
+  /**
+   * Whether the flag was PRESENT on the command line at all — including as an
+   * empty string (`--flag ''` / `--flag=`). Unlike {@link str}, which folds
+   * `""` into "absent", this is how a flag whose empty value MEANS something
+   * — the clear-by-empty convention on `routine-update`'s `--precheck` /
+   * `--base-branch` — tells "clear it" apart from "leave it alone".
+   */
+  present(name: string): boolean {
+    this.spec(name)
+    return this.flags.get(name) !== undefined
+  }
+
   /** Required string value (MISSING_FLAG when absent). */
   require(name: string): string {
     const v = this.str(name)

--- a/packages/kobe/src/cli/api/verbs-automations.ts
+++ b/packages/kobe/src/cli/api/verbs-automations.ts
@@ -55,11 +55,17 @@ const PERSISTENT_FLAG = {
     "Re-deliver into ONE standing task instead of a fresh worktree per run — for a routine that needs yesterday's context (a trend check). Its task is folded behind the sidebar's routine count row. Leave off for a routine that EDITS code: a week of runs on one branch is a branch nobody can land.",
 } as const
 
-/** Shared `--precheck` → payload shape. `--precheck ''` clears it on update. */
+/**
+ * Shared `--precheck` → payload shape. `--precheck ''` sends `precheck: null`,
+ * which the daemon reads as "clear it" on update (a no-op on create, which has
+ * nothing to clear). The flag must be read with {@link VerbArgs.present}, not
+ * `str`: `str` folds an empty value into "absent", so `--precheck ''` would
+ * otherwise omit the field and silently leave the existing precheck in place.
+ */
 function precheckPayload(ctx: Parameters<VerbSpec["handler"]>[0]): Record<string, unknown> {
+  if (!ctx.args.present("precheck")) return {}
   const command = ctx.args.str("precheck")
-  if (command === undefined) return {}
-  if (command.length === 0) return { precheck: null }
+  if (command === undefined) return { precheck: null }
   return { precheck: { command, timeoutSeconds: ctx.args.int("precheck-timeout") ?? 120 } }
 }
 
@@ -129,7 +135,9 @@ export const ROUTINE_VERBS: readonly VerbSpec[] = [
         ...(ctx.args.str("prompt") !== undefined ? { prompt: ctx.args.str("prompt") } : {}),
         ...(ctx.args.str("schedule") !== undefined ? { schedule: ctx.args.str("schedule") } : {}),
         ...(ctx.args.vendor() ? { vendor: ctx.args.vendor() } : {}),
-        ...(ctx.args.str("base-branch") !== undefined ? { baseRef: ctx.args.str("base-branch") } : {}),
+        // `--base-branch ''` clears the base ref (sends null); `present` keeps
+        // that empty value visible where `str` would fold it into "absent".
+        ...(ctx.args.present("base-branch") ? { baseRef: ctx.args.str("base-branch") ?? null } : {}),
         ...precheckPayload(ctx),
         ...(ctx.args.int("grace") !== undefined ? { missedRunGraceMinutes: ctx.args.int("grace") } : {}),
         ...(ctx.args.bool("persistent-session") ? { persistentSession: true } : {}),

--- a/packages/kobe/test/cli/api-routine-clear.test.ts
+++ b/packages/kobe/test/cli/api-routine-clear.test.ts
@@ -1,0 +1,51 @@
+/**
+ * `routine-update`'s clear-by-empty convention: `--precheck ''` and
+ * `--base-branch ''` must reach the daemon as an explicit `null`, which its
+ * `automation.update` handler reads as "clear this field". The CLI used to
+ * fold the empty value into "absent" (VerbArgs.str drops `""`), so the clear
+ * was silently dropped on the wire and the existing value stayed put.
+ */
+
+import { describe, expect, it } from "vitest"
+import { invokeVerb } from "../../src/cli/api-cmd.ts"
+import { FakeClient, stubRuntime } from "./api-handler-fixtures.ts"
+
+const ok = () => ({ automation: { id: "r1" } })
+
+async function updatePayload(argv: readonly string[]): Promise<Record<string, unknown>> {
+  const client = new FakeClient({ "automation.update": ok })
+  await invokeVerb("routine-update", argv, { client, runtime: stubRuntime() })
+  const call = client.requests.find((r) => r.name === "automation.update")
+  expect(call).toBeDefined()
+  return call?.payload as Record<string, unknown>
+}
+
+describe("routine-update clear-by-empty", () => {
+  it("sends precheck: null when --precheck is empty so the daemon clears it", async () => {
+    const payload = await updatePayload(["--id", "r1", "--precheck", ""])
+    expect("precheck" in payload).toBe(true)
+    expect(payload.precheck).toBeNull()
+  })
+
+  it("sends baseRef: null when --base-branch is empty so the daemon clears it", async () => {
+    const payload = await updatePayload(["--id", "r1", "--base-branch", ""])
+    expect("baseRef" in payload).toBe(true)
+    expect(payload.baseRef).toBeNull()
+  })
+
+  it("still sends the precheck command and timeout when --precheck has a value", async () => {
+    const payload = await updatePayload(["--id", "r1", "--precheck", "bun test", "--precheck-timeout", "30"])
+    expect(payload.precheck).toEqual({ command: "bun test", timeoutSeconds: 30 })
+  })
+
+  it("still sends a non-empty base ref verbatim", async () => {
+    const payload = await updatePayload(["--id", "r1", "--base-branch", "main"])
+    expect(payload.baseRef).toBe("main")
+  })
+
+  it("omits precheck and baseRef entirely when neither flag is passed", async () => {
+    const payload = await updatePayload(["--id", "r1", "--name", "renamed"])
+    expect("precheck" in payload).toBe(false)
+    expect("baseRef" in payload).toBe(false)
+  })
+})


### PR DESCRIPTION
## Direction

Bugs / correctness (a) + shipped-behavior-vs-documented-intent (e). Found by direct code review of the `rove api` CLI, not from an open issue.

## Problem

`rove api routine-update` documents two clear-by-empty flags:

- `routine-update` summary: *"…`--precheck ''` clears the precheck."*
- `--base-branch` description: *"New base ref ('' to clear)."*

Neither actually clears. `VerbArgs.str()` folds an empty string into "absent" (`return v && v.length > 0 ? v : undefined`), so:

- `precheckPayload` never reached its `command.length === 0 → { precheck: null }` branch — it was dead code. An empty `--precheck` returned `{}`, omitting the field.
- `routine-update`'s `--base-branch` guard (`str("base-branch") !== undefined`) dropped the key entirely for an empty value.

The daemon side is already correct and ready to clear: `automation.update` maps `precheck: null` and a present-but-empty `baseRef` to a cleared field (`handlers-automations.ts` + `automations-store.ts`). The clear was being lost on the CLI side before it ever went over the wire, so the existing value silently stayed and the command exited 0 looking like success.

Concrete failure: `rove api routine-update --id r_123 --precheck ''` sent `{ id: "r_123" }` (precheck untouched) instead of `{ id: "r_123", precheck: null }`.

## Fix

- Add `VerbArgs.present(name)` — reports whether a flag was passed at all, including as an empty string, so a flag whose empty value *means* something can tell "clear it" apart from "leave it alone".
- `precheckPayload` now keys off `present("precheck")`: passed-empty → `{ precheck: null }`, passed with a value → the precheck object, absent → `{}`. Removes the now-redundant dead branch.
- `routine-update`'s `--base-branch` now sends `{ baseRef: str("base-branch") ?? null }` when the flag is present, so an empty value clears. `routine-create` keeps `str` — it has no field to clear.

No behavior change for the non-empty and absent cases; on `routine-create`, `--precheck ''` sends `precheck: null`, which the daemon drops (no precheck) exactly as before.

## Verification

- New `test/cli/api-routine-clear.test.ts` drives the full `invokeVerb` path through a fake daemon client and pins the wire payload for all five cases: empty precheck → `null`, empty base-branch → `null`, non-empty precheck → object, non-empty base ref → verbatim, neither flag → both keys omitted. All pass.
- `bun run lint` and `bun run typecheck` green.
- Re-ran `api-dispatcher`, `api-cmd`, `api-handlers`, `api-handlers-digest`, `api-custom-vendor` suites — 95 + 16 tests pass, no regressions.
- `docs/API.md` already documents the intended behavior, so no doc change is needed — this makes the code match the docs.

## Follow-ups

None required. The empty-string "clear" convention is now expressible through `VerbArgs.present`; other verbs that grow a clear-by-empty flag can reuse it rather than re-deriving the distinction.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ETD1px1MoVsbZqtNzRMQHk)_