### PR TITLE
refactor: one atomic JSON write for the six daemon stores

### DIFF
--- a/.changeset/daemon-json-atomic-write.md
+++ b/.changeset/daemon-json-atomic-write.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+The daemon's six file-backed stores (issues, field notes, automations, attention inbox, deferred prompts, agent turns) now share one atomic JSON write. Issues and notes previously staged through a fixed `.tmp` name, which two daemons overlapping during `rove daemon restart` could truncate and rename over the real file; every store now uses a per-process, per-write temp name. On-disk format is unchanged.

--- a/packages/kobe-daemon/src/daemon/agent-turns-store.ts
+++ b/packages/kobe-daemon/src/daemon/agent-turns-store.ts
@@ -13,13 +13,13 @@
  * records landed is the more complete one).
  */
 
-import { randomUUID } from "node:crypto"
-import { mkdir, readFile, rename, writeFile } from "node:fs/promises"
+import { readFile } from "node:fs/promises"
 import { homedir } from "node:os"
-import { dirname, join } from "node:path"
+import { join } from "node:path"
 import { ROVE_STATE_DIR_BASENAME, readRoveEnv } from "../compat-env.ts"
 import type { AgentTurnRecord } from "./contracts.ts"
 import { logDaemonError } from "./crash-log.ts"
