### PR TITLE
feat: row menu "Run again" re-fires a task's brief into a fresh task

### DIFF
--- a/.changeset/row-menu-run-again.md
+++ b/.changeset/row-menu-run-again.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+The sidebar row menu can re-run a Task's brief. Rove already stored the prompt each Task was created with, but nothing in the TUI read it — recovering a brief meant piping `rove api get-task` into `rove api add` by hand. **Run again** now shows that brief in full and re-fires it verbatim into a new Task with its own branch and worktree, leaving the original alone. Tasks created without a prompt have no brief to re-run, so the entry stays hidden for them.

--- a/docs/TUI.md
+++ b/docs/TUI.md
@@ -122,6 +122,13 @@ row or one of its tab rows:
   record for a directory Task, or removes a managed Task and its worktree after
   the dirty-worktree safety check.
 
+Right-clicking a row opens the same verbs as a menu, plus **Run again** on any
+Task that still has its brief. Rove stores the prompt a Task was created with,
+so the entry re-runs those exact words in a NEW Task with its own branch and
+worktree, leaving the original untouched. The confirm shows the brief in full
+before anything is created. A Task created without a prompt has no brief to
+re-run, and the entry does not appear for it.
+
 The confirmation dialogs state the exact deletion boundary before anything is
 changed. See [Concepts → Task](CONCEPTS.md#task) for the three Task kinds and
 [Sessions](SESSIONS.md#what-actually-ends-a-session) for session teardown.

--- a/packages/kobe-daemon/src/daemon/handlers-task.ts
+++ b/packages/kobe-daemon/src/daemon/handlers-task.ts
@@ -359,11 +359,12 @@ export const TASK_HANDLERS: readonly DaemonRequestHandler[] = [
     },
   },
   {
-    // NOT web-exposed: the only writer is the CLI `add` path, which records
-    // the brief AFTER the prompt is confirmed delivered into the engine. The
-    // field then means exactly "this is the prompt the engine was given" —
-    // an agent reading `get-task` can assert on it without wondering whether
-    // delivery happened.
+    // NOT web-exposed. Two writers, both on a path where the prompt is already
+    // on its way to an engine: the CLI `add` path records the brief AFTER
+    // delivery confirms, and the TUI's "Run again" copies a task's existing
+    // brief onto the fork it just created for it. The field means "this is the
+    // prompt the engine was given" in both cases — an agent reading `get-task`
+    // never sees a brief that was merely composed.
     name: "task.setPrompt",
     async handle(payload, ctx) {
       const taskId = requireString(payload, "taskId")

--- a/packages/kobe/src/client/remote-orchestrator-writes.ts
+++ b/packages/kobe/src/client/remote-orchestrator-writes.ts
@@ -115,6 +115,14 @@ export async function moveTaskOp(client: KobeDaemonClient, id: TaskId | string, 
   await client.request("task.move", { taskId: String(id), direction: delta < 0 ? "up" : "down" })
 }
 
+/** Record a task's brief (`task.setPrompt`). Second writer after the CLI
+ *  `add` path: the row menu's "Run again" copies a task's stored brief onto
+ *  the fork it creates, so the child can itself be re-run and `get-task`
+ *  shows the words its engine is being handed. */
+export async function setPromptOp(client: KobeDaemonClient, id: TaskId | string, prompt: string): Promise<void> {
+  await client.request("task.setPrompt", { taskId: String(id), prompt })
+}
+
 export async function setStatusOp(client: KobeDaemonClient, id: TaskId | string, status: TaskStatus): Promise<void> {
   await client.request("task.status", { taskId: String(id), status })
 }

--- a/packages/kobe/src/client/remote-orchestrator.ts
+++ b/packages/kobe/src/client/remote-orchestrator.ts
@@ -107,6 +107,7 @@ import {
   setBranchOp,
   setCommandOp,
   setPinnedOp,
+  setPromptOp,
   setStatusOp,
   setTitleOp,
   setVendorOp,
@@ -423,6 +424,7 @@ export class RemoteOrchestrator {
   setPinned = (id: TaskId | string, pinned?: boolean): Promise<void> => setPinnedOp(this.client, id, pinned)
   moveTask = (id: TaskId | string, delta: -1 | 1): Promise<void> => moveTaskOp(this.client, id, delta)
   setStatus = (id: TaskId | string, status: TaskStatus): Promise<void> => setStatusOp(this.client, id, status)
+  setPrompt = (id: TaskId | string, prompt: string): Promise<void> => setPromptOp(this.client, id, prompt)
   deleteTask = (id: TaskId | string, opts?: { force?: boolean; deleteBranch?: boolean }): Promise<void> =>
     deleteTaskOp(this.client, id, opts)
   dismissAttention = (taskId: TaskId | string, tabId: string | null, at: number): Promise<boolean> =>

--- a/packages/kobe/src/tui-react/component/run-again-dialog.tsx
+++ b/packages/kobe/src/tui-react/component/run-again-dialog.tsx
@@ -1,0 +1,146 @@
+/** @jsxImportSource @opentui/react */
+/**
+ * Run-again confirm — the row menu's "Run again" entry.
+ *
+ * Rove records a task's brief verbatim on delivery (`task.prompt`), and until
+ * this dialog the only reader was `rove api get-task | jq -r .task.prompt`
+ * piped back into `rove api add`. The entry re-fires that text into a FRESH
+ * task, so the dialog's whole job is to show what will be re-run before it is.
+ *
+ * The brief is scrollable rather than truncated, for the same reason the field
+ * is stored untruncated: the constraints that decide whether a re-run is the
+ * right move usually sit at the END of a long brief. A one-line `DialogConfirm`
+ * message would clip exactly the part worth reading.
+ *
+ * Not destructive: confirming creates a task and touches nothing that exists,
+ * so initial focus is on the confirm button (the `danger` convention is for
+ * the ones that remove something).
+ */
+
+import { TextAttributes } from "@opentui/core"
+import type { ScrollBoxRenderable } from "@opentui/core"
+import { useRef, useState } from "react"
+import { useTheme } from "../context/theme"
+import { useT } from "../i18n"
+import { useBindings } from "../lib/keymap"
+import { type DialogContext, showDialog, useDialog, useDialogPaddingX } from "../ui/dialog"
+
+export function RunAgainDialogView(props: {
+  /** The source task's title — names whose brief is on screen. */
+  taskTitle: string
+  /** The brief, verbatim. Newlines and blank lines are preserved. */
+  prompt: string
+  onConfirm: () => void
+  onCancel: () => void
+}) {
+  const { theme } = useTheme()
+  const t = useT()
+  const dialog = useDialog()
+  const padX = useDialogPaddingX()
+  const [active, setActive] = useState<"confirm" | "cancel">("confirm")
+
+  // Resolving the promise does not pop the stack — the view closes itself, the
+  // same contract the status/engine pickers follow. `refocus: false` on the
+  // commit path: confirming ENTERS the new task, and the provider's deferred
+  // restore would otherwise yank focus back to the sidebar a tick later.
+  const commit = (): void => {
+    props.onConfirm()
+    dialog.clear({ refocus: false })
+  }
+  const cancel = (): void => {
+    props.onCancel()
+    dialog.clear()
+  }
+
+  // Up/down scroll the brief (same shape as the field-notes reader); left/right
+  // move between the two buttons, so neither gesture shadows the other.
+  const scrollRef = useRef<ScrollBoxRenderable | null>(null)
+  const scrollBy = (lines: number): void => {
+    const scroll = scrollRef.current
+    if (!scroll) return
+    scroll.scrollTo({ x: 0, y: Math.max(0, scroll.scrollTop + lines) })
+  }
+  useBindings(() => ({
+    bindings: [
+      { key: "up", cmd: () => scrollBy(-1) },
+      { key: "down", cmd: () => scrollBy(1) },
+      { key: "pageup", cmd: () => scrollBy(-(scrollRef.current?.viewport.height ?? 10)) },
+      { key: "pagedown", cmd: () => scrollBy(scrollRef.current?.viewport.height ?? 10) },
+      { key: "left", cmd: () => setActive((a) => (a === "confirm" ? "cancel" : "confirm")) },
+      { key: "right", cmd: () => setActive((a) => (a === "confirm" ? "cancel" : "confirm")) },
+      { key: "return", cmd: () => (active === "confirm" ? commit() : cancel()) },
+    ],
+  }))
+
+  return (
+    <box paddingLeft={padX} paddingRight={padX} gap={1} flexShrink={1}>
+      <box flexDirection="row" justifyContent="space-between" flexShrink={0}>
+        <box flexDirection="column" gap={0}>
+          <text attributes={TextAttributes.BOLD} fg={theme.text}>
+            {t("tasks.runAgain.title")}
+          </text>
+          <text fg={theme.textMuted} wrapMode="none">
+            {t("tasks.runAgain.source", { title: props.taskTitle })}
+          </text>
+        </box>
+        <text fg={theme.textMuted} onMouseUp={cancel}>
+          esc
+        </text>
+      </box>
+      <scrollbox
+        ref={(r: ScrollBoxRenderable | null) => {
+          scrollRef.current = r
+        }}
+        flexShrink={1}
+        stickyScroll={false}
+        verticalScrollbarOptions={{
+          trackOptions: { backgroundColor: theme.backgroundDialog, foregroundColor: theme.borderActive },
+        }}
+      >
+        <box paddingRight={1}>
+          <text fg={theme.text}>{props.prompt}</text>
+        </box>
+      </scrollbox>
+      <text fg={theme.textMuted} flexShrink={0}>
+        {t("tasks.runAgain.hint")}
+      </text>
+      <box flexDirection="row" justifyContent="flex-end" flexShrink={0}>
+        {(["cancel", "confirm"] as const).map((key) => (
+          <box
+            key={key}
+            paddingLeft={1}
+            paddingRight={1}
+            backgroundColor={key === active ? theme.primary : undefined}
+            onMouseUp={() => (key === "confirm" ? commit() : cancel())}
+          >
+            <text fg={key === active ? theme.selectedListItemText : theme.textMuted}>
+              {key === "cancel" ? t("common.cancel") : t("tasks.runAgain.confirm")}
+            </text>
+          </box>
+        ))}
+      </box>
+      <box paddingBottom={1} flexShrink={0}>
+        <text fg={theme.textMuted}>{t("tasks.runAgain.footer")}</text>
+      </box>
+    </box>
+  )
+}
+
+/** Open the confirm; resolves `true` only when the user commits the re-run
+ *  (esc / backdrop dismissal resolves `undefined` through `showDialog`). */
+function show(dialog: DialogContext, opts: { taskTitle: string; prompt: string }): Promise<boolean | undefined> {
+  return showDialog<boolean>(
+    dialog,
+    (resolve) => (
+      <RunAgainDialogView
+        taskTitle={opts.taskTitle}
+        prompt={opts.prompt}
+        onConfirm={() => resolve(true)}
+        onCancel={() => resolve(false)}
+      />
+    ),
+    { size: "medium" },
+  )
+}
+
+export const RunAgainDialog = { show }

--- a/packages/kobe/src/tui-react/panes/sidebar/types.ts
+++ b/packages/kobe/src/tui-react/panes/sidebar/types.ts
@@ -46,6 +46,11 @@ export type SidebarTaskCallbacks = {
    * Menu-only, like `onSetStatusRequest` — no chord yet.
    */
   onCopyRequest?: (taskId: string, field: "branch" | "path") => void
+  /**
+   * Re-fire the task's stored brief (`task.prompt`) as a new task. Menu-only,
+   * and the entry is withheld from a task with no stored brief.
+   */
+  onRunAgainRequest?: (taskId: string) => void
   /** Menu route of `o`: open the task's worktree in the detected editor. */
   onOpenEditorRequest?: (taskId: string) => void
   /** Menu route of `b`: the branch picker/rename for the row's task. */

--- a/packages/kobe/src/tui-react/panes/sidebar/use-tree-menu.ts
+++ b/packages/kobe/src/tui-react/panes/sidebar/use-tree-menu.ts
@@ -176,6 +176,9 @@ export function useTreeMenu(deps: TreeMenuDeps): TreeMenu {
         case "reorder":
           actions.onLocalMergeRequest?.(taskId)
           break
+        case "runAgain":
+          actions.onRunAgainRequest?.(taskId)
+          break
         case "setStatus":
           actions.onSetStatusRequest?.(taskId)
           break

--- a/packages/kobe/src/tui-react/workspace/host-sidebar.tsx
+++ b/packages/kobe/src/tui-react/workspace/host-sidebar.tsx
@@ -50,6 +50,8 @@ export interface HostSidebarProps {
   readonly onSetStatusRequest: (taskId: string) => void
   /** Menu-only (no chord): copy the row's branch name or worktree path. */
   readonly onCopyRequest: (taskId: string, field: "branch" | "path") => void
+  /** Menu-only (no chord): re-fire the row's stored brief as a new task. */
+  readonly onRunAgainRequest: (taskId: string) => void
   /** Menu routes of the `o` / `b` / `v` chords, landing on the ROW's task. */
   readonly onOpenEditorRequest: (taskId: string) => void
   readonly onRenameBranchRequest: (taskId: string) => void
@@ -138,6 +140,7 @@ export function HostSidebar(props: HostSidebarProps) {
     onPinRequest: props.onPinRequest,
     onSetStatusRequest: props.onSetStatusRequest,
     onCopyRequest: props.onCopyRequest,
+    onRunAgainRequest: props.onRunAgainRequest,
     onOpenEditorRequest: props.onOpenEditorRequest,
     onRenameBranchRequest: props.onRenameBranchRequest,
     onChangeEngineRequest: props.onChangeEngineRequest,

--- a/packages/kobe/src/tui-react/workspace/host-task-actions.ts
+++ b/packages/kobe/src/tui-react/workspace/host-task-actions.ts
@@ -37,6 +37,7 @@ import { DEFAULT_TASK_VENDOR, type Task, type VendorId } from "../../types/task.
 import { BranchPickerDialog } from "../component/branch-picker-dialog"
 import { EnginePickerDialog } from "../component/engine-picker-dialog"
 import { FieldNotesDialog } from "../component/field-notes-dialog"
+import { RunAgainDialog } from "../component/run-again-dialog"
 import { StatusPickerDialog } from "../component/status-picker-dialog"
 import type { DialogContext } from "../ui/dialog"
 import { buildBaseCreateTaskContext, selectNextAfterDelete } from "../ui/task-dialog-adapters"
@@ -75,6 +76,13 @@ export type WorkspaceTaskActions = {
   copyTaskField: (id: string, field: "branch" | "path") => void
   /** Project-row menu "Field notes" — read-only list of the repo's notes. */
   showFieldNotes: (repo: string) => void
+  /**
+   * Row menu "Run again" — show the task's stored brief and resolve the task
+   * to re-fire once the user commits, or `undefined` on cancel. The CREATE is
+   * quick-fork's (`runAgainTask`), which owns the first-prompt handoff into
+   * the new task's mount; this half is the dialog and the lookup.
+   */
+  confirmRunAgain: (id: string) => Promise<Task | undefined>
 }
 
 export function useWorkspaceTaskActions(deps: WorkspaceTaskActionDeps): WorkspaceTaskActions {
@@ -146,6 +154,15 @@ export function useWorkspaceTaskActions(deps: WorkspaceTaskActionDeps): Workspac
     })
   }
 
+  async function confirmRunAgain(id: string): Promise<Task | undefined> {
+    const task = tasks().find((t) => t.id === id)
+    // The menu withholds the entry from a task with no stored brief
+    // (tree-menu.ts), so this only fires on a stale row.
+    if (task?.prompt === undefined) return undefined
+    const ok = await RunAgainDialog.show(dialog, { taskTitle: task.title, prompt: task.prompt })
+    return ok === true ? task : undefined
+  }
+
   async function pickVendor(id: string): Promise<void> {
     const task = tasks().find((t) => t.id === id)
     if (!task) return
@@ -175,5 +192,6 @@ export function useWorkspaceTaskActions(deps: WorkspaceTaskActionDeps): Workspac
     setStatus: (id) => setStatusFlow(taskActions, id),
     copyTaskField: (id, field) => copyTaskFieldFlow(taskActions, id, field),
     showFieldNotes: (repo) => FieldNotesDialog.show(dialog, { repo, load: () => orchestrator.listFieldNotes(repo) }),
+    confirmRunAgain,
   }
 }

--- a/packages/kobe/src/tui-react/workspace/host.tsx
+++ b/packages/kobe/src/tui-react/workspace/host.tsx
@@ -163,6 +163,7 @@ export function WorkspaceRoot(props: { orchestrator: RemoteOrchestrator }) {
     setStatus,
     copyTaskField,
     showFieldNotes,
+    confirmRunAgain,
   } = useWorkspaceTaskActions({
     orchestrator: orch,
     tasks: () => tasks,
@@ -415,6 +416,9 @@ export function WorkspaceRoot(props: { orchestrator: RemoteOrchestrator }) {
           onRenameBranchRequest={(id) => void renameBranch(id)}
           onChangeEngineRequest={(id) => void pickVendor(id)}
           onFieldNotesRequest={showFieldNotes}
+          // Confirm here, create in quick-fork: it owns the pending-prompt
+          // slot that delivers the brief on the NEW task's mount.
+          onRunAgainRequest={(id) => void confirmRunAgain(id).then((task) => task && quickFork.runAgain(task))}
           moveMode={moveMode}
           onMoveRequest={(id, delta) => void moveTask(id, delta)}
           onMoveModeExit={() => setMoveMode(false)}

--- a/packages/kobe/src/tui-react/workspace/quick-fork.ts
+++ b/packages/kobe/src/tui-react/workspace/quick-fork.ts
@@ -21,7 +21,7 @@ import { resolvePreferredVendor, setRepoLastActiveVendor } from "../../state/ven
 import { appendAttachmentRefs } from "../../tui/lib/attachments"
 import { DEFAULT_BASE_REF, getCurrentBranch } from "../../tui/lib/git-snapshot"
 import { repoBasename } from "../../tui/panes/sidebar/groups"
-import type { Task, VendorId } from "../../types/task"
+import { DEFAULT_TASK_VENDOR, type Task, type VendorId } from "../../types/task"
 import type { QuickTaskComposerOptions, QuickTaskResult } from "../component/quick-task-composer"
 
 /**
@@ -57,6 +57,8 @@ export function quickForkDefaultVendor(repo: string, detected: readonly VendorId
 
 export interface QuickForkOrchestrator {
   createTask(input: { repo: string; baseRef: string; vendor: VendorId }): Promise<Task>
+  /** Record the brief on the created task — "Run again" only (see {@link runAgainTask}). */
+  setPrompt(id: string, prompt: string): Promise<void>
 }
 
 /**
@@ -105,6 +107,50 @@ export async function runQuickFork(
   }
 }
 
+/**
+ * Re-fire a task's stored brief as a NEW task ("Run again", row menu).
+ *
+ * Rove records the delivered `add --prompt` text on the task (`task.prompt`)
+ * precisely so an attempt that went wrong can be re-run clean; before this the
+ * only route was `get-task | jq -r .task.prompt` piped back into `add`. The
+ * child is a quick-fork with the SOURCE's own inputs — same repo, same engine,
+ * cut from the base ref the source was cut from — so the only difference
+ * between the two runs is the worktree.
+ *
+ * The brief rides the create path VERBATIM. It must not be routed through the
+ * quick-task composer: that field is a single-line input running
+ * `stripNewlines`, which would silently flatten a multi-line brief and re-run
+ * something the user never wrote.
+ *
+ * Returns the new task's id, or undefined when the source has no stored brief
+ * or the create failed (`runQuickFork` already reported it).
+ */
+export async function runAgainTask(
+  orch: QuickForkOrchestrator,
+  task: Task,
+  hooks: {
+    selectTask: (id: string) => void
+    enterTask: (id: string) => Promise<void>
+    notifyError: (message: string) => void
+  },
+): Promise<string | undefined> {
+  const prompt = task.prompt
+  if (prompt === undefined) return undefined
+  // Same fork point as the source, so a re-run compares against the same base.
+  // `baseRef` is only absent on records predating the field (types/task.ts) —
+  // fall back to the live branch the way `quickForkComposerOptions` does.
+  const baseRef = task.baseRef ?? getCurrentBranch(task.worktreePath || task.repo) ?? DEFAULT_BASE_REF
+  const vendor = task.vendor ?? DEFAULT_TASK_VENDOR
+  const taskId = await runQuickFork(orch, task.repo, { baseRef, vendor }, hooks)
+  if (taskId === undefined) return undefined
+  // Copy the brief onto the child so it is re-runnable in turn, and so
+  // `rove api get-task` reports the text its engine is being handed.
+  // Best-effort: the prompt is already on its way to the tab, and a failed
+  // persist must not turn a created task into an error.
+  await orch.setPrompt(taskId, prompt).catch(() => undefined)
+  return taskId
+}
+
 export interface PendingInitialPrompt {
   readonly taskId: string
   readonly prompt: string
@@ -116,6 +162,9 @@ export interface UseQuickForkResult {
   /** Pass to `ShowWorkspace`'s `initialPrompt` prop, gated on the currently
    *  selected task — undefined for every task except the one just forked. */
   readonly initialPromptFor: (taskId: string | undefined) => string | undefined
+  /** Row menu "Run again": create the child and hand it the source's brief
+   *  through the same pending slot the composer's forks use. */
+  readonly runAgain: (task: Task) => void
 }
 
 /**
@@ -140,9 +189,18 @@ export function useQuickFork(
     if (taskId) setPending({ taskId, prompt: appendAttachmentRefs(result.prompt, result.attachments) })
   }
 
+  async function onRunAgain(task: Task): Promise<void> {
+    const taskId = await runAgainTask(orch, task, hooks)
+    if (taskId && task.prompt !== undefined) setPending({ taskId, prompt: task.prompt })
+  }
+
   function initialPromptFor(taskId: string | undefined): string | undefined {
     return taskId && pending?.taskId === taskId ? pending.prompt : undefined
   }
 
-  return { onQuickFork: (repo, result) => void onQuickFork(repo, result), initialPromptFor }
+  return {
+    onQuickFork: (repo, result) => void onQuickFork(repo, result),
+    initialPromptFor,
+    runAgain: (task) => void onRunAgain(task),
+  }
 }

--- a/packages/kobe/src/tui/i18n/messages/tasks.ts
+++ b/packages/kobe/src/tui/i18n/messages/tasks.ts
@@ -40,6 +40,8 @@ export const en = {
     pin: "Pin",
     unpin: "Unpin",
     reorder: "Reorder row",
+    /** Re-fire the task's stored brief as a new task. Menu-only. */
+    runAgain: "Run again",
     /** The one entry with no chord behind it — status has no key yet, so the
      *  menu is its only route. */
     setStatus: "Set status",
@@ -75,6 +77,16 @@ export const en = {
     title: "Change engine",
     current: "current",
     footer: "↑↓ choose · enter set · esc cancel",
+  },
+  /** Run-again confirm dialog: the stored brief, verbatim and scrollable,
+   *  before it is re-fired into a fresh task. */
+  runAgain: {
+    title: "Run again",
+    source: "Brief from \u201C{title}\u201D",
+    /** Says what confirming actually does — a new worktree, not a restart. */
+    hint: "Runs this brief again in a new task, on its own branch and worktree.",
+    confirm: "Run again",
+    footer: "\u2191\u2193 scroll \u00B7 \u2190\u2192 choose \u00B7 enter run \u00B7 esc cancel",
   },
   /** Field-notes reader dialog (project row menu). */
   fieldNotes: {
@@ -187,6 +199,7 @@ export const zh: typeof en = {
     pin: "置顶",
     unpin: "取消置顶",
     reorder: "重新排序",
+    runAgain: "重新运行",
     setStatus: "设置状态",
     copyBranch: "复制分支名",
     copyPath: "复制路径",
@@ -212,6 +225,13 @@ export const zh: typeof en = {
     title: "切换引擎",
     current: "当前",
     footer: "↑↓ 选择 · enter 设置 · esc 取消",
+  },
+  runAgain: {
+    title: "重新运行",
+    source: "来自任务「{title}」的指令",
+    hint: "在新任务里重新执行这段指令，新任务有自己的分支和工作树。",
+    confirm: "重新运行",
+    footer: "\u2191\u2193 滚动 \u00B7 \u2190\u2192 选择 \u00B7 enter 运行 \u00B7 esc 取消",
   },
   fieldNotes: {
     title: "现场笔记",

--- a/packages/kobe/src/tui/panes/sidebar/tree-menu.ts
+++ b/packages/kobe/src/tui/panes/sidebar/tree-menu.ts
@@ -43,6 +43,7 @@ export type TreeMenuAction =
   | "rename"
   | "pin"
   | "reorder"
+  | "runAgain"
   | "setStatus"
   | "copyBranch"
   | "copyPath"
@@ -87,6 +88,11 @@ function taskVerbs(task: Task): TreeMenuItem[] {
     verbs.push({ action: "pin", labelKey: task.pinned === true ? "tasks.menu.unpin" : "tasks.menu.pin" })
   }
   verbs.push({ action: "reorder", labelKey: "tasks.menu.reorder" })
+  // Re-fire the task's stored brief as a NEW task. Gated on the brief being
+  // there: `prompt` is only recorded once a prompt was actually delivered, so
+  // a task created without one has nothing to re-run — the same
+  // "no entry beats a dead entry" rule `copyBranch` follows below.
+  if (task.prompt !== undefined) verbs.push({ action: "runAgain", labelKey: "tasks.menu.runAgain" })
   // Status and the two copies are menu-only (no chord — a chord is the
   // owner's call, AGENTS.md "Keybindings"). Status had no route outside
   // `rove api set-status`; the copies put the two strings a row's identity is

--- a/packages/kobe/test/render/host-sidebar-filetree.test.tsx
+++ b/packages/kobe/test/render/host-sidebar-filetree.test.tsx
@@ -57,6 +57,7 @@ function sidebarProps(over: Partial<HostSidebarProps> = {}): HostSidebarProps {
     onRenameBranchRequest: NOOP,
     onChangeEngineRequest: NOOP,
     onFieldNotesRequest: NOOP,
+    onRunAgainRequest: NOOP,
     moveMode: false,
     onMoveRequest: NOOP,
     onMoveModeExit: NOOP,

--- a/packages/kobe/test/render/quick-fork-run-again.test.tsx
+++ b/packages/kobe/test/render/quick-fork-run-again.test.tsx
@@ -1,0 +1,127 @@
+/**
+ * `runAgainTask` (`workspace/quick-fork.ts`) — the row menu's "Run again"
+ * create path, driven against a stub orchestrator.
+ *
+ * Three properties fail SILENTLY if they break, which is why each is asserted
+ * on what came out rather than on the call completing:
+ *
+ *  - The brief must reach the child VERBATIM. A re-run whose prompt lost its
+ *    blank lines looks completely successful and runs something the user never
+ *    wrote — the whole reason this path bypasses the single-line composer.
+ *  - The child must inherit the SOURCE's fork point and engine, not the
+ *    defaults, or the "same run, clean worktree" promise quietly becomes
+ *    "some other run".
+ *  - A task with no stored brief must create NOTHING. The menu withholds the
+ *    entry, so reaching here means a stale row, and creating an empty task
+ *    would be worse than doing nothing.
+ */
+
+import { describe, expect, test } from "bun:test"
+import { runAgainTask } from "../../src/tui-react/workspace/quick-fork"
+import { type Task, toTaskId } from "../../src/types/task"
+
+const BRIEF = "Print the third line of README.md and stop.\n\nDo not edit any file.\n"
+
+function task(over: Partial<Task> = {}): Task {
+  return {
+    id: toTaskId("src"),
+    title: "seed brief",
+    repo: "/repos/rove",
+    branch: "feat/seed",
+    worktreePath: "/wt/seed",
+    kind: "task",
+    status: "in_progress",
+    vendor: "claude",
+    baseRef: "release/2",
+    prompt: BRIEF,
+    createdAt: "2026-09-01T00:00:00.000Z",
+    updatedAt: "2026-09-01T00:00:00.000Z",
+    ...over,
+  }
+}
+
+/** Records what the flow asked the orchestrator to do. */
+function stub() {
+  const created: Array<{ repo: string; baseRef: string; vendor: string }> = []
+  const prompts: Array<{ id: string; prompt: string }> = []
+  const errors: string[] = []
+  const entered: string[] = []
+  return {
+    created,
+    prompts,
+    errors,
+    entered,
+    orch: {
+      async createTask(input: { repo: string; baseRef: string; vendor: string }) {
+        created.push(input)
+        return task({ id: toTaskId("child"), branch: "new-task", worktreePath: "/wt/child" })
+      },
+      async setPrompt(id: string, prompt: string) {
+        prompts.push({ id, prompt })
+      },
+    },
+    hooks: {
+      selectTask: () => {},
+      enterTask: async (id: string) => {
+        entered.push(id)
+      },
+      notifyError: (m: string) => errors.push(m),
+    },
+  }
+}
+
+describe("runAgainTask", () => {
+  test("hands the child the source's brief byte for byte", async () => {
+    const s = stub()
+    // biome-ignore lint/suspicious/noExplicitAny: structural stub for the two-method orchestrator port.
+    const id = await runAgainTask(s.orch as any, task(), s.hooks)
+
+    expect(id).toBe("child")
+    expect(s.prompts).toEqual([{ id: "child", prompt: BRIEF }])
+    // The blank line and the trailing newline are the halves a flattening
+    // composer would have eaten.
+    expect(s.prompts[0]?.prompt).toContain("\n\n")
+    expect(s.prompts[0]?.prompt.endsWith("\n")).toBe(true)
+    expect(s.errors).toEqual([])
+  })
+
+  test("the child forks from the SOURCE's base ref and engine, not the defaults", async () => {
+    const s = stub()
+    // biome-ignore lint/suspicious/noExplicitAny: structural stub.
+    await runAgainTask(s.orch as any, task({ baseRef: "release/2", vendor: "codex" }), s.hooks)
+    expect(s.created).toEqual([{ repo: "/repos/rove", baseRef: "release/2", vendor: "codex" }])
+    // And the new task is entered, so the brief's delivery mount actually runs.
+    expect(s.entered).toEqual(["child"])
+  })
+
+  test("a task with no stored brief creates nothing at all", async () => {
+    const s = stub()
+    // biome-ignore lint/suspicious/noExplicitAny: structural stub.
+    const id = await runAgainTask(s.orch as any, task({ prompt: undefined }), s.hooks)
+    expect(id).toBeUndefined()
+    expect(s.created).toEqual([])
+    expect(s.prompts).toEqual([])
+  })
+
+  test("a failed persist still returns the created task rather than erroring", async () => {
+    // The brief is already on its way to the tab by then; turning a created
+    // task into a failure would strand a worktree the user can see.
+    const s = stub()
+    const orch = { ...s.orch, setPrompt: async () => Promise.reject(new Error("daemon gone")) }
+    // biome-ignore lint/suspicious/noExplicitAny: structural stub.
+    const id = await runAgainTask(orch as any, task(), s.hooks)
+    expect(id).toBe("child")
+    expect(s.errors).toEqual([])
+  })
+
+  test("a failed create reports through notifyError and persists no brief", async () => {
+    const s = stub()
+    const orch = { ...s.orch, createTask: async () => Promise.reject(new Error("worktree busy")) }
+    // biome-ignore lint/suspicious/noExplicitAny: structural stub.
+    const id = await runAgainTask(orch as any, task(), s.hooks)
+    expect(id).toBeUndefined()
+    expect(s.prompts).toEqual([])
+    expect(s.errors.length).toBe(1)
+    expect(s.errors[0]).toContain("worktree busy")
+  })
+})

--- a/packages/kobe/test/render/run-again-dialog.test.tsx
+++ b/packages/kobe/test/render/run-again-dialog.test.tsx
@@ -1,0 +1,82 @@
+/** @jsxImportSource @opentui/react */
+/**
+ * Run-again confirm (`component/run-again-dialog.tsx`) — REAL keypresses
+ * against the mounted view.
+ *
+ * The load-bearing property is that the brief survives the round trip
+ * VERBATIM: the whole point of the entry is re-running the exact words, and a
+ * flattened or clipped multi-line brief looks completely correct on screen
+ * while re-running something the user never wrote. So the tests assert the
+ * blank line and the trailing constraint, not just the opening sentence.
+ *
+ * The second is the commit mapping. Confirming CREATES a task, so a stray
+ * Enter must not land on cancel and a stray Escape must not land on confirm.
+ */
+
+import { describe, expect, test } from "bun:test"
+import { RunAgainDialogView } from "../../src/tui-react/component/run-again-dialog"
+import { type RenderHandle, act, renderComponent, settle } from "./harness"
+
+const BRIEF = "Print the third line of README.md.\n\nStop after that — do not edit anything."
+
+function mount(prompt: string = BRIEF): Promise<RenderHandle> & { picked: boolean[] } {
+  const picked: boolean[] = []
+  const p = renderComponent(
+    <RunAgainDialogView
+      taskTitle="seed the brief"
+      prompt={prompt}
+      onConfirm={() => picked.push(true)}
+      onCancel={() => picked.push(false)}
+    />,
+    { providers: { dialog: true }, width: 90, height: 24 },
+  ) as Promise<RenderHandle> & { picked: boolean[] }
+  p.picked = picked
+  return p
+}
+
+describe("RunAgainDialogView", () => {
+  test("shows the source task and the brief's every line, blank line included", async () => {
+    const { frame } = await mount()
+    const f = await frame()
+    expect(f).toContain("Run again")
+    expect(f).toContain("seed the brief")
+    expect(f).toContain("Print the third line of README.md.")
+    // The constraint after the blank line is the half a single-line preview
+    // would have dropped.
+    expect(f).toContain("do not edit anything")
+    // And it says what confirming does — a new task, not a restart in place.
+    expect(f).toContain("new task")
+  })
+
+  test("enter commits the re-run — the confirm button is where focus opens", async () => {
+    const p = mount()
+    const { frame, mockInput } = await p
+    await frame()
+    act(() => mockInput.pressEnter())
+    await frame()
+    expect(p.picked).toEqual([true])
+  })
+
+  test("left moves to cancel, and enter there cancels instead of creating", async () => {
+    const p = mount()
+    const { frame, mockInput } = await p
+    await frame()
+    act(() => mockInput.pressArrow("left"))
+    act(() => mockInput.pressEnter())
+    await frame()
+    expect(p.picked).toEqual([false])
+  })
+
+  test("up/down scroll the brief instead of moving between the buttons", async () => {
+    // The two gestures share one dialog; if `down` were wired to the button
+    // row, a user scrolling a long brief would silently arm Cancel.
+    const p = mount(Array.from({ length: 60 }, (_, i) => `line ${i}`).join("\n"))
+    const { frame, mockInput } = await p
+    await frame()
+    act(() => mockInput.pressArrow("down"))
+    await settle()
+    act(() => mockInput.pressEnter())
+    await frame()
+    expect(p.picked).toEqual([true])
+  })
+})

--- a/packages/kobe/test/render/sidebar-recent-row.test.tsx
+++ b/packages/kobe/test/render/sidebar-recent-row.test.tsx
@@ -53,6 +53,7 @@ function sidebarProps(over: Partial<HostSidebarProps> = {}): HostSidebarProps {
     onRenameBranchRequest: NOOP,
     onChangeEngineRequest: NOOP,
     onFieldNotesRequest: NOOP,
+    onRunAgainRequest: NOOP,
     moveMode: false,
     onMoveRequest: NOOP,
     onMoveModeExit: NOOP,

--- a/packages/kobe/test/tui/sidebar-tree-menu-items.test.ts
+++ b/packages/kobe/test/tui/sidebar-tree-menu-items.test.ts
@@ -172,6 +172,49 @@ describe("treeMenuItems", () => {
     expect(actions(tabRow, { tabCount: 0 })).not.toContain("closeTab")
   })
 
+  test("Run again is offered only to a task that stored a brief", () => {
+    // `prompt` is recorded on the delivery path, so a task created without one
+    // has nothing to re-fire — the entry-that-does-nothing rule. It sits right
+    // after Reorder, before the status/copy block.
+    expect(actions(worktreeRow())).not.toContain("runAgain")
+    expect(actions(worktreeRow({ prompt: "print the third line\n\nthen stop" }))).toEqual([
+      "open",
+      "newChat",
+      "newShell",
+      "rename",
+      "pin",
+      "reorder",
+      "runAgain",
+      "setStatus",
+      "copyBranch",
+      "copyPath",
+      "openEditor",
+      "renameBranch",
+      "changeEngine",
+      "delete",
+    ])
+  })
+
+  test("Run again reaches a TAB row too, and never a project header", () => {
+    // Same rule as the rest of the task verbs: a tab row carries them because
+    // the chords walk up from a tab to its worktree.
+    const withBrief: TreeRow = {
+      kind: "tab",
+      id: "a::tab-2",
+      task: task({ prompt: "the brief" }),
+      tab: { id: "tab-2", label: "tab 2" },
+      depth: 2,
+    }
+    expect(actions(withBrief, { tabCount: 2 })).toContain("runAgain")
+    expect(actions(projectRow)).not.toContain("runAgain")
+  })
+
+  test("an empty-string brief still counts — only an ABSENT one hides the entry", () => {
+    // `setPrompt` rejects whitespace-only text, so "" can never be stored; the
+    // gate is presence, and testing it as truthiness would hide that.
+    expect(actions(worktreeRow({ prompt: "" }))).toContain("runAgain")
+  })
+
   test("pin reads the task's own state", () => {
     const label = (row: TreeRow) => treeMenuItems(row).find((item) => item.action === "pin")?.labelKey
     expect(label(worktreeRow())).toBe("tasks.menu.pin")


### PR DESCRIPTION
## What / why

Rove records the prompt a Task was created with (`task.prompt`, written on the delivery path so it means "the engine was given exactly this text"). Nothing in the TUI read it: the only route to a stored brief was `rove api get-task --task-id X | jq -r .task.prompt` piped into `rove api add --prompt`.

The sidebar row menu now offers **Run again** on any Task that has a brief. It shows the brief in full, then re-fires it verbatim into a NEW Task — same repo, same engine, cut from the same base ref, with its own branch and worktree. The original is untouched.

Three decisions worth naming:

- **Not routed through the quick-task composer.** Its prompt field is a single-line `<input>` running `stripNewlines`, which would silently flatten a multi-line brief and re-run something the user never wrote. The brief rides the create path verbatim instead.
- **The confirm scrolls rather than truncates.** `task.prompt` is stored untruncated because the constraints that decide whether a re-run is right usually sit at the END of a long brief; a one-line `DialogConfirm` message would clip exactly that part.
- **The brief is copied onto the child.** So the fork is itself re-runnable, and `rove api get-task` on it reports the words its engine is being handed. This makes the TUI the second writer of `task.setPrompt` after the CLI `add` path; the daemon handler comment now says so.

The entry is withheld from a Task with no stored brief — the same "no entry beats a dead entry" rule `copyBranch` and `closeTab` follow.

No new chord: right-click row menu only.

## Pass criteria — commands run and real output

**1. `add` records the brief verbatim** (isolated scratch home, real engine):

```
$ rove api add --repo <scratch>/repo --title "seed brief" --command claude --prompt-file brief.txt
{"taskId":"01M1GBV8E0HFTPZHD906WVB61K", ... "delivered":true,
 "prompt":"Print the third line of README.md and stop.\n\nDo not edit any file.\n" ...}
```

The brief deliberately contains a blank line and a trailing constraint — that is the multi-line check.

**2. Run again through the REAL TUI** (browser `/harness` → xterm → PTY sidecar → OpenTUI, isolated fixture on port base 5473). Right-click the row, pick Run again, press enter:

```
$ rove api list
01M1GBVZJNDE5MHM6165F2DBEE | Visual Fixture | branch= ''         | wt= (none)
01M1GC4TKXDRGYDDX9QC8WW29W | (new task)     | branch= 'new-task' | wt= snail

$ rove api get-task --task-id 01M1GC4TKXDRGYDDX9QC8WW29W
id       01M1GC4TKXDRGYDDX9QC8WW29W
branch   new-task
worktree .../opentui-visual-5473/home/.rove/worktrees/fixture-repo-eac09813d090/snail
prompt   'Print the third line of README.md and stop.\n\nDo not edit any file.\n'
```

Byte-identical to the source's, blank line and trailing newline included. New id, own branch, own worktree.

## Screenshots

All from the harness (fixed-viewport Chromium → `/harness` → xterm.js → PTY sidecar → real OpenTUI), on an isolated scratch home.

| | |
|---|---|
| BEFORE | `/Users/jacksonc/i/kobe/.scratch/runagain/runagain-before.png` |
| AFTER (menu) | `/Users/jacksonc/i/kobe/.scratch/runagain/runagain-after-menu.png` |
| AFTER (confirm) | `/Users/jacksonc/i/kobe/.scratch/runagain/runagain-after-dialog.png` |
| AFTER (task created) | `/Users/jacksonc/i/kobe/.scratch/runagain/runagain-after-created.png` |

The BEFORE shot is the fixture's own promptless Task: the menu goes straight from Reorder row to Set status, which is the gate working. The AFTER shots are the same fixture with a brief seeded into its `tasks.json`.

## Tests

- `test/tui/sidebar-tree-menu-items.test.ts` — three new cases: the entry is offered only with a stored brief, it reaches a tab row but never a project header, and the gate is presence rather than truthiness (an empty-string brief still counts, since `setPrompt` rejects whitespace-only text).
- `test/render/run-again-dialog.test.tsx` — real keypresses: the brief's blank line and trailing constraint both survive to the frame, enter commits, left-then-enter cancels, and up/down scroll instead of arming Cancel.

Both mutation-verified. Deleting the `task.prompt` gate turns the menu-items file red; making enter always confirm turns the dialog file red.

Green locally: root `bun run lint`, `tsc --noEmit`, `bun test test/render` (386 pass), `bun run test:fast`. `test:fast` shows four failures that are the known worktree-path fakes (`project-eligibility`, `open-dir-cmd` judge paths by shape and this branch lives under `~/.rove/worktrees`) plus one parallel-load flake in `terminal-pty-redraw-budget` that passes on its own. None touch files in this change.

file-size-exemption: packages/kobe/src/tui-react/workspace/host.tsx — already 527 lines before this change; the delta is two wiring lines (one destructure entry, one prop) and the only seam I can see is extracting the whole HostSidebar prop block, which is a refactor of its own rather than part of this feature.
file-size-exemption: packages/kobe/src/client/remote-orchestrator.ts — was exactly at the 500 cap; the delta is two lines (an import and one delegating method) in a file that is entirely a delegation index, so there is no seam short of splitting it by domain.
