### PR TITLE
fix: stop the daemon synthesizing a claude-only engine list

### DIFF
--- a/.changeset/daemon-engines-no-synthesized-claude.md
+++ b/.changeset/daemon-engines-no-synthesized-claude.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+The daemon's `/api/engines` route no longer invents a lone Claude entry when no engine is available. That synthesized row overwrote the web dashboard's own four-built-in fallback, so on a machine with no detected engine, or with every engine switched off in Settings, every vendor picker collapsed to Claude with no way to reach the rest. An empty list now stays empty and the New Task dialog offers all four built-ins again.

--- a/packages/kobe-daemon/src/daemon/web-server.ts
+++ b/packages/kobe-daemon/src/daemon/web-server.ts
@@ -185,7 +185,9 @@ async function enginesResponse(runtime: DaemonRuntimeAdapter): Promise<Response>
       label: runtime.engineDisplayName(id),
       effortLevels: runtime.engineEntry(id).effortLevels,
     }))
-    return Response.json({ engines: engines.length > 0 ? engines : [{ id: "claude", label: "Claude" }] })
+    // Empty stays empty: the SPA keeps its own four-built-in fallback only
+    // when the route yields nothing, and a synthesized entry defeats that.
+    return Response.json({ engines })
   } catch (err) {
     return webRpcErrorResponse(err, 500)
   }

