### PR TITLE
fix: a requested PTY close is not an engine death

### DIFF
--- a/.changeset/requested-close-is-not-a-death.md
+++ b/.changeset/requested-close-is-not-a-death.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Stop every successful task delete from raising a red error toast. Deleting a task tears down its engine sessions, and the PTY host recorded that requested kill in `pty-exits.json` exactly like a crash — the only thing separating the two was the exit status, and a killed child exits under `SIGKILL` either way. The daemon's exit watcher then replayed it as an engine death: a `dead` activity state, a durable Inbox episode, and an error toast titled with the raw task id, arriving a moment after the task itself was already gone. `PtyHost.kill()` now marks the session as closed on request and skips the death record, so a close you asked for is no longer reported as a death — this covers the sidebar delete, the Worktrees page delete, the headless task-deletion sweep, and closing a terminal tab. A crash still records and still toasts.

--- a/packages/kobe-daemon/src/daemon/pty-host-types.ts
+++ b/packages/kobe-daemon/src/daemon/pty-host-types.ts
@@ -86,6 +86,11 @@ export interface PtySessionState {
   parkedScreenBytes: number
   /** Death cause, recorded once by markExited; null while alive. */
   exit: PtySessionExit | null
+  /** Set by `kill()` — this session is ending because someone ASKED for it
+   *  (tab close, task-deletion teardown/sweep, `rove reset`). The child still
+   *  exits under a signal, so without this flag the exit is indistinguishable
+   *  from a crash and gets persisted as a death record. */
+  closedByRequest?: boolean
   /** True between "rebuilt from a freeze record at host boot" and the first
    *  `open` that respawns it — the marker that separates a host-death
    *  casualty (respawn on attach) from an ordinary corpse (view only). */

--- a/packages/kobe-daemon/src/daemon/pty-host.ts
+++ b/packages/kobe-daemon/src/daemon/pty-host.ts
@@ -125,15 +125,23 @@ export class PtyHost {
         // Final freeze: the exit record AND the scrollback as it stood at death
         // must both survive this host's own end (idle-exit, crash).
         this.maybeFreeze(session, true)
-        try {
-          this.opts.onSessionExit?.({
-            key: session.key,
-            pid: session.proc?.pid ?? null,
-            exit,
-            tail: ringTail(session.chunks, session.bytes, EXIT_TAIL_BYTES),
-          })
-        } catch {
-          // A death-record hook must never block session teardown.
+        // A session someone CLOSED did not die. The child still exits under a
+        // signal, so the death record's clean-exit noise rule cannot tell the
+        // two apart, and a requested close was reaching the UI as an engine
+        // death: deleting a task killed its engine, `pty-exit-watch` replayed
+        // that as `dead`, and `attentionKindFor` turned it into a red toast on
+        // every single successful delete.
+        if (!session.closedByRequest) {
+          try {
+            this.opts.onSessionExit?.({
+              key: session.key,
+              pid: session.proc?.pid ?? null,
+              exit,
+              tail: ringTail(session.chunks, session.bytes, EXIT_TAIL_BYTES),
+            })
+          } catch {
+            // A death-record hook must never block session teardown.
+          }
         }
         this.opts.onSessionEnd?.()
       },
@@ -286,7 +294,9 @@ export class PtyHost {
     if (!session) return Promise.resolve()
     this.sessions.delete(key)
     // An explicit close is not a restart casualty — drop the freeze record
-    // so the next host incarnation does not resurrect what was closed.
+    // so the next host incarnation does not resurrect what was closed. Nor is
+    // it a death: `onExit` reads this flag to skip the death record.
+    session.closedByRequest = true
     this.opts.freeze?.drop(key)
     return this.childController.endChild(session)
   }

--- a/packages/kobe/test/daemon/pty-host-exit-record.test.ts
+++ b/packages/kobe/test/daemon/pty-host-exit-record.test.ts
@@ -1,0 +1,90 @@
+/**
+ * PtyHost death records: which endings reach `onSessionExit`.
+ *
+ * The record is what `pty-exit-watch.ts` replays as an engine death — a `dead`
+ * activity state, a durable Inbox episode, and a red toast. A session someone
+ * CLOSED is not a death: its child still exits under a signal, so nothing
+ * downstream can tell it from a crash. Deleting a task tears its sessions down
+ * that way, which is how every successful delete used to toast an error.
+ *
+ * Driven through a fake `PtyDriver`, like `pty-host-freeze.test.ts`.
+ */
+
+import type { PtyChild, PtyDriver, PtyExit } from "@sma1lboy/kobe-daemon/daemon/pty-driver"
+import { PtyHost } from "@sma1lboy/kobe-daemon/daemon/pty-host"
+import type { PtySessionEndInfo } from "@sma1lboy/kobe-daemon/daemon/pty-observability"
+import { describe, expect, it } from "vitest"
+
+class FakeChild {
+  static nextPid = 2000
+  readonly pid = FakeChild.nextPid++
+  private settle!: (exit: PtyExit) => void
+  readonly exited = new Promise<PtyExit>((resolve) => {
+    this.settle = resolve
+  })
+  constructor(private readonly onData: (data: string | Uint8Array) => void) {}
+  write(data: string): void {
+    this.onData(data)
+  }
+  resize(): void {}
+  close(): void {}
+  kill(signal: NodeJS.Signals): void {
+    this.settle({ code: null, signal })
+  }
+  /** Test-only: the child dies on its own (a crash, or an outside `kill -9`). */
+  die(signal: NodeJS.Signals): void {
+    this.settle({ code: null, signal })
+  }
+}
+
+function harness(): { host: PtyHost; children: FakeChild[]; records: PtySessionEndInfo[] } {
+  const children: FakeChild[] = []
+  const records: PtySessionEndInfo[] = []
+  const driver: PtyDriver = (request) => {
+    const child = new FakeChild(request.onData)
+    children.push(child)
+    return child as unknown as PtyChild
+  }
+  return { children, records, host: new PtyHost({ driver, onSessionExit: (info) => records.push(info) }) }
+}
+
+const SPEC = { cwd: "/wt/t1", command: ["/bin/cat"], cols: 80, rows: 24 }
+
+/** `exited` settles a microtask before the host's onExit bookkeeping runs. */
+async function settle(): Promise<void> {
+  for (let i = 0; i < 5; i++) await Promise.resolve()
+}
+
+describe("PtyHost death records", () => {
+  it("records a child that died on its own", async () => {
+    const h = harness()
+    h.host.open("t1::tab-1", SPEC, {}, () => {})
+    h.children[0].write("boom")
+    h.children[0].die("SIGKILL")
+    await settle()
+
+    expect(h.records).toHaveLength(1)
+    expect(h.records[0]).toMatchObject({ key: "t1::tab-1", exit: { code: null, signal: "SIGKILL" } })
+    expect(h.records[0]?.tail).toContain("boom")
+  })
+
+  it("records NOTHING for a session that was killed on request", async () => {
+    const h = harness()
+    h.host.open("t1::tab-1", SPEC, {}, () => {})
+    await h.host.kill("t1::tab-1")
+    await settle()
+
+    expect(h.records).toEqual([])
+  })
+
+  it("records nothing for the task-deletion sweep either", async () => {
+    const h = harness()
+    h.host.open("gone::tab-1", SPEC, {}, () => {})
+    h.host.open("live::tab-1", SPEC, {}, () => {})
+    h.host.sweepTasks(new Set(["live"]))
+    await settle()
+
+    expect(h.records).toEqual([])
+    expect(h.host.list().map((s) => s.key)).toEqual(["live::tab-1"])
+  })
+})


### PR DESCRIPTION
## What

Deleting a task always popped a red error toast, and the delete always succeeded.

The toast was never about the delete. Deleting a task tears down its engine sessions
(`TaskDeletionRunner.run` → `tearDownTaskSession` → `pty.kill`), and the PTY host
persisted that **requested** kill into `pty-exits.json` exactly like a crash — the
noise rule in `recordPtyExit` only skips CLEAN exits (`code === 0 && signal === null`),
and a killed child exits with `signal: "SIGKILL"` whether you asked for it or not.
`pty-exit-watch.ts` then replayed the record as an engine death: `dead` activity state,
a durable Inbox episode, and — via `attentionKindFor("dead") === "error"` in
`use-attention.ts` — a red toast. It lands a beat *after* the task left the index, so
`taskById.get()` misses and the toast is titled with the raw ULID.

`PtyHost.kill()` already knew the close was deliberate ("An explicit close is not a
restart casualty — drop the freeze record"). It now says the same thing about the death
record: it flags the session `closedByRequest`, and `onExit` skips `onSessionExit` for it.

One guard at the chokepoint, so every caller of the explicit-close verb is fixed:
sidebar delete, Worktrees-page delete (`handlers-worktree.ts` tears the session down the
same way), the headless `sweepTasks`, `killAll`, and plain tab close. A child that dies
on its own still records, still badges, still toasts.

## Root cause, named

`packages/kobe-daemon/src/daemon/pty-host.ts` `kill()` → `PtyChildController.onExit` →
`opts.onSessionExit` → `recordPtyExit` (`pty-exit-store.ts:107`), whose only exclusion is
`info.exit.code === 0 && info.exit.signal === null`.

Not the RPC: `task.delete` returns in ~120 ms against a 20 s `rpcTimeoutMs()` deadline,
and `deleteTaskFlow`'s catch never ran in the repro.

## Repro evidence (scratch home, real Claude Code engine)

Isolated harness home `.scratch/opentui-visual-5873/home`, `KOBE_VISUAL_PORT_BASE=5873`.

**BEFORE** — `daemon.log`:

```
[2026-09-02T09:29:39.990Z] daemon [task-deletion-audit]: requested task 01M1GQ3A3Q5TA5GD85CA8QFR3J title="Visual Fixture" ... force=false deleteBranch=false (client=14)
[2026-09-02T09:29:40.114Z] daemon [task-deletion-audit]: removed   task 01M1GQ3A3Q5TA5GD85CA8QFR3J title="Visual Fixture" ...
```

Delete finished in 124 ms. Then, 422 ms after the task was already gone, `pty-exits.json`:

```json
{ "01M1GQ3A3Q5TA5GD85CA8QFR3J::tab-1": {
    "key": "01M1GQ3A3Q5TA5GD85CA8QFR3J::tab-1", "pid": 15627,
    "code": null, "signal": "SIGKILL", "at": "2026-09-02T09:29:40.536Z",
    "layer": "pty" } }
```

→ red toast `× 01M1GQ3A3Q5TA5GD85CA8QFR3J / › claude 1`.

The owner's own `~/.rove/client.log` shows the same edge on every delete, e.g. delete
requested 08:36:03.697 → `08:36:04.562 ... attention.inbox ... {"taskId":"01M1GEWKEQVJ9YHXFTQ6657297","tabId":"tab-1","state":"dead","detail":{"exit":{"code":null,"signal":"SIGKILL"}`.

**AFTER** — same keystrokes, fresh fixture, same live engine. `pty.log` proves the kill
still happened:

```
[pty-host pty] session 01M1GQD896CK5J83CD7EFTJZ1A::tab-1 exited (signal SIGKILL)
```

`daemon.log` proves the delete still succeeded:

```
[2026-09-02T09:34:06.158Z] daemon [task-deletion-audit]: requested task 01M1GQD896CK5J83CD7EFTJZ1A ...
[2026-09-02T09:34:06.314Z] daemon [task-deletion-audit]: removed   task 01M1GQD896CK5J83CD7EFTJZ1A ...
```

`pty-exits.json` was never created. No toast.

## Screenshots (harness, 1280×800 `/harness` → xterm → real OpenTUI)

| | |
|---|---|
| BEFORE (error toast, bottom right) | `/Users/jacksonc/i/kobe/.scratch/worktree-delete-error/before-toast.png` |
| AFTER (no toast, task gone) | `/Users/jacksonc/i/kobe/.scratch/worktree-delete-error/after-toast.png` |
| AFTER pre-delete: live Claude engine that gets SIGKILLed | `/Users/jacksonc/i/kobe/.scratch/worktree-delete-error/10-after-open.png` |
| BEFORE run, confirm dialog | `/Users/jacksonc/i/kobe/.scratch/worktree-delete-error/02-confirm.png` |
| BEFORE run, task opened | `/Users/jacksonc/i/kobe/.scratch/worktree-delete-error/01-open.png` |
| Baseline | `/Users/jacksonc/i/kobe/.scratch/worktree-delete-error/00-baseline.png` |

Captured with
`KOBE_VISUAL_PORT_BASE=5873 bun run visual:shot -- --out=<abs> ctrl+a h wait:800 down down down down wait:800 d wait:1200 right wait:300 enter wait:3000`
against an isolated home — the shared `.dev-sandbox` was never touched.

## Commands run

```
bun run lint                       # Checked 1332 files. No fixes applied.
cd packages/kobe && bun x tsc --noEmit           # exit 0
env -u ROVE_INVOKED_AS KOBE_INCLUDE_SOCKET=1 bun x vitest run test/daemon/pty-host-exit-record.test.ts
                                   # 1 passed | 3 tests
env -u ROVE_INVOKED_AS bun run test:socket       # 84 files, 710 tests passed
env -u ROVE_INVOKED_AS bun test test/render      # 402 pass, 0 fail (93 files)
env -u ROVE_INVOKED_AS bun run test:fast         # 419 passed | 2 failed (4 tests)
```

The 4 `test:fast` failures are environmental, not this PR: this worktree lives under
`~/.rove/worktrees`, so `pathRejection(REPO_ROOT)` returns `roveInternal` —
`expected 'roveInternal' to be null` in `test/state/project-eligibility.test.ts`, and
`test/cli/open-dir-cmd.test.ts` fails off the same predicate. Nothing in either file
imports the PTY host.

## Mutation check

`test/daemon/pty-host-exit-record.test.ts`, two different mutation sites:

1. `if (!session.closedByRequest)` → `if (true)` in `onExit`: **2 failed | 1 passed**
2. delete `session.closedByRequest = true` from `kill()`: **2 failed | 1 passed**

Restored: **3 passed**. The crash test stays green under both, which is the point —
the suppression is scoped to requested closes.
