### PR TITLE
Fix capture banner glyph clipping at the harness boundary

### DIFF
--- a/.changeset/fix-capture-glyph-renderer.md
+++ b/.changeset/fix-capture-glyph-renderer.md
@@ -1,0 +1,8 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Render every OpenTUI screenshot and recording through a renderer that supports
+xterm custom block glyphs. The shared harness now selects WebGL for opaque
+captures and Canvas for transparent captures, so engine banner logos no longer
+split into strips when a capture entry point omits its own renderer flag.

--- a/docs/HARNESS.md
+++ b/docs/HARNESS.md
@@ -198,8 +198,9 @@ only its beats. `--encode-only` re-encodes the take already on disk.
   engine banner art and pane borders meet without gaps. The DOM renderer draws
   each cell from the font and leaves visible seams; use
   `/harness?renderer=dom` only to compare renderers while diagnosing a capture.
-  If WebGL or Canvas cannot initialize, `ChatTerminal` still falls back to DOM
-  rather than failing the take.
+  If opaque WebGL cannot initialize or loses its context, `ChatTerminal` tries
+  Canvas before it falls back to DOM. Transparent Canvas failures fall back to
+  DOM rather than failing the take.
 - **The plugin takes need their plugins linked BEFORE the harness boots.** The
   TUI reads the plugin registry once at start (`loadPluginEngines()`, and the
   pane/settings sections alongside it), so a plugin linked mid-take contributes

--- a/docs/HARNESS.md
+++ b/docs/HARNESS.md
@@ -192,17 +192,14 @@ only its beats. `--encode-only` re-encodes the take already on disk.
   one, the seeded engine picks up Rove's contributor rules and narrates them.
   One take photographed an engine apologising for a commit flag those rules
   forbid, in a transcript meant to show a toy client getting a timeout.
-- **Recordings render through WebGL; stills do not.** The harness defaults to
-  xterm's DOM renderer, which draws every cell as its own span using the font
-  and therefore cannot use `customGlyphs` — xterm's geometric drawing of
-  block-element and box-drawing characters. Engine banner art and pane borders
-  are built from exactly those, so under DOM they photograph with a seam at
-  every cell boundary rather than the solid shapes a real terminal draws.
-  `hero-capture.ts` opens the harness with `?webgl=1`; `hero-shot.ts` takes an
-  optional `--webgl` for comparison but keeps DOM by default, because a WebGL
-  context is not guaranteed in every CI container and a still that fails to
-  render is worse than one with a seam. A failed context falls back to DOM
-  inside `ChatTerminal` either way, so the switch cannot break a take.
+- **The harness owns renderer selection for every capture.** Opaque stills and
+  recordings use WebGL. Transparent wallpaper captures use Canvas. Both can
+  draw xterm's `customGlyphs`, so block-element and box-drawing characters in
+  engine banner art and pane borders meet without gaps. The DOM renderer draws
+  each cell from the font and leaves visible seams; use
+  `/harness?renderer=dom` only to compare renderers while diagnosing a capture.
+  If WebGL or Canvas cannot initialize, `ChatTerminal` still falls back to DOM
+  rather than failing the take.
 - **The plugin takes need their plugins linked BEFORE the harness boots.** The
   TUI reads the plugin registry once at start (`loadPluginEngines()`, and the
   pane/settings sections alongside it), so a plugin linked mid-take contributes

