### PR TITLE
fix: identify an engine launched behind a long env-var prefix

### DIFF
--- a/.changeset/foreground-engine-long-env-prefix.md
+++ b/.changeset/foreground-engine-long-env-prefix.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+An engine launched behind a long environment prefix is recognized again. A tab identifies which engine is running by walking its process tree and reading each process's executable, skipping the `env`/`node` wrapper and any `VAR=value` assignments in front of the real binary — but that scan stopped after the first four tokens, so a launch line like `env ANTHROPIC_API_KEY=… ANTHROPIC_BASE_URL=… ANTHROPIC_MODEL=… claude` (an `env` wrapper plus three routing vars, exactly how a proxied Claude is started) pushed `claude` past the window and the tab read as a bare shell. That misidentified a live engine as "no engine": the delivery gate then refused to hand a prompt to it. The scan now runs to the first executable-position token however many assignments or wrappers precede it, and still ignores everything after the binary so an engine's own arguments can never masquerade as its identity.

--- a/packages/kobe/src/engine/foreground.ts
+++ b/packages/kobe/src/engine/foreground.ts
@@ -56,7 +56,15 @@ function binaryName(token: string): string {
  * is what identifies, and the tree walk finds that one).
  */
 export function vendorFromArgv(commandLine: string): VendorId | null {
-  for (const token of commandLine.trim().split(/\s+/).slice(0, 4)) {
+  // Walk the leading env-assignment (`FOO=1`) and wrapper (`env`, `node`, …)
+  // tokens an engine launches behind, and identify by the FIRST
+  // executable-position token after them — the loop returns there, so
+  // arguments past the binary are never scanned (scanning them is what made
+  // the title heuristic wrong). No fixed token window: a small cap silently
+  // dropped the engine once the prefix ran past it — `env A=1 B=2 C=3 claude`
+  // (a proxy wrapper plus three routing vars) read as a bare shell, breaking
+  // both the tab's engine identity and the delivery gate.
+  for (const token of commandLine.trim().split(/\s+/)) {
     // `env FOO=1 claude` — the assignments sit between wrapper and binary.
     if (/^[A-Za-z_][A-Za-z0-9_]*=/.test(token)) continue
     const name = binaryName(token)

--- a/packages/kobe/test/engine/foreground.test.ts
+++ b/packages/kobe/test/engine/foreground.test.ts
@@ -41,6 +41,20 @@ describe("vendorFromArgv", () => {
     expect(vendorFromArgv("env FOO=1 claude")).toBe("claude")
   })
 
+  it("sees past a long wrapper + env-assignment prefix (no fixed token window)", () => {
+    // A proxy launch — `env` plus three routing vars — pushes the binary to
+    // the fifth token; a fixed scan window used to stop before it and report a
+    // bare shell.
+    expect(vendorFromArgv("env A=1 B=2 C=3 claude")).toBe("claude")
+    expect(
+      vendorFromArgv(
+        "env ANTHROPIC_API_KEY=x ANTHROPIC_BASE_URL=y ANTHROPIC_MODEL=z /opt/homebrew/bin/claude --model opus",
+      ),
+    ).toBe("claude")
+    // Bare assignments (no `env` wrapper) past the old window resolve too.
+    expect(vendorFromArgv("FOO=1 BAR=2 BAZ=3 QUX=4 codex --search")).toBe("codex")
+  })
+
   it("identifies kimi by its rewritten process title (registry processNames)", () => {
     // Verbatim `ps -o args=` lines from two live kimi sessions (2026-08-15):
     // the Mach-O launcher rewrites argv[0] to `kimi-co`, and what follows is
@@ -99,6 +113,16 @@ describe("engineProcessIn (delivery foreground gate)", () => {
 `)
     // caller passed claude's bin; the running codex is still an engine
     expect(engineProcessIn(rows, 10, "claude")).toBe(true)
+  })
+
+  it("passes an engine launched behind a long env-var prefix", () => {
+    // `env` + three routing vars pushes `claude` past the old scan window;
+    // the delivery gate must still see a live engine, not a bare shell.
+    const rows = parsePsSnapshot(`
+10 1 -zsh
+11 10 env ANTHROPIC_API_KEY=x ANTHROPIC_BASE_URL=y ANTHROPIC_MODEL=z claude --model opus
+`)
+    expect(engineProcessIn(rows, 10)).toBe(true)
   })
 
   it("a live kimi session passes the gate despite its rewritten title", () => {


### PR DESCRIPTION
## Direction

Bugs / correctness — a self-found defect surfaced by an adversarial read of the pure-function surface (the two open GitHub issues were unsuitable: #551 is explicitly reserved by the owner as a semantics-contract decision, #307 is a broad memory investigation with a candidate PR already open).

## The problem

`vendorFromArgv` in `src/engine/foreground.ts` answers "which engine is running in this tab" by walking the PTY shell's process tree and reading each process's executable position, skipping the leading `env`/`node` wrapper and any `VAR=value` assignment tokens in front of the real binary.

The scan was capped at the **first four tokens** (`.slice(0, 4)`). But each skipped wrapper/assignment token still consumed a slot, so once three-or-more of them preceded the binary, the binary fell outside the window and the function returned `null`. A very common shape triggers it:

```
env ANTHROPIC_API_KEY=… ANTHROPIC_BASE_URL=… ANTHROPIC_MODEL=… claude
```

i.e. exactly how a proxied Claude is launched (an `env` wrapper plus three routing vars). Tokens `[env, KEY=…, URL=…, MODEL=…]` fill the window; `claude` at index 4 is never examined, so a live engine reads as a bare shell.

Impact: the tab's foreground-engine identity (`foregroundEngineIn`) and, worse, the **delivery gate** (`engineProcessIn`) both misclassify the session. The delivery gate exists to refuse pasting a prompt into a fallback shell — so under this bug it refuses to hand a prompt to a real, running engine.

## The fix

Remove the fixed token window. The loop already `return`s at the first executable-position (non-skip) token, so it never scans a binary's own arguments regardless of the cap — the cap was purely a (buggy) bound. It now runs to the first executable-position token however many assignments or wrappers precede it, preserving the "arguments never count" property that the original title heuristic got wrong.

## Verification

- Added two regression tests (`test/engine/foreground.test.ts`): one at the `vendorFromArgv` level (`env A=1 B=2 C=3 claude`, a realistic proxy launch line, and a bare `FOO=1 BAR=2 BAZ=3 QUX=4 codex`), one at the `engineProcessIn` delivery-gate level.
- Confirmed both tests **fail** with the old `.slice(0, 4)` restored and **pass** with the fix — they are genuine guards, not tautologies.
- `bun run lint` ✅, `bun run typecheck` ✅, full engine suite `bun x vitest run test/engine/` ✅ (625 passing, 1 pre-existing skip).

## Follow-ups (deliberately not in this slice)

- `engineProcessIn`'s `extraBin` custom-engine fallback matches only `basename(argv0)`, so a wrapper-launched custom engine (`node /usr/lib/aider/main.js` registered as `aider`) isn't seen. That's a documented name-only limitation, out of scope here — worth a separate look.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Eye8wc2kaB4vbnvwhmCxNp)_