### PR TITLE
fix: sidebar b/v/o chords act on the cursor row, not the active task

### DIFF
--- a/.changeset/sidebar-row-chords-follow-cursor.md
+++ b/.changeset/sidebar-row-chords-follow-cursor.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Sidebar `b` (rename branch), `v` (change engine) and `o` (open in editor) now act on the row under the cursor, like `d`/`r`/`shift+p` already did. Before, they acted on the active task even after `j`/`k` had moved the highlight elsewhere, so a rename or engine change could silently land on a different worktree than the one highlighted. The global `ctrl+a o` still opens the active task unless the sidebar has focus, where it follows the cursor too.

--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -128,6 +128,12 @@ is active.
 | `shift+p` | Pin / unpin managed Task | | `right` | Focus the current engine pane |
 | `shift+m` | Enter reorder mode (scope-aware: tab / task / project) | | `t` | Switch task sort (default ↔ recent) |
 
+Sidebar row verbs (`b`, `v`, `o`, `d`, `r`, `shift+p`, `shift+m`) act on the
+row under the cursor — the highlight `j`/`k` moves, which may differ from the
+active task until you press `enter`. Prefix chords (`ctrl+a o`, `ctrl+a p`)
+are global and act on the active task; only `ctrl+a o` follows the cursor
+while the sidebar has focus.
+
 In reorder mode, `j`/`k` moves the highlighted project and `enter` or `esc`
 finishes. Project headings themselves aren't cursor rows; the move routes
 through a Task row in that project.

--- a/packages/kobe/src/tui-react/panes/sidebar/SidebarTree.tsx
+++ b/packages/kobe/src/tui-react/panes/sidebar/SidebarTree.tsx
@@ -20,7 +20,7 @@
 import type { Task } from "@/types/task"
 import type { BoxRenderable, ScrollBoxRenderable } from "@opentui/core"
 import { useTerminalDimensions } from "@opentui/react"
