### PR TITLE
feat: set reasoning effort on an existing task

### DIFF
--- a/.changeset/set-effort-on-existing-task.md
+++ b/.changeset/set-effort-on-existing-task.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Reasoning effort is now settable on a task that already exists. The sidebar row menu's "Change engine" dialog gained a second row listing the engine's declared levels (codex's `none`/`low`/`medium`/`high`/`xhigh`), picked with `←→`; engines that declare no levels show no row. The new `rove api set-effort --task-id ID --level LEVEL` does the same from a shell, and rejects a level the task's engine does not declare instead of passing it through to a launch that would silently drop it.

--- a/docs/API.md
+++ b/docs/API.md
@@ -406,6 +406,12 @@ placeholder branch to a descriptive name. Prompts into existing sessions
   to it is derived from the command; the result reports which one, and
   `generic` when the command names no engine Rove knows. Replaces the
   removed `set-vendor`.
+- `set-effort --task-id ID --level LEVEL`: set a task's reasoning effort
+  level (takes effect on the next session rebuild). Levels are declared by
+  the task's engine — codex accepts `none`, `low`, `medium`, `high`, `xhigh`;
+  claude declares none. A level the engine does not declare is rejected
+  (`BAD_EFFORT`, naming the levels it does accept) rather than passed through,
+  because the launch path drops an unknown level silently.
 - `set-status --task-id ID --status S`: set lifecycle status:
   `backlog`, `in_progress`, `in_review`, `done`, `canceled`, `error`.
 

--- a/docs/ENGINES.md
+++ b/docs/ENGINES.md
@@ -69,6 +69,17 @@ Codex accepts `none`, `low`, `medium`, `high`, `xhigh`, passed as
 `-c model_reasoning_effort=<level>`. Other engines have no effort flag Rove
 can drive; a selected effort is ignored there rather than passed through.
 
+Three places select one:
+
+- the web board's engine picker, when you start a task from an issue;
+- the sidebar row menu's **Change engine** entry, whose second row lists the
+  engine's levels (`←→` picks one, and "engine default" clears it). Engines
+  that declare no levels show no row;
+- `rove api set-effort --task-id ID --level LEVEL` from a shell.
+
+All three take effect on the task's next session rebuild, not on the running
+one.
+
 ### Workspace trust
 
 Claude, Codex, and Kimi each gate a first launch in a never-seen directory

--- a/packages/kobe-daemon/src/daemon/contracts.ts
+++ b/packages/kobe-daemon/src/daemon/contracts.ts
@@ -207,7 +207,8 @@ export interface DaemonOrchestrator {
   setBranch(id: string, branch: string): Promise<void>
   /** Record the language a task's user writes in, from their own prompt text. */
   observeLanguage(id: string, text: string): Promise<void>
-  setVendor(id: string, vendor: VendorId): Promise<void>
+  /** `effort`: absent = keep the recorded level, `""` = clear it, else set it. */
+  setVendor(id: string, vendor: VendorId, effort?: string): Promise<void>
   /** Pin a raw launch command (and its caller-resolved protocol) on a task. */
   setCommand(id: string, command: string, vendor?: VendorId): Promise<void>
   setPinned(id: string, pinned?: boolean): Promise<void>

--- a/packages/kobe-daemon/src/daemon/handlers-task.ts
+++ b/packages/kobe-daemon/src/daemon/handlers-task.ts
@@ -114,7 +114,11 @@ export const TASK_HANDLERS: readonly DaemonRequestHandler[] = [
       const taskId = requireString(payload, "taskId")
       const vendor = optionalVendor(payload, "vendor")
       if (!vendor) throw new Error("task.setVendor: vendor is required")
-      await ctx.orch.setVendor(taskId, vendor)
+      // Not `optionalString`: that maps `""` to undefined, and `""` is the
+      // wire spelling of "clear the level". Absent stays absent.
+      const rawEffort = payload.effort
+      if (rawEffort !== undefined && typeof rawEffort !== "string") throw new Error("effort must be a string")
+      await ctx.orch.setVendor(taskId, vendor, rawEffort)
       return {}
     },
   },

--- a/packages/kobe/src/cli/api/handlers-engines.ts
+++ b/packages/kobe/src/cli/api/handlers-engines.ts
@@ -1,6 +1,7 @@
 /**
  * The engine face of `kobe api`: `engine-list` (what can I launch, and with
- * what command?) and `set-command` (pin a task's launch command).
+ * what command?), `set-command` (pin a task's launch command), and
+ * `set-effort` (pin its reasoning level).
  *
  * These are the two halves of the dispatch contract. `engine-list` is
  * WYSIWYG on purpose — it prints each entry's raw command line so an agent
@@ -16,14 +17,15 @@
  * the finished specs.
  */
 
+import type { SerializedTask } from "@sma1lboy/kobe-daemon/daemon/protocol"
 import { pluginEngineIds } from "../../engine/contrib-engines.ts"
 import { GENERIC_PROTOCOL, listEnginePresets, resolveCommandProtocol } from "../../engine/engine-presets.ts"
 import { loadPluginEngines } from "../../engine/plugin-engines.ts"
 import { engineEntry } from "../../engine/registry.ts"
-import type { VendorId } from "../../types/vendor.ts"
+import { type VendorId, coerceVendorId } from "../../types/vendor.ts"
 import { F } from "./flags.ts"
-import { simpleRpc } from "./handler-helpers.ts"
-import type { VerbContext, VerbSpec } from "./types.ts"
+import { daemonOf, simpleRpc } from "./handler-helpers.ts"
+import { ApiError, type VerbContext, type VerbSpec } from "./types.ts"
 
 function listAllEnginePresets() {
   // Plugin-contributed engines are loaded from enabled plugin manifests at
@@ -78,4 +80,73 @@ export const SET_COMMAND_VERB: VerbSpec = {
     "Set a task's engine launch command (takes effect on the next session rebuild). The protocol Rove speaks to it is derived from the command — the result reports which one, `generic` when the command names no engine Rove knows.",
   flags: [F.taskId(), { ...F.command(), required: true }],
   handler: setCommand,
+}
+
+/**
+ * The engine whose effort levels govern a task: its PINNED command when it
+ * has one, else its recorded protocol — the same resolution
+ * `engineLaunchArgv` performs, so the level this verb accepts is the level
+ * the launch actually carries.
+ */
+function taskEngine(task: Pick<SerializedTask, "command" | "vendor">): VendorId {
+  const command = task.command?.trim()
+  if (command) {
+    const resolved = resolveCommandProtocol(command)
+    if (resolved !== GENERIC_PROTOCOL) return resolved
+  }
+  return coerceVendorId(task.vendor)
+}
+
+export async function setEffort(ctx: VerbContext): Promise<unknown> {
+  const taskId = ctx.args.require("task-id")
+  const level = ctx.args.require("level").trim()
+  const daemon = daemonOf(ctx)
+  const { task } = await daemon.request<{ task: SerializedTask }>("task.get", { taskId })
+  const engine = taskEngine(task)
+  // Validated HERE rather than passed through: `withEngineEffort` drops a
+  // level the engine never declared, silently — which is how a user picks
+  // "high" and gets the default with no error anywhere.
+  const levels = engineEntry(engine).effortLevels ?? []
+  if (levels.length === 0) {
+    throw new ApiError(`engine ${engine} declares no reasoning effort levels`, "BAD_EFFORT", {
+      engine,
+      hint: `Only engines with declared levels accept one (codex today). Check the task's engine with \`get-task\`.`,
+      nextCommandArgs: ["api", "get-task", "--task-id", taskId],
+    })
+  }
+  if (!levels.includes(level)) {
+    throw new ApiError(
+      `engine ${engine} does not accept effort level ${JSON.stringify(level)} — it declares ${levels.join(", ")}`,
+      "BAD_EFFORT",
+      {
+        engine,
+        levels,
+        hint: `Pass one of: ${levels.join(", ")}.`,
+      },
+    )
+  }
+  await simpleRpc(ctx, "task.setVendor", { taskId, vendor: engine, effort: level })
+  return { ok: true, taskId, engine, effort: level }
+}
+
+export const SET_EFFORT_VERB: VerbSpec = {
+  name: "set-effort",
+  group: "edit",
+  summary:
+    "Set a task's reasoning effort level (takes effect on the next session rebuild). Rejected when the task's engine declares no levels, or does not declare THIS one — the error names the levels it does accept. Codex accepts none/low/medium/high/xhigh; claude has none.",
+  flags: [
+    F.taskId(),
+    // Deliberately not an enum: levels are declared PER ENGINE (registry
+    // `effortLevels`), including by plugin engines this static list cannot
+    // see — the same open-set reasoning as `F.vendor()`. The handler checks
+    // against the task's own engine, which is the only authoritative list.
+    {
+      name: "level",
+      type: "string",
+      required: true,
+      placeholder: "LEVEL",
+      description: "Effort level the task's engine declares (codex: none, low, medium, high, xhigh).",
+    },
+  ],
+  handler: setEffort,
 }

--- a/packages/kobe/src/cli/api/verbs-edit.ts
+++ b/packages/kobe/src/cli/api/verbs-edit.ts
@@ -10,7 +10,7 @@
 import type { TaskStatus } from "../../types/task.ts"
 import { F } from "./flags.ts"
 import { simpleRpc } from "./handler-helpers.ts"
-import { SET_COMMAND_VERB } from "./handlers-engines.ts"
+import { SET_COMMAND_VERB, SET_EFFORT_VERB } from "./handlers-engines.ts"
 import { TASK_STATUSES } from "./task-statuses.ts"
 import type { VerbSpec } from "./types.ts"
 
@@ -35,6 +35,7 @@ export const EDIT_VERBS: readonly VerbSpec[] = [
       simpleRpc(ctx, "task.setBranch", { taskId: ctx.args.require("task-id"), branch: ctx.args.require("branch") }),
   },
   SET_COMMAND_VERB,
+  SET_EFFORT_VERB,
   {
     name: "set-status",
     group: "edit",

--- a/packages/kobe/src/client/remote-orchestrator-writes.ts
+++ b/packages/kobe/src/client/remote-orchestrator-writes.ts
@@ -94,8 +94,15 @@ export async function setBranchOp(client: KobeDaemonClient, id: TaskId | string,
   await client.request("task.setBranch", { taskId: String(id), branch })
 }
 
-export async function setVendorOp(client: KobeDaemonClient, id: TaskId | string, vendor: VendorId): Promise<void> {
-  await client.request("task.setVendor", { taskId: String(id), vendor })
+export async function setVendorOp(
+  client: KobeDaemonClient,
+  id: TaskId | string,
+  vendor: VendorId,
+  effort?: string,
+): Promise<void> {
+  // `effort` is omitted from the payload when the caller has no opinion, so
+  // the daemon can tell "leave the level alone" from `""` = clear it.
+  await client.request("task.setVendor", { taskId: String(id), vendor, ...(effort !== undefined ? { effort } : {}) })
 }
 
 export async function setCommandOp(

--- a/packages/kobe/src/client/remote-orchestrator.ts
+++ b/packages/kobe/src/client/remote-orchestrator.ts
@@ -417,7 +417,8 @@ export class RemoteOrchestrator {
   forgetProject = (repo: string): Promise<void> => forgetProjectOp(this.client, repo)
   setTitle = (id: TaskId | string, title: string): Promise<void> => setTitleOp(this.client, id, title)
   setBranch = (id: TaskId | string, branch: string): Promise<void> => setBranchOp(this.client, id, branch)
-  setVendor = (id: TaskId | string, vendor: VendorId): Promise<void> => setVendorOp(this.client, id, vendor)
+  setVendor = (id: TaskId | string, vendor: VendorId, effort?: string): Promise<void> =>
+    setVendorOp(this.client, id, vendor, effort)
   setCommand = (id: TaskId | string, command: string, vendor?: VendorId): Promise<void> =>
     setCommandOp(this.client, id, command, vendor)
   setPinned = (id: TaskId | string, pinned?: boolean): Promise<void> => setPinnedOp(this.client, id, pinned)

--- a/packages/kobe/src/orchestrator/core.ts
+++ b/packages/kobe/src/orchestrator/core.ts
@@ -382,7 +382,8 @@ export class Orchestrator {
   setBranch = (id: TaskId | string, branch: string): Promise<void> => this.editor.setBranch(id, branch)
   /** Record the language a task's user writes in, from their own prompt text. */
   observeLanguage = (id: TaskId | string, text: string): Promise<void> => this.editor.observeLanguage(id, text)
-  setVendor = (id: TaskId | string, vendor: VendorId): Promise<void> => this.editor.setVendor(id, vendor)
+  setVendor = (id: TaskId | string, vendor: VendorId, effort?: string): Promise<void> =>
+    this.editor.setVendor(id, vendor, effort)
   setCommand = (id: TaskId | string, command: string, vendor?: VendorId): Promise<void> =>
     this.editor.setCommand(id, command, vendor)
   setPinned = (id: TaskId | string, pinned?: boolean): Promise<void> => this.editor.setPinned(id, pinned)

--- a/packages/kobe/src/orchestrator/task-editor.ts
+++ b/packages/kobe/src/orchestrator/task-editor.ts
@@ -142,10 +142,23 @@ export class TaskEditor {
     await this.store.update(task.id, { observedLanguage: observed })
   }
 
-  async setVendor(id: TaskId | string, vendor: VendorId): Promise<void> {
+  /**
+   * `effort` is a THREE-state field, because "leave it alone" and "clear it"
+   * are different asks: `undefined` keeps the task's recorded level (the
+   * caller had no opinion), `""` clears it (back to the engine's own
+   * default), any other string records that level. Without the tri-state the
+   * engine picker could never take a codex task back off `xhigh`.
+   *
+   * The same-vendor early return must not swallow an effort-only change — a
+   * user re-picking codex to move it from `medium` to `high` is changing
+   * something, even though the vendor is identical.
+   */
+  async setVendor(id: TaskId | string, vendor: VendorId, effort?: string): Promise<void> {
     const task = this.requireTask(id)
-    if (task.vendor === vendor) return
-    await this.store.update(task.id, { vendor })
+    const nextEffort = effort?.trim() ? effort.trim() : undefined
+    const effortChanges = effort !== undefined && task.modelEffort !== nextEffort
+    if (task.vendor === vendor && !effortChanges) return
+    await this.store.update(task.id, { vendor, ...(effort !== undefined ? { modelEffort: nextEffort } : {}) })
   }
 
   /**

--- a/packages/kobe/src/tui-react/component/engine-picker-dialog.tsx
+++ b/packages/kobe/src/tui-react/component/engine-picker-dialog.tsx
@@ -7,13 +7,22 @@
  * a plain pick over a closed list, no free text — the list IS what
  * `availableEngineIds()` returned, and a name outside it cannot launch.
  *
- * Picking persists the task's vendor and nothing else; like `v`, it takes
- * effect on the task's next enter (`applyVendorChange` says so in its toast).
+ * Engines that DECLARE reasoning levels (`EngineRegistryEntry.effortLevels` —
+ * codex today) get a second row under the list, so the level is settable on a
+ * task that already exists; before this the only surface that could set one
+ * was the web board's create-time picker, which left a codex task stuck on
+ * whatever it launched with. Engines with no declared levels render no row at
+ * all, matching the web picker's rule.
+ *
+ * Picking persists the task's vendor (and level) and nothing else; like `v`,
+ * it takes effect on the task's next enter (`applyVendorChange` says so in
+ * its toast).
  */
 
 import { TextAttributes } from "@opentui/core"
 import { useState } from "react"
 import { engineDisplayName } from "../../engine/interactive-command"
+import { engineEntry } from "../../engine/registry"
 import type { PickerWindow } from "../../tui/component/new-task-dialog/state"
 import { clampCursor } from "../../tui/component/new-task-dialog/state"
 import type { VendorId } from "../../types/vendor"
@@ -21,13 +30,37 @@ import { useTheme } from "../context/theme"
 import { useT } from "../i18n"
 import { useBindings } from "../lib/keymap"
 import { type DialogContext, showDialog, useDialog, useDialogPaddingX } from "../ui/dialog"
-import { PickerList } from "./new-task-dialog/picker-list"
+import { ChoiceRow, PickerList } from "./new-task-dialog/picker-list"
+
+/** What the dialog resolves to: the engine, plus the level when one applies. */
+export type EnginePickResult = {
+  readonly vendor: VendorId
+  /** Absent = the engine declares no levels, so leave the task's alone.
+   *  `""` = the user chose the engine's own default, i.e. clear it. */
+  readonly effort?: string
+}
+
+/** The sentinel choice meaning "no level — use the engine's own default". */
+const NO_EFFORT = ""
+
+function effortLevelsOf(vendor: VendorId): readonly string[] {
+  return engineEntry(vendor).effortLevels ?? []
+}
+
+/** The level to open on for `vendor`: the task's own when that engine still
+ *  declares it, else the engine's default (no level pinned). */
+function seedEffort(vendor: VendorId, current: string | undefined): string {
+  const trimmed = current?.trim()
+  return trimmed && effortLevelsOf(vendor).includes(trimmed) ? trimmed : NO_EFFORT
+}
 
 export function EnginePickerDialogView(props: {
   engines: readonly VendorId[]
   /** The task's current engine — the list opens on it and marks it. */
   current: VendorId
-  onSubmit: (value: VendorId) => void
+  /** The task's current reasoning level, when it has one. */
+  currentEffort?: string
+  onSubmit: (value: EnginePickResult) => void
   onCancel: () => void
 }) {
   const dialog = useDialog()
@@ -37,16 +70,35 @@ export function EnginePickerDialogView(props: {
   const { engines } = props
 
   const [cursor, setCursor] = useState(() => Math.max(0, engines.indexOf(props.current)))
+  const [effort, setEffort] = useState(() => seedEffort(props.current, props.currentEffort))
 
   // The available-engine list is a handful of rows; no window to slide.
   const window: PickerWindow = { items: [...engines], start: 0, total: engines.length }
 
+  const cursorEngine = engines[cursor] ?? props.current
+  const levels = effortLevelsOf(cursorEngine)
+  const effortChoices = levels.length > 0 ? [NO_EFFORT, ...levels] : []
+
   function move(delta: 1 | -1): void {
-    setCursor((c) => clampCursor(c + delta, engines.length))
+    setCursor((c) => {
+      const next = clampCursor(c + delta, engines.length)
+      // The level belongs to the engine under the cursor: carry it across
+      // engines that share it, otherwise fall back to that engine's default
+      // rather than submitting a level it never declared.
+      setEffort((e) => seedEffort(engines[next] ?? props.current, e))
+      return next
+    })
+  }
+
+  function stepEffort(delta: 1 | -1): void {
+    if (effortChoices.length === 0) return
+    const i = effortChoices.indexOf(effort)
+    setEffort(effortChoices[clampCursor((i < 0 ? 0 : i) + delta, effortChoices.length)] ?? NO_EFFORT)
   }
 
   function commit(engine: VendorId): void {
-    props.onSubmit(engine)
+    const applicable = effortLevelsOf(engine)
+    props.onSubmit({ vendor: engine, ...(applicable.length > 0 ? { effort: seedEffort(engine, effort) } : {}) })
     dialog.clear()
   }
 
@@ -61,6 +113,8 @@ export function EnginePickerDialogView(props: {
     bindings: [
       { key: "up", cmd: () => move(-1) },
       { key: "down", cmd: () => move(1) },
+      { key: "left", cmd: () => stepEffort(-1) },
+      { key: "right", cmd: () => stepEffort(1) },
       { key: "return", cmd: () => commit(engines[cursor] ?? props.current) },
     ],
   }))
@@ -80,10 +134,27 @@ export function EnginePickerDialogView(props: {
         cursor={cursor}
         rows={rows}
         onPick={(absoluteIndex) => commit(engines[absoluteIndex] ?? props.current)}
-        paddingBottom={1}
+        paddingBottom={effortChoices.length > 0 ? 0 : 1}
       />
+      {effortChoices.length > 0 ? (
+        <box paddingLeft={2}>
+          <ChoiceRow
+            choices={effortChoices}
+            selected={effort}
+            display={(choice) => (choice === NO_EFFORT ? t("tasks.changeEngine.noEffort") : choice)}
+            onPick={(choice) => setEffort(choice)}
+            label={
+              <text fg={theme.textMuted} wrapMode="none" flexShrink={0}>
+                {t("tasks.changeEngine.effortLabel")}
+              </text>
+            }
+          />
+        </box>
+      ) : null}
       <box paddingBottom={1}>
-        <text fg={theme.textMuted}>{t("tasks.changeEngine.footer")}</text>
+        <text fg={theme.textMuted}>
+          {effortChoices.length > 0 ? t("tasks.changeEngine.footerEffort") : t("tasks.changeEngine.footer")}
+        </text>
       </box>
     </box>
   )
@@ -92,12 +163,13 @@ export function EnginePickerDialogView(props: {
 /** Open the picker and resolve with the chosen engine — `undefined` on cancel. */
 function show(
   dialog: DialogContext,
-  opts: { engines: readonly VendorId[]; current: VendorId },
-): Promise<VendorId | undefined> {
-  return showDialog<VendorId>(dialog, (resolve) => (
+  opts: { engines: readonly VendorId[]; current: VendorId; currentEffort?: string },
+): Promise<EnginePickResult | undefined> {
+  return showDialog<EnginePickResult>(dialog, (resolve) => (
     <EnginePickerDialogView
       engines={opts.engines}
       current={opts.current}
+      currentEffort={opts.currentEffort}
       onSubmit={(v) => resolve(v)}
       onCancel={() => resolve(undefined)}
     />

--- a/packages/kobe/src/tui-react/workspace/host-task-actions.ts
+++ b/packages/kobe/src/tui-react/workspace/host-task-actions.ts
@@ -151,9 +151,17 @@ export function useWorkspaceTaskActions(deps: WorkspaceTaskActionDeps): Workspac
     if (!task) return
     const current = task.vendor ?? DEFAULT_TASK_VENDOR
     const engines = await availableEngineIds()
-    const next = await EnginePickerDialog.show(dialog, { engines: engines.length > 0 ? engines : [current], current })
-    if (!next || next === current) return
-    await applyVendorChange(taskActions, id, next)
+    const pick = await EnginePickerDialog.show(dialog, {
+      engines: engines.length > 0 ? engines : [current],
+      current,
+      currentEffort: task.modelEffort,
+    })
+    if (!pick) return
+    // Not `pick.vendor === current` — re-picking the same engine at a
+    // different reasoning level is a real change, and the early return used
+    // to eat it.
+    if (pick.vendor === current && (pick.effort === undefined || pick.effort === (task.modelEffort ?? ""))) return
+    await applyVendorChange(taskActions, id, pick.vendor, { effort: pick.effort })
   }
 
   return {

--- a/packages/kobe/src/tui-react/workspace/use-issue-chat.ts
+++ b/packages/kobe/src/tui-react/workspace/use-issue-chat.ts
@@ -62,7 +62,7 @@ export interface IssueChatOrchestrator {
   createTask(input: { repo: string; title?: string; vendor?: VendorId }): Promise<Task>
   ensureMainTask(repo: string): Promise<Task>
   ensureWorktree(id: string): Promise<string>
-  setVendor(id: string, vendor: VendorId): Promise<void>
+  setVendor(id: string, vendor: VendorId, effort?: string): Promise<void>
   mutateIssue(repoRoot: string, op: unknown): Promise<unknown>
 }
 

--- a/packages/kobe/src/tui/i18n/messages/tasks.ts
+++ b/packages/kobe/src/tui/i18n/messages/tasks.ts
@@ -71,6 +71,12 @@ export const en = {
     title: "Change engine",
     current: "current",
     footer: "↑↓ choose · enter set · esc cancel",
+    /** Leading label of the reasoning-level row (engines that declare levels). */
+    effortLabel: "Effort",
+    /** The level choice meaning "don't pin one — use the engine's own default". */
+    noEffort: "engine default",
+    /** Footer for an engine that HAS levels: the row needs its own keys. */
+    footerEffort: "↑↓ engine · ←→ effort · enter set · esc cancel",
   },
   /** Field-notes reader dialog (project row menu). */
   fieldNotes: {
@@ -185,6 +191,9 @@ export const zh: typeof en = {
     title: "切换引擎",
     current: "当前",
     footer: "↑↓ 选择 · enter 设置 · esc 取消",
+    effortLabel: "推理强度",
+    noEffort: "引擎默认",
+    footerEffort: "↑↓ 引擎 · ←→ 强度 · enter 设置 · esc 取消",
   },
   fieldNotes: {
     title: "现场笔记",

--- a/packages/kobe/src/tui/lib/task-actions.ts
+++ b/packages/kobe/src/tui/lib/task-actions.ts
@@ -335,11 +335,17 @@ export async function applyVendorChange(
    * not have, which is exactly the divergence this function was added to
    * surface.
    */
-  opts: { readonly silentSuccess?: boolean } = {},
+  opts: {
+    readonly silentSuccess?: boolean
+    /** Reasoning level to persist alongside the engine. Absent = leave the
+     *  task's alone (the engine declares none, or the caller has no opinion);
+     *  `""` = clear it back to the engine's own default. */
+    readonly effort?: string
+  } = {},
 ): Promise<boolean> {
   if (!ctx.orch) return false
   try {
-    await ctx.orch.setVendor(taskId, next)
+    await ctx.orch.setVendor(taskId, next, opts.effort)
   } catch (err) {
     ctx.logger.error(`${ctx.logPrefix} task.setVendor failed:`, err)
     ctx.notifyError?.(`Couldn't switch engine: ${errorMessage(err)}`)

--- a/packages/kobe/test/cli/api-cmd.test.ts
+++ b/packages/kobe/test/cli/api-cmd.test.ts
@@ -229,6 +229,7 @@ describe("API surface (full CRUD)", () => {
       "rename",
       "set-branch",
       "set-command",
+      "set-effort",
       "set-status",
       "pin",
       "land",

--- a/packages/kobe/test/cli/api-handlers-more.test.ts
+++ b/packages/kobe/test/cli/api-handlers-more.test.ts
@@ -225,6 +225,61 @@ describe("edit verbs — RPC name + payload", () => {
     ])
   })
 
+  describe("set-effort", () => {
+    /** A task.get responder — the verb reads the task to learn its engine. */
+    const taskOf = (task: Record<string, unknown>) => ({ "task.get": () => ({ task: { id: "t1", ...task } }) })
+
+    it("sends the level on task.setVendor once the task's engine declares it", async () => {
+      const client = new FakeClient({ ...taskOf({ vendor: "codex" }), "task.setVendor": () => ({}) })
+      const out = await invokeVerb("set-effort", ["--task-id", "t1", "--level", "xhigh"], {
+        client,
+        runtime: stubRuntime(),
+      })
+      expect(out).toEqual({ ok: true, taskId: "t1", engine: "codex", effort: "xhigh" })
+      expect(client.requests.at(-1)).toEqual({
+        name: "task.setVendor",
+        payload: { taskId: "t1", vendor: "codex", effort: "xhigh" },
+      })
+    })
+
+    it("resolves the engine from a PINNED command, not just the recorded vendor", async () => {
+      // A task launched with `--command "codex --search"` is a codex launch;
+      // reading `vendor` alone would judge the level against the wrong engine.
+      const client = new FakeClient({
+        ...taskOf({ vendor: "generic", command: "codex --search" }),
+        "task.setVendor": () => ({}),
+      })
+      await invokeVerb("set-effort", ["--task-id", "t1", "--level", "high"], { client, runtime: stubRuntime() })
+      expect(client.requests.at(-1)).toEqual({
+        name: "task.setVendor",
+        payload: { taskId: "t1", vendor: "codex", effort: "high" },
+      })
+    })
+
+    it("refuses a level the engine does not declare, naming the ones it does", async () => {
+      // The whole point of the verb: `withEngineEffort` DROPS an unknown
+      // level at launch, so passing it through would look like success and
+      // run at the default.
+      const client = new FakeClient(taskOf({ vendor: "codex" }))
+      await expectApiError(
+        () => invokeVerb("set-effort", ["--task-id", "t1", "--level", "turbo"], { client, runtime: stubRuntime() }),
+        "BAD_EFFORT",
+        /none, low, medium, high, xhigh/,
+      )
+      expect(client.requests.map((r) => r.name)).toEqual(["task.get"])
+    })
+
+    it("refuses any level on an engine with no declared levels", async () => {
+      const client = new FakeClient(taskOf({ vendor: "claude" }))
+      await expectApiError(
+        () => invokeVerb("set-effort", ["--task-id", "t1", "--level", "xhigh"], { client, runtime: stubRuntime() }),
+        "BAD_EFFORT",
+        /declares no reasoning effort levels/,
+      )
+      expect(client.requests.map((r) => r.name)).toEqual(["task.get"])
+    })
+  })
+
   it("set-status → task.status with a validated status", async () => {
     const client = new FakeClient({ "task.status": () => ({}) })
     await invokeVerb("set-status", ["--task-id", "t1", "--status", "in_review"], { client, runtime: stubRuntime() })

--- a/packages/kobe/test/client/remote-orchestrator-rpc.test.ts
+++ b/packages/kobe/test/client/remote-orchestrator-rpc.test.ts
@@ -79,6 +79,12 @@ describe("RemoteOrchestrator RPC wire mapping", () => {
     expect(request).toHaveBeenCalledWith("task.setBranch", { taskId: "t1", branch: "feat/x" })
     await orch.setVendor("t1", "codex")
     expect(request).toHaveBeenCalledWith("task.setVendor", { taskId: "t1", vendor: "codex" })
+    // `effort` rides the SAME rpc, and is omitted when the caller has no
+    // opinion so the daemon can tell "keep the level" from "" = clear it.
+    await orch.setVendor("t1", "codex", "xhigh")
+    expect(request).toHaveBeenCalledWith("task.setVendor", { taskId: "t1", vendor: "codex", effort: "xhigh" })
+    await orch.setVendor("t1", "codex", "")
+    expect(request).toHaveBeenCalledWith("task.setVendor", { taskId: "t1", vendor: "codex", effort: "" })
     await orch.setPinned("t1", true)
     expect(request).toHaveBeenCalledWith("task.pin", { taskId: "t1", pinned: true })
     await orch.setStatus("t1", "in_review")

--- a/packages/kobe/test/orchestrator/core-mutations.test.ts
+++ b/packages/kobe/test/orchestrator/core-mutations.test.ts
@@ -92,6 +92,37 @@ describe("setVendor", () => {
   it("throws TaskNotFoundError for an unknown id", async () => {
     await expect(orch.setVendor("nope", "codex")).rejects.toThrow(TaskNotFoundError)
   })
+
+  // `effort` is tri-state on purpose — absent, a level, and "" (clear) are
+  // three different asks, and collapsing any two of them strands a codex task
+  // on whatever level it launched with.
+  it("leaves the recorded level alone when no effort is passed", async () => {
+    const t = await makeTask()
+    await orch.setVendor(t.id, "codex", "xhigh")
+    expect(orch.getTask(t.id)?.modelEffort).toBe("xhigh")
+    await orch.setVendor(t.id, "codex")
+    expect(orch.getTask(t.id)?.modelEffort).toBe("xhigh")
+  })
+
+  it("persists an effort-only change even though the vendor is unchanged", async () => {
+    // The same-vendor early return used to swallow this: a user moving codex
+    // from medium to high changes nothing the store ever sees.
+    const t = await makeTask()
+    await orch.setVendor(t.id, "codex", "medium")
+    await orch.setVendor(t.id, "codex", "high")
+    expect(orch.getTask(t.id)?.modelEffort).toBe("high")
+  })
+
+  it("clears the level on an empty effort, and still no-ops when nothing changes", async () => {
+    const t = await makeTask()
+    await orch.setVendor(t.id, "codex", "high")
+    await orch.setVendor(t.id, "codex", "")
+    expect(orch.getTask(t.id)?.modelEffort).toBeUndefined()
+
+    const before = orch.getTask(t.id)?.updatedAt
+    await orch.setVendor(t.id, "codex", "")
+    expect(orch.getTask(t.id)?.updatedAt).toBe(before)
+  })
 })
 
 describe("setPinned", () => {

--- a/packages/kobe/test/render/engine-picker-dialog.test.tsx
+++ b/packages/kobe/test/render/engine-picker-dialog.test.tsx
@@ -6,21 +6,35 @@
  * The list is rendered from the `engines` prop and the commit indexes back
  * into it, so an off-by-one produces a dialog that looks right and persists
  * the neighbouring engine. Every test asserts the value that came OUT.
+ *
+ * The effort row is the second axis: it exists only for engines that DECLARE
+ * levels (codex), and a level must never ride along with an engine that
+ * declares none — that is the silent drop `withEngineEffort` performs at
+ * launch, and the dialog must not manufacture it.
  */
 
 import { describe, expect, test } from "bun:test"
-import { EnginePickerDialogView } from "../../src/tui-react/component/engine-picker-dialog"
+import { type EnginePickResult, EnginePickerDialogView } from "../../src/tui-react/component/engine-picker-dialog"
 import type { VendorId } from "../../src/types/task"
 import { type RenderHandle, act, renderComponent } from "./harness"
 
 const ENGINES: readonly VendorId[] = ["claude", "codex", "kimi"]
 
-function mount(current: VendorId = "claude"): Promise<RenderHandle> & { picked: VendorId[] } {
-  const picked: VendorId[] = []
+function mount(
+  current: VendorId = "claude",
+  currentEffort?: string,
+): Promise<RenderHandle> & { picked: EnginePickResult[] } {
+  const picked: EnginePickResult[] = []
   const p = renderComponent(
-    <EnginePickerDialogView engines={ENGINES} current={current} onSubmit={(v) => picked.push(v)} onCancel={() => {}} />,
+    <EnginePickerDialogView
+      engines={ENGINES}
+      current={current}
+      currentEffort={currentEffort}
+      onSubmit={(v) => picked.push(v)}
+      onCancel={() => {}}
+    />,
     { providers: { dialog: true } },
-  ) as Promise<RenderHandle> & { picked: VendorId[] }
+  ) as Promise<RenderHandle> & { picked: EnginePickResult[] }
   p.picked = picked
   return p
 }
@@ -36,12 +50,12 @@ describe("EnginePickerDialogView", () => {
   })
 
   test("opens ON the task's current engine — enter alone re-picks it, never a neighbour", async () => {
-    const p = mount("codex")
+    const p = mount("kimi")
     const { frame, mockInput } = await p
     await frame()
     act(() => mockInput.pressEnter())
     await frame()
-    expect(p.picked).toEqual(["codex"])
+    expect(p.picked).toEqual([{ vendor: "kimi" }])
   })
 
   test("down then enter commits the NEXT engine in list order", async () => {
@@ -51,7 +65,7 @@ describe("EnginePickerDialogView", () => {
     act(() => mockInput.pressArrow("down"))
     act(() => mockInput.pressEnter())
     await frame()
-    expect(p.picked).toEqual(["codex"])
+    expect(p.picked).toEqual([{ vendor: "codex", effort: "" }])
   })
 
   test("the cursor clamps at both ends instead of wrapping", async () => {
@@ -62,13 +76,77 @@ describe("EnginePickerDialogView", () => {
     act(() => mockInput.pressArrow("down"))
     act(() => mockInput.pressEnter())
     await frame()
-    expect(p.picked).toEqual(["kimi"])
+    expect(p.picked).toEqual([{ vendor: "kimi" }])
     act(() => mockInput.pressArrow("up"))
     act(() => mockInput.pressArrow("up"))
     act(() => mockInput.pressArrow("up"))
     act(() => mockInput.pressArrow("up"))
     act(() => mockInput.pressEnter())
     await frame()
-    expect(p.picked).toEqual(["kimi", "claude"])
+    expect(p.picked).toEqual([{ vendor: "kimi" }, { vendor: "claude" }])
+  })
+
+  test("an engine with no declared levels renders no effort row at all", async () => {
+    // Claude has no effort flag Rove can drive; offering one would promise a
+    // setting the launch path drops.
+    const p = mount("claude")
+    const { frame } = await p
+    const first = await frame()
+    expect(first).not.toContain("Effort")
+    expect(first).toContain("↑↓ choose")
+  })
+
+  test("codex shows its declared levels, and the footer names the new keys", async () => {
+    const p = mount("codex")
+    const { frame } = await p
+    const first = await frame()
+    expect(first).toContain("Effort")
+    expect(first).toContain("engine default")
+    for (const level of ["low", "medium", "high", "xhigh"]) expect(first).toContain(level)
+    expect(first).toContain("←→ effort")
+  })
+
+  test("right arrow steps the level and enter commits engine + level together", async () => {
+    const p = mount("codex")
+    const { frame, mockInput } = await p
+    await frame()
+    // choices are [engine default, none, low, medium, high, xhigh]
+    for (let i = 0; i < 5; i++) act(() => mockInput.pressArrow("right"))
+    act(() => mockInput.pressEnter())
+    await frame()
+    expect(p.picked).toEqual([{ vendor: "codex", effort: "xhigh" }])
+  })
+
+  test("opens ON the task's recorded level, so enter alone never rewrites it", async () => {
+    const p = mount("codex", "high")
+    const { frame, mockInput } = await p
+    await frame()
+    act(() => mockInput.pressEnter())
+    await frame()
+    expect(p.picked).toEqual([{ vendor: "codex", effort: "high" }])
+  })
+
+  test("a level never rides along to an engine that declares none", async () => {
+    // The task is on codex/xhigh; moving the cursor to kimi must submit no
+    // level rather than a codex level kimi would silently drop.
+    const p = mount("codex", "xhigh")
+    const { frame, mockInput } = await p
+    await frame()
+    act(() => mockInput.pressArrow("down"))
+    act(() => mockInput.pressEnter())
+    await frame()
+    expect(p.picked).toEqual([{ vendor: "kimi" }])
+  })
+
+  test("stepping left off the first level lands on the engine default, which clears it", async () => {
+    const p = mount("codex", "low")
+    const { frame, mockInput } = await p
+    await frame()
+    act(() => mockInput.pressArrow("left"))
+    act(() => mockInput.pressArrow("left"))
+    act(() => mockInput.pressEnter())
+    await frame()
+    // `""` is the wire spelling of "clear the level", distinct from absent.
+    expect(p.picked).toEqual([{ vendor: "codex", effort: "" }])
   })
 })

--- a/packages/kobe/test/tui/task-actions-rename.test.ts
+++ b/packages/kobe/test/tui/task-actions-rename.test.ts
@@ -208,7 +208,9 @@ describe("cycleVendorFlow", () => {
 
     // account-detect is mocked to ["claude", "codex"] — cycling from claude
     // lands on codex.
-    expect(orch.setVendor).toHaveBeenCalledWith("t1", "codex")
+    // `undefined` effort = the cycle chord has no opinion on the reasoning
+    // level, so the task keeps the one it has.
+    expect(orch.setVendor).toHaveBeenCalledWith("t1", "codex", undefined)
     expect(notifyInfo).toHaveBeenCalledWith(expect.stringContaining("applies on reopen"))
     expect(reload).toHaveBeenCalledTimes(1)
   })


### PR DESCRIPTION
## What / why

`docs/ENGINES.md` documents codex's five reasoning levels and the launch path
honours `task.modelEffort`, but the only surface that could SET one was the web
dashboard's create-time picker. A codex task started at the default was stuck
there for life: no TUI control, no `rove api` verb.

Two routes now set it on an existing task:

- **Row menu → Change engine.** The dialog renders a level row under the engine
  list when the engine under the cursor DECLARES levels (`effortLevels` in the
  registry — codex today). `←→` picks one, `engine default` clears it. Engines
  that declare none render no row at all, matching the web picker's rule.
- **`rove api set-effort --task-id ID --level LEVEL`.** Validated against the
  task's OWN engine, resolved the same way the launcher resolves it (a pinned
  `--command "codex --search"` is a codex launch). A level the engine does not
  declare is rejected instead of passed through — `withEngineEffort` drops an
  unknown level silently, which is how a user picks "high" and gets the default.

The level rides the existing `task.setVendor` RPC as one optional field. It is
tri-state on purpose: absent keeps the recorded level, `""` clears it, any other
string sets it. Collapsing any two of those makes the "engine default" choice
impossible, and the same-vendor early return in `setVendor` had to stop
swallowing an effort-only change (medium → high on codex is a real change).

## Pass criteria — real output

Against an isolated scratch home (`.scratch/set-effort/home`, own daemon +
PTY socket), on a codex task:

```console
$ rove api set-effort --task-id 01M1GC23YT68ZMSGCSDFYCMD1J --level xhigh
{"ok":true,"taskId":"01M1GC23YT68ZMSGCSDFYCMD1J","engine":"codex","effort":"xhigh"}
exit=0

$ rove api get-task --task-id 01M1GC23YT68ZMSGCSDFYCMD1J   # .task.modelEffort
xhigh

$ rove api set-effort --task-id 01M1GC23YT68ZMSGCSDFYCMD1J --level turbo
{"error":{"message":"engine codex does not accept effort level \"turbo\" — it declares none, low, medium, high, xhigh","code":"BAD_EFFORT","engine":"codex","levels":["none","low","medium","high","xhigh"],"hint":"Pass one of: none, low, medium, high, xhigh."}}
exit=1

$ rove api set-effort --task-id <a claude task> --level xhigh
{"error":{"message":"engine claude declares no reasoning effort levels","code":"BAD_EFFORT","engine":"claude","hint":"Only engines with declared levels accept one (codex today). Check the task's engine with `get-task`.","nextCommandArgs":["api","get-task","--task-id","01M1GC2QAYTAN5GB7WEEZ2B54Z"]}}
exit=1
```

Then the session was actually launched in that scratch home and its live argv
read back — the level reaches the process, not just the store:

```console
$ rove api pty-list
"command": ["/bin/zsh","-ilc","… codex -c model_reasoning_effort=xhigh -c 'tui.terminal_title=[\"activity\",\"thread-title\"]' hi; …"]
```

## Screenshots (harness, isolated home on port base 5893)

Same fixture task (codex, level `high`), same dialog; the only difference is the
new row. The "before" shot swaps ONLY `engine-picker-dialog.tsx` back to
`origin/main`.

- before: `/Users/jacksonc/.rove/worktrees/kobe-0aff3858ab76/crayfish/.scratch/set-effort/shots/before-no-effort-row.png`
- after: `/Users/jacksonc/.rove/worktrees/kobe-0aff3858ab76/crayfish/.scratch/set-effort/shots/after-effort-row.png`

## One deviation from the brief

`--level` is a `string` flag, not an `enum`. Effort levels are declared PER
ENGINE (including by plugin engines a static list cannot see), so a spec-level
enum built from today's built-ins would refuse a level some future engine
declares — the same open-set reasoning `F.vendor()` documents. The handler
checks against the task's own engine, which is the only authoritative list, and
its rejection names those levels.

## Gates

- `bun run lint` (repo root) clean; `tsc --noEmit` clean in both packages;
  `check-i18n` OK (729 keys × 2 locales).
- `bun test test/render` 388 pass; `bun run test:socket` 692 pass.
- `bun run test:fast`: the only failures are the 4 known `roveInternal`
  path-shape ones that fail for any branch run from `~/.rove/worktrees`
  (`project-eligibility`, `open-dir-cmd`) — untouched by this diff.
- New coverage: 6 render cases on the effort row (including "a level never
  rides along to an engine that declares none"), 4 CLI cases on `set-effort`,
  3 orchestrator cases pinning the tri-state write, RPC payload assertions.


## File-size cap

file-size-exemption: packages/kobe/src/client/remote-orchestrator.ts — 501 lines, one over, from a single wrapped signature (`setVendor` gained `effort?: string` and no longer fits on one line at 120 cols). The file's seams are already extracted — connect, events, payloads, writes, and reads each live in their own module, as its header records. What remains is the facade class itself, which must name every method it forwards; splitting that is splitting the public shape, not finding a seam.
