### PR TITLE
fix: refuse a link to a task that does not exist, and unlink on delete

### DIFF
--- a/.changeset/issue-link-existence.md
+++ b/.changeset/issue-link-existence.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Linking an issue to a task that does not exist is now refused, and deleting a task unlinks its issue. `rove api issue-update --task <id>` accepted any string, so a typo'd id parked the card in In progress pointing at nothing; deleting a linked task left the same dead link behind, because nothing ever cleared it. Both paths are fixed at the RPC the CLI and the web board share, and the kanban board now treats a link the task list cannot resolve as unlinked, so a card stranded by an older build falls back to Backlog where Start works again. The story drawer also gains an Unlink action next to "Open the linked session", so a stranded story is recoverable without the CLI.

--- a/packages/kobe-daemon/src/daemon/handlers-issues.ts
+++ b/packages/kobe-daemon/src/daemon/handlers-issues.ts
@@ -16,6 +16,22 @@ export const ISSUE_HANDLERS: readonly DaemonRequestHandler[] = [
     name: "issue.mutate",
     async handle(payload, ctx) {
       const repoRoot = requireString(payload, "repoRoot")
+      // A `link` op names a task, and until this guard NOTHING checked that the
+      // task exists — the store only type-checked `taskId` as a non-empty
+      // string. A typo'd id was accepted and the card sat in In progress
+      // pointing at nothing. The check lives HERE, not in the store: both the
+      // CLI (`issue-update --task`) and the web link route funnel through this
+      // one RPC, and the task index is on the handler context, so the issue
+      // store keeps knowing nothing about tasks. The prose is the same one
+      // every other handler throws, which `toApiError` maps to a typed
+      // TASK_NOT_FOUND with the `api list` recovery command.
+      const op = payload.op
+      if (op && typeof op === "object" && (op as { type?: unknown }).type === "link") {
+        const taskId = (op as { taskId?: unknown }).taskId
+        if (typeof taskId === "string" && taskId.length > 0 && !ctx.orch.getTask(taskId)) {
+          throw new Error(`task not found: ${taskId}`)
+        }
+      }
       const state = await ctx.issues.mutate(repoRoot, payload.op)
       ctx.bus.publish("issue.snapshot", state)
       ctx.plugins?.handleUiReport({

--- a/packages/kobe-daemon/src/daemon/handlers-task.ts
+++ b/packages/kobe-daemon/src/daemon/handlers-task.ts
@@ -164,6 +164,19 @@ export const TASK_HANDLERS: readonly DaemonRequestHandler[] = [
       // A hard task delete is an explicit user deletion, so it is the one
       // lifecycle action allowed to cascade its durable Inbox episodes.
       await ctx.inbox.deleteTaskBestEffort(taskId)
+      // Drop the issue link too, for the same reason: the issue owns the link
+      // (`Issue.taskId`), so nothing else would ever clear it, and a card whose
+      // task is gone would render In progress forever. Best-effort like the
+      // done-mirror above — the deletion already committed, so a missing repo
+      // or a raced issue write is logged, never surfaced as a failed delete.
+      if (task) {
+        try {
+          const next = await ctx.issues.unlinkTask(task.repo, taskId)
+          if (next) ctx.bus.publish("issue.snapshot", next)
+        } catch (err) {
+          logDaemonError("issue-delete-unlink", err)
+        }
+      }
       if (accepted) ctx.deletions.enqueue(taskId)
       // `accepted` is the whole point of the reply. Removal itself runs in the
       // background (a worktree teardown can take tens of seconds), so this can

--- a/packages/kobe-daemon/src/daemon/issues-store.ts
+++ b/packages/kobe-daemon/src/daemon/issues-store.ts
@@ -229,6 +229,31 @@ export class IssuesStore {
     })
   }
 
+  /**
+   * Drop the link from whatever issue points at `taskId` — the reverse of the
+   * `link` op, fired when the task itself is deleted. Without it the link
+   * outlives its task and `issueColumnKey` parks the card in In progress
+   * forever with no gesture to recover it.
+   *
+   * Same shape as {@link mirrorTaskDone}: one lock, reverse look-up on
+   * `Issue.taskId`, `null` when there is nothing to unlink.
+   */
+  async unlinkTask(repo: unknown, taskId: string): Promise<RepoIssues | null> {
+    const { repoRoot, repoKey } = await resolveRepo(repo)
+    if (!taskId) return null
+    return withLock(this.path, async () => {
+      const store = await readStore(this.path)
+      const record = store.repos[repoKey]
+      if (!record) return null
+      const issue = record.issues.find((i) => i.taskId === taskId)
+      if (!issue) return null
+      issue.taskId = undefined
+      record.repoRoot = repoRoot
+      await writeStore(this.path, store)
+      return response(repoRoot, record)
+    })
+  }
+
   async mutate(repo: unknown, op: unknown): Promise<RepoIssues> {
     const { repoRoot, repoKey } = await resolveRepo(repo)
     if (!op || typeof op !== "object" || Array.isArray(op) || typeof (op as { type?: unknown }).type !== "string") {

--- a/packages/kobe/src/state/issue-board.ts
+++ b/packages/kobe/src/state/issue-board.ts
@@ -75,14 +75,23 @@ export function moveBoardSelection(
   return currentId
 }
 
-export function issueColumnKey(issue: Issue): BoardColumnKey {
+/**
+ * `taskExists` is the DEFENSIVE half of the link contract: the daemon unlinks
+ * an issue when its task is deleted, so a link should always resolve — but a
+ * store restored from an older home (written before that unlink existed) can
+ * still carry one that doesn't. Given the predicate, an unresolvable link
+ * reads as unlinked and the card falls back to Backlog, where it is startable
+ * again. Omitted, the link alone decides — the behavior every caller had
+ * before, and the right one for a surface that cannot see the task index.
+ */
+export function issueColumnKey(issue: Issue, taskExists?: (taskId: string) => boolean): BoardColumnKey {
   // Terminal disposition (today: `done`) wins over a stale task link; parked
   // (`hold` / unknown) outranks the link too — a parked story stopped on
   // purpose and must not render as active work just because it's linked.
   const disposition = statusDisposition(issue.status)
   if (disposition === "terminal") return "done"
   if (disposition === "parked") return "parked"
-  if (issue.taskId !== undefined && issue.taskId !== "") return "in_progress"
+  if (issue.taskId !== undefined && issue.taskId !== "" && (taskExists?.(issue.taskId) ?? true)) return "in_progress"
   return "backlog"
 }
 
@@ -139,9 +148,12 @@ export function compareIssues(a: Issue, b: Issue): number {
 
 /** Bucket issues into the four render-ready columns, sorted; the accreting
  *  columns (Parked, Done) are capped. */
-export function buildIssueBoard(issues: readonly Issue[]): IssueBoardColumn[] {
+export function buildIssueBoard(
+  issues: readonly Issue[],
+  taskExists?: (taskId: string) => boolean,
+): IssueBoardColumn[] {
   const buckets: Record<BoardColumnKey, Issue[]> = { backlog: [], in_progress: [], parked: [], done: [] }
-  for (const issue of issues) buckets[issueColumnKey(issue)].push(issue)
+  for (const issue of issues) buckets[issueColumnKey(issue, taskExists)].push(issue)
   return BOARD_COLUMN_ORDER.map((key) => {
     const capped = key === "done" || key === "parked"
     const sorted = buckets[key].sort(compareIssues)

--- a/packages/kobe/src/tui-react/component/issue-detail-dialog.tsx
+++ b/packages/kobe/src/tui-react/component/issue-detail-dialog.tsx
@@ -36,7 +36,7 @@ import { useT } from "../i18n"
 import { useBindings } from "../lib/keymap"
 import { type DialogContext, showDialog, useDialog, useDialogPaddingX } from "../ui/dialog"
 import { FRAME } from "../ui/frame"
-import { IssueEventsSection, SectionHeader } from "./issue-detail-parts"
+import { ChipButton, IssueEventsSection, SectionHeader } from "./issue-detail-parts"
 
 export interface IssueDetailOptions {
   readonly issue: Issue
@@ -59,6 +59,11 @@ export interface IssueDetailOptions {
 export type IssueDetailOutcome =
   | { kind: "start"; vendor: VendorId; placement: IssueChatPlacement; jump: boolean; title: string; body: string }
   | { kind: "open"; taskId: string; title: string; body: string }
+  /** Drop the story's task link — the only way back out of In progress when
+   *  the linked task is gone (deleted before the daemon unlinked, or a store
+   *  restored from an older home). The page clears `taskId`; the task, its
+   *  branch and its worktree are untouched. */
+  | { kind: "unlink"; title: string; body: string }
   | { kind: "close"; title: string; body: string }
   /** Create-mode result — `start` null = save only ("New story" Save). */
   | {
@@ -68,7 +73,7 @@ export type IssueDetailOutcome =
       start: { vendor: VendorId; placement: IssueChatPlacement; jump: boolean } | null
     }
 
-type Field = "title" | "description" | "engine" | "workspace" | "jump" | "open"
+type Field = "title" | "description" | "engine" | "workspace" | "jump" | "open" | "unlink"
 
 /** Description editor height — tall enough to read a story, short enough
  *  to keep the start config on screen. */
@@ -110,7 +115,7 @@ export function IssueDetailDialogView(
   const fields: readonly Field[] = startable
     ? ["title", "description", "engine", "workspace", "jump"]
     : linkedTaskId
-      ? ["title", "description", "open"]
+      ? ["title", "description", "open", "unlink"]
       : ["title", "description"]
 
   function insertPlaceholders(paths: readonly string[]): void {
@@ -193,6 +198,12 @@ export function IssueDetailDialogView(
     dialog.clear()
   }
 
+  /** Unlink and close — a stranded card's way back to Backlog. */
+  function unlink(): void {
+    props.onSubmit({ kind: "unlink", ...draft() })
+    dialog.clear()
+  }
+
   function close(): void {
     // Detail esc saves (there's a record to patch); create esc cancels —
     // nothing exists yet, and esc-created empty stories would be litter.
@@ -234,8 +245,9 @@ export function IssueDetailDialogView(
             { key: "return", cmd: () => commit() },
           ]
         : []),
-      // The linked story's jump action — enter fires it when focused.
+      // The linked story's two actions — enter fires whichever is focused.
       ...(field === "open" ? [{ key: "return", cmd: () => commit() }] : []),
+      ...(field === "unlink" ? [{ key: "return", cmd: () => unlink() }] : []),
     ],
   }))
 
@@ -337,34 +349,18 @@ export function IssueDetailDialogView(
           <box gap={0}>
             {sectionHeader(t("kanban.detail.engine"), "engine", "←/→")}
             <box flexDirection="row" gap={1}>
-              {/* No fill on chips: border cells share the box bg, so a
-                  backgroundElement fill halos AROUND the border line — the
-                  primary border + bold text alone mark selection. */}
-              {props.engines.map((engine) => {
-                const selected = engine === vendor
-                return (
-                  <box
-                    key={engine}
-                    {...FRAME}
-                    borderColor={selected ? theme.primary : theme.borderSubtle}
-                    paddingLeft={2}
-                    paddingRight={2}
-                    paddingBottom={1}
-                    onMouseUp={() => {
-                      setField("engine")
-                      setVendor(engine)
-                    }}
-                  >
-                    <text
-                      fg={selected ? theme.primary : theme.textMuted}
-                      attributes={selected ? TextAttributes.BOLD : undefined}
-                      wrapMode="none"
-                    >
-                      {props.engineLabel(engine)}
-                    </text>
-                  </box>
-                )
-              })}
+              {props.engines.map((engine) => (
+                <ChipButton
+                  key={engine}
+                  label={props.engineLabel(engine)}
+                  selected={engine === vendor}
+                  paddingBottom={1}
+                  onPress={() => {
+                    setField("engine")
+                    setVendor(engine)
+                  }}
+                />
+              ))}
             </box>
           </box>
 
@@ -403,30 +399,17 @@ export function IssueDetailDialogView(
           <box gap={0} paddingBottom={1}>
             {sectionHeader(t("kanban.detail.jumpLabel"), "jump", "←/→")}
             <box flexDirection="row" gap={1}>
-              {([false, true] as const).map((option) => {
-                const active = option === jump
-                return (
-                  <box
-                    key={String(option)}
-                    {...FRAME}
-                    borderColor={active ? theme.primary : theme.borderSubtle}
-                    paddingLeft={2}
-                    paddingRight={2}
-                    onMouseUp={() => {
-                      setField("jump")
-                      setJump(option)
-                    }}
-                  >
-                    <text
-                      fg={active ? theme.primary : theme.textMuted}
-                      attributes={active ? TextAttributes.BOLD : undefined}
-                      wrapMode="none"
-                    >
-                      {t(option ? "kanban.detail.jump.follow" : "kanban.detail.jump.stay")}
-                    </text>
-                  </box>
-                )
-              })}
+              {([false, true] as const).map((option) => (
+                <ChipButton
+                  key={String(option)}
+                  label={t(option ? "kanban.detail.jump.follow" : "kanban.detail.jump.stay")}
+                  selected={option === jump}
+                  onPress={() => {
+                    setField("jump")
+                    setJump(option)
+                  }}
+                />
+              ))}
             </box>
           </box>
 
@@ -438,29 +421,31 @@ export function IssueDetailDialogView(
         </box>
       ) : linkedTaskId ? (
         <box gap={1}>
-          {/* SESSION — the visible jump to the story's running workspace
-              (mouse or enter); the board closes and the task activates. */}
+          {/* SESSION — jump to the story's running workspace (mouse or
+              enter; the board closes and the task activates), and the way
+              back out: Unlink returns the card to Backlog. Unlink is the
+              only recovery when the linked task no longer exists — the
+              Open action would then jump at nothing. */}
           <box gap={0}>
             {sectionHeader(t("kanban.detail.sessionLabel"), "open")}
-            <box flexDirection="row">
-              <box
-                {...FRAME}
-                borderColor={field === "open" ? theme.primary : theme.borderSubtle}
-                paddingLeft={2}
-                paddingRight={2}
-                onMouseUp={() => {
+            <box flexDirection="row" gap={1}>
+              <ChipButton
+                label={t("kanban.detail.openAction")}
+                selected={field === "open"}
+                tone="text"
+                onPress={() => {
                   setField("open")
                   commit()
                 }}
-              >
-                <text
-                  fg={field === "open" ? theme.primary : theme.text}
-                  attributes={field === "open" ? TextAttributes.BOLD : undefined}
-                  wrapMode="none"
-                >
-                  {t("kanban.detail.openAction")}
-                </text>
-              </box>
+              />
+              <ChipButton
+                label={t("kanban.detail.unlinkAction")}
+                selected={field === "unlink"}
+                onPress={() => {
+                  setField("unlink")
+                  unlink()
+                }}
+              />
             </box>
           </box>
           {/* EVENTS — what the linked session's engine has been doing. */}

--- a/packages/kobe/src/tui-react/component/issue-detail-parts.tsx
+++ b/packages/kobe/src/tui-react/component/issue-detail-parts.tsx
@@ -1,7 +1,9 @@
 /** @jsxImportSource @opentui/react */
 /**
  * Story-drawer parts that outgrew `issue-detail-dialog.tsx`: the BOLD CAPS
- * section header every section wears, and the EVENTS feed — the last
+ * section header every section wears, the bordered CHIP the drawer's four
+ * pickers and both linked-story actions are all built from, and the EVENTS
+ * feed — the last
  * {@link EVENT_FEED_LIMIT} engine lifecycle events of the story's linked
  * task (docs/design/plugin-events.md).
  *
@@ -16,6 +18,7 @@ import { useEffect, useState } from "react"
 import type { RemoteOrchestrator } from "../../client/remote-orchestrator"
 import { useTheme } from "../context/theme"
 import { useT } from "../i18n"
+import { FRAME } from "../ui/frame"
 import { EVENT_FEED_LIMIT, type EventRow, eventRows } from "./issue-events-core"
 
 /** Section header: BOLD CAPS, primary + underlined when its field is focused. */
@@ -35,6 +38,47 @@ export function SectionHeader(props: { label: string; focused: boolean; hint?: s
           {props.hint}
         </text>
       ) : null}
+    </box>
+  )
+}
+
+/**
+ * The drawer's one button shape: a bordered box that lights up PRIMARY +
+ * BOLD when it is the selected/focused choice. Engine chips, the after-start
+ * toggle, and the linked story's Open/Unlink actions were four copies of the
+ * same twenty lines; they are one component now, so a new action costs a
+ * label and a handler.
+ *
+ * No fill on purpose: border cells share the parent box's background, so a
+ * `backgroundElement` fill halos AROUND the border line. The primary border
+ * plus bold text alone mark selection.
+ */
+export function ChipButton(props: {
+  label: string
+  selected: boolean
+  onPress: () => void
+  /** Colour when NOT selected: `muted` for a picker option (default), `text`
+   *  for an action meant to stay readable while focus is elsewhere. */
+  tone?: "muted" | "text"
+  paddingBottom?: number
+}) {
+  const { theme } = useTheme()
+  return (
+    <box
+      {...FRAME}
+      borderColor={props.selected ? theme.primary : theme.borderSubtle}
+      paddingLeft={2}
+      paddingRight={2}
+      {...(props.paddingBottom === undefined ? {} : { paddingBottom: props.paddingBottom })}
+      onMouseUp={props.onPress}
+    >
+      <text
+        fg={props.selected ? theme.primary : props.tone === "text" ? theme.text : theme.textMuted}
+        attributes={props.selected ? TextAttributes.BOLD : undefined}
+        wrapMode="none"
+      >
+        {props.label}
+      </text>
     </box>
   )
 }

--- a/packages/kobe/src/tui-react/component/kanban-page.tsx
+++ b/packages/kobe/src/tui-react/component/kanban-page.tsx
@@ -104,8 +104,21 @@ export function KanbanPage(props: {
   const activeBoard: RepoIssues | undefined = boardList[activeIndex]
   const repoRoots = boardList.map((board) => board.repoRoot)
   // Rendering-only attention float: blocked-on-you cards lead In progress.
+  // The task index decides In progress, not the link alone: the daemon
+  // unlinks an issue when its task is deleted, but a store carried over from
+  // a build that predates that can still hold a link to a task nobody has —
+  // and such a card would sit In progress with no way back. Unresolvable =
+  // Backlog, where the drawer offers Start again.
+  //
+  // An EMPTY index means "not loaded yet", never "every task is gone": the
+  // page can render before the task list arrives, and demoting on that would
+  // dump every In-progress card into Backlog for a frame. No tasks known ⇒
+  // no predicate ⇒ the link alone decides, exactly as before.
+  const knownTaskIds = new Set<string>((props.orchestrator?.listTasks() ?? []).map((task) => task.id))
   const { columns, attentionCount } = applyBoardAttention(
-    activeBoard ? buildIssueBoard(activeBoard.issues) : [],
+    activeBoard
+      ? buildIssueBoard(activeBoard.issues, knownTaskIds.size === 0 ? undefined : (taskId) => knownTaskIds.has(taskId))
+      : [],
     (taskId) => props.engineStates?.get(taskId)?.state,
   )
 
@@ -159,6 +172,16 @@ export function KanbanPage(props: {
       }
       if (outcome.kind === "open") {
         props.onOpenTask(outcome.taskId)
+        return
+      }
+      if (outcome.kind === "unlink") {
+        await props.orchestrator
+          ?.mutateIssue(board.repoRoot, { type: "unlink", id: issue.id })
+          .catch((err: unknown) => {
+            console.error("[rove kanban] issue unlink failed:", err)
+            notifyError(t("kanban.unlinkFailed", { id: String(issue.id), error: errorMessage(err) }))
+          })
+        reload()
         return
       }
       // "close" saved above; "create" never comes from detail mode.

--- a/packages/kobe/src/tui/i18n/messages/kanban.ts
+++ b/packages/kobe/src/tui/i18n/messages/kanban.ts
@@ -61,10 +61,11 @@ export const en = {
       follow: "Jump to the session",
     },
     startLegend: "enter/ctrl+enter start · tab fields · ←→ engine · ↑↓ workspace · esc save & close",
-    /** Linked-story jump action: section header + the button itself. */
+    /** Linked-story actions: section header, the jump, and the way back out. */
     sessionLabel: "SESSION",
     openAction: "Open the linked session ↵",
-    openLegend: "enter/ctrl+enter open the linked session · tab fields · esc save & close",
+    unlinkAction: "Unlink",
+    openLegend: "enter open the focused action · tab fields · unlink returns the card to Backlog · esc save & close",
     /** EVENTS feed under a linked story — the engine's recent lifecycle events. */
     eventsLabel: "EVENTS",
     eventsLoading: "Loading events…",
@@ -96,6 +97,9 @@ export const en = {
   /** Linking a story to its new task was rejected. The task exists and runs;
    *  only the story↔task link is missing, so no `linked` badge appears. */
   linkFailed: "Story #{id} isn't linked to its task: {error}",
+  /** The drawer's Unlink was rejected — the card stays In progress, still
+   *  pointing at the task it was supposed to let go of. */
+  unlinkFailed: "Story #{id} is still linked: {error}",
 }
 
 export const zh: typeof en = {
@@ -142,7 +146,8 @@ export const zh: typeof en = {
     startLegend: "enter/ctrl+enter 启动 · tab 切字段 · ←→ 引擎 · ↑↓ 工作区 · esc 保存关闭",
     sessionLabel: "会话",
     openAction: "打开关联会话 ↵",
-    openLegend: "enter/ctrl+enter 打开已关联会话 · tab 切字段 · esc 保存关闭",
+    unlinkAction: "解除关联",
+    openLegend: "enter 执行选中操作 · tab 切字段 · 解除关联把卡片退回 Backlog · esc 保存关闭",
     eventsLabel: "事件",
     eventsLoading: "正在加载事件…",
     eventsNone: "暂无引擎事件记录。",
@@ -162,4 +167,5 @@ export const zh: typeof en = {
   updateFailed: "保存 story #{id} 失败：{error}",
   statusFailed: "Story #{id} 仍留在原来的列：{error}",
   linkFailed: "Story #{id} 未能关联到它的任务：{error}",
+  unlinkFailed: "Story #{id} 仍处于关联状态：{error}",
 }

--- a/packages/kobe/test/daemon/handler-test-context.ts
+++ b/packages/kobe/test/daemon/handler-test-context.ts
@@ -116,6 +116,13 @@ export function fakeCtx(orch: Record<string, unknown> = {}): {
         rec.issueCalls.push({ method: "mutate", repo, op })
         return { repoRoot: String(repo), exists: true, nextId: 2, issues: [] }
       },
+      // `task.delete` clears the deleted task's issue link. Returning a state
+      // (not null) keeps the snapshot-publish path covered by default; a test
+      // that wants the "nothing linked" branch supplies its own fake.
+      unlinkTask: async (repo: unknown, taskId: unknown) => {
+        rec.issueCalls.push({ method: "unlinkTask", repo, op: { taskId } })
+        return { repoRoot: String(repo), exists: true, nextId: 2, issues: [] }
+      },
     } as unknown as IssuesStore,
     // Field-note store fake. `appendThrows` lets a test drive the
     // persist-failure path — filing must degrade to routing-only, never

--- a/packages/kobe/test/daemon/handlers-task-crud.test.ts
+++ b/packages/kobe/test/daemon/handlers-task-crud.test.ts
@@ -134,6 +134,34 @@ describe("daemon handler registry — tasks, issues, worktrees", () => {
       expect(rec.deletions).toEqual(["t1"])
     })
 
+    // The issue owns the link (`Issue.taskId`), so nothing else would ever
+    // clear it: without this cascade a deleted task's card stayed In progress
+    // forever, its "open the linked session" action pointing at a task the
+    // sidebar no longer lists.
+    it("task.delete unlinks the deleted task's issue and republishes the board", async () => {
+      const { ctx, rec } = fakeCtx({
+        getTask: () => TASK,
+        prepareTaskDeletion: async () => true,
+      })
+      await dispatch("task.delete", { taskId: "t1" }, ctx)
+      expect(rec.issueCalls).toEqual([{ method: "unlinkTask", repo: "/repo", op: { taskId: "t1" } }])
+      expect(rec.published).toEqual([
+        { channel: "issue.snapshot", payload: { repoRoot: "/repo", exists: true, nextId: 2, issues: [] } },
+      ])
+    })
+
+    // The deletion already committed by the time the unlink runs, so an issue
+    // store that throws (missing repo, raced write) must not turn a completed
+    // delete into a failed RPC.
+    it("task.delete survives an issue store that throws on unlink", async () => {
+      const { ctx, rec } = fakeCtx({ getTask: () => TASK, prepareTaskDeletion: async () => true })
+      ;(ctx.issues as unknown as { unlinkTask: () => Promise<never> }).unlinkTask = () => {
+        throw new Error("disk on fire")
+      }
+      await expect(dispatch("task.delete", { taskId: "t1" }, ctx)).resolves.toEqual({ taskId: "t1", queued: true })
+      expect(rec.deletions).toEqual(["t1"])
+    })
+
     it("task.delete refuses a dirty worktree before any destructive step", async () => {
       // The dirty-worktree preflight lives in prepareTaskDeletion; when it
       // throws, the handler must abort BEFORE the destructive tail: no
@@ -242,6 +270,31 @@ describe("daemon handler registry — tasks, issues, worktrees", () => {
           payload: { repoRoot: "/repo", exists: true, nextId: 2, issues: [] },
         },
       ])
+    })
+
+    // The link op names a task and until this guard nothing checked it
+    // existed: `issue-update --task NOPE` returned exit 0 with taskId "NOPE"
+    // and the card sat In progress pointing at nothing, with no unlink
+    // gesture in the TUI to recover it. The guard is on the RPC (not in the
+    // store) so the CLI and the web link route are both covered; the prose
+    // matches every other handler's, which `toApiError` maps to a typed
+    // TASK_NOT_FOUND carrying the `api list` recovery command.
+    it("issue.mutate refuses a link to a task that does not exist", async () => {
+      const { ctx, rec } = fakeCtx({ getTask: () => undefined })
+      await expect(
+        dispatch("issue.mutate", { repoRoot: "/repo", op: { type: "link", id: 1, taskId: "NOPE" } }, ctx),
+      ).rejects.toThrow("task not found: NOPE")
+      // Refused BEFORE the store: nothing was written, nothing published.
+      expect(rec.issueCalls).toEqual([])
+      expect(rec.published).toEqual([])
+    })
+
+    it("issue.mutate links to a task that exists", async () => {
+      const { ctx, rec } = fakeCtx({ getTask: (id: string) => (id === "t1" ? TASK : undefined) })
+      await expect(
+        dispatch("issue.mutate", { repoRoot: "/repo", op: { type: "link", id: 1, taskId: "t1" } }, ctx),
+      ).resolves.toEqual({ repoRoot: "/repo", exists: true, nextId: 2, issues: [] })
+      expect(rec.issueCalls).toEqual([{ method: "mutate", repo: "/repo", op: { type: "link", id: 1, taskId: "t1" } }])
     })
   })
 

--- a/packages/kobe/test/daemon/issues-store.test.ts
+++ b/packages/kobe/test/daemon/issues-store.test.ts
@@ -176,6 +176,40 @@ describe("IssuesStore", () => {
     })
   })
 
+  // The reverse of `link`, fired by `task.delete`. Nothing else clears
+  // `Issue.taskId`, so before this the link outlived the task it named.
+  describe("unlinkTask", () => {
+    async function linkedStore(): Promise<{ repo: string; store: IssuesStore }> {
+      const repo = await makeRepo()
+      const home = await mkdtemp(join(tmpdir(), "kobe-issues-store-unlink-"))
+      cleanups.push(home)
+      const store = new IssuesStore(join(home, ".kobe", "issues.json"))
+      await store.mutate(repo, { type: "create", title: "Linked" })
+      await store.mutate(repo, { type: "link", id: 1, taskId: "task-abc" })
+      return { repo, store }
+    }
+
+    it("clears the link of the issue pointing at the task", async () => {
+      const { repo, store } = await linkedStore()
+      const next = await store.unlinkTask(repo, "task-abc")
+      expect(next?.issues.find((i) => i.id === 1)?.taskId).toBeUndefined()
+      // Persisted, not just returned — the board re-reads from disk.
+      expect((await store.list(repo)).issues.find((i) => i.id === 1)?.taskId).toBeUndefined()
+    })
+
+    it("leaves the issue otherwise untouched — status and title survive", async () => {
+      const { repo, store } = await linkedStore()
+      await store.mutate(repo, { type: "setStatus", id: 1, status: "doing" })
+      const next = await store.unlinkTask(repo, "task-abc")
+      expect(next?.issues.find((i) => i.id === 1)).toMatchObject({ title: "Linked", status: "doing" })
+    })
+
+    it("returns null when no issue is linked to that task", async () => {
+      const { repo, store } = await linkedStore()
+      expect(await store.unlinkTask(repo, "task-nope")).toBeNull()
+    })
+  })
+
   describe("created stamp", () => {
     // Pins the visual-fixture determinism seam: the Kanban screenshot gate
     // renders `created` on every card, so KOBE_ISSUES_TODAY must override the

--- a/packages/kobe/test/render/issue-detail-linked-actions.test.tsx
+++ b/packages/kobe/test/render/issue-detail-linked-actions.test.tsx
@@ -1,0 +1,136 @@
+/** @jsxImportSource @opentui/react */
+/**
+ * The linked story's half of the drawer: the two action chips and the EVENTS
+ * feed under them. Both only exist when the story HAS a task — a startable
+ * story renders the engine/workspace pickers instead — so nothing else in the
+ * render track reaches them.
+ *
+ * Unlink is the only way a card whose task is gone gets back to Backlog, and
+ * the chip's border says which action enter will fire. A chip drawn as
+ * focused whose binding was never registered looks identical to one that
+ * works, so the test presses the keys rather than reading the frame alone.
+ */
+
+import { expect, test } from "bun:test"
+import type { ReactNode } from "react"
+import type { RemoteOrchestrator } from "../../src/client/remote-orchestrator"
+import { IssueDetailDialogView, type IssueDetailOutcome } from "../../src/tui-react/component/issue-detail-dialog"
+import { act, renderComponent } from "./harness"
+
+const LINKED_ISSUE = {
+  id: 7,
+  title: "Cache the rate table",
+  status: "doing" as const,
+  created: "2026-08-20",
+  body: "The lookup runs per request.",
+  taskId: "01KZTASKLINKED",
+}
+
+/** Just the one call the EVENTS feed makes — everything else stays absent so
+ *  a second dependency can't creep in unnoticed. */
+function orchestratorWithEvents(events: readonly unknown[]): RemoteOrchestrator {
+  return {
+    recentTaskEvents: () => Promise.resolve({ events }),
+  } as unknown as RemoteOrchestrator
+}
+
+/** The feed's fetch resolves a microtask after mount, so the first captured
+ *  frame still says "Loading events…". Drain it before reading rows. */
+function flushFeed(): Promise<void> {
+  return act(async () => {})
+}
+
+function drawer(onSubmit: (outcome: IssueDetailOutcome) => void, orchestrator: RemoteOrchestrator | null): ReactNode {
+  return (
+    <IssueDetailDialogView
+      issue={LINKED_ISSUE}
+      engines={["claude"]}
+      defaultVendor="claude"
+      engineLabel={() => "Claude"}
+      orchestrator={orchestrator}
+      onSubmit={onSubmit}
+      onCancel={() => {}}
+    />
+  )
+}
+
+test("tab moves from Open to Unlink and enter drops the task link", async () => {
+  const outcomes: IssueDetailOutcome[] = []
+  const { frame, mockInput } = await renderComponent(
+    drawer((outcome) => outcomes.push(outcome), null),
+    { width: 120, height: 60, providers: { dialog: true } },
+  )
+
+  expect(await frame()).toContain("Unlink")
+
+  // Focus opens on Open — enter there would jump at the task instead.
+  act(() => mockInput.pressTab())
+  act(() => mockInput.pressEnter())
+
+  expect(outcomes).toEqual([{ kind: "unlink", title: LINKED_ISSUE.title, body: LINKED_ISSUE.body }])
+})
+
+test("enter on the Open chip resolves with the linked task id", async () => {
+  const outcomes: IssueDetailOutcome[] = []
+  const { mockInput, rerender } = await renderComponent(
+    drawer((outcome) => outcomes.push(outcome), null),
+    { width: 120, height: 60, providers: { dialog: true } },
+  )
+  await rerender()
+
+  act(() => mockInput.pressEnter())
+
+  expect(outcomes).toEqual([
+    { kind: "open", taskId: LINKED_ISSUE.taskId, title: LINKED_ISSUE.title, body: LINKED_ISSUE.body },
+  ])
+})
+
+test("the events feed renders the task's engine lifecycle, newest first", async () => {
+  const now = Date.now()
+  const { frame } = await renderComponent(
+    drawer(
+      () => {},
+      orchestratorWithEvents([
+        { kind: "turn-start", at: now - 20 * 60_000, vendor: "claude" },
+        { kind: "tool-use", at: now - 5 * 60_000, vendor: "claude", detail: { tool: { name: "Bash" } } },
+      ]),
+    ),
+    { width: 120, height: 60, providers: { dialog: true } },
+  )
+
+  await flushFeed()
+  const rendered = await frame()
+  expect(rendered).toContain("Bash · claude")
+  expect(rendered).toContain("turn-start")
+  expect(rendered.indexOf("tool-use")).toBeLessThan(rendered.indexOf("turn-start"))
+})
+
+test("no orchestrator reads as an empty feed, not an error", async () => {
+  const { frame } = await renderComponent(
+    drawer(() => {}, null),
+    {
+      width: 120,
+      height: 60,
+      providers: { dialog: true },
+    },
+  )
+
+  await flushFeed()
+  const rendered = await frame()
+  expect(rendered).toContain("EVENTS")
+  expect(rendered).toContain("No engine events recorded yet.")
+})
+
+test("a daemon that no longer knows the task also reads as empty", async () => {
+  const { frame } = await renderComponent(
+    drawer(() => {}, {
+      recentTaskEvents: () => Promise.reject(new Error("task not found")),
+    } as unknown as RemoteOrchestrator),
+    { width: 120, height: 60, providers: { dialog: true } },
+  )
+
+  await flushFeed()
+  const rendered = await frame()
+  expect(rendered).toContain("EVENTS")
+  expect(rendered).toContain("No engine events recorded yet.")
+})

--- a/packages/kobe/test/render/kanban-columns.test.tsx
+++ b/packages/kobe/test/render/kanban-columns.test.tsx
@@ -22,19 +22,31 @@ function issue(id: number, over: Record<string, unknown> = {}) {
   return { id, title: `story-${id}`, status: "open", created: "2026-08-01", body: "", ...over }
 }
 
-/** What KanbanPage touches on mount; everything else is unused here. */
-function orchestrator(issues: readonly unknown[]) {
+/** What KanbanPage touches on mount; everything else is unused here.
+ *  `listTasks` carries real ids because the board resolves each card's link
+ *  against it — a link naming a task the list doesn't have reads as unlinked. */
+function orchestrator(
+  issues: readonly unknown[],
+  tasks: readonly unknown[] = [
+    { id: "T1", repo: REPO },
+    { id: "T2", repo: REPO },
+  ],
+) {
   return {
-    listTasks: () => [{ repo: REPO }],
+    listTasks: () => tasks,
     listIssues: async () => ({ repoRoot: REPO, exists: true, nextId: 99, issues }),
     activeTaskSignal: () => ({ get: () => null }),
   } as never
 }
 
-async function board(issues: readonly unknown[], engineStates?: ReadonlyMap<string, TaskEngineState>) {
+async function board(
+  issues: readonly unknown[],
+  engineStates?: ReadonlyMap<string, TaskEngineState>,
+  tasks?: readonly unknown[],
+) {
   const { frame } = await renderComponent(
     <KanbanPage
-      orchestrator={orchestrator(issues)}
+      orchestrator={tasks ? orchestrator(issues, tasks) : orchestrator(issues)}
       focused={true}
       onClose={() => {}}
       onStartChat={async () => {}}
@@ -66,6 +78,30 @@ test("a blocked card's column header reports how many need you", async () => {
   // A board with nothing blocked must not spend a single cell on the count.
   const quiet = await board([issue(1, { taskId: "T1" })], new Map([["T1", { state: "running", at: 1 }]]))
   expect(quiet).not.toContain("need you")
+})
+
+/**
+ * A link the task index cannot resolve reads as unlinked. The daemon now
+ * unlinks an issue when its task is deleted, so this is the belt to that
+ * braces: a store carried over from a build without the cascade still holds
+ * dead links, and In progress used to be a one-way door for them — the
+ * drawer swapped Start for "open the linked session", which jumped at
+ * nothing. In Backlog the card is startable again.
+ */
+test("a card linked to a task the index does not have renders in Backlog", async () => {
+  const text = await board([issue(1, { taskId: "T1" }), issue(2, { taskId: "GONE" })], undefined, [
+    { id: "T1", repo: REPO },
+  ])
+  const backlog = text.indexOf("Backlog")
+  const inProgress = text.indexOf("In progress")
+  // Columns render side by side, so a card's COLUMN is the header its text
+  // sits under — compare the cards' horizontal offsets on their own rows.
+  const columnOf = (title: string) => {
+    const row = text.split("\n").find((line) => line.includes(title)) ?? ""
+    return row.indexOf(title) < inProgress - backlog + 4 ? "backlog" : "in_progress"
+  }
+  expect(columnOf("story-2")).toBe("backlog")
+  expect(columnOf("story-1")).toBe("in_progress")
 })
 
 /**

--- a/packages/kobe/test/state/issue-board.test.ts
+++ b/packages/kobe/test/state/issue-board.test.ts
@@ -48,6 +48,35 @@ describe("issueColumnKey", () => {
     expect(issueColumnKey(issue({ id: 9, status: "doing" }))).toBe("backlog")
     expect(issueColumnKey(issue({ id: 10, taskId: "" }))).toBe("backlog")
   })
+
+  // The defensive half of the link contract. The daemon unlinks an issue when
+  // its task is deleted, so a live link resolves — but a store carried over
+  // from a build that predates that cascade can hold one that doesn't, and
+  // such a card used to sit In progress with no gesture to get it out.
+  test("a link to a task that no longer exists reads as backlog", () => {
+    const gone = () => false
+    expect(issueColumnKey(issue({ id: 11, taskId: "01GONE" }), gone)).toBe("backlog")
+    expect(issueColumnKey(issue({ id: 12, taskId: "01LIVE" }), (id) => id === "01LIVE")).toBe("in_progress")
+  })
+
+  test("without a resolver the link alone still decides (surfaces with no task index)", () => {
+    expect(issueColumnKey(issue({ id: 13, taskId: "01GONE" }))).toBe("in_progress")
+  })
+
+  test("a dangling link does not park or un-done the card — disposition still wins", () => {
+    const gone = () => false
+    expect(issueColumnKey(issue({ id: 14, status: "done", taskId: "01GONE" }), gone)).toBe("done")
+    expect(issueColumnKey(issue({ id: 15, status: "hold", taskId: "01GONE" }), gone)).toBe("parked")
+  })
+
+  test("buildIssueBoard threads the resolver through to every column", () => {
+    const columns = buildIssueBoard(
+      [issue({ id: 16, taskId: "01GONE" }), issue({ id: 17, taskId: "01LIVE" })],
+      (id) => id === "01LIVE",
+    )
+    expect(columns.find((c) => c.key === "backlog")?.issues.map((i) => i.id)).toEqual([16])
+    expect(columns.find((c) => c.key === "in_progress")?.issues.map((i) => i.id)).toEqual([17])
+  })
 })
 
 describe("compareIssues", () => {


### PR DESCRIPTION
## What / why

`rove api issue-update --repo <r> --id N --task <anything>` linked the issue to whatever string it was given. Nothing checked the task existed, and nothing cleared the link when the task was later deleted — so a card could sit in **In progress** pointing at a task the sidebar no longer lists, its drawer offering only "Open the linked session" (which jumps at nothing) and no unlink gesture anywhere in the TUI.

All four bullets from the brief:

1. **Reject an unknown `--task`.** The existence check lives on the `issue.mutate` RPC rather than in `issueUpdate`, because the CLI *and* the web link route both funnel through that one handler — and `ctx.orch` is already on the handler context, so the issue store still knows nothing about tasks (the coupling the brief flagged is avoided). It throws the same `task not found: <id>` prose every other handler throws, which `toApiError` already maps to a typed `TASK_NOT_FOUND` with `hint` + `nextCommandArgs: ["api","list"]` — the exact shape `pin` returns.
2. **Unlink on delete.** `IssuesStore.unlinkTask` mirrors `mirrorTaskDone` (one lock, reverse look-up on `Issue.taskId`); `task.delete` calls it best-effort and republishes `issue.snapshot`. The deletion has already committed by then, so a throwing store is logged, never surfaced as a failed delete.
3. **Defensive column key.** `issueColumnKey(issue, taskExists?)` treats an unresolvable link as unlinked. The board passes a predicate built from `listTasks()` — and **only when that list is non-empty**: an empty index means "not loaded yet", not "every task is gone", and demoting on it would dump every In-progress card into Backlog for a frame. Callers with no task index (kobe-web's own copy of the column math) pass nothing and keep the old behavior.
4. **Drawer unlink action.** A second chip beside "Open the linked session", focusable by `tab`, fired by `enter`. Its four near-identical chip blocks (engine, after-start, open, unlink) are now one `ChipButton` in `issue-detail-parts.tsx` — that seam is what keeps the drawer at 476 lines instead of ~520.

## Pass criteria — actual output

Real CLI against an isolated daemon (`KOBE_HOME_DIR=…/.scratch/issue-unlink/home`, own socket/pty/web-port), built via `bun run build`:

```
$ rove api issue-update --repo $S/repo --id 1 --task NOPE
{"error":{"message":"task not found: NOPE","code":"TASK_NOT_FOUND","hint":"that task id does not exist (deleted or mistyped) — list live tasks and retry with a real id","nextCommandArgs":["api","list"]}}
exit=1
```

Issue 1 was left untouched (`issue-list` shows no `taskId`). Then the delete half:

```
$ rove api issue-update --repo $S/repo --id 2 --task 01M1GJ7RZ2ZSCDCFTHXAGWP27F
{... "issues":[{"id":2,...,"taskId":"01M1GJ7RZ2ZSCDCFTHXAGWP27F"}, ...]}

$ rove api delete --task-id 01M1GJ7RZ2ZSCDCFTHXAGWP27F --wait
{"taskId":"01M1GJ7RZ2ZSCDCFTHXAGWP27F","queued":true,"status":"removed"}

$ rove api issue-list --repo $S/repo
{... "issues":[{"id":2,"title":"Second issue","status":"open","created":"2026-09-02","body":""}, ...]}   # no taskId
```

## Screenshots (harness, `/harness` → xterm → PTY → real OpenTUI)

Own fixture home at `KOBE_VISUAL_PORT_BASE=5323`, never the shared `.dev-sandbox`. BEFORE frames are the same keys with only the files that decide the difference reverted to `HEAD`.

| | BEFORE | AFTER |
|---|---|---|
| Drawer of a linked story (`ctrl+a 1 wait:800 enter wait:600`) | `/Users/jacksonc/i/kobe/.scratch/issue-unlink/shots/before-drawer.png` — SESSION has only "Open the linked session ↵" | `/Users/jacksonc/i/kobe/.scratch/issue-unlink/shots/after-drawer.png` — "Open the linked session ↵" **+ "Unlink"**, legend now "enter open the focused action · tab fields · unlink returns the card to Backlog · esc save & close" |
| Board with a dangling link (`ctrl+a 1 r wait:600`) | `/Users/jacksonc/i/kobe/.scratch/issue-unlink/shots/before-column.png` — "In progress fixture #2" stuck in **In progress (1)** | `/Users/jacksonc/i/kobe/.scratch/issue-unlink/shots/after-column.png` — back in **Backlog (2)**, **In progress (0)** |

## Tests + mutation checks

Added: two `issue.mutate` link cases and two `task.delete` unlink cases (`test/daemon/handlers-task-crud.test.ts`), three `unlinkTask` cases (`test/daemon/issues-store.test.ts`), four column-key cases (`test/state/issue-board.test.ts`), and a render case proving the dangling card lands in Backlog (`test/render/kanban-columns.test.tsx`). The render fixture's `listTasks` now carries real ids, because the board resolves links against it.

Each guard was removed in turn and the matching test went red:

- drop `!ctx.orch.getTask(taskId)` → `× issue.mutate refuses a link to a task that does not exist`
- drop the `taskExists` term → `× a link to a task that no longer exists reads as backlog`, `× buildIssueBoard threads the resolver through`
- neutralize `unlinkTask` in `task.delete` → `× task.delete unlinks the deleted task's issue and republishes the board`
- pass `undefined` for the board predicate → `× a card linked to a task the index does not have renders in Backlog`

Suites: `bun run lint` clean, `tsc --noEmit` clean both packages, `check-i18n` OK (739 keys × 2 locales), `test:socket` 703 passed, `bun test test/render` 380 passed. `test:fast` shows the 4 known false failures this worktree's path shape causes (`open-dir-cmd`, `project-eligibility` — they judge `roveInternal`/`temporary` by path and this checkout lives under `~/.rove/worktrees`); everything else passed (4147).

## Out of scope, worth a follow-up

`packages/kobe-web/src/lib/board.ts` keeps its own copy of `issueColumnKey` with the same link-only rule. It is a second implementation that predates this change and the brief scoped this PR to the four TUI/daemon files, so it is untouched — but the web board will still park a dangling card in In progress until that copy takes the same predicate.