### PR TITLE
refactor: the engine registry owns account detection

### DIFF
--- a/.changeset/registry-owns-account-detection.md
+++ b/.changeset/registry-owns-account-detection.md
@@ -1,0 +1,10 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Account detection now dispatches through the engine registry instead of a
+second hand-written vendor list. Adding a built-in engine is one edit in its
+registry entry; previously a missing entry in the neutral status module made
+Settings → Accounts and `rove doctor` report "login not detectable" for an
+engine that had a working detector wired up. Nothing changes for existing
+engines — built-ins, contrib and custom engines all report exactly as before.

--- a/packages/kobe/src/engine/engine-status.ts
+++ b/packages/kobe/src/engine/engine-status.ts
@@ -2,6 +2,13 @@
  * "Can Rove launch this engine here, and is it logged in?" — for ANY engine
  * id, not just the four with a dedicated account detector.
  *
+ * WHICH detector runs is the registry's call, not this file's: an engine's
+ * entry either carries a `detectAccount` or it doesn't, so adding a built-in
+ * is one edit there. A vendor→detector table here would be a second list to
+ * keep in sync, and the one that silently loses is this one — an engine
+ * missing from it reads as "login not detectable" even with a working
+ * detector wired in its entry.
+ *
  * `account-detect.ts` answers both questions for the built-ins (claude /
  * codex / copilot / kimi), each against its own credential file. Everything
  * else Rove can launch — the shipped contrib catalog, plugin-registered
@@ -21,20 +28,16 @@ import { spawnSync } from "node:child_process"
 import { statSync } from "node:fs"
 import path from "node:path"
 import type { VendorId } from "@/types/vendor"
