### PR TITLE
fix: engineProtocol reaches trust, first-message delivery and history

### DIFF
--- a/.changeset/engine-protocol-trust-delivery-history.md
+++ b/.changeset/engine-protocol-trust-delivery-history.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+A custom engine's `engineProtocol.<id>` now reaches workspace trust, first-message delivery and the transcript reader, not just session pinning. A preset declaring the claude protocol reads its history again (so `ctrl+a c` can fork and `rove api read-output --source history` returns real entries) and gets its worktree pre-trusted instead of stopping at claude's trust dialog. A preset declaring the kimi protocol now gets its first message pasted after launch rather than appended to argv, where kimi read it as an unknown subcommand and exited.

--- a/packages/kobe/src/cli/api/read-output.ts
+++ b/packages/kobe/src/cli/api/read-output.ts
@@ -35,8 +35,8 @@
  */
 
 import type { PtyPeekResult, SerializedTask } from "@sma1lboy/kobe-daemon/daemon/protocol"
-import { engineLaunchArgv } from "../../engine/engine-presets.ts"
-import { type EngineHistoryReader, engineEntry, supportsStructuredHistory } from "../../engine/registry.ts"
+import { engineLaunchArgv, protocolEntry, sessionProtocol } from "../../engine/engine-presets.ts"
+import { type EngineHistoryReader, supportsStructuredHistory } from "../../engine/registry.ts"
 import type { Message } from "../../types/engine.ts"
 import type { VendorId } from "../../types/vendor.ts"
 import { daemonOf } from "./handler-helpers.ts"
