### PR TITLE
fix: land refuses an unresolvable branch instead of faking a merge conflict

### DIFF
--- a/.changeset/land-missing-ref.md
+++ b/.changeset/land-missing-ref.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+`rove api land` no longer reports a phantom merge conflict when a task's branch was renamed or deleted outside Rove. The ahead-count probe ignored git's exit status, so an unresolvable branch produced an unreadable count that read as "this branch has work", and the merge that followed failed for an unrelated reason and surfaced as `LAND_CONFLICT` with an empty conflicted-file list. Land now refuses up front with `MISSING_REF`, naming the branch, the base branch, and the base repo, and leaves the base checkout untouched.

--- a/docs/API.md
+++ b/docs/API.md
@@ -501,10 +501,11 @@ nothing to do), `skipped_missed`, `skipped_unavailable`, and
 - `land --task-id ID [--strategy merge|squash] [--delete-branch]
   [--remove-worktree=false]`: merge a task's branch back into its
   base repo's current branch (`--no-ff` merge, or one squash commit). Refuses
-  a dirty base checkout and a branch with no commits ahead of base
-  (`EMPTY_BRANCH`; `EMPTY_BRANCH_DIRTY_WORKTREE` when uncommitted work is
-  still sitting in the worktree, with a send-back recovery command); on
-  conflict it aborts and returns the conflicted files. Returns
+  a dirty base checkout, a branch that no longer resolves in the base repo
+  (`MISSING_REF` — renamed or deleted outside Rove), and a branch with no
+  commits ahead of base (`EMPTY_BRANCH`; `EMPTY_BRANCH_DIRTY_WORKTREE` when
+  uncommitted work is still sitting in the worktree, with a send-back recovery
+  command); on conflict it aborts and returns the conflicted files. Returns
   `{ landedOn, commit }`.
   **A successful land removes the task's worktree by default** — the
   directory is spent once the branch is in. Pass `--remove-worktree=false` to

