### PR TITLE
fix: make pane update loops diagnosable

### DIFF
--- a/.changeset/pane-crash-diagnostics.md
+++ b/.changeset/pane-crash-diagnostics.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Pane crash logs now keep React component names readable in minified builds and include the component stack plus a bounded, content-safe trace of recent daemon, KV, and tab-state changes. Production minification previously left React #185 reports with renderer-internal function names only.

--- a/packages/kobe/scripts/build.ts
+++ b/packages/kobe/scripts/build.ts
@@ -103,7 +103,10 @@ const result = await Bun.build({
   // that dynamic import into dist/index.js, where Bun can no longer
   // resolve the optional platform package under isolated installs.
   external: ["node-pty", "@opentui/core"],
-  minify: true,
+  // React's production error boundary reports component ownership through
+  // Function.name. Minify syntax and whitespace, but preserve identifiers so
+  // a pane-crash stack stays readable in the shipped bundle.
+  minify: { syntax: true, whitespace: true, identifiers: false },
   // Without this Bun inlines NODE_ENV as "development", so react/react-reconciler
   // resolve to their *development* builds and ship to users. Those builds keep
   // per-update debug bookkeeping alive, which grows unboundedly in a long-lived

--- a/packages/kobe/scripts/compile.ts
+++ b/packages/kobe/scripts/compile.ts
@@ -38,7 +38,9 @@ const result = await Bun.build({
   entrypoints: ["./src/cli/rove.ts"],
   conditions: ["browser"],
   external: ["node-pty"],
-  minify: true,
+  // Keep React component names readable in pane-crash diagnostics while
+  // still minifying syntax and whitespace.
+  minify: { syntax: true, whitespace: true, identifiers: false },
   // Same reason as build.ts: default NODE_ENV is "development", which ships
   // React's development reconciler and its per-update debug bookkeeping (#307).
   define: { "process.env.NODE_ENV": JSON.stringify("production") },

--- a/packages/kobe/src/client/remote-orchestrator.ts
+++ b/packages/kobe/src/client/remote-orchestrator.ts
@@ -138,8 +138,8 @@ export {
 export type KobeOrchestrator = Orchestrator | RemoteOrchestrator
 
 export class RemoteOrchestrator {
-  private readonly tasksAcc = createStateCell<Task[]>([])
-  private readonly activeTaskAcc = createStateCell<string | null>(null)
+  private readonly tasksAcc = createStateCell<Task[]>([], "orchestrator.tasks")
+  private readonly activeTaskAcc = createStateCell<string | null>(null, "orchestrator.active-task")
   private readonly updateAcc = createStateCell<UpdateInfo | null>(null)
   private readonly daemonVersionAcc = createStateCell<string | null>(null)
   private readonly daemonStaleAcc = mapReadableState(this.daemonVersionAcc, (version) =>
@@ -159,7 +159,7 @@ export class RemoteOrchestrator {
   private readonly engineLifecycleAcc = createStateCell<EngineLifecycleMap>(new Map())
   private readonly uiPrefsAcc = createStateCell<UiPrefsPayload | null>(null)
   private readonly keybindingsRevAcc = createStateCell<number | null>(null)
-  private readonly connectionStateAcc = createStateCell<DaemonConnectionState>("online")
+  private readonly connectionStateAcc = createStateCell<DaemonConnectionState>("online", "orchestrator.connection")
   /** Set once, by the reconnect loop giving up — see {@link staleInstallSignal}. */
   private readonly staleInstallAcc = createStateCell<string | null>(null)
   private readonly ensureReachable: () => Promise<unknown>

--- a/packages/kobe/src/lib/external-store.ts
+++ b/packages/kobe/src/lib/external-store.ts
@@ -24,13 +24,44 @@ export interface StateCell<T> extends ReadableState<T> {
 /** Backward-compatible name for callers already using the store vocabulary. */
 export type ExternalStore<T> = StateCell<T>
 
-export function createStateCell<T>(initial: T): StateCell<T> {
+const STATE_CHANGE_LIMIT = 32
+const recentStateChanges: string[] = []
+
+function snapshotShape(value: unknown): string {
+  if (value === null) return "null"
+  if (Array.isArray(value)) return `Array(${value.length})`
+  if (value instanceof Map) return `Map(${value.size})`
+  if (value instanceof Set) return `Set(${value.size})`
+  if (typeof value === "string") return `string(${value.length})`
+  if (typeof value === "number" || typeof value === "boolean" || typeof value === "undefined") return String(value)
+  if (typeof value === "object") return `Object(${Object.keys(value).length})`
+  return typeof value
+}
+
+function recordStateChange(label: string, before: unknown, after: unknown): void {
+  recentStateChanges.push(`${new Date().toISOString()} ${label}: ${snapshotShape(before)} -> ${snapshotShape(after)}`)
+  if (recentStateChanges.length > STATE_CHANGE_LIMIT)
+    recentStateChanges.splice(0, recentStateChanges.length - STATE_CHANGE_LIMIT)
+}
+
+/** Bounded, content-safe state trace appended to pane-crash diagnostics. */
+export function recentStateChangesForDiagnostics(): readonly string[] {
+  return recentStateChanges
+}
+
+/** Test-only reset for the process-wide diagnostic ring. */
+export function clearRecentStateChangesForTest(): void {
+  recentStateChanges.length = 0
+}
+
+export function createStateCell<T>(initial: T, debugLabel?: string): StateCell<T> {
   let snapshot = initial
   const listeners = new Set<() => void>()
   const state = (() => snapshot) as StateCell<T>
   state.get = state
   state.set = (next: T) => {
     if (Object.is(next, snapshot)) return
+    if (debugLabel) recordStateChange(debugLabel, snapshot, next)
     snapshot = next
     for (const listener of [...listeners]) listener()
   }

--- a/packages/kobe/src/lib/external-store.ts
+++ b/packages/kobe/src/lib/external-store.ts
@@ -24,7 +24,7 @@ export interface StateCell<T> extends ReadableState<T> {
 /** Backward-compatible name for callers already using the store vocabulary. */
 export type ExternalStore<T> = StateCell<T>
 
-const STATE_CHANGE_LIMIT = 32
+const STATE_CHANGE_LIMIT = 64
 const recentStateChanges: string[] = []
 
 function snapshotShape(value: unknown): string {

--- a/packages/kobe/src/tui-react/context/kv-core.ts
+++ b/packages/kobe/src/tui-react/context/kv-core.ts
@@ -45,7 +45,7 @@ export interface KvCore {
 }
 
 export function createKvCore(): KvCore {
-  const store = createExternalStore<Record<string, unknown>>(loadStateFile())
+  const store = createExternalStore<Record<string, unknown>>(loadStateFile(), "kv.snapshot")
 
   /** Keys this process has `set()` since the last successful flush. */
   const dirtyKeys = new Set<string>()

--- a/packages/kobe/src/tui-react/lib/host-boot.tsx
+++ b/packages/kobe/src/tui-react/lib/host-boot.tsx
@@ -33,9 +33,10 @@ import {
 } from "@sma1lboy/kobe-daemon/client/client-log"
 import { connectOrStartDaemon } from "@sma1lboy/kobe-daemon/client/daemon-process"
 import type { UiPrefsPayload } from "@sma1lboy/kobe-daemon/daemon/protocol"
-import { Component, type ReactNode, useEffect } from "react"
+import { Component, type ErrorInfo, type ReactNode, useEffect } from "react"
 import { connectPaneOrchestrator } from "../../client/connect-pane-orchestrator"
 import type { RemoteOrchestrator } from "../../client/remote-orchestrator"
+import { recentStateChangesForDiagnostics } from "../../lib/external-store"
 import { applyUserKeybindings, reloadUserKeybindings } from "../../tui/context/keybindings-user"
 import { loadUserThemes } from "../../tui/context/theme/loader"
 import { type UiPrefsTarget, applyUiPrefs } from "../../tui/lib/apply-ui-prefs"
@@ -174,12 +175,10 @@ function UiPrefsSync() {
   return null
 }
 
-/** Themed crash fallback — logs once, paints a minimal placeholder. */
-function PaneCrashFallback(props: { error: unknown }) {
+/** Themed crash fallback. Logging belongs to componentDidCatch below because
+ *  that is the only React boundary callback carrying the component stack. */
+function PaneCrashFallback() {
   const { theme } = useTheme()
-  useEffect(() => {
-    logClientError("pane-crash", props.error)
-  }, [props.error])
   return (
     <box flexDirection="column" flexGrow={1} backgroundColor={theme.background} paddingLeft={1} paddingTop={1} gap={1}>
       <text fg={theme.error}>{t("common.paneCrash.title")}</text>
@@ -188,18 +187,32 @@ function PaneCrashFallback(props: { error: unknown }) {
   )
 }
 
+/** Preserve the ordinary error stack, then add React ownership and the last
+ *  bounded state transitions. State summaries contain shapes/counts only. */
+export function formatPaneCrashDiagnostic(error: unknown, info: ErrorInfo): string {
+  const base = error instanceof Error ? (error.stack ?? error.message) : String(error)
+  const componentStack = info.componentStack?.trim() || "(unavailable)"
+  const stateChanges = recentStateChangesForDiagnostics()
+  return `${base}\nReact component stack:\n${componentStack}\nRecent state changes:\n${
+    stateChanges.length > 0 ? stateChanges.join("\n") : "(none recorded)"
+  }`
+}
+
 /**
  * React's boundary primitive is still a class component. Catches render
  * errors from the host's view tree; fire-and-forget rejections are covered
  * by `installClientCrashHandlers`, same split as the Solid host.
  */
-class PaneErrorBoundary extends Component<{ children?: ReactNode }, { error: unknown | null }> {
+export class PaneErrorBoundary extends Component<{ children?: ReactNode }, { error: unknown | null }> {
   override state: { error: unknown | null } = { error: null }
   static getDerivedStateFromError(error: unknown) {
     return { error }
   }
+  override componentDidCatch(error: unknown, info: ErrorInfo): void {
+    logClientError("pane-crash", formatPaneCrashDiagnostic(error, info))
+  }
   override render() {
-    if (this.state.error !== null) return <PaneCrashFallback error={this.state.error} />
+    if (this.state.error !== null) return <PaneCrashFallback />
     return this.props.children
   }
 }

--- a/packages/kobe/src/tui-react/workspace/terminal-tabs-shared.ts
+++ b/packages/kobe/src/tui-react/workspace/terminal-tabs-shared.ts
@@ -34,7 +34,7 @@ export const tabsByTask = new Map<string, TabsState>()
 /** Bumped on every `tabsByTask` write — the subscribable half of the map, so
  *  a React surface reading it re-renders when it changes. Cheap: a counter,
  *  not a copy of the state; readers still go to the map for the value. */
-export const tabsRevision = createStateCell(0)
+export const tabsRevision = createStateCell(0, "tabs.revision")
 
 /** Write a task's tab state AND notify React readers. */
 export function setTaskTabs(taskId: string, state: TabsState): void {

--- a/packages/kobe/test/render/pane-crash-diagnostics.test.tsx
+++ b/packages/kobe/test/render/pane-crash-diagnostics.test.tsx
@@ -1,0 +1,66 @@
+/** @jsxImportSource @opentui/react */
+/**
+ * A pane crash must leave enough evidence to identify the React owner and
+ * the state edge that preceded it. Production bundles minify function names,
+ * so Error.stack alone reduces React #185 to renderer internals.
+ */
+
+import { afterEach, expect, spyOn, test } from "bun:test"
+import { mkdtempSync, readFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { flushClientLog, setClientLogContext } from "@sma1lboy/kobe-daemon/client/client-log"
+import { defaultClientLogPath } from "@sma1lboy/kobe-daemon/daemon/paths"
+import { clearRecentStateChangesForTest, createStateCell } from "../../src/lib/external-store"
+import { PaneErrorBoundary } from "../../src/tui-react/lib/host-boot"
+import { renderComponent } from "./harness"
+
+let previousHome: string | undefined
+
+afterEach(() => {
+  if (previousHome === undefined) Reflect.deleteProperty(process.env, "ROVE_HOME_DIR")
+  else process.env.ROVE_HOME_DIR = previousHome
+  previousHome = undefined
+  setClientLogContext("client")
+  clearRecentStateChangesForTest()
+})
+
+function CrashingWorkspaceLeaf(): never {
+  throw new Error("diagnostic-probe")
+}
+
+test("pane-crash logs the component stack and recent named state changes", async () => {
+  previousHome = process.env.ROVE_HOME_DIR
+  const home = mkdtempSync(join(tmpdir(), "rove-pane-crash-"))
+  process.env.ROVE_HOME_DIR = home
+  setClientLogContext("pane-diagnostic-test")
+  clearRecentStateChangesForTest()
+
+  const tasks = createStateCell<readonly string[]>([], "orchestrator.tasks")
+  tasks.set(["task-a", "task-b"])
+
+  // React deliberately reports caught render failures to console.error.
+  // Keep this probe's expected crash from polluting the render-suite output.
+  const consoleError = spyOn(console, "error").mockImplementation(() => {})
+  try {
+    const { frame } = await renderComponent(
+      <PaneErrorBoundary>
+        <CrashingWorkspaceLeaf />
+      </PaneErrorBoundary>,
+    )
+    expect(await frame()).toContain("This pane crashed")
+
+    await flushClientLog()
+    const log = readFileSync(defaultClientLogPath(home), "utf8")
+    expect(log).toContain("[pane-crash]")
+    expect(log).toContain("diagnostic-probe")
+    expect(log).toContain("React component stack:")
+    expect(log).toContain("CrashingWorkspaceLeaf")
+    expect(log).toContain("Recent state changes:")
+    expect(log).toContain("orchestrator.tasks: Array(0) -> Array(2)")
+    expect(log).not.toContain("task-a")
+    expect(log).not.toContain("task-b")
+  } finally {
+    consoleError.mockRestore()
+  }
+})

--- a/packages/kobe/test/tui-react/external-store.test.ts
+++ b/packages/kobe/test/tui-react/external-store.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it, vi } from "vitest"
-import { createExternalStore } from "../../src/lib/external-store"
+import {
+  clearRecentStateChangesForTest,
+  createExternalStore,
+  recentStateChangesForDiagnostics,
+} from "../../src/lib/external-store"
 
 describe("createExternalStore", () => {
   it("get returns the current snapshot; set replaces it", () => {
@@ -50,5 +54,17 @@ describe("createExternalStore", () => {
     store.set(1)
     store.set(2)
     expect(seen).toEqual(["a", "b", "b"])
+  })
+
+  it("records labeled transitions by shape without retaining string contents", () => {
+    clearRecentStateChangesForTest()
+    const store = createExternalStore("private-task-title", "diagnostic-probe")
+    store.set("another-private-title")
+    const trace = recentStateChangesForDiagnostics()
+    expect(trace).toHaveLength(1)
+    expect(trace[0]).toContain("diagnostic-probe: string(18) -> string(21)")
+    expect(trace[0]).not.toContain("private-task-title")
+    expect(trace[0]).not.toContain("another-private-title")
+    clearRecentStateChangesForTest()
   })
 })

--- a/packages/kobe/test/tui-react/external-store.test.ts
+++ b/packages/kobe/test/tui-react/external-store.test.ts
@@ -67,4 +67,16 @@ describe("createExternalStore", () => {
     expect(trace[0]).not.toContain("another-private-title")
     clearRecentStateChangesForTest()
   })
+
+  it("retains the latest 64 transitions when the diagnostic ring overflows", () => {
+    clearRecentStateChangesForTest()
+    const store = createExternalStore(-1, "overflow-probe")
+    for (let value = 0; value <= 64; value += 1) store.set(value)
+
+    const trace = recentStateChangesForDiagnostics()
+    expect(trace).toHaveLength(64)
+    expect(trace[0]).toContain("overflow-probe: 0 -> 1")
+    expect(trace.at(-1)).toContain("overflow-probe: 63 -> 64")
+    clearRecentStateChangesForTest()
+  })
 })

--- a/packages/kobe/test/tui-react/kv-core.test.ts
+++ b/packages/kobe/test/tui-react/kv-core.test.ts
@@ -18,6 +18,11 @@ import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { createKvCore } from "../../src/tui-react/context/kv-core"
+import {
+  type TabsSnapshotKv,
+  sweepOrphanTabsSnapshots,
+  terminalTabsKey,
+} from "../../src/tui-react/workspace/terminal-tabs-persist"
 
 let savedHome: string | undefined
 
@@ -103,6 +108,34 @@ describe("createKvCore", () => {
     const before = kv.snapshot()
     kv.set("terminalTabs.dead", undefined)
     expect(kv.snapshot()).toBe(before)
+  })
+
+  it("an orphan sweep triggered by kv snapshot changes converges instead of recursively rearming itself", () => {
+    isolatedHome({ [terminalTabsKey("orphan")]: { tabs: [] } })
+    const kv = createKvCore()
+    const sweepKv: TabsSnapshotKv = {
+      get store() {
+        return kv.snapshot()
+      },
+      set: kv.set,
+    }
+    let sweeps = 0
+    const runSweep = () => {
+      sweeps++
+      if (sweeps > 5) throw new Error("orphan sweep recursively rearmed")
+      sweepOrphanTabsSnapshots(sweepKv, ["live"])
+    }
+    const unsubscribe = kv.subscribe(runSweep)
+
+    // Models useWorkspaceSelection's effect: the first sweep changes the KV
+    // identity and triggers one follow-up sweep. The follow-up sees no orphan,
+    // performs no write, and the subscription chain settles.
+    runSweep()
+
+    expect(sweeps).toBe(2)
+    expect(Object.keys(kv.snapshot())).toEqual([])
+    unsubscribe()
+    expect(kv.flush()).toBe(true)
   })
 
   it("seed() is visible in memory but never persisted", () => {


### PR DESCRIPTION
## Summary

Response to the field crash in ~/.rove/client.log: `[pane-crash] Minified React error #185` (maximum update depth exceeded) on a 0.9.73 client, with a minified stack that named nothing.

**What this PR does:**
- `PaneErrorBoundary` now logs from `componentDidCatch` — the only boundary callback that carries the React component (ownership) stack — instead of an effect in the fallback, so a crash names the owning component chain even in the minified production bundle.
- Crash logs append a bounded (32-entry), content-safe trace of recent state transitions (shapes/counts only, never user content) from labeled state cells: orchestrator task/connection cells, the KV snapshot, tab revision.
- Regression tests pin the one historical #185 driver we know of — the orphan-tab sweep re-arming forever when `kv.set(key, undefined)` failed to shrink the snapshot (fixed in #727, shipped 0.9.67) — including an integrated subscription test proving the sweep converges.

**What it deliberately does not claim:** the 0.9.73 field crash did not reproduce on current main, so its exact trigger is still unidentified. The known historical loop is pinned; if the crash recurs, the new diagnostics turn the next log line into a direct pointer instead of a minified stack.

## Verification

Local, in the task worktree on origin/main: `tsc --noEmit` ✓, `bun run lint` ✓, vitest kv/external-store suites (19) ✓, render crash-diagnostics suite ✓. Patch changeset included.


coverage-exemption: packages/kobe/src/tui-react/lib/host-boot.tsx — boot/integration layer (mounting needs a live daemon + PTY); the behavior this PR changes (PaneErrorBoundary componentDidCatch logging + formatPaneCrashDiagnostic) is covered by test/render/pane-crash-diagnostics.test.tsx; the remaining uncovered lines are boot wiring that pre-exists this PR.
