### PR TITLE
feat: read a repo's field notes from the project row menu

### DIFF
--- a/.changeset/field-notes-reader.md
+++ b/.changeset/field-notes-reader.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Read a repo's field notes without leaving Rove: the project header's right-click menu gained a **Field notes** entry that opens a read-only list of the notes agents filed with `rove api note`, newest first, each with its author and time. Until now `rove api note-list` in a shell was the only reader. Also trims `state/zen.ts` to the two state.json keys it actually owns (its three unused helpers and tmux-era doc are gone) and un-exports three onboarding helpers nothing imported.

--- a/docs/API.md
+++ b/docs/API.md
@@ -352,7 +352,8 @@ placeholder branch to a descriptive name. Prompts into existing sessions
   future worktree session on this repo starts with it in its system prompt;
   and forwarded to the dispatcher session for live relay to in-flight tasks.
 - `note-list --repo PATH`: read a repo's accumulated field notes, newest
-  first. Returns `{ notes }`.
+  first. Returns `{ notes }`. The same list is readable inside the TUI from
+  the project header's right-click menu (**Field notes**, see [TUI.md](./TUI.md)).
 - `set-active [--task-id ID] [--none]`: set (or clear) the shared active
   task every attached sidebar highlights.
 - `pane-open [--task-id ID] [--tab TAB] [--command CMD] [--direction

--- a/docs/TUI.md
+++ b/docs/TUI.md
@@ -26,8 +26,10 @@ from the keyboard, including **New conversation** and **New shell** for that
 Task's worktree, plus **Copy branch name** and **Copy path**, which put the
 Task's branch or worktree path on the system clipboard for a `git checkout` or
 `cd` in another shell, and **Open in editor**, **Rename branch**, and
-**Change engine** for the row you clicked. Clicking anywhere else dismisses
-that menu.
+**Change engine** for the row you clicked. Right-clicking a project header
+offers **New task**, **Field notes** (a read-only list of the notes agents filed
+on that repo with `rove api note`, newest first, each with its author and time)
+and **Remove project**. Clicking anywhere else dismisses that menu.
 
 Zen mode (`ctrl+a` `z`) hides Files and lets the workspace use the freed width.
 The Tasks rail remains visible. Below 70 columns, the separate

--- a/packages/kobe/src/cli/onboarding.ts
+++ b/packages/kobe/src/cli/onboarding.ts
@@ -71,16 +71,16 @@ export function installCompletions(shell: ShellKind, home: string = homedir(), c
   return rc
 }
 
-export function isOnboarded(): boolean {
+function isOnboarded(): boolean {
   return getPersistedBool(ONBOARDED_KEY, false)
 }
 
-export function markOnboarded(): void {
+function markOnboarded(): void {
   setPersistedBool(ONBOARDED_KEY, true)
 }
 
 /** The "Keyboard basics" page (and primer-mode re-run) was delivered. */
-export function isPrimerDone(): boolean {
+function isPrimerDone(): boolean {
   return getPersistedBool(PRIMER_KEY, false)
 }
 

--- a/packages/kobe/src/client/remote-orchestrator-writes.ts
+++ b/packages/kobe/src/client/remote-orchestrator-writes.ts
@@ -18,6 +18,7 @@ import type { SerializedTask } from "@sma1lboy/kobe-daemon/daemon/protocol"
 import type { WorkItem } from "@sma1lboy/kobe-daemon/daemon/work-items"
 import type { LandResult } from "../orchestrator/land.ts"
 import type { WorktreeResidue } from "../orchestrator/worktree/manager-remove.ts"
+import type { StoredFieldNote } from "../state/field-notes.ts"
 import type { Task, TaskId, TaskStatus, VendorId } from "../types/task.ts"
 import type { AdoptableWorktree, WorktreeProject } from "../types/worktree.ts"
 import { deserializeTask } from "./remote-orchestrator-payloads.ts"
@@ -244,6 +245,15 @@ export async function removeWorktreeOp(
 /** A repo's daemon-owned issues (`issue.list`) — the TUI kanban page's read. */
 export async function listIssuesOp(client: KobeDaemonClient, repoRoot: string): Promise<RepoIssues> {
   return client.request<RepoIssues>("issue.list", { repoRoot })
+}
+
+/** A repo's durable field notes, newest first (`note.list`) — the sidebar's
+ *  project-row reader. Same wire shape `state/field-notes.ts` reads at launch,
+ *  but through the daemon so the reader sees the whole live store (50), not
+ *  the 15-note launch cap. */
+export async function listFieldNotesOp(client: KobeDaemonClient, repo: string): Promise<readonly StoredFieldNote[]> {
+  const res = await client.request<{ notes?: readonly StoredFieldNote[] }>("note.list", { repo })
+  return res.notes ?? []
 }
 
 /** One issue-store mutation (`issue.mutate`) — the op union lives in the

--- a/packages/kobe/src/client/remote-orchestrator.ts
+++ b/packages/kobe/src/client/remote-orchestrator.ts
@@ -89,6 +89,7 @@ import {
   getDeferredPromptOp,
   landTaskOp,
   listAutomationsOp,
+  listFieldNotesOp,
   listIssuesOp,
   listWorkItemsOp,
   listWorktreesOp,
@@ -405,8 +406,7 @@ export class RemoteOrchestrator {
     return subscribeTasksOp(this.reads, listener)
   }
 
-  // --- write --- (each a thin delegate; bodies moved to remote-orchestrator-writes.ts)
-  // Terse one-liners on purpose: pure forwarding, and this file is at the cap.
+  // --- write --- thin delegates (bodies in remote-orchestrator-writes.ts); terse because this file is at the cap.
 
   createTask = (input: Parameters<typeof createTaskOp>[1]): Promise<Task> => createTaskOp(this.client, input)
   ensureMainTask = (repo: string): Promise<Task> => ensureMainTaskOp(this.client, repo)
@@ -465,8 +465,7 @@ export class RemoteOrchestrator {
     return mutateIssueOp(this.client, repoRoot, op)
   }
 
-  // Automations + external work items (docs/design/{automations,work-items}.md).
-  // Terse one-liners on purpose: pure forwarding, and this file is at the cap.
+  // Automations, work items, field notes — terse forwarding; this file is at the cap.
   listAutomations = () => listAutomationsOp(this.client)
   createAutomation = (i: Parameters<typeof createAutomationOp>[1]) => createAutomationOp(this.client, i)
   automationRuns = (id: string) => automationRunsOp(this.client, id)
@@ -474,6 +473,7 @@ export class RemoteOrchestrator {
   runAutomationNow = (id: string) => runAutomationNowOp(this.client, id)
   deleteAutomation = (id: string) => deleteAutomationOp(this.client, id)
   listWorkItems = (a: Parameters<typeof listWorkItemsOp>[1]) => listWorkItemsOp(this.client, a)
+  listFieldNotes = (repo: string) => listFieldNotesOp(this.client, repo)
   startWorkItem = (a: Parameters<typeof startWorkItemOp>[1]) => startWorkItemOp(this.client, a)
 
   /** Remove a worktree (`worktree.remove`); refuses a dirty one unless

--- a/packages/kobe/src/state/zen.ts
+++ b/packages/kobe/src/state/zen.ts
@@ -1,44 +1,17 @@
 /**
- * Zen mode — a session-wide "focus the engine" layout toggle that hides the
- * file/Ops pane and the terminal pane (and, when this switch is off, the
- * Tasks rail too) across EVERY ChatTab, leaving each engine/chat pane to fill
- * its window. The toggle itself (and its session-global on/off flag) lives in
- * `tui/panes/terminal/layout-actions.ts`; this module owns only the persisted
- * `zen.keepTasks` preference.
+ * Zen mode's two persisted state.json keys. Zen collapses the workspace to
+ * the engine pane (hiding Files and the terminal pane, and the Tasks rail too
+ * when `zen.keepTasks` is off).
  *
- * Stored in the shared state.json (the Settings dialog's KV writes the same
- * file) and read fresh at each toggle so flipping it needs no daemon restart.
- * Default ON — zen keeps the Tasks pane, so the create-PR-bar toggle and the
- * `prefix`-chord are always reachable to leave zen again.
+ * This module holds only the KEYS. The readers and writers are the KV context
+ * (`tui-react/workspace/use-zen-mode.ts`, `settings-dialog/use-settings-prefs.ts`),
+ * which shares the Settings dialog's cache — a second, uncached reader here
+ * would disagree with it until a reload, so there deliberately is none.
+ *
+ * Defaults: keep-tasks ON (so the prefix chord is always reachable to leave
+ * zen again), active OFF.
  */
-
-import { getPersistedBool, setPersistedBool } from "./store.ts"
 
 export const ZEN_KEEP_TASKS_KEY = "zen.keepTasks"
 
-/** Whether zen mode preserves the Tasks rail. Default `true`. */
-export function zenKeepsTasks(): boolean {
-  return getPersistedBool(ZEN_KEEP_TASKS_KEY, true)
-}
-
-/**
- * GLOBAL on/off intent for zen mode. Each kobe task is its OWN tmux session
- * (`kobe-<taskId>`), so the per-session `@kobe_zen` option only collapses the
- * session you toggled it in — switching to another project (another session)
- * lost zen. This persisted flag is the cross-session source of truth: the
- * toggle flips it, and entering any session (`switchTo` / initial attach)
- * reconciles that session's layout to it (see `syncSessionZen`). Stored in the
- * shared state.json and read fresh, so flipping it needs no daemon restart.
- * Default OFF.
- */
 export const ZEN_ACTIVE_KEY = "zen.active"
-
-/** Whether zen mode is globally on (across every project's session). */
-export function zenIsActive(): boolean {
-  return getPersistedBool(ZEN_ACTIVE_KEY, false)
-}
-
-/** Persist the global zen on/off intent. */
-export function setZenActive(on: boolean): void {
-  setPersistedBool(ZEN_ACTIVE_KEY, on)
-}

--- a/packages/kobe/src/tui-react/component/field-notes-dialog.tsx
+++ b/packages/kobe/src/tui-react/component/field-notes-dialog.tsx
@@ -1,0 +1,142 @@
+/** @jsxImportSource @opentui/react */
+/**
+ * Field-notes reader — the project row menu's "Field notes" entry. Agents file
+ * durable repo-level gotchas with `rove api note`; every fresh worktree
+ * session is seeded with the newest of them (`state/field-notes.ts`), but
+ * until this dialog a human could only read the store from a shell
+ * (`rove api note-list`).
+ *
+ * Read-only by design: the daemon is the store's only writer, and a note is a
+ * conclusion some session already paid for. Each row carries the note's
+ * author and time because provenance is the point — the reader's next move
+ * is usually opening the session that filed it.
+ *
+ * Reads through the daemon's `note.list` RPC rather than the launch-path
+ * reader so the dialog shows what the store holds (50 retained) instead of
+ * the 15-note injection cap.
+ */
+
+import { TextAttributes } from "@opentui/core"
+import type { ScrollBoxRenderable } from "@opentui/core"
+import { useEffect, useRef, useState } from "react"
+import type { StoredFieldNote } from "../../state/field-notes"
+import { useTheme } from "../context/theme"
+import { useT } from "../i18n"
+import { useBindings } from "../lib/keymap"
+import { type DialogContext, showDialog, useDialogPaddingX } from "../ui/dialog"
+
+type LoadState =
+  | { readonly kind: "loading" }
+  | { readonly kind: "ready"; readonly notes: readonly StoredFieldNote[] }
+  | { readonly kind: "error"; readonly message: string }
+
+/** `at` is an ISO stamp; show it to the minute in local time, and fall back
+ *  to the raw string for anything that does not parse rather than "Invalid Date". */
+function formatAt(at: string): string {
+  const d = new Date(at)
+  if (Number.isNaN(d.getTime())) return at
+  const pad = (n: number) => String(n).padStart(2, "0")
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`
+}
+
+export function FieldNotesDialogView(props: {
+  /** The repo root the notes belong to — shown under the title. */
+  repo: string
+  load: () => Promise<readonly StoredFieldNote[]>
+  onClose: () => void
+}) {
+  const { theme } = useTheme()
+  const t = useT()
+  const padX = useDialogPaddingX()
+  const [state, setState] = useState<LoadState>({ kind: "loading" })
+
+  useEffect(() => {
+    let live = true
+    props
+      .load()
+      .then((notes) => {
+        if (live) setState({ kind: "ready", notes })
+      })
+      .catch((err: unknown) => {
+        if (live) setState({ kind: "error", message: err instanceof Error ? err.message : String(err) })
+      })
+    return () => {
+      live = false
+    }
+  }, [props.load])
+
+  // Same keyboard-scroll shape as the help dialog: native navigation keys
+  // only, no Rove-owned chord; esc is the DialogProvider's.
+  const scrollRef = useRef<ScrollBoxRenderable | null>(null)
+  const scrollBy = (lines: number): void => {
+    const scroll = scrollRef.current
+    if (!scroll) return
+    scroll.scrollTo({ x: 0, y: Math.max(0, scroll.scrollTop + lines) })
+  }
+  useBindings(() => ({
+    bindings: [
+      { key: "up", cmd: () => scrollBy(-1) },
+      { key: "down", cmd: () => scrollBy(1) },
+      { key: "pageup", cmd: () => scrollBy(-(scrollRef.current?.viewport.height ?? 10)) },
+      { key: "pagedown", cmd: () => scrollBy(scrollRef.current?.viewport.height ?? 10) },
+    ],
+  }))
+
+  return (
+    <box paddingLeft={padX} paddingRight={padX} gap={1} flexShrink={1}>
+      <box flexDirection="row" justifyContent="space-between" flexShrink={0}>
+        <box flexDirection="column" gap={0}>
+          <text attributes={TextAttributes.BOLD} fg={theme.text}>
+            {t("tasks.fieldNotes.title")}
+          </text>
+          <text fg={theme.textMuted} wrapMode="none">
+            {props.repo}
+          </text>
+        </box>
+        <text fg={theme.textMuted} onMouseUp={props.onClose}>
+          esc
+        </text>
+      </box>
+      <scrollbox
+        ref={(r: ScrollBoxRenderable | null) => {
+          scrollRef.current = r
+        }}
+        flexShrink={1}
+        stickyScroll={false}
+        verticalScrollbarOptions={{
+          trackOptions: { backgroundColor: theme.backgroundDialog, foregroundColor: theme.borderActive },
+        }}
+      >
+        <box gap={1} paddingRight={1}>
+          {state.kind === "loading" ? <text fg={theme.textMuted}>{t("tasks.fieldNotes.loading")}</text> : null}
+          {state.kind === "error" ? <text fg={theme.error}>{state.message}</text> : null}
+          {state.kind === "ready" && state.notes.length === 0 ? (
+            <text fg={theme.textMuted}>{t("tasks.fieldNotes.empty")}</text>
+          ) : null}
+          {state.kind === "ready"
+            ? state.notes.map((note, i) => (
+                <box key={`${note.at}:${i}`} gap={0}>
+                  <text fg={theme.accent} wrapMode="none">
+                    {`${formatAt(note.at)} · ${note.author}`}
+                  </text>
+                  <text fg={theme.text}>{note.text}</text>
+                </box>
+              ))
+            : null}
+        </box>
+      </scrollbox>
+      <box paddingBottom={1} flexShrink={0}>
+        <text fg={theme.textMuted}>{t("tasks.fieldNotes.footer")}</text>
+      </box>
+    </box>
+  )
+}
+
+/** Open the reader; resolves when it closes (no value — it is read-only). */
+function show(dialog: DialogContext, opts: { repo: string; load: () => Promise<readonly StoredFieldNote[]> }): void {
+  void showDialog<void>(dialog, (resolve) => (
+    <FieldNotesDialogView repo={opts.repo} load={opts.load} onClose={() => resolve(undefined)} />
+  ))
+}
+
+export const FieldNotesDialog = { show }

