### PR TITLE
feat: copy a task's branch name or worktree path from the row's context menu

### DIFF
--- a/.changeset/copy-task-branch-and-path.md
+++ b/.changeset/copy-task-branch-and-path.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+A task row's right-click menu now offers **Copy branch name** and **Copy path**, so a `git checkout` or `cd` into a task's worktree from another shell no longer means retyping a truncated sidebar label or shelling out to `rove api get-task`. Both write through the same two channels the terminal's copy-on-select already uses (the local clipboard command plus OSC 52, which is what reaches your machine over SSH) and confirm with a toast naming what was copied. Copy path copies the recorded worktree path without creating the worktree, and a project-main or directory row, whose stored branch is empty, offers only Copy path.

--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -159,9 +159,13 @@ anywhere else, or `esc`, dismisses it. Common row actions also have direct
 chords. A Task or tab row also offers **New conversation** (the `ctrl+e`
 engine/shell picker) and **New shell** (a bare shell tab) for that worktree,
 both enter the Task first, exactly as pressing the chord there would.
-**Set status** is the one entry with no chord: it opens a picker over the six
-Task statuses and writes the one you choose. (If right-click opens your
-*terminal's* menu instead, see [Troubleshooting](./TROUBLESHOOTING.md).)
+Three entries have no chord. **Set status** opens a picker over the six Task
+statuses and writes the one you choose. **Copy branch name** and **Copy path**
+put the Task's branch or recorded worktree path on the system clipboard (local
+clipboard command plus OSC 52, so it also works over SSH); copying never
+creates the worktree, and a project-main or directory row, whose stored branch
+is empty, offers only Copy path. (If right-click opens your *terminal's* menu
+instead, see [Troubleshooting](./TROUBLESHOOTING.md).)
 
 ## Terminal scrollback
 

--- a/docs/TUI.md
+++ b/docs/TUI.md
@@ -23,7 +23,9 @@ moves left or right, and `ctrl+q` returns from the workspace to Tasks. From the
 Tasks pane, right arrow enters the current engine tab. Mouse clicks select rows
 and tabs; right-clicking a sidebar row opens the same common actions available
 from the keyboard, including **New conversation** and **New shell** for that
-Task's worktree. Clicking anywhere else dismisses that menu.
+Task's worktree, plus **Copy branch name** and **Copy path**, which put the
+Task's branch or worktree path on the system clipboard for a `git checkout` or
+`cd` in another shell. Clicking anywhere else dismisses that menu.
 
 Zen mode (`ctrl+a` `z`) hides Files and lets the workspace use the freed width.
 The Tasks rail remains visible. Below 70 columns, the separate

