### PR TITLE
fix: yield terminal selection to an app that owns the mouse

### DIFF
--- a/.changeset/selection-yields-to-mouse-aware-apps.md
+++ b/.changeset/selection-yields-to-mouse-aware-apps.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+A terminal selection now gets out of the way of an app that owns the mouse. Selecting text at a shell prompt and then starting Claude Code, `vim` or `less` used to leave Rove's highlight painted on top of the app's own screen, and a drag begun before the app launched kept extending underneath it. Launching a mouse-aware app clears the pane's selection; drag-to-copy still works everywhere the app does not want the mouse, and `shift`+drag still selects out of one.

--- a/docs/TUI.md
+++ b/docs/TUI.md
@@ -264,6 +264,15 @@ tab. Split layouts and custom names survive a Rove restart, but which split had
 focus does not. If a split process exits, its leaf disappears and the remaining
 layout collapses naturally.
 
+Who owns the mouse inside a terminal decides who owns selection. At a plain
+shell prompt — a `git log`, a `cat`, anything that never asks for the mouse —
+drag to select and Rove copies the text to your system clipboard on release.
+Inside an app that tracks the mouse itself (Claude Code, Codex, `vim`, `less`,
+`htop`) the click goes to the app instead, so its own selection and copy work
+as they do in any terminal, and Rove paints nothing over them. Launching such
+an app clears a selection Rove was still showing. Hold `shift` while dragging
+to select out of a mouse-aware app anyway, the way iTerm2 and kitty do.
+
 The optional horizontal tab strip can be always visible, visible only for
 multiple tabs, or hidden. The sidebar tree still lists every tab in all three
 modes. Persistence and process-lifetime details live in

