### PR TITLE
feat: rove api send/add/dispatch take --prompt-file so the shell never sees the text

### DIFF
--- a/.agents/skills/kobe/SKILL.md
+++ b/.agents/skills/kobe/SKILL.md
@@ -219,7 +219,7 @@ turn either. These five carry almost all traffic:
 
 ```text
 add      --repo(REQ) --prompt --title --command --count --agents --activate
-send     --prompt(REQ) --task-id --tab --command --plain
+send     --prompt|--prompt-file(REQ) --task-id --tab --command --plain
 get-task --task-id(REQ)          list  (no flags)
 collect  --group <groupId> | --task-ids <csv> | --repo
 ```
@@ -263,10 +263,14 @@ rove api add --repo "$PWD" --agents claude:2,codex:1 --prompt "<prompt>"
 # From inside a Rove task this auto-prefixes [ROVE PEER] provenance
 # (sender + reply command); --plain sends verbatim.
 #
-# SINGLE-QUOTE a prompt containing backticks, or your shell runs them as
-# command substitution and the words vanish from the message you send. In
-# double quotes `rove api send` becomes the OUTPUT of running that command.
-rove api send --task-id <id> --prompt "<complete next turn>"
+# A prompt with backticks, $vars, or quotes goes through --prompt-file, NEVER
+# a double-quoted --prompt: in double quotes `rove api send …` is command
+# substitution — the shell RUNS it and ships its output, and the words vanish.
+# Single quotes block $ROVE_TASK_ID too, so there is no quoting that fits both.
+rove api send --task-id <id> --prompt "<complete next turn>"      # plain text only
+rove api send --task-id <id> --prompt-file - <<'EOF'              # anything else
+<turn — backticks, $vars, quotes, multi-line, all verbatim>
+EOF
 
 # Reply home: no --task-id inside a dispatched task = the dispatcher's tab.
 rove api send --prompt "succeeded: <one line> (branch <final branch>)"

--- a/.agents/skills/kobe/references/api-flags.md
+++ b/.agents/skills/kobe/references/api-flags.md
@@ -17,9 +17,9 @@ Every `--repo` resolves relative paths against `$PWD` and wants the git toplevel
 These five carry almost all traffic. Nothing here should ever need `schema`.
 
 ```text
-add     --repo(REQ) --prompt --title --command --count --agents
+add     --repo(REQ) --prompt|--prompt-file --title --command --count --agents
         --branch --base-branch --status --pin --activate
-send    --prompt(REQ) --task-id --tab --command --plain
+send    --prompt|--prompt-file(REQ) --task-id --tab --command --plain
 get-task --task-id(REQ)
 list    (no flags)
 collect --task-ids <csv> | --repo
@@ -79,8 +79,8 @@ needs numbers, not when you want to know what a task is doing.
 ## drive
 
 ```text
-send        --prompt(REQ) --task-id --tab --command --plain
-dispatch    --task-id(REQ) --prompt(REQ) --tab
+send        --prompt|--prompt-file(REQ) --task-id --tab --command --plain
+dispatch    --task-id(REQ) --prompt|--prompt-file(REQ) --tab
 note        --task-id(REQ) --text(REQ)
 note-list   --repo(REQ)
 pane-open   --command --task-id --tab --direction[right|down] --placement[split|tab] --title

--- a/.changeset/send-prompt-file.md
+++ b/.changeset/send-prompt-file.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+`rove api send`, `add`, and `dispatch` accept `--prompt-file PATH` (`-` = stdin) as an alternative to `--prompt`. A message that names a reply command in backticks used to be eaten by the shell — inside double quotes `` `rove api send …` `` is command substitution, so the receiver got that command's output instead of the words, and single quotes would have blocked `$ROVE_TASK_ID`. Reading the text from a file sidesteps every quoting rule; the Rove skill now routes any prompt with backticks, `$vars`, or quotes through a heredoc on `--prompt-file -`.