--- a/packages/kobe/src/tui-react/panes/sidebar/types.ts
+++ b/packages/kobe/src/tui-react/panes/sidebar/types.ts
@@ -41,6 +41,11 @@ export type SidebarTaskCallbacks = {
    * unlike its siblings this one never arrives from `use-tree-bindings`.
    */
   onSetStatusRequest?: (taskId: string) => void
+  /**
+   * Copy the task's branch name or worktree path to the system clipboard.
+   * Menu-only, like `onSetStatusRequest` — no chord yet.
+   */
+  onCopyRequest?: (taskId: string, field: "branch" | "path") => void
 }
 
 export type SidebarProps = SidebarTaskCallbacks & {

--- a/packages/kobe/src/tui-react/panes/sidebar/use-tree-menu.ts
+++ b/packages/kobe/src/tui-react/panes/sidebar/use-tree-menu.ts
@@ -178,6 +178,12 @@ export function useTreeMenu(deps: TreeMenuDeps): TreeMenu {
         case "setStatus":
           actions.onSetStatusRequest?.(taskId)
           break
+        case "copyBranch":
+          actions.onCopyRequest?.(taskId, "branch")
+          break
+        case "copyPath":
+          actions.onCopyRequest?.(taskId, "path")
+          break
         case "delete":
           actions.onDeleteRequest?.(taskId)
           break

--- a/packages/kobe/src/tui-react/workspace/host-sidebar.tsx
+++ b/packages/kobe/src/tui-react/workspace/host-sidebar.tsx
@@ -48,6 +48,8 @@ export interface HostSidebarProps {
   readonly onPinRequest: (taskId: string) => void
   /** Menu-only (no chord): open the board-status picker for the row's task. */
   readonly onSetStatusRequest: (taskId: string) => void
+  /** Menu-only (no chord): copy the row's branch name or worktree path. */
+  readonly onCopyRequest: (taskId: string, field: "branch" | "path") => void
   readonly moveMode: boolean
   readonly onMoveRequest: (taskId: string, delta: -1 | 1) => void
   readonly onMoveModeExit: () => void
@@ -127,6 +129,7 @@ export function HostSidebar(props: HostSidebarProps) {
     onRenameRequest: props.onRenameRequest,
     onPinRequest: props.onPinRequest,
     onSetStatusRequest: props.onSetStatusRequest,
+    onCopyRequest: props.onCopyRequest,
     onLocalMergeRequest: props.onLocalMergeRequest,
     moveMode: props.moveMode,
     onMoveRequest: props.onMoveRequest,

--- a/packages/kobe/src/tui-react/workspace/host-task-actions.ts
+++ b/packages/kobe/src/tui-react/workspace/host-task-actions.ts
@@ -20,9 +20,12 @@
  */
 
 import { errorMessage } from "@/lib/error-message"
+import { useRenderer } from "@opentui/react"
 import type { RemoteOrchestrator } from "../../client/remote-orchestrator.ts"
+import { copyTextToSystemClipboard } from "../../tui/lib/clipboard-copy"
 import {
   applyVendorChange,
+  copyTaskFieldFlow,
   cycleVendorFlow,
   deleteTaskFlow,
   renameTaskFlow,
@@ -62,10 +65,13 @@ export type WorkspaceTaskActions = {
   moveTask: (id: string, delta: -1 | 1) => Promise<void>
   /** Tree-menu "Set status" — a picker over the six board statuses. */
   setStatus: (id: string) => Promise<void>
+  /** Tree-menu "Copy branch name" / "Copy path" — system clipboard + toast. */
+  copyTaskField: (id: string, field: "branch" | "path") => void
 }
 
 export function useWorkspaceTaskActions(deps: WorkspaceTaskActionDeps): WorkspaceTaskActions {
   const { orchestrator, tasks, dialog, notifyError } = deps
+  const renderer = useRenderer()
 
   const taskActions: CreateTaskContext = {
     ...buildBaseCreateTaskContext({
@@ -82,6 +88,10 @@ export function useWorkspaceTaskActions(deps: WorkspaceTaskActionDeps): Workspac
     // The set-status picker, supplied as an adapter so `setStatusFlow` stays
     // opentui-free like every other flow (task-actions.ts's testability rule).
     pickStatus: (current) => StatusPickerDialog.show(dialog, { current }),
+    // The clipboard writer, supplied the same way: both channels the terminal
+    // pane's copy-on-select uses (local pbcopy-style pipe + OSC52 through the
+    // renderer, which is the half that reaches the user's machine over SSH).
+    copyText: (text) => copyTextToSystemClipboard(text, (payload) => renderer?.copyToClipboardOSC52(payload)),
     onTaskDeleted: (() => {
       // Reclaim the deleted task's terminal-tab snapshot (O19), THEN move the
       // host cursor off it (the shared selection move — the base's bare
@@ -144,5 +154,6 @@ export function useWorkspaceTaskActions(deps: WorkspaceTaskActionDeps): Workspac
     togglePin,
     moveTask,
     setStatus: (id) => setStatusFlow(taskActions, id),
+    copyTaskField: (id, field) => copyTaskFieldFlow(taskActions, id, field),
   }
 }

--- a/packages/kobe/src/tui-react/workspace/host.tsx
+++ b/packages/kobe/src/tui-react/workspace/host.tsx
@@ -150,19 +150,29 @@ export function WorkspaceRoot(props: { orchestrator: RemoteOrchestrator }) {
 
   // Task-action callbacks (new/delete/rename/branch/engine/pin/move)
   // — the shared lib/task-actions flows live in host-task-actions.ts.
-  const { createTask, deleteTask, renameTask, renameBranch, cycleVendor, setVendor, togglePin, moveTask, setStatus } =
-    useWorkspaceTaskActions({
-      orchestrator: orch,
-      tasks: () => tasks,
-      dialog,
-      notifyError,
-      notifyInfo,
-      selectedId: () => selectedId,
-      setSelectedId,
-      selectedTask: () => selectedTask,
-      activateTask,
-      forgetTaskTabs: (id) => forgetTaskTabs(kv, id),
-    })
+  const {
+    createTask,
+    deleteTask,
+    renameTask,
+    renameBranch,
+    cycleVendor,
+    setVendor,
+    togglePin,
+    moveTask,
+    setStatus,
+    copyTaskField,
+  } = useWorkspaceTaskActions({
+    orchestrator: orch,
+    tasks: () => tasks,
+    dialog,
+    notifyError,
+    notifyInfo,
+    selectedId: () => selectedId,
+    setSelectedId,
+    selectedTask: () => selectedTask,
+    activateTask,
+    forgetTaskTabs: (id) => forgetTaskTabs(kv, id),
+  })
 
   // Imperative tab handles: refs handed by TerminalTabs + FileTree/PR actions.
   const editor = useEditorHandles({ orchestrator: orch, worktree, selectedId, focus, notifyError })
@@ -390,6 +400,7 @@ export function WorkspaceRoot(props: { orchestrator: RemoteOrchestrator }) {
           onRenameRequest={(id) => void renameTask(id)}
           onPinRequest={(id) => void togglePin(id)}
           onSetStatusRequest={(id) => void setStatus(id)}
+          onCopyRequest={(id, field) => copyTaskField(id, field)}
           moveMode={moveMode}
           onMoveRequest={(id, delta) => void moveTask(id, delta)}
           onMoveModeExit={() => setMoveMode(false)}

--- a/packages/kobe/src/tui/i18n/messages/tasks.ts
+++ b/packages/kobe/src/tui/i18n/messages/tasks.ts
@@ -40,6 +40,9 @@ export const en = {
     /** The one entry with no chord behind it — status has no key yet, so the
      *  menu is its only route. */
     setStatus: "Set status",
+    /** Also chord-less: put the row's branch / worktree path on the clipboard. */
+    copyBranch: "Copy branch name",
+    copyPath: "Copy path",
     delete: "Delete",
   },
   /** The six `TaskStatus` values, for the set-status picker and its row chip.
@@ -130,6 +133,8 @@ export const en = {
     worktreeGoneTitle: 'Worktree for "{title}" is gone',
     worktreeGoneBody:
       "Closed {count} tab(s). The branch {branch} is still there — reopen the task to re-create its worktree.",
+    copiedBranch: "Copied branch {text}",
+    copiedPath: "Copied path {text}",
   },
 }
 
@@ -161,6 +166,8 @@ export const zh: typeof en = {
     unpin: "取消置顶",
     reorder: "重新排序",
     setStatus: "设置状态",
+    copyBranch: "复制分支名",
+    copyPath: "复制路径",
     delete: "删除",
   },
   status: {
@@ -231,5 +238,7 @@ export const zh: typeof en = {
     scratchCloseFailed: "无法关闭临时任务:{message}",
     worktreeGoneTitle: '"{title}" 的 worktree 已消失',
     worktreeGoneBody: "已关闭 {count} 个标签页。分支 {branch} 仍在——重新打开该任务会重建 worktree。",
+    copiedBranch: "已复制分支 {text}",
+    copiedPath: "已复制路径 {text}",
   },
 }

--- a/packages/kobe/src/tui/lib/task-actions.ts
+++ b/packages/kobe/src/tui/lib/task-actions.ts
@@ -20,6 +20,7 @@ import { hostedTaskKeys, killHostedSessions, listHostedSessions, openHostedSessi
 import { engineDisplayName } from "@/engine/interactive-command"
 import { errorMessage } from "@/lib/error-message"
 import { DIRTY_WORKTREE_CODE } from "@/orchestrator/errors"
+import { t } from "@/tui/i18n"
 import { DEFAULT_TASK_VENDOR, type Task, type TaskStatus, type VendorId } from "@/types/task"
 import { nextVendorWithin } from "@/types/vendor"
 
@@ -79,6 +80,13 @@ export interface TaskActionContext {
    * dialog it never opens. Resolves `undefined` on cancel, like `promptText`.
    */
   readonly pickStatus?: (current: TaskStatus) => Promise<TaskStatus | undefined>
+  /**
+   * DIVERGENCE — system-clipboard writer behind {@link copyTaskFieldFlow}.
+   * Optional for the same reason as `pickStatus`: only the workspace host has
+   * a renderer to hand the OSC52 half to; a host that omits it makes the flow
+   * a no-op.
+   */
+  readonly copyText?: (text: string) => void
   readonly logger: TaskActionLogger
   /** Forensic log tag — `[rove]` (outer monitor) vs `[rove tasks]` (Tasks pane). */
   readonly logPrefix: string
@@ -383,4 +391,28 @@ export async function setStatusFlow(ctx: TaskActionContext, taskId: string): Pro
   }
   ctx.notifyInfo?.(`Status → ${next}`)
   await ctx.reload?.()
+}
+
+/**
+ * Copy a task's branch name or worktree path to the system clipboard (tree
+ * menu "Copy branch name" / "Copy path"), for a `git checkout` / `cd` in
+ * another shell.
+ *
+ * Reads the RECORDED `task.worktreePath` verbatim — it does NOT materialize the
+ * worktree the way opening the task does (`openTaskWorktreeFor` calls
+ * `ensureWorktree` first). A copy is a read; creating a directory as its side
+ * effect would be the kind of surprise `rove api get-task` never springs. A
+ * task never entered records "" for both fields, and the menu withholds the
+ * entries then (tree-menu.ts); the empty-string guard here is the backstop.
+ *
+ * The success toast is the only feedback a clipboard write can have on screen,
+ * so it echoes what was copied rather than a bare "copied".
+ */
+export function copyTaskFieldFlow(ctx: TaskActionContext, taskId: string, field: "branch" | "path"): void {
+  const task = ctx.tasks().find((candidate) => candidate.id === taskId)
+  if (!task || !ctx.copyText) return
+  const text = field === "branch" ? task.branch : task.worktreePath
+  if (text === "") return
+  ctx.copyText(text)
+  ctx.notifyInfo?.(t(field === "branch" ? "tasks.toast.copiedBranch" : "tasks.toast.copiedPath", { text }))
 }

--- a/packages/kobe/src/tui/panes/sidebar/tree-menu.ts
+++ b/packages/kobe/src/tui/panes/sidebar/tree-menu.ts
@@ -9,12 +9,13 @@
  * (`withCursorTask` walks up from a tab to its worktree, because rename /
  * delete have no tab-level meaning).
  *
- * `setStatus` is the one documented exception, and it is a SEQUENCING one
- * rather than a change of rule: a chord is the owner's call (AGENTS.md,
- * "Keybindings"), and until one is agreed the menu is the only place a human
- * can set a status the injected agent protocol already tells every engine to
- * write (`engine/worktree-protocol.ts`). When the chord lands, this entry
- * mirrors it like the rest.
+ * `setStatus`, `copyBranch` and `copyPath` are the documented exceptions, and
+ * they are SEQUENCING ones rather than a change of rule: a chord is the
+ * owner's call (AGENTS.md, "Keybindings"), and until one is agreed the menu is
+ * the only place a human can set a status the injected agent protocol already
+ * tells every engine to write (`engine/worktree-protocol.ts`), or copy the
+ * row's branch / worktree path for another shell. When a chord lands, the
+ * entry mirrors it like the rest.
  *
  * The new-conversation pair reads the same rule one pane over (owner ask
  * 2026-08-18): ctrl+e already opens the engine/shell picker for the task the
@@ -42,6 +43,8 @@ export type TreeMenuAction =
   | "pin"
   | "reorder"
   | "setStatus"
+  | "copyBranch"
+  | "copyPath"
   | "delete"
 
 export interface TreeMenuItem {
@@ -74,15 +77,24 @@ function newTabVerbs(): TreeMenuItem[] {
  *  is always pinned and `setPinned` silently no-ops on it (task-editor.ts),
  *  and an entry that does nothing is worse than no entry — the same rule
  *  `closeTab` follows above. */
-function taskVerbs(pinned: boolean, kind: Task["kind"]): TreeMenuItem[] {
+function taskVerbs(task: Task): TreeMenuItem[] {
   const verbs: TreeMenuItem[] = [{ action: "rename", labelKey: "tasks.menu.rename" }]
-  if (kind !== "main") verbs.push({ action: "pin", labelKey: pinned ? "tasks.menu.unpin" : "tasks.menu.pin" })
+  if (task.kind !== "main") {
+    verbs.push({ action: "pin", labelKey: task.pinned === true ? "tasks.menu.unpin" : "tasks.menu.pin" })
+  }
   verbs.push({ action: "reorder", labelKey: "tasks.menu.reorder" })
-  // The ONE entry with no chord behind it. Status had no route outside
-  // `rove api set-status` at all, and adding a chord is the owner's call
-  // (AGENTS.md) — so the menu carries it alone until one is agreed. Not
-  // danger-toned: it relabels the task and touches nothing else.
+  // Status and the two copies are menu-only (no chord — a chord is the
+  // owner's call, AGENTS.md "Keybindings"). Status had no route outside
+  // `rove api set-status`; the copies put the two strings a row's identity is
+  // made of on the clipboard, for a `git checkout` / `cd` in another shell.
+  // None is danger-toned: they relabel or read, and touch nothing else.
   verbs.push({ action: "setStatus", labelKey: "tasks.menu.setStatus" })
+  // Each copy shows only when its string is recorded — same rule as
+  // `closeTab`. A `main`/`dir` row stores `branch === ""` (its label is the
+  // live HEAD), and a task never entered stores BOTH as "" until
+  // `ensureWorktree` allocates them (orchestrator/core.ts).
+  if (task.branch !== "") verbs.push({ action: "copyBranch", labelKey: "tasks.menu.copyBranch" })
+  if (task.worktreePath !== "") verbs.push({ action: "copyPath", labelKey: "tasks.menu.copyPath" })
   verbs.push({ action: "delete", labelKey: "tasks.menu.delete", danger: true })
   return verbs
 }
@@ -99,11 +111,7 @@ export function treeMenuItems(row: TreeRow, ctx: TreeMenuContext = {}): TreeMenu
     ]
   }
   if (row.kind === "worktree") {
-    return [
-      { action: "open", labelKey: "tasks.menu.open" },
-      ...newTabVerbs(),
-      ...taskVerbs(row.task.pinned === true, row.task.kind),
-    ]
+    return [{ action: "open", labelKey: "tasks.menu.open" }, ...newTabVerbs(), ...taskVerbs(row.task)]
   }
   // The routine count row (issue #91) is a fold toggle, not a task — there is
   // no task for any verb here to act on, and an entry that does nothing is
@@ -111,5 +119,5 @@ export function treeMenuItems(row: TreeRow, ctx: TreeMenuContext = {}): TreeMenu
   if (row.kind === "routines") return []
   const tabItems: TreeMenuItem[] = [{ action: "open", labelKey: "tasks.menu.openTab" }]
   if ((ctx.tabCount ?? 0) > 0) tabItems.push({ action: "closeTab", labelKey: "tasks.menu.closeTab" })
-  return [...tabItems, ...newTabVerbs(), ...taskVerbs(row.task.pinned === true, row.task.kind)]
+  return [...tabItems, ...newTabVerbs(), ...taskVerbs(row.task)]
 }

--- a/packages/kobe/test/render/host-sidebar-filetree.test.tsx
+++ b/packages/kobe/test/render/host-sidebar-filetree.test.tsx
@@ -52,6 +52,7 @@ function sidebarProps(over: Partial<HostSidebarProps> = {}): HostSidebarProps {
     onRenameRequest: NOOP,
     onPinRequest: NOOP,
     onSetStatusRequest: NOOP,
+    onCopyRequest: NOOP,
     moveMode: false,
     onMoveRequest: NOOP,
     onMoveModeExit: NOOP,

--- a/packages/kobe/test/render/sidebar-recent-row.test.tsx
+++ b/packages/kobe/test/render/sidebar-recent-row.test.tsx
@@ -48,6 +48,7 @@ function sidebarProps(over: Partial<HostSidebarProps> = {}): HostSidebarProps {
     onRenameRequest: NOOP,
     onPinRequest: NOOP,
     onSetStatusRequest: NOOP,
+    onCopyRequest: NOOP,
     moveMode: false,
     onMoveRequest: NOOP,
     onMoveModeExit: NOOP,

--- a/packages/kobe/test/tui-react/host-task-actions-rename-branch.test.ts
+++ b/packages/kobe/test/tui-react/host-task-actions-rename-branch.test.ts
@@ -16,6 +16,12 @@ const mocks = vi.hoisted(() => ({
   branchPickerShow: vi.fn(),
 }))
 
+// The hook's one React import (the renderer the copy flow's OSC52 writer
+// needs); the real module drags in react-reconciler.
+vi.mock("@opentui/react", () => ({
+  useRenderer: () => ({ copyToClipboardOSC52: vi.fn() }),
+}))
+
 vi.mock("../../src/tui-react/component/branch-picker-dialog", () => ({
   BranchPickerDialog: { show: mocks.branchPickerShow },
 }))

--- a/packages/kobe/test/tui-react/host-task-actions-set-status.test.ts
+++ b/packages/kobe/test/tui-react/host-task-actions-set-status.test.ts
@@ -17,6 +17,17 @@ import { beforeEach, describe, expect, test, vi } from "vitest"
 
 const mocks = vi.hoisted(() => ({
   statusPickerShow: vi.fn(),
+  copyTextToSystemClipboard: vi.fn(),
+  copyToClipboardOSC52: vi.fn(),
+}))
+
+// The host's only React hook: the renderer whose OSC52 writer the copy flow
+// needs. Stubbed to the one method the adapter calls.
+vi.mock("@opentui/react", () => ({
+  useRenderer: () => ({ copyToClipboardOSC52: mocks.copyToClipboardOSC52 }),
+}))
+vi.mock("../../src/tui/lib/clipboard-copy", () => ({
+  copyTextToSystemClipboard: mocks.copyTextToSystemClipboard,
 }))
 
 vi.mock("../../src/tui-react/component/status-picker-dialog", () => ({
@@ -111,5 +122,38 @@ describe("setStatus (workspace host)", () => {
     // would be an invisible crash, not a message.
     await expect(actions.setStatus("missing")).resolves.toBeUndefined()
     expect(notifyError).not.toHaveBeenCalled()
+  })
+})
+
+/**
+ * The copy seam is the same shape as set-status: the flow is covered in
+ * `test/tui/task-actions-rename.test.ts`; what only exists HERE is the host
+ * handing the flow a clipboard writer that reaches BOTH channels (local pipe
+ * + the renderer's OSC52), and a flow with no writer is a menu row that
+ * silently copies nothing.
+ */
+describe("copyTaskField (workspace host)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test("routes the branch through the system clipboard AND the renderer's OSC52", () => {
+    const { actions } = makeActions([task("a", { branch: "feat/copy-me" })])
+
+    actions.copyTaskField("a", "branch")
+
+    expect(mocks.copyTextToSystemClipboard).toHaveBeenCalledTimes(1)
+    const [text, osc52] = mocks.copyTextToSystemClipboard.mock.calls[0] as [string, (t: string) => void]
+    expect(text).toBe("feat/copy-me")
+    osc52("payload")
+    expect(mocks.copyToClipboardOSC52).toHaveBeenCalledWith("payload")
+  })
+
+  test("path copies the recorded worktreePath", () => {
+    const { actions } = makeActions([task("a", { worktreePath: "/wt/somewhere" })])
+
+    actions.copyTaskField("a", "path")
+
+    expect(mocks.copyTextToSystemClipboard.mock.calls[0]?.[0]).toBe("/wt/somewhere")
   })
 })

--- a/packages/kobe/test/tui/sidebar-tree-menu-items.test.ts
+++ b/packages/kobe/test/tui/sidebar-tree-menu-items.test.ts
@@ -51,13 +51,40 @@ describe("treeMenuItems", () => {
       "pin",
       "reorder",
       "setStatus",
+      "copyBranch",
+      "copyPath",
       "delete",
     ])
   })
 
+  test("a row with no stored branch is offered Copy path but not Copy branch", () => {
+    // `main`/`dir` rows store `branch === ""` (their label is the live HEAD),
+    // so the entry would copy nothing — the entry-that-does-nothing rule.
+    const dirRow = worktreeRow({ kind: "dir", branch: "" })
+    expect(actions(dirRow)).toContain("copyPath")
+    expect(actions(dirRow)).not.toContain("copyBranch")
+  })
+
+  test("a task never entered (both fields still empty) is offered neither copy", () => {
+    // `ensureWorktree` fills branch + worktreePath on first enter; before that
+    // there is nothing to copy, and the menu says so by omission.
+    const lazy = worktreeRow({ branch: "", worktreePath: "" })
+    expect(actions(lazy)).not.toContain("copyBranch")
+    expect(actions(lazy)).not.toContain("copyPath")
+  })
+
   test("a main row (the project's own checkout) is not offered a pin — setPinned silently no-ops on it", () => {
     const mainRow = worktreeRow({ kind: "main", branch: "", worktreePath: "/repos/rove" })
-    expect(actions(mainRow)).toEqual(["open", "newChat", "newShell", "rename", "reorder", "setStatus", "delete"])
+    expect(actions(mainRow)).toEqual([
+      "open",
+      "newChat",
+      "newShell",
+      "rename",
+      "reorder",
+      "setStatus",
+      "copyPath",
+      "delete",
+    ])
     const mainTab: TreeRow = {
       kind: "tab",
       id: "a::tab-2",
@@ -73,6 +100,7 @@ describe("treeMenuItems", () => {
       "rename",
       "reorder",
       "setStatus",
+      "copyPath",
       "delete",
     ])
   })
@@ -93,6 +121,8 @@ describe("treeMenuItems", () => {
       "pin",
       "reorder",
       "setStatus",
+      "copyBranch",
+      "copyPath",
       "delete",
     ])
   })

--- a/packages/kobe/test/tui/task-actions-rename.test.ts
+++ b/packages/kobe/test/tui/task-actions-rename.test.ts
@@ -17,6 +17,7 @@ vi.mock("../../src/engine/account-detect", () => ({
 import type { KobeOrchestrator } from "../../src/client/remote-orchestrator"
 import {
   type TaskActionContext,
+  copyTaskFieldFlow,
   cycleVendorFlow,
   renameBranchFlow,
   renameTaskFlow,
@@ -62,16 +63,20 @@ function makeCtx(opts: {
    *  `pickStatus` unwired, the shape a host without the dialog has. */
   pickStatusResult?: TaskStatus | undefined
   wirePickStatus?: boolean
+  /** Same shape as `wirePickStatus`: false = a host with no clipboard writer. */
+  wireCopyText?: boolean
 }): {
   ctx: TaskActionContext
   promptText: ReturnType<typeof vi.fn>
   pickStatus: ReturnType<typeof vi.fn>
+  copyText: ReturnType<typeof vi.fn>
   notifyError: ReturnType<typeof vi.fn>
   notifyInfo: ReturnType<typeof vi.fn>
   reload: ReturnType<typeof vi.fn>
 } {
   const promptText = vi.fn(async () => opts.promptTextResult)
   const pickStatus = vi.fn(async () => opts.pickStatusResult)
+  const copyText = vi.fn()
   const notifyError = vi.fn()
   const notifyInfo = vi.fn()
   const reload = vi.fn(async () => {})
@@ -81,13 +86,14 @@ function makeCtx(opts: {
     confirm: async () => true,
     promptText,
     ...(opts.wirePickStatus === false ? {} : { pickStatus }),
+    ...(opts.wireCopyText === false ? {} : { copyText }),
     logger: { error: vi.fn() },
     logPrefix: "[test]",
     notifyError,
     notifyInfo,
     reload,
   }
-  return { ctx, promptText, pickStatus, notifyError, notifyInfo, reload }
+  return { ctx, promptText, pickStatus, copyText, notifyError, notifyInfo, reload }
 }
 
 describe("renameTaskFlow", () => {
@@ -359,5 +365,49 @@ describe("setStatusFlow", () => {
 
     expect(pickStatus).not.toHaveBeenCalled()
     expect(orch.setStatus).not.toHaveBeenCalled()
+  })
+})
+
+describe("copyTaskFieldFlow", () => {
+  test("branch: copies the stored branch verbatim and toasts it", () => {
+    const tasks = [makeTask({ id: "t1", branch: "feat/copy" })]
+    const { ctx, copyText, notifyInfo } = makeCtx({ tasks, orch: makeOrch() })
+
+    copyTaskFieldFlow(ctx, "t1", "branch")
+
+    expect(copyText).toHaveBeenCalledWith("feat/copy")
+    expect(notifyInfo).toHaveBeenCalledTimes(1)
+    expect(notifyInfo.mock.calls[0][0]).toContain("feat/copy")
+  })
+
+  test("path: copies the RECORDED worktree path — never materializes it", () => {
+    // The path may not exist yet (a task opened once never ran ensureWorktree);
+    // a copy is a read, so the flow has no orchestrator call to make at all.
+    const orch = makeOrch()
+    const tasks = [makeTask({ id: "t1", worktreePath: "/wt/not-yet" })]
+    const { ctx, copyText } = makeCtx({ tasks, orch })
+
+    copyTaskFieldFlow(ctx, "t1", "path")
+
+    expect(copyText).toHaveBeenCalledWith("/wt/not-yet")
+    for (const fn of Object.values(orch)) expect(fn).not.toHaveBeenCalled()
+  })
+
+  test("an empty branch (main/dir row) copies nothing and shows no toast", () => {
+    const tasks = [makeTask({ id: "t1", branch: "", kind: "main" })]
+    const { ctx, copyText, notifyInfo } = makeCtx({ tasks, orch: makeOrch() })
+
+    copyTaskFieldFlow(ctx, "t1", "branch")
+
+    expect(copyText).not.toHaveBeenCalled()
+    expect(notifyInfo).not.toHaveBeenCalled()
+  })
+
+  test("a host with no clipboard writer is a silent no-op, not a crash", () => {
+    const tasks = [makeTask({ id: "t1" })]
+    const { ctx, notifyInfo } = makeCtx({ tasks, orch: makeOrch(), wireCopyText: false })
+
+    expect(() => copyTaskFieldFlow(ctx, "t1", "path")).not.toThrow()
+    expect(notifyInfo).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## What / why

A task row's right-click menu gains **Copy branch name** and **Copy path**. Until now a `git checkout` or `cd` into a task's worktree from another shell meant retyping a truncated sidebar label or shelling out to `rove api get-task`; the TUI already wrote to the system clipboard, but only from a terminal drag-selection.

Wired along the exact route #754 used for **Set status**: `tree-menu.ts` (`taskVerbs`) → `use-tree-menu.ts` → `SidebarTaskCallbacks.onCopyRequest` → `host-sidebar.tsx` → `host.tsx` → `host-task-actions.ts` → new `copyTaskFieldFlow` in `tui/lib/task-actions.ts`.

- The flow stays opentui-free; the host supplies `copyText` from `useRenderer()`, routing through the same `copyTextToSystemClipboard` (local pbcopy-style pipe + OSC52) the terminal pane's copy-on-select uses.
- **Copy path copies the recorded `task.worktreePath` verbatim and never materializes the worktree** (unlike opening the task, which calls `ensureWorktree` first). Documented in the flow's comment.
- Each entry shows only when its string is recorded: a `main`/`dir` row (`branch === ""`) gets only Copy path; a task never entered (both fields `""` until first enter) gets neither — the "entry that does nothing is worse than no entry" rule `closeTab` already follows.
- i18n: `tasks.menu.copyBranch` / `copyPath` and `tasks.toast.copiedBranch` / `copiedPath` in both `en` and `zh`. `bun run check-i18n` → `740 keys × 2 locales in sync`.
- Docs: `docs/TUI.md` right-click sentence, `docs/KEYBINDINGS.md` context-menu paragraph.
- No new chord — menu-only, same as `setStatus`.

## Pass criteria — what I ran

**Harness, menu contents** (`bun run visual:serve` on my own port base 5873, isolated home under `.scratch/opentui-visual-5873`):

```
cd packages/kobe-web && KOBE_VISUAL_PORT_BASE=5873 bun run visual:shot -- rclick:29,136 --out=/Users/jacksonc/i/kobe/.scratch/copy-task-field/menu-before.png   # on origin/main tree
cd packages/kobe-web && KOBE_VISUAL_PORT_BASE=5873 bun run visual:shot -- rclick:29,136 --out=/Users/jacksonc/i/kobe/.scratch/copy-task-field/menu-after.png    # on this branch
```

BEFORE shows Open / New conversation / New shell / Rename / Pin / Reorder row / Set status / Delete and no copy entry. AFTER shows the same list plus **Copy branch name** and **Copy path** between Set status and Delete. (The fixture task is created lazily with both fields empty, so I ran `rove api ensure-worktree` against the fixture's own daemon first; the first AFTER shot before that showed neither entry — which is the withholding rule working.)

**Real proof of the copy.** Driving the harness's real OpenTUI (real PTY, real `pbcopy`) on this machine, then reading the clipboard in another shell:

```
$ KOBE_VISUAL_PORT_BASE=5873 bun run visual:shot -- rclick:29,136 j j j j j j j enter wait:300 --out=…/copy-branch-toast.png
$ pbpaste
visual-fixture

$ KOBE_VISUAL_PORT_BASE=5873 bun run visual:shot -- rclick:29,136 j j j j j j j j enter wait:300 --out=…/copy-path-toast.png
$ pbpaste
/Users/jacksonc/.rove/worktrees/kobe-0aff3858ab76/tamarin/.scratch/opentui-visual-5873/home/.rove/worktrees/fixture-repo-6ef86f3921ed/tanager
$ cd "$(pbpaste)" && git branch --show-current
visual-fixture
```

Both toasts are visible in the TUI (`✓ Copied branch visual-fixture`, `✓ Copied path /Users/jacksonc/.rove/work…`). **Half exercised: the local clipboard command (pbcopy).** The OSC52 half goes through the same `copyTextToSystemClipboard` call and is covered at the seam by `host-task-actions-set-status.test.ts` (asserts the writer handed in reaches `renderer.copyToClipboardOSC52`), but I did not exercise it over SSH.

**Tests**

```
cd packages/kobe && env -u ROVE_INVOKED_AS bun x vitest run test/tui/sidebar-tree-menu-items.test.ts test/tui/task-actions-rename.test.ts test/tui-react/host-task-actions-set-status.test.ts test/tui-react/host-task-actions-rename-branch.test.ts test/tui/i18n-catalog.test.ts
 → all passed
bun test test/render/sidebar-tree-menu.test.tsx test/render/host-sidebar-filetree.test.tsx test/render/sidebar-recent-row.test.tsx
 → 19 pass, 0 fail
bun x tsc --noEmit → clean · bun run lint (repo root) → clean · bun run check-i18n → OK
```

Full `test:fast` from this worktree: 4117 passed, 4 failed — the 4 are `project-eligibility` / `open-dir-cmd` asserting `pathRejection(REPO_ROOT) === null`, which rejects any checkout under `~/.rove/worktrees/` as `roveInternal` regardless of the diff (known, unrelated to this change).

## Screenshots

- BEFORE: `/Users/jacksonc/i/kobe/.scratch/copy-task-field/menu-before.png`
- AFTER: `/Users/jacksonc/i/kobe/.scratch/copy-task-field/menu-after.png`
- Copy branch name toast: `/Users/jacksonc/i/kobe/.scratch/copy-task-field/copy-branch-toast.png`
- Copy path toast: `/Users/jacksonc/i/kobe/.scratch/copy-task-field/copy-path-toast.png`

file-size-exemption: packages/kobe/src/tui-react/workspace/host.tsx — was 501 lines before this change (over since #754); the diff adds one JSX prop plus one destructured name, with biome reflowing the destructure onto separate lines. Same seam #754 named: `startWorkspaceHost` (the process-boot half) needs edits to `src/tui/index.tsx` and `test/tui/start-tui.test.ts`, outside this slice.
