### PR TITLE
fix: restore +x on node-pty's macOS spawn-helper after every install

### DIFF
--- a/.changeset/node-pty-spawn-helper-exec-bit.md
+++ b/.changeset/node-pty-spawn-helper-exec-bit.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Restore the exec bit on node-pty's macOS `spawn-helper` after every install. node-pty@1.1.0 is published with `prebuilds/darwin-*/spawn-helper` at mode 0644, and neither bun nor npm adds an exec bit the tarball never carried, so on macOS every PTY spawned through node-pty failed — and because `.rove/init.sh` runs `bun install` in each new worktree, the breakage came back on every task Rove created (issue #85). The root `postinstall` now runs `scripts/fix-node-pty-exec-bit.mjs`, which chmods any non-executable `spawn-helper` under `node_modules` (no-op off macOS, and a chmod failure warns instead of failing the install). `rove doctor` gains a `node-pty:` row that names the broken helpers on a tree from before this fix, and `--fix` offers the chmod.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -303,7 +303,8 @@ rove doctor [--report] [--fix]
 ```
 
 Read-only check of your build, terminal, git, engine CLIs and logins, daemon,
-running sessions, agent skill, and state files. The terminal section names
+running sessions, node-pty's macOS `spawn-helper` exec bit, agent skill, and
+state files. The terminal section names
 `TERM`/`TERM_PROGRAM`/`COLORTERM`, whether you are inside a multiplexer (tmux,
 zellij, screen — all three rewrite keys on the way in), and asks the terminal
 live whether it speaks the kitty keyboard protocol. That last answer settles
@@ -320,7 +321,8 @@ and prints its path; attach that to bug reports.
 
 - **Safe fixes run after a per-fix `y/N`** — each shows the exact command
   before asking (e.g. `rove daemon restart` for a stale/dead daemon or a dead
-  hook channel, `rove skill install` for a missing/stale agent skill). Nothing
+  hook channel, `rove skill install` for a missing/stale agent skill, `chmod
+  755` on a node-pty `spawn-helper` that lost its exec bit). Nothing
   is batched; declining one fix never skips the next prompt.
 - **Risky remedies are printed, never executed** — anything that kills live
   sessions (`rove reset`, closing engine tabs) or needs a human (installing

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "daemon:restart": "cd packages/kobe && bun run src/cli/rove.ts daemon restart",
     "daemon:status": "cd packages/kobe && bun run src/cli/rove.ts daemon status",
     "daemon:kobe": "cd packages/kobe && bun run src/cli/kobe.ts daemon start",
-    "postinstall": "bun --filter @sma1lboy/rove-plugin-sdk build",
+    "postinstall": "bun scripts/fix-node-pty-exec-bit.mjs && bun --filter @sma1lboy/rove-plugin-sdk build",
     "build": "bun --filter @sma1lboy/rove-plugin-sdk build && bun --filter @sma1lboy/rove build",
     "typecheck": "bun --filter @sma1lboy/rove-plugin-sdk build && bun --filter @sma1lboy/kobe-daemon typecheck && bun --filter @sma1lboy/rove typecheck && bun --filter @sma1lboy/rove-plugin-sdk typecheck",
     "test": "bun --filter @sma1lboy/rove-plugin-sdk build && bun --filter @sma1lboy/rove test && bun --filter @sma1lboy/rove-plugin-sdk test",

--- a/packages/kobe/src/cli/doctor-cmd.ts
+++ b/packages/kobe/src/cli/doctor-cmd.ts
@@ -30,8 +30,10 @@ import {
   reinstallManualFix,
   resetManualFix,
   skillInstallFix,
+  spawnHelperFix,
 } from "./doctor-fix.ts"
 import { classifyHookChannel, hookChannelDoctorLines } from "./doctor-hook-channel.ts"
+import { installedSpawnHelpers, spawnHelperDoctorLines } from "./doctor-node-pty.ts"
 import { terminalDoctorLines } from "./doctor-terminal.ts"
 import { probeEngines, probeGit } from "./env-checks.ts"
 import { inspectLegacyTmux, legacyTmuxDoctorLines } from "./legacy-tmux.ts"
@@ -290,6 +292,14 @@ async function collectDoctor(): Promise<{ lines: string[]; fixes: DoctorFix[] }>
         : "         node: ✗ not found on PATH — the Windows PTY host cannot start\n         → install Node.js from https://nodejs.org",
     )
     if (!node) fixes.push(humanOnlyFix("windowsNode"))
+  }
+  // macOS: node-pty@1.1.0 ships spawn-helper at 0644 (issue #85). The root
+  // postinstall restores +x on install; a tree from before that fix keeps
+  // failing every node-pty spawn with nothing on screen, so name it here.
+  if (process.platform === "darwin") {
+    const helpers = spawnHelperDoctorLines(installedSpawnHelpers())
+    out.push(...helpers.lines)
+    if (helpers.broken.length > 0) fixes.push(spawnHelperFix(helpers.broken))
   }
   out.push("")
 

--- a/packages/kobe/src/cli/doctor-fix.ts
+++ b/packages/kobe/src/cli/doctor-fix.ts
@@ -106,6 +106,17 @@ export function reinstallManualFix(): DoctorFix {
   }
 }
 
+/** node-pty's spawn-helper lost its exec bit (issue #85): chmod is idempotent and undoable. */
+export function spawnHelperFix(paths: readonly string[]): DoctorFix {
+  return {
+    kind: "run",
+    id: "spawn-helper-chmod",
+    label: t("doctor.fix.spawnHelper"),
+    command: ["chmod", "755", ...paths],
+    why: t("doctor.fix.spawnHelperWhy"),
+  }
+}
+
 type HumanOnlyReason = "git" | "noEngine" | "windowsNode" | "staleBun"
 
 /** Installs and logins: doctor can only point, a human has to act. */

--- a/packages/kobe/src/cli/doctor-node-pty.ts
+++ b/packages/kobe/src/cli/doctor-node-pty.ts
@@ -1,0 +1,58 @@
+/**
+ * `rove doctor` row for node-pty's macOS `spawn-helper`. node-pty@1.1.0 is
+ * published with `prebuilds/darwin-*\/spawn-helper` at 0644 and no installer
+ * adds the exec bit back, so every PTY spawn through node-pty fails until
+ * something runs chmod (issue #85). The root `postinstall` does that for
+ * installs made after the fix; this row is for the tree that predates it,
+ * so the symptom has a name instead of a silent dead terminal.
+ */
+
+import { readdirSync, statSync } from "node:fs"
+import { createRequire } from "node:module"
+import { dirname, join } from "node:path"
+
+export type SpawnHelper = { path: string; executable: boolean }
+
+/** node-pty's darwin spawn-helpers next to the package this process resolves. */
+export function installedSpawnHelpers(): SpawnHelper[] {
+  let pkg: string
+  try {
+    // createRequire, not import.meta.resolve: the latter is missing under
+    // vitest's SSR transform, and this row must be testable there.
+    pkg = dirname(createRequire(import.meta.url).resolve("node-pty/package.json"))
+  } catch {
+    return []
+  }
+  const prebuilds = join(pkg, "prebuilds")
+  let arches: string[]
+  try {
+    arches = readdirSync(prebuilds).filter((name) => name.startsWith("darwin-"))
+  } catch {
+    return []
+  }
+  const helpers: SpawnHelper[] = []
+  for (const arch of arches) {
+    const path = join(prebuilds, arch, "spawn-helper")
+    try {
+      helpers.push({ path, executable: (statSync(path).mode & 0o100) !== 0 })
+    } catch {
+      // no helper for this arch — nothing to check
+    }
+  }
+  return helpers
+}
+
+/** Doctor lines plus the broken paths (empty when healthy). */
+export function spawnHelperDoctorLines(helpers: readonly SpawnHelper[]): { lines: string[]; broken: string[] } {
+  const broken = helpers.filter((helper) => !helper.executable).map((helper) => helper.path)
+  if (helpers.length === 0) return { lines: ["node-pty: ? no darwin spawn-helper found next to node-pty"], broken }
+  if (broken.length === 0) return { lines: [`node-pty: ✓ spawn-helper executable (${helpers.length} arch)`], broken }
+  return {
+    lines: [
+      "node-pty: ✗ spawn-helper is not executable — every node-pty PTY spawn fails",
+      ...broken.map((path) => `          ${path}`),
+      `          → chmod 755 ${broken.join(" ")}`,
+    ],
+    broken,
+  }
+}

--- a/packages/kobe/src/tui/i18n/messages/doctor.ts
+++ b/packages/kobe/src/tui/i18n/messages/doctor.ts
@@ -46,6 +46,11 @@ export const en = {
     /** Agent skill older than this build expects */
     skillStale: "update the Rove agent skill to the version this build expects",
 
+    /** macOS: node-pty's spawn-helper prebuild lacks the exec bit */
+    spawnHelper: "restore the exec bit on node-pty's spawn-helper — every node-pty PTY spawn fails without it",
+    /** Why the chmod fix is safe */
+    spawnHelperWhy: "safe to run: chmod on two prebuilt binaries; idempotent, and `bun install` does the same",
+
     /** Why every `reset` fix is print-only */
     resetWhy: "stops the daemon, the PTY host, and every live session — not undoable, so doctor only prints it",
     /** Daemon process alive but its socket unreachable */
@@ -113,6 +118,9 @@ export const zh: typeof en = {
     skillInstallWhy: "可安全执行: 只写入 skill 文件; 重复运行是幂等的",
     skillMissing: "安装 Rove agent skill",
     skillStale: "把 Rove agent skill 更新到当前构建期望的版本",
+
+    spawnHelper: "恢复 node-pty spawn-helper 的可执行位 — 缺了它 node-pty 的每次 PTY 启动都会失败",
+    spawnHelperWhy: "可安全执行: 只对两个预编译二进制做 chmod; 幂等, `bun install` 也会做同样的事",
 
     resetWhy: "会停掉 daemon、PTY host 和所有活动会话 — 不可撤销, 所以 doctor 只打印",
     resetDaemonWedged: "daemon 进程存活但无法连接 (卡死)",

--- a/packages/kobe/test/architecture/node-pty-exec-bit.test.ts
+++ b/packages/kobe/test/architecture/node-pty-exec-bit.test.ts
@@ -1,0 +1,50 @@
+/**
+ * scripts/fix-node-pty-exec-bit.mjs — the postinstall backstop for node-pty
+ * shipping its macOS `spawn-helper` at 0644 (issue #85). Builds the tarball's
+ * layout in a temp tree at the broken mode and proves the fixer restores
+ * 0755, leaves an already-executable helper alone, and reports a helper it
+ * cannot change instead of throwing (postinstall must never fail the
+ * install). Mode assertions are darwin-only: Linux prebuilds carry no
+ * spawn-helper, so CI never takes this path for real.
+ */
+
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, statSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, expect, test } from "vitest"
+import { findSpawnHelpers, fixSpawnHelpers } from "../../../../scripts/fix-node-pty-exec-bit.mjs"
+
+const darwin = process.platform === "darwin"
+let root: string
+
+afterEach(() => rmSync(root, { recursive: true, force: true }))
+
+function plant(mode: number): string {
+  root = mkdtempSync(join(tmpdir(), "node-pty-exec-bit-"))
+  const dir = join(root, "node-pty", "prebuilds", "darwin-arm64")
+  mkdirSync(dir, { recursive: true })
+  const helper = join(dir, "spawn-helper")
+  writeFileSync(helper, "#!/bin/sh\n", { mode })
+  chmodSync(helper, mode)
+  return helper
+}
+
+test.runIf(darwin)("restores 0755 on a spawn-helper shipped at 0644", () => {
+  const helper = plant(0o644)
+  expect(findSpawnHelpers(root)).toEqual([{ path: helper, executable: false }])
+  expect(fixSpawnHelpers(root)).toEqual({ fixed: [helper], failed: [] })
+  expect(statSync(helper).mode & 0o777).toBe(0o755)
+  expect(findSpawnHelpers(root)).toEqual([{ path: helper, executable: true }])
+})
+
+test.runIf(darwin)("an already-executable helper is left untouched", () => {
+  const helper = plant(0o755)
+  expect(fixSpawnHelpers(root)).toEqual({ fixed: [], failed: [] })
+  expect(statSync(helper).mode & 0o777).toBe(0o755)
+})
+
+test("a missing tree is an empty result, not a throw", () => {
+  root = join(tmpdir(), `node-pty-exec-bit-absent-${process.pid}`)
+  expect(findSpawnHelpers(root)).toEqual([])
+  expect(fixSpawnHelpers(root)).toEqual({ fixed: [], failed: [] })
+})

--- a/packages/kobe/test/architecture/package-distribution.test.ts
+++ b/packages/kobe/test/architecture/package-distribution.test.ts
@@ -123,7 +123,8 @@ describe("Rove package distribution", () => {
     const commands = Object.values(root.scripts)
 
     expect(commands.some((command) => command.includes("--filter @sma1lboy/rove"))).toBe(true)
-    expect(root.scripts.postinstall).toBe("bun --filter @sma1lboy/rove-plugin-sdk build")
+    // The SDK build must stay in postinstall (the exec-bit backstop runs ahead of it).
+    expect(root.scripts.postinstall).toMatch(/bun --filter @sma1lboy\/rove-plugin-sdk build$/)
     expect(root.scripts.build).toMatch(/^bun --filter @sma1lboy\/rove-plugin-sdk build && /)
     expect(commands.some((command) => /--filter @sma1lboy\/kobe(?:\s|$)/.test(command))).toBe(false)
   })

--- a/packages/kobe/test/cli/doctor-node-pty.test.ts
+++ b/packages/kobe/test/cli/doctor-node-pty.test.ts
@@ -1,0 +1,39 @@
+/**
+ * `rove doctor` node-pty row (issue #85): the pure formatter over injected
+ * helper states, plus the real resolver against this checkout — which the
+ * root postinstall has already fixed, so on macOS it must report healthy.
+ */
+
+import { describe, expect, test } from "vitest"
+import { installedSpawnHelpers, spawnHelperDoctorLines } from "../../src/cli/doctor-node-pty"
+
+describe("spawnHelperDoctorLines", () => {
+  test("healthy helpers make one ✓ line and no fix", () => {
+    const result = spawnHelperDoctorLines([
+      { path: "/nm/prebuilds/darwin-arm64/spawn-helper", executable: true },
+      { path: "/nm/prebuilds/darwin-x64/spawn-helper", executable: true },
+    ])
+    expect(result.lines).toEqual(["node-pty: ✓ spawn-helper executable (2 arch)"])
+    expect(result.broken).toEqual([])
+  })
+
+  test("a 0644 helper is named with the chmod that fixes it", () => {
+    const result = spawnHelperDoctorLines([
+      { path: "/nm/prebuilds/darwin-arm64/spawn-helper", executable: false },
+      { path: "/nm/prebuilds/darwin-x64/spawn-helper", executable: true },
+    ])
+    expect(result.lines[0]).toBe("node-pty: ✗ spawn-helper is not executable — every node-pty PTY spawn fails")
+    expect(result.lines).toContain("          → chmod 755 /nm/prebuilds/darwin-arm64/spawn-helper")
+    expect(result.broken).toEqual(["/nm/prebuilds/darwin-arm64/spawn-helper"])
+  })
+
+  test("no helper at all is a question, not a verdict", () => {
+    expect(spawnHelperDoctorLines([]).lines[0]).toMatch(/^node-pty: \?/)
+  })
+})
+
+test.runIf(process.platform === "darwin")("this checkout's node-pty helpers are executable after postinstall", () => {
+  const helpers = installedSpawnHelpers()
+  expect(helpers.length).toBeGreaterThan(0)
+  expect(helpers.every((helper) => helper.executable)).toBe(true)
+})

--- a/scripts/fix-node-pty-exec-bit.mjs
+++ b/scripts/fix-node-pty-exec-bit.mjs
@@ -1,0 +1,65 @@
+#!/usr/bin/env bun
+// Restore the exec bit on node-pty's macOS `spawn-helper`.
+//
+// The published node-pty@1.1.0 tarball archives
+// `prebuilds/darwin-{arm64,x64}/spawn-helper` at mode 0644 (`npm pack
+// node-pty@1.1.0 && tar -tvzf …` shows it), and neither bun nor npm invents
+// an exec bit the archive never carried. spawn-helper is the binary node-pty
+// forks for every PTY on macOS, so without +x every spawn fails — and since
+// `.rove/init.sh` runs `bun install` in each new worktree, the breakage came
+// back on every task Rove created. Linux prebuilds ship no spawn-helper, so
+// CI never saw it (issue #85).
+//
+// Runs from the root `postinstall`, the one hook both Rove-made worktrees and
+// hand clones pass through. Idempotent; a no-op off macOS; never fails the
+// install — a read-only store degrades to a warning, not a dead `bun install`.
+//
+// Usage: bun scripts/fix-node-pty-exec-bit.mjs [node_modules dir]
+
+import { chmodSync, readdirSync, statSync } from "node:fs"
+import { join } from "node:path"
+import { fileURLToPath } from "node:url"
+
+/** Every `spawn-helper` file under `root`, with whether the owner may execute it. */
+export function findSpawnHelpers(root) {
+  let entries
+  try {
+    entries = readdirSync(root, { recursive: true, withFileTypes: true })
+  } catch {
+    return []
+  }
+  return entries
+    .filter((entry) => entry.isFile() && entry.name === "spawn-helper")
+    .map((entry) => {
+      const path = join(entry.parentPath, entry.name)
+      return { path, executable: (statSync(path).mode & 0o100) !== 0 }
+    })
+}
+
+/**
+ * chmod 0755 every non-executable spawn-helper under `root`. Returns the
+ * paths fixed and the ones that could not be (reason attached).
+ */
+export function fixSpawnHelpers(root) {
+  const fixed = []
+  const failed = []
+  for (const helper of findSpawnHelpers(root)) {
+    if (helper.executable) continue
+    try {
+      chmodSync(helper.path, 0o755)
+      fixed.push(helper.path)
+    } catch (err) {
+      failed.push({ path: helper.path, reason: String(err) })
+    }
+  }
+  return { fixed, failed }
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  if (process.platform === "darwin") {
+    const root = process.argv[2] ?? join(fileURLToPath(new URL("..", import.meta.url)), "node_modules")
+    const { fixed, failed } = fixSpawnHelpers(root)
+    for (const path of fixed) console.log(`[fix-node-pty-exec-bit] chmod 755 ${path}`)
+    for (const { path, reason } of failed) console.warn(`[fix-node-pty-exec-bit] could not chmod ${path}: ${reason}`)
+  }
+}