--- a/packages/kobe/src/tui-react/panes/terminal/Terminal.tsx
+++ b/packages/kobe/src/tui-react/panes/terminal/Terminal.tsx
@@ -231,6 +231,10 @@ export function Terminal(props: TerminalProps) {
     snapshot,
     snapshotWindow,
     scrollBy: scrollFromPointer,
+    // Same `mouseTrackingMode` the forwarded press is gated on, read rather
+    // than clicked — the pane has to notice the app taking the mouse under a
+    // selection that already exists, and no click announces that.
+    appOwnsMouse: pty?.appOwnsMouse ?? false,
   })
 
   const terminalColors = useMemo(() => {

--- a/packages/kobe/src/tui-react/panes/terminal/use-terminal-selection.ts
+++ b/packages/kobe/src/tui-react/panes/terminal/use-terminal-selection.ts
@@ -58,6 +58,7 @@ import {
   type SelectionRange,
   type SelectionShadow,
   type SelectionShiftState,
+  appTookMouse,
   extractShadowedSelection,
   followContentShift,
   followWindowShift,
@@ -92,6 +93,16 @@ export interface UseTerminalSelectionOpts {
    * to start measuring content shifts against the snapshot.
    */
   scrollBy: (lines: number, screenX: number, screenY: number) => boolean
+  /**
+   * The app inside the PTY has mouse tracking on right now — see
+   * {@link appTookMouse} for why the pane's own selection yields to it.
+   * Re-read on every render, so the flip is noticed on the frame the app
+   * repaints with.
+   * ponytail: an app that enabled tracking and drew NOTHING would go
+   * unnoticed until its next output; entering vim/claude/less always
+   * repaints, so that frame is the flip.
+   */
+  appOwnsMouse: boolean
 }
 
 export interface UseTerminalSelectionResult {
@@ -194,6 +205,13 @@ export function useTerminalSelection(opts: UseTerminalSelectionOpts): UseTermina
     if (!autoScrollRef.current) return
     clearInterval(autoScrollRef.current)
     autoScrollRef.current = null
+  }
+
+  const stopDragging = (): void => {
+    draggingRef.current = false
+    captureDrag(null)
+    dragPointRef.current = null
+    stopAutoScroll()
   }
 
   /**
@@ -300,6 +318,23 @@ export function useTerminalSelection(opts: UseTerminalSelectionOpts): UseTermina
     applyShift(followContentShift(state, prevSnapshot, opts.snapshot, draggingRef.current))
   }, [opts.snapshot, opts.snapshotWindow])
 
+  // The app TAKING the mouse ends the pane's claim on the selection: `vim`
+  // typed at a prompt where text is still highlighted, or launched mid-drag,
+  // would otherwise leave a second highlight stacked on the app's own — and a
+  // live drag would keep extending it INSIDE the app, since the press that
+  // started it was never forwarded. Edge-triggered on purpose (see
+  // `appTookMouse`): a shift-drag begun while the app already owned the mouse
+  // sees no edge and keeps its highlight.
+  const appOwnedMouseRef = useRef(opts.appOwnsMouse)
+  // biome-ignore lint/correctness/useExhaustiveDependencies: keyed on the ownership flip alone; the two teardown helpers are re-made every render and listing them would re-run this on every frame.
+  useEffect(() => {
+    const took = appTookMouse(appOwnedMouseRef.current, opts.appOwnsMouse)
+    appOwnedMouseRef.current = opts.appOwnsMouse
+    if (!took) return
+    stopDragging()
+    clearSelectionState()
+  }, [opts.appOwnsMouse])
+
   // Unmount mid-drag (tab closed, pane swapped) must not leave a timer behind.
   useEffect(
     () => () => {
@@ -320,12 +355,7 @@ export function useTerminalSelection(opts: UseTerminalSelectionOpts): UseTermina
     beginSelection,
     dragTo,
     isDragging: () => draggingRef.current,
-    endDragging: () => {
-      draggingRef.current = false
-      captureDrag(null)
-      dragPointRef.current = null
-      stopAutoScroll()
-    },
+    endDragging: stopDragging,
     clearSelection: clearSelectionState,
     copySelection,
     noteAppScroll: () => {

--- a/packages/kobe/src/tui/panes/terminal/pty-types.ts
+++ b/packages/kobe/src/tui/panes/terminal/pty-types.ts
@@ -178,6 +178,16 @@ export interface TaskPtyLike {
     row: number,
     modifiers?: { shift?: boolean; alt?: boolean; ctrl?: boolean },
   ): boolean
+  /**
+   * True while the app has mouse tracking enabled — the SAME
+   * `mouseTrackingMode` read `click()` gates on, exposed so the pane can see
+   * the app TAKE the mouse without waiting for a click. That is the case a
+   * forwarded press cannot cover: `vim` typed at a prompt where the pane's
+   * own selection is still highlighted leaves two highlights stacked, and
+   * the app cannot see (or clear) ours. Backends with no emulator behind
+   * them (`PipeTaskPty`) omit it and the pane keeps the mouse.
+   */
+  readonly appOwnsMouse?: boolean
   resize(cols: number, rows: number): void
   /** Current emulator geometry in cells — the last size pushed via
    *  `resize()` (the spawn size before any resize). Backends without a

--- a/packages/kobe/src/tui/panes/terminal/pty-xterm-base.ts
+++ b/packages/kobe/src/tui/panes/terminal/pty-xterm-base.ts
@@ -204,6 +204,16 @@ export abstract class XtermTaskPty implements TaskPtyLike {
     return false
   }
 
+  get appOwnsMouse(): boolean {
+    if (this._killed) return false
+    try {
+      return this.term.modes.mouseTrackingMode !== "none"
+    } catch {
+      /* mode probe is best-effort */
+      return false
+    }
+  }
+
   onData(
     cb: (snapshot: readonly TerminalRow[], cursor: CursorPos | null, window: TerminalSnapshotWindow | null) => void,
   ): () => void {

--- a/packages/kobe/src/tui/panes/terminal/terminal-selection.ts
+++ b/packages/kobe/src/tui/panes/terminal/terminal-selection.ts
@@ -350,6 +350,29 @@ export function extractShadowedSelection(
 }
 
 /**
+ * Whether the app inside the PTY just TOOK the mouse — the moment the pane's
+ * own selection has to get out of its way.
+ *
+ * Mouse ownership decides selection ownership. An app with mouse tracking on
+ * (claude, vim, htop, less) draws and copies its own selection, so a second
+ * highlight painted over it is always the wrong one — the app cannot see it
+ * and neither layer can clear the other's. A forwarded PRESS already keeps the
+ * pane out of a mouse-aware app (`encodeMouseButton` returns null only while
+ * tracking is `none`, and `Terminal.tsx` starts a selection only when the
+ * press was NOT forwarded). What a press cannot cover is the app arriving
+ * afterwards: `vim` typed at a prompt where text is still highlighted, or
+ * launched while a drag is live.
+ *
+ * So this is a RISING EDGE, not the steady state. A selection begun while the
+ * app ALREADY owned the mouse is the shift bypass — the iTerm/kitty escape
+ * hatch for pulling text out of a mouse-aware app — and a deliberate override
+ * must survive, highlight included.
+ */
+export function appTookMouse(previouslyOwned: boolean, ownedNow: boolean): boolean {
+  return ownedNow && !previouslyOwned
+}
+
+/**
  * Paint the selection over VIEWPORT rows. `firstRow` is the absolute
  * snapshot index of `rows[0]` (the viewport start), mapping the
  * absolute-addressed range onto the visible slice.

--- a/packages/kobe/test/render/terminal-selection-mouse-gate.test.tsx
+++ b/packages/kobe/test/render/terminal-selection-mouse-gate.test.tsx
@@ -1,0 +1,141 @@
+/** @jsxImportSource @opentui/react */
+/**
+ * The pane's own selection yields the screen to an app that owns the mouse.
+ *
+ * #785 already keeps the pane out of a mouse-aware app on the PRESS — the
+ * click is forwarded and no selection starts. What it cannot cover is the app
+ * arriving AFTER the selection: `vim` typed at a prompt where text is still
+ * highlighted, or launched mid-drag. Both highlights then paint on the same
+ * screen and the app cannot see (or clear) the pane's.
+ *
+ * The measurement is the highlight itself — cells carrying the selection
+ * background — compared against a CONTROL pane that reaches the identical
+ * final screen without ever selecting. Comparing to a control rather than to
+ * zero keeps the assertion honest about the cursor cell, which comes back the
+ * moment the selection is gone.
+ */
+
+import { expect, test } from "bun:test"
+import type { CapturedFrame } from "@opentui/core"
+import { Terminal } from "../../src/tui-react/panes/terminal/Terminal"
+import { createScriptedPtyRegistry } from "../../src/tui/panes/terminal/pty-scripted"
+import { type RenderHandle, act, renderComponent } from "./harness"
+
+/** The theme's resolved selection/inverse background. */
+const SELECTION_BG = [234, 231, 223] as const
+const PROMPT_SCREEN = Array.from({ length: 12 }, (_, i) => `line-${i + 1}`).join("\r\n")
+/** What a mouse-aware app repaints the pane with when it takes over. */
+const APP_SCREEN = "VIM SCREEN\r\nrow2\r\nrow3\r\nrow4"
+
+const highlightedCells = (frame: CapturedFrame): number => {
+  let cells = 0
+  for (const line of frame.lines) {
+    for (const span of line.spans) {
+      const [r, g, b] = span.bg.toInts()
+      if (r === SELECTION_BG[0] && g === SELECTION_BG[1] && b === SELECTION_BG[2]) cells += span.width
+    }
+  }
+  return cells
+}
+
+const mountPane = async (taskId: string) => {
+  const harness = createScriptedPtyRegistry()
+  let handle: RenderHandle | undefined
+  await act(async () => {
+    handle = await renderComponent(
+      // Two spacer rows stand in for the workspace tab strip above the pane.
+      <box flexDirection="column" height={18}>
+        <box height={2}>
+          <text>spacer</text>
+        </box>
+        <Terminal cwd="/wt" taskId={taskId} focused registry={harness.registry} />
+      </box>,
+      { width: 60, height: 18, providers: { dialog: true } },
+    )
+  })
+  if (!handle) throw new Error("terminal mount failed")
+  const mounted = handle
+  await act(async () => {
+    harness.last().feed(PROMPT_SCREEN)
+    await mounted.frame()
+  })
+  return { handle: mounted, harness }
+}
+
+/** The app enables mouse tracking and repaints, the way entering vim does. */
+const appTakesOver = async (
+  handle: RenderHandle,
+  harness: Awaited<ReturnType<typeof mountPane>>["harness"],
+): Promise<number> => {
+  harness.last().appOwnsMouse = true
+  await act(async () => {
+    harness.last().replaceScreen(APP_SCREEN)
+    await handle.frame()
+  })
+  return highlightedCells(await settled(handle))
+}
+
+/**
+ * The render carrying a just-changed selection commits when `act` EXITS, so a
+ * frame captured inside the same block is always one render behind.
+ */
+const settled = async (handle: RenderHandle): Promise<CapturedFrame> => {
+  await act(async () => {
+    await handle.frame()
+  })
+  return handle.spans()
+}
+
+/**
+ * Neither drag RELEASES: mouse-up copies the selection, and that writes to the
+ * real system clipboard.
+ */
+test("a selection is cleared when the app takes the mouse under it", async () => {
+  const control = await mountPane("gate-control")
+  const dragged = await mountPane("gate-dragged")
+  try {
+    await act(async () => {
+      await dragged.handle.mockMouse.pressDown(2, 4)
+      await dragged.handle.mockMouse.emitMouseEvent("drag", 40, 6)
+    })
+    const selected = highlightedCells(await settled(dragged.handle))
+    const baseline = highlightedCells(await settled(control.handle))
+    // The drag really did paint a highlight — otherwise the assertion below
+    // would pass on a pane that never selected anything.
+    expect(selected).toBeGreaterThan(baseline)
+
+    // The app takes the mouse and repaints. Both panes now show the same
+    // screen, so any remaining difference is the pane's stale highlight.
+    expect(await appTakesOver(dragged.handle, dragged.harness)).toBe(
+      await appTakesOver(control.handle, control.harness),
+    )
+  } finally {
+    dragged.handle.destroy()
+    control.handle.destroy()
+  }
+})
+
+/**
+ * The shift bypass (#785's iTerm/kitty escape hatch) is how text still gets
+ * pulled out of a mouse-aware app, so a selection begun while the app ALREADY
+ * owned the mouse is a deliberate override — it keeps its highlight.
+ */
+test("a shift-drag inside a mouse-aware app keeps its highlight", async () => {
+  const { handle, harness } = await mountPane("gate-shift")
+  try {
+    harness.last().appOwnsMouse = true
+    await act(async () => {
+      harness.last().replaceScreen(APP_SCREEN)
+      await handle.frame()
+    })
+    const baseline = highlightedCells(await settled(handle))
+
+    await act(async () => {
+      await handle.mockMouse.pressDown(2, 3, 0, { modifiers: { shift: true } })
+      await handle.mockMouse.emitMouseEvent("drag", 40, 4, 0, { modifiers: { shift: true } })
+    })
+    expect(highlightedCells(await settled(handle))).toBeGreaterThan(baseline)
+  } finally {
+    handle.destroy()
+  }
+})

--- a/packages/kobe/test/tui/terminal-selection-mouse-gate.test.ts
+++ b/packages/kobe/test/tui/terminal-selection-mouse-gate.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Who owns the mouse owns the selection — the two halves of that gate.
+ *
+ * The PRESS half is `encodeMouseButton`: `Terminal.tsx` starts a selection
+ * only when the press was NOT forwarded, so "the app got the click" and "the
+ * pane keeps its selection" are the same predicate read from opposite sides.
+ * The FLIP half is `appTookMouse`, for the app that arrives after the fact —
+ * `vim` typed at a prompt where text is still highlighted.
+ */
+
+import { describe, expect, it } from "vitest"
+import { encodeMouseButton } from "../../src/tui/panes/terminal/keys-pure"
+import { appTookMouse } from "../../src/tui/panes/terminal/terminal-selection"
+
+/** What the pane does with a left press at (10,3), per #785's routing. */
+const pressStartsSelection = (
+  mouseTracking: "none" | "x10" | "vt200" | "drag" | "any",
+  modifiers?: { shift?: boolean },
+): boolean => {
+  // The shift bypass is checked before the PTY is consulted at all.
+  if (modifiers?.shift) return true
+  return encodeMouseButton({ mouseTracking }, "down", 0, 10, 3, modifiers) === null
+}
+
+describe("press: the app's mouse tracking decides who gets the click", () => {
+  it("yields the press in a mouse-aware app, so no selection starts", () => {
+    for (const mode of ["x10", "vt200", "drag", "any"] as const) {
+      expect(pressStartsSelection(mode)).toBe(false)
+    }
+  })
+
+  it("keeps the press at a plain prompt, so a selection starts", () => {
+    expect(pressStartsSelection("none")).toBe(true)
+  })
+
+  it("keeps the press when shift bypasses a mouse-aware app", () => {
+    expect(pressStartsSelection("any", { shift: true })).toBe(true)
+  })
+})
+
+describe("flip: an app that takes the mouse under a live selection", () => {
+  it("clears when tracking turns on mid-selection", () => {
+    expect(appTookMouse(false, true)).toBe(true)
+  })
+
+  it("leaves a shift-bypass selection alone — the app already owned the mouse", () => {
+    expect(appTookMouse(true, true)).toBe(false)
+  })
+
+  it("does not clear at a plain prompt, or when the app gives the mouse back", () => {
+    expect(appTookMouse(false, false)).toBe(false)
+    expect(appTookMouse(true, false)).toBe(false)
+  })
+})


### PR DESCRIPTION
## What / why

After #785 a pane running claude / codex / `vim` / `less` receives real clicks, so the app draws and copies its own selection. The press is already yielded there — `encodeMouseButton` returns a sequence only while `mouseTrackingMode !== "none"`, and `Terminal.tsx` starts a selection only when the press was NOT forwarded.

What that cannot cover is the app arriving **after** the selection. Select text at a shell prompt, then type `vim` — Rove's highlight stays painted on top of the app's screen, and a drag begun before the launch keeps extending underneath it. Two highlights, and only one of them is wrong.

So: the same `mouseTrackingMode` the press is gated on is now readable as `TaskPtyLike.appOwnsMouse` (a getter on `XtermTaskPty`; `PipeTaskPty` omits it, `MockTaskPty` already had the field), and the selection hook clears on the **rising edge** of it. Edge-triggered on purpose — a `shift`+drag begun while the app already owned the mouse is #785's iTerm/kitty escape hatch, a deliberate override, and keeps its highlight. No new chord. `docs/TUI.md` gains one paragraph on the two modes.

## Pass criteria, with real output

**Pure gate + mutation** — `test/tui/terminal-selection-mouse-gate.test.ts`:

```
$ env -u ROVE_INVOKED_AS bun x vitest run test/tui/terminal-selection-mouse-gate.test.ts
 ✓ test/tui/terminal-selection-mouse-gate.test.ts (6 tests) 2ms
      Tests  6 passed (6)
```

Two mutations at **different sites**, each red:

| mutation | result |
|---|---|
| `appTookMouse`: `ownedNow && !previouslyOwned` → `ownedNow` | `× leaves a shift-bypass selection alone — the app already owned the mouse` (1 failed \| 5 passed) |
| `encodeMouseButton`: drop `if (modes.mouseTracking === "none") return null` | `× keeps the press at a plain prompt, so a selection starts` (1 failed \| 5 passed) |

Restored: `Tests  6 passed (6)`.

**Wiring regression guard** — `test/render/terminal-selection-mouse-gate.test.tsx` counts highlighted cells against a control pane that reaches the identical final screen without selecting. With the two wiring files reverted to `main` it fails `Expected: 0 / Received: 118`; with the fix, `2 pass  0 fail`.

**Suites** (rebased onto `origin/main` @ 88725547c)

```
$ bun run lint            (repo root)   Checked 1333 files in 299ms. No fixes applied.
$ cd packages/kobe && bun x tsc --noEmit    (clean, no output)
$ bun test test/render                  404 pass, 0 fail — Ran 404 tests across 94 files. [108.45s]
$ env -u ROVE_INVOKED_AS bun run test:fast
      Test Files  2 failed | 420 passed (422)
      Tests  4 failed | 4169 passed (4173)
```

Those 4 vitest failures are `test/cli/open-dir-cmd.test.ts` + `test/state/project-eligibility.test.ts`, which judge project eligibility by path shape and reject a checkout under `~/.rove/worktrees` — the worktree this branch was developed in. A baseline run with every change of mine stashed produced the same 4 (`Test Files 2 failed | 419 passed`). CI's `typecheck-and-test` and `render-track` are both green.

*(Before the rebase this branch also hit `test/render/sidebar-update-chip.test.tsx` — `SyntaxError: Export named 'setThemeMode' not found`. That was #781 vs #766 racing, already fixed on `main` by #790; the rebase picked it up.)*

## Screenshots

Real OpenTUI through `/harness` on an isolated fixture (`KOBE_VISUAL_PORT_BASE=5883`), same warm serve and identical gesture for both sides — only `use-terminal-selection.ts` and `Terminal.tsx` were swapped to `main` for the BEFORE pair. The drag is a scratch variant of `visual:shot` with a `drag:x1,y1,x2,y2` token (not committed).

Gesture: open a shell tab → `seq 1 40` → drag lines 5–12 → launch `vim -u NONE -c "set mouse=a ttymouse=sgr" README.md`.

| | |
|---|---|
| **BEFORE** — Rove's highlight painted on top of vim | `/Users/jacksonc/i/kobe/.scratch/selection-gate/before-vim-stale-highlight.png` |
| **AFTER** — only vim's own screen | `/Users/jacksonc/i/kobe/.scratch/selection-gate/after-vim-app-owns-selection.png` |
| **AFTER** — plain shell, drag selects and copies | `/Users/jacksonc/i/kobe/.scratch/selection-gate/after-shell-drag-copies.png` |
| BEFORE of that same shell drag (unchanged by this PR, for reference) | `/Users/jacksonc/i/kobe/.scratch/selection-gate/before-shell-drag-copies.png` |

The copy is real — `pbpaste` right after the shell drag in the AFTER run:

```
5
6
7
8
9
10
11
12
```