### PR TITLE
fix: gate land --delete-branch on the worktree actually being gone

### DIFF
--- a/.changeset/land-delete-branch-gate.md
+++ b/.changeset/land-delete-branch-gate.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+`land --delete-branch` no longer reports a deletion it did not perform. git refuses to delete a branch a live worktree has checked out, so pairing `--delete-branch` with `--remove-worktree=false` — or with a removal that got refused for a dirty tree, the base checkout, or the caller's own worktree — left the branch in place while the land reported success. The branch deletion is now gated on the worktree actually being gone, and a land that keeps the branch says so in the result's new `branchKept` field with the reason. It also no longer returns a `branchAnchor` naming a salvage ref for a branch nothing deleted.

--- a/docs/API.md
+++ b/docs/API.md
@@ -491,6 +491,12 @@ nothing to do), `skipped_missed`, `skipped_unavailable`, and
   checkout, and the worktree the caller is running from are all refused, and
   the outcome lands in the result's `worktree` field
   (`{ removed, reason? }`) instead of failing the land.
+
+  **`--delete-branch` needs the worktree gone.** git refuses to delete a
+  branch a live worktree has checked out, so pairing `--delete-branch` with
+  `--remove-worktree=false` — or with a removal that got refused (dirty tree,
+  base checkout, the caller's own worktree) — keeps the branch. The result
+  says so in `branchKept` (`{ reason }`) and writes no `branchAnchor`.
 - `delete --task-id ID [--force] [--delete-branch] [--wait]`: remove a task
   and its worktree. **The git branch stays** unless `--delete-branch` is
   passed; git is the durable record, the task row is not. Needs `--force` on a

--- a/docs/WORKTREES.md
+++ b/docs/WORKTREES.md
@@ -163,7 +163,13 @@ git branch <recovered-name> refs/rove/salvage/<branch>-<timestamp>
 ```
 
 No anchor is written when another ref already reaches the tip, which is the
-ordinary merge case.
+ordinary merge case, nor when no branch was deleted at all.
+
+The delete needs the worktree to be gone first: git refuses to delete a branch
+a live worktree has checked out. A land that kept the worktree — because you
+passed `--remove-worktree=false`, or because removal was refused (dirty tree,
+base checkout, the worktree you are running from) — keeps the branch too, and
+reports it as `branchKept` with the reason. Clear the worktree and re-run.
 
 ### Recovering work a force delete destroyed
 

--- a/packages/kobe-daemon/src/daemon/contracts.ts
+++ b/packages/kobe-daemon/src/daemon/contracts.ts
@@ -160,6 +160,10 @@ export interface LandResult {
    *  squash-land case). Absent on a `--no-ff` merge and when no branch was
    *  deleted. */
   readonly branchAnchor?: { readonly ref: string; readonly commit: string }
+  /** Set when `--delete-branch` was asked for and the branch was kept anyway,
+   *  because its worktree is still on disk with the branch checked out — git
+   *  would refuse the delete. `reason` is why the worktree stayed. */
+  readonly branchKept?: { readonly reason: string }
 }
 
 export interface AdoptableWorktree {

--- a/packages/kobe/src/cli/api/verbs-lifecycle.ts
+++ b/packages/kobe/src/cli/api/verbs-lifecycle.ts
@@ -43,7 +43,7 @@ export const LIFECYCLE_VERBS: readonly VerbSpec[] = [
         name: "delete-branch",
         type: "bool",
         description:
-          "Delete the task's branch after a successful land. Uses `git branch -D`, which drops the branch's reflog too; with --strategy squash the base's new commit does not reach the branch's own commits, so Rove first anchors the tip at refs/rove/salvage/<branch>-<stamp> and returns it as `branchAnchor`.",
+          "Delete the task's branch after a successful land. Uses `git branch -D`, which drops the branch's reflog too; with --strategy squash the base's new commit does not reach the branch's own commits, so Rove first anchors the tip at refs/rove/salvage/<branch>-<stamp> and returns it as `branchAnchor`. Requires the worktree to be gone: git refuses to delete a branch a live worktree has checked out, so a land that kept the worktree keeps the branch too and says so in `branchKept`.",
       },
       {
         name: "remove-worktree",

--- a/packages/kobe/src/orchestrator/land.ts
+++ b/packages/kobe/src/orchestrator/land.ts
@@ -109,8 +109,22 @@ export async function landTaskWithCleanup(task: Task, opts: LandTaskOpts, deps: 
   // so without an anchor those commits are reachable from nothing at all.
   // `deleteBranch` writes one and reports it here; on a `--no-ff` merge it
   // finds the merge commit already reaches the tip and writes nothing.
+  //
+  // Gate it on the worktree ACTUALLY being gone. git refuses to delete a
+  // branch a live worktree has checked out, and `deleteBranch` is best-effort
+  // (`allowFail`, exit code discarded) — so every path that keeps the worktree
+  // (`removeWorktree: false`, a dirty tree, the caller's own cwd) used to run
+  // the delete, have git refuse it, and report success anyway, anchor and all.
+  // A task that never materialised a worktree has nothing holding the branch,
+  // so it deletes normally.
   let branchAnchor: SalvageRecord | null = null
-  if (opts.deleteBranch) {
+  let branchKept: { readonly reason: string } | undefined
+  const worktreeGone = !task.worktreePath.trim() || worktree?.removed === true
+  if (opts.deleteBranch && !worktreeGone) {
+    branchKept = {
+      reason: worktree?.reason ?? `worktree ${task.worktreePath} was kept, and still has the branch checked out`,
+    }
+  } else if (opts.deleteBranch) {
     await deps.worktrees.deleteBranch(task.repo, result.branch, {
       force: true,
       onAnchor: (record) => {
@@ -122,6 +136,7 @@ export async function landTaskWithCleanup(task: Task, opts: LandTaskOpts, deps: 
     ...result,
     ...(worktree ? { worktree } : {}),
     ...(branchAnchor ? { branchAnchor } : {}),
+    ...(branchKept ? { branchKept } : {}),
   }
 }
 
@@ -234,6 +249,15 @@ export interface LandResult {
    * without knowing `refs/rove/salvage` exists.
    */
   readonly branchAnchor?: { readonly ref: string; readonly commit: string }
+  /**
+   * Set when `deleteBranch` was asked for and the branch was NOT deleted,
+   * because its worktree is still on disk with the branch checked out — git
+   * would refuse the delete, so Rove does not pretend it happened. `reason` is
+   * the worktree cleanup's own refusal (dirty tree, base checkout, caller's own
+   * cwd) or the explicit `removeWorktree: false`. Re-run the land's cleanup
+   * (or remove the worktree by hand) and the branch deletes.
+   */
+  readonly branchKept?: { readonly reason: string }
 }
 
 /** Resolve the git working dir + ExecHost for the base repo — local path or remote basePath. */

--- a/packages/kobe/test/orchestrator/land.test.ts
+++ b/packages/kobe/test/orchestrator/land.test.ts
@@ -390,6 +390,64 @@ describe("landTaskWithCleanup worktree cleanup", () => {
     expect(fs.existsSync(wt)).toBe(false)
   })
 
+  /**
+   * The gate: `git branch -D` cannot delete a branch a live worktree has
+   * checked out, and `deleteBranch` is best-effort (exit code discarded), so
+   * without the gate `--delete-branch` ran, git refused, and land reported a
+   * clean success — anchor included — for a branch that is still right there.
+   *
+   * Mutation: drop `&& !worktreeGone` from the gate in `land.ts` and this goes
+   * red on `branchKept` (the delete runs and reports nothing).
+   */
+  test("keeps the branch when the worktree it is checked out in stays", async () => {
+    makeWorktree()
+    const { deps: d } = deps()
+    const res = await landTaskWithCleanup(
+      { ...task("feat"), worktreePath: wt },
+      { removeWorktree: false, deleteBranch: true, strategy: "squash" },
+      d,
+    )
+    // git kept the branch either way — the fix is that the RESULT now says so.
+    expect(branchExists("feat")).toBe(true)
+    expect(res.branchKept?.reason).toMatch(/still has the branch checked out/)
+    // No anchor: it used to be written before the delete was even attempted,
+    // naming a salvage ref for a branch nothing deleted.
+    expect(res.branchAnchor).toBeUndefined()
+  })
+
+  test("a refused removal keeps the branch too, and reports the refusal as the reason", async () => {
+    makeWorktree()
+    fs.writeFileSync(path.join(wt, "wip.txt"), "uncommitted\n")
+    const { deps: d } = deps()
+    const res = await landTaskWithCleanup({ ...task("feat"), worktreePath: wt }, { deleteBranch: true }, d)
+    expect(res.worktree?.removed).toBe(false)
+    expect(branchExists("feat")).toBe(true)
+    expect(res.branchKept?.reason).toMatch(/dirty/)
+  })
+
+  test("the worktree going lets --delete-branch through", async () => {
+    makeWorktree()
+    const { deps: d } = deps()
+    const res = await landTaskWithCleanup({ ...task("feat"), worktreePath: wt }, { deleteBranch: true }, d)
+    expect(res.worktree?.removed).toBe(true)
+    expect(branchExists("feat")).toBe(false)
+    expect(res.branchKept).toBeUndefined()
+  })
+
+  test("a task that never materialised a worktree still deletes its branch", async () => {
+    // Nothing holds the branch, so the gate must not block it.
+    git(["branch", "feat"], repo)
+    git(["checkout", "feat"], repo)
+    write("b.txt", "feature\n")
+    git(["add", "."], repo)
+    git(["commit", "-m", "feat commit"], repo)
+    git(["checkout", "main"], repo)
+    const { deps: d } = deps()
+    const res = await landTaskWithCleanup(task("feat"), { deleteBranch: true }, d)
+    expect(branchExists("feat")).toBe(false)
+    expect(res.branchKept).toBeUndefined()
+  })
+
   test("never removes the base checkout even if worktreePath points at it", async () => {
     makeWorktree()
     const { deps: d } = deps()


### PR DESCRIPTION
## What / why

`land --delete-branch` reported deletions it never performed.

`landTaskWithCleanup` skips worktree removal when `removeWorktree === false`, and `removeLandedWorktree` also returns `{removed:false, reason}` without throwing for a dirty worktree, the base checkout, or the caller's own cwd. Branch deletion then ran **regardless**, reaching `deleteBranchIn`, which runs `git branch -D` with `allowFail: true` and discards the result. git refuses to delete a branch a live worktree has checked out — so the branch survived and land reported success.

`deleteBranchAnchored` also writes the salvage anchor **before** attempting the delete, so `branchAnchor` came back populated for a branch nothing deleted — contradicting its own doc contract in `land.ts` ("Absent … when no branch was deleted").

## Fix

- Branch deletion is gated on the worktree actually being gone: `!task.worktreePath.trim() || worktree?.removed === true`. A task that never materialised a worktree has nothing holding the branch, so it still deletes normally.
- When the gate blocks it, the result carries a new `branchKept: { reason }` naming why (the worktree cleanup's own refusal, or the explicit `removeWorktree: false`).
- No `branchAnchor` when no branch was deleted — the gate short-circuits before `deleteBranch` is called at all.
- `removeWorktree` still defaults to removal. `manager-branch.ts` untouched: the swallow there is correct for the task-delete path (`manager-remove.ts:255`).
- Docs: `docs/API.md` `land` entry, `docs/WORKTREES.md` `--delete-branch` section, the `--delete-branch` CLI flag help, and the daemon `LandResult` contract.

Not wired into the Worktrees page: `worktrees-page.tsx` never passes `deleteBranch`, so a `branchKept` toast branch there would be unreachable today. The result field is in place for when it does. **No UI change ⇒ no screenshots.**

## Pass criteria — real output

Throwaway repo `/tmp/landrepo` (git init, one `base` commit), scratch home `/tmp/lfhome`, env inlined:

```
env -u ROVE_INVOKED_AS KOBE_HOME_DIR=/tmp/lfhome KOBE_DAEMON_SOCKET_PATH=/tmp/lf.sock \
  bun ./src/cli/rove.ts api <verb> …
```

Each run: `api add --repo /tmp/landrepo` → `api ensure-worktree` → one commit on branch `new-task` → `api land`. `--strategy squash` is what surfaces the phantom anchor (a `--no-ff` merge writes none, since the merge commit already reaches the tip).

### 1. `--remove-worktree=false --delete-branch`

**BEFORE** (`origin/main` `land.ts`, same fixture, same commands):

```json
{
  "ok": true,
  "taskId": "01M1FJZY4P2W0XQNT599HJP706",
  "branch": "new-task",
  "strategy": "squash",
  "landedOn": "main",
  "commit": "71ffd16",
  "branchAnchor": {
    "ref": "refs/rove/salvage/new-task-20260901T225621Z",
    "commit": "6d041e8ebe6fddbfccbefe41db2b9af03f6942e8"
  }
}
```
```
$ git -C /tmp/landrepo branch --list
* main
+ new-task
```
Reported success, anchored a salvage ref, and the branch is still right there.

**AFTER**:

```json
{
  "ok": true,
  "taskId": "01M1FK0B0CW03ZGZ90S9846AX3",
  "branch": "new-task",
  "strategy": "squash",
  "landedOn": "main",
  "commit": "0797ece",
  "branchKept": {
    "reason": "worktree /tmp/lfhome/.rove/worktrees/landrepo-89d1aa970c92/heron was kept, and still has the branch checked out"
  }
}
```
```
$ git -C /tmp/landrepo branch --list
* main
+ new-task
$ git -C /tmp/landrepo for-each-ref refs/rove/salvage --format='%(refname)'
   (no output)
```
Branch still listed — but the report now matches reality, and no anchor was written.

### 2. Same land **without** `--remove-worktree=false`

```json
{
  "ok": true,
  "taskId": "01M1FK0NJWM6TVT4M2VM4X6B2H",
  "branch": "new-task",
  "strategy": "squash",
  "landedOn": "main",
  "commit": "306001e",
  "worktree": { "removed": true },
  "branchAnchor": {
    "ref": "refs/rove/salvage/new-task-20260901T225640Z",
    "commit": "01c4417cdbeff0217f8050d1a367ed2d8e093a7f"
  }
}
```
```
$ git -C /tmp/landrepo branch --list
* main
```
Branch gone, no `branchKept`, and the anchor is correct here — the branch really was deleted after a squash.

### 3. Test + mutation

Four tests in `test/orchestrator/land.test.ts`: the gate, the refused-removal path, the removal-succeeded path, and a never-materialised task (which must still delete).

Mutation A — drop `&& !worktreeGone` from the gate:
```
× keeps the branch when the worktree it is checked out in stays
× a refused removal keeps the branch too, and reports the refusal as the reason
  Tests  2 failed | 20 passed (22)
```

Mutation B — keep `branchKept` but let the delete run anyway (the old anchor-before-delete order):
```
× keeps the branch when the worktree it is checked out in stays
  → expected { …(2) } to be undefined     [branchAnchor]
  Tests  1 failed | 21 passed (22)
```

### 4. Gates

```
$ bun run test:fast
  Test Files  2 failed | 413 passed (415)
       Tests  4 failed | 4081 passed (4085)
$ bun run lint          # repo root — Checked 1310 files. No fixes applied.
$ bun x tsc --noEmit    # packages/kobe and packages/kobe-daemon — both clean
```

The 4 failures are pre-existing and environmental: `test/cli/open-dir-cmd.test.ts` (2) and `test/state/project-eligibility.test.ts` (2) reject `REPO_ROOT` as `"roveInternal"` on path shape alone, because this worktree lives under `~/.rove/worktrees/`. Proven not mine — checking out the unmodified `origin/main` versions of all four changed source files in this same directory and re-running those two files gives the identical `Tests 4 failed | 26 passed (30)`.