### PR TITLE
feat: Issues page opens the linked task instead of duplicating it

### DIFF
--- a/.changeset/issues-page-open-linked-task.md
+++ b/.changeset/issues-page-open-linked-task.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+The Issues page (`ctrl+a` `3`) no longer duplicates work. An issue that already has a task shows that task's title on its detail line, and `enter` opens the existing task instead of creating a second worktree, branch and engine session. Unlinked issues still start a fresh task as before.

--- a/docs/TUI.md
+++ b/docs/TUI.md
@@ -414,8 +414,10 @@ When the page opens, `a` filters to issues assigned to you, `tab` switches
 repos, and `r` refreshes past the cache. `enter` starts a Rove task from the
 selected issue: the issue body arrives as the first prompt (fenced, and
 explicitly marked as an untrusted report), and the task keeps a
-`linkedWorkItem` pointer back to the issue. Nothing is imported into the local
-issue store and nothing is written back to GitHub.
+`linkedWorkItem` pointer back to the issue. An issue that already has a task
+shows that task's title on its detail line, and `enter` opens the task instead
+of creating a second one. Nothing is imported into the local issue store and
+nothing is written back to GitHub.
 
 ## Updates and version warnings
 

--- a/docs/design/work-items.md
+++ b/docs/design/work-items.md
@@ -95,7 +95,9 @@ available when the TUI is not open.
 When it is shown, it is pointed at the selected task's project.
 
 `enter` is the page: it starts a task on the highlighted issue and lands on its
-workspace. `a` toggles assigned-to-me, `tab` cycles projects, `r` forces past
+workspace. When a task already carries that issue in `linkedWorkItem`, the row
+shows its title and `enter` opens it instead of starting another — the daemon's
+`workitem-start` creates unconditionally, so the guard lives on the page. `a` toggles assigned-to-me, `tab` cycles projects, `r` forces past
 the daemon's 60s cache, `j`/`k` move.
 
 A `gh` failure renders its own message verbatim — the three fixes differ, and

--- a/packages/kobe/src/tui-react/component/work-items-page.tsx
+++ b/packages/kobe/src/tui-react/component/work-items-page.tsx
@@ -9,7 +9,9 @@
  *
  * Enter is the whole point of the page — it creates a task whose branch derives
  * from the issue title and whose engine opens with the issue already in hand,
- * replacing copy-title → invent-branch → create-task → paste-body.
+ * replacing copy-title → invent-branch → create-task → paste-body. An issue
+ * that already has a task (`task.linkedWorkItem`) shows that task on its
+ * detail line, and enter opens it instead of minting a duplicate.
  */
 
 import { TextAttributes } from "@opentui/core"
@@ -19,6 +21,7 @@ import type { RemoteOrchestrator } from "../../client/remote-orchestrator"
 import { errorMessage } from "../../lib/error-message"
 import { clampCursor } from "../../tui/component/new-task-dialog/state"
 import { sidebarProjectLabel } from "../../tui/panes/sidebar/groups"
+import type { Task } from "../../types/task"
 import { useNotifications } from "../context/notifications"
 import { useTheme } from "../context/theme"
 import { useT } from "../i18n"
@@ -33,6 +36,11 @@ function reposOf(orch: RemoteOrchestrator | null): string[] {
     if (task.repo && !seen.includes(task.repo)) seen.push(task.repo)
   }
   return seen
