### PR TITLE
chore: list the launcher bin as a knip entry

### DIFF
--- a/packages/kobe/knip.json
+++ b/packages/kobe/knip.json
@@ -1,6 +1,12 @@
 {
   "$schema": "https://unpkg.com/knip@6/schema.json",
-  "entry": ["src/cli/kobe.ts!", "src/cli/rove.ts!", "scripts/build.ts", "test/**/*.test.{ts,tsx}"],
+  "entry": [
+    "src/cli/kobe.ts!",
+    "src/cli/rove.ts!",
+    "src/cli/launcher.ts!",
+    "scripts/build.ts",
+    "test/**/*.test.{ts,tsx}"
+  ],
   "project": ["src/**/*.{ts,tsx}", "scripts/**/*.ts"],
   "ignoreBinaries": ["tmux", "claude", "codex", "copilot"],
   "ignoreDependencies": ["node-pty"]


### PR DESCRIPTION
knip listed `src/cli/launcher.ts` as the one unused file in the repo, but it is the published bin (scripts/build.ts entrypoint, asserted by test/architecture/package-distribution.test.ts, carved out by the coverage gate as subprocess-only). Adding it to `entry` makes `bun x knip` report zero unused files. No changeset: config only, no shipped behavior.