### PR TITLE
chore: delete seven exported helpers with no callers

### DIFF
--- a/.changeset/prune-seven-dead-exports.md
+++ b/.changeset/prune-seven-dead-exports.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Delete seven exported helpers that nothing called. Four were in the TUI package (a combined protocol sniff wrapper, a theme-mode setter that duplicated the live context method, a best-effort orchestrator connect, and a one-line sidebar id mapper), and three in the daemon and web dashboard (an environment-variable delete helper, a board card accessor, and a command palette open that callers reached through the toggle instead). No behavior changes: every remaining path already went through the live equivalents.

--- a/packages/kobe-daemon/src/compat-env.ts
+++ b/packages/kobe-daemon/src/compat-env.ts
@@ -53,21 +53,6 @@ export function setRoveEnv(suffix: string, value: string, env: NodeJS.ProcessEnv
 }
 
 /**
- * Unset a control in BOTH namespaces.
- *
- * The mirror image of {@link setRoveEnv}, and required for the same reason:
- * deleting only `KOBE_*` leaves the `ROVE_*` twin behind, which the next
- * wrapper faithfully mirrors back. Isolated launchers (dev sandbox, e2e
- * fixtures) use this to drop an INHERITED path override that would otherwise
- * outrank their own home — see `scripts/dev-sandbox-args.ts`.
- */
-export function deleteRoveEnv(suffix: string, env: NodeJS.ProcessEnv = process.env): NodeJS.ProcessEnv {
-  delete env[`${ROVE_ENV_PREFIX}${suffix}`]
-  delete env[`${LEGACY_KOBE_ENV_PREFIX}${suffix}`]
-  return env
-}
-
-/**
  * Mirror every public ROVE_* control into the legacy internal namespace.
  * Existing KOBE_* values remain when no new-name value was supplied.
  */

--- a/packages/kobe-web/src/lib/board.ts
+++ b/packages/kobe-web/src/lib/board.ts
@@ -27,11 +27,6 @@ export interface BoardCard {
   issue: Issue
 }
 
-/** A card's repo — typed accessor (kept for call-site symmetry). */
-export function cardRepo(card: BoardCard): string {
-  return card.repo
-}
-
 export interface BoardColumnSpec {
   key: string
   title: string

--- a/packages/kobe-web/src/lib/global-ui.ts
+++ b/packages/kobe-web/src/lib/global-ui.ts
@@ -18,10 +18,6 @@ export function useGlobalUiState(): GlobalUiState {
   return store.useSnapshot()
 }
 
-export function openCommandPalette(): void {
-  store.update((state) => ({ ...state, paletteOpen: true }))
-}
-
 export function closeCommandPalette(): void {
   store.update((state) => ({ ...state, paletteOpen: false }))
 }

--- a/packages/kobe/src/engine/protocol-sniff.ts
+++ b/packages/kobe/src/engine/protocol-sniff.ts
@@ -91,18 +91,6 @@ export async function sniffProtocolFromSessions(worktree: string | undefined): P
   return found.length === 1 ? found[0] : null
 }
 
