### PR TITLE
fix: apply --status and --pin to every parallel add sibling

### DIFF
--- a/.changeset/add-parallel-status-pin.md
+++ b/.changeset/add-parallel-status-pin.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+`rove api add --count`/`--agents` now applies `--status` and `--pin` to every sibling it creates. Both flags previously validated, exited 0, and silently did nothing on a parallel round, so a fleet meant to land pinned and in review arrived unpinned in the backlog. The single and parallel paths now share one `applyPostCreateFlags` helper so they cannot drift apart again.

--- a/packages/kobe/src/cli/api/handlers-add.ts
+++ b/packages/kobe/src/cli/api/handlers-add.ts
@@ -22,6 +22,7 @@ import { resolveCommandProtocol } from "../../engine/engine-presets.ts"
 import { ulid } from "../../orchestrator/index/ulid.ts"
 import type { TaskStatus } from "../../types/task.ts"
 import type { VendorId } from "../../types/vendor.ts"
+import type { DaemonRpc } from "../daemon-session.ts"
 import { dispatcherEnvPayload, withPeerProvenance } from "./dispatcher.ts"
 import { FANOUT_CAP, buildCountPlan, parseAgentsSpec } from "./flags.ts"
 import { daemonOf } from "./handler-helpers.ts"
@@ -50,6 +51,22 @@ async function engineChoice(ctx: VerbContext, repo: string): Promise<EngineChoic
 /** The engine fields as a flat `task.create` payload fragment. */
 function enginePayload(choice: EngineChoice): Record<string, string> {
   return { ...(choice.command ? { command: choice.command } : {}), ...(choice.vendor ? { vendor: choice.vendor } : {}) }
+}
+
+/**
+ * `--status` / `--pin` aren't create-time fields on the RPC — apply them as
+ * follow-ups so `add` is the one-stop "make me a task exactly like this".
+ * Shared by the single and parallel paths so the two cannot drift: the
+ * parallel path once read neither flag, and both validated, passed, and
+ * silently evaporated. Returns whether anything was applied (the caller
+ * decides whether a refreshed `task.get` is worth the round-trip).
+ */
+async function applyPostCreateFlags(daemon: DaemonRpc, taskId: string, args: VerbContext["args"]): Promise<boolean> {
+  const status = args.enumOf<TaskStatus>("status")
+  if (status) await daemon.request("task.status", { taskId, status })
+  const pin = args.bool("pin")
+  if (pin !== undefined) await daemon.request("task.pin", { taskId, pinned: pin })
+  return Boolean(status) || pin !== undefined
 }
 
 export async function add(ctx: VerbContext): Promise<unknown> {
@@ -84,15 +101,8 @@ async function addOne(ctx: VerbContext, repo: string): Promise<unknown> {
   // pull focus" taste.
   if (args.bool("activate")) await daemon.request("task.setActive", { taskId })
 
-  // status / pin aren't create-time fields on the RPC — apply them as
-  // follow-ups so `add` is the one-stop "make me a task exactly like this".
-  const status = args.enumOf<TaskStatus>("status")
-  if (status) await daemon.request("task.status", { taskId, status })
-  const pin = args.bool("pin")
-  if (pin !== undefined) await daemon.request("task.pin", { taskId, pinned: pin })
-
   let task = res.task
-  if (status || pin !== undefined) {
+  if (await applyPostCreateFlags(daemon, taskId, args)) {
     task = (await daemon.request<{ task: SerializedTask }>("task.get", { taskId })).task
   }
 
@@ -191,7 +201,9 @@ async function addParallel(
   // `--command` / `--count` alongside it have nothing left to say. Refuse
   // rather than silently ignore — a caller who wrote both believes both
   // applied, and a fleet is expensive to spawn wrong (same reasoning as
-  // `send --command` without `--tab new`).
+  // `send --command` without `--tab new`). `--status` / `--pin` are NOT
+  // conflicts: they apply per sibling below (applyPostCreateFlags), the same
+  // as on a single `add`.
   if (agentsSpec) {
     const conflict = count !== undefined ? "--count" : args.str("command") ? "--command" : null
     if (conflict) {
@@ -249,6 +261,11 @@ async function addParallel(
       break
     }
   }
+
+  // Same `--status` / `--pin` follow-ups a single `add` applies, once per
+  // created sibling — before delivery so the row already reads right when the
+  // engine boots.
+  for (const { taskId } of created) await applyPostCreateFlags(daemon, taskId, args)
 
   const settled = await Promise.allSettled(
     created.map(({ taskId, vendor, task }) =>

--- a/packages/kobe/test/cli/api-add-parallel.test.ts
+++ b/packages/kobe/test/cli/api-add-parallel.test.ts
@@ -91,6 +91,26 @@ describe("add --count (parallel round)", () => {
     expect(calls.every((call) => call.target.newTask === true)).toBe(true)
   })
 
+  it("applies --status and --pin to every sibling, not just a single add", async () => {
+    const client = new FakeClient({
+      "task.create": (_payload, index) => ({ taskId: `t${index + 1}`, task: taskFixture({ id: `t${index + 1}` }) }),
+      "task.status": () => ({}),
+      "task.pin": () => ({}),
+    })
+    const { deliver } = recordingDelivery()
+    await invokeVerb("add", ["--repo", "/repo/x", "--prompt", "go", "--count", "2", "--status", "in_review", "--pin"], {
+      client,
+      runtime: stubRuntime({ deliverPrompt: deliver }),
+    })
+    const followUps = client.requests.filter((r) => r.name === "task.status" || r.name === "task.pin")
+    expect(followUps).toEqual([
+      { name: "task.status", payload: { taskId: "t1", status: "in_review" } },
+      { name: "task.pin", payload: { taskId: "t1", pinned: true } },
+      { name: "task.status", payload: { taskId: "t2", status: "in_review" } },
+      { name: "task.pin", payload: { taskId: "t2", pinned: true } },
+    ])
+  })
+
   it("expands per-vendor agent counts in order", async () => {
     const { calls, deliver } = recordingDelivery()
     await invokeVerb("add", ["--repo", "/repo/x", "--prompt", "go", "--agents", "claude:2,codex:1"], {


### PR DESCRIPTION
## What / why

`rove api add --count N` / `--agents` silently dropped `--status` and `--pin`. `addParallel` read only `prompt`, `branch`, `agents`, `command`, `title`, `base-branch` from `args`, so the `task.status` / `task.pin` follow-up RPCs that the single path issues had no counterpart. Both flags validated against the `add` spec, passed schema checking, exited 0, and evaporated — a fleet meant to land pinned and in review arrived unpinned in the backlog with no warning. The author already treated an unsupported flag here as loud (`--branch` throws `BAD_FLAG`); these two just fell through.

Fix per the brief's decision: apply per sibling, don't throw. `addOne`'s status/pin block is lifted into a shared `applyPostCreateFlags(daemon, taskId, args)` helper that both paths call, so they cannot drift again. The parallel path runs it once per created sibling, after the create loop and before delivery, so the row already reads right when the engine boots. The `--agents` conflict comment now records that `--status`/`--pin` are deliberately not conflicts.

## Pass criteria

Live repro against an isolated scratch home (`KOBE_HOME_DIR` + its own socket/pid/port), running this branch's source:

```
rove api add --repo "$R" --title solo --status in_review --pin
rove api add --repo "$R" --title par --count 2 --prompt "say hi" --status in_review --pin --command sh
rove api list
```

`list` now shows all three matching:

```
par #1/2     status=in_review  pinned=True
par #2/2     status=in_review  pinned=True
solo         status=in_review  pinned=True
```

## Mutation check

New case in `packages/kobe/test/cli/api-add-parallel.test.ts` asserts the exact `task.status` / `task.pin` traffic, once per sibling, in order.

- Delete the `status` read in `applyPostCreateFlags` → `Tests 1 failed | 12 passed (13)`, only the new case red.
- Second site, apply to the first sibling only (`created.slice(0, 1)`) → `Tests 1 failed | 12 passed (13)`, same single red.

## Other gates

- `bun x vitest run test/cli/api-add-parallel.test.ts test/cli/api-handlers.test.ts` → 43 passed.
- Full `test/cli/`: `2 failed | 790 passed`. Both failures are in `open-dir-cmd.test.ts` and are pre-existing — reverting my two files on this same tree reproduces the identical 2 failures. They are the known project-eligibility path-shape failures that appear when the suite runs from inside `~/.rove/worktrees`.
- `bun run lint` (repo root) clean, `bun x tsc --noEmit` clean.
- Changeset: `.changeset/add-parallel-status-pin.md`, `patch`.

## Screenshots

None — no UI-visible change. This is CLI request traffic; the `rove api list` output above is the evidence, as the brief specifies.