### PR TITLE
fix: honour the attached --flag=value form in rove web and plugin install (#58 residual)

### DIFF
--- a/.changeset/attached-flag-value-cli.md
+++ b/.changeset/attached-flag-value-cli.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+`rove web --port=5399` now binds port 5399, and `rove plugin install owner/repo --ref=v1.2` now checks out `v1.2`. Both value flags only recognised the separated form (`--port 5399`), so the attached `--flag=value` spelling fell through to the default with no error: `rove web --port=foo` proceeded on the default port where `--port foo` already exited with "--port needs a number". The two forms now behave identically, and the port check rejects partial numbers like `51abc` instead of binding 51.

--- a/packages/kobe/src/cli/argv.ts
+++ b/packages/kobe/src/cli/argv.ts
@@ -1,0 +1,30 @@
+/**
+ * Shared argv flag helpers for CLI subcommands and engine command guards.
+ *
+ * Both forms of a value flag are one idiom to the user but two token shapes
+ * to us: `--flag value` (two tokens) and `--flag=value` (one token).
+ * `parseEngineCommand` keeps the attached form as a single token, and so does
+ * `process.argv`. A bare `argv.includes("--flag")` / `argv.indexOf("--flag")`
+ * therefore misses the attached form silently — the bug class behind double
+ * `--session-id` (#361 → #365 → #386) and behind `rove web --port=N` binding
+ * the default port with no error (#58). Every flag probe goes through these
+ * two; `test/architecture/argv-flag-guards.test.ts` rejects new bare checks.
+ */
+
+/** True when `argv` carries `flag` as `--flag` or `--flag=…`. Prefix-safe: `--resume-x` ≠ `--resume`. */
+export function argvHasFlag(argv: readonly string[], flag: string): boolean {
+  return argv.some((a) => a === flag || a.startsWith(`${flag}=`))
+}
+
+/**
+ * The value of `flag` from `argv`, accepting `--flag value` and `--flag=value`.
+ * `undefined` when the flag is absent OR is the last token with nothing after
+ * it — pair with {@link argvHasFlag} to tell those apart.
+ */
+export function flagValue(argv: readonly string[], flag: string): string | undefined {
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === flag) return argv[i + 1]
+    if (argv[i].startsWith(`${flag}=`)) return argv[i].slice(flag.length + 1)
+  }
+  return undefined
+}

--- a/packages/kobe/src/cli/hook-cmd.ts
+++ b/packages/kobe/src/cli/hook-cmd.ts
@@ -32,6 +32,7 @@ import type { EngineActivityDetail } from "../engine/hook-events.ts"
 import { isEngineActivityKind } from "../engine/hook-events.ts"
 import { getPersistedString, setPersistedString } from "../state/repos.ts"
 import { ALL_VENDORS } from "../types/vendor.ts"