-/**
- * Combined sniff: the title first (it answers instantly and describes the
- * process that is running RIGHT NOW), then the session store (slower, and a
- * file can outlive the engine that wrote it). Null = stay generic.
- */
-export async function sniffProtocol(input: {
-  readonly title?: string | null
-  readonly worktree?: string
-}): Promise<VendorId | null> {
-  return sniffProtocolFromTitle(input.title) ?? (await sniffProtocolFromSessions(input.worktree))
-}
-
 /** What the observer knows about one LIVE, walked engine-tab session. */
 export interface LiveSessionEvidence {
   /** Foreground-walk verdict for the session's pid: a built-in vendor whose

--- a/packages/kobe/src/tui-react/context/theme.tsx
+++ b/packages/kobe/src/tui-react/context/theme.tsx
@@ -99,10 +99,6 @@ export function setFocusAccent(v: FocusAccentSlot): void {
   store.update((s) => ({ ...s, focusAccent: v }))
 }
 
-export function setThemeMode(mode: "dark" | "light"): void {
-  store.update((s) => ({ ...s, mode }))
-}
-
 export type ThemeContextValue = {
   /** The resolved palette. Plain object — re-renders arrive via context. */
   theme: Theme

--- a/packages/kobe/src/tui-react/lib/host-boot.tsx
+++ b/packages/kobe/src/tui-react/lib/host-boot.tsx
@@ -31,7 +31,6 @@ import {
   logClientError,
   setClientLogContext,
 } from "@sma1lboy/kobe-daemon/client/client-log"
-import { connectOrStartDaemon } from "@sma1lboy/kobe-daemon/client/daemon-process"
 import type { UiPrefsPayload } from "@sma1lboy/kobe-daemon/daemon/protocol"
 import { Component, type ReactNode, useEffect } from "react"
 import { connectPaneOrchestrator } from "../../client/connect-pane-orchestrator"
@@ -274,20 +273,4 @@ export async function bootPaneHost(opts: BootPaneHostOpts): Promise<void> {
   installPaneExitBackstop()
   installOrphanExitWatchdog()
   installEventLoopStallTelemetry()
-}
-
-/**
- * Best-effort daemon connection for a page host (new-task / quick-task):
- * the page still renders without a daemon — mutations are unavailable and
- * the failure is log-only. Hosts that REQUIRE the daemon (the workspace
- * host's gui attach) keep their own throwing connect.
- */
-export async function connectOrchestratorBestEffort(logContext: string): Promise<RemoteOrchestrator | null> {
-  // SPAWNING on purpose — the injected connect boots the daemon if needed
-  // (a page host is a gui-adjacent surface, not a helper pane). The seam
-  // still owns the init sequence, logs the failure cause under `logContext`,
-  // and disposes a half-built orchestrator instead of leaking it.
-  const orch = await connectPaneOrchestrator({ logTag: logContext, connect: connectOrStartDaemon })
-  if (!orch) console.error(`[rove ${logContext}] daemon unavailable; cannot create task`)
-  return orch
 }

--- a/packages/kobe/src/tui/panes/sidebar/groups.ts
+++ b/packages/kobe/src/tui/panes/sidebar/groups.ts
@@ -203,11 +203,6 @@ export function cursorIndexForProjectScope(rows: readonly SidebarRow[], projectF
   return projectRow?.flatIndex ?? rows[0]?.flatIndex ?? -1
 }
 
-/** Extract the flat list of navigable task ids. */
-export function flattenIds(rows: readonly SidebarRow[]): string[] {
-  return rows.map((r) => r.task.id)
-}
-
 /**
  * Where the cursor should sit after the external selection or the flat id list
  * changed — the single owner of the "follow selection / clamp into range" policy


### PR DESCRIPTION
## What / why

Deletes seven exported functions that had exactly one repo-wide reference each — their own declaration. 62 lines removed, no behavior change.

**In `packages/kobe`:**
- `sniffProtocol` (`src/engine/protocol-sniff.ts`) — wrapper over `sniffProtocolFromTitle` / `sniffProtocolFromSessions`, both of which stay and keep their tests.
- `setThemeMode` (`src/tui-react/context/theme.tsx`) — duplicated the context value's own `setMode`, which is the live path.
- `connectOrchestratorBestEffort` (`src/tui-react/lib/host-boot.tsx`) — its `connectOrStartDaemon` import went with it; `connectPaneOrchestrator` still has a caller at line 131.
- `flattenIds` (`src/tui/panes/sidebar/groups.ts`) — a one-line `rows.map((r) => r.task.id)`.

**In `packages/kobe-daemon` and `packages/kobe-web`:**
- `deleteRoveEnv` (`kobe-daemon/src/compat-env.ts`) — its doc comment claimed `scripts/dev-sandbox-args.ts` used it; that file contains no environment deletion. The real compat shims (`installRoveEnvCompatibility`, `setRoveEnv`, `legacyKobeEnvKey`) all stay.
- `cardRepo` (`kobe-web/src/lib/board.ts`) — a speculative accessor over `card.repo`.
- `openCommandPalette` (`kobe-web/src/lib/global-ui.ts`) — callers use `toggleCommandPalette`; its eight siblings in that module all have callers.

## Pass criteria — commands run and real output

### Absence proof (repo root)

```
$ for s in sniffProtocol setThemeMode connectOrchestratorBestEffort flattenIds deleteRoveEnv cardRepo openCommandPalette; do \
    printf "%s: " "$s"; grep -rnw "$s" --include="*.ts" --include="*.tsx" --include="*.mjs" --include="*.md" \
      --include="*.json" --include="*.yml" packages docs scripts .github 2>/dev/null \
      | grep -v node_modules | grep -v "/dist/" | wc -l; done
sniffProtocol: 0
setThemeMode: 0
connectOrchestratorBestEffort: 0
flattenIds: 0
deleteRoveEnv: 0
cardRepo: 0
openCommandPalette: 0
```

`connectOrStartDaemon` still resolves (24 hits) — only the now-unused import in `host-boot.tsx` was dropped.

### Suites

```
$ cd packages/kobe && env -u ROVE_INVOKED_AS bun x tsc --noEmit
(exit 0, no output)

$ env -u ROVE_INVOKED_AS bun test test/render
 377 pass
 0 fail
 1153 expect() calls
Ran 377 tests across 88 files. [102.96s]

$ bun run lint                       # repo root, covers kobe + kobe-daemon
Checked 1326 files in 302ms. No fixes applied.

$ bun --filter @sma1lboy/kobe-daemon typecheck
@sma1lboy/kobe-daemon typecheck: Exited with code 0
```

`bun run test:fast` reports 4 failures **in this worktree only**, in `test/cli/open-dir-cmd.test.ts` and `test/state/project-eligibility.test.ts`. Both judge project eligibility by path shape, and this worktree lives under `~/.rove/worktrees`. Proven pre-existing and unrelated: a fresh `origin/main` worktree under `~/i` passes those two files, and passes them again with this exact diff applied.

```
# clean-path baseline worktree, this diff applied
$ env -u ROVE_INVOKED_AS bun run test:fast
      Tests  4144 passed (4144)
```

### knip

Measured against a pristine `origin/main` worktree:

| | Unused exports | Unused exported types |
|---|---|---|
| baseline (`origin/main`) | 133 | 66 |
| this branch | 129 | 66 |

Four fewer exports, types unchanged. (The brief predicted 70 types; the real baseline is 66, and this change does not move it.)

### kobe-web

```
$ cd packages/kobe-web && bun run test
 Test Files  70 passed (70)
      Tests  570 passed (570)

$ bun run build
built (no errors)

$ bun x biome check src/lib/board.ts src/lib/global-ui.ts
Checked 2 files in 9ms. No fixes applied.
```

The package-wide `bun run check` fails on five pre-existing formatter complaints in files this PR does not touch (`src/lib/issues.ts`, `src/lib/markdown.ts`, and three others). The same five appear on a pristine `origin/main` checkout.

## Screenshots

`theme.tsx`, `host-boot.tsx`, and the two web files are UI-adjacent, so both surfaces were captured through the OpenTUI harness on an isolated fixture home (`KOBE_VISUAL_PORT_BASE=5473`), BEFORE from a pristine `origin/main` worktree and AFTER from this branch. Both pairs are **byte-identical**.

| Surface | BEFORE | AFTER | sha256 |
|---|---|---|---|
| workspace | `/Users/jacksonc/i/kobe/.scratch/prune-7-dead-exports/workspace-before.png` | `/Users/jacksonc/i/kobe/.scratch/prune-7-dead-exports/workspace-after.png` | `e19e0991…24fb9` (both) |
| board (`ctrl+a c`) | `/Users/jacksonc/i/kobe/.scratch/prune-7-dead-exports/board-before.png` | `/Users/jacksonc/i/kobe/.scratch/prune-7-dead-exports/board-after.png` | `d1ab25df…4e1b80` (both) |

## Coverage gate

coverage-exemption: packages/kobe/src/tui-react/lib/host-boot.tsx — pre-existing gap, not introduced by this PR; the diff deletes a dead function and its now-unused import, and measured coverage goes up, not down.

The render-track floor is 50% on touched files. Measured line coverage for that file:

| | host-boot.tsx line coverage |
|---|---|
| pristine `origin/main` | 23.12% (40/173) |
| this branch | 23.17% (38/164) |

The baseline number comes from a fresh `origin/main` worktree running `bun run test:render` and reading `coverage-render/lcov.info`; the branch number is what the gate itself reported. Deleting `connectOrchestratorBestEffort` removed 9 uncovered lines plus a 2-line covered import, so the ratio moves slightly in the right direction. Writing a render test to lift this file over 50% would mean mounting the OpenTUI host boot path (renderer creation, daemon attach, exit backstops), which is what the behavior and visual-ground-truth tracks cover instead — out of scope for a deletion-only PR.

## Scope

Seven files, deletions only, plus one changeset. Nothing outside the brief was touched.