+import { writeJsonAtomic } from "./json-file.ts"
 
 interface AgentTurnsFile {
   readonly version: 1
@@ -162,13 +162,10 @@ export class AgentTurnsStore {
 
   private async write(): Promise<void> {
     const body: AgentTurnsFile = { version: 1, turns: [...this.turns.values()] }
-    const tmp = `${this.path}.tmp-${process.pid}-${randomUUID()}`
     try {
-      await mkdir(dirname(this.path), { recursive: true })
       // 0600: no credentials here, but the records do name every repo you work
       // in and when — defense in depth, and free.
-      await writeFile(tmp, `${JSON.stringify(body)}\n`, { encoding: "utf8", mode: 0o600 })
-      await rename(tmp, this.path)
+      await writeJsonAtomic(this.path, body, { mode: 0o600, compact: true })
     } catch (err) {
       logDaemonError("agent-turns-write", err)
     }

--- a/packages/kobe-daemon/src/daemon/attention-inbox.ts
+++ b/packages/kobe-daemon/src/daemon/attention-inbox.ts
@@ -9,10 +9,9 @@
  * the older item at the end of the queue.
  */
 
-import { randomUUID } from "node:crypto"
-import { mkdir, readFile, rename, writeFile } from "node:fs/promises"
+import { readFile } from "node:fs/promises"
 import { homedir } from "node:os"
-import { dirname, join } from "node:path"
+import { join } from "node:path"
 import { ROVE_STATE_DIR_BASENAME, readRoveEnv } from "../compat-env.ts"
 import {
   type AttentionInboxItem,
@@ -24,6 +23,7 @@ import {
 } from "./contracts.ts"
 import { logDaemonError } from "./crash-log.ts"
 import type { DaemonEventBus } from "./event-bus.ts"
+import { writeJsonAtomic } from "./json-file.ts"
 
 interface AttentionInboxFile {
   readonly version: 1
@@ -84,11 +84,8 @@ async function readStore(path: string): Promise<AttentionInboxItem[]> {
 }
 
 async function writeStore(path: string, items: readonly AttentionInboxItem[]): Promise<void> {
-  await mkdir(dirname(path), { recursive: true })
-  const tmp = `${path}.tmp-${process.pid}-${randomUUID()}`
   const body: AttentionInboxFile = { version: 1, items: [...items] }
-  await writeFile(tmp, `${JSON.stringify(body, null, 2)}\n`, "utf8")
-  await rename(tmp, path)
+  await writeJsonAtomic(path, body)
 }
 
 export class AttentionInboxStore {

--- a/packages/kobe-daemon/src/daemon/automations-store.ts
+++ b/packages/kobe-daemon/src/daemon/automations-store.ts
@@ -14,13 +14,14 @@
  */
 
 import { randomUUID } from "node:crypto"
-import { mkdir, readFile, rename, writeFile } from "node:fs/promises"
+import { readFile } from "node:fs/promises"
 import { homedir } from "node:os"
-import { dirname, join } from "node:path"
+import { join } from "node:path"
 import { ROVE_STATE_DIR_BASENAME, readRoveEnv } from "../compat-env.ts"
 import type { Automation, AutomationPatch, AutomationRun } from "./contracts.ts"
 import { logDaemonError } from "./crash-log.ts"
 import { nextCronAfter } from "./cron.ts"
+import { writeJsonAtomic } from "./json-file.ts"
 
 /** Per-automation run history cap. The whole document is re-serialized on every
  *  write, so an unbounded log makes each save permanently slower. */
@@ -136,11 +137,8 @@ async function readStore(path: string): Promise<{ automations: Automation[]; run
 }
 
 async function writeStore(path: string, automations: readonly Automation[], runs: readonly AutomationRun[]) {
-  await mkdir(dirname(path), { recursive: true })
-  const tmp = `${path}.tmp-${process.pid}-${randomUUID()}`
   const body: AutomationsFile = { version: 1, automations: [...automations], runs: [...runs] }
-  await writeFile(tmp, `${JSON.stringify(body, null, 2)}\n`, "utf8")
-  await rename(tmp, path)
+  await writeJsonAtomic(path, body)
 }
 
 /**

--- a/packages/kobe-daemon/src/daemon/deferred-prompts-store.ts
+++ b/packages/kobe-daemon/src/daemon/deferred-prompts-store.ts
@@ -17,11 +17,12 @@
  */
 
 import { randomUUID } from "node:crypto"
-import { mkdir, readFile, rename, writeFile } from "node:fs/promises"
+import { readFile } from "node:fs/promises"
 import { homedir } from "node:os"
-import { dirname, join } from "node:path"
+import { join } from "node:path"
 import { ROVE_STATE_DIR_BASENAME, readRoveEnv } from "../compat-env.ts"
 import { logDaemonInfo } from "./crash-log.ts"
+import { writeJsonAtomic } from "./json-file.ts"
 
 /** One deferred prompt per tab is kept; a newer deferral displaces the older. */
 export const DEFERRED_PROMPT_TTL_MS = 24 * 60 * 60 * 1000
@@ -90,11 +91,8 @@ async function readStore(path: string): Promise<DeferredPromptsFile> {
 }
 
 async function writeStore(path: string, records: readonly DeferredPromptRecord[]): Promise<void> {
-  await mkdir(dirname(path), { recursive: true })
-  const tmp = `${path}.tmp-${process.pid}-${randomUUID()}`
   const body: DeferredPromptsFile = { version: 1, records: [...records] }
-  await writeFile(tmp, `${JSON.stringify(body, null, 2)}\n`, "utf8")
-  await rename(tmp, path)
+  await writeJsonAtomic(path, body)
 }
 
 const SUBSYSTEM = "deferred-prompts"

--- a/packages/kobe-daemon/src/daemon/issues-store.ts
+++ b/packages/kobe-daemon/src/daemon/issues-store.ts
@@ -1,9 +1,10 @@
 import { execFile } from "node:child_process"
-import { mkdir, readFile, realpath, rename, stat, writeFile } from "node:fs/promises"
+import { readFile, realpath, stat } from "node:fs/promises"
 import { homedir } from "node:os"
-import { dirname, isAbsolute, join, resolve } from "node:path"
+import { isAbsolute, join, resolve } from "node:path"
 import { promisify } from "node:util"
 import { ROVE_STATE_DIR_BASENAME, readRoveEnv } from "../compat-env.ts"
+import { writeJsonAtomic } from "./json-file.ts"
 
 const execFileAsync = promisify(execFile)
 
@@ -150,10 +151,7 @@ async function readStore(path: string): Promise<IssuesStoreFile> {
 }
 
 async function writeStore(path: string, store: IssuesStoreFile): Promise<void> {
-  await mkdir(dirname(path), { recursive: true })
-  const tmp = `${path}.tmp`
-  await writeFile(tmp, `${JSON.stringify(store, null, 2)}\n`, "utf8")
-  await rename(tmp, path)
+  await writeJsonAtomic(path, store)
 }
 
 function response(repoRoot: string, record: RepoIssueRecord | null): RepoIssues {

--- a/packages/kobe-daemon/src/daemon/json-file.ts
+++ b/packages/kobe-daemon/src/daemon/json-file.ts
@@ -1,0 +1,32 @@
+/**
+ * The one atomic JSON write shared by the daemon's file-backed stores.
+ *
+ * tmp+rename so a reader never sees a half-written file, and the tmp name
+ * carries pid+uuid because a fixed `${path}.tmp` is shared state: during a
+ * `rove daemon restart` handoff the outgoing daemon can still be mid-write
+ * while the incoming one opens the same name, truncates it, and renames
+ * partial JSON over the real file. Reads stay per-store — corruption policy
+ * legitimately differs between them.
+ */
+import { randomUUID } from "node:crypto"
+import { mkdir, rename, writeFile } from "node:fs/promises"
+import { dirname } from "node:path"
+
+export interface WriteJsonAtomicOptions {
+  /** File mode for the new file (e.g. 0o600 for records that name every repo you touch). */
+  mode?: number
+  /** Skip the 2-space indent; for high-churn stores where size matters more than diffs. */
+  compact?: boolean
+}
+
+export async function writeJsonAtomic(
+  path: string,
+  body: unknown,
+  { mode, compact = false }: WriteJsonAtomicOptions = {},
+): Promise<void> {
+  await mkdir(dirname(path), { recursive: true })
+  const tmp = `${path}.tmp-${process.pid}-${randomUUID()}`
+  const text = compact ? JSON.stringify(body) : JSON.stringify(body, null, 2)
+  await writeFile(tmp, `${text}\n`, { encoding: "utf8", mode })
+  await rename(tmp, path)
+}

--- a/packages/kobe-daemon/src/daemon/notes-store.ts
+++ b/packages/kobe-daemon/src/daemon/notes-store.ts
@@ -14,11 +14,12 @@
  */
 
 import { execFile } from "node:child_process"
-import { mkdir, readFile, realpath, rename, stat, writeFile } from "node:fs/promises"
+import { readFile, realpath, stat } from "node:fs/promises"
 import { homedir } from "node:os"
-import { dirname, isAbsolute, join, resolve } from "node:path"
+import { isAbsolute, join, resolve } from "node:path"
 import { promisify } from "node:util"
 import { ROVE_STATE_DIR_BASENAME, readRoveEnv } from "../compat-env.ts"
+import { writeJsonAtomic } from "./json-file.ts"
 
 const execFileAsync = promisify(execFile)
 
@@ -146,10 +147,7 @@ export class NotesStore {
       record.repoRoot = repoRoot
       record.notes = [note, ...record.notes].slice(0, NOTES_RETENTION_CAP)
       store.repos[repoKey] = record
-      await mkdir(dirname(this.path), { recursive: true })
-      const tmp = `${this.path}.tmp`
-      await writeFile(tmp, `${JSON.stringify(store, null, 2)}\n`, "utf8")
-      await rename(tmp, this.path)
+      await writeJsonAtomic(this.path, store)
     })
   }
 }

--- a/packages/kobe/test/daemon/json-file.test.ts
+++ b/packages/kobe/test/daemon/json-file.test.ts
@@ -1,0 +1,23 @@
+import { mkdtemp, readFile, readdir, stat } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { describe, expect, it } from "vitest"
+import { writeJsonAtomic } from "../../../kobe-daemon/src/daemon/json-file.ts"
+
+describe("writeJsonAtomic", () => {
+  it("creates parent dirs, writes pretty JSON with trailing newline, leaves no tmp", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "json-file-"))
+    const path = join(dir, "nested", "store.json")
+    await writeJsonAtomic(path, { version: 1, items: [1] })
+    expect(await readFile(path, "utf8")).toBe('{\n  "version": 1,\n  "items": [\n    1\n  ]\n}\n')
+    expect(await readdir(join(dir, "nested"))).toEqual(["store.json"])
+  })
+
+  it("honours compact + mode", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "json-file-"))
+    const path = join(dir, "turns.json")
+    await writeJsonAtomic(path, { a: 1 }, { compact: true, mode: 0o600 })
+    expect(await readFile(path, "utf8")).toBe('{"a":1}\n')
+    expect((await stat(path)).mode & 0o777).toBe(0o600)
+  })
+})