--- a/claude-plugin/skills/rove/SKILL.md
+++ b/claude-plugin/skills/rove/SKILL.md
@@ -219,7 +219,7 @@ turn either. These five carry almost all traffic:
 
 ```text
 add      --repo(REQ) --prompt --title --command --count --agents --activate
-send     --prompt(REQ) --task-id --tab --command --plain
+send     --prompt|--prompt-file(REQ) --task-id --tab --command --plain
 get-task --task-id(REQ)          list  (no flags)
 collect  --group <groupId> | --task-ids <csv> | --repo
 ```
@@ -263,10 +263,14 @@ rove api add --repo "$PWD" --agents claude:2,codex:1 --prompt "<prompt>"
 # From inside a Rove task this auto-prefixes [ROVE PEER] provenance
 # (sender + reply command); --plain sends verbatim.
 #
-# SINGLE-QUOTE a prompt containing backticks, or your shell runs them as
-# command substitution and the words vanish from the message you send. In
-# double quotes `rove api send` becomes the OUTPUT of running that command.
-rove api send --task-id <id> --prompt "<complete next turn>"
+# A prompt with backticks, $vars, or quotes goes through --prompt-file, NEVER
+# a double-quoted --prompt: in double quotes `rove api send …` is command
+# substitution — the shell RUNS it and ships its output, and the words vanish.
+# Single quotes block $ROVE_TASK_ID too, so there is no quoting that fits both.
+rove api send --task-id <id> --prompt "<complete next turn>"      # plain text only
+rove api send --task-id <id> --prompt-file - <<'EOF'              # anything else
+<turn — backticks, $vars, quotes, multi-line, all verbatim>
+EOF
 
 # Reply home: no --task-id inside a dispatched task = the dispatcher's tab.
 rove api send --prompt "succeeded: <one line> (branch <final branch>)"

--- a/claude-plugin/skills/rove/references/api-flags.md
+++ b/claude-plugin/skills/rove/references/api-flags.md
@@ -17,9 +17,9 @@ Every `--repo` resolves relative paths against `$PWD` and wants the git toplevel
 These five carry almost all traffic. Nothing here should ever need `schema`.
 
 ```text
-add     --repo(REQ) --prompt --title --command --count --agents
+add     --repo(REQ) --prompt|--prompt-file --title --command --count --agents
         --branch --base-branch --status --pin --activate
-send    --prompt(REQ) --task-id --tab --command --plain
+send    --prompt|--prompt-file(REQ) --task-id --tab --command --plain
 get-task --task-id(REQ)
 list    (no flags)
 collect --task-ids <csv> | --repo
@@ -79,8 +79,8 @@ needs numbers, not when you want to know what a task is doing.
 ## drive
 
 ```text
-send        --prompt(REQ) --task-id --tab --command --plain
-dispatch    --task-id(REQ) --prompt(REQ) --tab
+send        --prompt|--prompt-file(REQ) --task-id --tab --command --plain
+dispatch    --task-id(REQ) --prompt|--prompt-file(REQ) --tab
 note        --task-id(REQ) --text(REQ)
 note-list   --repo(REQ)
 pane-open   --command --task-id --tab --direction[right|down] --placement[split|tab] --title

