### PR TITLE
docs: explain what closing a project's last tab does to the sidebar

### DIFF
--- a/.changeset/closing-last-tab-concepts.md
+++ b/.changeset/closing-last-tab-concepts.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Document what closing a project's last tab means on the Concepts page: the project leaves the sidebar but nothing is deleted, and New task → "the project itself" brings it back. Forgetting a project stays the separate un-saving gesture.

--- a/docs/CONCEPTS.md
+++ b/docs/CONCEPTS.md
@@ -90,6 +90,16 @@ Close a tab when you're done; the Task's directory stays. Exiting the engine
 CLI itself returns an engine tab to its shell prompt. The hosted session ends
 only when that wrapping shell exits or Rove explicitly closes it.
 
+**Closing the last tab is "done for now", not "forget".** Close every tab of a
+managed Task and its row stays in the sidebar; entering it again opens a fresh
+tab in the same worktree. Close every tab of a project whose only row is its
+main checkout (or of a directory Task) and the whole project leaves the
+sidebar, header and row together. Nothing is deleted: the main Task record and
+the saved repository both stay on disk. To bring it back, open New task
+(`n`), pick the same repository, and choose "the project itself" instead of a
+new task worktree (see [TUI](./TUI.md#creating-a-task)). Forgetting a project
+(`d` on its row) is the separate, un-saving gesture.
+
 Each engine tab may pin its own engine; otherwise it inherits the Task's engine,
 so tabs in one Task can use different vendors. A Task-level reasoning-effort
 choice is forwarded when that engine supports it. The embedded engine CLI owns


### PR DESCRIPTION
## What / why

Issue #90 asked for a way back to a project that left the sidebar after its last tab closed. The code half already shipped in #711 (New task → Existing → "the project itself" routes through `ensureMainTask`; the empty pane binds its own ⏎ / ctrl+e; the `isClosedDownProject` comment and `docs/TUI.md` were updated there). This PR closes the remaining gap: `docs/CONCEPTS.md` never said what closing the last tab means to a project row. It now names the gesture, states nothing is deleted, points at the route back, and separates it from Forget.

Docs + changeset only. No UI change, so no harness screenshots.

## Verification

Pass criteria from the brief re-run against this branch (which contains #711):

```
env -u ROVE_INVOKED_AS bun x vitest run test/tui/create-task-flow-open-project.test.ts test/tui/sidebar-tree-core.test.ts test/tui/new-task-dialog/state.test.ts
 Test Files  3 passed (3)
      Tests  91 passed (91)
```

`sidebar-tree-core.test.ts` still carries the six hide cases plus "opening the project does not mint a second row for the same repo"; `create-task-flow-open-project.test.ts` asserts the open path resolves the existing main row, creates no task, and enters it.

`bun run lint`: Checked 1313 files, no fixes applied.