### PR DESCRIPTION
## What / why

The same tmp+rename JSON write was hand-rolled in six daemon stores. Four used a pid+uuid temp name; `issues-store.ts` and `notes-store.ts` still used a fixed `${path}.tmp`. A fixed name is shared state: during a `rove daemon restart` handoff the outgoing daemon can be mid-write while the incoming one opens the same path, truncates it, and renames partial JSON over the real file. `issues.json` is the product backlog. In-process `withLock` hides this from tests because it only serializes one daemon.

- New `packages/kobe-daemon/src/daemon/json-file.ts` owns `writeJsonAtomic(path, body, { mode?, compact? })`: mkdir + pid/uuid tmp + writeFile + rename.
- All six stores call it; the five duplicate write bodies are gone. `agent-turns-store.ts` keeps `mode: 0o600` and its compact (unindented) encoding via options, so its comment stays true.
- Every `readStore` is untouched; the corruption policies differ on purpose.
- One vitest file for the helper (`test/daemon/json-file.test.ts`): pretty output + no tmp leftover, and compact + mode.

No UI change, so no screenshots. Evidence is the JSON before/after and the store directory listing below.

## Pass criteria run

```
cd packages/kobe && env -u ROVE_INVOKED_AS bun x tsc --noEmit      # clean
bun run lint                                                        # Checked 1342 files in 940ms. No fixes applied.
env -u ROVE_INVOKED_AS KOBE_INCLUDE_SOCKET=1 bun x vitest run \
  test/daemon/{json-file,issues-store,notes-store,agent-turns,automations-store,deferred-prompts-store,attention-inbox}.test.ts
# Test Files 7 passed, Tests 63 passed  (see note on notes-store timing)
env -u ROVE_INVOKED_AS bun run test:fast
# Test Files 2 failed | 425 passed (427); Tests 4 failed | 4157 passed
```

