### PR TITLE
fix: empty-success guard measures against the task's recorded base branch

### DIFF
--- a/.changeset/empty-success-guard-base-ref.md
+++ b/.changeset/empty-success-guard-base-ref.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+`rove api send` now measures a `succeeded:` report against the task's recorded base branch (`add --base-branch`), the same read `collect` makes. Before, a task cut from a branch ahead of `main` was measured against the `origin/main` guess, so an empty branch read as having commits and a hollow success reached the coordinator unrefused, only to be caught later by `land`. The opposite mistake, a false refusal when the worktree sat behind the guessed base, is gone too.

--- a/packages/kobe/src/cli/api/handlers-tasks.ts
+++ b/packages/kobe/src/cli/api/handlers-tasks.ts
@@ -93,7 +93,14 @@ async function assertNotEmptySuccess(daemon: DaemonRpc, ctx: VerbContext, prompt
   // exactly like the `ahead: null` it returns for an unresolvable base.
   let ahead: number | null
   try {
-    ahead = (await ctx.runtime.readBranchSignals(sender.worktreePath)).ahead
+    // Paired with `collect`'s read in handlers-fanout.ts: both measure against
+    // the task's RECORDED base (`add --base-branch`), never the origin/main
+    // guess. Reading against the guess produced BOTH failure modes at once on
+    // a task cut from `release/2.x` two commits ahead of `main`: an empty
+    // branch read `ahead: 2` (the guard let a hollow success through), and a
+    // HEAD behind the guessed base read a false positive — the exact
+    // "false POSITIVE blocks a worker" case the paragraph above warns against.
+    ahead = (await ctx.runtime.readBranchSignals(sender.worktreePath, sender.baseRef)).ahead
   } catch {
     return
   }

--- a/packages/kobe/test/cli/api-send-empty-success.test.ts
+++ b/packages/kobe/test/cli/api-send-empty-success.test.ts
@@ -126,6 +126,26 @@ describe("send refuses an empty-branch success report", () => {
     expect(calls).toHaveLength(0)
   })
 
+  it("measures against the task's RECORDED base, not the origin/main guess", async () => {
+    // A task cut from `release/2.x` (ahead of main) with no commits of its
+    // own: against the recorded base it is empty; against the guess it reads
+    // ahead — the read that let a hollow success walk past this guard.
+    const { calls, deliver } = recordingDelivery()
+    await expect(
+      invokeVerb("send", ["--task-id", "coord-1", "--prompt", "succeeded: done"], {
+        client: clientWith({ baseRef: "release/2.x" }),
+        runtime: stubRuntime({
+          deliverPrompt: deliver,
+          readBranchSignals: async (_worktree, recordedBaseRef) =>
+            recordedBaseRef === "release/2.x"
+              ? { baseRef: "release/2.x", ahead: 0, diff: null }
+              : { baseRef: "origin/main", ahead: 2, diff: null },
+        }),
+      }),
+    ).rejects.toMatchObject({ code: "EMPTY_SUCCESS_REPORT" })
+    expect(calls).toHaveLength(0)
+  })
+
   it("--plain is not an escape hatch — a verbatim false claim is the same false claim", async () => {
     const { calls, deliver } = recordingDelivery()
     await expectApiError(


### PR DESCRIPTION
## What / why

`assertNotEmptySuccess` (`packages/kobe/src/cli/api/handlers-tasks.ts`) called `ctx.runtime.readBranchSignals(sender.worktreePath)` with the second argument omitted, so `resolveMeasureBase` skipped the task's recorded base and fell to the `origin/HEAD → origin/main → origin/master → main` guess. `collect` already gets this right (`handlers-fanout.ts:69`), and `branch-signals.ts` states the contract: "The base ref comes from the TASK RECORD first."

On a task cut with `--base-branch release/2.x` where that branch is 2 commits ahead of `main`, an empty branch read `ahead: 2`, so the guard returned early and a `succeeded:` report with zero commits reached the coordinator unrefused — `land`'s `EMPTY_BRANCH` then caught it two steps later, exactly the late catch this guard replaced. The mirror case is worse: a worktree whose HEAD is an ancestor of the guessed base produces a **false refusal**, the failure mode the docblock's own "a false POSITIVE blocks a worker" paragraph warns against. Both are noted in the new comment.

**Caller audit:** all `readBranchSignals` call sites checked. `runtime.ts:294` forwards both arguments, `handlers-fanout.ts:69` already passed `task.baseRef`; `handlers-tasks.ts` was the only omission. No interface change — `ApiRuntime.readBranchSignals` already takes the optional base.

## Repro, before and after

Scratch repo where `release/2.x` is 2 commits ahead of `main`, task created on it with nothing committed, run against an isolated daemon (`KOBE_HOME_DIR` under `.scratch/`, never the shared sandbox):

```
task=01M1GBA3P0R81TJTXK9B448TMP  baseRef=release/2.x
rev-list release/2.x..HEAD = 0   # what collect uses
rev-list main..HEAD        = 2   # what the guard used
```

`readBranchSignals` against that real worktree:

```
BEFORE (base omitted, the old guard call):  {"baseRef":"main","ahead":2,"diff":{"files":2,"insertions":2,"deletions":0}}
AFTER  (recorded base passed, as collect):  {"baseRef":"release/2.x","ahead":0,"diff":{"files":0,"insertions":0,"deletions":0}}
```

`collect` agrees the worker delivered nothing:

```
collect base: {"baseRef": "release/2.x", "ahead": 0, "diff": {"files": 0, "insertions": 0, "deletions": 0}}
```

End-to-end, a `succeeded:` send issued from **inside** a hosted PTY on that task (real verified self session, `IDENT=01M1GBA3P0R81TJTXK9B448TMP/tab-3`):

BEFORE (fix reverted) — the guard passes the report through and it only dies later, at delivery routing, well past `assertNotEmptySuccess`:

```
{"error":{"message":"... has live tabs ... but none resolves as its engine tab — refusing to spawn a new engine","code":"NO_ENGINE_TAB", ...}}
```

AFTER — refused at the guard, before any delivery attempt:

```
{"error":{"message":"refusing to report success: release/stacked has 0 commits — \"succeeded\" means COMMITTED, and this report would reach the coordinator as a clean success with nothing to land","code":"EMPTY_SUCCESS_REPORT","taskId":"01M1GBA3P0R81TJTXK9B448TMP","branch":"release/stacked","hint":"commit your work with a real message and send again — or, if this task genuinely produced no commits (an investigation or a review), re-send with --allow-empty to say so explicitly","nextCommandArgs":["api","send","--allow-empty","--prompt","succeeded: nothing committed"]}}
```

## Mutation check

New case in `packages/kobe/test/cli/api-send-empty-success.test.ts`: sender carries `baseRef: "release/2.x"`, and the fake `readBranchSignals` returns `ahead: 0` only when the recorded base is passed (`ahead: 2` otherwise). Dropping the second argument again:

```
× ... > measures against the task's RECORDED base, not the origin/main guess
Tests  1 failed | 13 passed (14)
```

Only the new case turns red; the existing cases stay green. With the fix in place, 14/14 pass.

## Gates

```
bun x vitest run test/cli/api-send-empty-success.test.ts test/cli/api-handlers-lifecycle.test.ts test/cli/branch-signals.test.ts
  Test Files  3 passed (3)   Tests  43 passed (43)

bun x tsc --noEmit      # clean
bun run lint            # Checked 1340 files. No fixes applied.
```

Full `test/cli` shows 2 failures in `open-dir-cmd.test.ts`, both pre-existing and environmental: that file is byte-identical to `origin/main` on this branch, and it passes 18/18 from an `origin/main` worktree checked out under `~/i`. The failures are the known project-eligibility path-shape effect of running inside `~/.rove/worktrees`.

## Screenshots

None — no UI-visible change. This is a CLI guard; repro output above stands in per the brief.