+}
+
+/** The task already started from `number` on `repo`, if any. */
+function linkedTaskFor(orch: RemoteOrchestrator | null, repo: string, number: number): Task | undefined {
+  return orch?.listTasks().find((task) => task.repo === repo && task.linkedWorkItem?.number === number)
 }
 
 function errorHint(error: string, t: ReturnType<typeof useT>): string {
@@ -136,6 +144,14 @@ export function WorkItemsPage(props: {
     const orch = props.orchestrator
     const item = rows[cursor]
     if (!orch || !item || !repo || starting) return
+    // Already started: land on that task. The daemon creates unconditionally
+    // by contract; this page is the surface that knows what the user sees.
+    const linked = linkedTaskFor(orch, repo, item.number)
+    if (linked) {
+      setNotice(t("workItems.openingLinked", { title: linked.title }))
+      props.onOpenTask?.(linked.id)
+      return
+    }
     setStarting(true)
     setNotice(t("workItems.starting", { number: item.number }))
     try {
@@ -199,6 +215,7 @@ export function WorkItemsPage(props: {
             // line. The number leads the title because that is how an issue is
             // referred to out loud, and it survives truncation there.
             const chrome = resolveRowSelectionChrome(theme, { cursor: index === cursor, selected: false })
+            const linked = linkedTaskFor(props.orchestrator, repo, item.number)
             return (
               <box
                 key={`${item.number}`}
@@ -232,6 +249,11 @@ export function WorkItemsPage(props: {
                     <text fg={theme.textMuted} wrapMode="none" flexGrow={1}>
                       {[item.author, ...item.labels.slice(0, 2)].filter(Boolean).join(" · ")}
                     </text>
+                    {linked ? (
+                      <text fg={theme.textMuted} wrapMode="none">
+                        {t("workItems.linkedChip", { title: linked.title })}
+                      </text>
+                    ) : null}
                     <text fg={theme.textMuted} wrapMode="none">
                       {relativeAge(item.updatedAt, now)}
                     </text>

--- a/packages/kobe/src/tui/i18n/messages/workItems.ts
+++ b/packages/kobe/src/tui/i18n/messages/workItems.ts
@@ -10,6 +10,9 @@ export const en = {
   assignedFilter: "assigned to me",
   starting: "Starting work on #{number}…",
   startedNoEngine: "Created {title}, but its engine did not start.",
+  /** Detail-line chip on an issue that already has a task. `{title}` = that task's title. */
+  linkedChip: "→ {title}",
+  openingLinked: "Opening {title}…",
   /** Error-toast title when starting work fails. `{number}` = issue number, `{error}` = the daemon's message. */
   startFailed: "Couldn't start work on #{number}: {error}",
   errorHint: {
@@ -27,6 +30,9 @@ export const zh: typeof en = {
   assignedFilter: "分配给我的",
   starting: "正在开始处理 #{number}…",
   startedNoEngine: "已创建 {title}，但引擎没有启动。",
+  /** 已有任务的议题在详情行上的标记。`{title}` = 那个任务的标题。 */
+  linkedChip: "→ {title}",
+  openingLinked: "正在打开 {title}…",
   /** 开始处理失败时的错误 toast 标题。`{number}` = 议题编号，`{error}` = daemon 返回的信息。 */
   startFailed: "开始处理 #{number} 失败：{error}",
   errorHint: {

--- a/packages/kobe/test/render/work-items-page-linked.test.tsx
+++ b/packages/kobe/test/render/work-items-page-linked.test.tsx
@@ -1,0 +1,61 @@
+/** @jsxImportSource @opentui/react */
+/**
+ * An issue that already has a task opens that task on enter instead of
+ * starting a second one, and shows the task on its detail line.
+ */
+
+import { expect, test } from "bun:test"
+import { WorkItemsPage } from "../../src/tui-react/component/work-items-page"
+import { renderComponent, settle } from "./harness"
+
+const REPO = "/x/kobe"
+const ITEM = { number: 412, title: "Fix the thing", author: "octocat", labels: [], updatedAt: new Date().toISOString() }
+
+function orch(tasks: unknown[], startWorkItem: () => Promise<unknown>) {
+  return { listTasks: () => tasks, listWorkItems: async () => ({ items: [ITEM] }), startWorkItem } as never
+}
+
+test("enter on an already-started issue opens its task, never a second start", async () => {
+  let starts = 0
+  const opened: string[] = []
+  const linked = { id: "T1", repo: REPO, title: "issue-412-fix", linkedWorkItem: { number: 412, title: "x", url: "u" } }
+  const { frame, mockInput } = await renderComponent(
+    <WorkItemsPage
+      orchestrator={orch([linked], async () => ({ started: true, taskId: `T${++starts + 1}`, title: "dup" }))}
+      focused={true}
+      onClose={() => {}}
+      onOpenTask={(id) => opened.push(id)}
+    />,
+    { width: 90, height: 12, providers: { notifications: true } },
+  )
+  await settle(150)
+  expect(await frame()).toContain("→ issue-412-fix")
+  mockInput.pressEnter()
+  await settle(150)
+  mockInput.pressEnter()
+  await settle(150)
+  expect(starts).toBe(0)
+  expect(opened).toEqual(["T1", "T1"])
+})
+
+test("a task on another repo or issue does not count as linked", async () => {
+  let starts = 0
+  const other = [
+    { id: "A", repo: "/x/other", title: "elsewhere", linkedWorkItem: { number: 412, title: "x", url: "u" } },
+    { id: "B", repo: REPO, title: "sibling", linkedWorkItem: { number: 413, title: "x", url: "u" } },
+  ]
+  const { frame, mockInput } = await renderComponent(
+    <WorkItemsPage
+      orchestrator={orch(other, async () => ({ started: true, taskId: `T${++starts}`, title: "new" }))}
+      focusRepo={REPO}
+      focused={true}
+      onClose={() => {}}
+    />,
+    { width: 90, height: 12, providers: { notifications: true } },
+  )
+  await settle(150)
+  expect(await frame()).not.toContain("→ ")
+  mockInput.pressEnter()
+  await settle(150)
+  expect(starts).toBe(1)
+})


### PR DESCRIPTION
## What

On the Issues page (`ctrl+a` `3`), `enter` always called `orch.startWorkItem` — so pressing it twice on the same issue silently produced two worktrees, two branches and two engine sessions, with nothing on the page marking that the first one existed. `workitem-start` already stamps `task.linkedWorkItem`, but no renderer read it.

The page now derives the linked task (`task.repo === repo && task.linkedWorkItem?.number === item.number`) and:

- renders its title as a muted chip on the issue's detail line;
- on `enter`, opens that task via `onOpenTask` and returns, never starting a second one.

Unlinked issues take the unchanged create path. The daemon is untouched: `workitem-start` creates unconditionally by contract, and the guard belongs on the surface that knows what the user is looking at.

## Why

Duplicating a task is expensive and invisible — a second worktree and engine session for work already in flight, with no signal on the page.

## Pass criteria, actually run

Against an isolated scratch home (`.scratch/opentui-visual-5773/`) whose fixture repo has a real GitHub remote:

```
$ rove api workitem-start --repo <fixture-repo> --number 307
{"taskId":"01M1GBA4RNXK74TWBGRYS2F8NK","title":"#307 memory","started":true,
 "linkedWorkItem":{"number":307,"title":"memory","url":"https://github.com/Sma1lboy/rove/issues/307"}}

$ rove api list
[{"id":"01M1GB74E8YKXKXGHA9C1NME83","title":"Visual Fixture","linked":null},
 {"id":"01M1GBA4RNXK74TWBGRYS2F8NK","title":"#307 memory","linked":307}]
```

Then, in the real TUI through the harness: `ctrl+a` `3`, cursor down to #307, `enter`, back to the page, `enter` again. Afterwards `rove api list` is byte-identical to the JSON above — still exactly one task for #307 — and both presses landed in that task's workspace (its `claude 1` tab is focused and running in the screenshot below).

Checks: `bun run lint` clean, `bun x tsc --noEmit` clean, `bun run check-i18n` OK (755 keys x 2 locales), `bun x vitest run test/orchestrator test/client` 405 passed, `bun test test/render` 378 passed with one pre-existing unrelated failure in `sidebar-tree.test.tsx` ("escape leaves search and restores the full tree") that also fails with this PR's test file removed.

## Screenshots

Real OpenTUI through the browser `/harness` -> xterm -> PTY, isolated home on `KOBE_VISUAL_PORT_BASE=5773`.

- BEFORE (only `work-items-page.tsx` reverted, everything else at HEAD) — issue #307 already has a task, and the page shows nothing: `/Users/jacksonc/i/kobe/.scratch/issues-linked-task/before.png`
- AFTER — issue #307's detail line carries `-> #307 memory`: `/Users/jacksonc/i/kobe/.scratch/issues-linked-task/after.png`
- AFTER, after pressing `enter` twice on #307 — landed in the existing task's workspace, no second task: `/Users/jacksonc/i/kobe/.scratch/issues-linked-task/after-enter-twice.png`

## Scope

`work-items-page.tsx`, `messages/workItems.ts` (`linkedChip` + `openingLinked`, en + zh), `docs/TUI.md`, `docs/design/work-items.md`, one render test, one changeset. No new chord — `enter` already existed and only changes what it resolves to. Read-only against the tracker, unchanged.