--- a/docs/API.md
+++ b/docs/API.md
@@ -218,7 +218,7 @@ replacement in `nextCommandArgs`.
 
 - `add --repo PATH [--title T] [--branch B] [--base-branch B]
   [--command CMD] [--count N | --agents claude:2,codex:1] [--status S]
-  [--pin] [--activate] [--prompt TEXT]`: create a task (appears in the
+  [--pin] [--activate] [--prompt TEXT | --prompt-file PATH]`: create a task (appears in the
   sidebar immediately). With `--prompt` it also materializes the worktree,
   starts the engine, and delivers the prompt. Does not steal focus unless
   `--activate`. Alias: `spawn-task`. Without `--branch`, the branch name is
@@ -270,9 +270,14 @@ placeholder branch to a descriptive name. Prompts into existing sessions
 
 ## drive
 
-- `send [--task-id ID] --prompt TEXT [--tab TAB] [--command CMD] [--plain]
-  [--allow-empty]`: paste a
-  follow-up into a task's running engine (one full turn). Without
+- `send [--task-id ID] (--prompt TEXT | --prompt-file PATH) [--tab TAB]
+  [--command CMD] [--plain] [--allow-empty]`: paste a
+  follow-up into a task's running engine (one full turn). `--prompt-file`
+  reads the text from a file (`-` = stdin) so the shell never sees it:
+  backticks inside a double-quoted `--prompt` are command substitution, and
+  a message that names a reply command (`` `rove api send …` ``) ships that
+  command's OUTPUT instead of the words. `add` and `dispatch` take the same
+  flag. Without
   `--task-id`, a task that has a `dispatcher` on record replies to that
   exact tab, falling back to the dispatcher task's live canonical engine
   tab when the tab died, and failing loud (`DISPATCHER_UNREACHABLE`) when
@@ -322,7 +327,7 @@ placeholder branch to a descriptive name. Prompts into existing sessions
     engines that collapse a large paste into a `[Pasted text #1]` placeholder
     never echo the text, so a positive proves delivery while a negative
     merely fails to.
-- `dispatch --task-id ID --prompt TEXT [--tab TAB]`: route text into a
+- `dispatch --task-id ID (--prompt TEXT | --prompt-file PATH) [--tab TAB]`: route text into a
   task's live session via the daemon's `session.deliver` channel (the
   dispatcher's messenger; see
   [design/dispatcher.md](./design/dispatcher.md)). Broadcast-only: it does

--- a/packages/kobe/src/cli/api/flags.ts
+++ b/packages/kobe/src/cli/api/flags.ts
@@ -6,6 +6,7 @@
  * the table of specs.
  */
 
+import { readFileSync } from "node:fs"
 import { resolve } from "node:path"
 import { expandTilde } from "../../lib/path-home.ts"
 import { getCustomEngineIds } from "../../state/repos.ts"
@@ -79,7 +80,20 @@ export const F = {
     type: "string",
     required,
     placeholder: "TEXT",
-    description: desc,
+    description: `${desc} Required unless --prompt-file is given.`,
+  }),
+  /**
+   * The escape hatch for a prompt the shell would mangle: backticks inside
+   * double quotes are command substitution, so a `--prompt "reply via
+   * `rove api send …`"` RUNS that command and ships its output instead.
+   * Read the text from a file (or stdin as `-`) and no quoting rule applies.
+   */
+  promptFile: (): FlagSpec => ({
+    name: "prompt-file",
+    type: "string",
+    placeholder: "PATH",
+    description:
+      "Read the prompt from this file instead of --prompt (`-` = stdin). Use it whenever the text has backticks, $vars, or quotes you don't want the shell to touch. Exactly one of --prompt / --prompt-file.",
   }),
 }
 
