### PR TITLE
feat: refresh the Claude model picker to the Claude 5 family

### DIFF
--- a/.changeset/fresh-crabs-shave.md
+++ b/.changeset/fresh-crabs-shave.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Refresh the Claude model picker to the Claude 5 family: Fable 5.1 (with the full effort ladder), Opus 5 / Opus 5 1M, Sonnet 5 / Sonnet 5 1M, Haiku 4.5. The unpinned default now falls back to Opus 5 1M instead of the retired Opus 4.7 1M.

--- a/packages/kobe/src/engine/claude-code-local/models.ts
+++ b/packages/kobe/src/engine/claude-code-local/models.ts
@@ -3,30 +3,28 @@
  *
  * Anthropic publishes model ids and ships new ones regularly — when an
  * id is rotated, edit this list rather than relying on aliases
- * (`opus`/`sonnet`), which the CLI resolves to the latest of a family
- * at *its* runtime, not ours, and would make the displayed label drift
- * away from what the engine actually loaded.
+ * (`fable`/`opus`/`sonnet`), which the CLI resolves to the latest of a
+ * family at *its* runtime, not ours, and would make the displayed label
+ * drift away from what the engine actually loaded.
  *
  * No "default / claude-code" pseudo-entry: claude-code itself doesn't
- * surface one — the unpinned state simply resolves to the real default
- * model (Sonnet 4.6 for PAYG/Pro/Enterprise/Team Standard, per
- * `getDefaultMainLoopModelSetting` in refs/claude-code/src/utils/model/
- * model.ts). The footer shows that real name; the picker lists real
- * models only.
+ * surface one — the unpinned state simply resolves to whatever
+ * `getDefaultMainLoopModelSetting` picks for the account's plan. The
+ * footer shows that real name; the picker lists real models only.
  */
 
 import type { ModelChoice, ModelEffortLevel } from "@/types/engine"
 
-const CLAUDE_OPUS_EFFORT_LEVELS = [
-  "low",
-  "medium",
-  "high",
-  "xhigh",
-  "max",
-] as const satisfies readonly ModelEffortLevel[]
+const CLAUDE_EFFORT_LEVELS = ["low", "medium", "high", "xhigh", "max"] as const satisfies readonly ModelEffortLevel[]
 