@@ -360,7 +360,7 @@ async function handleReadOutput(ctx: VerbContext): Promise<unknown> {
   const vendor = task.vendor as VendorId | undefined
   const tab = ctx.args.str("tab")
   const deps: ReadOutputDeps = {
-    history: vendor && supportsStructuredHistory(vendor) ? engineEntry(vendor).history : null,
+    history: vendor && supportsStructuredHistory(sessionProtocol(vendor)) ? protocolEntry(vendor).history : null,
     peekTerminal: (tabId, sinceOffset) => peekTaskTerminal(taskId, vendor, tabId, sinceOffset),
   }
   const envelope = await readTaskOutput(

--- a/packages/kobe/src/engine/engine-presets.ts
+++ b/packages/kobe/src/engine/engine-presets.ts
@@ -30,7 +30,7 @@
  */
 
 import { randomUUID } from "node:crypto"
-import { engineEntry } from "@/engine/registry"
+import { type EngineRegistryEntry, engineEntry } from "@/engine/registry"
 import { getCustomEngineIds, getPersistedString } from "@/state/repos"
 import { BUILTIN_VENDORS, type VendorId, isBuiltinVendor } from "@/types/vendor"
 import { vendorFromArgv } from "./foreground.ts"
@@ -215,6 +215,23 @@ export function sessionProtocol(vendor: VendorId | undefined): VendorId {
   const id = vendor?.trim()
   if (!id) return "claude"
   return getEngineProtocol(id) ?? id
+}
+
+/**
+ * The registry entry whose PROTOCOL behaviour applies to `vendor` — its
+ * declared `engineProtocol.<id>` when it is a custom preset, else its own.
+ *
+ * `engineEntry(vendor)` answers "what IS this engine" (display name, default
+ * command) and must stay keyed on the raw id. This answers "how do we TALK to
+ * it": the transcript reader, the workspace-trust store and first-message
+ * delivery are all the wrapped engine's, exactly as `docs/ENGINES.md`
+ * promises. Keying those off the raw id found the empty custom entry, so a
+ * `claudecpa` preset read no history, got the trust dialog Rove is supposed
+ * to pre-answer, and — for a kimi-protocol preset — took the first message on
+ * argv, which kills the launch.
+ */
+export function protocolEntry(vendor: VendorId | undefined): EngineRegistryEntry {
+  return engineEntry(sessionProtocol(vendor))
 }
 
 /**

--- a/packages/kobe/src/engine/session-discovery.ts
+++ b/packages/kobe/src/engine/session-discovery.ts
@@ -15,15 +15,15 @@
  * question actually being asked, and every engine can answer it.
  */
 
-import { type VendorId, coerceVendorId } from "../types/vendor.ts"
-import { engineEntry } from "./registry.ts"
+import type { VendorId } from "../types/vendor.ts"
+import { protocolEntry } from "./engine-presets.ts"
 import { pickUnclaimedSessionId } from "./session-identity.ts"
 
 /** Session ids this engine recorded for `worktree`, oldest-first; `[]` on error. */
 async function sessionIds(vendor: VendorId | undefined, worktree: string): Promise<readonly string[]> {
   if (!worktree) return []
   try {
-    return await engineEntry(coerceVendorId(vendor)).history.listSessionIdsForWorktree(worktree)
+    return await protocolEntry(vendor).history.listSessionIdsForWorktree(worktree)
   } catch {
     // Readers are best-effort by contract; an unreadable store is "no
     // evidence", never an error the tab has to handle.

--- a/packages/kobe/src/engine/session-launch.ts
+++ b/packages/kobe/src/engine/session-launch.ts
@@ -3,8 +3,8 @@ import { worktreeInitMarkerPath } from "../env.ts"
 import { quoteShellArg, quoteShellArgv } from "../lib/shell-command.ts"
 import { readFieldNotes } from "../state/field-notes.ts"
 import { type PromptDeliveryIntent, resolveEngineLaunchInit } from "../state/repo-init.ts"
-import { type VendorId, coerceVendorId } from "../types/vendor.ts"
-import { engineEntry } from "./registry.ts"
+import type { VendorId } from "../types/vendor.ts"
+import { protocolEntry } from "./engine-presets.ts"
 import { withDispatcherProtocol, withWorktreeProtocol } from "./worktree-protocol.ts"
 
 export const SIGINT_GUARD = "trap ':' INT; "
@@ -191,8 +191,7 @@ export function buildEngineSessionLaunch(input: EngineSessionLaunchInput): Engin
   // in their argv: their positional slot is a subcommand, so the text would
   // kill the launch as an unknown command. The spawner pastes it instead
   // (see EngineSessionLaunch.firstMessage).
-  const delivery =
-    input.firstMessageDelivery ?? engineEntry(coerceVendorId(input.task.vendor)).firstMessageDelivery ?? "argv"
+  const delivery = input.firstMessageDelivery ?? protocolEntry(input.task.vendor).firstMessageDelivery ?? "argv"
   const pasteFirstMessage = delivery === "paste" ? launchInit.firstMessage?.text : undefined
   if (launchInit.firstMessage && !pasteFirstMessage) argv = [...argv, launchInit.firstMessage.text]
   const markerPath = launchInit.initScript ? worktreeInitMarkerPath(input.worktreePath) : undefined

--- a/packages/kobe/src/engine/trust-worktree.ts
+++ b/packages/kobe/src/engine/trust-worktree.ts
@@ -9,12 +9,12 @@
  * launch (a failed write leaves the pre-#28 status quo — the dialog).
  */
 
-import { type VendorId, coerceVendorId } from "../types/vendor.ts"
-import { engineEntry } from "./registry.ts"
+import type { VendorId } from "../types/vendor.ts"
+import { protocolEntry } from "./engine-presets.ts"
 
 export function trustEngineWorktree(vendor: VendorId | undefined, worktreePath: string): void {
   try {
-    engineEntry(coerceVendorId(vendor)).trustWorktree?.(worktreePath)
+    protocolEntry(vendor).trustWorktree?.(worktreePath)
   } catch {
     /* best-effort — see the module doc */
   }

--- a/packages/kobe/src/monitor/activity.ts
+++ b/packages/kobe/src/monitor/activity.ts
@@ -16,7 +16,7 @@
  * pane's import stays put.
  */
 
-import { engineEntry } from "@/engine/registry"
+import { protocolEntry } from "@/engine/engine-presets"
 import type { VendorId } from "@/types/task"
 
 /**
@@ -29,5 +29,5 @@ import type { VendorId } from "@/types/task"
  */
 export async function latestTranscriptMtime(vendor: VendorId, worktree: string): Promise<number> {
   if (!worktree) return 0
-  return engineEntry(vendor).history.latestTranscriptMtimeForWorktree(worktree)
+  return protocolEntry(vendor).history.latestTranscriptMtimeForWorktree(worktree)
 }

--- a/packages/kobe/src/monitor/auto-title.ts
+++ b/packages/kobe/src/monitor/auto-title.ts
@@ -20,7 +20,7 @@
  * transcripts.
  */
 
-import { engineEntry } from "@/engine/registry"
+import { protocolEntry } from "@/engine/engine-presets"
 import { deriveTitleFromPrompt } from "@/orchestrator/title"
 import type { Message } from "@/types/engine"
 import { DEFAULT_TASK_VENDOR, type VendorId } from "@/types/task"
@@ -56,7 +56,7 @@ export async function deriveTitleFromSession(
   vendor: VendorId = DEFAULT_TASK_VENDOR,
 ): Promise<string> {
   if (!worktree) return ""
-  const { history } = engineEntry(vendor)
+  const { history } = protocolEntry(vendor)
   const ids = await history.listSessionIdsForWorktree(worktree)
   // Walk sessions oldest-first (the task's origin conversation comes
   // first) and return the first that yields a usable title. We don't
@@ -81,7 +81,7 @@ export async function deriveTitleFromSession(
 export async function deriveTitleFromSessionId(vendor: VendorId, sessionId: string): Promise<string> {
   if (!sessionId) return ""
   try {
-    return titleFromMessages(await engineEntry(vendor).history.readHistory(sessionId))
+    return titleFromMessages(await protocolEntry(vendor).history.readHistory(sessionId))
   } catch {
     return ""
   }

--- a/packages/kobe/src/tui-react/workspace/fork-chat-tab.ts
+++ b/packages/kobe/src/tui-react/workspace/fork-chat-tab.ts
@@ -9,9 +9,8 @@
  * keeping it thin is what stops either of them leaking into the component.
  */
 
-import { engineCanFork } from "@/engine/engine-presets"
+import { engineCanFork, protocolEntry } from "@/engine/engine-presets"
 import { engineDisplayName } from "@/engine/interactive-command"
-import { engineEntry } from "@/engine/registry"
 import { buildHandoffPrompt } from "@/engine/session-handoff"
 import type { VendorId } from "@/types/vendor"
 import {
@@ -54,7 +53,7 @@ export async function planChatContinuation(
   const sessionId = await forkSourceSessionId(active, source, worktree)
   if (!sessionId) return { kind: "no-session" }
   if (target === source && engineCanFork(source)) return { kind: "fork", sessionId }
-  const transcriptPath = await engineEntry(source).history.transcriptPath(sessionId, worktree)
+  const transcriptPath = await protocolEntry(source).history.transcriptPath(sessionId, worktree)
   if (!transcriptPath) return { kind: "no-transcript", engine: engineDisplayName(source) }
   return {
     kind: "handoff",
@@ -76,7 +75,7 @@ export async function planWorktreeHandoff(
 ): Promise<ChatForkPlan> {
   const sessionId = await forkSourceSessionId(active, source, worktree)
   if (!sessionId) return { kind: "no-session" }
-  const transcriptPath = await engineEntry(source).history.transcriptPath(sessionId, worktree)
+  const transcriptPath = await protocolEntry(source).history.transcriptPath(sessionId, worktree)
   if (!transcriptPath) return { kind: "no-transcript", engine: engineDisplayName(source) }
   return {
     kind: "handoff",
@@ -99,7 +98,7 @@ export async function forkSourceSessionId(
 ): Promise<string | null> {
   if (active.kind !== "engine") return null
   if (active.sessionId) return active.sessionId
-  const ids = await engineEntry(vendor).history.listSessionIdsForWorktree(worktree)
+  const ids = await protocolEntry(vendor).history.listSessionIdsForWorktree(worktree)
   return ids.at(-1) ?? null
 }
 

--- a/packages/kobe/src/web/history.ts
+++ b/packages/kobe/src/web/history.ts
@@ -26,7 +26,7 @@
 
 import { isAbsolute } from "node:path"
 import { errorMessage } from "@/lib/error-message"
-import { engineEntry } from "../engine/registry.ts"
+import { protocolEntry } from "../engine/engine-presets.ts"
 
 const SESSIONS_ROUTE = "/api/history/sessions"
 const MESSAGES_ROUTE = "/api/history/messages"
@@ -55,7 +55,7 @@ async function handleSessions(url: URL): Promise<Response> {
     return Response.json({ error: "invalid vendor" }, { status: 400 })
   }
   try {
-    const reader = engineEntry(vendor).history
+    const reader = protocolEntry(vendor).history
     const [sessions, latestMtime] = await Promise.all([
       reader.listSessionIdsForWorktree(worktreePath),
       reader.latestTranscriptMtimeForWorktree(worktreePath),
@@ -76,7 +76,7 @@ async function handleMessages(url: URL): Promise<Response> {
     return Response.json({ error: "invalid sessionId" }, { status: 400 })
   }
   try {
-    const reader = engineEntry(vendor).history
+    const reader = protocolEntry(vendor).history
     const messages = await reader.readHistory(sessionId)
     const usage = reader.readUsageSnapshot ? await reader.readUsageSnapshot(sessionId) : undefined
     return Response.json({ messages, ...(usage ? { usage } : {}) })

--- a/packages/kobe/test/engine/engine-declared-vendor-flags.test.ts
+++ b/packages/kobe/test/engine/engine-declared-vendor-flags.test.ts
@@ -17,31 +17,44 @@ import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
-const registry = await vi.hoisted(async () => ({ effortArgv: undefined as unknown }))
+const trusted = vi.hoisted(() => ({ paths: [] as string[] }))
 
 vi.mock("../../src/engine/registry.ts", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../src/engine/registry.ts")>()
   return {
     ...actual,
-    engineEntry: (vendor: string) =>
-      vendor === "fakeengine"
-        ? {
-            ...actual.engineEntry(vendor),
-            effortLevels: ["low", "high"],
-            effortArgv: (base: readonly string[], level: string) => [...base, "--reasoning", level],
-          }
-        : actual.engineEntry(vendor),
+    engineEntry: (vendor: string) => {
+      const entry = actual.engineEntry(vendor)
+      if (vendor === "fakeengine") {
+        return {
+          ...entry,
+          effortLevels: ["low", "high"],
+          effortArgv: (base: readonly string[], level: string) => [...base, "--reasoning", level],
+        }
+      }
+      // Claude's real trustWorktree writes the user's ~/.claude.json (it
+      // takes homedir() with no seam), so record the call instead.
+      if (vendor === "claude") {
+        return { ...entry, trustWorktree: (worktreePath: string) => trusted.paths.push(worktreePath) }
+      }
+      return entry
+    },
   }
 })
 
 const { withEngineEffort } = await import("../../src/engine/interactive-command.ts")
 const { engineLaunchArgv } = await import("../../src/engine/engine-presets.ts")
 const { withDispatcherProtocol, withWorktreeProtocol } = await import("../../src/engine/worktree-protocol.ts")
+const { trustEngineWorktree } = await import("../../src/engine/trust-worktree.ts")
+const { buildEngineSessionLaunch } = await import("../../src/engine/session-launch.ts")
+const { latestTranscriptMtime } = await import("../../src/monitor/activity.ts")
+const { encodeCwd } = await import("../../src/engine/claude-code-local/history.ts")
 
 const on = () => true
 
 let home: string
 let originalHome: string | undefined
+let originalClaudeConfigDir: string | undefined
 
 function writeState(state: Record<string, unknown>): void {
   const dir = join(home, ".config", "rove")
@@ -61,7 +74,12 @@ function registerClaudeWrapper(): void {
 beforeEach(() => {
   home = mkdtempSync(join(tmpdir(), "kobe-declared-flags-"))
   originalHome = process.env.KOBE_HOME_DIR
+  originalClaudeConfigDir = process.env.CLAUDE_CONFIG_DIR
   process.env.KOBE_HOME_DIR = home
+  // Claude's transcript reader honours this, so the history assertions read
+  // fixtures under the temp home instead of the developer's ~/.claude.
+  process.env.CLAUDE_CONFIG_DIR = join(home, ".claude")
+  trusted.paths.length = 0
   writeState({})
 })
 
@@ -70,6 +88,10 @@ afterEach(() => {
     // biome-ignore lint/performance/noDelete: the var must be truly unset when it started unset.
     delete process.env.KOBE_HOME_DIR
   } else process.env.KOBE_HOME_DIR = originalHome
+  if (originalClaudeConfigDir === undefined) {
+    // biome-ignore lint/performance/noDelete: the var must be truly unset when it started unset.
+    delete process.env.CLAUDE_CONFIG_DIR
+  } else process.env.CLAUDE_CONFIG_DIR = originalClaudeConfigDir
   rmSync(home, { recursive: true, force: true })
 })
 
@@ -133,5 +155,72 @@ describe("system-prompt protocols reach a wrapper engine", () => {
     registerClaudeWrapper()
     const own = ["claudecpa", "--append-system-prompt=mine"]
     expect(withWorktreeProtocol(own, "claudecpa", "t1", { status: on, notes: on })).toEqual(own)
+  })
+})
+
+/**
+ * `docs/ENGINES.md` promises that setting `engineProtocol.<id>` makes "the
+ * transcript reader, workspace-trust pre-answer, and first-message delivery
+ * all apply". All three looked the entry up by the RAW preset id, which finds
+ * the empty custom entry — so a wrapper got the trust dialog Rove is supposed
+ * to pre-answer, read no history, and (on a kimi protocol) took its first
+ * message on argv, where kimi reads it as an unknown subcommand and exits.
+ */
+describe("a declared protocol reaches trust, delivery and history", () => {
+  /** A worktree with one claude transcript in the temp CLAUDE_CONFIG_DIR. */
+  function seedClaudeTranscript(): string {
+    const worktree = join(home, "wt")
+    const dir = join(home, ".claude", "projects", encodeCwd(worktree))
+    mkdirSync(dir, { recursive: true })
+    writeFileSync(
+      join(dir, "11111111-2222-3333-4444-555555555555.jsonl"),
+      `${JSON.stringify({ type: "user", message: { role: "user", content: "hello" } })}\n`,
+      "utf8",
+    )
+    return worktree
+  }
+
+  it("pre-answers the trust dialog through the wrapped engine's store", () => {
+    registerClaudeWrapper()
+    trustEngineWorktree("claudecpa", "/repo/.worktrees/t1")
+    expect(trusted.paths).toEqual(["/repo/.worktrees/t1"])
+  })
+
+  it("still writes no trust entry for a preset that declares no protocol", () => {
+    // A generic preset has no store to pre-answer — the honest answer is to
+    // do nothing, not to guess claude's.
+    writeState({ customEngineIds: ["plainshim"], "engineCommand.plainshim": "plain-shim" })
+    trustEngineWorktree("plainshim", "/repo/.worktrees/t1")
+    expect(trusted.paths).toEqual([])
+  })
+
+  it("pastes a kimi-protocol preset's first message instead of putting it on argv", () => {
+    writeState({
+      customEngineIds: ["mykimi"],
+      "engineCommand.mykimi": "kimi-wrapper",
+      "engineProtocol.mykimi": "kimi",
+    })
+    const launch = buildEngineSessionLaunch({
+      task: { id: "t1", kind: "task", vendor: "mykimi", repo: "/repo" },
+      worktreePath: "/repo/.worktrees/t1",
+      shell: "/bin/zsh",
+      argv: ["kimi-wrapper"],
+      promptIntent: { kind: "explicit", prompt: "fix it" },
+      protocolGates: { status: () => false, notes: () => false, dispatcher: () => false },
+      readNotes: () => [],
+    })
+    expect(launch.firstMessage).toBe("fix it")
+    expect(launch.command[2]).not.toContain("fix it")
+  })
+
+  it("reads the wrapped engine's transcripts", async () => {
+    registerClaudeWrapper()
+    expect(await latestTranscriptMtime("claudecpa", seedClaudeTranscript())).toBeGreaterThan(0)
+  })
+
+  it("still reads no transcripts for a preset that declares no protocol", async () => {
+    const worktree = seedClaudeTranscript()
+    writeState({ customEngineIds: ["plainshim"], "engineCommand.plainshim": "plain-shim" })
+    expect(await latestTranscriptMtime("plainshim", worktree)).toBe(0)
   })
 })


### PR DESCRIPTION
## What / why

`docs/ENGINES.md` promises that setting `engineProtocol.<id>` on a custom preset makes "the transcript reader, workspace-trust pre-answer, and first-message delivery all apply". `sessionProtocol()` already resolved a preset id to its declared protocol, but only session pinning / resume / fork / system-prompt injection called it. All three documented consumers looked the registry up by the **raw** preset id, which lands on the empty `customEngineEntry`:

- **Trust** (`trust-worktree.ts`) — no `trustWorktree`, so the user gets the dialog Rove is supposed to pre-answer.
- **Delivery** (`session-launch.ts`) — falls through to `"argv"`; for a kimi-protocol preset that is the launch-killing failure `builtin-engines.ts` documents.
- **History** — eight call sites resolved to `EMPTY_HISTORY`: no transcript, and `ctrl+a c` refuses with `no-transcript`.

Tasks created via `rove api add --command <preset>` worked by accident (the resolved protocol is stored in `task.vendor`). TUI-created tasks store the **raw** preset id, so they hit all three.

Fixed at the shared seam: one `protocolEntry(vendor)` in `engine-presets.ts` (`engineEntry(sessionProtocol(vendor))`), swapped into the ten call sites. `engineEntry(vendor)` stays keyed on the raw id — it answers "what IS this engine" (display name, default command); `protocolEntry` answers "how do we TALK to it".

## Pass criteria — live run

Isolated harness fixture on port base 5673 (own home, socket, pid, ports; owner's `~/.rove` and `.dev-sandbox` untouched). Registered a real wrapper preset in the fixture's `state.json`:

```json
"customEngineIds": ["claudecpa"],
"engineCommand.claudecpa": "<fixture>/bin/claudecpa",   // shim -> real claude
"engineProtocol.claudecpa": "claude"
```

Task created through the **TUI new-task dialog** (not `rove api add`), which stores the raw id:

```
new-task-3 -> vendor: "claudecpa", worktreePath: <fixture>/.rove/worktrees/fixture-repo-f756cad97764/hippo
```

**1. Trust store, no dialog** — `<VISUAL_HOME>/.claude.json` after the run:

```json
{
  "…/fixture-repo-f756cad97764/hippo": { "hasTrustDialogAccepted": true }
}
```

Pre-fix, the same flow left `.claude.json` with **no `projects` key at all**, and real Claude Code v2.1.258 stopped at the trust prompt (see BEFORE screenshot).

**2. `read-output --source history`** against that `claudecpa` task:

```
$ rove api read-output --task-id 01M1GJ5J8CEHPCM01ZRFY8ZA3G --source history
{"vendor":"claudecpa","source":"history","history":{"sessionId":"aaaaaaaa-…","messages":[
  {"role":"user","blocks":[{"type":"text","text":"wire the protocol seam"}],…},
  {"role":"assistant","blocks":[{"type":"text","text":"Done — engineProtocol now reaches history."}],…}],
  "returnedMessageCount":2,"totalMessages":2,"limited":false},"fallbackReason":null,"warnings":[]}
```

**3. kimi-protocol paste delivery** — proven against the real `buildEngineSessionLaunch` rather than a live kimi (weekly-quota-gated): a `mykimi` preset declaring the kimi protocol returns `firstMessage: "fix it"` with the text absent from the launch script. Mutation-verified below.

## Tests

Extended `test/engine/engine-declared-vendor-flags.test.ts` (same bug class, as the brief asked) with 5 cases — 3 positive, 2 negative (an undeclared preset must still get no trust write and no history, so this isn't "everything is claude now").

```
$ env -u ROVE_INVOKED_AS bun x vitest run test/engine/engine-declared-vendor-flags.test.ts
 ✓ test/engine/engine-declared-vendor-flags.test.ts (13 tests) 56ms
 Test Files  1 passed (1)   Tests  13 passed (13)
```

Mutation check — `protocolEntry` reverted to the raw-id lookup:

```
 × … > pre-answers the trust dialog through the wrapped engine's store
 × … > pastes a kimi-protocol preset's first message instead of putting it on argv
 × … > reads the wrapped engine's transcripts
 Tests  3 failed | 10 passed (13)
```

Other gates: `bun x tsc --noEmit` clean; `bun run lint` clean (1330 files); `bun run test:fast` → 4148/4152, the 4 failures being the documented `project-eligibility` / `open-dir-cmd` path-shape false failures from running inside `~/.rove/worktrees` (plus one flaky render `act()` warning that passes in isolation).

## Screenshots

Same isolated fixture, same click sequence (`New task` → `claudecpa` → `Create`), only the code differs.

- BEFORE — trust dialog, cursor on "No, exit", which a hosted session cannot answer:
  `/Users/jacksonc/i/kobe/.scratch/engine-protocol/BEFORE-trust-dialog.png`
- AFTER — claude straight to its prompt in the worktree; the tab label also upgrades from `claude 1` to `Claude Code 1` now that identity resolves:
  `/Users/jacksonc/i/kobe/.scratch/engine-protocol/AFTER-no-trust-dialog.png`

Supporting frames (fresh, un-onboarded claude home — onboarding runs ahead of the trust prompt, so these two look alike; the file-level evidence above is what separates them):
`/Users/jacksonc/i/kobe/.scratch/engine-protocol/AFTER-engine-pane.png`, `/Users/jacksonc/i/kobe/.scratch/engine-protocol/BEFORE-engine-pane.png`, `/Users/jacksonc/i/kobe/.scratch/engine-protocol/01-newtask.png`