+import { flagValue } from "./argv.ts"
 import { activeCliName } from "./rename-compat.ts"
 
 /** Default timeout for the stdin race — bounds a manual invocation without
@@ -76,14 +77,6 @@ async function readStdinPayload(): Promise<Record<string, unknown>> {
   } catch {
     return {}
   }
-}
-
-function flagValue(argv: readonly string[], name: string): string | undefined {
-  for (let i = 0; i < argv.length; i++) {
-    if (argv[i] === name) return argv[i + 1]
-    if (argv[i].startsWith(`${name}=`)) return argv[i].slice(name.length + 1)
-  }
-  return undefined
 }
 
 export async function runHookSubcommand(argv: readonly string[]): Promise<void> {

--- a/packages/kobe/src/cli/plugin-cmd.ts
+++ b/packages/kobe/src/cli/plugin-cmd.ts
@@ -22,6 +22,7 @@ import {
   removePluginEntry,
   savePluginRegistry,
 } from "@sma1lboy/kobe-daemon/plugins/registry"
+import { flagValue } from "./argv.ts"
 import { PluginCliError, installPlugin, linkPlugin } from "./plugin-install.ts"
 import { activeCliName } from "./rename-compat.ts"
 import { SUBCOMMAND_VERBS } from "./subcommands.ts"
@@ -226,11 +227,6 @@ function tailLog(id: string, count: number): void {
   }
   const lines = text.trimEnd().split("\n")
   for (const line of lines.slice(-count)) console.log(line)
-}
-
-function flagValue(rest: string[], flag: string): string | undefined {
-  const i = rest.indexOf(flag)
-  return i >= 0 ? rest[i + 1] : undefined
 }
 
 export async function runPluginSubcommand(rest: string[]): Promise<void> {

--- a/packages/kobe/src/cli/web-cmd.ts
+++ b/packages/kobe/src/cli/web-cmd.ts
@@ -20,6 +20,8 @@ import { errorMessage } from "@/lib/error-message"
 import { ensureDaemonReachable } from "@sma1lboy/kobe-daemon/client/daemon-process"
 import { readRoveEnv, setRoveEnv } from "@sma1lboy/kobe-daemon/compat-env"
 import { DEFAULT_DAEMON_WEB_PORT } from "@sma1lboy/kobe-daemon/daemon/paths"
+import { parsePositiveInt } from "./api/flags.ts"
+import { argvHasFlag, flagValue } from "./argv.ts"
 import { activeCliName } from "./rename-compat.ts"
 
 const CLI_NAME = activeCliName()
@@ -181,10 +183,11 @@ export async function runWebSubcommand(args: readonly string[]): Promise<void> {
   enforceResetGate()
 
   let port = DEFAULT_DAEMON_WEB_PORT
-  const portIdx = args.indexOf("--port")
-  if (portIdx !== -1) {
-    const value = Number.parseInt(args[portIdx + 1] ?? "", 10)
-    if (!Number.isFinite(value)) {
+  if (argvHasFlag(args, "--port")) {
+    // `--port 5399` and `--port=5399` alike; a whole-value integer check so
+    // `--port 51abc` fails loudly instead of binding 51.
+    const value = parsePositiveInt(flagValue(args, "--port") ?? "")
+    if (value === undefined) {
       process.stderr.write(`${CLI_NAME} web: --port needs a number\n`)
       process.exit(2)
     }

--- a/packages/kobe/src/engine/interactive-command.ts
+++ b/packages/kobe/src/engine/interactive-command.ts
@@ -177,21 +177,9 @@ export function withEngineEffort(
   return entry.effortArgv?.(argv, trimmed) ?? argv
 }
 
-/**
- * True when `argv` carries `flag` — in EITHER the separated form
- * (`--flag value`, the flag its own token) or the attached form
- * (`--flag=value`, one token). {@link parseEngineCommand} deliberately keeps
- * the attached form as a single token ("the common CLI idiom"), so a bare
- * `argv.includes(flag)` silently misses `--resume=<id>` /
- * `--append-system-prompt="…"` — the root cause behind double session
- * control and double prompt injection. Every "the command already sets this
- * flag, don't add our own" guard must go through this helper; an
- * architecture test (`test/architecture/argv-flag-guards.test.ts`) rejects
- * new `argv.includes("--…")` guards. Prefix-safe: `--resume-x` ≠ `--resume`.
- */
-export function argvHasFlag(argv: readonly string[], flag: string): boolean {
-  return argv.some((a) => a === flag || a.startsWith(`${flag}=`))
-}
+// `argvHasFlag` moved to `../cli/argv.ts` (neutral, no engine import) so the
+// CLI value-flag parsers share it; re-exported here for the engine callers.
+export { argvHasFlag } from "../cli/argv.ts"
 
 /**
  * `withClaudeSessionId` lived here (removed 2026-08-29). Its first line was

--- a/packages/kobe/test/architecture/argv-flag-guards.test.ts
+++ b/packages/kobe/test/architecture/argv-flag-guards.test.ts
@@ -1,15 +1,15 @@
 /**
  * Architecture guard: argv flag checks must see the attached --flag=value form.
  *
- * `parseEngineCommand` deliberately keeps `--flag=value` as ONE token, so a
- * bare `argv.includes("--flag")` guard silently misses the attached form —
+ * `parseEngineCommand` (and `process.argv`) keep `--flag=value` as ONE token,
+ * so a bare `argv.includes("--flag")` guard silently misses the attached form —
  * the recurring bug class behind double `--session-id` (claude refuses to
  * launch) and double `--append-system-prompt` injection, fixed one guard at
- * a time across three PRs (#361 → #365 → #386) before this test existed.
- * The rule: any "does the command already carry this flag" check goes
- * through `argvHasFlag` (src/engine/interactive-command.ts), which matches
- * both forms. A guard that genuinely must match ONLY the bare token needs an
- * allowlist entry here with its reason.
+ * a time across three PRs (#361 → #365 → #386) before this test existed, and
+ * behind `rove web --port=N` binding the default port with no error (#58).
+ * The rule: presence checks go through `argvHasFlag`, value reads through
+ * `flagValue` (both in src/cli/argv.ts). A check that genuinely must match
+ * ONLY the bare token needs an allowlist entry here with its reason.
  */
 
 import { readFileSync, readdirSync } from "node:fs"
