### PR TITLE
fix: restore setThemeMode, raced between #766 and #781

### DIFF
--- a/.changeset/restore-set-theme-mode.md
+++ b/.changeset/restore-set-theme-mode.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Restore the `setThemeMode` helper that two concurrent changes raced on: one deleted it as unused while the other added its only caller, and main failed to typecheck once both landed.

--- a/packages/kobe/src/tui-react/context/theme.tsx
+++ b/packages/kobe/src/tui-react/context/theme.tsx
@@ -99,6 +99,11 @@ export function setFocusAccent(v: FocusAccentSlot): void {
   store.update((s) => ({ ...s, focusAccent: v }))
 }
 
+/** Test seam: flip dark/light without a Settings round-trip (sidebar-update-chip.test.tsx). */
+export function setThemeMode(mode: "dark" | "light"): void {
+  store.update((s) => ({ ...s, mode }))
+}
+
 export type ThemeContextValue = {
   /** The resolved palette. Plain object — re-renders arrive via context. */
   theme: Theme


### PR DESCRIPTION
main is red: #781 deleted `setThemeMode` (zero callers at the time) and #766 landed a render test importing it. Restores the two-line helper. Local: tsc clean, `bun test test/render` 402/0. No changeset: test-seam only, no shipped behavior.