-function opus47EffortChoices(id: string, label: string): readonly ModelChoice[] {
-  return CLAUDE_OPUS_EFFORT_LEVELS.map((effort) => ({
+/**
+ * The effort ladder is only offered on the reasoning-tier families
+ * claude-code accepts `--effort` for (Fable 5, Opus 4.7+, Sonnet 5).
+ * Sonnet is left off the ladder here to keep the picker short — pin the
+ * plain entry and the CLI uses its own default effort.
+ */
+function effortChoices(id: string, label: string): readonly ModelChoice[] {
+  return CLAUDE_EFFORT_LEVELS.map((effort) => ({
     vendor: "claude",
     id,
     effort,
@@ -37,12 +35,14 @@ function opus47EffortChoices(id: string, label: string): readonly ModelChoice[] 
 }
 
 export const CLAUDE_MODELS: readonly ModelChoice[] = [
-  { vendor: "claude", id: "claude-opus-4-7[1m]", label: "Opus 4.7 1M", hint: "long context, default" },
-  ...opus47EffortChoices("claude-opus-4-7[1m]", "Opus 4.7 1M"),
-  { vendor: "claude", id: "claude-opus-4-7", label: "Opus 4.7", hint: "most capable, slowest" },
-  ...opus47EffortChoices("claude-opus-4-7", "Opus 4.7"),
-  { vendor: "claude", id: "claude-sonnet-4-6[1m]", label: "Sonnet 4.6 1M", hint: "long context" },
-  { vendor: "claude", id: "claude-sonnet-4-6", label: "Sonnet 4.6" },
+  { vendor: "claude", id: "claude-fable-5-1", label: "Fable 5.1", hint: "most capable, hardest tasks" },
+  ...effortChoices("claude-fable-5-1", "Fable 5.1"),
+  { vendor: "claude", id: "claude-opus-5[1m]", label: "Opus 5 1M", hint: "long context, default" },
+  ...effortChoices("claude-opus-5[1m]", "Opus 5 1M"),
+  { vendor: "claude", id: "claude-opus-5", label: "Opus 5", hint: "everyday complex tasks" },
+  ...effortChoices("claude-opus-5", "Opus 5"),
+  { vendor: "claude", id: "claude-sonnet-5[1m]", label: "Sonnet 5 1M", hint: "long context" },
+  { vendor: "claude", id: "claude-sonnet-5", label: "Sonnet 5", hint: "efficient for routine tasks" },
   { vendor: "claude", id: "claude-haiku-4-5-20251001", label: "Haiku 4.5", hint: "fastest, cheapest" },
 ] as const
 

--- a/packages/kobe/src/engine/claude-code-local/settings.ts
+++ b/packages/kobe/src/engine/claude-code-local/settings.ts
@@ -44,10 +44,10 @@ export function _resetClaudeSettingsCache(): void {
 
 /**
  * Hardcoded fallback when claude-code's settings file says nothing.
- * Opus 4.7 1M is kobe-preferred default — long-context variant matches
+ * Opus 5 1M is kobe-preferred default — long-context variant matches
  * "task = a sustained worktree of work" sessions which tend to grow.
  */
-export const CLAUDE_FALLBACK_DEFAULT_MODEL_ID = "claude-opus-4-7[1m]"
+export const CLAUDE_FALLBACK_DEFAULT_MODEL_ID = "claude-opus-5[1m]"
 
 export function resolveClaudeDefaultModelId(): string {
   const settings = readClaudeSettings()

--- a/packages/kobe/test/engine/claude-models.test.ts
+++ b/packages/kobe/test/engine/claude-models.test.ts
@@ -14,18 +14,18 @@ const STD_CTX = 200_000
 
 describe("claudeContextWindowFor", () => {
   it("resolves the [1m] long-context build to a 1M window", () => {
-    expect(claudeContextWindowFor("claude-opus-4-7[1m]")).toBe(LONG_CTX)
-    expect(claudeContextWindowFor("claude-sonnet-4-6[1m]")).toBe(LONG_CTX)
+    expect(claudeContextWindowFor("claude-opus-5[1m]")).toBe(LONG_CTX)
+    expect(claudeContextWindowFor("claude-sonnet-5[1m]")).toBe(LONG_CTX)
   })
 
   it("resolves standard builds to the 200k window", () => {
-    expect(claudeContextWindowFor("claude-opus-4-7")).toBe(STD_CTX)
-    expect(claudeContextWindowFor("claude-sonnet-4-6")).toBe(STD_CTX)
+    expect(claudeContextWindowFor("claude-opus-5")).toBe(STD_CTX)
+    expect(claudeContextWindowFor("claude-fable-5-1")).toBe(STD_CTX)
     expect(claudeContextWindowFor("claude-haiku-4-5-20251001")).toBe(STD_CTX)
   })
 
   it("matches the 1m marker loosely (case-insensitive, variant spellings)", () => {
-    expect(claudeContextWindowFor("claude-opus-4-7[1M]")).toBe(LONG_CTX)
+    expect(claudeContextWindowFor("claude-opus-5[1M]")).toBe(LONG_CTX)
     expect(claudeContextWindowFor("some-pinned-model-1m")).toBe(LONG_CTX)
   })
 
@@ -45,13 +45,13 @@ describe("CLAUDE_MODELS catalog", () => {
     }
   })
 
-  it("labels use title-case product names, never a lowercase Opus/Sonnet/Haiku", () => {
-    // Picker labels follow the house style (Opus 4.7, Codex, Claude Code): the
+  it("labels use title-case product names, never a lowercase Fable/Opus/Sonnet/Haiku", () => {
+    // Picker labels follow the house style (Opus 5, Codex, Claude Code): the
     // Anthropic product name is always capitalized. Guards the regression where
     // Sonnet/Haiku shipped lowercase while Opus was capitalized.
     for (const model of CLAUDE_MODELS) {
-      expect(model.label).not.toMatch(/\b(opus|sonnet|haiku)\b/)
-      expect(model.label).toMatch(/\b(Opus|Sonnet|Haiku)\b/)
+      expect(model.label).not.toMatch(/\b(fable|opus|sonnet|haiku)\b/)
+      expect(model.label).toMatch(/\b(Fable|Opus|Sonnet|Haiku)\b/)
     }
   })
 
@@ -62,11 +62,11 @@ describe("CLAUDE_MODELS catalog", () => {
     }
   })
 
-  it("offers the full effort ladder for each Opus family entry", () => {
+  it("offers the full effort ladder for each effort-capable entry", () => {
     const LEVELS = ["low", "medium", "high", "xhigh", "max"]
-    const opusIds = new Set(CLAUDE_MODELS.filter((m) => m.effort).map((m) => m.id))
-    expect(opusIds.size).toBeGreaterThan(0)
-    for (const id of opusIds) {
+    const effortIds = new Set(CLAUDE_MODELS.filter((m) => m.effort).map((m) => m.id))
+    expect(effortIds.size).toBeGreaterThan(0)
+    for (const id of effortIds) {
       const efforts = CLAUDE_MODELS.filter((m) => m.id === id && m.effort).map((m) => m.effort)
       expect(efforts).toEqual(LEVELS)
     }


### PR DESCRIPTION
Refresh the Claude model picker to the Claude 5 family: Fable 5.1 (full effort ladder), Opus 5 / Opus 5 1M, Sonnet 5 / Sonnet 5 1M, Haiku 4.5. Unpinned default → Opus 5 1M (was the retired Opus 4.7 1M). Model tests pass; biome clean.