### PR TITLE
feat: close terminal tabs through rove api tab-close

### DIFF
--- a/.agents/skills/kobe/SKILL.md
+++ b/.agents/skills/kobe/SKILL.md
@@ -3,7 +3,7 @@ name: rove
 description: Use when controlling Rove tasks, parallel coding attempts, hosted agent sessions, task lifecycle, or the daemon-owned issue tracker from a shell. Also the ONLY channel for messaging another agent session on this machine — `rove api send`, never a peer/MCP side channel.
 ---
 
-<!-- rove-skill-version: 38 — bump in lockstep with KOBE_SKILL_VERSION (src/lib/skill-install.ts). -->
+<!-- rove-skill-version: 39 — bump in lockstep with KOBE_SKILL_VERSION (src/lib/skill-install.ts). -->
 
 # Rove shell control
 
@@ -331,6 +331,10 @@ rove api pane-open --placement tab --title logs --command "tail -f app.log"
 
 # Close panes you opened, by their --title (engine panes are never closed).
 rove api pane-close --title logs
+
+# Close one whole Terminal Tab by the id from `get-task .tabs[]`.
+# This works with or without an attached TUI.
+rove api tab-close --task-id <id> --tab tab-3
 
 # Toast a one-liner in every attached Rove UI — surface "done / needs input /
 # error" moments without touching any session (kinds get severity styling).

--- a/.agents/skills/kobe/references/api-flags.md
+++ b/.agents/skills/kobe/references/api-flags.md
@@ -85,6 +85,7 @@ note        --task-id(REQ) --text(REQ)
 note-list   --repo(REQ)
 pane-open   --command --task-id --tab --direction[right|down] --placement[split|tab] --title
 pane-close  --title(REQ) --task-id --tab
+tab-close   --task-id(REQ) --tab(REQ)
 notify      --title(REQ) --kind --task-id --source
 prompt      --title(REQ) --placeholder --initial --timeout
 set-active  --task-id | --none
@@ -105,6 +106,12 @@ treatment and an unread mark, anything else renders neutrally.
 
 `pane-open --command` runs through the login shell's `-ilc`, so pipes and
 your rc's PATH work.
+
+`tab-close` names one exact Terminal Tab from `get-task .tabs[].id`. Unlike
+`pane-close`, it also works headless: it removes the persisted tab snapshot
+and ends that tab's hosted PTYs. It accepts engine, shell/command, and content
+tabs; closing the last tab leaves the task open with no session. A missing or
+already-closed id returns `TAB_NOT_FOUND` and points back to `get-task`.
 
 ## create / edit / lifecycle
 

--- a/.changeset/close-terminal-tabs-from-api.md
+++ b/.changeset/close-terminal-tabs-from-api.md
@@ -1,0 +1,8 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Add `rove api tab-close --task-id <id> --tab <tab-N>` to close an exact
+Terminal Tab with or without an attached TUI. The command follows the normal
+ctrl+w lifecycle, including hosted PTY cleanup and the empty-task result when
+the last tab closes.

--- a/claude-plugin/skills/rove/SKILL.md
+++ b/claude-plugin/skills/rove/SKILL.md
@@ -3,7 +3,7 @@ name: rove
 description: Use when controlling Rove tasks, parallel coding attempts, hosted agent sessions, task lifecycle, or the daemon-owned issue tracker from a shell. Also the ONLY channel for messaging another agent session on this machine — `rove api send`, never a peer/MCP side channel.
 ---
 
-<!-- rove-skill-version: 38 — bump in lockstep with KOBE_SKILL_VERSION (src/lib/skill-install.ts). -->
+<!-- rove-skill-version: 39 — bump in lockstep with KOBE_SKILL_VERSION (src/lib/skill-install.ts). -->
 
 # Rove shell control
 
@@ -331,6 +331,10 @@ rove api pane-open --placement tab --title logs --command "tail -f app.log"
 
 # Close panes you opened, by their --title (engine panes are never closed).
 rove api pane-close --title logs
+
+# Close one whole Terminal Tab by the id from `get-task .tabs[]`.
+# This works with or without an attached TUI.
+rove api tab-close --task-id <id> --tab tab-3
 
 # Toast a one-liner in every attached Rove UI — surface "done / needs input /
 # error" moments without touching any session (kinds get severity styling).