-import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { type MutableRefObject, useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { createSidebarController } from "../../../tui/panes/sidebar/controller"
 import { RECENT_ROW_ID, type TreeRow, parseRowId } from "../../../tui/panes/sidebar/tree-core"
 import { MAIN_BRANCH_POLL_MS, SIDEBAR_WIDTH } from "../../../tui/panes/sidebar/view-core"
@@ -35,7 +35,7 @@ import { SidebarBrandHeader, SidebarCreateAction, SidebarNavRail, SidebarSearchI
 import { SidebarTreeBody } from "./tree-panel"
 import type { TreeRowShared } from "./tree-rows"
 import type { SidebarProps } from "./types"
-import { useTreeBindings } from "./use-tree-bindings"
+import { cursorTaskIdOf, useTreeBindings } from "./use-tree-bindings"
 import { useTreeMenu } from "./use-tree-menu"
 import { useTreeSearch } from "./use-tree-search"
 import { useTreeState } from "./use-tree-state"
@@ -55,6 +55,9 @@ export type SidebarTreeProps = SidebarProps & {
   /** Narrow mode's "↩ recent" jump target (issue #14, 2A) — renders as the
    *  first navigable row; ⏎ re-enters that task's workspace. */
   recentTask?: Task | null
+  /** Filled with a reader of the task under the cursor, so the host's
+   *  sidebar-scope chords (`b`/`v`/`o`) can target the highlighted row. */
+  cursorTaskIdRef?: MutableRefObject<() => string | null>
 }
 
 export function SidebarTree(props: SidebarTreeProps) {
@@ -101,6 +104,14 @@ export function SidebarTree(props: SidebarTreeProps) {
     setCursorIndexState(next)
   }, [])
   const flatIdsRef = useLatest(tree.flatIds)
+  // Hand the host a reader, not a value: the cursor ref is written
+  // synchronously on every move, so a chord in the same tick as the `j`
+  // still sees the new row.
+  const cursorTaskIdRef = props.cursorTaskIdRef
+  useEffect(() => {
+    if (!cursorTaskIdRef) return
+    cursorTaskIdRef.current = () => cursorTaskIdOf(flatIdsRef.current[cursorRef.current])
+  }, [cursorTaskIdRef])
 
   // Follow the active row when the selection moves from elsewhere (the F7
   // attention jump, the inbox). EDGE-triggered on the active row CHANGING —

--- a/packages/kobe/src/tui-react/panes/sidebar/use-tree-bindings.ts
+++ b/packages/kobe/src/tui-react/panes/sidebar/use-tree-bindings.ts
@@ -44,6 +44,17 @@ export interface TreeBindingsOpts {
   readonly markKeysUsed: () => void
 }
 
+/**
+ * The task a cursor row names, or null when the row is not a task (the
+ * "↩ recent" jump row, an empty tree). Shared by the tree's own row verbs
+ * and the host's sidebar-scope chords (`b`/`v`/`o`) so both resolve the
+ * same target.
+ */
+export function cursorTaskIdOf(rowId: string | undefined): string | null {
+  if (rowId === undefined || rowId === RECENT_ROW_ID) return null
+  return parseRowId(rowId).taskId
+}
+
 export function useTreeBindings(opts: TreeBindingsOpts): void {
   const {
     focused,
@@ -63,10 +74,8 @@ export function useTreeBindings(opts: TreeBindingsOpts): void {
   } = opts
 
   function withCursorTask(fn?: (taskId: string) => void): void {
-    const rowId = flatIdsRef.current[cursorRef.current]
-    if (rowId === undefined || !fn) return
-    if (rowId === RECENT_ROW_ID) return
-    fn(parseRowId(rowId).taskId)
+    const taskId = cursorTaskIdOf(flatIdsRef.current[cursorRef.current])
+    if (taskId !== null && fn) fn(taskId)
   }
 
   // 1. Main navigation & per-row verbs — only when no transient mode has the

--- a/packages/kobe/src/tui-react/workspace/host-keybindings.ts
+++ b/packages/kobe/src/tui-react/workspace/host-keybindings.ts
@@ -45,7 +45,15 @@ export type WorkspaceKeybindingDeps = {
   /** False while the files pane is unmounted (zen, or a rail page). */
   filesPaneVisible?: boolean
   searchActive: boolean
+  /** The ACTIVE task — what the workspace shows. Global-scope verbs act on it. */
   selectedId: string | null
+  /**
+   * The task under the sidebar CURSOR (null on a non-task row or an empty
+   * tree). `j`/`k` move the cursor without selecting, so the two diverge the
+   * moment the user walks the tree; sidebar-scope row verbs act on this one,
+   * like the tree's own `d`/`r`/`P` do.
+   */
+  cursorTaskId: () => string | null
   openTaskWorktree: (id: string) => void
   createTask: () => void
   renameBranch: (id: string) => void
@@ -140,8 +148,11 @@ export function useWorkspaceKeybindings(deps: WorkspaceKeybindingDeps): void {
         // the chord was dead outside the sidebar.
         "settings.open": prefixAction(() => deps.pages.openSettings()),
         "files.createPR": prefixAction(() => deps.createPR()),
+        // Global scope, so it acts on the active task — except while the
+        // sidebar has focus, where the highlighted row is what the user means.
         "task.openEditor": prefixAction(() => {
-          if (deps.selectedId) deps.openTaskWorktree(deps.selectedId)
+          const id = (focus.focused === "sidebar" ? deps.cursorTaskId() : null) ?? deps.selectedId
+          if (id) deps.openTaskWorktree(id)
         }),
       }),
     ],
@@ -176,20 +187,23 @@ export function useWorkspaceKeybindings(deps: WorkspaceKeybindingDeps): void {
   // d/a/r/pin/move fire from the Sidebar's OWN keys via the Request props;
   // these three are host-scoped in both hosts. Gated on sidebar focus + no
   // dialog + search inactive (typing `n` into the search box must not open
-  // the new-task dialog — same chord-leak class).
+  // the new-task dialog — same chord-leak class). Like the tree's own row
+  // verbs they act on the CURSOR row, not the active task: after a `j`
+  // without enter the two differ, and `b`/`v` rewrite a real worktree.
   useBindings(() => ({
     enabled: pagesClosed && focus.focused === "sidebar" && !deps.searchActive,
     bindings: bindByIds({
       "task.new": () => deps.createTask(),
       "tasks.openWorktree": () => {
-        if (deps.selectedId) deps.openTaskWorktree(deps.selectedId)
+        const id = deps.cursorTaskId()
+        if (id) deps.openTaskWorktree(id)
       },
       "tasks.renameBranch": () => {
-        const id = deps.selectedId
+        const id = deps.cursorTaskId()
         if (id) deps.renameBranch(id)
       },
       "tasks.cycleEngine": () => {
-        const id = deps.selectedId
+        const id = deps.cursorTaskId()
         if (id) deps.cycleVendor(id)
       },
       // Right arrow — the tmux Tasks pane's "go right into the engine"

--- a/packages/kobe/src/tui-react/workspace/host-sidebar.tsx
+++ b/packages/kobe/src/tui-react/workspace/host-sidebar.tsx
@@ -10,7 +10,7 @@
 
 import type { TaskEngineState, TaskJobState } from "@/client/remote-orchestrator"
 import type { Task } from "@/types/task"
-import { useCallback } from "react"
+import { type MutableRefObject, useCallback } from "react"
 import type { TaskSortMode } from "../../tui/panes/sidebar/groups"
 import type { SidebarNav } from "../../tui/panes/sidebar/nav-core"
 import type { WorktreeChanges } from "../../tui/panes/sidebar/worktree-changes"
@@ -71,6 +71,8 @@ export interface HostSidebarProps {
   readonly recentTask?: Task | null
   /** Global task sort mode driven by the `t` chord. */
   readonly sortMode?: TaskSortMode
+  /** Reader of the task under the tree cursor — see `SidebarTreeProps`. */
+  readonly cursorTaskIdRef?: MutableRefObject<() => string | null>
 }
 
 export function HostSidebar(props: HostSidebarProps) {
@@ -167,6 +169,7 @@ export function HostSidebar(props: HostSidebarProps) {
         onNewTab={newTab}
         onMoveTabRequest={moveTab}
         recentTask={props.recentTask ?? null}
+        cursorTaskIdRef={props.cursorTaskIdRef}
       />
       {/* First-use key hint (component/keyboard-hints.tsx): renders until
           the sidebar's own keys have been used, then never again. */}

--- a/packages/kobe/src/tui-react/workspace/host.tsx
+++ b/packages/kobe/src/tui-react/workspace/host.tsx
@@ -248,11 +248,14 @@ export function WorkspaceRoot(props: { orchestrator: RemoteOrchestrator }) {
     activateTask,
   })
 
-  // `o` and the row menu's "Open in editor" share this; the chord passes the
-  // active task, the menu passes its row.
+  // `o` and the row menu's "Open in editor" share this; both pass the row
+  // under the cursor (the menu's row IS the cursor row).
   const openTaskWorktree = (id: string): void =>
     openTaskWorktreeFor(id, { tasks, ensureWorktree: orch.ensureWorktree.bind(orch), notifyError })
 
+  // Filled by the mounted SidebarTree; null until it mounts (a rail page,
+  // zen), which is fine — every reader is gated on sidebar focus.
+  const cursorTaskIdRef = useRef<() => string | null>(() => null)
   useWorkspaceKeybindings({
     focus,
     dialog,
@@ -260,6 +263,7 @@ export function WorkspaceRoot(props: { orchestrator: RemoteOrchestrator }) {
     filesPaneVisible: !zen && pages.nav === "terminal" && pageRender.showSidebar && pageRender.showContent,
     searchActive,
     selectedId,
+    cursorTaskId: () => cursorTaskIdRef.current(),
     openTaskWorktree,
     createTask: () => void createTask(),
     renameBranch: (id) => void renameBranch(id),
@@ -426,6 +430,7 @@ export function WorkspaceRoot(props: { orchestrator: RemoteOrchestrator }) {
           onZenClick={toggleZen}
           onFocusRequest={() => focus.setFocused("sidebar")}
           recentTask={pageRender.recentTask}
+          cursorTaskIdRef={cursorTaskIdRef}
         />
       ) : null}
 

--- a/packages/kobe/test/render/keyboard-hints.test.tsx
+++ b/packages/kobe/test/render/keyboard-hints.test.tsx
@@ -85,6 +85,7 @@ function WorkspaceDriver(props: { children?: React.ReactNode; onToggleZen?: () =
     filesPaneVisible: true,
     searchActive: false,
     selectedId: null,
+    cursorTaskId: () => null,
     openTaskWorktree: NOOP,
     createTask: NOOP,
     renameBranch: NOOP,

--- a/packages/kobe/test/render/sidebar-row-chords-cursor.test.tsx
+++ b/packages/kobe/test/render/sidebar-row-chords-cursor.test.tsx
@@ -1,0 +1,137 @@
+/** @jsxImportSource @opentui/react */
+/**
+ * The sidebar's `b` / `v` / `o` chords target the CURSOR row, not the active
+ * task. `j`/`k` move the cursor without selecting (only enter selects), so
+ * after one `j` the two differ — and before this contract `b` renamed the
+ * ACTIVE task's git branch while the highlight sat on another row. Same shape
+ * as sidebar-sort-key.test.tsx: the real host binding hook mounted next to
+ * the real tree, keys pressed through the mock input.
+ */
+import { expect, test } from "bun:test"
+import { useRef } from "react"
+import { useFocus } from "../../src/tui-react/context/focus"
+import { SidebarTree } from "../../src/tui-react/panes/sidebar/SidebarTree"
+import { useDialog } from "../../src/tui-react/ui/dialog"
+import { useWorkspaceKeybindings } from "../../src/tui-react/workspace/host-keybindings"
+import type { HostPagesState } from "../../src/tui-react/workspace/host-pages"
+import type { Task } from "../../src/types/task"
+import { toTaskId } from "../../src/types/task"
+import { renderComponent } from "./harness"
+
+const SETTLE = 80
+
+function task(id: string): Task {
+  return {
+    id: toTaskId(id),
+    title: id,
+    repo: "/repos/rove",
+    branch: `feat/${id}`,
+    worktreePath: `/wt/${id}`,
+    kind: "task",
+    status: "in_progress",
+    createdAt: "2026-08-01T00:00:00.000Z",
+    updatedAt: "2026-08-01T00:00:00.000Z",
+  }
+}
+
+const A = task("a")
+const B = task("b")
+
+function closedPages(): HostPagesState {
+  const noop = () => {}
+  return {
+    nav: "terminal",
+    setNav: noop,
+    goToNav: noop,
+    settingsOpen: false,
+    openSettings: noop,
+    closeSettings: noop,
+    worktreesOpen: false,
+    openWorktrees: noop,
+    closeWorktrees: noop,
+    updateOpen: false,
+    openUpdate: noop,
+    closeUpdate: noop,
+    kanbanOpen: false,
+    openKanban: noop,
+    closeKanban: noop,
+    agentsOpen: false,
+    openAgents: noop,
+    closeAgents: noop,
+    automationsOpen: false,
+    openAutomations: noop,
+    closeAutomations: noop,
+    workItemsOpen: false,
+    openWorkItems: noop,
+    closeWorkItems: noop,
+  }
+}
+
+type Spies = { renameBranch: string[]; cycleVendor: string[]; openTaskWorktree: string[] }
+
+/** The real host wiring: the tree fills the cursor reader, the hook reads it. */
+function ChordHost({ spies }: { spies: Spies }) {
+  const focus = useFocus()
+  const dialog = useDialog()
+  const cursorTaskIdRef = useRef<() => string | null>(() => null)
+  useWorkspaceKeybindings({
+    focus,
+    dialog,
+    pages: closedPages(),
+    searchActive: false,
+    selectedId: A.id,
+    cursorTaskId: () => cursorTaskIdRef.current(),
+    openTaskWorktree: (id) => spies.openTaskWorktree.push(id),
+    createTask: () => {},
+    renameBranch: (id) => spies.renameBranch.push(id),
+    cycleVendor: (id) => spies.cycleVendor.push(id),
+    toggleZen: () => {},
+    jumpToNextAttention: () => {},
+    openInbox: () => {},
+    enterMoveMode: () => {},
+    createPR: () => {},
+    toggleSortMode: () => {},
+  })
+  return (
+    <SidebarTree
+      tasks={[A, B]}
+      selectedId={A.id}
+      selectedTabId={null}
+      onSelect={() => {}}
+      focused={focus.focused === "sidebar"}
+      width={28}
+      cursorTaskIdRef={cursorTaskIdRef}
+    />
+  )
+}
+
+test("b / v / o act on the row under the cursor after a j without enter", async () => {
+  const spies: Spies = { renameBranch: [], cycleVendor: [], openTaskWorktree: [] }
+  const { mockInput } = await renderComponent(<ChordHost spies={spies} />, {
+    width: 28,
+    height: 20,
+    providers: { focus: true, dialog: true },
+  })
+  await new Promise((r) => setTimeout(r, SETTLE))
+
+  // Cursor starts on the active row, so with no movement both agree.
+  mockInput.typeText("b")
+  await new Promise((r) => setTimeout(r, SETTLE))
+  expect(spies.renameBranch).toEqual([A.id])
+
+  // `j` moves the cursor to `b` WITHOUT selecting it — the active task is
+  // still `a`. Every sidebar-scope row verb must now name `b`.
+  mockInput.typeText("j")
+  await new Promise((r) => setTimeout(r, SETTLE))
+  mockInput.typeText("b")
+  await new Promise((r) => setTimeout(r, SETTLE))
+  expect(spies.renameBranch).toEqual([A.id, B.id])
+
+  mockInput.typeText("v")
+  await new Promise((r) => setTimeout(r, SETTLE))
+  expect(spies.cycleVendor).toEqual([B.id])
+
+  mockInput.typeText("o")
+  await new Promise((r) => setTimeout(r, SETTLE))
+  expect(spies.openTaskWorktree).toEqual([B.id])
+})

--- a/packages/kobe/test/render/sidebar-sort-key.test.tsx
+++ b/packages/kobe/test/render/sidebar-sort-key.test.tsx
@@ -85,6 +85,7 @@ function SortHost() {
     pages: closedPages(),
     searchActive: false,
     selectedId: OLDER.id,
+    cursorTaskId: () => null,
     openTaskWorktree: () => {},
     createTask: () => {},
     renameBranch: () => {},

--- a/packages/kobe/test/render/which-key-help.test.tsx
+++ b/packages/kobe/test/render/which-key-help.test.tsx
@@ -62,6 +62,7 @@ function WorkspaceHelpDriver() {
     filesPaneVisible: true,
     searchActive: false,
     selectedId: null,
+    cursorTaskId: () => null,
     openTaskWorktree: NOOP,
     createTask: NOOP,
     renameBranch: NOOP,

--- a/packages/kobe/test/tui-react/workspace-open-worktree-bindings.test.ts
+++ b/packages/kobe/test/tui-react/workspace-open-worktree-bindings.test.ts
@@ -67,6 +67,10 @@ describe("workspace open-worktree bindings", () => {
       pages,
       searchActive: false,
       selectedId: "task-1",
+      // The cursor sits on a DIFFERENT row than the active task — the
+      // sidebar-scope chords must follow the cursor; the global prefix `o`
+      // follows the cursor too while the sidebar has focus.
+      cursorTaskId: () => "task-2",
       openTaskWorktree,
       createTask: vi.fn(),
       renameBranch,
@@ -98,8 +102,10 @@ describe("workspace open-worktree bindings", () => {
     cycleEngine?.cmd({} as never)
     sort?.cmd({} as never)
     expect(openTaskWorktree).toHaveBeenCalledTimes(2)
-    expect(renameBranch).toHaveBeenCalledWith("task-1")
-    expect(cycleVendor).toHaveBeenCalledWith("task-1")
+    expect(openTaskWorktree).toHaveBeenNthCalledWith(1, "task-2")
+    expect(openTaskWorktree).toHaveBeenNthCalledWith(2, "task-2")
+    expect(renameBranch).toHaveBeenCalledWith("task-2")
+    expect(cycleVendor).toHaveBeenCalledWith("task-2")
     expect(toggleSortMode).toHaveBeenCalledTimes(1)
   })
 
@@ -140,6 +146,7 @@ describe("workspace open-worktree bindings", () => {
       pages,
       searchActive: false,
       selectedId: "task-1",
+      cursorTaskId: () => "task-2",
       openTaskWorktree: vi.fn(),
       createTask: vi.fn(),
       renameBranch: vi.fn(),
@@ -193,6 +200,7 @@ describe("workspace open-worktree bindings", () => {
       pages,
       searchActive: false,
       selectedId: null,
+      cursorTaskId: () => null,
       openTaskWorktree: vi.fn(),
       createTask: vi.fn(),
       renameBranch: vi.fn(),


### PR DESCRIPTION
## What / why

The tree's own `d`/`r`/`shift+p` verbs resolve their target from the cursor row (`withCursorTask` in `use-tree-bindings.ts`), but the host-scoped `b` (rename branch), `v` (change engine) and `o` (open in editor) read `selectedId`, the ACTIVE task. `j`/`k` only move the cursor (`controller.moveDown/moveUp` call `setCursor`; `onSelect` fires solely from `selectCurrent`), so after one keystroke without enter the two differ, and `b`/`v` rewrote a different task's real worktree, silently.

`SidebarTree` now fills a `cursorTaskIdRef` reader (from the `cursorRef`/`flatIdsRef` it already owns, through the same `RECENT_ROW_ID`/`parseRowId` filter as `withCursorTask`, extracted as `cursorTaskIdOf`). `WorkspaceKeybindingDeps` gains `cursorTaskId: () => string | null`; the three sidebar-scope chords use it.

## Behavior change

- Sidebar `b` / `v` / `o` now act on the row under the cursor, matching `d` / `r` / `shift+p`. Previously they acted on the active task.
- Global `ctrl+a o` still acts on the active task, except while the sidebar has focus, where it follows the cursor.
- No chord was added or moved. This is target semantics, not placement, so no keybinding sign-off is needed. `docs/KEYBINDINGS.md` records the rule (sidebar-scope row verbs = cursor row; prefix chords = active task).

## Pass criteria

New render test `packages/kobe/test/render/sidebar-row-chords-cursor.test.tsx`: two tasks `a`/`b`, `selectedId="a"`, presses `b`, then `j` `b` `v` `o` for real through the mock input against the real `useWorkspaceKeybindings` + `SidebarTree`.

```
$ cd packages/kobe && bun test test/render/sidebar-row-chords-cursor.test.tsx
 1 pass
 0 fail
 4 expect() calls
```

Mutation check: restored `const id = deps.selectedId` in the `tasks.renameBranch` handler.

```
error: expect(received).toEqual(expected)
- Expected  - 1
+ Received  + 1
(fail) b / v / o act on the row under the cursor after a j without enter [390.43ms]
 0 pass
 1 fail
```

Full suites:

```
$ bun test test/render                     → 379 pass, 0 fail (after rebase onto main @6595956f)
$ env -u ROVE_INVOKED_AS bun x vitest run test/tui-react → 47 files, 352 tests passed
$ bun x tsc --noEmit                        → clean
$ bun run lint (repo root)                  → Checked 1314 files. No fixes applied.
```

Rebased onto main after #759 (row menu Open in editor / Rename branch / Change engine) landed; the one conflict was `host.tsx`, resolved by keeping main's shared `openTaskWorktree` helper and wiring `cursorTaskId` beside it.

`test/tui-react/workspace-open-worktree-bindings.test.ts` indexes registrations positionally; registration order is unchanged (still passes at indices 0 and 3). Its assertions were updated to give the cursor a different task than `selectedId` and expect the cursor's id.

## Screenshots

Isolated harness (`KOBE_VISUAL_PORT_BASE=5781`, own scratch home, never the shared `.dev-sandbox`), fixture seeded with two tasks: active task on branch `feat/active-task`, second row on `feat/cursor-row`. Keys: `j j b` (two `j` because the engine tab row sits between them), i.e. cursor on the second row, active task unchanged.

- BEFORE (pre-fix `host-keybindings.ts`, only that file swapped): `/Users/jacksonc/i/kobe/.scratch/sidebar-row-chords-cursor/bv-before.png` — highlight on `feat/cursor-row`, Set-branch dialog prefilled with `feat/active-task`.
- AFTER (this branch): `/Users/jacksonc/i/kobe/.scratch/sidebar-row-chords-cursor/bv-after.png` — same highlight, dialog prefilled with `feat/cursor-row`.

Command: `cd packages/kobe-web && KOBE_VISUAL_PORT_BASE=5781 bun run visual:shot -- --out=<abs path> j j b wait:800`

## File size

file-size-exemption: packages/kobe/src/tui-react/workspace/host.tsx — 520 lines on main (already exempted in #754, #757 and #759); this diff adds a 3-line ref declaration, one dep, and one JSX prop (+5 net). The remaining seam (`startWorkspaceHost`, the process-boot half) needs `src/tui/index.tsx` + `test/tui/start-tui.test.ts`, outside this slice.
