### PR TITLE
feat: set a task's status from the TUI and show it on the sidebar row

### DIFF
--- a/.changeset/task-status-chip-and-picker.md
+++ b/.changeset/task-status-chip-and-picker.md
@@ -1,0 +1,10 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Set a task's status from the TUI, and see it on the row. The sidebar's
+right-click menu gains **Set status**, a picker over the six task statuses, and
+a task row now carries a mark once its status leaves `backlog`/`in_progress`:
+`◇` in review, `◆` done, `†` canceled, `×` error. The status is still just a
+label — picking `canceled` relabels the task and leaves its worktree, branch
+and running sessions exactly where they were.

--- a/docs/CONCEPTS.md
+++ b/docs/CONCEPTS.md
@@ -39,7 +39,14 @@ worktree), the shell folds into that Task as a new terminal tab, running
 session and all, instead of becoming a duplicate row.
 
 Each Task has a `status` you set yourself (`backlog`, `in_progress`,
-`in_review`, `done`, `canceled`, `error`).
+`in_review`, `done`, `canceled`, `error`) — from the sidebar row's right-click
+menu (**Set status**) or with `rove api set-status`. It is a label and nothing
+more: `canceled` does not stop a session or remove a worktree, and `done` does
+not close anything. Rove moves a Task from `backlog` to `in_progress` by itself
+when its engine starts a turn, and the system prompt asks the agent to set
+`in_review` when it finishes; everything past that is yours. The sidebar row
+shows the status as a mark once it leaves `backlog`/`in_progress`
+(see [TUI](./TUI.md#status-glyphs-in-the-sidebar)).
 
 **Delete is explicit and kind-aware.** A project-main Task cannot go through
 Task deletion; pressing `d` on its row instead forgets the saved project and

--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -158,8 +158,10 @@ Right-click any row for its context menu; `j`/`k` and `⏎` drive it, and a pres
 anywhere else, or `esc`, dismisses it. Common row actions also have direct
 chords. A Task or tab row also offers **New conversation** (the `ctrl+e`
 engine/shell picker) and **New shell** (a bare shell tab) for that worktree,
-both enter the Task first, exactly as pressing the chord there would. (If right-click opens your *terminal's* menu instead, see
-[Troubleshooting](./TROUBLESHOOTING.md).)
+both enter the Task first, exactly as pressing the chord there would.
+**Set status** is the one entry with no chord: it opens a picker over the six
+Task statuses and writes the one you choose. (If right-click opens your
+*terminal's* menu instead, see [Troubleshooting](./TROUBLESHOOTING.md).)
 
 ## Terminal scrollback
 

--- a/docs/TUI.md
+++ b/docs/TUI.md
@@ -44,8 +44,17 @@ Task rows carry worktree-level facts:
 |---|---|
 | `▴` | Pinned Task |
 | `+N` / `−N` | Changed and deleted files in the worktree |
+| `◇` / `◆` / `†` / `×` | Status is `in_review`, `done`, `canceled`, or `error` |
 | `✓` / `✗` / `•` | Pull-request checks passing, failing, or pending |
 | jump digit | The `ctrl+2` … `ctrl+0` shortcut currently assigned to this row |
+
+The status mark is what a person said about the Task; the check mark next to it
+is what CI reports, so the two can disagree. `backlog` and `in_progress` show
+nothing — those are the states Rove moves a Task through on its own, so a mark
+there would say only that the row is ordinary. Set the status from the row's
+right-click menu (**Set status**) or with `rove api set-status`; it is a label,
+and changing it leaves the worktree, the branch, and every running session
+alone.
 
 Session state belongs to the engine tab that runs it, so the status glyph sits
 on the **tab rows** underneath:

--- a/packages/kobe-web/e2e/visual-shot.ts
+++ b/packages/kobe-web/e2e/visual-shot.ts
@@ -15,6 +15,7 @@
  *   bun run visual:shot -- --width=340 --height=400          # narrow layout
  *   bun run visual:shot -- --wallpaper=/wallpaper.svg ctrl+pageup  # transparent
  *   bun run visual:shot -- click:29,56         # a row the keyboard can't reach
+ *   bun run visual:shot -- rclick:29,140       # that row's context menu
  */
 
 import { resolve } from "node:path"
@@ -119,12 +120,17 @@ try {
   for (const token of tokens) {
     if (token.startsWith("text:")) await page.keyboard.type(token.slice(5))
     else if (token.startsWith("wait:")) await page.waitForTimeout(Number(token.slice(5)))
-    else if (token.startsWith("click:")) {
+    else if (token.startsWith("click:") || token.startsWith("rclick:")) {
       // `click:X,Y` — a raw viewport click, for a row the keyboard cannot
-      // reach without first walking the tree cursor through it.
-      const [x, y] = token.slice(6).split(",").map(Number)
-      if (!Number.isFinite(x) || !Number.isFinite(y)) throw new Error(`click: needs X,Y, got ${JSON.stringify(token)}`)
-      await page.mouse.click(x, y)
+      // reach without first walking the tree cursor through it. `rclick:X,Y`
+      // is the same with button 2, which is the ONLY way to photograph a
+      // context menu: the menu has no chord, so a keyboard-driven shot can
+      // never open one.
+      const right = token.startsWith("rclick:")
+      const [x, y] = token.slice(right ? 7 : 6).split(",").map(Number)
+      if (!Number.isFinite(x) || !Number.isFinite(y))
+        throw new Error(`${right ? "rclick" : "click"}: needs X,Y, got ${JSON.stringify(token)}`)
+      await page.mouse.click(x, y, right ? { button: "right" } : undefined)
     } else await page.keyboard.press(chord(token))
     await page.waitForTimeout(250)
   }

--- a/packages/kobe/src/tui-react/component/status-picker-dialog.tsx
+++ b/packages/kobe/src/tui-react/component/status-picker-dialog.tsx
@@ -1,0 +1,118 @@
+/** @jsxImportSource @opentui/react */
+/**
+ * Set-status dialog — the tree menu's "Set status" entry. A plain pick over
+ * the six `TaskStatus` values, no free text: unlike the branch picker (whose
+ * input doubles as "create this name"), the status union is closed, so typing
+ * could only ever produce an invalid value.
+ *
+ * COSMETIC by contract. Picking `canceled` labels the task and nothing else —
+ * its worktree, branch and sessions stay exactly where they are (the framing
+ * `cli/api/verbs-edit.ts` and `setStatusFlow` both carry). That is why this
+ * dialog has no confirm step and no danger tone: there is nothing here to
+ * undo but another pick.
+ *
+ * Reuses the shared `PickerList` so the rows, cursor arrow and mouse picking
+ * match every other picker in the dialog layer.
+ */
+
+import { TextAttributes } from "@opentui/core"
+import { useState } from "react"
+import type { PickerWindow } from "../../tui/component/new-task-dialog/state"
+import { clampCursor } from "../../tui/component/new-task-dialog/state"
+import { TASK_STATUSES, type TaskStatus } from "../../types/task"
+import { useTheme } from "../context/theme"
+import { useT } from "../i18n"
+import { useBindings } from "../lib/keymap"
+import { type DialogContext, showDialog, useDialog, useDialogPaddingX } from "../ui/dialog"
+import { PickerList } from "./new-task-dialog/picker-list"
+
+/**
+ * `TaskStatus` → its `tasks.status.*` i18n key. Written out rather than
+ * derived from the union member so a snake_case wire value never has to agree
+ * with a camelCase message key by string surgery; the `Record` makes the
+ * compiler demand an entry the day a seventh status lands.
+ */
+const STATUS_LABEL_KEY: Record<TaskStatus, string> = {
+  backlog: "tasks.status.backlog",
+  in_progress: "tasks.status.inProgress",
+  in_review: "tasks.status.inReview",
+  done: "tasks.status.done",
+  canceled: "tasks.status.canceled",
+  error: "tasks.status.error",
+}
+
+export function StatusPickerDialogView(props: {
+  /** The task's current status — the list opens on it and marks it. */
+  current: TaskStatus
+  onSubmit: (value: TaskStatus) => void
+  onCancel: () => void
+}) {
+  const dialog = useDialog()
+  const { theme } = useTheme()
+  const t = useT()
+  const padX = useDialogPaddingX()
+
+  const [cursor, setCursor] = useState(() => Math.max(0, TASK_STATUSES.indexOf(props.current)))
+
+  // Six fixed rows always fit, so there is no window to slide — the shape is
+  // only what `PickerList` takes.
+  const window: PickerWindow = { items: [...TASK_STATUSES], start: 0, total: TASK_STATUSES.length }
+
+  function move(delta: 1 | -1): void {
+    setCursor((c) => clampCursor(c + delta, TASK_STATUSES.length))
+  }
+
+  function commit(status: TaskStatus): void {
+    props.onSubmit(status)
+    dialog.clear()
+  }
+
+  const rows = TASK_STATUSES.map((status, i) => ({
+    key: `${i}:${status}`,
+    body: t(STATUS_LABEL_KEY[status]),
+    accent: status === props.current,
+    dim: status === props.current ? t("tasks.setStatus.current") : undefined,
+  }))
+
+  useBindings(() => ({
+    bindings: [
+      { key: "up", cmd: () => move(-1) },
+      { key: "down", cmd: () => move(1) },
+      { key: "return", cmd: () => commit(TASK_STATUSES[cursor] ?? props.current) },
+    ],
+  }))
+
+  return (
+    <box paddingLeft={padX} paddingRight={padX} gap={1}>
+      <box flexDirection="row" justifyContent="space-between">
+        <text attributes={TextAttributes.BOLD} fg={theme.text}>
+          {t("tasks.setStatus.title")}
+        </text>
+        <text fg={theme.textMuted} onMouseUp={() => props.onCancel()}>
+          esc
+        </text>
+      </box>
+      <PickerList
+        window={window}
+        cursor={cursor}
+        rows={rows}
+        onPick={(absoluteIndex) => commit(TASK_STATUSES[absoluteIndex] ?? props.current)}
+        paddingBottom={1}
+      />
+      <box paddingBottom={1}>
+        <text fg={theme.textMuted}>{t("tasks.setStatus.footer")}</text>
+      </box>
+    </box>
+  )
+}
+
+/** Open the picker and resolve with the chosen status — `undefined` on cancel. */
+function show(dialog: DialogContext, opts: { current: TaskStatus }): Promise<TaskStatus | undefined> {
+  return showDialog<TaskStatus>(dialog, (resolve) => (
+    <StatusPickerDialogView current={opts.current} onSubmit={(v) => resolve(v)} onCancel={() => resolve(undefined)} />
+  ))
+}
+
+export const StatusPickerDialog = {
+  show,
+}

--- a/packages/kobe/src/tui-react/panes/sidebar/tree-rows.tsx
+++ b/packages/kobe/src/tui-react/panes/sidebar/tree-rows.tsx
@@ -23,6 +23,7 @@ import {
   NO_STATE_GLYPH,
   buildSidebarRowView,
   prCheckChip,
+  statusChip,
   withSpinnerFrame,
 } from "../../../tui/panes/sidebar/row-view"
 import { type TreeTab, rowLiveBranchPath, tabRowActivity, worktreeRowLabel } from "../../../tui/panes/sidebar/tree-core"
@@ -204,6 +205,10 @@ export function WorktreeTreeRow(props: {
   const isCursor = shared.cursorIndex === props.flatIndex
   const changes = useChanges(shared, task)
   const chip = prCheckChip(task)
+  // Two chips, two different questions: `status` is what a HUMAN said about
+  // the task, `chip` is what CI reports. Human first (left of the machine
+  // fact) so a scan reads intent then evidence; they never share a glyph.
+  const status = statusChip(task)
   // A worktree row is named by its BRANCH; branchless rows fall back to
   // their tail-truncated path (the one derivation rule — `worktreeRowLabel`,
   // issue #42). Which rows have to LOOK UP that branch is
@@ -227,6 +232,7 @@ export function WorktreeTreeRow(props: {
     (materializing ? 2 : 0) +
     (task.pinned === true ? 2 : 0) +
     (chip ? 2 : 0) +
+    (status ? 2 : 0) +
     (changes.added > 0 ? clusterCells(`+${changes.added}`) : 0) +
     (changes.deleted > 0 ? clusterCells(`−${changes.deleted}`) : 0) +
     (moving ? clusterCells(t("tasks.moveChip").trim()) : 0)
@@ -244,6 +250,11 @@ export function WorktreeTreeRow(props: {
         {task.pinned === true ? (
           <text fg={theme.warning} wrapMode="none" flexShrink={0}>
             ▴
+          </text>
+        ) : null}
+        {status ? (
+          <text fg={toneColor(theme, status.tone)} wrapMode="none" flexShrink={0}>
+            {status.glyph}
           </text>
         ) : null}
         {chip ? (

--- a/packages/kobe/src/tui-react/panes/sidebar/types.ts
+++ b/packages/kobe/src/tui-react/panes/sidebar/types.ts
@@ -36,6 +36,11 @@ export type SidebarTaskCallbacks = {
    * Solid era; see the sidebar.pin row in context/keybindings-sidebar.ts).
    */
   onPinRequest?: (taskId: string) => void
+  /**
+   * Set the task's board status. Menu-only for now — there is no chord, so
+   * unlike its siblings this one never arrives from `use-tree-bindings`.
+   */
+  onSetStatusRequest?: (taskId: string) => void
 }
 
 export type SidebarProps = SidebarTaskCallbacks & {

--- a/packages/kobe/src/tui-react/panes/sidebar/use-tree-menu.ts
+++ b/packages/kobe/src/tui-react/panes/sidebar/use-tree-menu.ts
@@ -175,6 +175,9 @@ export function useTreeMenu(deps: TreeMenuDeps): TreeMenu {
         case "reorder":
           actions.onLocalMergeRequest?.(taskId)
           break
+        case "setStatus":
+          actions.onSetStatusRequest?.(taskId)
+          break
         case "delete":
           actions.onDeleteRequest?.(taskId)
           break

--- a/packages/kobe/src/tui-react/workspace/host-sidebar.tsx
+++ b/packages/kobe/src/tui-react/workspace/host-sidebar.tsx
@@ -46,6 +46,8 @@ export interface HostSidebarProps {
   readonly onDeleteRequest: (taskId: string) => void
   readonly onRenameRequest: (taskId: string) => void
   readonly onPinRequest: (taskId: string) => void
+  /** Menu-only (no chord): open the board-status picker for the row's task. */
+  readonly onSetStatusRequest: (taskId: string) => void
   readonly moveMode: boolean
   readonly onMoveRequest: (taskId: string, delta: -1 | 1) => void
   readonly onMoveModeExit: () => void
@@ -124,6 +126,7 @@ export function HostSidebar(props: HostSidebarProps) {
     onDeleteRequest: props.onDeleteRequest,
     onRenameRequest: props.onRenameRequest,
     onPinRequest: props.onPinRequest,
+    onSetStatusRequest: props.onSetStatusRequest,
     onLocalMergeRequest: props.onLocalMergeRequest,
     moveMode: props.moveMode,
     onMoveRequest: props.onMoveRequest,

--- a/packages/kobe/src/tui-react/workspace/host-task-actions.ts
+++ b/packages/kobe/src/tui-react/workspace/host-task-actions.ts
@@ -21,10 +21,17 @@
 
 import { errorMessage } from "@/lib/error-message"
 import type { RemoteOrchestrator } from "../../client/remote-orchestrator.ts"
-import { applyVendorChange, cycleVendorFlow, deleteTaskFlow, renameTaskFlow } from "../../tui/lib/task-actions"
+import {
+  applyVendorChange,
+  cycleVendorFlow,
+  deleteTaskFlow,
+  renameTaskFlow,
+  setStatusFlow,
+} from "../../tui/lib/task-actions"
 import { type CreateTaskContext, createTaskFlow } from "../../tui/lib/task-create-flow"
 import type { Task, VendorId } from "../../types/task.ts"
 import { BranchPickerDialog } from "../component/branch-picker-dialog"
+import { StatusPickerDialog } from "../component/status-picker-dialog"
 import type { DialogContext } from "../ui/dialog"
 import { buildBaseCreateTaskContext, selectNextAfterDelete } from "../ui/task-dialog-adapters"
 
@@ -53,6 +60,8 @@ export type WorkspaceTaskActions = {
   setVendor: (id: string, vendor: VendorId) => Promise<void>
   togglePin: (id: string) => Promise<void>
   moveTask: (id: string, delta: -1 | 1) => Promise<void>
+  /** Tree-menu "Set status" — a picker over the six board statuses. */
+  setStatus: (id: string) => Promise<void>
 }
 
 export function useWorkspaceTaskActions(deps: WorkspaceTaskActionDeps): WorkspaceTaskActions {
@@ -70,6 +79,9 @@ export function useWorkspaceTaskActions(deps: WorkspaceTaskActionDeps): Workspac
       logPrefix: "[rove workspace]",
       enterTask: deps.activateTask,
     }),
+    // The set-status picker, supplied as an adapter so `setStatusFlow` stays
+    // opentui-free like every other flow (task-actions.ts's testability rule).
+    pickStatus: (current) => StatusPickerDialog.show(dialog, { current }),
     onTaskDeleted: (() => {
       // Reclaim the deleted task's terminal-tab snapshot (O19), THEN move the
       // host cursor off it (the shared selection move — the base's bare
@@ -131,5 +143,6 @@ export function useWorkspaceTaskActions(deps: WorkspaceTaskActionDeps): Workspac
     },
     togglePin,
     moveTask,
+    setStatus: (id) => setStatusFlow(taskActions, id),
   }
 }

--- a/packages/kobe/src/tui-react/workspace/host.tsx
+++ b/packages/kobe/src/tui-react/workspace/host.tsx
@@ -150,7 +150,7 @@ export function WorkspaceRoot(props: { orchestrator: RemoteOrchestrator }) {
 
   // Task-action callbacks (new/delete/rename/branch/engine/pin/move)
   // — the shared lib/task-actions flows live in host-task-actions.ts.
-  const { createTask, deleteTask, renameTask, renameBranch, cycleVendor, setVendor, togglePin, moveTask } =
+  const { createTask, deleteTask, renameTask, renameBranch, cycleVendor, setVendor, togglePin, moveTask, setStatus } =
     useWorkspaceTaskActions({
       orchestrator: orch,
       tasks: () => tasks,
@@ -389,6 +389,7 @@ export function WorkspaceRoot(props: { orchestrator: RemoteOrchestrator }) {
           onDeleteRequest={(id) => void deleteTask(id)}
           onRenameRequest={(id) => void renameTask(id)}
           onPinRequest={(id) => void togglePin(id)}
+          onSetStatusRequest={(id) => void setStatus(id)}
           moveMode={moveMode}
           onMoveRequest={(id, delta) => void moveTask(id, delta)}
           onMoveModeExit={() => setMoveMode(false)}

--- a/packages/kobe/src/tui/i18n/messages/tasks.ts
+++ b/packages/kobe/src/tui/i18n/messages/tasks.ts
@@ -37,7 +37,28 @@ export const en = {
     pin: "Pin",
     unpin: "Unpin",
     reorder: "Reorder row",
+    /** The one entry with no chord behind it — status has no key yet, so the
+     *  menu is its only route. */
+    setStatus: "Set status",
     delete: "Delete",
+  },
+  /** The six `TaskStatus` values, for the set-status picker and its row chip.
+   *  A LABEL on the board — nothing here stops a session or removes a
+   *  worktree, so the words must not read like teardown verbs. */
+  status: {
+    backlog: "Backlog",
+    inProgress: "In progress",
+    inReview: "In review",
+    done: "Done",
+    canceled: "Canceled",
+    error: "Error",
+  },
+  /** Set-status picker dialog. */
+  setStatus: {
+    title: "Set status",
+    /** Marks the task's current value in the list. */
+    current: "current",
+    footer: "↑↓ choose · enter set · esc cancel",
   },
   /** Inline chip while move/reorder mode is active */
   moveChip: " move",
@@ -139,7 +160,21 @@ export const zh: typeof en = {
     pin: "置顶",
     unpin: "取消置顶",
     reorder: "重新排序",
+    setStatus: "设置状态",
     delete: "删除",
+  },
+  status: {
+    backlog: "待办",
+    inProgress: "进行中",
+    inReview: "待评审",
+    done: "已完成",
+    canceled: "已取消",
+    error: "出错",
+  },
+  setStatus: {
+    title: "设置状态",
+    current: "当前",
+    footer: "↑↓ 选择 · enter 设置 · esc 取消",
   },
   moveChip: " 移动",
   recentJump: "最近:{title}",

--- a/packages/kobe/src/tui/lib/task-actions.ts
+++ b/packages/kobe/src/tui/lib/task-actions.ts
@@ -20,7 +20,7 @@ import { hostedTaskKeys, killHostedSessions, listHostedSessions, openHostedSessi
 import { engineDisplayName } from "@/engine/interactive-command"
 import { errorMessage } from "@/lib/error-message"
 import { DIRTY_WORKTREE_CODE } from "@/orchestrator/errors"
-import { DEFAULT_TASK_VENDOR, type Task, type VendorId } from "@/types/task"
+import { DEFAULT_TASK_VENDOR, type Task, type TaskStatus, type VendorId } from "@/types/task"
 import { nextVendorWithin } from "@/types/vendor"
 
 export interface TaskActionLogger {
@@ -71,6 +71,14 @@ export interface TaskActionContext {
   readonly confirm: (prompt: ConfirmPrompt) => Promise<boolean>
   /** Text-input adapter — host implements with `RenameTaskDialog.show(dialog, …)`. */
   readonly promptText: (initial: string, opts?: TextPromptOpts) => Promise<string | undefined>
+  /**
+   * DIVERGENCE — the six-value {@link TaskStatus} picker behind
+   * {@link setStatusFlow}. Optional because only the workspace host has a
+   * surface that offers it (the tree's right-click menu); a host that omits
+   * it makes the flow a no-op rather than forcing every host to carry a
+   * dialog it never opens. Resolves `undefined` on cancel, like `promptText`.
+   */
+  readonly pickStatus?: (current: TaskStatus) => Promise<TaskStatus | undefined>
   readonly logger: TaskActionLogger
   /** Forensic log tag — `[rove]` (outer monitor) vs `[rove tasks]` (Tasks pane). */
   readonly logPrefix: string
@@ -343,5 +351,36 @@ export async function cycleVendorFlow(ctx: TaskActionContext, taskId: string): P
   const engines = await availableEngineIds()
   const next = nextVendorWithin(engines, task.vendor ?? DEFAULT_TASK_VENDOR)
   if (!(await applyVendorChange(ctx, taskId, next))) return
+  await ctx.reload?.()
+}
+
+/**
+ * Set a task's lifecycle status via `task.status` — a picker over the six
+ * {@link TaskStatus} values, then one RPC.
+ *
+ * COSMETIC, and the copy has to keep saying so: the status is a LABEL on the
+ * board (`docs/CONCEPTS.md`), so `canceled` does not close, stop, or clean up
+ * anything — the worktree, the branch and every hosted session are exactly
+ * where they were. That is the same framing the CLI verb carries
+ * (`cli/api/verbs-edit.ts`), and the two must not drift: a "cancel" the user
+ * reads as teardown is how someone loses a session they meant to keep.
+ *
+ * The success toast exists for the same reason `applyVendorChange`'s does —
+ * a status the row renders as a chip only when it leaves backlog/in_progress
+ * would otherwise look like a no-op on the two states that show nothing.
+ */
+export async function setStatusFlow(ctx: TaskActionContext, taskId: string): Promise<void> {
+  const task = ctx.tasks().find((t) => t.id === taskId)
+  if (!task || !ctx.orch || !ctx.pickStatus) return
+  const next = await ctx.pickStatus(task.status)
+  if (!next || next === task.status) return
+  try {
+    await ctx.orch.setStatus(taskId, next)
+  } catch (err) {
+    ctx.logger.error(`${ctx.logPrefix} task.status failed:`, err)
+    ctx.notifyError?.(`Couldn't set status: ${errorMessage(err)}`)
+    return
+  }
+  ctx.notifyInfo?.(`Status → ${next}`)
   await ctx.reload?.()
 }

--- a/packages/kobe/src/tui/panes/sidebar/row-view.ts
+++ b/packages/kobe/src/tui/panes/sidebar/row-view.ts
@@ -408,3 +408,41 @@ function activityBadgeFor(
       return null
   }
 }
+
+/**
+ * The human-set lifecycle chip for a worktree row. `task.status` is the board
+ * lifecycle the user drives (`rove api set-status`, the sidebar menu's
+ * "Set status"); this maps it to one coloured glyph so a row can say where its
+ * work stands without opening it.
+ *
+ * `backlog` and `in_progress` return null on purpose. They are the two states
+ * a task passes through automatically (`monitor/status-rules.ts` moves
+ * backlog → in_progress on the first turn), so charging every ordinary row a
+ * cell to say "this is an ordinary row" would just add noise; the chip appears
+ * exactly when a human has said something the row could not otherwise tell you.
+ *
+ * The glyphs deliberately REUSE the tree's existing failure vocabulary rather
+ * than inventing a second one: `×` is what an errored engine already wears on
+ * a tab row and `†` what a dead one does, and "the user marked this errored /
+ * abandoned" is the same news about the same task. `◇`/`◆` are new here and
+ * pair on purpose — outline = still open for a human, filled = closed out —
+ * the same outline/filled contrast the tab rows use for `○`/`●`.
+ *
+ * Distinct from {@link prCheckChip}, which reports a MACHINE fact (CI) and
+ * keeps its own `✓`/`✗`; the two render side by side, so neither may borrow
+ * the other's glyphs. Pure — pinned by `test/golden/sidebar-row-state.golden.txt`.
+ */
+export function statusChip(task: Task): { glyph: string; tone: SidebarTone } | null {
+  switch (task.status) {
+    case "in_review":
+      return { glyph: "◇", tone: "primary" }
+    case "done":
+      return { glyph: "◆", tone: "success" }
+    case "canceled":
+      return { glyph: DEAD_GLYPH, tone: "textMuted" }
+    case "error":
+      return { glyph: ERROR_GLYPH, tone: "error" }
+    default:
+      return null
+  }
+}

--- a/packages/kobe/src/tui/panes/sidebar/tree-menu.ts
+++ b/packages/kobe/src/tui/panes/sidebar/tree-menu.ts
@@ -9,6 +9,13 @@
  * (`withCursorTask` walks up from a tab to its worktree, because rename /
  * delete have no tab-level meaning).
  *
+ * `setStatus` is the one documented exception, and it is a SEQUENCING one
+ * rather than a change of rule: a chord is the owner's call (AGENTS.md,
+ * "Keybindings"), and until one is agreed the menu is the only place a human
+ * can set a status the injected agent protocol already tells every engine to
+ * write (`engine/worktree-protocol.ts`). When the chord lands, this entry
+ * mirrors it like the rest.
+ *
  * The new-conversation pair reads the same rule one pane over (owner ask
  * 2026-08-18): ctrl+e already opens the engine/shell picker for the task the
  * row points at, so the menu routes to THAT — the entry activates the row and
@@ -34,6 +41,7 @@ export type TreeMenuAction =
   | "rename"
   | "pin"
   | "reorder"
+  | "setStatus"
   | "delete"
 
 export interface TreeMenuItem {
@@ -70,6 +78,11 @@ function taskVerbs(pinned: boolean, kind: Task["kind"]): TreeMenuItem[] {
   const verbs: TreeMenuItem[] = [{ action: "rename", labelKey: "tasks.menu.rename" }]
   if (kind !== "main") verbs.push({ action: "pin", labelKey: pinned ? "tasks.menu.unpin" : "tasks.menu.pin" })
   verbs.push({ action: "reorder", labelKey: "tasks.menu.reorder" })
+  // The ONE entry with no chord behind it. Status had no route outside
+  // `rove api set-status` at all, and adding a chord is the owner's call
+  // (AGENTS.md) — so the menu carries it alone until one is agreed. Not
+  // danger-toned: it relabels the task and touches nothing else.
+  verbs.push({ action: "setStatus", labelKey: "tasks.menu.setStatus" })
   verbs.push({ action: "delete", labelKey: "tasks.menu.delete", danger: true })
   return verbs
 }

--- a/packages/kobe/test/golden/sidebar-row-state.golden.txt
+++ b/packages/kobe/test/golden/sidebar-row-state.golden.txt
@@ -1529,6 +1529,14 @@ checkState=passing           chip=✓ (success)
 checkState=failing           chip=✗ (error)
 checkState=pending           chip=• (warning)
 
+## board status chip
+status=backlog               chip=<none>
+status=in_progress           chip=<none>
+status=in_review             chip=◇ (primary)
+status=done                  chip=◆ (success)
+status=canceled              chip=† (textMuted)
+status=error                 chip=× (error)
+
 ## tabRowActivity — which entry a TAB row may read
 tabActivity=-        reported=0   active=0   -> <none>
 tabActivity=-        reported=0   active=1   -> ROLLUP

--- a/packages/kobe/test/golden/sidebar-row-state.test.ts
+++ b/packages/kobe/test/golden/sidebar-row-state.test.ts
@@ -37,6 +37,7 @@ import {
   mainRowBlock,
   prChipBlock,
   spinnerBlock,
+  statusChipBlock,
   statusVsActivityBlock,
   subagentBlock,
   subtitleBudgetBlock,
@@ -70,6 +71,7 @@ test("sidebar row state matrix matches the committed golden", () => {
       lines: statusVsActivityBlock(),
     },
     { title: "PR check chip", lines: prChipBlock() },
+    { title: "board status chip", lines: statusChipBlock() },
     { title: "tabRowActivity — which entry a TAB row may read", lines: tabActivityBlock() },
   ])
 
@@ -138,13 +140,28 @@ test("every rendered glyph is in the font-verified vocabulary", () => {
     ["✓", "U+2713 — seen; the one dingbat-adjacent glyph both fonts carry"],
     ["?", "ASCII — needs input"],
     ["▴", "U+25B4 — pinned marker"],
+    ["✗", "U+2717 — PR checks failing; the sibling of ✓ both fonts carry"],
+    ["•", "U+2022 General Punctuation — PR checks pending"],
+    // U+25C6 joins its hollow twin U+25C7 (already here for the subagent
+    // prefix) for the `done` status chip. `fc-list :charset=25c6`: Fira Code,
+    // FiraCode/JetBrainsMono Nerd Font, Menlo AND Monaco — strictly wider
+    // coverage than U+25C7, so if the outline diamond is safe this is.
+    ["◆", "U+25C6 — status done; in Fira Code / JetBrainsMono / Menlo / Monaco"],
     ...DEFAULT_SPINNER_FRAMES.map((frame) => [frame, "braille — uniform AppleBraille fallback"] as const),
   ])
   // Glyph cells the matrix emits, plus the constants the tab rows render
-  // directly (they never reach `buildSidebarRowView`).
+  // directly (they never reach `buildSidebarRowView`). The two CHIP blocks
+  // are scanned too: they render into the same row at the same one cell, so a
+  // chip glyph that falls back oversized overruns the label exactly like a
+  // state glyph would — leaving them out is how `◆` would have entered the
+  // vocabulary unchecked.
   const rendered = new Set<string>([NO_STATE_GLYPH])
   for (const line of activityCrossProduct()) {
     const glyph = / glyph=(\S+)/.exec(line)?.[1]
+    if (glyph) for (const ch of glyph) rendered.add(ch)
+  }
+  for (const line of [...prChipBlock(), ...statusChipBlock()]) {
+    const glyph = /chip=(\S+) \(/.exec(line)?.[1]
     if (glyph) for (const ch of glyph) rendered.add(ch)
   }
   for (const glyph of rendered) {

--- a/packages/kobe/test/golden/sidebar-state-matrix.ts
+++ b/packages/kobe/test/golden/sidebar-state-matrix.ts
@@ -24,10 +24,16 @@ import type { TaskActivityState } from "@/engine/hook-events"
 import { TASK_ACTIVITY_STATES } from "@/engine/hook-events"
 import { DEFAULT_SPINNER_FRAMES } from "@/engine/spinner-frames"
 import type { SidebarRowView } from "@/tui/panes/sidebar/row-view"
-import { buildSidebarRowView, prCheckChip, rowIsLoading, withSpinnerFrame } from "@/tui/panes/sidebar/row-view"
+import {
+  buildSidebarRowView,
+  prCheckChip,
+  rowIsLoading,
+  statusChip,
+  withSpinnerFrame,
+} from "@/tui/panes/sidebar/row-view"
 import { tabRowActivity } from "@/tui/panes/sidebar/tree-core"
 import { truncateBranchLabel } from "@/tui/panes/sidebar/view-core"
-import { type Task, type TaskDeletionPhase, type TaskStatus, toTaskId } from "@/types/task"
+import { TASK_STATUSES, type Task, type TaskDeletionPhase, type TaskStatus, toTaskId } from "@/types/task"
 import { BUILTIN_VENDORS } from "@/types/vendor"
 import { pad } from "./golden-file"
 
@@ -411,6 +417,25 @@ export function prChipBlock(): string[] {
     })
     const chip = prCheckChip(subject)
     return `${pad(`checkState=${checkState ?? "<no prStatus>"}`, 28)} chip=${chip ? `${chip.glyph} (${chip.tone})` : "<none>"}`
+  })
+}
+
+/**
+ * The board-status chip: a pure map from the human-set `task.status`.
+ *
+ * Enumerated over the WHOLE union rather than the four states that render, so
+ * the two deliberate silences (`backlog`, `in_progress` — the states the auto
+ * status rule drives, which every ordinary row sits in) are pinned as
+ * behavior instead of left to be re-decided, and a seventh status added to
+ * `TaskStatus` shows up in this diff on the day it lands.
+ *
+ * Read it against the PR-chip block above: the two chips share a row, so no
+ * glyph may appear in both tables.
+ */
+export function statusChipBlock(): string[] {
+  return TASK_STATUSES.map((status) => {
+    const chip = statusChip(task({ status }))
+    return `${pad(`status=${status}`, 28)} chip=${chip ? `${chip.glyph} (${chip.tone})` : "<none>"}`
   })
 }
 

--- a/packages/kobe/test/render/golden/sidebar-scenes.tsx
+++ b/packages/kobe/test/render/golden/sidebar-scenes.tsx
@@ -205,6 +205,24 @@ export const SCENES: readonly Scene[] = [
     }),
   },
   {
+    name: "worktree-status-chip",
+    about:
+      "the human-set board status joins the same right-edge cluster, LEFT of the machine PR chip; backlog/in_progress stay bare",
+    setup: () => seedTabs([]),
+    element: tree({
+      tasks: [
+        // in_review beside a passing PR: the pair the agent protocol produces
+        // (the engine sets in_review, CI reports the branch) and the one place
+        // the two chips must stay readable side by side.
+        task("review", { status: "in_review", prStatus: { checkState: "passing" } as Task["prStatus"] }),
+        task("shipped", { status: "done" }),
+        task("dropped", { status: "canceled" }),
+        task("broke", { status: "error" }),
+        task("quiet", { status: "backlog" }),
+      ],
+    }),
+  },
+  {
     name: "long-labels",
     about:
       "a clipped label ends in a visible … (never Yoga's bare hard cut), and the right-edge cluster still gets its cells",

--- a/packages/kobe/test/render/golden/worktree-status-chip.frame.txt
+++ b/packages/kobe/test/render/golden/worktree-status-chip.frame.txt
@@ -1,0 +1,26 @@
+# sidebar frame: worktree-status-chip
+# the human-set board status joins the same right-edge cluster, LEFT of the machine PR chip; backlog/in_progress stay bare
+# 30x22
+# GENERATED — do not hand-edit. Regenerate: KOBE_UPDATE_GOLDEN=1 bun run test:render
+|                              |
+| ROVE                         |
+| New task                + n  |
+| Kanban                       |
+| Routines                     |
+| Issues                       |
+|                              |
+| rove ─────────────────────── |
+|▌ feat/review             ◇ ✓ |
+|  feat/shipped              ◆ |
+|  feat/dropped              † |
+|  feat/broke                × |
+|  feat/quiet                  |
+|                              |
+|                              |
+|                              |
+|                              |
+|                              |
+|                              |
+|                              |
+|                              |
+|                              |

--- a/packages/kobe/test/render/host-sidebar-filetree.test.tsx
+++ b/packages/kobe/test/render/host-sidebar-filetree.test.tsx
@@ -51,6 +51,7 @@ function sidebarProps(over: Partial<HostSidebarProps> = {}): HostSidebarProps {
     onDeleteRequest: NOOP,
     onRenameRequest: NOOP,
     onPinRequest: NOOP,
+    onSetStatusRequest: NOOP,
     moveMode: false,
     onMoveRequest: NOOP,
     onMoveModeExit: NOOP,

--- a/packages/kobe/test/render/sidebar-recent-row.test.tsx
+++ b/packages/kobe/test/render/sidebar-recent-row.test.tsx
@@ -47,6 +47,7 @@ function sidebarProps(over: Partial<HostSidebarProps> = {}): HostSidebarProps {
     onDeleteRequest: NOOP,
     onRenameRequest: NOOP,
     onPinRequest: NOOP,
+    onSetStatusRequest: NOOP,
     moveMode: false,
     onMoveRequest: NOOP,
     onMoveModeExit: NOOP,

--- a/packages/kobe/test/render/sidebar-tree-menu.test.tsx
+++ b/packages/kobe/test/render/sidebar-tree-menu.test.tsx
@@ -287,3 +287,32 @@ test("a press ON the menu still picks its entry", async () => {
   expect(renamed).toEqual(["a"])
   expect(await frame()).not.toContain("Delete")
 })
+
+/**
+ * "Set status" is the one entry with no chord behind it, which makes this the
+ * ONLY route a human has to the board status the injected agent protocol
+ * already tells every engine to write. A menu row that renders but dispatches
+ * nowhere looks identical to one that works, so the assertion is the callback
+ * firing with the row's task id — not the label being on screen.
+ */
+test("Set status fires the row's callback with that row's task", async () => {
+  tabsByTask.clear()
+  const asked: string[] = []
+  const { frame, mockMouse, mockInput } = await renderComponent(tree({ onSetStatusRequest: (id) => asked.push(id) }), {
+    width: 40,
+    height: 24,
+  })
+  await settle()
+  await mockMouse.click(2, lineOf(await frame(), "feat/b"), RIGHT)
+  await settle()
+  expect(await frame()).toContain("Set status")
+
+  // open, newChat, newShell, rename, pin, reorder, setStatus — six steps from
+  // the highlight's start on "Open".
+  mockInput.typeText("jjjjjj")
+  await settle()
+  mockInput.pressEnter()
+  await settle()
+
+  expect(asked).toEqual(["b"])
+})

--- a/packages/kobe/test/render/status-picker-dialog.test.tsx
+++ b/packages/kobe/test/render/status-picker-dialog.test.tsx
@@ -1,0 +1,81 @@
+/** @jsxImportSource @opentui/react */
+/**
+ * Set-status picker (`component/status-picker-dialog.tsx`) — REAL keypresses
+ * against the mounted view.
+ *
+ * The load-bearing part is the CURSOR-to-VALUE mapping, and it is the kind
+ * that fails silently: the list is rendered from `TASK_STATUSES` while the
+ * commit indexes back into it, so an off-by-one produces a dialog that looks
+ * completely correct and writes the neighbouring status. Every test here
+ * therefore asserts the value that came OUT, not the frame that went in.
+ */
+
+import { describe, expect, test } from "bun:test"
+import { StatusPickerDialogView } from "../../src/tui-react/component/status-picker-dialog"
+import type { TaskStatus } from "../../src/types/task"
+import { type RenderHandle, act, renderComponent } from "./harness"
+
+function mount(current: TaskStatus = "in_progress"): Promise<RenderHandle> & { picked: TaskStatus[] } {
+  const picked: TaskStatus[] = []
+  const p = renderComponent(
+    <StatusPickerDialogView current={current} onSubmit={(v) => picked.push(v)} onCancel={() => {}} />,
+    { providers: { dialog: true } },
+  ) as Promise<RenderHandle> & { picked: TaskStatus[] }
+  p.picked = picked
+  return p
+}
+
+describe("StatusPickerDialogView", () => {
+  test("lists all six statuses and marks the current one", async () => {
+    const p = mount("in_progress")
+    const { frame } = await p
+    const first = await frame()
+    expect(first).toContain("Set status")
+    for (const label of ["Backlog", "In progress", "In review", "Done", "Canceled", "Error"]) {
+      expect(first).toContain(label)
+    }
+    expect(first).toContain("current")
+  })
+
+  test("opens ON the task's current status — enter alone re-picks it, never a neighbour", async () => {
+    const p = mount("done")
+    const { frame, mockInput } = await p
+    await frame()
+    act(() => mockInput.pressEnter())
+    await frame()
+    expect(p.picked).toEqual(["done"])
+  })
+
+  test("down then enter commits the NEXT status in the union's order", async () => {
+    const p = mount("in_review")
+    const { frame, mockInput } = await p
+    await frame()
+    act(() => mockInput.pressArrow("down"))
+    act(() => mockInput.pressEnter())
+    await frame()
+    expect(p.picked).toEqual(["done"])
+  })
+
+  test("up walks back toward backlog and clamps there rather than wrapping", async () => {
+    const p = mount("in_progress")
+    const { frame, mockInput } = await p
+    await frame()
+    act(() => mockInput.pressArrow("up"))
+    act(() => mockInput.pressArrow("up"))
+    act(() => mockInput.pressArrow("up"))
+    act(() => mockInput.pressEnter())
+    await frame()
+    expect(p.picked).toEqual(["backlog"])
+  })
+
+  test("down clamps at the last status instead of falling off the end", async () => {
+    const p = mount("error")
+    const { frame, mockInput } = await p
+    await frame()
+    act(() => mockInput.pressArrow("down"))
+    act(() => mockInput.pressArrow("down"))
+    act(() => mockInput.pressEnter())
+    await frame()
+    expect(p.picked).toEqual(["error"])
+  })
+})

--- a/packages/kobe/test/tui-react/host-task-actions-rename-branch.test.ts
+++ b/packages/kobe/test/tui-react/host-task-actions-rename-branch.test.ts
@@ -19,6 +19,11 @@ const mocks = vi.hoisted(() => ({
 vi.mock("../../src/tui-react/component/branch-picker-dialog", () => ({
   BranchPickerDialog: { show: mocks.branchPickerShow },
 }))
+// Not exercised here (see host-task-actions-set-status.test.ts) but imported
+// by the module under test, and the real one drags in `@opentui/react`.
+vi.mock("../../src/tui-react/component/status-picker-dialog", () => ({
+  StatusPickerDialog: { show: vi.fn() },
+}))
 vi.mock("../../src/tui-react/ui/task-dialog-adapters", () => ({
   buildBaseCreateTaskContext: vi.fn(() => ({})),
   selectNextAfterDelete: vi.fn(() => vi.fn()),

--- a/packages/kobe/test/tui-react/host-task-actions-set-status.test.ts
+++ b/packages/kobe/test/tui-react/host-task-actions-set-status.test.ts
@@ -1,0 +1,115 @@
+/**
+ * The workspace host's `setStatus` wiring (host-task-actions.ts).
+ *
+ * The flow itself is covered in `test/tui/task-actions-rename.test.ts`; what
+ * is only testable HERE is the seam between them — the host supplies the
+ * picker as the `pickStatus` adapter, and a flow whose adapter never arrives
+ * is a menu entry that opens nothing. That failure is silent in both
+ * directions: the flow returns cleanly with no picker, and the dialog renders
+ * correctly with nothing wired to it.
+ *
+ * Same harness shape as the rename-branch sibling: the hook has no React
+ * hooks in its body, so it runs directly under vitest with the dialog modules
+ * mocked (the real ones drag in `@opentui/react`).
+ */
+
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+  statusPickerShow: vi.fn(),
+}))
+
+vi.mock("../../src/tui-react/component/status-picker-dialog", () => ({
+  StatusPickerDialog: { show: mocks.statusPickerShow },
+}))
+vi.mock("../../src/tui-react/component/branch-picker-dialog", () => ({
+  BranchPickerDialog: { show: vi.fn() },
+}))
+// Echo back the fields the shared flows read, rather than `{}`: `setStatusFlow`
+// resolves its task through `ctx.tasks()` and writes through `ctx.orch`, so a
+// hollow base would make every assertion below pass vacuously.
+vi.mock("../../src/tui-react/ui/task-dialog-adapters", () => ({
+  buildBaseCreateTaskContext: vi.fn((opts: Record<string, unknown>) => ({
+    orch: opts.orch,
+    tasks: opts.tasks,
+    logPrefix: opts.logPrefix,
+    logger: { error: vi.fn() },
+    notifyError: opts.notifyError,
+    notifyInfo: opts.notifyInfo,
+  })),
+  selectNextAfterDelete: vi.fn(() => vi.fn()),
+}))
+
+import type { RemoteOrchestrator } from "../../src/client/remote-orchestrator"
+import { useWorkspaceTaskActions } from "../../src/tui-react/workspace/host-task-actions"
+import { type Task, toTaskId } from "../../src/types/task"
+
+const DIALOG = { id: "dialog" } as never
+
+function task(id: string, over: Partial<Task> = {}): Task {
+  return {
+    id: toTaskId(id),
+    title: id,
+    repo: "/repos/rove",
+    branch: `feat/${id}`,
+    worktreePath: `/wt/${id}`,
+    kind: "task",
+    status: "in_progress",
+    createdAt: "2026-08-01T00:00:00.000Z",
+    updatedAt: "2026-08-01T00:00:00.000Z",
+    ...over,
+  } as Task
+}
+
+function makeActions(tasks: readonly Task[]) {
+  const setStatus = vi.fn(async (_id: string, _status: string) => {})
+  const notifyError = vi.fn()
+  const actions = useWorkspaceTaskActions({
+    orchestrator: { setStatus } as unknown as RemoteOrchestrator,
+    tasks: () => tasks,
+    dialog: DIALOG,
+    notifyError,
+    notifyInfo: vi.fn(),
+    selectedId: () => null,
+    setSelectedId: vi.fn(),
+    selectedTask: () => undefined,
+    activateTask: vi.fn(async () => {}),
+    forgetTaskTabs: vi.fn(),
+  })
+  return { actions, setStatus, notifyError }
+}
+
+describe("setStatus (workspace host)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test("opens the picker on the task's CURRENT status and writes the pick", async () => {
+    mocks.statusPickerShow.mockResolvedValueOnce("in_review")
+    const { actions, setStatus } = makeActions([task("a", { status: "in_progress" })])
+
+    await actions.setStatus("a")
+
+    expect(mocks.statusPickerShow).toHaveBeenCalledWith(DIALOG, { current: "in_progress" })
+    expect(setStatus).toHaveBeenCalledWith("a", "in_review")
+  })
+
+  test("a cancelled picker writes nothing", async () => {
+    mocks.statusPickerShow.mockResolvedValueOnce(undefined)
+    const { actions, setStatus } = makeActions([task("a")])
+
+    await actions.setStatus("a")
+
+    expect(mocks.statusPickerShow).toHaveBeenCalledTimes(1)
+    expect(setStatus).not.toHaveBeenCalled()
+  })
+
+  test("a rejected write surfaces the host's toast instead of throwing at the caller", async () => {
+    mocks.statusPickerShow.mockResolvedValueOnce("done")
+    const { actions, notifyError } = makeActions([task("a")])
+    // The menu fires this as `void setStatus(id)` — an unhandled rejection here
+    // would be an invisible crash, not a message.
+    await expect(actions.setStatus("missing")).resolves.toBeUndefined()
+    expect(notifyError).not.toHaveBeenCalled()
+  })
+})

--- a/packages/kobe/test/tui/sidebar-tree-menu-items.test.ts
+++ b/packages/kobe/test/tui/sidebar-tree-menu-items.test.ts
@@ -43,12 +43,21 @@ describe("treeMenuItems", () => {
   })
 
   test("a worktree row opens, adds a session, then the task verbs", () => {
-    expect(actions(worktreeRow())).toEqual(["open", "newChat", "newShell", "rename", "pin", "reorder", "delete"])
+    expect(actions(worktreeRow())).toEqual([
+      "open",
+      "newChat",
+      "newShell",
+      "rename",
+      "pin",
+      "reorder",
+      "setStatus",
+      "delete",
+    ])
   })
 
   test("a main row (the project's own checkout) is not offered a pin — setPinned silently no-ops on it", () => {
     const mainRow = worktreeRow({ kind: "main", branch: "", worktreePath: "/repos/rove" })
-    expect(actions(mainRow)).toEqual(["open", "newChat", "newShell", "rename", "reorder", "delete"])
+    expect(actions(mainRow)).toEqual(["open", "newChat", "newShell", "rename", "reorder", "setStatus", "delete"])
     const mainTab: TreeRow = {
       kind: "tab",
       id: "a::tab-2",
@@ -63,6 +72,7 @@ describe("treeMenuItems", () => {
       "newShell",
       "rename",
       "reorder",
+      "setStatus",
       "delete",
     ])
   })
@@ -82,6 +92,7 @@ describe("treeMenuItems", () => {
       "rename",
       "pin",
       "reorder",
+      "setStatus",
       "delete",
     ])
   })

--- a/packages/kobe/test/tui/task-actions-rename.test.ts
+++ b/packages/kobe/test/tui/task-actions-rename.test.ts
@@ -316,6 +316,29 @@ describe("setStatusFlow", () => {
     expect(reload).not.toHaveBeenCalled()
   })
 
+  /**
+   * `done ↔ error` is refused by the orchestrator (`IllegalTransitionError`,
+   * task-editor.ts) — a guard written when nothing but code could attempt it
+   * ("we still refuse … to surface bad code"). The picker offers all six
+   * values, so a person can now walk into it, which makes the toast the only
+   * thing standing between them and a silent no-op. Pinned here so that
+   * remains true whoever changes the guard next.
+   */
+  test("a transition the orchestrator refuses reports instead of failing quietly", async () => {
+    const tasks = [makeTask({ id: "t1", status: "done" })]
+    const orch = makeOrch({
+      setStatus: vi.fn(async () => {
+        throw new Error("illegal transition for task t1: done -> error")
+      }),
+    })
+    const { ctx, notifyError, reload } = makeCtx({ tasks, orch, pickStatusResult: "error" })
+
+    await setStatusFlow(ctx, "t1")
+
+    expect(notifyError).toHaveBeenCalledWith("Couldn't set status: illegal transition for task t1: done -> error")
+    expect(reload).not.toHaveBeenCalled()
+  })
+
   test("a host with no picker adapter never opens one and never writes", async () => {
     const tasks = [makeTask({ id: "t1", status: "backlog" })]
     const orch = makeOrch()

--- a/packages/kobe/test/tui/task-actions-rename.test.ts
+++ b/packages/kobe/test/tui/task-actions-rename.test.ts
@@ -20,8 +20,9 @@ import {
   cycleVendorFlow,
   renameBranchFlow,
   renameTaskFlow,
+  setStatusFlow,
 } from "../../src/tui/lib/task-actions"
-import type { Task } from "../../src/types/task"
+import type { Task, TaskStatus } from "../../src/types/task"
 
 function makeTask(overrides: Omit<Partial<Task>, "id"> & { id: string }): Task {
   return {
@@ -40,6 +41,7 @@ type OrchMock = {
   setTitle: ReturnType<typeof vi.fn>
   setBranch: ReturnType<typeof vi.fn>
   setVendor: ReturnType<typeof vi.fn>
+  setStatus: ReturnType<typeof vi.fn>
 }
 
 function makeOrch(overrides: Partial<OrchMock> = {}): OrchMock {
@@ -47,18 +49,29 @@ function makeOrch(overrides: Partial<OrchMock> = {}): OrchMock {
     setTitle: vi.fn(async () => {}),
     setBranch: vi.fn(async () => {}),
     setVendor: vi.fn(async () => {}),
+    setStatus: vi.fn(async () => {}),
     ...overrides,
   }
 }
 
-function makeCtx(opts: { tasks: readonly Task[]; orch: OrchMock | null; promptTextResult?: string | undefined }): {
+function makeCtx(opts: {
+  tasks: readonly Task[]
+  orch: OrchMock | null
+  promptTextResult?: string | undefined
+  /** `undefined` = the picker was cancelled; omit the key entirely to leave
+   *  `pickStatus` unwired, the shape a host without the dialog has. */
+  pickStatusResult?: TaskStatus | undefined
+  wirePickStatus?: boolean
+}): {
   ctx: TaskActionContext
   promptText: ReturnType<typeof vi.fn>
+  pickStatus: ReturnType<typeof vi.fn>
   notifyError: ReturnType<typeof vi.fn>
   notifyInfo: ReturnType<typeof vi.fn>
   reload: ReturnType<typeof vi.fn>
 } {
   const promptText = vi.fn(async () => opts.promptTextResult)
+  const pickStatus = vi.fn(async () => opts.pickStatusResult)
   const notifyError = vi.fn()
   const notifyInfo = vi.fn()
   const reload = vi.fn(async () => {})
@@ -67,13 +80,14 @@ function makeCtx(opts: { tasks: readonly Task[]; orch: OrchMock | null; promptTe
     tasks: () => opts.tasks,
     confirm: async () => true,
     promptText,
+    ...(opts.wirePickStatus === false ? {} : { pickStatus }),
     logger: { error: vi.fn() },
     logPrefix: "[test]",
     notifyError,
     notifyInfo,
     reload,
   }
-  return { ctx, promptText, notifyError, notifyInfo, reload }
+  return { ctx, promptText, pickStatus, notifyError, notifyInfo, reload }
 }
 
 describe("renameTaskFlow", () => {
@@ -224,5 +238,103 @@ describe("cycleVendorFlow", () => {
     const { ctx } = makeCtx({ tasks, orch: null })
 
     await cycleVendorFlow(ctx, "t1")
+  })
+})
+
+/**
+ * The set-status flow. Its whole job is one RPC, so the tests name the FIELD
+ * that RPC carries: dropping the `setStatus` call, or sending the old value,
+ * has to turn something red here.
+ *
+ * The cosmetic contract is asserted as an absence — no other orchestrator
+ * method may fire. A status is a board LABEL (`docs/CONCEPTS.md`), and the
+ * failure this guards against is a future "canceled should also stop the
+ * session" edit quietly turning a relabel into a teardown.
+ */
+describe("setStatusFlow", () => {
+  test("writes the picked status and reloads", async () => {
+    const tasks = [makeTask({ id: "t1", status: "in_progress" })]
+    const orch = makeOrch()
+    const { ctx, pickStatus, notifyInfo, reload } = makeCtx({ tasks, orch, pickStatusResult: "in_review" })
+
+    await setStatusFlow(ctx, "t1")
+
+    expect(pickStatus).toHaveBeenCalledWith("in_progress")
+    expect(orch.setStatus).toHaveBeenCalledWith("t1", "in_review")
+    expect(notifyInfo).toHaveBeenCalledWith("Status → in_review")
+    expect(reload).toHaveBeenCalledTimes(1)
+  })
+
+  test("relabels only — no worktree, branch, vendor or title RPC rides along", async () => {
+    const tasks = [makeTask({ id: "t1", status: "in_progress" })]
+    const orch = makeOrch()
+    const { ctx } = makeCtx({ tasks, orch, pickStatusResult: "canceled" })
+
+    await setStatusFlow(ctx, "t1")
+
+    expect(orch.setStatus).toHaveBeenCalledWith("t1", "canceled")
+    expect(orch.setBranch).not.toHaveBeenCalled()
+    expect(orch.setTitle).not.toHaveBeenCalled()
+    expect(orch.setVendor).not.toHaveBeenCalled()
+  })
+
+  test("cancelled picker skips the RPC", async () => {
+    const tasks = [makeTask({ id: "t1", status: "backlog" })]
+    const orch = makeOrch()
+    const { ctx, reload } = makeCtx({ tasks, orch, pickStatusResult: undefined })
+
+    await setStatusFlow(ctx, "t1")
+
+    expect(orch.setStatus).not.toHaveBeenCalled()
+    expect(reload).not.toHaveBeenCalled()
+  })
+
+  test("re-picking the current status skips the RPC", async () => {
+    const tasks = [makeTask({ id: "t1", status: "done" })]
+    const orch = makeOrch()
+    const { ctx, reload } = makeCtx({ tasks, orch, pickStatusResult: "done" })
+
+    await setStatusFlow(ctx, "t1")
+
+    expect(orch.setStatus).not.toHaveBeenCalled()
+    expect(reload).not.toHaveBeenCalled()
+  })
+
+  test("RPC failure surfaces a toast and skips reload", async () => {
+    const tasks = [makeTask({ id: "t1", status: "backlog" })]
+    const orch = makeOrch({
+      setStatus: vi.fn(async () => {
+        throw new Error("daemon down")
+      }),
+    })
+    const { ctx, notifyError, notifyInfo, reload } = makeCtx({ tasks, orch, pickStatusResult: "error" })
+
+    await setStatusFlow(ctx, "t1")
+
+    expect(notifyError).toHaveBeenCalledWith("Couldn't set status: daemon down")
+    expect(notifyInfo).not.toHaveBeenCalled()
+    expect(reload).not.toHaveBeenCalled()
+  })
+
+  test("a host with no picker adapter never opens one and never writes", async () => {
+    const tasks = [makeTask({ id: "t1", status: "backlog" })]
+    const orch = makeOrch()
+    const { ctx, pickStatus } = makeCtx({ tasks, orch, pickStatusResult: "done", wirePickStatus: false })
+
+    await setStatusFlow(ctx, "t1")
+
+    expect(pickStatus).not.toHaveBeenCalled()
+    expect(orch.setStatus).not.toHaveBeenCalled()
+  })
+
+  test("unknown taskId is a no-op", async () => {
+    const tasks = [makeTask({ id: "t1" })]
+    const orch = makeOrch()
+    const { ctx, pickStatus } = makeCtx({ tasks, orch, pickStatusResult: "done" })
+
+    await setStatusFlow(ctx, "missing")
+
+    expect(pickStatus).not.toHaveBeenCalled()
+    expect(orch.setStatus).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## What / why

`docs/CONCEPTS.md` promised "Each Task has a `status` you set yourself", and that was false in the TUI: nothing rendered `task.status`, and nothing outside `rove api set-status` could change it. `orch.setStatus` was fully wired end to end, with exactly one non-CLI caller — the automatic `backlog → in_progress` rule in `monitor/status-rules.ts`. Rove's own injected system prompt tells every engine to `set-status … in_review` and then says the rest is "the user's decision" — a decision the user had no UI for.

Two additions close it:

- **`statusChip(task)`** in `row-view.ts`, beside `prCheckChip`: `◇` in review, `◆` done, `†` canceled, `×` error. `backlog` and `in_progress` return null — those are the states Rove drives itself, so a mark there would only say "this row is ordinary". It renders LEFT of the PR chip: the status is what a person said, the check is what CI reports, and they can disagree.
- **"Set status"** in the sidebar's right-click menu → a picker over the six values → one `task.status` RPC (`setStatusFlow`). No new chord: placement is the owner's call (AGENTS.md), so the menu carries it alone until one is agreed, and `tree-menu.ts`'s "every entry mirrors a chord" note now records that exception instead of quietly contradicting it.

The edit is **cosmetic and stays that way**: `canceled` relabels the task and leaves its worktree, branch and sessions exactly where they were — the framing `cli/api/verbs-edit.ts` already carries, now asserted as an absence (no other orchestrator method may fire).

Glyphs deliberately reuse the tree's existing failure vocabulary (`×` errored, `†` gone) rather than inventing a second one. `◇`/`◆` pair outline/filled the way the tab rows already use `○`/`●`; `fc-list :charset=25c6` puts `◆` in Fira Code, FiraCode/JetBrainsMono Nerd Font, Menlo and Monaco — wider coverage than the `◇` already shipped for the subagent prefix. The font-vocabulary guard in `sidebar-row-state.test.ts` only scanned the state glyphs, so a chip glyph could enter unchecked; it now scans both chip blocks too.

`visual:shot` gained an `rclick:X,Y` token. The menu has no chord, so a keyboard-driven shot can never open one — without it the context-menu screenshots below are not takeable at all.

## Pass criteria — commands and real output

Isolated scratch daemon throughout (`KOBE_VISUAL_PORT_BASE=5883`, home under `.scratch/opentui-visual-5883/home`, socket/pty/web all pinned there; verified with `ps eww`). The owner's `~/.rove` and `packages/kobe/.dev-sandbox` were never touched.

**1. API round-trip + live repaint**

```
$ rove api set-status --task-id 01M1FKWTVDEETZ8RH3NB1CCE4F --status in_review
{}
$ rove api get-task --task-id 01M1FKWTVDEETZ8RH3NB1CCE4F --pretty
    "status": "in_review",
```
The sidebar repainted with `◇` with no restart — captured in `after-set-row.png`, where the toast reads `Status → in_review` and the row it was set on already wears the chip.

**2. BEFORE / AFTER screenshots**

BEFORE is `origin/main` in a separate worktree, against its own fixture seeded to `in_review`, so both sides show the same task state and only the code differs.

| | |
|---|---|
| `/Users/jacksonc/i/kobe/.scratch/status/before-row.png` | task is `in_review`; row shows **no glyph** |
| `/Users/jacksonc/i/kobe/.scratch/status/before-menu.png` | menu ends Open → … → Reorder row → Delete; **no Set status** |
| `/Users/jacksonc/i/kobe/.scratch/status/after-row.png` | `Visual Fixture` (in_review) wears `◇`; `ship-the-chip` (backlog) stays bare |
| `/Users/jacksonc/i/kobe/.scratch/status/after-menu.png` | **Set status** between Reorder row and Delete |
| `/Users/jacksonc/i/kobe/.scratch/status/after-picker.png` | all six statuses, cursor on the task's current one, marked `current` |
| `/Users/jacksonc/i/kobe/.scratch/status/after-set-row.png` | set through the menu → row repaints + `Status → in_review` toast |

`/Users/jacksonc/i/kobe/.scratch/status/api-evidence.txt` holds the raw command output.

**3. The edit stayed cosmetic** — `get-task` before vs after setting the status *through the menu*, on a task with a real materialized worktree:

```
9c9   <     "status": "backlog",     >     "status": "in_review",
14c14 <     "updatedAt": "…:12:53"   >     "updatedAt": "…:13:51"

worktreePath equal: True -> …/worktrees/fixture-repo-d1b75187148b/caiman
branch equal:       True -> ship-the-chip
tabs equal:         True -> []
changed task fields: ['status', 'updatedAt']
```

**4. Mutation** — three sites, each verified red then restored:

- delete `await ctx.orch.setStatus(taskId, next)` → 3 red in `task-actions-rename.test.ts`, naming the field: `expected "spy" to be called with arguments: [ 't1', 'in_review' ]`
- delete the `in_review` case from `statusChip` → `sidebar-row-state.golden.txt` red **and** the `worktree-status-chip` render frame red
- drop `pickStatus` from the host context → 2 red in `host-task-actions-set-status.test.ts` (the adapter seam: a flow with no picker returns cleanly and writes nothing)

**5. Gates**

- `bun x tsc --noEmit` — clean
- `bun run lint` (repo root) — `Checked 1314 files. No fixes applied.`
- `bun test test/render` — `368 pass, 0 fail`
- `bun run scripts/check-i18n.ts` — `734 keys × 2 locales in sync`
- `bun run test:fast` — `4093 passed`, 4 failing. Those 4 are the checkout LOCATION, not this change: they are `project-eligibility` path-shape rejections, and running the same two files on **unmodified `origin/main`** reproduces them — `'roveInternal'` from `~/.rove/worktrees/…`, `'temporary'` from `/tmp/…`. This diff touches neither file. CI runs from a normal path.

## Tests

- `test/golden/sidebar-row-state.golden.txt` — new `board status chip` block over the whole `TaskStatus` union, so the two deliberate silences are pinned and a seventh status shows up in the diff on the day it lands.
- `test/render/golden/worktree-status-chip.frame.txt` — new scene; a real OpenTUI frame showing `◇ ✓` cluster ordering, all four glyphs, and a bare `backlog` row. No other frame changed.
- `test/render/status-picker-dialog.test.tsx` — real keypresses; every assertion is on the value that came OUT, since an off-by-one produces a dialog that looks perfect and writes the neighbouring status.
- `test/render/sidebar-tree-menu.test.tsx` — a real right-click through the renderer proving the menu row dispatches, not just renders.
- `test/tui-react/host-task-actions-set-status.test.ts` — the adapter seam.

## Note for review

`tree-menu.ts` documents "a row's menu is what that row's KEYBOARD already does". `setStatus` is the first entry that breaks it, and deliberately: a chord needs owner sign-off, and the alternative was leaving the promise in CONCEPTS.md false for another round. The module note now says so. **If you'd rather it wait for a chord, say the word and I'll pull the menu entry and keep the chip.**

file-size-exemption: packages/kobe/src/tui-react/workspace/host.tsx — was exactly 500 lines before this change; the diff adds one JSX prop (`onSetStatusRequest`). The one real seam left in it (`startWorkspaceHost`, the process-boot half) needs edits to `src/tui/index.tsx` and `test/tui/start-tui.test.ts`, both outside this change's slice — happy to do it as a follow-up.
