### PR TITLE
test: the selection-trim test's own timeout must cover the settle budget it hands out

### DIFF
--- a/.changeset/selection-trim-test-timeout.md
+++ b/.changeset/selection-trim-test-timeout.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+The selection-across-trim test gave its settle waits a 30-second budget while the test itself kept vitest's 5-second cap, so a loaded CI runner timed the test out underneath its own wait and blocked the 0.9.76 publish. The test now declares a timeout that covers the budget it hands out.

--- a/packages/kobe/test/tui/terminal-selection-trim.test.ts
+++ b/packages/kobe/test/tui/terminal-selection-trim.test.ts
@@ -62,72 +62,79 @@ const SCROLLBACK = 50
  * a papered-over race: nothing here is unordered, the work just takes as long
  * as it takes to win a scheduling slot (issue #94).
  */
-const settleUntil = (check: () => void): Promise<void> => vi.waitFor(check, { timeout: 30_000, interval: 10 })
+const SETTLE_MS = 30_000
+const settleUntil = (check: () => void): Promise<void> => vi.waitFor(check, { timeout: SETTLE_MS, interval: 10 })
 
 type Frame = { snapshot: readonly TerminalRow[]; window: TerminalSnapshotWindow | null }
 
 describe("selection across a bounded-scrollback trim", () => {
-  it("keeps the highlight on the content it selected while output streams", async () => {
-    const pty = new FakeTransportPty({ taskId: "t1", cwd: "/wt", cols: COLS, rows: ROWS, scrollback: SCROLLBACK })
-    // A subscriber is what makes the backend refresh at output cadence.
-    const unsubscribe = pty.onData(() => {})
-    try {
-      for (let i = 0; i < 200; i++) pty.pump(`line-${i}\r\n`)
-      // The buffer is saturated: the backend numbers lines, and row 0 is no
-      // longer line-0. Both are preconditions for the drift, so WAIT for them
-      // rather than assert against whatever a fixed sleep happened to catch.
-      await settleUntil(() => {
-        expect(pty.captureWindow()).not.toBeNull()
-        expect(pty.capture().length).toBe(ROWS + SCROLLBACK)
-      })
-      const before: Frame = { snapshot: pty.capture(), window: pty.captureWindow() }
+  // The waits above may spend the full SETTLE_MS; vitest's default 5s test
+  // cap must not expire underneath them, or the budget is fiction (#94).
+  it(
+    "keeps the highlight on the content it selected while output streams",
+    { timeout: SETTLE_MS + 5_000 },
+    async () => {
+      const pty = new FakeTransportPty({ taskId: "t1", cwd: "/wt", cols: COLS, rows: ROWS, scrollback: SCROLLBACK })
+      // A subscriber is what makes the backend refresh at output cadence.
+      const unsubscribe = pty.onData(() => {})
+      try {
+        for (let i = 0; i < 200; i++) pty.pump(`line-${i}\r\n`)
+        // The buffer is saturated: the backend numbers lines, and row 0 is no
+        // longer line-0. Both are preconditions for the drift, so WAIT for them
+        // rather than assert against whatever a fixed sleep happened to catch.
+        await settleUntil(() => {
+          expect(pty.captureWindow()).not.toBeNull()
+          expect(pty.capture().length).toBe(ROWS + SCROLLBACK)
+        })
+        const before: Frame = { snapshot: pty.capture(), window: pty.captureWindow() }
 
-      // Select two whole rows in the frozen scrollback, far enough down that
-      // the coming trim moves them rather than dropping them entirely.
-      const selected = { anchor: { row: 20, col: 0 }, head: { row: 21, col: 7 } } satisfies SelectionRange
-      const text = extractSelection(before.snapshot, selected)
-      expect(text).toMatch(/^line-\d+\nline-\d+$/)
+        // Select two whole rows in the frozen scrollback, far enough down that
+        // the coming trim moves them rather than dropping them entirely.
+        const selected = { anchor: { row: 20, col: 0 }, head: { row: 21, col: 7 } } satisfies SelectionRange
+        const text = extractSelection(before.snapshot, selected)
+        expect(text).toMatch(/^line-\d+\nline-\d+$/)
 
-      for (let i = 200; i < 210; i++) pty.pump(`line-${i}\r\n`)
-      // Wait for the shift to have LANDED, not for it to equal exactly ten.
-      //
-      // The backend refreshes at output cadence, so how much it folds in per
-      // refresh depends on how much output piled up first — which under a
-      // loaded runner is more than one write. Waiting on `=== start + 10`
-      // therefore waits on a value the pipeline is free to step straight past,
-      // and when it does the wait can only time out. That is this test's whole
-      // flake history: it blocked four unrelated PRs and one release in a day
-      // while passing in 50ms unloaded, because unloaded every refresh folds
-      // exactly one line (issue #94).
-      //
-      // `>=` is not a weaker assertion here. What the test is about is that a
-      // selection follows the window it was taken in, and `followWindowShift`
-      // is handed both windows and derives the distance itself — so the
-      // assertions below hold for ANY landed shift, and a larger one exercises
-      // the same arithmetic over a longer distance.
-      const minimumStart = (before.window?.startLine ?? 0) + 10
-      await settleUntil(() => {
-        expect(pty.captureWindow()?.startLine).toBeGreaterThanOrEqual(minimumStart)
-      })
-      const after: Frame = { snapshot: pty.capture(), window: pty.captureWindow() }
-      expect(after.window?.startLine).toBeGreaterThanOrEqual(minimumStart)
+        for (let i = 200; i < 210; i++) pty.pump(`line-${i}\r\n`)
+        // Wait for the shift to have LANDED, not for it to equal exactly ten.
+        //
+        // The backend refreshes at output cadence, so how much it folds in per
+        // refresh depends on how much output piled up first — which under a
+        // loaded runner is more than one write. Waiting on `=== start + 10`
+        // therefore waits on a value the pipeline is free to step straight past,
+        // and when it does the wait can only time out. That is this test's whole
+        // flake history: it blocked four unrelated PRs and one release in a day
+        // while passing in 50ms unloaded, because unloaded every refresh folds
+        // exactly one line (issue #94).
+        //
+        // `>=` is not a weaker assertion here. What the test is about is that a
+        // selection follows the window it was taken in, and `followWindowShift`
+        // is handed both windows and derives the distance itself — so the
+        // assertions below hold for ANY landed shift, and a larger one exercises
+        // the same arithmetic over a longer distance.
+        const minimumStart = (before.window?.startLine ?? 0) + 10
+        await settleUntil(() => {
+          expect(pty.captureWindow()?.startLine).toBeGreaterThanOrEqual(minimumStart)
+        })
+        const after: Frame = { snapshot: pty.capture(), window: pty.captureWindow() }
+        expect(after.window?.startLine).toBeGreaterThanOrEqual(minimumStart)
 
-      // The bug, stated: the untranslated endpoints now cover ten lines later.
-      expect(extractSelection(after.snapshot, selected)).not.toBe(text)
+        // The bug, stated: the untranslated endpoints now cover ten lines later.
+        expect(extractSelection(after.snapshot, selected)).not.toBe(text)
 
-      const rolled = followWindowShift(
-        { anchor: selected.anchor, head: selected.head, shadow: EMPTY_SHADOW },
-        before.window,
-        after.window,
-        after.snapshot.length,
-        false,
-      )
-      const moved = rolled?.anchor && rolled.head ? { anchor: rolled.anchor, head: rolled.head } : null
-      expect(moved).not.toBeNull()
-      expect(extractSelection(after.snapshot, moved as SelectionRange)).toBe(text)
-    } finally {
-      unsubscribe()
-      pty.kill()
-    }
-  })
+        const rolled = followWindowShift(
+          { anchor: selected.anchor, head: selected.head, shadow: EMPTY_SHADOW },
+          before.window,
+          after.window,
+          after.snapshot.length,
+          false,
+        )
+        const moved = rolled?.anchor && rolled.head ? { anchor: rolled.anchor, head: rolled.head } : null
+        expect(moved).not.toBeNull()
+        expect(extractSelection(after.snapshot, moved as SelectionRange)).toBe(text)
+      } finally {
+        unsubscribe()
+        pty.kill()
+      }
+    },
+  )
 })


### PR DESCRIPTION
\`settleUntil\` in \`terminal-selection-trim.test.ts\` waits up to 30s, but the \`it()\` kept vitest's default 5s cap, so a loaded runner timed the test out underneath its own wait. Third flake fix on this file (#704, #732); this one is the reason the earlier budget never applied. It blocked the 0.9.76 publish (main CI run 33566572154, green on rerun).

Change: one \`SETTLE_MS\` constant, and the test declares \`{ timeout: SETTLE_MS + 5_000 }\`.