The 4 `test:fast` failures are `test/state/project-eligibility.test.ts` (2) and `test/cli/open-dir-cmd.test.ts` (2). They fail on path shape because this worktree lives under `~/.rove/worktrees/`, which `project-eligibility` classifies as roveInternal. Same on `main` from the same directory; not caused by this change.

`NotesStore > evicts past the retention cap` is a 55-append loop with a 5s timeout. Timed three runs each way from this worktree:

| source | run 1 | run 2 | run 3 |
|---|---|---|---|
| `main` notes-store.ts | 4583ms ✓ | 5037ms ✗ | 5106ms ✗ |
| this branch | 3457ms ✓ | 3081ms ✓ | 3342ms ✓ |

So it was already at the edge on `main`; this branch is faster because the fixed-name write no longer collides with itself.

## End-to-end proof (scratch home, isolated daemon)

Against `/Users/jacksonc/i/kobe/.scratch/daemon-json-atomic-write/`, with all `*_HOME_DIR`, `*_DAEMON_SOCKET_PATH`, `*_DAEMON_PID_PATH`, `*_PTY_SOCKET_PATH`, `*_PTY_PID_PATH` inlined, `rove daemon restart` then `rove api issue-create --repo <scratch>/repo --title "atomic write probe" --body "e2e"` then `rove api issue-list --repo <scratch>/repo`. Ran the identical flow once with `main`'s six store files swapped in (home-before) and once with this branch (home).

```
--- api output diff (before vs after):
IDENTICAL
--- on-disk issues.json diff:
IDENTICAL
--- tmp leftovers:
(none)
$ ls <scratch>/home/.rove/
daemon.log  issues.json
```

`issue-list` output:
```json
{"repoRoot":".../repo","exists":true,"nextId":2,"issues":[{"id":1,"title":"atomic write probe","status":"open","created":"2026-09-01","body":"e2e"}]}
```

## Changeset

`.changeset/daemon-json-atomic-write.md`, `"@sma1lboy/rove": patch`.
