### PR TITLE
fix: rove api reaches the six shipped contrib engines

### DIFF
--- a/.changeset/contrib-engines-reach-the-api.md
+++ b/.changeset/contrib-engines-reach-the-api.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+`rove api` now reaches the six shipped contrib engines. `engine-list` lists Gemini CLI, OpenCode, Cursor Agent, Grok CLI, Droid and Amp whenever their CLI is on `PATH` — the same set Settings → Engines already offered — and `add --command opencode` / `set-command --command cursor` record that engine's protocol instead of falling through to `generic`, so an agent-dispatched fleet gets the activity badges a hand-picked one already had. Existing tasks already recorded as `generic` keep that value; re-run `set-command` to move one over.

--- a/docs/API.md
+++ b/docs/API.md
@@ -78,8 +78,10 @@ spec, and unknown flags are rejected (exit 2). `--repo` resolves relative
 paths against `$PWD` (`~` expanded). `spawn-task` is an alias of `add`.
 
 Engines are chosen by COMMAND, not by a vendor enum: `--command` takes an
-engine id from `engine-list` (`claude`, `codex`, `copilot`, `kimi`, plus any
-engine you registered) **or** a full command line Rove runs verbatim
+engine id from `engine-list` (`claude`, `codex`, `copilot`, `kimi`, the shipped
+contrib engines whose CLI is installed — `gemini`, `opencode`, `cursor`,
+`grok`, `droid`, `amp` — plus any engine you registered) **or** a full command
+line Rove runs verbatim
 (`--command "codex --search"`). Nothing validates an engine's flags, so probe
 an unfamiliar one with `<cmd> --help` before dispatching. See
 [ENGINES.md](./ENGINES.md#engine-presets-and-protocols) for how the protocol
@@ -95,8 +97,10 @@ replacement in `nextCommandArgs`.
   (groups + verb summaries, no flags); drill in with `--verb <name>` (full
   flag detail for one verb), `--group <g>`, or `--all` (everything; large).
   Includes an `apiVersion` agents can gate on.
-- `engine-list` *(offline)*: every engine Rove can launch — built-ins, your
-  registered presets, and engines contributed by enabled plugins — each with
+- `engine-list` *(offline)*: every engine Rove can launch — the same set the
+  TUI's engine pickers offer: built-ins, your registered presets, the shipped
+  contrib engines whose CLI is on `PATH`, and engines contributed by enabled
+  plugins — each with
   the RAW command it runs, its display
   name, and its `protocol` (the adapter Rove speaks to it: history reads,
   trust pre-answer, first-message delivery; `generic` = none). What it

--- a/docs/ENGINES.md
+++ b/docs/ENGINES.md
@@ -224,9 +224,9 @@ Rove separates two things a "vendor" used to conflate:
 
 The protocol is **derived** from the command, never declared beside it:
 
-1. `argv[0]` names a registered preset (built-in or yours) → that preset's
-   protocol. Deterministic, and it answers before anything spawns. This is
-   the normal path.
+1. `argv[0]` names a preset — a built-in, a contrib engine from the table
+   above, or one of yours → that preset's protocol. Deterministic, and it
+   answers before anything spawns. This is the normal path.
 2. Otherwise Rove can recognise a known engine binary through wrappers
    (`env FOO=1 claude`, `node …/codex.js`), the same walk the process probe
    uses at runtime.

--- a/packages/kobe/src/cli/api/handlers-engines.ts
+++ b/packages/kobe/src/cli/api/handlers-engines.ts
@@ -18,8 +18,13 @@
  */
 
 import type { SerializedTask } from "@sma1lboy/kobe-daemon/daemon/protocol"
-import { pluginEngineIds } from "../../engine/contrib-engines.ts"
-import { GENERIC_PROTOCOL, listEnginePresets, resolveCommandProtocol } from "../../engine/engine-presets.ts"
+import { installedEngineIds } from "../../engine/account-detect.ts"
+import {
+  GENERIC_PROTOCOL,
+  describePreset,
+  listEnginePresets,
+  resolveCommandProtocol,
+} from "../../engine/engine-presets.ts"
 import { loadPluginEngines } from "../../engine/plugin-engines.ts"
 import { engineEntry } from "../../engine/registry.ts"
 import { type VendorId, coerceVendorId } from "../../types/vendor.ts"
@@ -27,20 +32,23 @@ import { F } from "./flags.ts"
 import { daemonOf, simpleRpc } from "./handler-helpers.ts"
 import { ApiError, type VerbContext, type VerbSpec } from "./types.ts"
 
-function listAllEnginePresets() {
+/**
+ * The same engines the TUI's pickers offer: `listEnginePresets()` (built-ins +
+ * registered custom presets) widened with everything else
+ * `installedEngineIds()` finds — the shipped contrib engines whose binary is
+ * on PATH, and every plugin-contributed engine. One list, so `engine-list` and
+ * Settings → Engines cannot disagree about what Rove can launch; a contrib
+ * engine `engine-list` could not name was dispatched as `generic` and lost its
+ * activity badges.
+ */
+async function listAllEnginePresets() {
   // Plugin-contributed engines are loaded from enabled plugin manifests at
   // process start in the TUI, but the CLI path must load them explicitly.
   loadPluginEngines()
   const presets = [...listEnginePresets()]
-  for (const id of pluginEngineIds()) {
-    const entry = engineEntry(id as VendorId)
-    presets.push({
-      id,
-      name: entry.displayName,
-      command: entry.defaultCommand.join(" "),
-      protocol: GENERIC_PROTOCOL,
-      builtin: false,
-    })
+  const seen = new Set(presets.map((p) => p.id))
+  for (const id of await installedEngineIds()) {
+    if (!seen.has(id)) presets.push(describePreset(id))
   }
   return presets
 }
@@ -49,11 +57,11 @@ export const ENGINE_LIST_VERB: VerbSpec = {
   name: "engine-list",
   group: "discover",
   summary:
-    "List every engine Rove can launch — built-ins, registered presets, and engines contributed by enabled plugins — each with its RAW launch command, exactly as it runs. Copy one into `add --command` / `send --tab new --command` verbatim, or edit its flags first. `protocol` is the adapter Rove speaks to it (history, trust, delivery); `generic` = none, which still runs fine but loses transcript reads. Returns { engines }.",
+    "List every engine Rove can launch — built-ins, registered presets, the shipped contrib engines whose CLI is on PATH (gemini, opencode, cursor, grok, droid, amp), and engines contributed by enabled plugins — each with its RAW launch command, exactly as it runs. Copy one into `add --command` / `send --tab new --command` verbatim, or edit its flags first. `protocol` is the adapter Rove speaks to it (history, trust, delivery); `generic` = none, which still runs fine but loses transcript reads. Returns { engines }.",
   flags: [],
   // Presets live in state.json + plugin manifests, not the daemon — no RPC, no daemon needed.
   offline: true,
-  handler: async () => ({ engines: listAllEnginePresets() }),
+  handler: async () => ({ engines: await listAllEnginePresets() }),
 }
 
 export async function setCommand(ctx: VerbContext): Promise<unknown> {

--- a/packages/kobe/src/engine/engine-presets.ts
+++ b/packages/kobe/src/engine/engine-presets.ts
@@ -33,6 +33,7 @@ import { randomUUID } from "node:crypto"
 import { engineEntry } from "@/engine/registry"
 import { getCustomEngineIds, getPersistedString } from "@/state/repos"
 import { BUILTIN_VENDORS, type VendorId, isBuiltinVendor } from "@/types/vendor"
+import { isContribEngine } from "./contrib-engines.ts"
 import { vendorFromArgv } from "./foreground.ts"
 import {
   defaultEngineCommand,
@@ -71,16 +72,23 @@ export function engineProtocolKey(id: string): string {
   return `engineProtocol.${id}`
 }
 
-/** A preset's declared protocol, or undefined (built-ins ARE their protocol). */
+/**
+ * A preset's declared protocol, or undefined.
+ *
+ * Built-ins and contrib engines ARE their own protocol: each has a registry
+ * entry carrying the knowledge a protocol names (a screen manifest, for a
+ * contrib engine), so answering `generic` for `opencode` would throw away
+ * the badge rules `engineEntry("opencode")` already holds.
+ */
 export function getEngineProtocol(id: string): VendorId | undefined {
-  if (isBuiltinVendor(id)) return id
+  if (isBuiltinVendor(id) || isContribEngine(id)) return id
   const raw = getPersistedString(engineProtocolKey(id))?.trim()
   return raw && ENGINE_PROTOCOLS.includes(raw) ? raw : undefined
 }
 
 /** True when `id` names an engine kobe can launch by NAME alone. */
 export function isPresetId(id: string): boolean {
-  return isBuiltinVendor(id) || getCustomEngineIds().includes(id)
+  return isBuiltinVendor(id) || isContribEngine(id) || getCustomEngineIds().includes(id)
 }
 
 /** Every registered engine id, built-ins first. */

--- a/packages/kobe/test/engine/engine-presets.test.ts
+++ b/packages/kobe/test/engine/engine-presets.test.ts
@@ -12,7 +12,13 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { afterEach, beforeEach, describe, expect, it } from "vitest"
-import { engineCanFork, engineForkArgv, engineLaunchArgv } from "../../src/engine/engine-presets.ts"
+import {
+  GENERIC_PROTOCOL,
+  engineCanFork,
+  engineForkArgv,
+  engineLaunchArgv,
+  resolveCommandProtocol,
+} from "../../src/engine/engine-presets.ts"
 
 let home: string
 let originalHome: string | undefined
@@ -142,5 +148,32 @@ describe("fork through a declared protocol", () => {
     })
     expect(engineCanFork("mykimi")).toBe(false)
     expect(engineForkArgv(["kimi-wrapper"], "mykimi", "src")).toBeNull()
+  })
+})
+
+// Why: the six shipped contrib engines (`contrib-engines.ts`) each carry a
+// screen manifest, which is exactly the badge knowledge a protocol names —
+// but resolution only consulted the built-in and custom registries, so
+// `rove api add --command opencode` recorded `generic` and the task's
+// activity monitor read "unknown" forever. The TUI's own engine picker never
+// had this gap, so an agent-dispatched fleet was badge-blind while a
+// hand-picked one was not.
+describe("contrib engines resolve as their own protocol", () => {
+  it("names a bare contrib id instead of falling through to generic", () => {
+    expect(resolveCommandProtocol("opencode")).toBe("opencode")
+    expect(resolveCommandProtocol("cursor")).toBe("cursor")
+    expect(resolveCommandProtocol("gemini")).toBe("gemini")
+  })
+
+  it("launches a contrib id through its catalog command, honouring an override", () => {
+    // `cursor` launches `cursor-agent` — the id is not the binary, so a
+    // verbatim argv split would run a binary that does not exist.
+    expect(engineLaunchArgv({ command: "cursor" })).toEqual(["cursor-agent"])
+    writeState({ "engineCommand.opencode": "opencode --model sonnet" })
+    expect(engineLaunchArgv({ command: "opencode" })).toEqual(["opencode", "--model", "sonnet"])
+  })
+
+  it("still answers generic for a command that names no engine", () => {
+    expect(resolveCommandProtocol("some-random-agent --go")).toBe(GENERIC_PROTOCOL)
   })
 })


### PR DESCRIPTION
## What

`rove api` could not name the six shipped contrib engines. `resolveCommandProtocol()` consulted `isPresetId()` (built-ins + `customEngineIds`), then the argv walk, then custom presets — never the contrib catalog — so every id in `CONTRIB_ENGINE_IDS` (gemini, opencode, cursor, grok, droid, amp) fell through to `GENERIC_PROTOCOL`. `listAllEnginePresets()` had the same blind spot, appending `pluginEngineIds()` but not the contrib ids.

Downstream that made an agent-dispatched fleet badge-blind: `engineEntry("generic")` carries zero screen rules while `engineEntry("opencode")` carries three, so `activity-monitor.ts` returned `"unknown"` forever. The TUI never had the gap — Settings → Engines, the Change-engine dialog and the issue-intake picker all offered these engines, and `applyVendorChange` persisted `vendor: "opencode"` with its manifest intact.

## Why this shape

A contrib engine already carries a registry entry with the knowledge a protocol names, so it **is** its own protocol — the same rule built-ins follow. That is one branch in `getEngineProtocol()` / `isPresetId()`, and it fixes `add`, `send --tab new`, and `set-command` at once because all three route through `resolveCommandProtocol`.

`engine-list` now answers from `installedEngineIds()` — the list Settings → Engines already builds — instead of a second hand-maintained union, so the two surfaces cannot drift again. That also replaces the open-coded plugin-engine loop.

Two side-effects worth naming: `--command cursor` now launches `cursor-agent` (the catalog command) rather than a nonexistent `cursor` binary, and an `engineCommand.opencode` override set in Settings now reaches an API-dispatched task.

## Decision (per brief)

No migration: tasks already recorded as `generic` keep that value until re-set. Stated in the changeset.

## Pass criteria — real output

Unit test (`packages/kobe`):

```
$ env -u ROVE_INVOKED_AS bun x vitest run test/engine/engine-presets.test.ts
 ✓ test/engine/engine-presets.test.ts (15 tests) 42ms
 Test Files  1 passed (1)
      Tests  15 passed (15)
```

Mutation check — reverting the contrib branch in `getEngineProtocol`/`isPresetId`:

```
     → expected 'generic' to be 'opencode' // Object.is equality
     → expected [ 'cursor' ] to deeply equal [ 'cursor-agent' ]
      Tests  2 failed | 13 passed (15)
```

API before/after against a scratch home with stub `opencode` + `cursor-agent` on PATH:

```
BEFORE  engine-list
  claude | codex | copilot | kimi

AFTER   engine-list
  claude | codex | copilot | kimi
  {"id":"opencode","name":"OpenCode","command":"opencode","protocol":"opencode","builtin":false}
  {"id":"cursor","name":"Cursor Agent","command":"cursor-agent","protocol":"cursor","builtin":false}

BEFORE  add --command opencode   → {"vendor": "generic",  "command": "opencode"}
AFTER   add --command opencode   → {"vendor": "opencode", "command": "opencode"}

BEFORE  set-command --command opencode → {"ok":true,"command":"opencode","protocol":"generic","generic":true}
AFTER   set-command --command opencode → {"ok":true,"command":"opencode","protocol":"opencode"}
```

Gates:

```
$ bun run lint                      # repo root
Checked 1330 files in 1390ms. No fixes applied.

$ bun x tsc --noEmit                # packages/kobe — exit 0

$ bun run test:fast
 Test Files  2 failed | 421 passed (423)
      Tests  4 failed | 4146 passed (4150)
```

The 4 failures are the documented path-shape false failures from running inside `~/.rove/worktrees` (`test/state/project-eligibility.test.ts` ×2, `test/cli/open-dir-cmd.test.ts` ×2 — both assert a checkout path is project-eligible, which this worktree's location denies). Proven pre-existing: with only my two `src/` files reverted to `HEAD`, `open-dir-cmd.test.ts` still reports `Tests 2 failed | 16 passed (18)`.

## Screenshots

Real OpenTUI through the `/harness` → xterm → PTY path, isolated fixture at `KOBE_VISUAL_PORT_BASE=5373`, rebuilt `--fresh` between the two shots. Both ran the same command — `rove api add --command opencode --prompt hello --activate` — against the fixture daemon; only the built `dist` differs.

- BEFORE — sidebar tab reads `generic 1`: `/Users/jacksonc/i/kobe/.scratch/contrib-engines/before-sidebar.png`
- AFTER — same tab reads `opencode 1`: `/Users/jacksonc/i/kobe/.scratch/contrib-engines/after-sidebar.png`

(The engine pane shows a shell error in both: the fixture PATH has no real `opencode`. The tab label comes from the recorded vendor, which is the thing under test.)