@@ -27,9 +27,37 @@ const BARE_TOKEN_ALLOWED = new Set([
   join(SRC_ROOT, "cli", "reset-cmd.ts"),
 ])
 
-// An argv-named receiver (`argv`, `baseArgv`, …) probed for a flag literal
-// with an exact-token method. `argvHasFlag` is the correct spelling.
-const BARE_FLAG_GUARD = /[\w$]*[Aa]rgv\.(?:includes|indexOf)\(\s*["'`]-/
+// Boolean flags whose presence check may stay exact-token anywhere: an
+// attached `--yes=…` form carries no meaning for them, so a user typing it
+// gets nothing worse than the flag being ignored — never a wrong value.
+const BOOLEAN_FLAG_ALLOWED = new Set([
+  "--help", // help output
+  "-h", // help output
+  "--yes", // `plugin install/update`: skip the confirmation prompt
+  "--all", // `plugin update`: every installed plugin
+  "--routes-only", // `web`: daemon transport without static assets
+  "--bridge-only", // `web`: legacy spelling of --routes-only
+  "--no-takeover", // `web`: leave a running PTY server alone
+])
+
+// Rule 1 — any receiver probed with an exact-token method for a `-`-leading
+// flag literal (`args.includes("--port")`, `rest.indexOf("--ref")`). The
+// receiver name is deliberately unconstrained: the first version of this
+// guard required it to end in `argv`, and every CLI file names it `args`.
+const BARE_FLAG_LITERAL = /\.(includes|indexOf)\(\s*(["'`])(-[-\w][^"'`]*)\2/
+
+// Rule 2 — value extraction: `indexOf` on an argv-shaped receiver, flag
+// passed as anything at all (`rest.indexOf(flag)` then `rest[i + 1]`). The
+// only reason to take the INDEX of a flag is to read the token after it,
+// which the attached form never has. `flagValue` is the correct spelling.
+const ARGV_INDEXOF = /\b(?:[\w$]*[Aa]rgv|args|rest)\.indexOf\(/
+
+function isOffender(line: string): boolean {
+  if (ARGV_INDEXOF.test(line)) return true
+  const m = BARE_FLAG_LITERAL.exec(line)
+  if (!m) return false
+  return !(m[1] === "includes" && BOOLEAN_FLAG_ALLOWED.has(m[3]))
+}
 
 function sourceFiles(dir: string, files: string[] = []): string[] {
   for (const entry of readdirSync(dir, { withFileTypes: true })) {
@@ -49,20 +77,30 @@ describe("argv flag guards recognize the attached --flag=value form", () => {
           .split("\n")
           .map((line, i) => ({ line, i }))
           .filter(({ line }) => !line.trimStart().startsWith("//") && !line.trimStart().startsWith("*"))
-          .filter(({ line }) => BARE_FLAG_GUARD.test(line))
+          .filter(({ line }) => isOffender(line))
           .map(({ i }) => `${relative(SRC_ROOT, file)}:${i + 1}`),
       )
 
     expect(
       offenders,
-      `exact-token argv flag check misses the attached --flag=value form; use argvHasFlag (src/engine/interactive-command.ts) or allowlist with a reason: ${offenders.join(", ")}`,
+      `exact-token argv flag check misses the attached --flag=value form; use argvHasFlag / flagValue (src/cli/argv.ts) or allowlist with a reason: ${offenders.join(", ")}`,
     ).toEqual([])
+  })
+
+  test("the guard catches the shapes that escaped its first version", () => {
+    expect(isOffender('const portIdx = args.indexOf("--port")')).toBe(true)
+    expect(isOffender("const i = rest.indexOf(flag)")).toBe(true)
+    expect(isOffender('yes: args.includes("--yes")')).toBe(false)
+    expect(isOffender('const dash = version.indexOf("-")')).toBe(false)
   })
 
   test("the allowlisted files still exist and still contain the pattern they excuse", () => {
     for (const file of BARE_TOKEN_ALLOWED) {
       const source = readFileSync(file, "utf8")
-      expect(BARE_FLAG_GUARD.test(source), `${relative(SRC_ROOT, file)} no longer needs its allowlist entry`).toBe(true)
+      expect(
+        source.split("\n").some((line) => isOffender(line)),
+        `${relative(SRC_ROOT, file)} no longer needs its allowlist entry`,
+      ).toBe(true)
     }
   })
 })

--- a/packages/kobe/test/cli/argv.test.ts
+++ b/packages/kobe/test/cli/argv.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest"
+import { argvHasFlag, flagValue } from "../../src/cli/argv.ts"
+
+describe("flagValue", () => {
+  it("reads both forms, prefix-safe, and distinguishes absent from empty", () => {
+    expect(flagValue(["web", "--port", "5399"], "--port")).toBe("5399")
+    expect(flagValue(["web", "--port=5399"], "--port")).toBe("5399")
+    expect(flagValue(["web", "--port="], "--port")).toBe("")
+    expect(flagValue(["web", "--port-x=1"], "--port")).toBeUndefined()
+    expect(flagValue(["web", "--port"], "--port")).toBeUndefined()
+    expect(argvHasFlag(["web", "--port"], "--port")).toBe(true)
+  })
+})

--- a/packages/kobe/test/cli/plugin-cmd-install-flags.test.ts
+++ b/packages/kobe/test/cli/plugin-cmd-install-flags.test.ts
@@ -1,0 +1,29 @@
+/**
+ * `rove plugin install owner/repo --ref=X` must reach `installPlugin` with
+ * `ref: "X"`. The old local `flagValue` did an exact-token `indexOf`, so the
+ * attached form silently installed the default branch (#58 residual).
+ * Sibling of plugin-cmd.test.ts, which drives the real link/list flow.
+ */
+
+import { describe, expect, it, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({ installPlugin: vi.fn() }))
+
+vi.mock("../../src/cli/plugin-install.ts", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../src/cli/plugin-install.ts")>()),
+  installPlugin: mocks.installPlugin,
+}))
+
+import { runPluginSubcommand } from "../../src/cli/plugin-cmd.ts"
+
+describe("plugin install flag parsing", () => {
+  it("passes --ref in both the separated and attached form", async () => {
+    mocks.installPlugin.mockResolvedValue("x")
+    await runPluginSubcommand(["install", "owner/repo", "--ref", "v1.2"])
+    await runPluginSubcommand(["install", "owner/repo", "--ref=v1.2", "--yes"])
+    expect(mocks.installPlugin.mock.calls.map(([, opts]) => opts)).toEqual([
+      { yes: false, ref: "v1.2" },
+      { yes: true, ref: "v1.2" },
+    ])
+  })
+})

--- a/packages/kobe/test/cli/web-cmd.test.ts
+++ b/packages/kobe/test/cli/web-cmd.test.ts
@@ -85,6 +85,23 @@ describe("runWebSubcommand", () => {
     expect(err()).toContain("--port needs a number")
   })
 
+  // The attached form used to fall through to the default port with no
+  // error (#58): `indexOf("--port")` never saw the `--port=…` token.
+  it("--port=foo exits 2 exactly like the separated form", async () => {
+    await expect(runWebSubcommand(["--port=foo"])).rejects.toThrow("exit 2")
+    expect(err()).toContain("--port needs a number")
+    expect(mocks.ensureDaemonReachable).not.toHaveBeenCalled()
+  })
+
+  it("--port=N binds N, not the default", async () => {
+    fetchMock.mockResolvedValue({ ok: true, text: () => Promise.resolve("kobe-web") })
+    void runWebSubcommand(["--port=5399", "--routes-only"])
+    await vi.waitFor(() => {
+      expect(out()).toContain("listening on http://localhost:5399 (routes only)")
+    })
+    expect(process.env.ROVE_DAEMON_WEB_PORT).toBe("5399")
+  })
+
   it("routes-only success: sets the port env, verifies the health marker, prints the URL + home label", async () => {
     fetchMock.mockResolvedValue({ ok: true, text: () => Promise.resolve("kobe-web") })
     process.env.ROVE_DAEMON_WEB_PORT = "4999"


### PR DESCRIPTION
## What / why

`rove web --port=5399` bound the default port, and `rove plugin install owner/repo --ref=v1.2` installed the default branch. Both value-flag parsers did an exact-token `indexOf`, which returns -1 for the one-token attached form, so they fell through to a default with no error. Residual of #58: the engine half (`argvHasFlag`) shipped in #579, but the CLI parsers and the guard that was supposed to catch them were never touched.

- New neutral `src/cli/argv.ts` with `argvHasFlag` + `flagValue` (both forms, prefix-safe). `hook-cmd.ts`'s correct copy moved there; `plugin-cmd.ts`'s broken copy deleted; `web-cmd.ts` uses it plus the previously caller-less `parsePositiveInt` (so `--port 51abc` fails instead of binding 51). `engine/interactive-command.ts` re-exports `argvHasFlag` from the new module — import direction is cli→neutral, engine→neutral.
- `test/architecture/argv-flag-guards.test.ts` widened: rule 1 catches any receiver probed with `.includes`/`.indexOf` on a `-`-leading literal (the old regex required the receiver name to end in `argv`; every CLI file names it `args`); rule 2 catches `argv|args|rest.indexOf(<anything>)`, the value-extraction shape neither bug's site matched before. Boolean flags (`--help`, `-h`, `--yes`, `--all`, `--routes-only`, `--bridge-only`, `--no-takeover`) allowlisted by name with reasons; `reset-cmd.ts` file allowlist untouched.

No UI change, so no screenshots. The command output below is the evidence.

## Pass criteria run (scratch home, all `*_SOCKET_PATH` unset inline, `env -u ROVE_INVOKED_AS`)

BEFORE (HEAD `web-cmd.ts`):
```
$ rove web --port=foo --routes-only
rove daemon web transport listening on http://localhost:45174 (routes only)
exit=0
$ rove web --port=5399 --routes-only
rove daemon web transport listening on http://localhost:45174 (routes only)
```
AFTER:
```
$ rove web --port=foo --routes-only
rove web: --port needs a number
exit=2
$ rove web --port=5399 --routes-only
rove daemon web transport listening on http://localhost:5399 (routes only)
bound: bun 51384 127.0.0.1:5399      # lsof -iTCP:5399 -sTCP:LISTEN
```

`plugin install owner/repo --ref=v1.2` → `installPlugin` receives `{ yes: true, ref: "v1.2" }`: `test/cli/plugin-cmd-install-flags.test.ts` (mocks `installPlugin`, asserts both forms).

Mutation check on the guard (both restored to the pre-fix shape, then reverted):
```
restore `const portIdx = args.indexOf("--port")`      → × cli/web-cmd.ts:186
restore `const i = rest.indexOf(flag)` helper          → × cli/plugin-cmd.ts:358
clean tree                                             → 3 passed
```

Gates:
```
bun x tsc --noEmit                 → exit 0
bun run lint (repo root)           → Checked 1316 files. No fixes applied.
bun run test:fast                  → 418 files passed, 4126 tests passed
```
The 4 remaining `test:fast` failures (`open-dir-cmd.test.ts` ×2, `project-eligibility.test.ts` ×2) are the known path-shape false failures of running under `~/.rove/worktrees/…` (project-eligibility classifies the worktree path as roveInternal); they touch no file in this diff.