--- a/packages/kobe-web/test/bridge-routes.test.ts
+++ b/packages/kobe-web/test/bridge-routes.test.ts
@@ -223,13 +223,22 @@ describe("daemon web request handler", () => {
   })
 
   describe("/api/engines", () => {
-    it("returns at least the claude entry", async () => {
-      const { handle } = build()
+    it("lists exactly the engines the runtime reports available", async () => {
+      const { handle } = build({ runtime: { availableEngineIds: async () => ["codex", "kimi"] } })
       const res = await handle(new Request("http://localhost/api/engines"))
       expect(res.status).toBe(200)
       const json = (await res.json()) as { engines: Array<{ id: string; label: string }> }
-      expect(json.engines.length).toBeGreaterThan(0)
-      expect(json.engines.some((e) => e.id === "claude")).toBe(true)
+      expect(json.engines.map((e) => e.id)).toEqual(["codex", "kimi"])
+      expect(json.engines.every((e) => typeof e.label === "string" && e.label.length > 0)).toBe(true)
+    })
+
+    it("returns an empty list when no engine is available — never a synthesized entry", async () => {
+      // The SPA keeps its own four-built-in fallback only when this is
+      // empty; a made-up claude row would overwrite that with one engine.
+      const { handle } = build({ runtime: { availableEngineIds: async () => [] } })
+      const res = await handle(new Request("http://localhost/api/engines"))
+      expect(res.status).toBe(200)
+      expect(await res.json()).toEqual({ engines: [] })
     })
   })
 

--- a/packages/kobe-web/test/route-fakes.ts
+++ b/packages/kobe-web/test/route-fakes.ts
@@ -5,6 +5,7 @@
  */
 
 import type { DaemonRequestName } from "@sma1lboy/kobe-daemon/daemon/protocol"
+import type { DaemonRuntimeAdapter } from "@sma1lboy/kobe-daemon/daemon/runtime"
 import { createDaemonWebRequestHandler, type DaemonWebLink } from "@sma1lboy/kobe-daemon/daemon/web-server"
 import { daemonRuntime } from "../../kobe/src/core/daemon-runtime.ts"
 import { vi } from "vitest"
@@ -12,6 +13,9 @@ import { vi } from "vitest"
 export interface FakeOpts {
   snapshot?: unknown
   onRequest?: (name: string, payload: unknown) => unknown
+  /** Overrides spread over the real daemonRuntime, so a test can pin what
+   *  the machine would otherwise decide (e.g. which engines are installed). */
+  runtime?: Partial<DaemonRuntimeAdapter>
 }
 
 export function fakeLink(opts: FakeOpts = {}): DaemonWebLink & { calls: Array<{ name: string; payload: unknown }> } {
@@ -32,7 +36,8 @@ export function build(opts: FakeOpts = {}) {
   const link = fakeLink(opts)
   const tearDown = vi.fn()
   const sseSends = new Set<(type: string, data: unknown) => void>()
-  const handle = createDaemonWebRequestHandler({ runtime: daemonRuntime, link, sseSends, tearDownSession: tearDown })
+  const runtime = { ...daemonRuntime, ...opts.runtime }
+  const handle = createDaemonWebRequestHandler({ runtime, link, sseSends, tearDownSession: tearDown })
   return { handle, link, tearDown, sseSends }
 }
 

--- a/packages/kobe/test/architecture/engine-owned-copy.test.ts
+++ b/packages/kobe/test/architecture/engine-owned-copy.test.ts
@@ -38,12 +38,13 @@ const VENDOR_WORD = /\b(Claude|Codex|Copilot|Kimi)\b/
  * line contains one of its allowed fragments.
  */
 const EXEMPT_LINES: Record<string, readonly string[]> = {
-  // Both serve the engine-owned list; the literals only fire against an
-  // older bridge / empty registry (see each file's header comment). The SPA
-  // covers every BUILTIN_VENDOR because that fallback is the only other path
-  // to a vendor — a short list silently made the rest unselectable.
+  // The SPA's fallback only fires before `/api/engines` answers or against an
+  // older bridge (see the file's header comment). It covers every
+  // BUILTIN_VENDOR because it is the only other path to a vendor — a short
+  // list silently made the rest unselectable. The daemon route has NO
+  // fallback of its own: an empty registry yields `{ engines: [] }`, which is
+  // what lets the SPA keep this list.
   "packages/kobe-web/src/lib/engines.ts": ['label: "Claude"', 'label: "Codex"', 'label: "Copilot"', 'label: "Kimi"'],
-  "packages/kobe-daemon/src/daemon/web-server.ts": ['label: "Claude"'],
 }
 
 function sourceFiles(dir: string, files: string[] = []): string[] {


### PR DESCRIPTION
## What / why

`packages/kobe-daemon/src/daemon/web-server.ts` returned `[{ id: "claude", label: "Claude" }]` whenever `availableEngineIds()` was empty. The web SPA (`packages/kobe-web/src/lib/engines.ts`) keeps its own four-built-in fallback only when `/api/engines` yields an empty list, so that one synthesized row passed the guard and replaced four vendors with one. On a machine with no detected engine, or with every engine disabled in Settings, every web vendor picker collapsed to Claude with no path to the rest.

- `web-server.ts`: return `{ engines }` unchanged. The vendor literal goes with the ternary.
- `packages/kobe-web/test/route-fakes.ts`: `build()` takes an optional `runtime` partial spread over the real `daemonRuntime`.
- `packages/kobe-web/test/bridge-routes.test.ts`: the old test passed only because this machine has Claude installed. It now stubs `availableEngineIds` and asserts the exact list; a second case pins zero engines → `{ engines: [] }`.
- `packages/kobe/test/architecture/engine-owned-copy.test.ts`: dropped the `web-server.ts` exemption, as the test itself asks once the fragment is gone.
- `engines.ts` untouched.

## Pass criteria (ran locally)

```
$ cd packages/kobe-web && bun run test
 Test Files  70 passed (70)
      Tests  570 passed (570)

$ bun run lint            # repo root
Checked 1310 files in 334ms. No fixes applied.

$ cd packages/kobe && env -u ROVE_INVOKED_AS bun x tsc --noEmit
(exit 0)

$ cd packages/kobe && env -u ROVE_INVOKED_AS bun run test:fast
 Test Files  2 failed | 413 passed (415)
      Tests  4 failed | 4077 passed (4081)
```

The 4 remaining `test:fast` failures are `test/state/project-eligibility.test.ts` and `test/cli/open-dir-cmd.test.ts`, the known path-shape false positives when running inside `~/.rove/worktrees`; those files are byte-identical to `origin/main`. `test/architecture/engine-owned-copy.test.ts` passes.

## End to end

Scratch home `/Users/jacksonc/i/kobe/.scratch/enginefallback/home` with `state.json` = `{"disabledEngineIds":["claude","codex","kimi","opencode","cursor","copilot"]}`, sandbox daemon on :5283 serving the built SPA.

```
# BEFORE (origin/main web-server.ts)
$ curl -s -H "Authorization: Bearer $(cat $H/.rove/web-token)" localhost:5283/api/engines
{"engines":[{"id":"claude","label":"Claude"}]}

# AFTER
$ curl -s -H "Authorization: Bearer $(cat $H/.rove/web-token)" localhost:5283/api/engines
{"engines":[]}
```

## Screenshots (New Task dialog, engine picker)

- BEFORE: `/Users/jacksonc/i/kobe/.scratch/enginefallback/before-engine-picker.png` — one button, "Claude"
- AFTER: `/Users/jacksonc/i/kobe/.scratch/enginefallback/after-engine-picker.png` — Claude / Codex / Copilot / Kimi