-import {
-  type BinaryStatus,
-  type ClaudeAccount,
-  type CodexAccount,
-  type CopilotAccount,
-  type DetectDeps,
-  type EngineAccountStatus,
-  type KimiAccount,
-  detectClaudeAccount,
-  detectCodexAccount,
-  detectCopilotAccount,
-  detectKimiAccount,
+import type {
+  BinaryStatus,
+  ClaudeAccount,
+  CodexAccount,
+  CopilotAccount,
+  DetectDeps,
+  KimiAccount,
 } from "./account-detect"
 import { interactiveEngineCommand } from "./interactive-command"
+import { engineEntry } from "./registry"
 
 /** Any built-in engine's account shape (the union the Accounts view renders). */
 export type EngineAccount = ClaudeAccount | CodexAccount | CopilotAccount | KimiAccount
@@ -45,13 +48,6 @@ export interface EngineStatus {
   /** `null` = no account detector for this engine (contrib / plugin / custom). */
   readonly account: EngineAccount | null
   readonly accountError?: string
-}
-
-const BUILTIN_DETECTORS: Record<string, (deps?: DetectDeps) => Promise<EngineAccountStatus<EngineAccount>>> = {
-  claude: detectClaudeAccount,
-  codex: detectCodexAccount,
-  copilot: detectCopilotAccount,
-  kimi: detectKimiAccount,
 }
 
 export interface EngineStatusDeps {
@@ -107,7 +103,7 @@ export async function detectEngineStatus(
   over: Partial<EngineStatusDeps> = {},
 ): Promise<EngineStatus> {
   const deps = { ...defaultDeps, ...over }
-  const detector = BUILTIN_DETECTORS[vendor]
+  const detector = engineEntry(vendor).detectAccount
   if (!detector) {
     return { vendor, binary: probeLaunchBinary(deps.command(vendor), deps.which), account: null }
   }

--- a/packages/kobe/src/engine/registry.ts
+++ b/packages/kobe/src/engine/registry.ts
@@ -139,8 +139,14 @@ export interface EngineRegistryEntry {
   /**
    * Read-only binary + login probe (Settings → Accounts). `deps` is the
    * injectable fs/env surface from `account-detect.ts`; omit for production.
+   *
+   * Absent = Rove has no login detector for this engine (contrib, plugin,
+   * user-registered), which `engine-status.ts` reports as `account: null` —
+   * "not detectable", NOT "not logged in". Writing an explicit stub that
+   * answers `{ kind: "none" }` instead would mark every such engine
+   * unusable, because that kind means "detector ran, found no login".
    */
-  readonly detectAccount: (deps?: DetectDeps) => Promise<EngineAccountStatus<EngineAccount>>
+  readonly detectAccount?: (deps?: DetectDeps) => Promise<EngineAccountStatus<EngineAccount>>
   /** Activity-hook adapter — a no-op adapter for engines without wired hooks. */
   readonly createHookAdapter: () => EngineHookAdapter
   /**
@@ -246,10 +252,8 @@ function customEngineEntry(vendor: VendorId): EngineRegistryEntry {
     displayName: vendor,
     defaultCommand: [vendor],
     history: EMPTY_HISTORY,
-    detectAccount: async () => ({
-      binary: { found: false, error: "custom engine: Rove has no account detector for it" },
-      account: { kind: "none" },
-    }),
+    // No `detectAccount`: see the field's doc — absent is how "no detector"
+    // is spelled, and `contribEngineEntry` inherits it by spreading this.
     createHookAdapter: () => new NoopHookAdapter(vendor),
     createTurnDetector: () => new UnknownTurnDetector(vendor),
   }

--- a/packages/kobe/test/engine/registry.test.ts
+++ b/packages/kobe/test/engine/registry.test.ts
@@ -113,23 +113,30 @@ describe("engineEntry — built-in vendors", () => {
   })
 
   it("routes detectAccount to the vendor's own detector (claude oauth)", async () => {
-    const status = await engineEntry("claude").detectAccount(
+    const detect = engineEntry("claude").detectAccount
+    // Every built-in must CARRY a detector — `engine-status.ts` dispatches on
+    // this field alone, so an absent one silently degrades the engine to
+    // "login not detectable".
+    expect(detect).toBeDefined()
+    const status = await detect?.(
       deps({
         // ~/.claude.json shape — only the claude detector understands this.
         readFile: () => JSON.stringify({ oauthAccount: { emailAddress: "a@b.com" } }),
       }),
     )
-    expect(status.account.kind).toBe("oauth")
+    expect(status?.account.kind).toBe("oauth")
   })
 
   it("routes detectAccount to the vendor's own detector (codex api key)", async () => {
-    const status = await engineEntry("codex").detectAccount(
+    const detect = engineEntry("codex").detectAccount
+    expect(detect).toBeDefined()
+    const status = await detect?.(
       deps({
         // ~/.codex/auth.json shape — only the codex detector understands this.
         readFile: () => JSON.stringify({ OPENAI_API_KEY: "sk-test" }),
       }),
     )
-    expect(status.account.kind).toBe("apikey")
+    expect(status?.account.kind).toBe("apikey")
   })
 })
 
@@ -191,10 +198,12 @@ describe("engineEntry — custom (user-registered) vendors", () => {
     expect(detector.vendor).toBe("aider")
     expect(detector.supportsCompletionMarkers()).toBe(false)
     expect(await detector.latestCompletion("/some/worktree")).toBeNull()
-    // No account detection, no hooks.
-    const status = await entry.detectAccount()
-    expect(status.account).toEqual({ kind: "none" })
-    expect(status.binary.found).toBe(false)
+    // No account detection, no hooks. ABSENT, not a stub answering
+    // `{ kind: "none" }`: that kind means "we looked and found no login", and
+    // `engineUsable` treats it as unusable — a stub here would mark every
+    // contrib/custom engine unlaunchable. Absent is what becomes the
+    // `account: null` ("not detectable") the Accounts view renders.
+    expect(entry.detectAccount).toBeUndefined()
     expect(entry.createHookAdapter().supportsHooks()).toBe(false)
   })
 })


### PR DESCRIPTION
## What / why

`engine-status.ts` carried `BUILTIN_DETECTORS` — a hand-written vendor→detector map naming claude/codex/copilot/kimi — beside the registry's own `detectAccount` field, which already does the identical dispatch and had zero runtime consumers. Adding a fifth built-in meant editing both, and forgetting the neutral file makes Settings → Accounts and `rove doctor` report "login not detectable" for an engine whose registry entry has a working detector. That is the engine-owned-UI-data rule in CLAUDE.md failing in the direction that is silent.

- `detectAccount` is now optional on `EngineRegistryEntry`; `engine-status.ts` reads `engineEntry(vendor).detectAccount`.
- The `customEngineEntry` stub that answered `{ kind: "none" }` is deleted. That kind means "detector ran, found no login", and `engineUsable` treats it as unusable — keeping the stub while switching the lookup would have marked every contrib and custom engine unlaunchable. Absence is what already becomes `account: null` ("not detectable") downstream.
- `contribEngineEntry` spreads the base entry, so it inherits the absence with no edit. `grep detectAccount` afterwards shows only the four built-in wirings, the field, and its tests.

No import cycle: nothing under `src/engine/` imports `engine-status.ts` (only `cli/env-checks.ts` and two settings-dialog files do).

## Pass criteria

### 1. `rove doctor` engines block byte-identical

Run from source in this worktree, before and after the change, against this machine's real engine list (built-ins claude/codex/copilot/kimi + customs claudecpa/cluadex/kimip/claudeqwen):

```
env -u ROVE_INVOKED_AS bun ./src/cli/rove.ts doctor > .scratch/detect/doctor-{before,after}.txt
sed -n '/^engines:/,/^$/p' doctor-$f.txt > engines-$f.txt
diff engines-before.txt engines-after.txt
```

```
diff-exit=0 (0 = byte-identical)
--- sha256 ---
1e968ca3c4d6c8ffa3c299e5fb68b33ca33db99734d3cbba99be818ee18c0a1f  engines-before.txt
1e968ca3c4d6c8ffa3c299e5fb68b33ca33db99734d3cbba99be818ee18c0a1f  engines-after.txt
```

The diff is empty. Notably `kimip ✓ … — login not detectable` (a custom engine reached through a launch-command override) reads the same on both sides — that row is the one the deleted stub would have flipped.

### 2. Harness screenshots, Settings → Accounts

Fixed-viewport Chromium → `/harness` → xterm.js → PTY sidecar → real OpenTUI, on an isolated port base (`KOBE_VISUAL_PORT_BASE=5473`, its own `.scratch/opentui-visual-5473/home`), never the shared `.dev-sandbox`:

```
cd packages/kobe-web
KOBE_VISUAL_PORT_BASE=5473 bun run visual:shot -- --out=<path> ctrl+a , wait:1500 down wait:3500
```

- `/Users/jacksonc/i/kobe/.scratch/detect/accounts-before.png`
- `/Users/jacksonc/i/kobe/.scratch/detect/accounts-after.png`

```
bee6fbb0528a5f08c92eb60043df4f60f3f37ef45372cdd5b0f4d08a01cfdbd3  accounts-before.png
bee6fbb0528a5f08c92eb60043df4f60f3f37ef45372cdd5b0f4d08a01cfdbd3  accounts-after.png
pixel-identical: True | sizes 80292 80292
```

The frames are useful beyond "unchanged": the built-ins render a `Not logged in` line while **OpenCode and Cursor Agent (contrib) render no account line at all** — that is the `account: null` branch, i.e. exactly the case the deleted stub would have regressed. It is identical on both sides.

### 3. Gates

- `bun x tsc --noEmit` — clean.
- `bun run lint` (repo root) — `Checked 1310 files in 302ms. No fixes applied.`
- `env -u ROVE_INVOKED_AS bun run test:fast` — `Test Files 2 failed | 413 passed (415)`, `Tests 4 failed | 4077 passed (4081)`.

  The 4 failures are **pre-existing and unrelated**: `test/state/project-eligibility.test.ts` (2) and `test/cli/open-dir-cmd.test.ts` (2) reject their own repo root with `expected 'roveInternal' to be null`, because this worktree lives under `~/.rove/worktrees/` and those tests judge eligibility by path shape. Verified against baseline by checking `packages/kobe/src/engine` + `packages/kobe/test/engine` back out to `origin/main` and re-running: **the same 4 fail with the diff reverted.** CI runs from an ordinary checkout, so they are green there.

- Existing engine tests pass unchanged (`engine-status.test.ts` 9/9, `contrib-engines.test.ts` 5/5). `registry.test.ts` needed three assertions updated because the field is now optional; the custom-entry one changed from asserting the stub's `{ kind: "none" }` to asserting `detectAccount` is `undefined`, which is the behavior that replaced it.

### Mutation check (two different sites)

- Reintroduce the stub on `customEngineEntry` → 2 red: `registry > returns the documented empty entry`, `engine-status > probes an engine without an account detector from its launch command`.
- Drop `detectAccount` from the claude built-in entry → 2 red at other sites: `registry > routes detectAccount to the vendor's own detector (claude oauth)`, `engine-status > reads a built-in's account through its own detector`.

## Changeset

`.changeset/registry-owns-account-detection.md`, `patch`.