### PR TITLE
chore: retract the three EngineIdentity fields nobody reads

### DIFF
--- a/.changeset/retract-unread-engine-identity.md
+++ b/.changeset/retract-unread-engine-identity.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Retire the `productName`, `assistantName`, and `inputPlaceholder` fields on engine identity. Nothing ever read them: only `shortName` reaches the UI, so the built-in engines, plugin engines, and the plugin manifest parser now carry `shortName` alone. Plugin manifests that still set `product_name`, `assistant_name`, or `input_placeholder` keep loading unchanged, since unknown identity keys are ignored.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,7 +85,7 @@ opentui boxes are Yoga flexbox. Default to flex flow (`flexGrow`/`flexShrink`/`f
 
 ### Engine-owned UI data
 The engine adapter is the source of truth for agent/product identity, capabilities, history, and telemetry. Neutral layers (TUI, web, orchestrator) must NOT hard-code Claude/Codex strings or derive vendor metrics themselves:
-- Name/label/placeholder copy comes from the engine registry (`AIEngine.identity`: `productName`/`shortName`/…) — e.g. `Ask ${engine.shortName}`, never a literal `"Ask Claude…"`.
+- Name/label copy comes from the engine registry (`AIEngine.identity.shortName`) — e.g. `Ask ${engine.shortName}`, never a literal `"Ask Claude…"`.
 - Model catalogs + context math come from `EngineCapabilities`, keyed by the task's vendor. History is an engine-owned `EngineHistory`; token/context/speed are engine-normalized — don't parse vendor transcript files or reconstruct speed in the UI.
 - Subagent steps are engine-owned nested data (tagged by `parentId`, nested one level under the parent Agent row), not flattened transcript noise.
 - A new pane needing engine-specific data → extend the engine contract first; don't thread ad-hoc vendor checks through TUI/orchestrator code.

--- a/docs/PLUGIN-AUTHORING.md
+++ b/docs/PLUGIN-AUTHORING.md
@@ -173,11 +173,8 @@ name = "Aider"                   # display name in the selector and Settings
 command = ["aider"]              # launch argv; argv[0] is the binary
 # process_names = ["aider-core"] # extra ps basenames (post-launch renames)
 
-[engines.identity]               # optional product identity for UI copy
-product_name = "Aider"           # each field falls back to `name`
-short_name = "Aider"
-assistant_name = "Aider"         # how the assistant is referred to
-input_placeholder = "Ask Aider…" # composer placeholder
+[engines.identity]               # optional product identity for UI labels
+short_name = "Aider"             # falls back to `name`
 
 [[engines.rules]]                # screen-state rules, first match wins;
 state = "blocked"                # declare blocked before working

--- a/packages/kobe-daemon/src/plugins/manifest.ts
+++ b/packages/kobe-daemon/src/plugins/manifest.ts
@@ -102,13 +102,10 @@ export interface PluginEngine {
   readonly processNames?: readonly string[]
   /** Screen-state rules, first match wins (declare blocked before working). */
   readonly rules: readonly PluginEngineRule[]
-  /** Product identity for UI copy (composer placeholder, labels). Absent
-   *  fields fall back to `name`/id derivations. */
+  /** Product identity for UI labels. Absent `shortName` falls back to `name`.
+   *  Unknown keys in the table are ignored. */
   readonly identity?: {
-    readonly productName?: string
     readonly shortName?: string
-    readonly assistantName?: string
-    readonly inputPlaceholder?: string
   }
 }
 
@@ -434,15 +431,9 @@ function parseCanonicalPluginManifest(text: string): ParsedPluginManifest {
       const idt = identityRaw as Record<string, unknown>
       const opt = (key: string): string | undefined =>
         idt[key] === undefined ? undefined : asString(idt[key], `engines[${i}].identity.${key}`)
-      const productName = opt("product_name")
       const shortName = opt("short_name")
-      const assistantName = opt("assistant_name")
-      const inputPlaceholder = opt("input_placeholder")
       identity = {
-        ...(productName !== undefined ? { productName } : {}),
         ...(shortName !== undefined ? { shortName } : {}),
-        ...(assistantName !== undefined ? { assistantName } : {}),
-        ...(inputPlaceholder !== undefined ? { inputPlaceholder } : {}),
       }
     }
     return {

--- a/packages/kobe/src/engine/claude-code-local/capabilities.ts
+++ b/packages/kobe/src/engine/claude-code-local/capabilities.ts
@@ -26,8 +26,5 @@ export const claudeCapabilities: EngineCapabilities = {
 
 export const claudeIdentity: EngineIdentity = {
   vendorId: "claude",
-  productName: "Claude Code",
   shortName: "Claude",
-  assistantName: "Claude",
-  inputPlaceholder: "Ask Claude…",
 }

--- a/packages/kobe/src/engine/codex-local/capabilities.ts
+++ b/packages/kobe/src/engine/codex-local/capabilities.ts
@@ -23,8 +23,5 @@ export const codexCapabilities: EngineCapabilities = {
 
 export const codexIdentity: EngineIdentity = {
   vendorId: "codex",
-  productName: "Codex",
   shortName: "Codex",
-  assistantName: "Codex",
-  inputPlaceholder: "Ask Codex…",
 }

--- a/packages/kobe/src/engine/plugin-engines.ts
+++ b/packages/kobe/src/engine/plugin-engines.ts
@@ -30,14 +30,11 @@ export function loadPluginEngines(homeDir?: string): readonly string[] {
       try {
         const { manifest } = readPluginManifest(entry.root)
         for (const engine of manifest.engines) {
-          // Identity falls back per-field to the engine's display name — a
-          // plugin declaring nothing still gets sensible composer copy.
+          // shortName falls back to the engine's display name — a plugin
+          // declaring nothing still gets a sensible label.
           const identity = {
             vendorId: engine.id,
-            productName: engine.identity?.productName ?? engine.name,
             shortName: engine.identity?.shortName ?? engine.name,
-            assistantName: engine.identity?.assistantName ?? engine.name,
-            inputPlaceholder: engine.identity?.inputPlaceholder ?? `Ask ${engine.identity?.shortName ?? engine.name}…`,
           }
           const ok = registerPluginEngine(engine.id, {
             displayName: engine.name,

--- a/packages/kobe/src/types/engine.ts
+++ b/packages/kobe/src/types/engine.ts
@@ -123,10 +123,7 @@ export interface EngineCapabilities {
  */
 export interface EngineIdentity {
   readonly vendorId: VendorId
-  readonly productName: string
   readonly shortName: string
-  readonly assistantName: string
-  readonly inputPlaceholder: string
 }
 
 /**

--- a/packages/kobe/test/engine/plugin-engines-load.test.ts
+++ b/packages/kobe/test/engine/plugin-engines-load.test.ts
@@ -61,6 +61,7 @@ name = "Aider"
 command = ["aider"]
 
 [engines.identity]
+short_name = "Aid"
 input_placeholder = "Ask Aider anything…"
 
 [[engines.rules]]
@@ -69,18 +70,21 @@ any = ["ctrl-c to interrupt"]
 `
 
 describe("loadPluginEngines", () => {
-  it("registers enabled plugins' engines with identity fallbacks", () => {
+  it("registers enabled plugins' engines, ignoring retired identity keys", () => {
     homeWith([{ id: "acme.engines", root: pluginRoot(MANIFEST) }])
     expect(loadPluginEngines()).toEqual(["aider"])
     const entry = engineEntry("aider")
     expect(entry.displayName).toBe("Aider")
-    // Declared field survives; undeclared ones fall back to the name.
-    expect(entry.identity).toMatchObject({
-      vendorId: "aider",
-      productName: "Aider",
-      shortName: "Aider",
-      inputPlaceholder: "Ask Aider anything…",
-    })
+    // The manifest still sets `input_placeholder` (a retired key): it must
+    // register without throwing and the field is simply absent.
+    expect(entry.identity).toEqual({ vendorId: "aider", shortName: "Aid" })
+  })
+
+  it("shortName falls back to the engine name when identity is absent", () => {
+    const bare = MANIFEST.replace(/\[engines\.identity\][^\[]*/, "")
+    homeWith([{ id: "acme.engines", root: pluginRoot(bare) }])
+    expect(loadPluginEngines()).toEqual(["aider"])
+    expect(engineEntry("aider").identity).toEqual({ vendorId: "aider", shortName: "Aider" })
   })
 
   it("skips disabled plugins and unreadable manifests without throwing", () => {

--- a/packages/kobe/test/engine/plugin-engines.test.ts
+++ b/packages/kobe/test/engine/plugin-engines.test.ts
@@ -82,12 +82,9 @@ product_name = "Aider"
 short_name = "Aider"
 input_placeholder = "Ask Aider…"`,
     )
+    // Retired keys (product_name / input_placeholder) are ignored, not errors.
     const { manifest } = parsePluginManifest(withIdentity)
-    expect(manifest.engines[0]?.identity).toEqual({
-      productName: "Aider",
-      shortName: "Aider",
-      inputPlaceholder: "Ask Aider…",
-    })
+    expect(manifest.engines[0]?.identity).toEqual({ shortName: "Aider" })
   })
 
   it("a manifest without engines parses to an empty list", () => {
@@ -105,13 +102,7 @@ describe("plugin engine registration", () => {
       displayName: "Aider",
       defaultCommand: ["aider"],
       screenManifest: { rules: [{ state: "working", any: ["ctrl-c to interrupt"] }] },
-      identity: {
-        vendorId: "aider",
-        productName: "Aider",
-        shortName: "Aider",
-        assistantName: "Aider",
-        inputPlaceholder: "Ask Aider…",
-      },
+      identity: { vendorId: "aider", shortName: "Aider" },
     })
     expect(ok).toBe(true)
     expect(pluginEngineIds()).toEqual(["aider"])
@@ -121,13 +112,7 @@ describe("plugin engine registration", () => {
     expect(entry.screenManifest).toBeDefined()
     expect(entry.builtin).toBe(false)
     // Identity rides the overlay — TUI copy comes from here, never hard-coded.
-    expect(entry.identity).toEqual({
-      vendorId: "aider",
-      productName: "Aider",
-      shortName: "Aider",
-      assistantName: "Aider",
-      inputPlaceholder: "Ask Aider…",
-    })
+    expect(entry.identity).toEqual({ vendorId: "aider", shortName: "Aider" })
   })
 
   it("a shipped catalog id cannot be overridden by a plugin", () => {

--- a/packages/kobe/test/engine/registry.test.ts
+++ b/packages/kobe/test/engine/registry.test.ts
@@ -102,7 +102,7 @@ describe("engineEntry — built-in vendors", () => {
 
   it("exposes Codex identity and its harness default model through capabilities", () => {
     const entry = engineEntry("codex")
-    expect(entry.identity?.inputPlaceholder).toBe("Ask Codex…")
+    expect(entry.identity?.shortName).toBe("Codex")
     expect(entry.capabilities?.defaultModelId()).toBe("gpt-5.3-codex")
     expect(entry.capabilities?.permissionModes).toEqual([])
     expect(entry.terminalTitle?.ownsStatus).toBe(true)


### PR DESCRIPTION
Closes #87 (also #49 item 1).

## What / why

`productName`, `assistantName`, and `inputPlaceholder` on `EngineIdentity` were produced by both vendors, populated with per-field fallbacks for plugins, parsed from plugin manifests, and read by nothing. Only `shortName` has a consumer (it becomes `displayName` in `builtin-engines.ts`). This drops the three fields from the type, both vendor identity objects, `plugin-engines.ts`, and the daemon manifest parser, and narrows `docs/PLUGIN-AUTHORING.md` plus the "Engine-owned UI data" bullet in `AGENTS.md` to `shortName`.

Old manifests that still set `product_name` / `assistant_name` / `input_placeholder` keep loading: unknown identity keys were already ignored, and `plugin-engines-load.test.ts` now pins that with a manifest that sets `input_placeholder` and registers fine with the field absent.

## Deletion proven by absence

```
$ grep -rn "productName\|assistantName\|inputPlaceholder\|product_name\|assistant_name\|input_placeholder" packages/ docs/ AGENTS.md --include='*.ts' --include='*.tsx' --include='*.md' | grep -v node_modules
packages/kobe/test/engine/plugin-engines-load.test.ts:65:input_placeholder = "Ask Aider anything…"
packages/kobe/test/engine/plugin-engines-load.test.ts:78:    // The manifest still sets `input_placeholder` (a retired key): it must
packages/kobe/test/engine/plugin-engines.test.ts:81:product_name = "Aider"
packages/kobe/test/engine/plugin-engines.test.ts:83:input_placeholder = "Ask Aider…"`,
packages/kobe/test/engine/plugin-engines.test.ts:85:    // Retired keys (product_name / input_placeholder) are ignored, not errors.
```

The only remaining hits are the two tests that deliberately feed the retired snake_case keys to prove they are ignored. Zero hits in `src/`, `docs/`, `AGENTS.md`.

## Pass criteria

```
$ cd packages/kobe && env -u ROVE_INVOKED_AS bun x vitest run test/engine/registry.test.ts test/engine/plugin-engines.test.ts test/engine/plugin-engines-load.test.ts
 Test Files  3 passed (3)
      Tests  37 passed (37)

$ env -u ROVE_INVOKED_AS bun run test:fast
 Test Files  2 failed | 413 passed (415)
      Tests  4 failed | 4078 passed (4082)
```
The 4 failures are `test/state/project-eligibility.test.ts` (2) and `test/cli/open-dir-cmd.test.ts` (2), the known path-shape false failures when the checkout lives under `~/.rove/worktrees` (project-eligibility treats that path as roveInternal). Neither file references identity; CI runs from a plain checkout.

```
$ bun run lint
Checked 1310 files in 1164ms. No fixes applied.

$ cd packages/kobe && env -u ROVE_INVOKED_AS bun x tsc --noEmit   # exit 0
$ cd packages/kobe-daemon && bun x tsc --noEmit                    # exit 0
```

## End-to-end: `rove api engine-list --pretty` before vs after (scratch home)

```
$ diff engine-list-before.txt engine-list-after.txt && echo IDENTICAL
IDENTICAL
```
Both captures: `/Users/jacksonc/i/kobe/.scratch/retract-engineident/engine-list-{before,after}.txt`. Output:

```json
{
  "engines": [
    { "id": "claude",  "name": "Claude",  "command": "claude",  "protocol": "claude",  "builtin": true },
    { "id": "codex",   "name": "Codex",   "command": "codex",   "protocol": "codex",   "builtin": true },
    { "id": "copilot", "name": "Copilot", "command": "copilot", "protocol": "copilot", "builtin": true },
    { "id": "kimi",    "name": "Kimi",    "command": "kimi",    "protocol": "kimi",    "builtin": true }
  ]
}
```

No UI change, so no screenshots. Daemon code changed (`manifest.ts`): `rove daemon restart` after install.