--- a/packages/kobe-web/e2e/atlas/shoot.ts
+++ b/packages/kobe-web/e2e/atlas/shoot.ts
@@ -201,10 +201,7 @@ async function shootFlow(flow: Flow): Promise<void> {
   const runId = `atlas-${flow.name}-${Date.now()}`
   const page = await browser.newPage({ viewport: { width, height }, deviceScaleFactor: 1 })
   try {
-    // `webgl=1` for the same reason the stills use it: the DOM renderer cannot
-    // draw xterm's `customGlyphs`, so pane borders photograph with a seam at
-    // every cell boundary. A failed context falls back to DOM in ChatTerminal.
-    await page.goto(`http://localhost:${HERO_WEB_PORT}/harness?run=${runId}&webgl=1`).catch(() => {
+    await page.goto(`http://localhost:${HERO_WEB_PORT}/harness?run=${runId}`).catch(() => {
       throw new Error(`no server on :${HERO_WEB_PORT} — start \`bun e2e/hero-serve.ts\` first`)
     })
     await page.getByTestId("opentui-harness").waitFor({ timeout: 15_000 })

--- a/packages/kobe-web/e2e/hero-capture.ts
+++ b/packages/kobe-web/e2e/hero-capture.ts
@@ -163,27 +163,17 @@ export async function record(workDir: string, storyboard: (page: Page) => Promis
   })
   try {
     const page = await context.newPage()
-    // `webgl=1`: recordings need xterm's WebGL renderer, not the DOM one the
-    // harness defaults to. The DOM renderer draws every cell as its own span
-    // using the font, which disables `customGlyphs` — xterm's geometric
-    // drawing of block-element and box-drawing characters. Engine banner art
-    // is built from those (Claude Code's logo is `▛█▝▀`), so under DOM it
-    // photographs with a seam down every cell boundary instead of the solid
-    // shape a real terminal shows. Stills keep the DOM default: a WebGL
-    // context is not guaranteed in every CI container, and a still that fails
-    // to render is worse than one with a seam. A failed context falls back to
-    // DOM inside ChatTerminal either way.
     // `HERO_CAPTURE_WALLPAPER` swaps the flat backdrop for a desktop wallpaper
     // showing through a transparent terminal, which is what makes a capture
-    // read as a window rather than a rectangle. The renderer follows from that
-    // choice (see ChatTerminal): transparent takes the canvas renderer, opaque
-    // ones take WebGL. Both tile block-drawing glyphs without a seam; the DOM
-    // renderer, which does not, is only ever the fallback.
+    // read as a window rather than a rectangle. `/harness` owns renderer
+    // selection for both wallpaper and opaque captures.
     const wallpaper = process.env.HERO_CAPTURE_WALLPAPER
-    const query = wallpaper
-      ? `wallpaper=${encodeURIComponent(wallpaper)}`
-      : "webgl=1"
-    await page.goto(`http://localhost:${HERO_WEB_PORT}/harness?run=${runId}&${query}`)
+    const wallpaperQuery = wallpaper
+      ? `&wallpaper=${encodeURIComponent(wallpaper)}`
+      : ""
+    await page.goto(
+      `http://localhost:${HERO_WEB_PORT}/harness?run=${runId}${wallpaperQuery}`,
+    )
     await page.getByTestId("opentui-harness").waitFor({ timeout: 15_000 })
     await look(page, "orbit-sdk", 60_000)
     await page.getByTestId("opentui-terminal").click({ position: { x: 24, y: 400 } })

--- a/packages/kobe-web/e2e/hero-shot.ts
+++ b/packages/kobe-web/e2e/hero-shot.ts
@@ -58,10 +58,9 @@ const runId = `hero-${Date.now()}`
 const browser = await chromium.launch({ headless: true })
 try {
   const page = await browser.newPage({ viewport: { width, height }, deviceScaleFactor })
-  const webgl = args.includes("--webgl") ? "&webgl=1" : ""
   const wp = args.find((a) => a.startsWith("--wallpaper="))?.slice(12)
   const wallpaper = wp ? `&wallpaper=${encodeURIComponent(wp)}` : ""
-  await page.goto(`http://localhost:${HERO_WEB_PORT}/harness?run=${runId}${webgl}${wallpaper}`).catch(() => {
+  await page.goto(`http://localhost:${HERO_WEB_PORT}/harness?run=${runId}${wallpaper}`).catch(() => {
     throw new Error(`no server on :${HERO_WEB_PORT} — start \`bun e2e/hero-serve.ts\` first`)
   })
   await page.getByTestId("opentui-harness").waitFor({ timeout: 15_000 })

--- a/packages/kobe-web/e2e/hero-stills.ts
+++ b/packages/kobe-web/e2e/hero-stills.ts
@@ -200,11 +200,7 @@ try {
       viewport: { width, height },
       deviceScaleFactor: still.scale ?? STILL_SCALE,
     })
-    // `webgl=1` for the same reason recordings use it: the DOM renderer cannot
-    // use xterm's `customGlyphs`, so block-element and box-drawing characters
-    // (pane borders, engine banner art) photograph with a seam at every cell
-    // boundary. A failed context falls back to DOM inside ChatTerminal.
-    await page.goto(`http://localhost:${HERO_WEB_PORT}/harness?run=${runId}&webgl=1`)
+    await page.goto(`http://localhost:${HERO_WEB_PORT}/harness?run=${runId}`)
     await page.getByTestId("opentui-harness").waitFor({ timeout: 15_000 })
     await look(page, "orbit-sdk", 60_000)
     await page.getByTestId("opentui-terminal").click({ position: { x: 24, y: Math.min(400, height - 80) } })

--- a/packages/kobe-web/src/components/ChatTerminal.tsx
+++ b/packages/kobe-web/src/components/ChatTerminal.tsx
@@ -241,9 +241,9 @@ export function ChatTerminal({
       // Plain URLs in engine output become clickable.
       term.loadAddon(new WebLinksAddon())
       term.open(el)
-      // The visual harness pins the stock renderer so browser screenshots and
-      // buffer synchronization do not depend on GPU/WebGL availability.
-      // Renderer choice, and it is a three-way trade rather than a preference:
+      // The visual harness normally keeps this renderer policy. Its explicit
+      // DOM diagnostic mode passes `disableWebgl`; buffer reads stay renderer-
+      // independent either way. Renderer choice is a three-way trade:
       //
       //   DOM    — always available, but each cell is its own span drawn with
       //            the font, so `customGlyphs` is off and block-drawing

--- a/packages/kobe-web/src/components/ChatTerminal.tsx
+++ b/packages/kobe-web/src/components/ChatTerminal.tsx
@@ -12,12 +12,10 @@
  * scrollback ring on re-attach, so reattaching is loss-free.
  */
 
-import { CanvasAddon } from "@xterm/addon-canvas"
 import { ClipboardAddon } from "@xterm/addon-clipboard"
 import { FitAddon } from "@xterm/addon-fit"
 import { Unicode11Addon } from "@xterm/addon-unicode11"
 import { WebLinksAddon } from "@xterm/addon-web-links"
-import { WebglAddon } from "@xterm/addon-webgl"
 import { Terminal } from "@xterm/xterm"
 import "@xterm/xterm/css/xterm.css"
 import { CornerDownLeft, RotateCw } from "lucide-react"
@@ -30,6 +28,10 @@ import {
 import { useAppState } from "../lib/store.ts"
 import { consumePendingPrompt } from "../lib/tabs.ts"
 import { type PtyMode, ptyUrl } from "../lib/terminal.ts"
+import {
+  loadTerminalRenderer,
+  type TerminalRendererMode,
+} from "../lib/terminal-renderer.ts"
 import { xtermTheme } from "../lib/theme.ts"
 import { isWebTransportOffline } from "../lib/web-transport.ts"
 
@@ -116,7 +118,7 @@ type ChatTerminalProps = {
   taskId: string
   mode: PtyMode
   testId?: string
-  disableWebgl?: boolean
+  renderer?: TerminalRendererMode
   /**
    * Let whatever is behind the terminal show through the cells the TUI does
    * not paint. The product already renders with a transparent background by
@@ -154,7 +156,7 @@ export function ChatTerminal({
   taskId,
   mode,
   testId,
-  disableWebgl = false,
+  renderer = "automatic",
   transparent = false,
   hostBackground,
   onStatusChange,
@@ -242,8 +244,8 @@ export function ChatTerminal({
       term.loadAddon(new WebLinksAddon())
       term.open(el)
       // The visual harness normally keeps this renderer policy. Its explicit
-      // DOM diagnostic mode passes `disableWebgl`; buffer reads stay renderer-
-      // independent either way. Renderer choice is a three-way trade:
+      // DOM diagnostic mode skips both accelerated addons; buffer reads stay
+      // renderer-independent either way. Renderer choice is a three-way trade:
       //
       //   DOM    — always available, but each cell is its own span drawn with
       //            the font, so `customGlyphs` is off and block-drawing
@@ -254,22 +256,9 @@ export function ChatTerminal({
       //   Canvas — draws glyphs the same way WebGL does, on a 2D context that
       //            composites over what is behind it.
       //
-      // So transparency picks canvas and opacity picks WebGL.
-      if (transparent) {
-        try {
-          term.loadAddon(new CanvasAddon())
-        } catch {
-          /* DOM renderer fallback */
-        }
-      } else if (!disableWebgl) {
-        try {
-          const webgl = new WebglAddon()
-          webgl.onContextLoss(() => webgl.dispose())
-          term.loadAddon(webgl)
-        } catch {
-          /* DOM renderer fallback */
-        }
-      }
+      // So transparency picks Canvas and opacity picks WebGL. Opaque WebGL
+      // failures fall through Canvas before the final DOM fallback.
+      loadTerminalRenderer(term, renderer, transparent)
       try {
         fit.fit()
       } catch {
@@ -345,7 +334,7 @@ export function ChatTerminal({
     taskId,
     mode,
     epoch,
-    disableWebgl,
+    renderer,
     transparent,
     hostBackground,
     onStatusChange,

--- a/packages/kobe-web/src/lib/harness-renderer.ts
+++ b/packages/kobe-web/src/lib/harness-renderer.ts
@@ -1,4 +1,4 @@
-export type HarnessRenderer = "automatic" | "dom"
+import type { TerminalRendererMode } from "./terminal-renderer.ts"
 
 /**
  * Captures use xterm's custom-glyph renderers by default. They draw block and
@@ -8,6 +8,6 @@ export type HarnessRenderer = "automatic" | "dom"
  */
 export function resolveHarnessRenderer(
   search: URLSearchParams,
-): HarnessRenderer {
+): TerminalRendererMode {
   return search.get("renderer") === "dom" ? "dom" : "automatic"
 }

--- a/packages/kobe-web/src/lib/harness-renderer.ts
+++ b/packages/kobe-web/src/lib/harness-renderer.ts
@@ -1,0 +1,13 @@
+export type HarnessRenderer = "automatic" | "dom"
+
+/**
+ * Captures use xterm's custom-glyph renderers by default. They draw block and
+ * box glyphs as geometry, while the DOM renderer draws them from the font and
+ * leaves visible gaps between cells. Keep DOM available only for renderer
+ * comparisons and environments that need an explicit diagnostic fallback.
+ */
+export function resolveHarnessRenderer(
+  search: URLSearchParams,
+): HarnessRenderer {
+  return search.get("renderer") === "dom" ? "dom" : "automatic"
+}

--- a/packages/kobe-web/src/lib/terminal-renderer.ts
+++ b/packages/kobe-web/src/lib/terminal-renderer.ts
@@ -1,0 +1,45 @@
+import { CanvasAddon } from "@xterm/addon-canvas"
+import { WebglAddon } from "@xterm/addon-webgl"
+import type { Terminal } from "@xterm/xterm"
+
+export type TerminalRendererMode = "automatic" | "dom"
+
+type TerminalAddonLoader = Pick<Terminal, "loadAddon">
+
+function loadCanvasRenderer(terminal: TerminalAddonLoader): void {
+  try {
+    terminal.loadAddon(new CanvasAddon())
+  } catch {
+    /* DOM renderer fallback */
+  }
+}
+
+export function loadTerminalRenderer(
+  terminal: TerminalAddonLoader,
+  renderer: TerminalRendererMode,
+  transparent: boolean,
+): void {
+  if (renderer === "dom") return
+  if (transparent) {
+    loadCanvasRenderer(terminal)
+    return
+  }
+
+  let webgl: WebglAddon | undefined
+  const fallbackToCanvas = (): void => {
+    try {
+      webgl?.dispose()
+    } catch {
+      /* renderer is already unusable */
+    }
+    loadCanvasRenderer(terminal)
+  }
+
+  try {
+    webgl = new WebglAddon()
+    webgl.onContextLoss(fallbackToCanvas)
+    terminal.loadAddon(webgl)
+  } catch {
+    fallbackToCanvas()
+  }
+}

--- a/packages/kobe-web/src/routes/harness.tsx
+++ b/packages/kobe-web/src/routes/harness.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router"
 import { useState } from "react"
 import { ChatTerminal, type WsStatus } from "../components/ChatTerminal.tsx"
+import { resolveHarnessRenderer } from "../lib/harness-renderer.ts"
 
 /**
  * `/harness` — the one fixed-viewport observation surface for the real
@@ -12,16 +13,13 @@ function PtyHarness() {
   const rawRun =
     new URLSearchParams(window.location.search).get("run") ?? "manual"
   const runId = rawRun.replace(/[^a-zA-Z0-9_-]/g, "").slice(0, 48) || "manual"
-  // `?webgl=1` opts INTO the WebGL renderer. The DOM renderer stays the
-  // default because it cannot fail to initialize, but it renders every cell
-  // as its own span using the font — and xterm's `customGlyphs`, which draws
-  // block-element and box-drawing characters geometrically so they tile with
-  // no seam, is documented as DOM-renderer-incompatible. Engine banner art
-  // (Claude Code's logo is `▛█▝▀`) therefore photographs with a gap in every
-  // cell. Recordings turn this on; a WebGL context that fails to come up
-  // falls back to DOM inside ChatTerminal, so the switch cannot break a take.
-  const useWebgl =
-    new URLSearchParams(window.location.search).get("webgl") === "1"
+  // Renderer policy belongs to the one capture boundary, not to every script
+  // that opens it. Opaque captures use WebGL and transparent captures use
+  // Canvas inside ChatTerminal; both draw custom block glyphs without gaps.
+  // `?renderer=dom` remains a diagnostic comparison path.
+  const renderer = resolveHarnessRenderer(
+    new URLSearchParams(window.location.search),
+  )
   // `?wallpaper=<path>` paints a backdrop behind the terminal. Same-origin
   // paths only: this route renders whatever it is handed, and a capture URL is
   // not a place to accept an arbitrary remote image.
@@ -78,7 +76,7 @@ function PtyHarness() {
         taskId={sessionId}
         mode="shell"
         testId="opentui-terminal"
-        disableWebgl={!useWebgl}
+        disableWebgl={renderer === "dom"}
         transparent={wallpaper !== null || hostbg !== null}
         hostBackground={hostbg ?? undefined}
         onStatusChange={setStatus}

--- a/packages/kobe-web/src/routes/harness.tsx
+++ b/packages/kobe-web/src/routes/harness.tsx
@@ -76,7 +76,7 @@ function PtyHarness() {
         taskId={sessionId}
         mode="shell"
         testId="opentui-terminal"
-        disableWebgl={renderer === "dom"}
+        renderer={renderer}
         transparent={wallpaper !== null || hostbg !== null}
         hostBackground={hostbg ?? undefined}
         onStatusChange={setStatus}

--- a/packages/kobe-web/test/harness-renderer.test.ts
+++ b/packages/kobe-web/test/harness-renderer.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest"
+import { resolveHarnessRenderer } from "../src/lib/harness-renderer.ts"
+
+describe("harness renderer policy", () => {
+  it("uses the automatic WebGL or Canvas path by default", () => {
+    expect(resolveHarnessRenderer(new URLSearchParams())).toBe("automatic")
+    expect(resolveHarnessRenderer(new URLSearchParams("wallpaper=/capture-wallpaper.svg"))).toBe("automatic")
+  })
+
+  it("keeps DOM rendering behind an explicit diagnostic query", () => {
+    expect(resolveHarnessRenderer(new URLSearchParams("renderer=dom"))).toBe("dom")
+    expect(resolveHarnessRenderer(new URLSearchParams("renderer=webgl"))).toBe("automatic")
+  })
+})

--- a/packages/kobe-web/test/terminal-renderer.test.ts
+++ b/packages/kobe-web/test/terminal-renderer.test.ts
@@ -1,0 +1,144 @@
+import type { ITerminalAddon } from "@xterm/xterm"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+type RendererMockState = {
+  canvasConstructions: number
+  contextLoss: (() => void) | undefined
+  webglConstructions: number
+  webglDisposals: number
+}
+
+const rendererState = vi.hoisted<RendererMockState>(() => ({
+  canvasConstructions: 0,
+  contextLoss: undefined,
+  webglConstructions: 0,
+  webglDisposals: 0,
+}))
+
+vi.mock("@xterm/addon-canvas", () => ({
+  CanvasAddon: class CanvasAddon implements ITerminalAddon {
+    constructor() {
+      rendererState.canvasConstructions += 1
+    }
+
+    activate(): void {}
+    dispose(): void {}
+  },
+}))
+
+vi.mock("@xterm/addon-webgl", () => ({
+  WebglAddon: class WebglAddon implements ITerminalAddon {
+    constructor() {
+      rendererState.webglConstructions += 1
+    }
+
+    activate(): void {}
+
+    onContextLoss(listener: () => void): { dispose(): void } {
+      rendererState.contextLoss = listener
+      return { dispose() {} }
+    }
+
+    dispose(): void {
+      rendererState.webglDisposals += 1
+    }
+  },
+}))
+
+import { CanvasAddon } from "@xterm/addon-canvas"
+import { WebglAddon } from "@xterm/addon-webgl"
+import { loadTerminalRenderer } from "../src/lib/terminal-renderer.ts"
+
+function createTerminalLoader() {
+  const loaded: ITerminalAddon[] = []
+  let failCanvas = false
+  let failWebgl = false
+
+  return {
+    loaded,
+    failCanvas() {
+      failCanvas = true
+    },
+    failWebgl() {
+      failWebgl = true
+    },
+    terminal: {
+      loadAddon(addon: ITerminalAddon): void {
+        if (failWebgl && addon instanceof WebglAddon) {
+          throw new Error("WebGL initialization failed")
+        }
+        if (failCanvas && addon instanceof CanvasAddon) {
+          throw new Error("Canvas initialization failed")
+        }
+        loaded.push(addon)
+      },
+    },
+  }
+}
+
+describe("terminal renderer addon selection", () => {
+  beforeEach(() => {
+    rendererState.canvasConstructions = 0
+    rendererState.contextLoss = undefined
+    rendererState.webglConstructions = 0
+    rendererState.webglDisposals = 0
+  })
+
+  it("keeps transparent DOM mode on the DOM renderer", () => {
+    const loader = createTerminalLoader()
+
+    loadTerminalRenderer(loader.terminal, "dom", true)
+
+    expect(loader.loaded).toEqual([])
+    expect(rendererState.canvasConstructions).toBe(0)
+    expect(rendererState.webglConstructions).toBe(0)
+  })
+
+  it("uses Canvas for transparent automatic mode", () => {
+    const loader = createTerminalLoader()
+
+    loadTerminalRenderer(loader.terminal, "automatic", true)
+
+    expect(loader.loaded).toHaveLength(1)
+    expect(loader.loaded[0]).toBeInstanceOf(CanvasAddon)
+    expect(rendererState.webglConstructions).toBe(0)
+  })
+
+  it("falls back from failed WebGL initialization through Canvas to DOM", () => {
+    const loader = createTerminalLoader()
+    loader.failWebgl()
+
+    loadTerminalRenderer(loader.terminal, "automatic", false)
+
+    expect(rendererState.webglDisposals).toBe(1)
+    expect(loader.loaded).toHaveLength(1)
+    expect(loader.loaded[0]).toBeInstanceOf(CanvasAddon)
+
+    const domFallback = createTerminalLoader()
+    domFallback.failWebgl()
+    domFallback.failCanvas()
+    expect(() =>
+      loadTerminalRenderer(domFallback.terminal, "automatic", false),
+    ).not.toThrow()
+    expect(domFallback.loaded).toEqual([])
+  })
+
+  it("falls back from WebGL context loss through Canvas to DOM", () => {
+    const loader = createTerminalLoader()
+
+    loadTerminalRenderer(loader.terminal, "automatic", false)
+    expect(loader.loaded[0]).toBeInstanceOf(WebglAddon)
+
+    rendererState.contextLoss?.()
+
+    expect(rendererState.webglDisposals).toBe(1)
+    expect(loader.loaded[1]).toBeInstanceOf(CanvasAddon)
+
+    const domFallback = createTerminalLoader()
+    loadTerminalRenderer(domFallback.terminal, "automatic", false)
+    domFallback.failCanvas()
+    expect(() => rendererState.contextLoss?.()).not.toThrow()
+    expect(domFallback.loaded).toHaveLength(1)
+    expect(domFallback.loaded[0]).toBeInstanceOf(WebglAddon)
+  })
+})


### PR DESCRIPTION
## Summary

- Move xterm renderer selection to the shared `/harness` capture boundary. Opaque screenshots and recordings now use WebGL; transparent wallpaper captures use Canvas. Both support xterm custom block glyphs.
- Keep the DOM renderer available only through `?renderer=dom` for diagnosis, with the existing safe fallback when an addon cannot initialize.
- Remove the caller-specific WebGL flags from the static, recording, still, and atlas entry points. `visual-shot.ts` and every flow built on `hero-capture.ts` now inherit the same policy without their own patch.

## Root cause and proof

The recurring defect was renderer-policy drift, not viewport sizing, line-height measurement, glyph overflow, or capture timing.

I held the 1280x800 viewport, terminal buffer, Claude 2.1.258 onboarding banner, and settled capture timing constant, then changed only the xterm renderer:

- DOM reproduced the reported vertical strips and cut mascot.
- WebGL rendered the same banner as a continuous solid shape.
- Canvas rendered the same banner as a continuous solid shape over the wallpaper path.
- A Playwright `recordVideo` run through WebGL also retained the complete banner in the encoded frame.

xterm's own type documentation gives the causal mechanism: `customGlyphs` draws block and box glyphs geometrically so adjacent cells remain continuous, and it does not work with the DOM renderer. The old `/harness` default was DOM, while capture callers inconsistently opted into WebGL. Any omitted or newly added caller therefore reintroduced the defect.

`packages/branding` quicklook `capture-core` is outside this path: it captures ANSI frames for a later React replay and does not select an xterm renderer.

## Archaeology and consolidation

- `a1d7b281` (merged as `f30dd880`, 2026-08-27) added `?webgl=1` to `hero-capture.ts`, an optional `--webgl` to `hero-shot.ts`, and the matching harness opt-in. This fixed recordings only because those callers remembered the flag.
- `e35f814d` (2026-08-28) created `hero-stills.ts` with another hard-coded `&webgl=1` point fix.
- `f43e132b` (2026-08-29) repeated the hard-coded flag in `e2e/atlas/shoot.ts`.
- `7eafafdd` (2026-08-29) added the wallpaper branch in `hero-capture.ts`, selecting Canvas indirectly for transparent takes and WebGL explicitly otherwise.

The old patches can now be removed for one reason each:

- `hero-capture.ts`: both opaque recordings and transparent wallpaper recordings are selected by `/harness`; the shared `hero-kanban`, `hero-routines`, and `hero-plugin-demos` flows inherit it.
- `hero-stills.ts`: stills no longer need to opt in independently.
- `hero-shot.ts`: the old optional `--webgl` would make correctness depend on a caller flag; DOM comparison now has the explicit `?renderer=dom` diagnostic.
- `e2e/atlas/shoot.ts`: atlas captures use the same harness default.
- `visual-shot.ts`: no local patch existed, which is why the defect remained there; it is fixed by the shared default without a file-specific edit.

No files were deleted.

## Verification

- `bun run lint` — passed, 1329 files.
- `bun run typecheck` — passed for plugin SDK, daemon, and Rove.
- `bun --filter kobe-web test` — 71 files, 572 tests passed.
- `bun --filter kobe-web build` — passed.
- `KOBE_VISUAL_PORT_BASE=5373 KOBE_VISUAL_FRESH=1 bun run visual` — 5/5 real `/harness` → xterm → PTY → OpenTUI journeys passed.
- `bun run test:socket` — 79 files, 675 tests passed.
- `bun run build && bun run test:behavior` in `packages/kobe` — 11 files, 31 tests passed.
- Touched source files remain at or below 500 lines.
- Patch changeset: `@sma1lboy/rove`.

The broad fast-test command in this Rove-owned worktree reported five path-sensitive baseline failures: four tests classify `.rove/worktrees` as an internal path by design, and one concurrent protocol-sniff case timed out. The same three failing test files passed 44/44 unchanged on `main` in a durable non-Rove clone at `/Users/narwhal/.codex/verification/kobe-capture-base-01M1FYKRP2W75DS1VQ8FY27AMF`.

Local acceptance artifacts:

- Static screenshot: `/Users/narwhal/.rove/worktrees/kobe-d0b1d48497f6/springbok/packages/kobe-web/.scratch/capture-logo-fix/static-banner.png`
- Recording: `/Users/narwhal/.rove/worktrees/kobe-d0b1d48497f6/springbok/packages/kobe-web/.scratch/capture-logo-fix/recording-banner.mp4`
- Extracted recording frame: `/Users/narwhal/.rove/worktrees/kobe-d0b1d48497f6/springbok/packages/kobe-web/.scratch/capture-logo-fix/recording-frame.png`

coverage-exemption: `packages/kobe-web/src/components/ChatTerminal.tsx` — comment-only update; renderer behavior is covered by the browser `/harness` visual track.