--- a/packages/kobe/src/tui-react/panes/sidebar/types.ts
+++ b/packages/kobe/src/tui-react/panes/sidebar/types.ts
@@ -53,6 +53,8 @@ export type SidebarTaskCallbacks = {
   /** Menu route of `v`, as a picker over the available engines rather than
    *  the chord's blind cycle (owner call 2026-09-01). */
   onChangeEngineRequest?: (taskId: string) => void
+  /** Project row's "Field notes": read the repo's durable notes. Menu-only. */
+  onFieldNotesRequest?: (repo: string) => void
 }
 
 export type SidebarProps = SidebarTaskCallbacks & {

--- a/packages/kobe/src/tui-react/panes/sidebar/use-tree-menu.ts
+++ b/packages/kobe/src/tui-react/panes/sidebar/use-tree-menu.ts
@@ -138,6 +138,7 @@ export function useTreeMenu(deps: TreeMenuDeps): TreeMenu {
       setMenu(null)
       if (row.kind === "project") {
         if (action === "newTask") deps.onAddTask?.()
+        if (action === "fieldNotes") actions.onFieldNotesRequest?.(row.repo)
         // Forget routes to the SAME flow `d` runs (task-actions.ts sends a
         // main row to `forgetProject` behind a confirm). The header itself is
         // not navigable, so the row the flow needs is the project's main

--- a/packages/kobe/src/tui-react/workspace/host-sidebar.tsx
+++ b/packages/kobe/src/tui-react/workspace/host-sidebar.tsx
@@ -54,6 +54,8 @@ export interface HostSidebarProps {
   readonly onOpenEditorRequest: (taskId: string) => void
   readonly onRenameBranchRequest: (taskId: string) => void
   readonly onChangeEngineRequest: (taskId: string) => void
+  /** Menu-only (no chord): open the repo's field-notes reader. */
+  readonly onFieldNotesRequest: (repo: string) => void
   readonly moveMode: boolean
   readonly onMoveRequest: (taskId: string, delta: -1 | 1) => void
   readonly onMoveModeExit: () => void
@@ -137,6 +139,7 @@ export function HostSidebar(props: HostSidebarProps) {
     onOpenEditorRequest: props.onOpenEditorRequest,
     onRenameBranchRequest: props.onRenameBranchRequest,
     onChangeEngineRequest: props.onChangeEngineRequest,
+    onFieldNotesRequest: props.onFieldNotesRequest,
     onLocalMergeRequest: props.onLocalMergeRequest,
     moveMode: props.moveMode,
     onMoveRequest: props.onMoveRequest,

--- a/packages/kobe/src/tui-react/workspace/host-task-actions.ts
+++ b/packages/kobe/src/tui-react/workspace/host-task-actions.ts
@@ -36,6 +36,7 @@ import { type CreateTaskContext, createTaskFlow } from "../../tui/lib/task-creat
 import { DEFAULT_TASK_VENDOR, type Task, type VendorId } from "../../types/task.ts"
 import { BranchPickerDialog } from "../component/branch-picker-dialog"
 import { EnginePickerDialog } from "../component/engine-picker-dialog"
+import { FieldNotesDialog } from "../component/field-notes-dialog"
 import { StatusPickerDialog } from "../component/status-picker-dialog"
 import type { DialogContext } from "../ui/dialog"
 import { buildBaseCreateTaskContext, selectNextAfterDelete } from "../ui/task-dialog-adapters"
@@ -72,6 +73,8 @@ export type WorkspaceTaskActions = {
   setStatus: (id: string) => Promise<void>
   /** Tree-menu "Copy branch name" / "Copy path" — system clipboard + toast. */
   copyTaskField: (id: string, field: "branch" | "path") => void
+  /** Project-row menu "Field notes" — read-only list of the repo's notes. */
+  showFieldNotes: (repo: string) => void
 }
 
 export function useWorkspaceTaskActions(deps: WorkspaceTaskActionDeps): WorkspaceTaskActions {
@@ -171,5 +174,6 @@ export function useWorkspaceTaskActions(deps: WorkspaceTaskActionDeps): Workspac
     moveTask,
     setStatus: (id) => setStatusFlow(taskActions, id),
     copyTaskField: (id, field) => copyTaskFieldFlow(taskActions, id, field),
+    showFieldNotes: (repo) => FieldNotesDialog.show(dialog, { repo, load: () => orchestrator.listFieldNotes(repo) }),
   }
 }

--- a/packages/kobe/src/tui-react/workspace/host.tsx
+++ b/packages/kobe/src/tui-react/workspace/host.tsx
@@ -162,6 +162,7 @@ export function WorkspaceRoot(props: { orchestrator: RemoteOrchestrator }) {
     moveTask,
     setStatus,
     copyTaskField,
+    showFieldNotes,
   } = useWorkspaceTaskActions({
     orchestrator: orch,
     tasks: () => tasks,
@@ -409,6 +410,7 @@ export function WorkspaceRoot(props: { orchestrator: RemoteOrchestrator }) {
           onOpenEditorRequest={openTaskWorktree}
           onRenameBranchRequest={(id) => void renameBranch(id)}
           onChangeEngineRequest={(id) => void pickVendor(id)}
+          onFieldNotesRequest={showFieldNotes}
           moveMode={moveMode}
           onMoveRequest={(id, delta) => void moveTask(id, delta)}
           onMoveModeExit={() => setMoveMode(false)}

--- a/packages/kobe/src/tui/i18n/messages/tasks.ts
+++ b/packages/kobe/src/tui/i18n/messages/tasks.ts
@@ -34,6 +34,8 @@ export const en = {
     newTask: "New task",
     /** Project row: un-save the repo + drop its row. Mirrors `d` on that row. */
     forgetProject: "Remove project",
+    /** Project row: read the repo's durable field notes (`rove api note`). */
+    fieldNotes: "Field notes",
     rename: "Rename",
     pin: "Pin",
     unpin: "Unpin",
@@ -73,6 +75,13 @@ export const en = {
     title: "Change engine",
     current: "current",
     footer: "↑↓ choose · enter set · esc cancel",
+  },
+  /** Field-notes reader dialog (project row menu). */
+  fieldNotes: {
+    title: "Field notes",
+    empty: "No field notes for this repo yet — agents file one with `rove api note`.",
+    loading: "Loading…",
+    footer: "↑↓ scroll · esc close",
   },
   /** Inline chip while move/reorder mode is active */
   moveChip: " move",
@@ -173,6 +182,7 @@ export const zh: typeof en = {
     newShell: "新建终端",
     newTask: "新建任务",
     forgetProject: "移除项目",
+    fieldNotes: "现场笔记",
     rename: "重命名",
     pin: "置顶",
     unpin: "取消置顶",
@@ -202,6 +212,12 @@ export const zh: typeof en = {
     title: "切换引擎",
     current: "当前",
     footer: "↑↓ 选择 · enter 设置 · esc 取消",
+  },
+  fieldNotes: {
+    title: "现场笔记",
+    empty: "该仓库暂无现场笔记——agent 可用 `rove api note` 记录。",
+    loading: "加载中…",
+    footer: "↑↓ 滚动 · esc 关闭",
   },
   moveChip: " 移动",
   recentJump: "最近:{title}",

--- a/packages/kobe/src/tui/panes/sidebar/tree-menu.ts
+++ b/packages/kobe/src/tui/panes/sidebar/tree-menu.ts
@@ -35,6 +35,7 @@ import type { TreeRow } from "./tree-core"
 export type TreeMenuAction =
   | "open"
   | "forgetProject"
+  | "fieldNotes"
   | "closeTab"
   | "newChat"
   | "newShell"
@@ -115,8 +116,12 @@ export function treeMenuItems(row: TreeRow, ctx: TreeMenuContext = {}): TreeMenu
     // rows to `forgetProject` behind a confirm). The menu was missing the
     // entry, which broke this module's own rule: a row's menu is what that
     // row's keyboard already does.
+    // Field notes are menu-only, like `setStatus` (no chord — a chord is the
+    // owner's call). Agents file them with `rove api note`; before this entry
+    // `rove api note-list` in a shell was the only reader.
     return [
       { action: "newTask", labelKey: "tasks.menu.newTask" },
+      { action: "fieldNotes", labelKey: "tasks.menu.fieldNotes" },
       { action: "forgetProject", labelKey: "tasks.menu.forgetProject", danger: true },
     ]
   }

--- a/packages/kobe/test/render/field-notes-dialog.test.tsx
+++ b/packages/kobe/test/render/field-notes-dialog.test.tsx
@@ -1,0 +1,64 @@
+/** @jsxImportSource @opentui/react */
+/**
+ * Field-notes reader (`component/field-notes-dialog.tsx`) against the
+ * mounted view. Three states matter and each fails silently if wrong: an
+ * empty repo must show the empty MESSAGE (a blank card looks like a load
+ * that never finished), a filled list must show each note's provenance
+ * (author + time — the point of the reader), and a rejected load must
+ * surface its error rather than sit on "Loading…" forever.
+ */
+
+import { describe, expect, test } from "bun:test"
+import type { StoredFieldNote } from "../../src/state/field-notes"
+import { FieldNotesDialogView } from "../../src/tui-react/component/field-notes-dialog"
+import { renderComponent, settle } from "./harness"
+
+function mount(load: () => Promise<readonly StoredFieldNote[]>) {
+  return renderComponent(<FieldNotesDialogView repo="/repos/rove" load={load} onClose={() => {}} />, {
+    providers: { dialog: true },
+    width: 90,
+    height: 24,
+  })
+}
+
+describe("FieldNotesDialogView", () => {
+  test("a repo with no notes renders the empty message, not a blank box", async () => {
+    const { frame } = await mount(async () => [])
+    await settle()
+    const f = await frame()
+    expect(f).toContain("Field notes")
+    expect(f).toContain("/repos/rove")
+    expect(f).toContain("No field notes for this repo yet")
+    expect(f).not.toContain("Loading")
+  })
+
+  test("each note shows its text, author and time, newest first", async () => {
+    const notes: StoredFieldNote[] = [
+      { at: "2026-09-01T10:30:00.000Z", text: "the gotcha", taskId: "t1", author: "fix-the-pty" },
+      { at: "2026-08-30T08:00:00.000Z", text: "older lesson", taskId: "t2", author: "seed-branch" },
+    ]
+    const { frame } = await mount(async () => notes)
+    await settle()
+    const f = await frame()
+    expect(f).toContain("the gotcha")
+    expect(f).toContain("fix-the-pty")
+    expect(f).toContain("older lesson")
+    expect(f).toContain("seed-branch")
+    // Provenance line precedes its note body, and the newer note comes first.
+    expect(f.indexOf("fix-the-pty")).toBeLessThan(f.indexOf("the gotcha"))
+    expect(f.indexOf("the gotcha")).toBeLessThan(f.indexOf("older lesson"))
+    // The time is rendered to the minute in local time — assert the shape,
+    // not the zone-dependent digits.
+    expect(f).toMatch(/\d{4}-\d{2}-\d{2} \d{2}:\d{2} · fix-the-pty/)
+  })
+
+  test("a failed load shows the error instead of staying on Loading", async () => {
+    const { frame } = await mount(async () => {
+      throw new Error("daemon unreachable")
+    })
+    await settle()
+    const f = await frame()
+    expect(f).toContain("daemon unreachable")
+    expect(f).not.toContain("Loading")
+  })
+})

--- a/packages/kobe/test/render/host-sidebar-filetree.test.tsx
+++ b/packages/kobe/test/render/host-sidebar-filetree.test.tsx
@@ -56,6 +56,7 @@ function sidebarProps(over: Partial<HostSidebarProps> = {}): HostSidebarProps {
     onOpenEditorRequest: NOOP,
     onRenameBranchRequest: NOOP,
     onChangeEngineRequest: NOOP,
+    onFieldNotesRequest: NOOP,
     moveMode: false,
     onMoveRequest: NOOP,
     onMoveModeExit: NOOP,

--- a/packages/kobe/test/render/sidebar-recent-row.test.tsx
+++ b/packages/kobe/test/render/sidebar-recent-row.test.tsx
@@ -52,6 +52,7 @@ function sidebarProps(over: Partial<HostSidebarProps> = {}): HostSidebarProps {
     onOpenEditorRequest: NOOP,
     onRenameBranchRequest: NOOP,
     onChangeEngineRequest: NOOP,
+    onFieldNotesRequest: NOOP,
     moveMode: false,
     onMoveRequest: NOOP,
     onMoveModeExit: NOOP,

--- a/packages/kobe/test/render/sidebar-tree-menu.test.tsx
+++ b/packages/kobe/test/render/sidebar-tree-menu.test.tsx
@@ -132,6 +132,8 @@ test("right-click on a project header offers the project's own actions", async (
   // Forget mirrors `d` on the project's row (task-actions.ts sends a main row
   // to `forgetProject` behind a confirm) — the menu was missing it.
   expect(after).toContain("Remove project")
+  // The repo's durable note store had no in-product reader before this entry.
+  expect(after).toContain("Field notes")
   // A project is not a checkout — no per-task verbs on its header.
   expect(after).not.toContain("Rename")
   expect(after).not.toContain("Delete")

--- a/packages/kobe/test/tui/sidebar-tree-menu-items.test.ts
+++ b/packages/kobe/test/tui/sidebar-tree-menu-items.test.ts
@@ -3,7 +3,7 @@
  * list is a data assertion; the real right-click that produces it is covered
  * in the render track's `sidebar-tree-menu.test.tsx`).
  *
- * The rules worth locking: a project header is only ever "New task", the
+ * The rules worth locking: a project header offers exactly its three entries, the
  * per-task verbs reach a tab row too, `closeTab` appears only above one tab,
  * and the new-conversation pair rides both task-bearing row kinds.
  */
@@ -35,11 +35,11 @@ const tabRow: TreeRow = { kind: "tab", id: "a::tab-2", task: task(), tab: { id: 
 const actions = (row: TreeRow, ctx = {}) => treeMenuItems(row, ctx).map((item) => item.action)
 
 describe("treeMenuItems", () => {
-  test("a project header offers New task and Remove project", () => {
-    // Both mirror a chord the row already answers to — `d` on a project row
-    // has always routed to `forgetProject` behind a confirm; the menu was
-    // simply missing it.
-    expect(actions(projectRow)).toEqual(["newTask", "forgetProject"])
+  test("a project header offers New task, Field notes, then Remove project", () => {
+    // New task / Remove project mirror chords the row already answers to (`d`
+    // routes to `forgetProject` behind a confirm). Field notes is menu-only,
+    // like setStatus: the repo's durable note store had no in-product reader.
+    expect(actions(projectRow)).toEqual(["newTask", "fieldNotes", "forgetProject"])
   })
 
   test("a worktree row opens, adds a session, then the task verbs", () => {


### PR DESCRIPTION
## What / why

Agents file durable repo-level notes with `rove api note`, and `state/field-notes.ts` seeds every fresh worktree session with them, but nothing in the TUI or web could show them to a person: `rove api note-list --repo PATH` in a shell was the only reader.

- **`Field notes`** is now the project header's third right-click entry (between New task and Remove project). It opens a read-only dialog listing the repo's notes newest first, each with its author and time; the reader's next move is usually opening the session that filed it, so provenance is on every row.
- Reads through the daemon's **`note.list` RPC** (`RemoteOrchestrator.listFieldNotes`), not the launch-path reader: the store retains 50 notes while launch injection caps at 15, and a reader should show what the store holds.
- Menu-only, no chord (a chord is the owner's call), same rule `setStatus` / `copyBranch` / `copyPath` already follow in `tree-menu.ts`.
- i18n: `tasks.menu.fieldNotes` + `tasks.fieldNotes.{title,empty,loading,footer}` in both `en` and `zh`; `check-i18n` reports 780 keys × 2 locales in sync (after rebasing onto #759).
- docs: `docs/TUI.md` (project header menu) and `docs/API.md` (`note-list` now points at its in-product reader).

### Same PR, independent files: prune `state/zen.ts`

`zenKeepsTasks` / `zenIsActive` / `setZenActive` had zero importers (the two grep hits for `zenKeepsTasks` are a different local function on the settings-prefs object). The live readers go through the KV context on purpose (`use-zen-mode.ts:11-13`), so these were an uncached copy of live logic waiting to hand someone a stale read. The doc block also cited `layout-actions.ts`, `@kobe_zen` and `syncSessionZen`, none of which exist. The file now holds the two keys and a doc that says so (44 → 17 lines). `isOnboarded` / `markOnboarded` / `isPrimerDone` in `cli/onboarding.ts` lose only their `export` keyword; they are still called inside the file and the state keys stay live.

## Pass criteria — commands and real output

Isolated harness throughout: `KOBE_VISUAL_PORT_BASE=5701`, home under `.scratch/opentui-visual-5701/home`, socket/pid/pty pinned there (the full `VISUAL_PTY_COMMAND` env inlined into every CLI call). The owner's `~/.rove` and `packages/kobe/.dev-sandbox` were never touched.

**1. Seed + API round-trip**

```
$ env -u ROVE_INVOKED_AS <fixture env> bun dist/cli/rove.js api note --task-id 01M1G5N7NMREB06GSJVT4VQE8X --text "the gotcha: fixture daemons self-stop 3s after the last GUI detaches"
{"ok":true,"routed":false,"persisted":true}
$ env -u ROVE_INVOKED_AS <fixture env> bun dist/cli/rove.js api note-list --repo .scratch/opentui-visual-5701/fixture-repo --pretty
{
  "notes": [
    { "at": "2026-09-02T04:28:11.829Z", "text": "the gotcha: fixture daemons self-stop 3s after the last GUI detaches", "taskId": "01M1G5N7NMREB06GSJVT4VQE8X", "author": "Visual Fixture" },
    { "at": "2026-09-02T04:28:11.545Z", "text": "an older lesson, filed earlier", "taskId": "01M1G5N7NMREB06GSJVT4VQE8X", "author": "Visual Fixture" }
  ]
}
```

**2. BEFORE / AFTER screenshots** — taken before the rebase onto #759, which added Open in editor / Rename branch / Change engine to the worktree and tab rows only; the project header menu these shots exercise is untouched by it. (`cd packages/kobe-web && bun run visual:shot -- …`; BEFORE swaps only `tree-menu.ts` / `zen.ts` back to `HEAD`, everything else current). Each PNG was read back to confirm the menu actually opened rather than the keys leaking into the composer.

| PNG | tokens | shows |
|---|---|---|
| `/Users/jacksonc/i/kobe/.scratch/field-notes/before-menu.png` | `rclick:50,120` | project header menu: exactly **New task**, **Remove project** |
| `/Users/jacksonc/i/kobe/.scratch/field-notes/after-menu.png` | `rclick:50,120` | **New task**, **Field notes**, **Remove project** |
| `/Users/jacksonc/i/kobe/.scratch/field-notes/after-empty.png` | `rclick:50,120 down enter` | dialog on a repo with no notes: the empty message, not a blank box |
| `/Users/jacksonc/i/kobe/.scratch/field-notes/after-notes.png` | `rclick:50,120 down enter` | the two seeded notes, newest first, each as `2026-09-01 21:28 · Visual Fixture` + text |
| `/Users/jacksonc/i/kobe/.scratch/field-notes/zen-before.png` | `ctrl+a z` (HEAD `zen.ts`) | collapsed zen layout |
| `/Users/jacksonc/i/kobe/.scratch/field-notes/zen-after.png` | `ctrl+a z` (this branch) | `cmp` reports the two PNGs **byte-identical** |

**3. Test gates** (`packages/kobe`, `env -u ROVE_INVOKED_AS`)

```
bun x vitest run test/tui/sidebar-tree-menu-items.test.ts test/cli/onboarding.test.ts \
  test/tui-react/host-task-actions-set-status.test.ts test/tui-react/host-task-actions-rename-branch.test.ts
 Test Files  4 passed (4)   Tests  42 passed (42)
bun run test:render        371 pass  0 fail  (86 files)
bun run test:fast          416 passed | 2 failed (418 files) — 4 tests, all in
                           project-eligibility / open-dir-cmd asserting `pathRejection(REPO_ROOT) === null`;
                           they read `roveInternal` because this checkout lives under ~/.rove/worktrees/,
                           and fail identically on untouched HEAD in the same checkout.
bun x tsc --noEmit         clean
bun run lint (repo root)   Checked 1315 files. No fixes applied.
bun run check-i18n         i18n check OK — 780 keys × 2 locales in sync
scripts/coverage-gate.mjs  field-notes-dialog.tsx 92% · use-tree-menu.ts 80% · host-sidebar.tsx 94% · host-task-actions.ts 74% · host.tsx 83%
```

`sidebar-tree-menu-items.test.ts` now asserts the project row returns `["newTask", "fieldNotes", "forgetProject"]` in order; `test/render/field-notes-dialog.test.tsx` mounts the real view for the empty, filled (provenance line before body, newest first) and failed-load states; the render `sidebar-tree-menu.test.tsx` right-click asserts the new label.

file-size-exemption: packages/kobe/src/tui-react/workspace/host.tsx — was already over the cap (#754 carried the same exemption); this diff adds one destructured name and one JSX prop. The remaining seam (`startWorkspaceHost`, the process-boot half) needs edits to `src/tui/index.tsx` and `test/tui/start-tui.test.ts`, outside this slice.