--- a/docs/API.md
+++ b/docs/API.md
@@ -380,6 +380,15 @@ placeholder branch to a descriptive name. Prompts into existing sessions
   `tab.close` channel; an attached TUI performs the close (headless, nothing
   happens). The result's `clients` is the reach signal: `0` = no attached TUI
   performed the close (same semantics as `dispatch`'s).
+- `tab-close --task-id ID --tab TAB`: close one exact Terminal Tab using the
+  id returned by `get-task` in `.tabs[].id`. Engine, interactive-shell,
+  command, and content tabs are all valid. With an attached TUI, the command
+  runs the same close path as ctrl+w, so the tab strip updates immediately;
+  headless, it removes the persisted tab snapshot and ends the tab's hosted
+  PTY plus any split-leaf PTYs directly. Closing the last tab leaves the task
+  open with no session, matching ctrl+w. A tab that still exists in the
+  snapshot may be closed after its process dies; an absent or already-closed
+  id returns `TAB_NOT_FOUND` with a `get-task` recovery command.
 - `notify --title TEXT [--kind KIND] [--task-id ID] [--source TAG]`: show
   a toast in every attached Rove UI. `done` / `needs_input` / `error` get
   severity styling; any other kind renders neutrally. The result's `clients`

--- a/packages/kobe-daemon/package.json
+++ b/packages/kobe-daemon/package.json
@@ -48,6 +48,7 @@
     "./daemon/platform-shell": "./src/daemon/platform-shell.js",
     "./daemon/pr-status-collector": "./src/daemon/pr-status-collector.ts",
     "./daemon/prompt-broker": "./src/daemon/prompt-broker.ts",
+    "./daemon/tab-close-broker": "./src/daemon/tab-close-broker.ts",
     "./daemon/protocol": "./src/daemon/protocol.ts",
     "./daemon/pty-driver": "./src/daemon/pty-driver.ts",
     "./daemon/pty-env": "./src/daemon/pty-env.js",

--- a/packages/kobe-daemon/src/daemon/channels.ts
+++ b/packages/kobe-daemon/src/daemon/channels.ts
@@ -322,8 +322,8 @@ export interface TabOpenPayload {
   readonly at: number
 }
 
-/** The `tab.close` channel payload — close panes opened under `title`. */
-export interface TabClosePayload {
+/** The `tab.close` channel's pane-close variant. */
+export interface PaneClosePayload {
   readonly taskId: string
   /** Pane label to close — matches the `title` split leaves / command tabs
    *  were opened with (`tab.open`); engine leaves are never closed. */
@@ -334,6 +334,19 @@ export interface TabClosePayload {
   /** Publish time (ms epoch) — the consumer-side dedupe key. */
   readonly at: number
 }
+
+/** The `tab.close` channel's exact Terminal Tab close variant. */
+export interface TerminalTabClosePayload {
+  readonly kind: "terminal-tab"
+  readonly taskId: string
+  readonly tabId: string
+  /** Correlates the TUI's close result with the waiting CLI request. */
+  readonly requestId: string
+  readonly at: number
+}
+
+/** Pane closes retain their existing wire shape; exact tab closes discriminate by `kind`. */
+export type TabClosePayload = PaneClosePayload | TerminalTabClosePayload
 
 /** The `ui.prompt` channel payload — one host-dialog text-input request. */
 export interface UiPromptPayload {

--- a/packages/kobe-daemon/src/daemon/handlers-ui.ts
+++ b/packages/kobe-daemon/src/daemon/handlers-ui.ts
@@ -11,13 +11,16 @@
  */
 
 import { randomUUID } from "node:crypto"
-import { optionalString, requireString } from "./handler-validators.ts"
+import { optionalBoolean, optionalString, requireString } from "./handler-validators.ts"
 import type { DaemonRequestHandler } from "./handlers.ts"
 import { displayTaskTitle } from "./protocol.ts"
 
 /** `ui.prompt` timeout bounds — a plugin must not hang the CLI forever. */
 const PROMPT_DEFAULT_TIMEOUT_MS = 120_000
 const PROMPT_MAX_TIMEOUT_MS = 600_000
+/** A live TUI normally acknowledges in one render turn. Bound the wait so a
+ * stale GUI connection cannot turn a headless close into a hung CLI. */
+const TAB_CLOSE_TUI_TIMEOUT_MS = 750
 
 export const UI_HANDLERS: readonly DaemonRequestHandler[] = [
   {
@@ -184,6 +187,35 @@ export const UI_HANDLERS: readonly DaemonRequestHandler[] = [
       // A close with no attached TUI silently matched nothing — without this
       // the caller cannot tell "pane closed" from "nobody was listening".
       return { ok: true, clients: ctx.daemon.clientCount() }
+    },
+  },
+  {
+    name: "terminalTab.close",
+    async handle(payload, ctx) {
+      const taskId = requireString(payload, "taskId")
+      const tabId = requireString(payload, "tabId")
+      if (!ctx.orch.getTask(taskId)) throw new Error(`task not found: ${taskId}`)
+      const broker = ctx.tabCloses
+      if (!broker || ctx.daemon.guiCount() === 0) return { ok: true, handled: false }
+
+      const requestId = randomUUID()
+      const handled = broker.create(requestId, TAB_CLOSE_TUI_TIMEOUT_MS)
+      ctx.bus.publish("tab.close", {
+        kind: "terminal-tab",
+        taskId,
+        tabId,
+        requestId,
+        at: Date.now(),
+      })
+      return { ok: true, handled: await handled }
+    },
+  },
+  {
+    name: "terminalTab.closeReply",
+    handle(payload, ctx) {
+      const requestId = requireString(payload, "requestId")
+      const closed = optionalBoolean(payload, "closed") ?? false
+      return { ok: ctx.tabCloses?.settle(requestId, closed) ?? false }
     },
   },
   {

--- a/packages/kobe-daemon/src/daemon/handlers.ts
+++ b/packages/kobe-daemon/src/daemon/handlers.ts
@@ -66,6 +66,7 @@ import {
 } from "./protocol.ts"
 import type { QuotaUsageCache } from "./quota-usage-cache.ts"
 import type { DaemonRuntimeAdapter } from "./runtime.ts"
+import type { TabCloseBroker } from "./tab-close-broker.ts"
 import type { TaskDeletionScheduler } from "./task-deletion-runner.ts"
 import type { WorkItemCache } from "./work-items.ts"
 
@@ -121,6 +122,8 @@ export interface DaemonHandlerContext {
   readonly engineEvents?: import("./engine-events-log.ts").EngineEventLog
   /** Pending host-dialog prompts (`ui.prompt` / `ui.promptReply`). */
   readonly prompts?: import("./prompt-broker.ts").PromptBroker
+  /** Pending exact Terminal Tab closes awaiting a TUI acknowledgement. */
+  readonly tabCloses?: TabCloseBroker
   /** Plugin sink for agent-lifecycle events — a direct feed, deliberately NOT a bus channel. */
   readonly plugins?: Pick<import("../plugins/runtime.ts").PluginHost, "handleEngineReport" | "handleUiReport">
   /** Daemon-process facts + lifecycle controls handlers surface or drive. */

--- a/packages/kobe-daemon/src/daemon/protocol.ts
+++ b/packages/kobe-daemon/src/daemon/protocol.ts
@@ -258,6 +258,11 @@ export type DaemonRequestName =
   // The inverse: publish a `tab.close` channel event asking the TUI hosting
   // the task to close panes previously opened under a title.
   | "tab.close"
+  // Exact Terminal Tab lifecycle: ask an attached TUI to run its normal
+  // ctrl+w close path, then acknowledge whether it owned the tab. The CLI
+  // falls back to the standalone PTY Host when nobody confirms.
+  | "terminalTab.close"
+  | "terminalTab.closeReply"
   // Broadcast one toast to every attached UI over the `notice.event`
   // channel (`kobe api notify`). The daemon only validates + publishes.
   | "notice.send"

--- a/packages/kobe-daemon/src/daemon/server.ts
+++ b/packages/kobe-daemon/src/daemon/server.ts
@@ -43,6 +43,7 @@ import type { DaemonServer, DaemonServerOptions } from "./server-options.ts"
 import { createSocketOwnershipGuard, listenOnUnixSocket } from "./socket-guard.ts"
 import { initDaemonStores } from "./stores.ts"
 import { handleSubscribe } from "./subscribe.ts"
+import { TabCloseBroker } from "./tab-close-broker.ts"
 import { type DaemonWebServer, createDirectWebLink, startDaemonWebServer } from "./web-server.ts"
 import { WorkItemCache } from "./work-items.ts"
 
@@ -275,6 +276,7 @@ export async function startDaemonServer(orch: DaemonOrchestrator, options: Daemo
 
   // Pending host-dialog prompts (`ui.prompt` ↔ `ui.promptReply`).
   const prompts = new PromptBroker()
+  const tabCloses = new TabCloseBroker()
 
   let webServer: DaemonWebServer | null = null
   // Why the web transport isn't listening (port taken, bind failed). Surfaced
@@ -314,6 +316,7 @@ export async function startDaemonServer(orch: DaemonOrchestrator, options: Daemo
       // Awaited: [[shutdown]] hooks finish inside stop()'s bounded grace.
       await pluginHost?.stop()
       prompts.clear()
+      tabCloses.clear()
       activity.close()
       // Hosted PTYs are deliberately NOT touched here: they live in the
       // standalone `kobe pty-host` process, so `kobe daemon restart` never
@@ -380,6 +383,7 @@ export async function startDaemonServer(orch: DaemonOrchestrator, options: Daemo
       engineEvents,
       ...(pluginHost ? { plugins: pluginHost } : {}),
       prompts,
+      tabCloses,
       daemon: {
         startedAt,
         socketPath,

--- a/packages/kobe-daemon/src/daemon/tab-close-broker.ts
+++ b/packages/kobe-daemon/src/daemon/tab-close-broker.ts
@@ -1,0 +1,46 @@
+/**
+ * Pending exact Terminal Tab closes (`terminalTab.close` -> TUI close path ->
+ * `terminalTab.closeReply`). A daemon request waits only when a TUI is
+ * attached. The first client that confirms a close settles the request;
+ * negative replies leave room for another attached TUI with fresher state.
+ */
+
+type Pending = {
+  readonly resolve: (closed: boolean) => void
+  readonly timer: ReturnType<typeof setTimeout>
+}
+
+export class TabCloseBroker {
+  private readonly pending = new Map<string, Pending>()
+
+  /** Resolve true on the first confirmed close, false when the wait expires. */
+  create(requestId: string, timeoutMs: number): Promise<boolean> {
+    return new Promise((resolve) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(requestId)
+        resolve(false)
+      }, timeoutMs)
+      this.pending.set(requestId, { resolve, timer })
+    })
+  }
+
+  /** Confirm a close. False acknowledgements do not pre-empt another TUI. */
+  settle(requestId: string, closed: boolean): boolean {
+    const entry = this.pending.get(requestId)
+    if (!entry) return false
+    if (!closed) return true
+    this.pending.delete(requestId)
+    clearTimeout(entry.timer)
+    entry.resolve(true)
+    return true
+  }
+
+  /** Settle every waiter during daemon shutdown. */
+  clear(): void {
+    for (const [id, entry] of this.pending) {
+      clearTimeout(entry.timer)
+      entry.resolve(false)
+      this.pending.delete(id)
+    }
+  }
+}

--- a/packages/kobe/src/cli/api/handlers-pane.ts
+++ b/packages/kobe/src/cli/api/handlers-pane.ts
@@ -121,3 +121,28 @@ export const PANE_CLOSE_VERB: VerbSpec = {
     })
   },
 }
+
+export const TAB_CLOSE_VERB: VerbSpec = {
+  name: "tab-close",
+  group: "drive",
+  summary:
+    "Close one Terminal Tab by the id returned in get-task .tabs[]. Runs the same close path as ctrl+w when a TUI is attached; otherwise removes the persisted tab snapshot and ends its hosted PTYs directly. Engine, shell/command, and content tabs are all valid. Closing the last tab leaves the task open with no session.",
+  flags: [
+    F.taskId(true),
+    {
+      name: "tab",
+      type: "string",
+      required: true,
+      placeholder: "TAB",
+      description: "Exact Terminal Tab id from get-task .tabs[].id (for example tab-3).",
+    },
+  ],
+  handler: async (ctx) => {
+    const taskId = ctx.args.require("task-id")
+    const tabId = ctx.args.require("tab")
+    const reply = await daemonOf(ctx).request<{ handled?: boolean }>("terminalTab.close", { taskId, tabId })
+    if (reply.handled) return { ok: true, taskId, tabId, handledBy: "tui" }
+    const result = await ctx.runtime.closeTerminalTab(taskId, tabId)
+    return { ok: true, taskId, tabId, handledBy: "headless", ...result }
+  },
+}

--- a/packages/kobe/src/cli/api/runtime.ts
+++ b/packages/kobe/src/cli/api/runtime.ts
@@ -11,6 +11,7 @@ import { engineLaunchArgv, withPinnedSessionId } from "../../engine/engine-prese
 
 import { buildEngineSessionLaunch } from "../../engine/session-launch.ts"
 import { trustEngineWorktree } from "../../engine/trust-worktree.ts"
+import { type TerminalTab, tabPtyKeyFor } from "../../tui/workspace/terminal-tabs-core.ts"
 import { type DaemonRpc, resolveActiveTaskId } from "../daemon-session.ts"
 
 // Kept for existing callers in this directory; new callers should import from
@@ -27,6 +28,7 @@ import {
 } from "./pty-delivery.ts"
 import {
   type TaskSessionRow,
+  closeTabsSnapshot,
   hasLiveEngineTab,
   joinTaskTabs,
   markCliTabSession,
@@ -152,6 +154,47 @@ const realPromptDeliveryOps: PromptDeliveryOps = {
   deliverHosted: (target, worktree, prompt, defer) => deliverHosted(target, worktree, prompt, defer),
 }
 
+/** Headless half of ctrl+w: remove the persisted tab, then end every hosted
+ * PTY the tab owns. Attached TUIs run their existing close path instead. */
+async function closeHeadlessTerminalTab(
+  taskId: string,
+  tabId: string,
+): Promise<{ kind: TerminalTab["kind"]; wasAlive: boolean }> {
+  const host = await openPtyHost()
+  try {
+    const sessions = host ? await listSessions(host.rpc) : []
+    const snapshot = readTabsSnapshot(taskId)
+    const saved = snapshot?.tabs.find((tab) => tab.id === tabId)
+    const directKey = `${taskId}::${tabId}`
+    const unregisteredAlive = sessions.some((session) => session.key === directKey && session.alive)
+    if (!saved && !unregisteredAlive) {
+      throw new ApiError(`tab ${tabId} does not exist on task ${taskId}`, "TAB_NOT_FOUND", {
+        hint: "refresh the task's tab ids with get-task, then retry with one of its .tabs[].id values",
+        nextCommandArgs: ["api", "get-task", "--task-id", taskId],
+      })
+    }
+
+    const closing = saved ? closeTabsSnapshot(taskId, tabId) : undefined
+    if (saved && !closing) {
+      throw new ApiError(`tab ${tabId} no longer exists on task ${taskId}`, "TAB_NOT_FOUND", {
+        hint: "the tab closed while this command was running; refresh with get-task before retrying",
+        nextCommandArgs: ["api", "get-task", "--task-id", taskId],
+      })
+    }
+
+    const baseKey = closing ? tabPtyKeyFor(taskId, closing) : directKey
+    const ownsBase = !(closing?.kind === "engine" && closing.ptyTask)
+    const keys = sessions
+      .filter((session) => (ownsBase && session.key === baseKey) || session.key.startsWith(`${baseKey}::`))
+      .map((session) => session.key)
+    const wasAlive = sessions.some((session) => keys.includes(session.key) && session.alive)
+    if (host) await killTaskSessions(host.rpc, keys)
+    return { kind: closing?.kind ?? "engine", wasAlive }
+  } finally {
+    host?.close()
+  }
+}
+
 export async function deliverPrompt(
   client: DaemonRpc,
   target: PromptTarget,
@@ -239,6 +282,7 @@ export const defaultApiRuntime: ApiRuntime = {
       running: hasLiveEngineTab(snapshot, taskId, sessions),
     }
   },
+  closeTerminalTab: closeHeadlessTerminalTab,
   deliverPrompt: (client, target, prompt) => deliverPrompt(client, target, prompt),
   resolveRepoRoot: async (absPath) => (await import("../../state/repos.ts")).resolveMainRepoRoot(absPath),
   defaultVendor: async (repo) => {

--- a/packages/kobe/src/cli/api/tab-snapshot.ts
+++ b/packages/kobe/src/cli/api/tab-snapshot.ts
@@ -22,9 +22,9 @@
  */
 
 import type { PtySessionExit } from "@sma1lboy/kobe-daemon/daemon/protocol"
-import { loadStateFile, patchStateFile } from "../../state/store.ts"
+import { loadStateFile, patchStateFile, updateStateFile } from "../../state/store.ts"
 import { terminalTabsKey } from "../../tui-react/workspace/terminal-tabs-persist.ts"
-import { type TabsState, type TerminalTab, initialTabs } from "../../tui/workspace/terminal-tabs-core.ts"
+import { type TabsState, type TerminalTab, closeTab, initialTabs } from "../../tui/workspace/terminal-tabs-core.ts"
 import type { VendorId } from "../../types/vendor.ts"
 
 /**
@@ -70,6 +70,31 @@ export function readTabsSnapshot(taskId: string): TabsState | undefined {
   } catch {
     return undefined
   }
+}
+
+/**
+ * Remove one persisted tab with the same pure transition ctrl+w uses.
+ * Returns the removed tab, or undefined when the current snapshot does not
+ * name it. The fresh-state transaction prevents a stale CLI snapshot from
+ * overwriting a newer TUI tab list.
+ */
+export function closeTabsSnapshot(taskId: string, tabId: string): TerminalTab | undefined {
+  let closing: TerminalTab | undefined
+  const key = terminalTabsKey(taskId)
+  updateStateFile((store) => {
+    const state = store[key] as TabsState | undefined
+    if (!state || !Array.isArray(state.tabs)) return false
+    closing = state.tabs.find((tab) => tab.id === tabId)
+    if (!closing) return false
+    const { state: next, closedId } = closeTab(state, tabId, { allowEmpty: true })
+    if (!closedId) {
+      closing = undefined
+      return false
+    }
+    store[key] = next
+    return undefined
+  })
+  return closing
 }
 
 const aliveKeysOf = (sessions: readonly TaskSessionRow[]): Set<string> =>

--- a/packages/kobe/src/cli/api/types.ts
+++ b/packages/kobe/src/cli/api/types.ts
@@ -252,6 +252,8 @@ export interface ApiRuntime {
    * gives, from the same read (`get-task` needs both, one host round-trip).
    */
   taskTabs(taskId: string): Promise<{ tabs: readonly TaskTabRow[]; running: boolean }>
+  /** Close one exact Terminal Tab without a mounted TUI. */
+  closeTerminalTab(taskId: string, tabId: string): Promise<{ kind: TaskTabRow["kind"]; wasAlive: boolean }>
   /** Deliver a prompt into a task's engine pane (building the session if needed). */
   deliverPrompt(client: DaemonRpc, target: PromptTarget, prompt: string): Promise<DeliveredPrompt>
   /** Canonical source repo for task creation and grouping. */

--- a/packages/kobe/src/cli/api/verbs-drive.ts
+++ b/packages/kobe/src/cli/api/verbs-drive.ts
@@ -10,7 +10,7 @@
 
 import { F } from "./flags.ts"
 import { simpleRpc } from "./handler-helpers.ts"
-import { PANE_CLOSE_VERB, PANE_VERB } from "./handlers-pane.ts"
+import { PANE_CLOSE_VERB, PANE_VERB, TAB_CLOSE_VERB } from "./handlers-pane.ts"
 import { DISPATCH_VERB, note, send, setActive } from "./handlers-tasks.ts"
 import type { VerbSpec } from "./types.ts"
 
@@ -80,6 +80,7 @@ export const DRIVE_VERBS: readonly VerbSpec[] = [
   },
   PANE_VERB,
   PANE_CLOSE_VERB,
+  TAB_CLOSE_VERB,
   {
     name: "notify",
     group: "drive",

--- a/packages/kobe/src/client/remote-orchestrator-events.ts
+++ b/packages/kobe/src/client/remote-orchestrator-events.ts
@@ -324,7 +324,14 @@ export function handleOrchestratorEvent(name: string, payload: unknown, signals:
   }
   if (name === "tab.close") {
     const p = payload as Partial<TabClosePayload> | undefined
-    if (typeof p?.taskId !== "string" || typeof p.at !== "number" || typeof p.title !== "string") {
+    const terminalTab = p && "kind" in p && p.kind === "terminal-tab"
+    const valid = terminalTab
+      ? typeof p.taskId === "string" &&
+        typeof p.tabId === "string" &&
+        typeof p.requestId === "string" &&
+        typeof p.at === "number"
+      : typeof p?.taskId === "string" && typeof p.at === "number" && "title" in p && typeof p.title === "string"
+    if (!valid) {
       logClientError("orch", `dropped tab.close event: malformed payload (${describePayload(payload)})`)
       return
     }

--- a/packages/kobe/src/client/remote-orchestrator-writes.ts
+++ b/packages/kobe/src/client/remote-orchestrator-writes.ts
@@ -319,3 +319,12 @@ export async function startWorkItemOp(
 export async function setActiveTaskOp(client: KobeDaemonClient, id: TaskId | string | null): Promise<void> {
   await client.request("task.setActive", { taskId: id === null ? null : String(id) })
 }
+
+/**
+ * Acknowledge whether this TUI closed an exact Terminal Tab request
+ * (`terminalTab.closeReply`). Fire-and-forget: a dead daemon just means the
+ * broker times out on its side.
+ */
+export function replyTabCloseOp(client: KobeDaemonClient, requestId: string, closed: boolean): void {
+  void client.request("terminalTab.closeReply", { requestId, closed }).catch(() => {})
+}

--- a/packages/kobe/src/client/remote-orchestrator.ts
+++ b/packages/kobe/src/client/remote-orchestrator.ts
@@ -357,8 +357,12 @@ export class RemoteOrchestrator {
   /** Latest `tab.open` request (plugin panes) — consumers dedupe on `at`. */
   readonly tabOpenStore = (): ExternalStore<TabOpenPayload | null> => this.tabOpenAcc
 
-  /** Latest `tab.close` request (pane-close) — consumers dedupe on `at`. */
+  /** Latest `tab.close` request (pane or exact Terminal Tab) — consumers dedupe on `at`. */
   readonly tabCloseStore = (): ExternalStore<TabClosePayload | null> => this.tabCloseAcc
+
+  /** Acknowledge whether this TUI closed an exact Terminal Tab request. */
+  readonly replyTerminalTabClose = (requestId: string, closed: boolean): void =>
+    void this.client.request("terminalTab.closeReply", { requestId, closed }).catch(() => {})
 
   /** Latest `ui.prompt` request (host input dialog) — consumers dedupe on `at`. */
   readonly uiPromptStore = (): ExternalStore<UiPromptPayload | null> => this.uiPromptAcc

--- a/packages/kobe/src/client/remote-orchestrator.ts
+++ b/packages/kobe/src/client/remote-orchestrator.ts
@@ -97,6 +97,7 @@ import {
   mutateIssueOp,
   openDirectoryTaskOp,
   removeWorktreeOp,
+  replyTabCloseOp,
   reportEngineInterruptOp,
   resolveDeferredPromptOp,
   runAutomationNowOp,
@@ -360,9 +361,7 @@ export class RemoteOrchestrator {
   /** Latest `tab.close` request (pane or exact Terminal Tab) — consumers dedupe on `at`. */
   readonly tabCloseStore = (): ExternalStore<TabClosePayload | null> => this.tabCloseAcc
 
-  /** Acknowledge whether this TUI closed an exact Terminal Tab request. */
-  readonly replyTerminalTabClose = (requestId: string, closed: boolean): void =>
-    void this.client.request("terminalTab.closeReply", { requestId, closed }).catch(() => {})
+  replyTerminalTabClose = (requestId: string, closed: boolean): void => replyTabCloseOp(this.client, requestId, closed)
 
   /** Latest `ui.prompt` request (host input dialog) — consumers dedupe on `at`. */
   readonly uiPromptStore = (): ExternalStore<UiPromptPayload | null> => this.uiPromptAcc

--- a/packages/kobe/src/lib/skill-install.ts
+++ b/packages/kobe/src/lib/skill-install.ts
@@ -44,7 +44,7 @@ import { getPersistedString, setPersistedString } from "../state/repos.ts"
  * didn't, so we prompt the developer to re-run the active CLI's
  * `skill install` command.
  */
-export const KOBE_SKILL_VERSION = 38
+export const KOBE_SKILL_VERSION = 39
 
 /**
  * Where an installed kobe skill can be FOUND, relative to a home/project

--- a/packages/kobe/src/tui-react/lib/use-daemon-notices.ts
+++ b/packages/kobe/src/tui-react/lib/use-daemon-notices.ts
@@ -21,8 +21,10 @@ import type { RemoteOrchestrator } from "../../client/remote-orchestrator"
 import { createStateCell } from "../../lib/external-store"
 import type { NotifyInput } from "../../tui/lib/notify-state"
 import { RenameTaskDialog } from "../component/rename-task-dialog"
+import { useKV } from "../context/kv"
 import { t } from "../i18n"
 import type { DialogContext } from "../ui/dialog"
+import { closeTaskTab } from "../workspace/terminal-tabs-close"
 import { requestPaneClose, requestTabOpen } from "../workspace/terminal-tabs-shared"
 import { useAccessor } from "./use-accessor"
 
@@ -52,16 +54,22 @@ function useDaemonTabOpens(orch: RemoteOrchestrator | null): void {
   }, [request])
 }
 
-/** Bridge `tab.close` broadcasts (pane-close) the same way. */
+/** Bridge pane-close and exact Terminal Tab close broadcasts. */
 function useDaemonTabCloses(orch: RemoteOrchestrator | null): void {
+  const kv = useKV()
   const request = useAccessor(orch ? orch.tabCloseStore() : NO_TAB_CLOSES)
   const seenAt = useRef<number | null>(null)
   useEffect(() => {
     if (!request || request.at === seenAt.current) return
     seenAt.current = request.at
     if (Date.now() - request.at > STALE_NOTICE_MS) return
+    if ("requestId" in request) {
+      const closed = closeTaskTab(kv, request.taskId, request.tabId)
+      orch?.replyTerminalTabClose(request.requestId, closed)
+      return
+    }
     requestPaneClose(request.taskId, request.title, request.tabId)
-  }, [request])
+  }, [request, kv, orch])
 }
 
 /**

--- a/packages/kobe/src/tui-react/workspace/terminal-tabs-close.ts
+++ b/packages/kobe/src/tui-react/workspace/terminal-tabs-close.ts
@@ -88,13 +88,16 @@ function backgroundTabsState(kv: TabsSnapshotKv, taskId: string): TabsState | nu
  * empties the list and leaves the row, exactly as the mounted path does.
  */
 export function closeTaskTab(kv: TabsSnapshotKv, taskId: string, tabId: string): boolean {
+  const state = backgroundTabsState(kv, taskId)
+  // Check before publishing: a mounted component claims requests by task, so
+  // publishing an unknown id first would look like a successful close even
+  // though closeById made no state transition.
+  if (!state || !state.tabs.some((tab) => tab.id === tabId)) return false
   requestTabClose(taskId, tabId)
   const unclaimed = takeUnclaimedTabClose()
   // Claimed: the mounted TerminalTabs already ran its own close path.
   if (!unclaimed) return true
 
-  const state = backgroundTabsState(kv, taskId)
-  if (!state) return false
   const closing = state.tabs.find((tab) => tab.id === tabId)
   // `allowEmpty`, matching the mounted path (`useTabClose`): a task's last tab
   // may go, leaving the row to be revived on re-entry (`reviveEmptiedTabs`).

--- a/packages/kobe/test/behavior/pty-api-autostart.test.ts
+++ b/packages/kobe/test/behavior/pty-api-autostart.test.ts
@@ -20,6 +20,10 @@ interface PtyListResult {
   sessions: Array<{ key: string; alive: boolean; command: string[] }>
 }
 
+interface GetTaskResult {
+  tabs: Array<{ id: string; alive: boolean }>
+}
+
 /**
  * Poll `check` until it reports convergence (returns null) or the deadline
  * passes, then fail with the last observed state. Deletion is deliberately
@@ -74,12 +78,50 @@ describe("rove api hosted PTY lifecycle (behavior)", () => {
     expect(sessions).toContainEqual(expect.objectContaining({ key: session, alive: true }))
   }, 30_000)
 
-  it("send reuses the canonical session and delete tears it down", async () => {
+  it("tab-close removes one headless tab and ends only its hosted session", () => {
     const sent = runRove(["api", "send", "--task-id", taskId, "--prompt", "follow-up", "--pretty"], env)
     expect(sent.code, `send failed: stdout=${JSON.stringify(sent.stdout)} stderr=${sent.stderr}`).toBe(0)
     const afterSend = JSON.parse(runRove(["api", "pty-list", "--pretty"], env).stdout) as PtyListResult
     expect(afterSend.sessions.filter((entry) => entry.key === session && entry.alive)).toHaveLength(1)
 
+    const opened = runRove(
+      ["api", "send", "--task-id", taskId, "--tab", "new", "--prompt", "second tab", "--pretty"],
+      env,
+    )
+    expect(opened.code, `new tab failed: stdout=${JSON.stringify(opened.stdout)} stderr=${opened.stderr}`).toBe(0)
+    const secondSession = (JSON.parse(opened.stdout) as AddResult).session
+    expect(secondSession).toBe(`${taskId}::tab-2`)
+
+    const closed = runRove(["api", "tab-close", "--task-id", taskId, "--tab", "tab-2", "--pretty"], env)
+    expect(closed.code, `tab-close failed: stdout=${JSON.stringify(closed.stdout)} stderr=${closed.stderr}`).toBe(0)
+    expect(JSON.parse(closed.stdout)).toMatchObject({
+      ok: true,
+      taskId,
+      tabId: "tab-2",
+      handledBy: "headless",
+      kind: "engine",
+      wasAlive: true,
+    })
+
+    const task = JSON.parse(runRove(["api", "get-task", "--task-id", taskId, "--pretty"], env).stdout) as GetTaskResult
+    expect(task.tabs.map((tab) => tab.id)).toEqual(["tab-1"])
+    const afterClose = JSON.parse(runRove(["api", "pty-list", "--pretty"], env).stdout) as PtyListResult
+    expect(afterClose.sessions.some((entry) => entry.key === secondSession)).toBe(false)
+    expect(afterClose.sessions.some((entry) => entry.key === session && entry.alive)).toBe(true)
+
+    const alreadyClosed = runRove(["api", "tab-close", "--task-id", taskId, "--tab", "tab-2", "--pretty"], env)
+    expect(alreadyClosed.code).toBe(1)
+    const error = JSON.parse(alreadyClosed.stderr) as {
+      error: { code: string; hint: string; nextCommandArgs: string[] }
+    }
+    expect(error.error).toMatchObject({
+      code: "TAB_NOT_FOUND",
+      nextCommandArgs: ["api", "get-task", "--task-id", taskId],
+    })
+    expect(error.error.hint).toContain("get-task")
+  }, 30_000)
+
+  it("delete tears down the remaining session and worktree", async () => {
     const deleted = runRove(["api", "delete", "--task-id", taskId, "--force"], env)
     expect(deleted.code, `delete failed: stdout=${JSON.stringify(deleted.stdout)} stderr=${deleted.stderr}`).toBe(0)
 

--- a/packages/kobe/test/cli/api-cmd.test.ts
+++ b/packages/kobe/test/cli/api-cmd.test.ts
@@ -207,6 +207,7 @@ describe("API surface (full CRUD)", () => {
       "note-list",
       "pane-open",
       "pane-close",
+      "tab-close",
       "notify",
       "prompt",
       "engine-report",

--- a/packages/kobe/test/cli/api-handler-fixtures.ts
+++ b/packages/kobe/test/cli/api-handler-fixtures.ts
@@ -67,6 +67,7 @@ export function stubRuntime(overrides: Partial<ApiRuntime> = {}): ApiRuntime {
   return {
     isTaskRunning: async () => false,
     taskTabs: async () => ({ tabs: [], running: false }),
+    closeTerminalTab: async () => ({ kind: "engine", wasAlive: false }),
     deliverPrompt: async () => {
       throw new Error("deliverPrompt should not run in this test")
     },

--- a/packages/kobe/test/cli/api-handlers-more.test.ts
+++ b/packages/kobe/test/cli/api-handlers-more.test.ts
@@ -47,6 +47,7 @@ function stubRuntime(): ApiRuntime {
   return {
     isTaskRunning: async () => false,
     taskTabs: async () => ({ tabs: [], running: false }),
+    closeTerminalTab: async () => ({ kind: "engine", wasAlive: false }),
     deliverPrompt: async () => {
       throw new Error("deliverPrompt should not run in this test")
     },

--- a/packages/kobe/test/cli/api-tab-close.test.ts
+++ b/packages/kobe/test/cli/api-tab-close.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest"
+import { invokeVerb } from "../../src/cli/api-cmd.ts"
+import { FakeClient, expectApiError, stubRuntime } from "./api-handler-fixtures.ts"
+
+describe("tab-close handler", () => {
+  it("uses the attached TUI's normal close path when it confirms the tab", async () => {
+    const client = new FakeClient({ "terminalTab.close": () => ({ ok: true, handled: true }) })
+    let headlessCalls = 0
+    const result = await invokeVerb("tab-close", ["--task-id", "t1", "--tab", "tab-3"], {
+      client,
+      runtime: stubRuntime({
+        closeTerminalTab: async () => {
+          headlessCalls++
+          return { kind: "engine", wasAlive: true }
+        },
+      }),
+    })
+    expect(client.requests).toEqual([{ name: "terminalTab.close", payload: { taskId: "t1", tabId: "tab-3" } }])
+    expect(headlessCalls).toBe(0)
+    expect(result).toEqual({ ok: true, taskId: "t1", tabId: "tab-3", handledBy: "tui" })
+  })
+
+  it("falls back to the headless snapshot and PTY close path", async () => {
+    const client = new FakeClient({ "terminalTab.close": () => ({ ok: true, handled: false }) })
+    const calls: string[][] = []
+    const result = await invokeVerb("tab-close", ["--task-id", "t1", "--tab", "tab-2"], {
+      client,
+      runtime: stubRuntime({
+        closeTerminalTab: async (taskId, tabId) => {
+          calls.push([taskId, tabId])
+          return { kind: "command", wasAlive: false }
+        },
+      }),
+    })
+    expect(calls).toEqual([["t1", "tab-2"]])
+    expect(result).toEqual({
+      ok: true,
+      taskId: "t1",
+      tabId: "tab-2",
+      handledBy: "headless",
+      kind: "command",
+      wasAlive: false,
+    })
+  })
+
+  it("requires both task and tab ids", async () => {
+    const client = new FakeClient()
+    await expectApiError(
+      () => invokeVerb("tab-close", ["--task-id", "t1"], { client, runtime: stubRuntime() }),
+      "MISSING_FLAG",
+    )
+    await expectApiError(
+      () => invokeVerb("tab-close", ["--tab", "tab-1"], { client, runtime: stubRuntime() }),
+      "MISSING_FLAG",
+    )
+    expect(client.requestNames).toEqual([])
+  })
+})

--- a/packages/kobe/test/cli/api-tab-snapshot.test.ts
+++ b/packages/kobe/test/cli/api-tab-snapshot.test.ts
@@ -19,6 +19,7 @@ import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { afterEach, beforeEach, describe, expect, it } from "vitest"
 import {
+  closeTabsSnapshot,
   hasLiveEngineTab,
   joinTaskTabs,
   markCliTabSession,
@@ -163,6 +164,30 @@ describe("readTabsSnapshot", () => {
     expect(readTabsSnapshot("t1")).toEqual(snap)
     expect(readTabsSnapshot("bad")).toBeUndefined()
     expect(readTabsSnapshot("missing")).toBeUndefined()
+  })
+})
+
+describe("closeTabsSnapshot", () => {
+  it("uses ctrl+w semantics, including closing the last tab", () => {
+    writeState({
+      "terminalTabs.t1": {
+        tabs: [{ kind: "command", id: "tab-4", title: "shell", ordinal: 4, command: ["/bin/zsh"] }],
+        activeId: "tab-4",
+        nextOrdinal: 5,
+      },
+      unrelated: "keep",
+    })
+    expect(closeTabsSnapshot("t1", "tab-4")).toMatchObject({ id: "tab-4", kind: "command" })
+    const state = readState()
+    expect((state["terminalTabs.t1"] as TabsState).tabs).toEqual([])
+    expect(state.unrelated).toBe("keep")
+  })
+
+  it("does not write when the tab is absent", () => {
+    const snapshot = { tabs: [], activeId: "tab-1", nextOrdinal: 2 }
+    writeState({ "terminalTabs.t1": snapshot })
+    expect(closeTabsSnapshot("t1", "tab-9")).toBeUndefined()
+    expect(readState()["terminalTabs.t1"]).toEqual(snapshot)
   })
 })
 

--- a/packages/kobe/test/daemon/handler-test-context.ts
+++ b/packages/kobe/test/daemon/handler-test-context.ts
@@ -11,6 +11,7 @@ import {
   createDaemonHandlerRegistry,
   dispatchDaemonRequest,
 } from "@sma1lboy/kobe-daemon/daemon/server"
+import { TabCloseBroker } from "@sma1lboy/kobe-daemon/daemon/tab-close-broker"
 import type { WorkItemCache } from "@sma1lboy/kobe-daemon/daemon/work-items"
 import { daemonRuntime } from "../../src/core/daemon-runtime.ts"
 import type { Orchestrator } from "../../src/orchestrator/core.ts"
@@ -146,6 +147,7 @@ export function fakeCtx(orch: Record<string, unknown> = {}): {
     // Never hits `gh`: work-item behavior has its own suite.
     workItems: { list: async () => [], clear: () => {} } as unknown as WorkItemCache,
     selfLink: { request: async () => ({}) } as unknown as DaemonRpcClient,
+    tabCloses: new TabCloseBroker(),
     daemon: {
       startedAt: new Date("2026-06-01T00:00:00.000Z"),
       socketPath: "/tmp/fake/daemon.sock",

--- a/packages/kobe/test/daemon/handlers.test.ts
+++ b/packages/kobe/test/daemon/handlers.test.ts
@@ -83,6 +83,8 @@ describe("daemon handler registry", () => {
       "ui.promptReply",
       "tab.open",
       "tab.close",
+      "terminalTab.close",
+      "terminalTab.closeReply",
       "notice.send",
       "note.file",
       "note.list",
@@ -182,6 +184,33 @@ describe("daemon handler registry", () => {
       await dispatch("tab.close", { taskId: "t1", title: "demo", tabId: "tab-3" }, ctx)
       const event = rec.published[0] as { payload: Record<string, unknown> }
       expect(event.payload.tabId).toBe("tab-3")
+    })
+  })
+
+  describe("terminalTab.close", () => {
+    it("waits for an attached TUI to confirm the exact tab close", async () => {
+      const { ctx, rec } = fakeCtx({ getTask: () => TASK })
+      const pending = dispatch("terminalTab.close", { taskId: "t1", tabId: "tab-3" }, ctx)
+      const event = rec.published[0] as { channel: string; payload: Record<string, unknown> }
+      expect(event.channel).toBe("tab.close")
+      expect(event.payload).toMatchObject({ kind: "terminal-tab", taskId: "t1", tabId: "tab-3" })
+      const requestId = event.payload.requestId as string
+      expect(await dispatch("terminalTab.closeReply", { requestId, closed: true }, ctx)).toEqual({ ok: true })
+      expect(await pending).toEqual({ ok: true, handled: true })
+      expect(await dispatch("terminalTab.closeReply", { requestId, closed: true }, ctx)).toEqual({ ok: false })
+    })
+
+    it("returns immediately for headless callers and rejects an unknown task", async () => {
+      const { ctx, rec } = fakeCtx({ getTask: (id: string) => (id === "t1" ? TASK : undefined) })
+      ;(ctx.daemon as { guiCount: () => number }).guiCount = () => 0
+      await expect(dispatch("terminalTab.close", { taskId: "t1", tabId: "tab-1" }, ctx)).resolves.toEqual({
+        ok: true,
+        handled: false,
+      })
+      expect(rec.published).toHaveLength(0)
+      await expect(dispatch("terminalTab.close", { taskId: "missing", tabId: "tab-1" }, ctx)).rejects.toThrow(
+        /task not found/,
+      )
     })
   })
 

--- a/packages/kobe/test/render/terminal-tabs-close.test.ts
+++ b/packages/kobe/test/render/terminal-tabs-close.test.ts
@@ -127,6 +127,23 @@ test("a tab the task does not have reports failure", () => {
   expect(closeTaskTab(fakeKv(), "t1", "tab-9")).toBe(false)
 })
 
+test("a mounted task does not claim a tab id it does not have", () => {
+  tabsByTask.clear()
+  tabsByTask.set("t1", state(["tab-1"]))
+  const claimed: string[] = []
+  const listener = () => {
+    const id = takeTabClose("t1")
+    if (id) claimed.push(id)
+  }
+  tabActivationListeners.add(listener)
+  try {
+    expect(closeTaskTab(fakeKv(), "t1", "tab-9")).toBe(false)
+  } finally {
+    tabActivationListeners.delete(listener)
+  }
+  expect(claimed).toEqual([])
+})
+
 test("a task with only a restart snapshot still closes", () => {
   // The tree lists tabs for worktrees that have not mounted since restart —
   // those live in kv, not the module map.


### PR DESCRIPTION
## What / why

Rebase of #742 (`feat/api-tab-close`) onto current `main` — the two commits cherry-picked cleanly, zero conflicts. Adds `rove api tab-close --task-id ID --tab tab-N` so a script or agent that opened panes with `pane-open` can close a terminal tab it created without an attached TUI. Attached, it goes through the new `tab-close-broker` so the TUI runs its existing ctrl+w path; headless, the daemon drops the persisted tab and ends its hosted PTY. No new chord.

Rebase checks: changeset `.changeset/close-terminal-tabs-from-api.md` intact (`"@sma1lboy/rove": patch`); `KOBE_SKILL_VERSION` 39 > main's 38 and the skill markdown markers match; no new `t(...)` so no i18n; `docs/API.md` `tab-close` entry reconciled against main's verb list.

Closes #742.

## Pass criteria (headless, isolated scratch home under `.scratch/api-tab-close/home`, all `*_SOCKET_PATH`/`*_PID_PATH` inlined)

```
$ rove api add --repo /tmp/api-tab-close-repo --command "bash -c 'echo SENTINEL; sleep 3600'" …
{"taskId":"01M1FSBGRV3RX7XJHK1E62NDPW",…,"started":false}
$ rove api send --task-id 01M1FSBGRV3RX7XJHK1E62NDPW --prompt hello        # tab-1
$ rove api send --task-id 01M1FSBGRV3RX7XJHK1E62NDPW --tab new --prompt y  # tab-2
$ rove api get-task --task-id … | jq -c '[.tabs[]|{id,kind,alive}]'
[{"id":"tab-1","kind":"engine","alive":true},{"id":"tab-2","kind":"engine","alive":true}]
$ rove api tab-close --task-id 01M1FSBGRV3RX7XJHK1E62NDPW --tab tab-1
{"ok":true,"taskId":"01M1FSBGRV3RX7XJHK1E62NDPW","tabId":"tab-1","handledBy":"headless","kind":"engine","wasAlive":true}
$ rove api get-task --task-id … | jq -c '[.tabs[]|{id,kind,alive}]'
[{"id":"tab-2","kind":"engine","alive":true}]
$ rove api tab-close --task-id 01M1FSBGRV3RX7XJHK1E62NDPW --tab tab-99 ; echo exit=$?
{"error":{"message":"tab tab-99 does not exist on task 01M1FSBGRV3RX7XJHK1E62NDPW","code":"TAB_NOT_FOUND","hint":"refresh the task's tab ids with get-task, then retry with one of its .tabs[].id values","nextCommandArgs":["api","get-task","--task-id","01M1FSBGRV3RX7XJHK1E62NDPW"]}}
exit=1
```

## Local gates

- `bun x tsc --noEmit` clean (after `bun install` — main's Agent Topology added `@dagrejs/dagre`)
- `bun run lint`: 1189 files, clean
- vitest touched files (api-tab-close, api-tab-snapshot, api-handlers-more, api-cmd): 101/101
- `bun test test/render/terminal-tabs-close.test.ts`: 10/10
- `KOBE_INCLUDE_SOCKET=1 vitest test/daemon/handlers.test.ts`: 28/28

## Screenshots (harness, isolated base 5695, attached TUI)

Fixture task given a sentinel engine command (`bash /tmp/sentinel-742.sh`), two tabs opened via `send` / `send --tab new`, then with a TUI attached:

```
$ rove api tab-close --task-id 01M1FSCFEZGGX4RKGDNY5S8C03 --tab tab-1
{"ok":true,"taskId":"01M1FSCFEZGGX4RKGDNY5S8C03","tabId":"tab-1","handledBy":"tui"}
$ rove api get-task … | jq -c '[.tabs[]|{id,kind,alive}]'
[{"id":"tab-2","kind":"engine","alive":true}]
```

`handledBy: "tui"` = the attached TUI performed the close through the broker (headless run above reports `handledBy: "headless"`).

- BEFORE (two tabs, `generic 1` / `generic 2` under the task): `/Users/jacksonc/i/kobe/.scratch/api-tab-close/742-before.png`
- AFTER (one tab left): `/Users/jacksonc/i/kobe/.scratch/api-tab-close/742-after.png`