### PR DESCRIPTION
Closes #85.

## What / why

The published `node-pty@1.1.0` tarball archives `prebuilds/darwin-{arm64,x64}/spawn-helper` at mode 0644 and neither bun nor npm invents an exec bit the archive never carried (issue #85's attribution to bun's unpacking is wrong; a fresh `npm i` produces the same 0644). `spawn-helper` is the binary node-pty forks for every macOS PTY, so every spawn failed with `posix_spawnp failed`, and `.rove/init.sh`'s `bun install` brought it back in every worktree Rove created. Linux prebuilds carry no spawn-helper, so CI never saw it.

- Root `postinstall` now runs `scripts/fix-node-pty-exec-bit.mjs` first: walks `node_modules` for files named `spawn-helper`, chmods 0755 any without `u+x`. Idempotent, no-op off darwin, and a chmod failure warns instead of failing the install.
- `rove doctor` gains a `node-pty:` row (darwin only) naming any non-executable helper; `--fix` offers the chmod as a runnable fix. Uses `createRequire` rather than `import.meta.resolve` so it works under vitest.
- Unit test builds a temp tree with a 0644 `spawn-helper`, runs the fixer, asserts 0755 (darwin-gated). Mutation check: replacing the `chmodSync` call turned it red (`1 failed | 2 passed`), restored → green.
- `package-distribution.test.ts`'s postinstall assertion loosened from exact string to "ends with the SDK build" — it guards the package name, not the script text.

CI runs `bun install --frozen-lockfile` on Ubuntu; the darwin guard makes the new step a no-op there.

## Pass criteria (real output)

`bun install` then `find node_modules -name spawn-helper -exec ls -l {} \;`

Before (helpers reset to 0644, then a direct node-pty spawn from `packages/kobe-web`):
```
-rw-r--r--@ 1 jacksonc  staff  9248 Aug  8 01:04 node_modules/.bun/node-pty@1.1.0/node_modules/node-pty/prebuilds/darwin-x64/spawn-helper
-rw-r--r--@ 1 jacksonc  staff  50480 Aug  8 01:04 node_modules/.bun/node-pty@1.1.0/node_modules/node-pty/prebuilds/darwin-arm64/spawn-helper
SPAWN FAILED: posix_spawnp failed.
```

After `bun install` (postinstall output, then the same probe):
```
[fix-node-pty-exec-bit] chmod 755 …/node_modules/.bun/node-pty@1.1.0/node_modules/node-pty/prebuilds/darwin-x64/spawn-helper
[fix-node-pty-exec-bit] chmod 755 …/node_modules/.bun/node-pty@1.1.0/node_modules/node-pty/prebuilds/darwin-arm64/spawn-helper
-rwxr-xr-x@ 1 jacksonc  staff  9248 Aug  8 01:04 node_modules/.bun/node-pty@1.1.0/node_modules/node-pty/prebuilds/darwin-x64/spawn-helper
-rwxr-xr-x@ 1 jacksonc  staff  50480 Aug  8 01:04 node_modules/.bun/node-pty@1.1.0/node_modules/node-pty/prebuilds/darwin-arm64/spawn-helper
exit 0: PTY_ALIVE
```

`rove doctor` on a 0644 tree:
```
node-pty: ✗ spawn-helper is not executable — every node-pty PTY spawn fails
          …/prebuilds/darwin-x64/spawn-helper
          …/prebuilds/darwin-arm64/spawn-helper
          → chmod 755 …
```
after the fix: `node-pty: ✓ spawn-helper executable (2 arch)`.

`cd packages/kobe-web && KOBE_VISUAL_PORT_BASE=5373 bun run visual:serve` reached a live PTY (`Rove PTY server listening on 127.0.0.1:5375`) and `visual:shot` rendered the real OpenTUI through it:

- AFTER (live PTY through the harness): `/Users/jacksonc/i/kobe/.scratch/node-pty-exec-bit/after-pty-live.png` (worktree copy: `/Users/jacksonc/.rove/worktrees/kobe-0aff3858ab76/basilisk/.scratch/node-pty-exec-bit/after-pty-live.png`)
- BEFORE: no PNG is possible — with 0644 helpers the harness's PTY never spawns and `visual:shot` times out waiting for the terminal (`waitForFunction: Timeout 45000ms exceeded`). That timeout IS the before state; the `posix_spawnp failed` probe above is the same failure one layer down.

No UI change otherwise.

## Draft upstream issue (microsoft/node-pty) — not filed

**Title:** 1.1.0 npm tarball ships darwin spawn-helper prebuilds without the exec bit

**Body:** `npm pack node-pty@1.1.0 && tar -tvzf node-pty-1.1.0.tgz | grep spawn-helper` shows `package/prebuilds/darwin-arm64/spawn-helper` and `package/prebuilds/darwin-x64/spawn-helper` at `-rw-r--r--`. Both npm and bun install them as archived, so on macOS every `pty.spawn` fails with `posix_spawnp failed` until the user runs `chmod +x` by hand. Reproduces in a clean temp dir with `npm i node-pty@1.1.0` (node 22) and `bun add node-pty@1.1.0` (bun 1.3.14). Suggest packing the prebuilds with 0755 (or restoring the mode in the package's own install/postinstall). Consumers pinned to 1.1.0 will still need a local backstop since the published artifact can't change.