### PR TITLE
fix: Files pane header stops opening with a two-row hole

### DIFF
--- a/.changeset/files-pane-header-hints.md
+++ b/.changeset/files-pane-header-hints.md
@@ -1,0 +1,11 @@
+---
+"@sma1lboy/rove": patch
+---
+
+The Files pane header no longer opens with a two-row hole. Its Zen and Create-PR
+chips always wrap (they are wider than the pane), and the row's `gap` was
+applying vertically as well as horizontally, so the header spent five rows on
+two hints. It now spends two or three. A project's `main` row also stops
+offering **Ask agent to create PR** — that row is the repo's own checkout with no
+task branch, so the action could only answer with its already-on-the-target-branch
+toast. `ctrl+a` `p` still fires there and still says why.

--- a/docs/TUI.md
+++ b/docs/TUI.md
@@ -211,7 +211,9 @@ active engine. The prompt asks the agent to review the diff, commit remaining
 changes, push the branch, and run `gh pr create`.
 
 Watch the engine tab for progress, failures, or questions. The action is
-unavailable on the target branch and requires an active engine session. A repo
+unavailable on the target branch and requires an active engine session. A
+project's `main` row is that repo's own checkout rather than a task branch, so
+the chip is not offered there; `ctrl+a` `p` still answers with the reason. A repo
 can replace the prompt with `.rove/pr-instructions.md`; see
 [Per-repo init](CONFIGURATION.md#per-repo-init). Because the engine performs the
 work, its own skills and approval rules still apply. The default prompt expects

--- a/packages/kobe/src/tui-react/panes/filetree/header-view.tsx
+++ b/packages/kobe/src/tui-react/panes/filetree/header-view.tsx
@@ -48,7 +48,20 @@ export function FileTreeHeaderView(props: FileTreeHeaderProps) {
         // squeeze the chips' inner gaps first ("[~]Zen"), and with shrink
         // forbidden the row would overflow the pane border instead — wrapping
         // stacks the chips right-aligned, both still whole.
-        <box flexDirection="row" flexWrap="wrap" justifyContent="flex-end" gap={2} paddingBottom={1} flexShrink={0}>
+        //
+        // columnGap, NOT gap: Yoga's `gap` sets BOTH gutters, so the wrap this
+        // row is designed around also inherited a 2-row vertical gutter — and
+        // the chips ALWAYS wrap (8 + 2 + 30 cells against the pane's 22-34
+        // cell clamp), so the header permanently opened with Zen, two blank
+        // rows, Create PR. Only the horizontal gutter is wanted here.
+        <box
+          flexDirection="row"
+          flexWrap="wrap"
+          justifyContent="flex-end"
+          columnGap={2}
+          paddingBottom={1}
+          flexShrink={0}
+        >
           {props.onZenToggle ? (
             // stopPropagation: the chip click must NOT bubble to the host
             // pane box's own onMouseUp (workspace host focuses the files

--- a/packages/kobe/src/tui-react/workspace/host-banner.tsx
+++ b/packages/kobe/src/tui-react/workspace/host-banner.tsx
@@ -1,0 +1,86 @@
+/** @jsxImportSource @opentui/react */
+/**
+ * Which banner the workspace host shows across the top of the window, and the
+ * daemon signals that decide it.
+ *
+ * Its own module because the host renders the result in THREE places — the
+ * settings page, a full-window page, and `WorkspaceFrame` all wrap it — while
+ * the choice between the two banners is one question with one answer. The
+ * WIRING is what has historically been wrong here (both banners were correct
+ * components nobody mounted), so `host-version-skew-banner.test.tsx` drives
+ * these signals through the real `WorkspaceRoot` rather than through this hook.
+ */
+
+import type { ColorInput } from "@opentui/core"
+import type { ReactNode } from "react"
+import type { RemoteOrchestrator } from "../../client/remote-orchestrator.ts"
+import { CURRENT_VERSION } from "../../version.ts"
+import { StaleInstallBanner, VersionSkewBanner } from "../component/version-skew-banner"
+import { useAccessor } from "../lib/use-accessor"
+
+export interface HostBanner {
+  /** The banner element — rendered by every one of the host's return paths. */
+  readonly element: ReactNode
+  /** Daemon-polled npm check (collectors' update channel). Read here because
+   *  it is the same "is this install current" family as the two banners; the
+   *  chip itself is the passive half of the update surface, and `u` / a click
+   *  opens the page. */
+  readonly update: { readonly hasUpdate: boolean; readonly latest: string } | null
+}
+
+/**
+ * The skew banner's problem, and its fix. `daemonStaleSignal()` has been
+ * accurate since it was written and its ONLY reader was the mock workbench —
+ * so the state it names was invisible in the product the whole time. That
+ * state is not an edge case: Rove ships several times a day and the daemon is
+ * a long-lived process that outlives an `npm i -g`, which makes "new binary,
+ * old daemon" the ordinary result of updating.
+ *
+ * Skew only. A daemon-disconnect banner used to sit in front of this one: a
+ * full-width red alert on every socket drop. It was the wrong weight — the
+ * reconnect loop recovers most drops in under a second, and Rove keeps working
+ * through the ones it doesn't, so the alert interrupted to announce something
+ * with nothing to act on. Skew is different: it persists until someone
+ * restarts the daemon, which is why it kept its banner.
+ *
+ * The one condition that outranks skew: this process's install was deleted, so
+ * it cannot start a daemon at all. It used to be invisible — the client just
+ * looked like it was reconnecting, for two days (issue #96). Latched, never
+ * cleared: only a reinstall fixes it.
+ */
+export function useHostBanner(orch: RemoteOrchestrator, width: number): HostBanner {
+  const daemonStale = useAccessor(orch.daemonStaleSignal())
+  const daemonVersion = useAccessor(orch.daemonVersionSignal())
+  const update = useAccessor(orch.updateSignal())
+  const staleInstall = useAccessor(orch.staleInstallSignal())
+  const element = staleInstall ? (
+    <StaleInstallBanner message={staleInstall} width={width} />
+  ) : (
+    <VersionSkewBanner
+      stale={daemonStale}
+      daemonVersion={daemonVersion}
+      clientVersion={CURRENT_VERSION}
+      width={width}
+    />
+  )
+  return { element, update }
+}
+
+/**
+ * A page that replaces the WHOLE window — Settings, or a full-window rail
+ * page. Those bypass `WorkspaceFrame`, which is what normally carries the
+ * banner, so they have to re-wrap it themselves; this is the one place that
+ * pairing is written down instead of once per page kind.
+ */
+export function FullWindowPage(props: {
+  banner: ReactNode
+  background: ColorInput
+  children: ReactNode
+}): ReactNode {
+  return (
+    <box flexDirection="column" flexGrow={1} backgroundColor={props.background}>
+      {props.banner}
+      {props.children}
+    </box>
+  )
+}

--- a/packages/kobe/src/tui-react/workspace/host-files-pane.tsx
+++ b/packages/kobe/src/tui-react/workspace/host-files-pane.tsx
@@ -28,6 +28,13 @@ export function HostFilesPane(props: {
   readonly onMention: (relPath: string) => void
   readonly onZenToggle: () => void
   readonly onCreatePR: () => void
+  /** Selected task's `kind`. A `"main"` row IS the repo's root checkout —
+   *  `branch: ""`, `worktreePath === repo` — so it has no task branch to open
+   *  a PR from and `createPRAction` can only answer with its
+   *  already-on-the-target-branch toast. The header withholds the chip there.
+   *  `"dir"` rows point at a directory whose branch Rove does not own, so they
+   *  keep it. */
+  readonly taskKind: "main" | "task" | "dir" | undefined
 }) {
   const { theme } = useTheme()
   const focus = useFocus()
@@ -52,7 +59,10 @@ export function HostFilesPane(props: {
         onOpenDiff={props.onOpenDiff}
         onMention={props.onMention}
         onZenToggle={props.onZenToggle}
-        onCreatePR={props.onCreatePR}
+        // Withholding the chip is not withholding the action: `files.createPR`
+        // is a GLOBAL prefix binding, so prefix+P still fires on a main row and
+        // still explains itself with the toast.
+        onCreatePR={props.taskKind === "main" ? undefined : props.onCreatePR}
       />
     </box>
   )

--- a/packages/kobe/src/tui-react/workspace/host.tsx
+++ b/packages/kobe/src/tui-react/workspace/host.tsx
@@ -12,10 +12,8 @@ import { useEffect, useRef, useState } from "react"
 import { RemoteOrchestrator } from "../../client/remote-orchestrator.ts"
 import { sidebarWidthFor } from "../../tui/panes/sidebar/view-core"
 import { getDefaultPtyRegistry } from "../../tui/panes/terminal/registry"
-import { CURRENT_VERSION } from "../../version.ts"
 import { PrefixHud } from "../component/prefix-hud"
 import { ToastOverlay } from "../component/toast-overlay"
-import { StaleInstallBanner, VersionSkewBanner } from "../component/version-skew-banner"
 import { useFocus } from "../context/focus"
 import { useKV } from "../context/kv"
 import { useNotifications } from "../context/notifications"
@@ -27,6 +25,7 @@ import { useDaemonNotices } from "../lib/use-daemon-notices"
 import { useLatest } from "../lib/use-latest"
 import { useSidebarHostState } from "../panes/sidebar/use-sidebar-host-state.tsx"
 import { useDialog } from "../ui/dialog"
+import { FullWindowPage, useHostBanner } from "./host-banner"
 import { HostFilesPane } from "./host-files-pane"
 import { WorkspaceFrame } from "./host-footer"
 import { useWorkspaceKeybindings } from "./host-keybindings"
@@ -297,62 +296,20 @@ export function WorkspaceRoot(props: { orchestrator: RemoteOrchestrator }) {
   // live `focus.focused` so the pane frame stays lit under the dim backdrop.
   const activePane = dialog.stack.length > 0 ? null : focus.focused
 
-  // The skew banner's problem, and its fix. `daemonStaleSignal()`
-  // has been accurate since it was written and its ONLY reader was the mock
-  // workbench — so the state it names has been invisible in the product the
-  // whole time. That state is not an edge case here: Rove ships several times
-  // a day and the daemon is a long-lived process that outlives an `npm i -g`,
-  // which makes "new binary, old daemon" the ordinary result of updating.
-  //
-  const daemonStale = useAccessor(orch.daemonStaleSignal())
-  const daemonVersion = useAccessor(orch.daemonVersionSignal())
-  // Daemon-polled npm check (collectors' update channel). The chip is the
-  // passive half of the update surface; `u` / a click opens the page.
-  const updateInfo = useAccessor(orch.updateSignal())
-  // Skew only. A daemon-disconnect banner used to sit in front of this one:
-  // a full-width red alert on every socket drop. It was the wrong weight —
-  // the reconnect loop recovers most drops in under a second, and Rove keeps
-  // working through the ones it doesn't, so the alert interrupted to announce
-  // something with nothing to act on. Skew is different: it persists until
-  // someone restarts the daemon, which is why it kept its banner.
-  // The one condition that outranks skew: this process's install was deleted,
-  // so it cannot start a daemon at all. It used to be invisible — the client
-  // just looked like it was reconnecting, for two days (issue #96). Latched,
-  // never cleared: only a reinstall fixes it.
-  const staleInstall = useAccessor(orch.staleInstallSignal())
-  const banner = staleInstall ? (
-    <StaleInstallBanner message={staleInstall} width={dims.width} />
-  ) : (
-    <VersionSkewBanner
-      stale={daemonStale}
-      daemonVersion={daemonVersion}
-      clientVersion={CURRENT_VERSION}
-      width={dims.width}
-    />
-  )
+  // Top-of-window banner (skew / gone-install) + the update chip's payload —
+  // one question, three render paths below. See `host-banner.tsx`.
+  const banner = useHostBanner(orch, dims.width)
 
-  // Settings and the full-window pages replace the WHOLE window, frame
-  // included, so each needs the banner wrapped around it rather than relying
-  // on WorkspaceFrame.
-  if (pageRender.settingsPage) {
+  const fullWindow = pageRender.settingsPage ?? pageRender.fullWindowPage
+  if (fullWindow)
     return (
-      <box flexDirection="column" flexGrow={1} backgroundColor={theme.background}>
-        {banner}
-        {pageRender.settingsPage}
-      </box>
+      <FullWindowPage banner={banner.element} background={theme.background}>
+        {fullWindow}
+      </FullWindowPage>
     )
-  }
-  if (pageRender.fullWindowPage) {
-    return (
-      <box flexDirection="column" flexGrow={1} backgroundColor={theme.background}>
-        {banner}
-        {pageRender.fullWindowPage}
-      </box>
-    )
-  }
 
   return (
-    <WorkspaceFrame orchestrator={orch} onOpenSettings={pages.openSettings} banner={banner}>
+    <WorkspaceFrame orchestrator={orch} onOpenSettings={pages.openSettings} banner={banner.element}>
       {/* Tasks sidebar stays visible in zen (tmux parity) — its
           ☯ ZEN chip is also the exit affordance. */}
       {/* Borderless rail (owner call 2026-07-27): no frame, no divider —
@@ -430,7 +387,7 @@ export function WorkspaceRoot(props: { orchestrator: RemoteOrchestrator }) {
             emphasize: inbox.counts.total > 0,
           }}
           onHeaderStatusClick={inbox.show}
-          updateChip={updateInfo?.hasUpdate ? { label: t("update.chip", { version: updateInfo.latest }) } : null}
+          updateChip={banner.update?.hasUpdate ? { label: t("update.chip", { version: banner.update.latest }) } : null}
           onUpdateChipClick={pages.openUpdate}
           zenActive={zen}
           onZenClick={toggleZen}
@@ -486,7 +443,11 @@ export function WorkspaceRoot(props: { orchestrator: RemoteOrchestrator }) {
           onOpenDiff={editor.onOpenDiff}
           onMention={editor.onMention}
           onZenToggle={toggleZen}
-          onCreatePR={() => void editor.onCreatePR()}
+          // A `kind:"main"` row IS the repo's root checkout — `branch: ""`,
+          // `worktreePath === repo` — so there is no task branch to open a PR
+          // from, and `createPRAction` can only answer with its
+          // already-on-the-target-branch toast. Don't advertise it there.
+          onCreatePR={selectedTask?.kind === "main" ? undefined : () => void editor.onCreatePR()}
         />
       ) : null}
 

--- a/packages/kobe/src/tui-react/workspace/host.tsx
+++ b/packages/kobe/src/tui-react/workspace/host.tsx
@@ -443,11 +443,8 @@ export function WorkspaceRoot(props: { orchestrator: RemoteOrchestrator }) {
           onOpenDiff={editor.onOpenDiff}
           onMention={editor.onMention}
           onZenToggle={toggleZen}
-          // A `kind:"main"` row IS the repo's root checkout — `branch: ""`,
-          // `worktreePath === repo` — so there is no task branch to open a PR
-          // from, and `createPRAction` can only answer with its
-          // already-on-the-target-branch toast. Don't advertise it there.
-          onCreatePR={selectedTask?.kind === "main" ? undefined : () => void editor.onCreatePR()}
+          onCreatePR={() => void editor.onCreatePR()}
+          taskKind={selectedTask?.kind}
         />
       ) : null}
 

--- a/packages/kobe/test/render/host-files-pane-border.test.tsx
+++ b/packages/kobe/test/render/host-files-pane-border.test.tsx
@@ -42,6 +42,7 @@ function mounted(worktree: string, initial: "workspace" | "files") {
         onMention={NOOP}
         onZenToggle={NOOP}
         onCreatePR={NOOP}
+        taskKind="task"
       />
     </FocusProvider>
   )

--- a/packages/kobe/test/render/host-files-pane-header.test.tsx
+++ b/packages/kobe/test/render/host-files-pane-header.test.tsx
@@ -1,0 +1,93 @@
+/** @jsxImportSource @opentui/react */
+/**
+ * The Files pane's header row — both halves of the owner's 2026-09-02
+ * screenshot.
+ *
+ * 1. The Zen and Create-PR chips ALWAYS wrap: `[~] Zen` + `[^ A P] Ask agent
+ *    to create PR` is 40 cells against the pane's 22-34 cell width clamp
+ *    (`host-files-pane.tsx`). Yoga's `gap` sets both gutters, so the wrap the
+ *    row is designed around also opened a two-row hole between the chips and
+ *    the header ate five rows of a pane whose whole job is listing files.
+ *
+ * 2. A `kind:"main"` row is the repo's root checkout (`branch: ""`,
+ *    `worktreePath === repo`) — there is no task branch, and `createPRAction`
+ *    can only answer with its already-on-the-target-branch toast — so the
+ *    chip must not be offered there.
+ *
+ * `HostFilesPane` decides (2) from `taskKind` rather than being handed a
+ * pre-resolved callback, so this mount tests the RULE and not a hand-set
+ * outcome. The host's job shrinks to forwarding `selectedTask?.kind`, which
+ * the prop's type pins. Mounting the whole `WorkspaceRoot` would cover that
+ * last hop too, but a host mount with a live task starts a daemon client, git
+ * reads and fs watchers that outlive the test — and the render track runs in
+ * ONE bun process, where that surfaced as timeouts in unrelated timing tests.
+ */
+
+import { expect, test } from "bun:test"
+import { execSync } from "node:child_process"
+import { mkdtempSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { FocusProvider } from "../../src/tui-react/context/focus"
+import { HostFilesPane } from "../../src/tui-react/workspace/host-files-pane"
+import type { Task } from "../../src/types/task"
+import { renderComponent, waitForFrameText } from "./harness"
+
+const NOOP = (): void => {}
+
+function repoWithFile(): string {
+  const repo = mkdtempSync(join(tmpdir(), "kobe-files-header-"))
+  execSync("git init -q -b main && git -c user.email=t@t -c user.name=t commit -q --allow-empty -m init", {
+    cwd: repo,
+  })
+  writeFileSync(join(repo, "alpha.ts"), "export {}\n")
+  execSync("git add . && git -c user.email=t@t -c user.name=t commit -q -m files", { cwd: repo })
+  return repo
+}
+
+/** Rendered lines at the real harness grid (1280×800 → 160×40 cells): the
+ *  pane's width clamp is what makes the chips wrap, so a narrow mount would
+ *  not lay out the row under test. */
+async function headerLines(taskKind: Task["kind"]): Promise<string[]> {
+  const { frame } = await renderComponent(
+    <FocusProvider initial="files">
+      <HostFilesPane
+        worktree={repoWithFile()}
+        prBaseRef={undefined}
+        focused={false}
+        onOpenFile={NOOP}
+        onOpenDiff={NOOP}
+        onMention={NOOP}
+        onZenToggle={NOOP}
+        onCreatePR={NOOP}
+        taskKind={taskKind}
+      />
+    </FocusProvider>,
+    { width: 160, height: 40 },
+  )
+  // The tree arrives through an async git read — poll for it rather than
+  // sleeping, so the header is measured on a settled frame.
+  return (await waitForFrameText(frame, "alpha.ts")).split("\n")
+}
+
+test("a worktree task's chips wrap onto ADJACENT rows, not across a two-row hole", async () => {
+  const lines = await headerLines("task")
+  const zen = lines.findIndex((line) => line.includes("Zen"))
+  const pr = lines.findIndex((line) => line.includes("Ask agent to create PR"))
+  expect(zen).toBeGreaterThanOrEqual(0)
+  expect(pr).toBeGreaterThanOrEqual(0)
+  // The whole defect in one number: `gap={2}` put the chips three rows apart.
+  expect(pr - zen).toBe(1)
+})
+
+test("a project-main row offers no Create-PR chip — it has no branch to PR", async () => {
+  const text = (await headerLines("main")).join("\n")
+  // Zen still applies to any task, so its absence would mean the header
+  // vanished rather than the one chip being withheld.
+  expect(text).toContain("Zen")
+  expect(text).not.toContain("Ask agent to create PR")
+})
+
+test("a directory task keeps the chip — Rove does not own that checkout's branch", async () => {
+  expect((await headerLines("dir")).join("\n")).toContain("Ask agent to create PR")
+})

--- a/packages/kobe/test/render/host-sidebar-filetree.test.tsx
+++ b/packages/kobe/test/render/host-sidebar-filetree.test.tsx
@@ -181,6 +181,7 @@ describe("HostFilesPane", () => {
           onMention={(p) => mentions.push(p)}
           onZenToggle={NOOP}
           onCreatePR={NOOP}
+          taskKind="task"
         />,
         24,
       ),


### PR DESCRIPTION
Owner-reported, from a real-terminal screenshot of the Files pane's top rows (two arrows: one at `[~] Zen`, one at `[^ A P] Ask agent to create PR`).

## Two defects, both visible in that picture

**1. Layout — `header-view.tsx`.** The chip row is `flexWrap="wrap" … gap={2}`. Yoga's `gap` sets BOTH gutters, and these chips *always* wrap: `[~] Zen` (8 cells) + `[^ A P] Ask agent to create PR` (30 cells) is 40 against the pane's documented 22–34 cell width clamp (`host-files-pane.tsx`). So the wrap the row was designed around also inherited a 2-row *vertical* gutter, and the header permanently opened with Zen, two blank rows, Create PR, blank, tabs — five rows of a pane whose job is listing files. Fixed with `columnGap={2}`.

**2. Content — `host-files-pane.tsx`.** The Create-PR chip was offered unconditionally. The owner's status bar reads `main | main`, the tree lists the repo root, and the subagent rows report `Repo: /Users/jacksonc/i/kobe` — the selected row is the project's `kind:"main"` task, which by invariant has `branch: ""` and `worktreePath === repo`. `createPRAction` (`use-create-pr.ts:39`) can only answer that with its `prOnTargetBranch` toast, so the chip advertised an action that could not run. `HostFilesPane` now takes the task's `kind` and withholds the chip on `"main"` only — `"dir"` rows point at a directory whose branch Rove does not own, so they keep it.

`files.createPR` is a **global** prefix binding (`host-keybindings.ts:149`), not a pane key, so `ctrl+a` `p` still fires on a main row and still explains itself with the toast. No chord added or moved, and no silent dead key.

## The `refactor:` commit

`host.tsx` was already past the 500-line cap before this branch (the first CI run failed on exactly that), so touching it means owning a split. The seam taken is the top-of-window banner: four daemon signals read for one question, a precedence between the skew and gone-install banners, and the wrapper three separate return paths need. `host-banner.tsx` (`useHostBanner` + `FullWindowPage`) now owns it; `host.tsx` keeps the layout and drops from 531 to 489 lines.

## Where the rule lives, and what that costs

The first version of this branch put the `kind === "main"` check in `host.tsx` and tested it by mounting the real `WorkspaceRoot`. That mount, with a live task, starts a daemon client, git reads and fs watchers that outlive the test — and the render track runs in ONE bun process. It showed up as timeouts in unrelated timing tests (`StatusKeyHintBar`, then a sidebar test), two different ones on two runs, while the same suite with the file removed was green twice.

So the rule moved into `HostFilesPane`, which is where the header's contents belong anyway, and the test mounts just that pane. The one hop no longer asserted is `host.tsx` forwarding `selectedTask?.kind`, which the prop's type pins. That is a deliberate trade: a heavyweight mount that destabilizes the whole shared render process is worse than a narrower assertion.

## Screenshots (harness `/harness` → xterm → PTY → real OpenTUI, 1280×800)

Fixture seeded with both a `kind:"main"` row and a worktree task; `rove api set-active` pins which one the TUI opens on, so BEFORE/AFTER differ only by the source. AFTER re-taken against the code in this PR.

| | BEFORE | AFTER |
|---|---|---|
| project-main row | `/Users/jacksonc/i/kobe/.scratch/files-pane-header/before-project-main.png` | `/Users/jacksonc/i/kobe/.scratch/files-pane-header/after-project-main.png` |
| worktree task | `/Users/jacksonc/i/kobe/.scratch/files-pane-header/before-worktree-task.png` | `/Users/jacksonc/i/kobe/.scratch/files-pane-header/after-worktree-task.png` |

Header rows: 5 → 2 on a main row, 5 → 3 on a worktree task.

## Pass criteria — commands run and real output

```
$ env -u ROVE_INVOKED_AS bun test test/render/host-files-pane-header.test.tsx
 3 pass
 0 fail
```

Mutation check at three sites — revert one thing, the matching test goes red:

```
### MUT 1 (columnGap -> gap)
(fail) a worktree task's chips wrap onto ADJACENT rows, not across a two-row hole
 2 pass  1 fail

### MUT 2 (drop the taskKind gate)
(fail) a project-main row offers no Create-PR chip — it has no branch to PR
 2 pass  1 fail

### MUT 3 (gate on "dir" instead of "main")
(fail) a project-main row offers no Create-PR chip — it has no branch to PR
(fail) a directory task keeps the chip — Rove does not own that checkout's branch
 1 pass  2 fail
```

Full render suite, three consecutive runs after the test was made lightweight:

```
$ env -u ROVE_INVOKED_AS bun test test/render     # ×3
 405 pass  0 fail   Ran 405 tests across 94 files. [117.16s]
 405 pass  0 fail   Ran 405 tests across 94 files. [107.19s]
 405 pass  0 fail   Ran 405 tests across 94 files. [107.29s]
```

Other gates:

```
$ bun run lint                     # repo root
Checked 1333 files in 268ms. No fixes applied.

$ bun x tsc --noEmit               # packages/kobe
(clean)

$ env -u ROVE_INVOKED_AS bun run scripts/check-i18n.ts
i18n check OK — 755 keys × 2 locales in sync

$ env -u ROVE_INVOKED_AS bun run test:fast
 Test Files  2 failed | 421 passed (423)
      Tests  4 failed | 4143 passed (4147)
```

Those 4 vitest failures are the known pre-existing ones for a checkout living under `~/.rove/worktrees` — `test/state/project-eligibility.test.ts` and `test/cli/open-dir-cmd.test.ts` judge by path shape and classify this worktree as rove-internal. This branch touches no CLI or state code.

No new i18n strings (both labels already existed). `docs/TUI.md`'s Create-a-PR section updated to say the chip is not offered on a project `main` row.