@@ -144,7 +158,9 @@ export function validateAgainstSpec(verb: VerbSpec, flags: Flags): void {
     }
   }
   for (const f of verb.flags) {
-    if (f.required && !flags.get(f.name))
+    // --prompt-file stands in for a required --prompt; `promptText` rejects both at once.
+    const satisfied = flags.get(f.name) || (f.name === "prompt" && flags.get("prompt-file"))
+    if (f.required && !satisfied)
       throw new ApiError(`--${f.name} is required for "${verb.name}"`, "MISSING_FLAG", helpStep(verb.name))
     if (f.type === "enum" && f.values) {
       const raw = flags.get(f.name)
@@ -202,6 +218,23 @@ export class VerbArgs {
   present(name: string): boolean {
     this.spec(name)
     return this.flags.get(name) !== undefined
+  }
+
+  /**
+   * The prompt text from `--prompt` or `--prompt-file` (`-` = stdin), never
+   * both. `undefined` when neither was given — callers that need one wrap
+   * this in their own MISSING_FLAG.
+   */
+  promptText(): string | undefined {
+    const inline = this.str("prompt")
+    const file = this.str("prompt-file")
+    if (inline !== undefined && file !== undefined) {
+      throw new ApiError("pass --prompt or --prompt-file, not both", "BAD_FLAG", helpStep(this.verb.name))
+    }
+    if (file === undefined) return inline
+    const text = readFileSync(file === "-" ? 0 : resolve(process.cwd(), expandTilde(file)), "utf8")
+    if (text.trim().length === 0) throw new ApiError(`--prompt-file ${file} is empty`, "BAD_FLAG")
+    return text
   }
 
   /** Required string value (MISSING_FLAG when absent). */

--- a/packages/kobe/src/cli/api/handlers-add.ts
+++ b/packages/kobe/src/cli/api/handlers-add.ts
@@ -96,7 +96,7 @@ async function addOne(ctx: VerbContext, repo: string): Promise<unknown> {
     task = (await daemon.request<{ task: SerializedTask }>("task.get", { taskId })).task
   }
 
-  const prompt = args.str("prompt")
+  const prompt = args.promptText()
   if (!prompt) return { taskId, task, started: false }
   // Same provenance prefix `send` carries: a task created from inside another
   // kobe session is agent-to-agent, and its opening brief is where the reply
@@ -172,7 +172,7 @@ async function addParallel(
   const { args } = ctx
   // A parallel round with nothing to deliver would spawn N idle worktrees —
   // the prompt IS the round.
-  const prompt = args.str("prompt")
+  const prompt = args.promptText()
   if (!prompt) {
     throw new ApiError(
       "--count/--agents spawn parallel attempts of ONE prompt — pass --prompt",

--- a/packages/kobe/src/cli/api/handlers-tasks.ts
+++ b/packages/kobe/src/cli/api/handlers-tasks.ts
@@ -111,9 +111,16 @@ async function assertNotEmptySuccess(daemon: DaemonRpc, ctx: VerbContext, prompt
   )
 }
 
+/** `--prompt` or `--prompt-file`, and one of them must be there. */
+export function requirePromptText(ctx: VerbContext, verb: string): string {
+  const text = ctx.args.promptText()
+  if (text === undefined) throw new ApiError("--prompt (or --prompt-file) is required", "MISSING_FLAG", helpStep(verb))
+  return text
+}
+
 export async function send(ctx: VerbContext): Promise<unknown> {
   const daemon = daemonOf(ctx)
-  const prompt = ctx.args.require("prompt")
+  const prompt = requirePromptText(ctx, "send")
   let tab = ctx.args.str("tab")
   if (tab && tab !== "new" && !/^tab-[A-Za-z0-9-]+$/.test(tab)) {
     throw new ApiError(`--tab must be "new" or a tab id like tab-2 (got ${JSON.stringify(tab)})`, "BAD_TAB")
@@ -208,7 +215,7 @@ export async function send(ctx: VerbContext): Promise<unknown> {
 export async function dispatch(ctx: VerbContext): Promise<unknown> {
   const daemon = daemonOf(ctx)
   const taskId = ctx.args.require("task-id")
-  const text = ctx.args.require("prompt")
+  const text = requirePromptText(ctx, "dispatch")
   const tabId = ctx.args.str("tab")
   const reply = (await daemon.request("session.deliver", {
     taskId,
@@ -241,6 +248,7 @@ export const DISPATCH_VERB: VerbSpec = {
   flags: [
     F.taskId(true),
     F.prompt(true, "Text delivered into the task's engine session."),
+    F.promptFile(),
     {
       name: "tab",
       type: "string",

--- a/packages/kobe/src/cli/api/verbs-create.ts
+++ b/packages/kobe/src/cli/api/verbs-create.ts
@@ -58,6 +58,7 @@ export const CREATE_VERBS: readonly VerbSpec[] = [
         false,
         "Optional first message — when set, materializes the worktree, starts the engine, and pastes it. Required with --count/--agents.",
       ),
+      F.promptFile(),
     ],
     handler: add,
   },

--- a/packages/kobe/src/cli/api/verbs-drive.ts
+++ b/packages/kobe/src/cli/api/verbs-drive.ts
@@ -23,6 +23,7 @@ export const DRIVE_VERBS: readonly VerbSpec[] = [
     flags: [
       F.taskId(false),
       F.prompt(true, "Text pasted + submitted into the engine pane."),
+      F.promptFile(),
       {
         name: "tab",
         type: "string",

--- a/packages/kobe/test/cli/api-handlers.test.ts
+++ b/packages/kobe/test/cli/api-handlers.test.ts
@@ -1,6 +1,9 @@
 /** Request-traffic tests for single-task `add` and the `send` handler.
  *  The parallel `add --count` round lives in `./api-add-parallel.test.ts`. */
 
+import { mkdtempSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
 import { afterEach, beforeEach, describe, expect, it } from "vitest"
 import { ApiError, type ApiRuntime, invokeVerb } from "../../src/cli/api-cmd.ts"
 import { resetVerifiedSelfSession, verifiedSelfSession } from "../../src/cli/api/dispatcher.ts"
@@ -226,6 +229,46 @@ describe("send handler", () => {
       runtime: stubRuntime({ deliverPrompt: deliver }),
     })
     expect(calls[1].target.tab).toBe("tab-3")
+  })
+
+  // The shell, not Rove, was eating prompts: backticks inside a double-quoted
+  // --prompt are command substitution, so the text that names a reply
+  // command (`rove api send …`) shipped as that command's OUTPUT. A file (or
+  // stdin) bypasses every quoting rule — the bytes on disk are the message.
+  it("--prompt-file delivers the file's bytes verbatim, backticks and all", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "rove-prompt-"))
+    const file = join(dir, "msg.md")
+    const body = "reply via `rove api send --task-id t1 --tab tab-2` and $(echo no)\n"
+    writeFileSync(file, body)
+    const client = new FakeClient({ "task.get": () => ({ task: taskFixture({ id: "abc" }) }) })
+    const { calls, deliver } = recordingDelivery()
+    await invokeVerb("send", ["--task-id", "abc", "--prompt-file", file], {
+      client,
+      runtime: stubRuntime({ deliverPrompt: deliver }),
+    })
+    expect(calls[0].prompt).toBe(body)
+  })
+
+  it("--prompt and --prompt-file together is a BAD_FLAG, not a silent pick", async () => {
+    await expectApiError(
+      () =>
+        invokeVerb("send", ["--task-id", "abc", "--prompt", "a", "--prompt-file", "/dev/null"], {
+          client: new FakeClient(),
+          runtime: stubRuntime(),
+        }),
+      "BAD_FLAG",
+    )
+  })
+
+  it("an empty --prompt-file is refused (a blank turn is never what was meant)", async () => {
+    await expectApiError(
+      () =>
+        invokeVerb("send", ["--task-id", "abc", "--prompt-file", "/dev/null"], {
+          client: new FakeClient(),
+          runtime: stubRuntime(),
+        }),
+      "BAD_FLAG",
+    )
   })
 
   it("a new tab can run a DIFFERENT engine than the task (two agents, one worktree)", async () => {


### PR DESCRIPTION
## What

`rove api send`, `add`, and `dispatch` accept `--prompt-file PATH` (`-` = stdin) as an alternative to `--prompt`. Exactly one of the two; empty file refused.

## Why

Agents were avoiding `rove api …` text inside `send` prompts. The shell, not Rove, was eating it: in a double-quoted `--prompt`, `` `rove api send --task-id …` `` is command substitution, so the receiver got that command's output instead of the words. Single quotes block `$ROVE_TASK_ID`, so no quoting rule fit both. Reading the text from a file sidesteps every quoting rule.

## Changes

- `VerbArgs.promptText()` + `F.promptFile()` in `flags.ts`; required-`--prompt` validation accepts `--prompt-file` in its place
- `send` / `dispatch` / `add` read through it
- Skill (`.agents/skills/kobe` and the `claude-plugin` mirror) and `docs/API.md` route backtick/`$var` prompts to a heredoc on `--prompt-file -`
- Tests: verbatim bytes with backticks and `$(…)`, both-flags conflict, empty file. Mutation check: forcing the file path to return a constant turns 2 tests red.

## Verified

- `bun run test:fast`: 4081 passed
- built CLI: stdin heredoc reaches daemon lookup; `--prompt` + `--prompt-file` → `BAD_FLAG`; `--help` and `schema --verb send` list the flag