### PR TITLE
fix: i18n key guard scans tui-react, so the Kanban badge stops painting a raw key

### DIFF
--- a/.changeset/i18n-key-guard-covers-tui-react.md
+++ b/.changeset/i18n-key-guard-covers-tui-react.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+The Kanban card's activity badge showed the raw key `tasks.status.working` instead of "working" while a linked task's engine was mid-turn, crowding the card's created date off the row. The badge now points at `tasks.activity.working`, which exists in both locales, and the pages that showed `common.loading` while their data loaded render a real string too. The CI guard that catches an i18n key missing from every catalog only walked `src/tui`, so the whole React UI could ship keys with no catalog entry — it now scans `src/tui-react` as well, and reads `labelKey:` lookup tables, which is how the Kanban badge slipped past a literal-only scan.

--- a/packages/kobe/src/tui-react/component/kanban-card.tsx
+++ b/packages/kobe/src/tui-react/component/kanban-card.tsx
@@ -25,7 +25,7 @@ import { FRAME } from "../ui/frame"
 const ACTIVITY_BADGE: Partial<
   Record<TaskActivityState, { labelKey: string; tone: "accent" | "warning" | "error" | "success" }>
 > = {
-  running: { labelKey: "tasks.status.working", tone: "accent" },
+  running: { labelKey: "tasks.activity.working", tone: "accent" },
   turn_complete: { labelKey: "kanban.turnComplete", tone: "success" },
   rate_limited: { labelKey: "tasks.activity.rateLimited", tone: "warning" },
   permission_needed: { labelKey: "tasks.activity.permissionNeeded", tone: "warning" },

--- a/packages/kobe/src/tui/i18n/messages/common.ts
+++ b/packages/kobe/src/tui/i18n/messages/common.ts
@@ -5,6 +5,8 @@
 
 export const en = {
   cancel: "Cancel",
+  /** Placeholder text a page shows while its data is still null. */
+  loading: "Loading…",
   /** Footer verb for a step that leads to another prompt. */
   create: "create",
   confirm: "Confirm",
@@ -31,6 +33,7 @@ export const en = {
 
 export const zh: typeof en = {
   cancel: "取消",
+  loading: "加载中…",
   create: "创建",
   confirm: "确认",
   paneCrash: {

--- a/packages/kobe/src/tui/i18n/messages/tasks.ts
+++ b/packages/kobe/src/tui/i18n/messages/tasks.ts
@@ -111,6 +111,8 @@ export const en = {
   },
   /** Row-view engine activity labels (shown in subtitle, override branch) */
   activity: {
+    /** A turn is in flight — the engine is producing output right now. */
+    working: "working",
     rateLimited: "rate limited",
     permissionNeeded: "needs permission",
     error: "error",
@@ -230,6 +232,7 @@ export const zh: typeof en = {
     noActive: "暂无活跃任务——在上方新建。",
   },
   activity: {
+    working: "运行中",
     rateLimited: "请求受限",
     permissionNeeded: "等待授权",
     error: "错误",

--- a/packages/kobe/test/tui/i18n-key-resolution.test.ts
+++ b/packages/kobe/test/tui/i18n-key-resolution.test.ts
@@ -9,9 +9,11 @@
  * fallback is meant to make loud, surfaced one layer too late (at runtime, in
  * front of the user, instead of in CI).
  *
- * This scans `src/tui/**` for the i18n call sites and fails on any key that
- * doesn't resolve in English:
- *   - literal `t("…")` / `t('…')` calls, and
+ * This scans `src/tui/**` and `src/tui-react/**` for the i18n call sites and
+ * fails on any key that doesn't resolve in English:
+ *   - literal `t("…")` / `t('…')` calls,
+ *   - `labelKey: "…"` table entries, whose `t(row.labelKey)` call site has no
+ *     literal of its own, and
  *   - the two enumerable dynamic `t()` template families
  *     (`settings.sections.<id>` and `settings.general.accent<Slot>`), checked
  *     against their runtime value sets so a new section / accent slot can't
@@ -30,7 +32,12 @@ import { SECTIONS } from "../../src/tui/component/settings-dialog/model"
 import { en } from "../../src/tui/i18n/catalog"
 import { UI_PREFS_FOCUS_ACCENT_SLOTS } from "../../src/tui/lib/apply-ui-prefs"
 
-const TUI_ROOT = fileURLToPath(new URL("../../src/tui", import.meta.url))
+const SRC_ROOT = fileURLToPath(new URL("../../src", import.meta.url))
+
+/** Both TUI trees: the legacy `src/tui` (which still owns the i18n catalog and
+ *  the dialogs) and `src/tui-react`, the active React UI. Scanning only the
+ *  first let `tui-react` ship keys with no catalog entry. */
+const TUI_ROOTS = [join(SRC_ROOT, "tui"), join(SRC_ROOT, "tui-react")]
 
 /** Top-level catalog namespaces — a literal `t()` key starting with one of
  *  these is unambiguously an i18n key (and not some other `t(`-shaped call). */
@@ -66,18 +73,27 @@ function listSources(dir: string, acc: string[] = []): string[] {
  *  call. `\bt\(` ignores `tKeys(` (no `t(` boundary) and `format(` (`t` mid-word). */
 const T_CALL_RE = /\bt\(\s*["']([^"'\n]+)["']/g
 
-/** Every literal i18n key referenced under `src/tui`, with the files using it. */
+/** Keys parked in a lookup table and passed to `t()` indirectly — e.g. the
+ *  Kanban card's `ACTIVITY_BADGE[state].labelKey`, whose `t(badge.labelKey)`
+ *  call site carries no literal for `T_CALL_RE` to see. */
+const LABEL_KEY_RE = /\blabelKey:\s*["']([^"'\n]+)["']/g
+
+/** Every literal i18n key referenced under the TUI trees, with the files using it. */
 function collectLiteralKeys(): Map<string, string[]> {
   const keyToFiles = new Map<string, string[]>()
-  for (const file of listSources(TUI_ROOT)) {
-    const source = readFileSync(file, "utf8")
-    const rel = file.slice(TUI_ROOT.length + 1)
-    for (const match of source.matchAll(T_CALL_RE)) {
-      const key = match[1] as string
-      if (!isI18nKey(key)) continue
-      const files = keyToFiles.get(key) ?? []
-      if (!files.includes(rel)) files.push(rel)
-      keyToFiles.set(key, files)
+  for (const root of TUI_ROOTS) {
+    for (const file of listSources(root)) {
+      const source = readFileSync(file, "utf8")
+      const rel = file.slice(SRC_ROOT.length + 1)
+      for (const re of [T_CALL_RE, LABEL_KEY_RE]) {
+        for (const match of source.matchAll(re)) {
+          const key = match[1] as string
+          if (!isI18nKey(key)) continue
+          const files = keyToFiles.get(key) ?? []
+          if (!files.includes(rel)) files.push(rel)
+          keyToFiles.set(key, files)
+        }
+      }
     }
   }
   return keyToFiles


### PR DESCRIPTION
## What / why

`test/tui/i18n-key-resolution.test.ts` exists to catch a `t()` key that is missing from **both** catalogs — the case catalog parity structurally cannot see, where `t()` falls back to painting the raw dotted key. Its root was `src/tui`, so `src/tui-react` — the active React UI — was never scanned, and three call sites there referenced keys with no catalog entry.

The visible one: `ACTIVITY_BADGE.running.labelKey` in `kanban-card.tsx` was `"tasks.status.working"`. `tasks.status` holds only the six `TaskStatus` values; the engine-activity siblings live under `tasks.activity`. A card linked to a task mid-turn rendered `2026-07-tasks.status.worki` — the raw key also crowds out the created date, since both `<text>` are `wrapMode="none"` in a `space-between` row. `common.loading` was missing outright (`automations-page.tsx`, `work-items-page.tsx`).

That badge case is also why widening the root alone is not enough: the call site is `t(badge.labelKey)`, with the literal parked in a lookup table. The scan now reads `labelKey: "…"` entries too.

Changes:
- `tasks.activity.working` + `common.loading` added to both locales; badge repointed at `tasks.activity.working`.
- Guard scans `src/tui` **and** `src/tui-react`, and captures `labelKey:` table entries.
- `scripts/check-i18n.ts` untouched — it is a catalog-parity check by design.

The widened scan surfaced exactly these two keys and no others; nothing is allowlisted.

## Pass criteria — commands run and real output

```
$ env -u ROVE_INVOKED_AS bun x vitest run test/tui/i18n-key-resolution.test.ts test/tui/i18n-catalog.test.ts
 ✓ test/tui/i18n-catalog.test.ts (6 tests) 5ms
 ✓ test/tui/i18n-key-resolution.test.ts (3 tests) 53ms
 Test Files  2 passed (2)
      Tests  9 passed (9)

$ bun run check-i18n
i18n check OK — 737 keys × 2 locales in sync

$ bun x tsc --noEmit          # exit 0
$ bun run lint                # Checked 1329 files in 737ms. No fixes applied.
$ bun test test/render        # 379 pass, 0 fail (89 files)
$ bun run test:fast           # 4143 passed, 4 failed
```

The 4 `test:fast` failures are `test/cli/open-dir-cmd.test.ts` (2) and `test/state/project-eligibility.test.ts` (2) — untouched files that fail for anyone running the suite from inside `~/.rove/worktrees`, because project-eligibility classifies a path as rove-internal by its shape. Not reachable from this diff; CI runs outside that tree.

### Mutation check (two different sites, both red, then restored green)

```
# A — repoint the labelKey back (proves LABEL_KEY_RE fires at all)
+   "tasks.status.working (used in tui-react/component/kanban-card.tsx)",
      Tests  1 failed | 2 passed (3)

# B — drop common.loading from the catalog (proves the tui-react root is scanned)
+   "common.loading (used in tui-react/component/automations-page.tsx, tui-react/component/work-items-page.tsx)",
      Tests  1 failed | 2 passed (3)

# restored
      Tests  3 passed (3)
```

## Screenshots

Harness `/harness` → xterm → PTY → real OpenTUI, isolated home at `.scratch/opentui-visual-5373` (`KOBE_VISUAL_PORT_BASE=5373`). The `running` state is real: a `rove hook turn-start` replayed against the fixture's own daemon while the shot was in flight. BEFORE differs from AFTER by exactly one line — the `labelKey` — everything else identical.

- BEFORE: `/Users/jacksonc/i/kobe/.scratch/i18n-key-guard/before-kanban-raw-key.png` — card #2 reads `2026-07-tasks.status.worki`
- AFTER: `/Users/jacksonc/i/kobe/.scratch/i18n-key-guard/after-kanban-working-badge.png` — card #2 reads `2026-07-15` plus a `working` badge


---

Rebased onto `origin/main` (0.9.81) after the first push. One conflict, in `common.ts`: upstream removed `common.next`, my commit added `common.loading` next to it — resolved by keeping the removal and my addition. Every command and mutation check above was re-run on the rebased tree; the two mutation sites are still red and still restore green.
