### PR TITLE
test: close the Automation field round-trip class

### DIFF
--- a/.changeset/automation-field-roundtrip-guard.md
+++ b/.changeset/automation-field-roundtrip-guard.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Guard every Automation field across a daemon restart. A new test creates an automation with all seventeen fields set, reloads the store from disk the way a restart does, and compares the whole record, so a field the loader forgets now fails CI instead of silently disappearing after `rove daemon restart`. The same test checks that every `AutomationPatch` key actually changes the record through update, and that clearing precheck, baseRef, or the standing-session link removes the field on disk.

--- a/packages/kobe/test/daemon/automations-roundtrip-fields.test.ts
+++ b/packages/kobe/test/daemon/automations-roundtrip-fields.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Field guard for the Automations store — the same class of bug that shipped
+ * twice on `Task` (`observedLanguage`): `create()` persists via `...input`
+ * spread, but `normalizeAutomation` rebuilds the record field-by-field on
+ * load, so a new optional field works perfectly until the daemon restarts and
+ * is then silently gone. `update()` is a third hand-written list with the
+ * same failure mode.
+ *
+ * Same technique as `serialize-task-fields.test.ts`: `DeepRequired` makes the
+ * fixture name every field at compile time, so adding an optional to
+ * `Automation` or `AutomationPatch` breaks the build here until it is listed,
+ * and the assertion then goes red until the loader / patch applier carry it.
+ */
+
+import { mkdtempSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { describe, expect, it } from "vitest"
+import { AutomationsStore } from "../../../kobe-daemon/src/daemon/automations-store.ts"
+import type { Automation, AutomationPatch } from "../../../kobe-daemon/src/daemon/contracts.ts"
+
+type DeepRequired<T> = {
+  [K in keyof T]-?: NonNullable<T[K]> extends string | number | boolean
+    ? NonNullable<T[K]>
+    : DeepRequired<NonNullable<T[K]>>
+}
+
+const NOW = new Date(2026, 6, 31, 10, 0, 0).getTime()
+
+/** Every field the store can carry, each with a distinguishable value. The
+ *  store owns id/nextRunAt/createdAt/updatedAt, so those are omitted on
+ *  create and read back from what it returned. */
+const FULL: Omit<DeepRequired<Automation>, "id" | "nextRunAt" | "createdAt" | "updatedAt"> = {
+  name: "nightly audit",
+  repo: "/repo",
+  prompt: "run the audit",
+  vendor: "codex",
+  schedule: "0 9 * * *",
+  precheck: { command: "git fetch --dry-run", timeoutSeconds: 45 },
+  baseRef: "release/1.x",
+  persistentSession: true,
+  sessionTaskId: "01ARZ3NDEKTSV4RRFFQ69G5FAV",
+  enabled: true,
+  missedRunGraceMinutes: 15,
+  lastRunAt: "2026-07-30T09:00:00.000Z",
+}
+
+/** Every patch key, each with a value that differs from FULL. `null` keys are
+ *  exercised separately below, so this fixture uses the set-a-value form. */
+const PATCH: DeepRequired<AutomationPatch> = {
+  name: "renamed",
+  prompt: "run the other audit",
+  vendor: "claude",
+  schedule: "*/15 * * * *",
+  precheck: { command: "true", timeoutSeconds: 5 },
+  baseRef: "main",
+  enabled: false,
+  missedRunGraceMinutes: 120,
+  persistentSession: false,
+  sessionTaskId: "01ARZ3NDEKTSV4RRFFQ69G5FAW",
+}
+
+function tempPath(): string {
+  return join(mkdtempSync(join(tmpdir(), "kobe-automations-fields-")), "automations.json")
+}
+
+describe("Automation field round-trip", () => {
+  it("every field survives create → daemon restart → get", async () => {
+    const path = tempPath()
+    const store = new AutomationsStore(path, () => NOW)
+    await store.init()
+    const created = await store.create(FULL)
+
+    const reborn = new AutomationsStore(path, () => NOW)
+    await reborn.init()
+    // Whole-object equality: a field the loader forgets shows up as a missing
+    // key, not as a passing test that only checked the keys it knew about.
+    expect(reborn.get(created.id)).toEqual(created)
+    expect(created).toMatchObject(FULL)
+  })
+
+  it("every AutomationPatch key mutates through update()", async () => {
+    const store = new AutomationsStore(tempPath(), () => NOW)
+    await store.init()
+    const created = await store.create(FULL)
+    const updated = await store.update(created.id, PATCH)
+    expect(updated).toMatchObject(PATCH)
+    // Sanity: the fixture really did change every key, or a no-op update
+    // would pass toMatchObject against values it never touched.
+    for (const key of Object.keys(PATCH) as (keyof typeof PATCH)[]) {
+      expect(created[key], key).not.toEqual(PATCH[key])
+    }
+  })
+
+  it("nullable patch keys clear the field on disk, not just in memory", async () => {
+    const path = tempPath()
+    const store = new AutomationsStore(path, () => NOW)
+    await store.init()
+    const created = await store.create(FULL)
+    await store.update(created.id, { precheck: null, baseRef: null, sessionTaskId: null })
+
+    const reborn = new AutomationsStore(path, () => NOW)
+    await reborn.init()
+    const loaded = reborn.get(created.id)
+    expect(loaded).not.toHaveProperty("precheck")
+    expect(loaded).not.toHaveProperty("baseRef")
+    expect(loaded).not.toHaveProperty("sessionTaskId")
+  })
+})


### PR DESCRIPTION
## What / why

`Automation` (17 fields) is enumerated by hand in four places that all typecheck when a field is added: the type, `normalizeAutomation` (disk loader), `update()` (patch applier), and the wire parsers. `create()` persists via `...input` spread while the loader rebuilds field by field, so a new optional field works until the daemon restarts and is then silently gone. Same class that shipped twice on `Task` (`observedLanguage`).

New test `packages/kobe/test/daemon/automations-roundtrip-fields.test.ts` uses the `DeepRequired<T>` fixture technique from `serialize-task-fields.test.ts`:

- a fixture naming every `Automation` field goes through `create → new AutomationsStore(samePath) → init → get` and is compared as a whole object
- a fixture naming every `AutomationPatch` key goes through `update()` and every key is asserted to have changed
- the three nullable patch keys (`precheck`, `baseRef`, `sessionTaskId`) are asserted absent on disk after a `null` patch

Test-only. The store already carried every field, so no source change. Adding an optional to `Automation` or `AutomationPatch` now breaks the build here until listed, then goes red until the loader / applier carry it.

## Contract proof (mutation)

Delete `...(str(raw.sessionTaskId) ? { sessionTaskId: raw.sessionTaskId } : {})` from `normalizeAutomation`:

```
   × Automation field round-trip > every field survives create → daemon restart → get 8ms
-   "sessionTaskId": "01ARZ3NDEKTSV4RRFFQ69G5FAV",
      Tests  1 failed | 2 passed (3)
```

Delete `...(patch.persistentSession !== undefined ? { persistentSession: patch.persistentSession } : {})` from `update()`:

```
   × Automation field round-trip > every AutomationPatch key mutates through update() 7ms
-   "persistentSession": false,
+   "persistentSession": true,
      Tests  1 failed | 2 passed (3)
```

Restored: `Tests  3 passed (3)`.

## Commands run (packages/kobe, `env -u ROVE_INVOKED_AS`)

```
KOBE_INCLUDE_SOCKET=1 bun x vitest run test/daemon/automations-roundtrip-fields.test.ts
 ✓ test/daemon/automations-roundtrip-fields.test.ts (3 tests) 14ms
 Tests  3 passed (3)

bun x tsc --noEmit            → exit 0
bun run lint (repo root)      → Checked 1341 files in 1665ms. No fixes applied.

bun run test:socket
 Test Files  3 failed | 79 passed (82)
      Tests  6 failed | 689 passed (695)
   automation-precheck.test.ts ×3, automation-runner.test.ts ×2, notes-store.test.ts ×1 — all 5000ms timeouts

bun run test:fast
 Test Files  3 failed | 424 passed (427)
      Tests  5 failed | 4156 passed (4161)
   project-eligibility.test.ts ×2 ("expected 'roveInternal' to be null"), open-dir-cmd.test.ts ×2, terminal-pty-lazy-snapshot.test.ts ×1
```

The failures are environmental and touch no file in this PR: the worktree lives under `~/.rove/worktrees/`, which `project-eligibility` classifies as `roveInternal` by path shape (and `open-dir-cmd` sits on top of that); the socket-track timeouts are the interactive login-shell spawn (`zsh -ilc`) taking ~4s without a tty in this agent shell. CI runs from a plain checkout and will not see either.

No UI change, so no screenshots.