--- a/packages/kobe/src/cli/api/verbs-lifecycle.ts
+++ b/packages/kobe/src/cli/api/verbs-lifecycle.ts
@@ -29,7 +29,7 @@ export const LIFECYCLE_VERBS: readonly VerbSpec[] = [
     name: "land",
     group: "lifecycle",
     summary:
-      "Merge a task's branch back into its base repo's current branch. Refuses a dirty base checkout and refuses a branch with zero commits ahead of the base (EMPTY_BRANCH; EMPTY_BRANCH_DIRTY_WORKTREE with a send-back recovery path when the worktree still holds the uncommitted work). On conflict, aborts and returns the conflicted files (resolve by hand). Returns { landedOn, commit }.",
+      "Merge a task's branch back into its base repo's current branch. Refuses a dirty base checkout, a branch that no longer resolves in the base repo (MISSING_REF — renamed or deleted outside Rove), and a branch with zero commits ahead of the base (EMPTY_BRANCH; EMPTY_BRANCH_DIRTY_WORKTREE with a send-back recovery path when the worktree still holds the uncommitted work). On conflict, aborts and returns the conflicted files (resolve by hand). Returns { landedOn, commit }.",
     flags: [
       F.taskId(),
       {

--- a/packages/kobe/src/orchestrator/errors.ts
+++ b/packages/kobe/src/orchestrator/errors.ts
@@ -159,6 +159,33 @@ export class EmptyBranchDirtyWorktreeError extends Error {
 }
 
 /**
+ * Stable sentinel embedded in {@link MissingRefError}'s message — same
+ * wire-boundary reason as {@link DIRTY_WORKTREE_CODE}.
+ */
+export const MISSING_REF_CODE = "MISSING_REF"
+
+/**
+ * Thrown by `landTask` when git cannot resolve the `<base>..<branch>` range at
+ * all — the recorded branch was renamed or deleted outside Rove, so
+ * `git rev-list --count` exits non-zero instead of printing a number. Distinct
+ * from {@link EmptyBranchError}: that one means "git counted, and the answer
+ * was zero"; this one means "git could not count", which is a broken task
+ * record, not an empty branch.
+ */
+export class MissingRefError extends Error {
+  constructor(
+    public readonly branch: string,
+    public readonly landedOn: string,
+    public readonly dir: string,
+  ) {
+    super(
+      `${MISSING_REF_CODE}: '${branch}' does not resolve in the base repo at ${dir} (comparing against '${landedOn}') — the branch was renamed or deleted outside Rove; re-point the task with \`rove api set-branch\` or recreate the branch`,
+    )
+    this.name = "MissingRefError"
+  }
+}
+
+/**
  * Stable sentinel embedded in {@link LandConflictError}'s message — same
  * wire-boundary reason as {@link DIRTY_WORKTREE_CODE}. The conflicted-file list
  * rides along in the message so a CLI/TUI caller can print it after matching.

--- a/packages/kobe/src/orchestrator/land.ts
+++ b/packages/kobe/src/orchestrator/land.ts
@@ -21,7 +21,13 @@ import path from "node:path"
 import type { ExecHost } from "../exec/exec-host.ts"
 import { READ_ONLY_GIT_ENV } from "../lib/git-env.ts"
 import type { Task, TaskId } from "../types/task.ts"
-import { EmptyBranchDirtyWorktreeError, EmptyBranchError, LandConflictError, MainCheckoutDirtyError } from "./errors.ts"
+import {
+  EmptyBranchDirtyWorktreeError,
+  EmptyBranchError,
+  LandConflictError,
+  MainCheckoutDirtyError,
+  MissingRefError,
+} from "./errors.ts"
 import { type WorktreeExecDeps, defaultExecDeps } from "./worktree/exec-deps.ts"
 import type { WorktreeResidue } from "./worktree/manager-remove.ts"
 import { GitWorktreeManager } from "./worktree/manager.ts"
@@ -311,6 +317,13 @@ function porcelainPaths(stdout: string): string[] {
  *   - worktree clean/gone → genuine no-op ({@link EmptyBranchError}).
  * An unreadable worktree (already removed, remote path mismatch) falls through
  * to the clean case — ambiguity must not hide the no-op signal.
+ *
+ * The count itself has a THIRD outcome that is neither: `git rev-list` exiting
+ * non-zero, which means git could not resolve `<base>..<branch>` at all (the
+ * branch was renamed or deleted outside Rove). That is a broken task record —
+ * {@link MissingRefError} — and must not fall through to the merge, which would
+ * fail with "not something we can merge" and get reported as a phantom
+ * LAND_CONFLICT carrying an empty conflicted-file list.
  */
 async function assertBranchHasWork(
   task: Task,
@@ -321,6 +334,13 @@ async function assertBranchHasWork(
   deps: WorktreeExecDeps,
 ): Promise<void> {
   const aheadOut = await git(exec, dir, ["rev-list", "--count", `${landedOn}..${branch}`], { readOnly: true })
+  // Exit code first, and it is NOT the same question as an unparseable count:
+  // non-zero means git never counted (the ref does not resolve) → refuse the
+  // land; exit 0 with output we cannot parse means git counted and we failed to
+  // read it, where assuming "has work" and letting the merge speak is the safe
+  // fallback. Collapsing the two is what made a renamed branch look like a
+  // merge conflict.
+  if (aheadOut.exitCode !== 0) throw new MissingRefError(branch, landedOn, dir)
   const ahead = Number.parseInt(aheadOut.stdout.trim(), 10)
   if (!Number.isFinite(ahead) || ahead > 0) return
   const worktreePath = task.worktreePath.trim()
@@ -350,6 +370,9 @@ async function assertBranchHasWork(
  *   - the task has a branch to land (a never-materialised task has none);
  *   - the base checkout is clean — a merge into a dirty tree would entangle the
  *     user's in-progress work with the landed branch, so we refuse;
+ *   - the branch RESOLVES in the base repo — a branch renamed or deleted
+ *     outside Rove is a stale task record, refused as {@link MissingRefError}
+ *     rather than handed to a merge that fails for an unrelated reason;
  *   - the branch has at least one commit ahead of the base — a zero-commit
  *     branch is a no-op land ("worker reported success, delivered nothing"),
  *     refused as {@link EmptyBranchError}, or as

--- a/packages/kobe/test/orchestrator/land.test.ts
+++ b/packages/kobe/test/orchestrator/land.test.ts
@@ -19,7 +19,9 @@ import {
   EmptyBranchDirtyWorktreeError,
   EmptyBranchError,
   LandConflictError,
+  MISSING_REF_CODE,
   MainCheckoutDirtyError,
+  MissingRefError,
 } from "../../src/orchestrator/errors.ts"
 import { landTask, landTaskWithCleanup } from "../../src/orchestrator/land.ts"
 import { GitWorktreeManager } from "../../src/orchestrator/worktree/manager.ts"
@@ -168,6 +170,29 @@ describe("landTask", () => {
     // The uncommitted file survives the refusal, and the base is untouched.
     expect(fs.existsSync(path.join(wt, "wip.txt"))).toBe(true)
     expect(fs.existsSync(path.join(repo, "wip.txt"))).toBe(false)
+  })
+
+  test("a branch that no longer resolves is MISSING_REF, not a phantom conflict", async () => {
+    // The recorded branch was renamed outside Rove, so `git rev-list --count
+    // main..feat` exits 128 with empty stdout. Before the exitCode guard the
+    // unparseable count read as "has work", the merge then failed with "not
+    // something we can merge", and land reported LAND_CONFLICT with an empty
+    // conflicted-file list — sending the operator hunting for files to resolve.
+    git(["checkout", "-b", "feat"], repo)
+    write("b.txt", "feature\n")
+    git(["add", "."], repo)
+    git(["commit", "-m", "feat commit"], repo)
+    git(["checkout", "main"], repo)
+    git(["branch", "-m", "feat", "feat-renamed"], repo)
+    const head = spawnSync("git", ["rev-parse", "HEAD"], { cwd: repo, encoding: "utf8" }).stdout.trim()
+
+    await expect(landTask(task("feat"))).rejects.toBeInstanceOf(MissingRefError)
+    await expect(landTask(task("feat"))).rejects.toThrow(MISSING_REF_CODE)
+    await expect(landTask(task("feat"))).rejects.toThrow(/'feat' does not resolve/)
+    // No merge was attempted: base checkout clean, HEAD unmoved.
+    const status = spawnSync("git", ["status", "--porcelain"], { cwd: repo, encoding: "utf8" }).stdout.trim()
+    expect(status).toBe("")
+    expect(spawnSync("git", ["rev-parse", "HEAD"], { cwd: repo, encoding: "utf8" }).stdout.trim()).toBe(head)
   })
 
   test("refuses a dirty base checkout", async () => {


### PR DESCRIPTION
## What / why

`rove api land` reported `LAND_CONFLICT ... conflicted files: (none reported)` when a task's branch had been renamed or deleted outside Rove. Nothing conflicted — the branch simply did not exist.

Root cause is in `assertBranchHasWork` (`packages/kobe/src/orchestrator/land.ts`): it ran `git rev-list --count <base>..<branch>` through the local `git()` helper, which returns `exitCode` but never inspects it. An unresolvable branch makes git exit 128 with empty stdout, `Number.parseInt("")` yields `NaN`, and the guard `if (!Number.isFinite(ahead) || ahead > 0) return` treated the unreadable count as "this branch has work". Control fell through to `git merge`, which failed with "not something we can merge", and `conflictedFiles` correctly found nothing — producing a conflict report for a merge that never had a conflict.

The fix checks the exit code before parsing and throws a new typed `MissingRefError` (`MISSING_REF`) naming the branch, the base branch, and the base repo. `!Number.isFinite(ahead)` stays for the exit-0-but-unparseable case, with a comment saying why the two differ: non-zero means git never counted (refuse); exit 0 with unreadable output means git counted and we failed to read it, where assuming "has work" and letting the merge speak is the safe fallback.

## The other two probes (asked for in the brief)

Checked both; neither hides a failure, and neither is changed.

- **`isDirty` (line ~284)** — runs on the base repo after `git rev-parse --abbrev-ref HEAD` has already succeeded on the same directory, so by then the dir is a working repo with a checked-out branch. An unreadable repo dies earlier with the detached-HEAD error. `git status --porcelain` does not exit non-zero in that state, so the unchecked exit code has no reachable failure mode here.
- **`conflictedFiles` (line ~289)** — only runs after a merge already exited non-zero, so the `LAND_CONFLICT` itself is not phantom; only the file list can be empty. The empty list in this bug came from a **non-conflict merge failure**, not from the diff probe failing. `git diff --name-only --diff-filter=U` does not exit non-zero in a healthy repo. The `rev-list` guard now pre-empts the unresolvable-ref case before the merge runs, which is the path that produced the empty list.

For reference, the two sibling `rev-list --count` parsers in the codebase already check exit status (`src/cli/api/branch-signals.ts:91`, `src/core/daemon-worktree-adapter.ts:61`), so `land.ts` was the only site missing it.

## Repro — before / after

Both runs used a fully isolated scratch home (`KOBE_HOME_DIR` / `ROVE_HOME_DIR` / `KOBE_DAEMON_SOCKET_PATH` / `ROVE_DAEMON_SOCKET_PATH` under `.scratch/land-missing-ref/`), never the shared `.dev-sandbox`. Script: create repo, `add --branch feat/landbug`, `ensure-worktree`, rename the branch in the worktree, `land`.

**BEFORE** (installed `rove 0.9.79`):
```json
{"error":{"message":"LAND_CONFLICT: merging 'feat/landbug' hit conflicts, merge aborted — conflicted files: (none reported)","code":"RPC_ERROR"}}
```
```
exit=1
base checkout status: (clean)   HEAD=a5871a9
```

**AFTER** (this branch, run via the local source CLI):
```json
{"error":{"message":"MISSING_REF: 'feat/landbug' does not resolve in the base repo at /Users/jacksonc/i/kobe/.scratch/land-missing-ref/repo-after (comparing against 'main') — the branch was renamed or deleted outside Rove; re-point the task with `rove api set-branch` or recreate the branch","code":"RPC_ERROR"}}
```
```
exit=1
base checkout status: (clean)   HEAD=cfdcbde
```

Base checkout stays clean and HEAD unmoved in both, as required.

## Tests + mutation check

New case in `test/orchestrator/land.test.ts`: `a branch that no longer resolves is MISSING_REF, not a phantom conflict`. The file is deliberately mock-free (real git in a tmp repo), so instead of stubbing an exec host returning `{stdout:"", exitCode:128}` the test produces exactly that from real git — a task whose recorded branch was renamed away, which makes `git rev-list --count main..feat` exit 128 with empty stdout. Same observable, no mock, consistent with the file's stated rationale.

Two mutations, at different sites, both red only on the new case:

| Mutation | Result |
|---|---|
| delete `if (aheadOut.exitCode !== 0) throw …` | `1 failed \| 22 passed` — only the new case red |
| change the guard to `… exitCode !== 0) return` | `1 failed \| 22 passed` — only the new case red |

The three existing empty-branch cases (`EMPTY_BRANCH` x2, `EMPTY_BRANCH_DIRTY_WORKTREE`) stayed green under both.

## Commands run

```
env -u ROVE_INVOKED_AS bun x vitest run test/orchestrator/land.test.ts
  → Test Files 1 passed (1) / Tests 23 passed (23)

env -u ROVE_INVOKED_AS bun x vitest run test/orchestrator/land.test.ts \
  test/orchestrator/git-readonly-env.test.ts \
  test/orchestrator/branch-anchor.test.ts test/orchestrator/dir-task.test.ts
  → Test Files 4 passed (4) / Tests 43 passed (43)

cd packages/kobe && bun x tsc --noEmit        → exit 0
bun run lint  (repo root)                     → Checked 1340 files. No fixes applied.
```

**Pre-existing failure, not from this change.** `test/cli/open-dir-cmd.test.ts` fails 2 of 18 in this worktree (`runOpenDirectory > a git repo ROOT opens as the project`). Proven unrelated two ways: it passes on a clean `origin/main` worktree checked out under `~/i`, and it fails identically in *this* worktree with my source changes reverted to `HEAD`. It is the known path-shape sensitivity of project-eligibility under `~/.rove/worktrees`.

## Screenshots

None — no UI-visible change. This is an orchestrator/CLI error path; the before/after JSON above is the evidence, per the brief.

## Docs

`docs/API.md` and the `land` verb summary in `src/cli/api/verbs-lifecycle.ts` (what `rove api schema --verb land` prints) both enumerate land's refusals, so both now list `MISSING_REF`. The agent-skill copies under `claude-plugin/skills/` and `.agents/skills/` carry a curated *subset* of error codes (they already omit `MAIN_CHECKOUT_DIRTY` and `LAND_CONFLICT`) and are version-locked to `KOBE_SKILL_VERSION`, so they are left alone.

## File size

`land.ts` goes 427 → 442 lines, under the cap. There is a real seam if it grows further — the `git()` / `isDirty` / `conflictedFiles` probe trio versus the merge state machine — but splitting it was not needed for a 15-line guard.