### PR TITLE
fix: resolve a wrapper engine's protocol from the process it is running

### DIFF
--- a/.changeset/ctrl-e-continue-live-vendor.md
+++ b/.changeset/ctrl-e-continue-live-vendor.md
@@ -1,0 +1,11 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Continue a conversation from a wrapper engine. ctrl+e → continue on a tab
+running a custom preset that wraps a built-in CLI (a `claudecpa` shell
+function around `claude`) refused with "No conversation in this tab to fork
+yet": the preset id resolved to the empty engine entry, so kobe read no
+transcripts and found no fork verb. It now resolves the source engine from
+the live process the tab is actually running, and the forked tab still
+launches the preset the user picked.

--- a/packages/kobe/src/tui-react/workspace/fork-chat-tab.ts
+++ b/packages/kobe/src/tui-react/workspace/fork-chat-tab.ts
@@ -9,7 +9,7 @@
  * keeping it thin is what stops either of them leaking into the component.
  */
 
-import { engineCanFork, protocolEntry } from "@/engine/engine-presets"
+import { engineCanFork, getEngineProtocol, protocolEntry } from "@/engine/engine-presets"
 import { engineDisplayName } from "@/engine/interactive-command"
 import { buildHandoffPrompt } from "@/engine/session-handoff"
 import type { VendorId } from "@/types/vendor"
@@ -17,6 +17,7 @@ import {
   type TabsState,
   type TerminalTab,
   addTab,
+  setTabEngineCommand,
   setTabForkFrom,
   setTabInitialPrompt,
 } from "../../tui/workspace/terminal-tabs-core"
@@ -34,6 +35,27 @@ export type ChatForkPlan =
   /** There IS a conversation, but its engine keeps no transcript kobe can
    *  name (kimi, copilot, custom), so there is nothing to hand over. */
   | { readonly kind: "no-transcript"; readonly engine: string }
+
+/**
+ * The protocol the active tab's engine actually SPEAKS, which is not always
+ * the id it was launched under.
+ *
+ * A custom preset registered without `engineProtocol.<id>` (the shape every
+ * pre-`engineProtocol` preset has on disk) resolves to the empty custom
+ * registry entry: no transcript reader, no fork verb — so a `claudecpa` tab
+ * that has been talking to claude all along reported "nothing to continue"
+ * (owner report 2026-09-02). The process-tree walk already answered this
+ * question and recorded it as `EngineTab.liveVendor`; this is the join.
+ *
+ * Evidence, never a default. A declared protocol (built-in, contrib, or a
+ * preset that named one) is authoritative and wins; a live vendor that names
+ * no protocol of its own is no better than the id we started with.
+ */
+export function liveSourceProtocol(active: TerminalTab, tabVendor: VendorId): VendorId {
+  if (getEngineProtocol(tabVendor)) return tabVendor
+  const live = active.kind === "engine" ? active.liveVendor : undefined
+  return live && getEngineProtocol(live) ? live : tabVendor
+}
 
 /**
  * Resolve "continue this chat in `target`" to one outcome.
@@ -102,11 +124,21 @@ export async function forkSourceSessionId(
   return ids.at(-1) ?? null
 }
 
-/** New engine tab pinned to `vendor` (always CONCRETE — `engineTabArgv`
- *  only forks a tab whose vendor it can read), marked as its fork. */
-export function addForkTab(state: TabsState, vendor: VendorId, sourceSessionId: string): TabsState {
-  const next = addTab(state, vendor)
-  return setTabForkFrom(next, next.activeId, sourceSessionId)
+/**
+ * New engine tab that LAUNCHES `pick` but speaks `protocol`, marked as a fork
+ * of `sourceSessionId`.
+ *
+ * The two split for a wrapper preset: the user picked `claudecpa` and the new
+ * tab must still run it (its zsh function passes `"$@"` through), while every
+ * session verb `engineTabArgv` reaches for — the fork flags above all — is
+ * claude's. `EngineTab.engineCommand` already means exactly that ("wins over
+ * `vendor` at spawn; `vendor` then carries the protocol kobe resolved for
+ * it"), so pinning the pick there is what keeps the launch honest.
+ */
+export function addForkTab(state: TabsState, pick: VendorId, protocol: VendorId, sourceSessionId: string): TabsState {
+  const next = addTab(state, protocol)
+  const launched = pick === protocol ? next : setTabEngineCommand(next, next.activeId, pick)
+  return setTabForkFrom(launched, launched.activeId, sourceSessionId)
 }
 
 /** New engine tab pinned to `vendor`, opening on the handoff brief. */

--- a/packages/kobe/src/tui-react/workspace/use-tab-dialogs.ts
+++ b/packages/kobe/src/tui-react/workspace/use-tab-dialogs.ts
@@ -48,6 +48,7 @@ import {
   type ChatForkPlan,
   addForkTab,
   addHandoffTab,
+  liveSourceProtocol,
   planChatContinuation,
   planWorktreeHandoff,
 } from "./fork-chat-tab"
@@ -105,12 +106,17 @@ export function useTabDialogs(deps: {
     )
 
   /** destination=tab: land the picked engine as a sibling tab — fresh
-   *  (plain `addTab`) or continuing (fork/handoff, old `ctrl+a c`). */
-  const openTabHere = async (choice: NewChatChoice, source: VendorId): Promise<void> => {
+   *  (plain `addTab`) or continuing (fork/handoff, old `ctrl+a c`).
+   *  `tabVendor` is the id the active tab was LAUNCHED under, `source` the
+   *  protocol it speaks; picking that same id is "continue here", so it
+   *  continues under the same protocol rather than reading as a handoff to a
+   *  foreign engine. */
+  const openTabHere = async (choice: NewChatChoice, tabVendor: VendorId, source: VendorId): Promise<void> => {
     const vendor = choice.pick as VendorId
     if (choice.context === "continue") {
-      const plan = await planChatContinuation(active, source, vendor, deps.worktree)
-      if (plan.kind === "fork") update(pinSession(addForkTab(state, vendor, plan.sessionId), vendor))
+      const target = vendor === tabVendor ? source : vendor
+      const plan = await planChatContinuation(active, source, target, deps.worktree)
+      if (plan.kind === "fork") update(pinSession(addForkTab(state, vendor, target, plan.sessionId), target))
       else if (plan.kind === "handoff") update(pinSession(addHandoffTab(state, vendor, plan.prompt), vendor))
       else notifyRefusal(plan)
       return
@@ -161,7 +167,8 @@ export function useTabDialogs(deps: {
    *  open it with a toggle pre-flipped. Dispatches the four combos above. */
   const requestNewChat = (preset: NewChatPreset = {}): void => {
     void (async () => {
-      const source = (active.kind === "engine" ? active.vendor : undefined) ?? deps.vendor
+      const tabVendor = (active.kind === "engine" ? active.vendor : undefined) ?? deps.vendor
+      const source = liveSourceProtocol(active, tabVendor)
       const available = await availableEngineIds()
       // Installed plugin panes ride the same picker (owner ask 2026-07-29):
       // ctrl+e is "what runs in this tab", and a pane is exactly that. Reads
@@ -179,7 +186,7 @@ export function useTabDialogs(deps: {
         // Continue-presets highlight the tab's own engine (the conversation
         // being continued); the pristine entry keeps ctrl+e's task-engine
         // default.
-        preset.context === "continue" ? source : deps.vendor,
+        preset.context === "continue" ? tabVendor : deps.vendor,
         {
           allowShell: true,
           allowScratch: deps.onOpenScratch !== undefined,
@@ -212,7 +219,7 @@ export function useTabDialogs(deps: {
         deps.onOpenScratch?.()
         return
       }
-      await openTabHere(choice, source)
+      await openTabHere(choice, tabVendor, source)
     })()
   }
 

--- a/packages/kobe/src/tui/workspace/terminal-tabs-core.ts
+++ b/packages/kobe/src/tui/workspace/terminal-tabs-core.ts
@@ -270,6 +270,20 @@ export function setTabForkFrom(state: TabsState, id: string, sourceSessionId: st
   return { ...state, tabs }
 }
 
+/**
+ * Pin the RAW launch command on an engine tab (see `EngineTab.engineCommand`),
+ * so the tab launches `command` while its `vendor` carries the protocol kobe
+ * resolved for it. Set together with a vendor when the two differ — a custom
+ * preset (`claudecpa`) launches by its own name but speaks the wrapped
+ * engine's session verbs.
+ */
+export function setTabEngineCommand(state: TabsState, id: string, command: string): TabsState {
+  const tabs = state.tabs.map(
+    (t): TerminalTab => (t.id === id && t.kind === "engine" ? { ...t, engineCommand: command } : t),
+  )
+  return { ...state, tabs }
+}
+
 /** Give an engine tab its own first-spawn prompt (see
  *  `EngineTab.initialPrompt`) — the cross-engine handoff brief. */
 export function setTabInitialPrompt(state: TabsState, id: string, prompt: string): TabsState {

--- a/packages/kobe/test/render/new-chat-flow.test.tsx
+++ b/packages/kobe/test/render/new-chat-flow.test.tsx
@@ -34,7 +34,7 @@ import type { QuickTaskResult } from "../../src/tui-react/component/quick-task-c
 import { useT } from "../../src/tui-react/i18n"
 import { useDialog } from "../../src/tui-react/ui/dialog"
 import { type NewChatPreset, useTabDialogs } from "../../src/tui-react/workspace/use-tab-dialogs"
-import type { TabsState } from "../../src/tui/workspace/terminal-tabs-core"
+import { type EngineTab, type TabsState, engineTabArgv } from "../../src/tui/workspace/terminal-tabs-core"
 import { act, renderComponent, settle, waitForFrameText } from "./harness"
 
 let root: string
@@ -77,6 +77,15 @@ beforeAll(() => {
   fs.mkdirSync(process.env.KOBE_HOME_DIR, { recursive: true })
   repo = path.join(root, "repo")
   worktree = path.join(root, "wt")
+  // A wrapper preset registered the way every pre-`engineProtocol` one is on
+  // disk: a command and a name, NO `engineProtocol.claudecpa`. That absence is
+  // the bug under test, so the fixture must not paper over it.
+  const stateDir = path.join(process.env.KOBE_HOME_DIR as string, ".config", "rove")
+  fs.mkdirSync(stateDir, { recursive: true })
+  fs.writeFileSync(
+    path.join(stateDir, "state.json"),
+    JSON.stringify({ customEngineIds: ["claudecpa"], "engineCommand.claudecpa": "claudecpa" }),
+  )
   fs.mkdirSync(repo)
   git(repo, "init", "-b", "main")
   git(repo, "commit", "--allow-empty", "-m", "init")
@@ -161,6 +170,41 @@ describe("requestNewChat dispatch", () => {
     await frame()
     expect(captured.updates).toHaveLength(0)
     expect(captured.errors).toEqual(["No conversation in this tab to fork yet"])
+  })
+
+  // Why (owner report 2026-09-02): `claudecpa` is a zsh function that ends up
+  // running the real claude binary. Registered with no `engineProtocol`, its id
+  // resolves to the empty custom registry entry — no transcript reader, no fork
+  // verb — so this gesture refused with the "nothing to continue" toast on a tab
+  // that had been talking to claude all along. The walk already recorded the
+  // truth as `liveVendor`; this drives the same keys the owner did.
+  test("tab+continue forks through a wrapper preset's LIVE engine (issue: claudecpa)", async () => {
+    const projectDir = path.join(process.env.CLAUDE_CONFIG_DIR as string, "projects", encodeCwd(worktree))
+    fs.mkdirSync(projectDir, { recursive: true })
+    fs.writeFileSync(path.join(projectDir, "wrapped.jsonl"), "{}\n")
+
+    const { frame, mockInput, captured } = await mountFlow({
+      // The reported shape: launched as claudecpa, walked to claude, no pin.
+      tabs: [{ kind: "engine", id: "tab-1", title: null, ordinal: 1, vendor: "claudecpa", liveVendor: "claude" }],
+      activeId: "tab-1",
+      nextOrdinal: 2,
+    })
+    act(() => captured.request({ context: "continue" }))
+    await waitForFrameText(frame, "continue this conversation")
+    act(() => mockInput.pressEnter())
+    await waitFor(() => captured.updates.length > 0 || captured.errors.length > 0)
+    expect(captured.errors).toHaveLength(0)
+
+    const next = captured.updates[0]!
+    const forked = next.tabs[1]!
+    // Still LAUNCHES the preset the user picked; only the protocol is claude's.
+    expect(forked).toMatchObject({ kind: "engine", engineCommand: "claudecpa", vendor: "claude" })
+    expect(engineTabArgv(forked as EngineTab, ["claudecpa"], false)).toEqual([
+      "claudecpa",
+      "--resume",
+      "wrapped",
+      "--fork-session",
+    ])
   })
 
   test("fork+fresh opens the QuickTaskComposer; submit reaches onQuickFork", async () => {

--- a/packages/kobe/test/render/new-chat-flow.test.tsx
+++ b/packages/kobe/test/render/new-chat-flow.test.tsx
@@ -77,15 +77,6 @@ beforeAll(() => {
   fs.mkdirSync(process.env.KOBE_HOME_DIR, { recursive: true })
   repo = path.join(root, "repo")
   worktree = path.join(root, "wt")
-  // A wrapper preset registered the way every pre-`engineProtocol` one is on
-  // disk: a command and a name, NO `engineProtocol.claudecpa`. That absence is
-  // the bug under test, so the fixture must not paper over it.
-  const stateDir = path.join(process.env.KOBE_HOME_DIR as string, ".config", "rove")
-  fs.mkdirSync(stateDir, { recursive: true })
-  fs.writeFileSync(
-    path.join(stateDir, "state.json"),
-    JSON.stringify({ customEngineIds: ["claudecpa"], "engineCommand.claudecpa": "claudecpa" }),
-  )
   fs.mkdirSync(repo)
   git(repo, "init", "-b", "main")
   git(repo, "commit", "--allow-empty", "-m", "init")
@@ -182,29 +173,46 @@ describe("requestNewChat dispatch", () => {
     const projectDir = path.join(process.env.CLAUDE_CONFIG_DIR as string, "projects", encodeCwd(worktree))
     fs.mkdirSync(projectDir, { recursive: true })
     fs.writeFileSync(path.join(projectDir, "wrapped.jsonl"), "{}\n")
+    // A wrapper preset registered the way every pre-`engineProtocol` one is on
+    // disk: a command and a name, NO `engineProtocol.claudecpa`. That absence is
+    // the bug under test, so the fixture must not paper over it.
+    //
+    // Scoped to THIS test, not the file: custom engines are always offered, so
+    // a registration left standing changes what the picker highlights for
+    // everyone else — and on a runner with no claude binary it becomes the only
+    // entry, which is how it broke the two neighbours that assert on "claude".
+    const statePath = path.join(process.env.KOBE_HOME_DIR as string, ".config", "rove", "state.json")
+    fs.mkdirSync(path.dirname(statePath), { recursive: true })
+    fs.writeFileSync(
+      statePath,
+      JSON.stringify({ customEngineIds: ["claudecpa"], "engineCommand.claudecpa": "claudecpa" }),
+    )
+    try {
+      const { frame, mockInput, captured } = await mountFlow({
+        // The reported shape: launched as claudecpa, walked to claude, no pin.
+        tabs: [{ kind: "engine", id: "tab-1", title: null, ordinal: 1, vendor: "claudecpa", liveVendor: "claude" }],
+        activeId: "tab-1",
+        nextOrdinal: 2,
+      })
+      act(() => captured.request({ context: "continue" }))
+      await waitForFrameText(frame, "continue this conversation")
+      act(() => mockInput.pressEnter())
+      await waitFor(() => captured.updates.length > 0 || captured.errors.length > 0)
+      expect(captured.errors).toHaveLength(0)
 
-    const { frame, mockInput, captured } = await mountFlow({
-      // The reported shape: launched as claudecpa, walked to claude, no pin.
-      tabs: [{ kind: "engine", id: "tab-1", title: null, ordinal: 1, vendor: "claudecpa", liveVendor: "claude" }],
-      activeId: "tab-1",
-      nextOrdinal: 2,
-    })
-    act(() => captured.request({ context: "continue" }))
-    await waitForFrameText(frame, "continue this conversation")
-    act(() => mockInput.pressEnter())
-    await waitFor(() => captured.updates.length > 0 || captured.errors.length > 0)
-    expect(captured.errors).toHaveLength(0)
-
-    const next = captured.updates[0]!
-    const forked = next.tabs[1]!
-    // Still LAUNCHES the preset the user picked; only the protocol is claude's.
-    expect(forked).toMatchObject({ kind: "engine", engineCommand: "claudecpa", vendor: "claude" })
-    expect(engineTabArgv(forked as EngineTab, ["claudecpa"], false)).toEqual([
-      "claudecpa",
-      "--resume",
-      "wrapped",
-      "--fork-session",
-    ])
+      const next = captured.updates[0]!
+      const forked = next.tabs[1]!
+      // Still LAUNCHES the preset the user picked; only the protocol is claude's.
+      expect(forked).toMatchObject({ kind: "engine", engineCommand: "claudecpa", vendor: "claude" })
+      expect(engineTabArgv(forked as EngineTab, ["claudecpa"], false)).toEqual([
+        "claudecpa",
+        "--resume",
+        "wrapped",
+        "--fork-session",
+      ])
+    } finally {
+      fs.rmSync(statePath, { force: true })
+    }
   })
 
   test("fork+fresh opens the QuickTaskComposer; submit reaches onQuickFork", async () => {

--- a/packages/kobe/test/tui/continue-live-vendor.test.ts
+++ b/packages/kobe/test/tui/continue-live-vendor.test.ts
@@ -1,0 +1,123 @@
+/**
+ * "Continue this conversation" on a WRAPPER preset (owner report 2026-09-02).
+ *
+ * A custom engine registered before `engineProtocol.<id>` existed — the
+ * `claudecpa` zsh function that ends up running the real claude binary — has
+ * a command and a display name in state.json and nothing else. Every session
+ * verb keys on `sessionProtocol(vendor)`, which lands such an id on the empty
+ * custom registry entry: no transcript reader (so `forkSourceSessionId` finds
+ * zero sessions) and no fork verb, and ctrl+e → continue answered "nothing to
+ * continue from" on a tab that had been talking to claude the whole time.
+ *
+ * The evidence was already recorded: the process-tree walk sees through the
+ * wrapper and writes `EngineTab.liveVendor`. These pin the join — resolution
+ * AND the launch line it has to produce, because fixing only the dialog moves
+ * the same silent failure to spawn time.
+ */
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { encodeCwd } from "@/engine/claude-code-local/history"
+import { addForkTab, liveSourceProtocol, planChatContinuation } from "@/tui-react/workspace/fork-chat-tab"
+import {
+  type EngineTab,
+  type TabsState,
+  engineTabArgv,
+  initialTabs,
+  setTabSessionId,
+} from "@/tui/workspace/terminal-tabs-core"
+import { afterAll, beforeAll, describe, expect, it } from "vitest"
+
+const WORKTREE = "/repo/wt-claudecpa"
+const SESSION = "11111111-2222-3333-4444-555555555555"
+
+/** The reported shape: launched as `claudecpa`, walked to claude, no pin. */
+const wrapperTab = (over: Partial<EngineTab> = {}): EngineTab => ({
+  kind: "engine",
+  id: "tab-1",
+  title: null,
+  ordinal: 1,
+  vendor: "claudecpa",
+  liveVendor: "claude",
+  ...over,
+})
+
+let claudeDir: string
+let prevConfigDir: string | undefined
+
+beforeAll(() => {
+  // A real claude transcript store, so the history read under test is the
+  // real reader rather than a stub that could agree with a broken caller.
+  claudeDir = mkdtempSync(join(tmpdir(), "rove-claudecpa-"))
+  const projectDir = join(claudeDir, "projects", encodeCwd(WORKTREE))
+  mkdirSync(projectDir, { recursive: true })
+  writeFileSync(join(projectDir, `${SESSION}.jsonl`), '{"type":"user","message":{"role":"user","content":"hi"}}\n')
+  prevConfigDir = process.env.CLAUDE_CONFIG_DIR
+  process.env.CLAUDE_CONFIG_DIR = claudeDir
+})
+
+afterAll(() => {
+  // Empty restores the real store: the reader falls back on a blank value.
+  process.env.CLAUDE_CONFIG_DIR = prevConfigDir ?? ""
+  rmSync(claudeDir, { recursive: true, force: true })
+})
+
+describe("liveSourceProtocol", () => {
+  it("resolves a preset with no declared protocol through the walked live vendor", () => {
+    expect(liveSourceProtocol(wrapperTab(), "claudecpa")).toBe("claude")
+  })
+
+  it("keeps a declared protocol — walk evidence never re-labels a known engine", () => {
+    expect(liveSourceProtocol(wrapperTab({ vendor: "codex", liveVendor: "claude" }), "codex")).toBe("codex")
+  })
+
+  it("stays on the id when there is no live evidence, or none that names a protocol", () => {
+    expect(liveSourceProtocol(wrapperTab({ liveVendor: null }), "claudecpa")).toBe("claudecpa")
+    expect(liveSourceProtocol(wrapperTab({ liveVendor: "other-wrapper" }), "claudecpa")).toBe("claudecpa")
+  })
+})
+
+describe("continuing a wrapper-preset tab", () => {
+  it("finds the wrapped engine's session and forks it", async () => {
+    const source = liveSourceProtocol(wrapperTab(), "claudecpa")
+    // The picker offers `claudecpa`; picking the id this tab already runs is
+    // "continue here", so source and target are the same protocol.
+    expect(await planChatContinuation(wrapperTab(), source, source, WORKTREE)).toEqual({
+      kind: "fork",
+      sessionId: SESSION,
+    })
+  })
+
+  it("still reports nothing to continue when the id resolves to no protocol", async () => {
+    // The pre-fix behaviour, kept as the contract for a genuinely unknown
+    // engine: no reader, so no session, so a refusal instead of a blank tab.
+    expect(await planChatContinuation(wrapperTab({ liveVendor: null }), "claudecpa", "claudecpa", WORKTREE)).toEqual({
+      kind: "no-session",
+    })
+  })
+
+  it("launches the preset the user picked and resumes-and-forks with the wrapped engine's flags", () => {
+    const state: TabsState = { ...initialTabs(), tabs: [wrapperTab()] }
+    const forked = setTabSessionId(addForkTab(state, "claudecpa", "claude", SESSION), "tab-2", "new-id")
+    const tab = forked.tabs.find((t) => t.id === forked.activeId) as EngineTab
+    // The launch stays the preset (its zsh function passes "$@" through);
+    // only the protocol — and so the session verbs — is claude's.
+    expect(tab.engineCommand).toBe("claudecpa")
+    expect(tab.vendor).toBe("claude")
+    expect(engineTabArgv(tab, ["claudecpa"], false)).toEqual([
+      "claudecpa",
+      "--resume",
+      SESSION,
+      "--fork-session",
+      "--session-id",
+      "new-id",
+    ])
+  })
+
+  it("pins no redundant command when the pick already IS its protocol", () => {
+    const state: TabsState = { ...initialTabs(), tabs: [wrapperTab()] }
+    const tab = addForkTab(state, "claude", "claude", SESSION).tabs.at(-1) as EngineTab
+    expect(tab.engineCommand).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## The bug

ctrl+e → continue (`context=continue`) → enter on a task whose engine is the custom preset `claudecpa` (a zsh function that ends up running the real `claude` binary) did nothing but toast **"No conversation in this tab to fork yet"**. The same gesture on a plain `claude` task worked, and claude itself forks fine by hand.

`~/.config/rove/state.json` has `engineCommand.claudecpa` and `engineName.claudecpa` but no `engineProtocol.claudecpa` — the shape of every preset registered before that key existed. So `sessionProtocol("claudecpa")` answers `"claudecpa"`, which lands on the documented empty custom registry entry: `listSessionIdsForWorktree` → 0 ids, `engineCanFork` → false. The tab has no pinned `sessionId` either (bare `claudecpa` argv, `withPinnedSessionId` skips for the same reason), so `forkSourceSessionId` falls through to the empty history read and the plan comes back `no-session`.

Meanwhile the ground truth was already recorded. The process-tree walk in `src/engine/foreground.ts` sees straight through `claudecpa` → `cc-switch` → `claude`, and `use-tab-turn-state.ts` writes it to `EngineTab.liveVendor`. `rove api get-task` on the reporting task says so today:

```
tab-60 engine vendor=None       liveVendor=claude
tab-66 engine vendor=claudecpa  liveVendor=claude
```

The continue path never looked at it.

## The change

One resolver, `liveSourceProtocol` in `fork-chat-tab.ts` (the join module). A declared protocol — built-in, contrib, or a preset that named one — stays authoritative; only an id that names no protocol falls back to the walked live vendor, and only when that names one. No literal vendor strings: it asks `getEngineProtocol`.

Two call sites, because fixing only the first moves the silent failure one step later:

- **The dialog** (`use-tab-dialogs.ts`) resolves `source` through it, and picking the id the tab already runs now reads as "continue here" rather than a handoff to a foreign engine.
- **The launch line.** `engineTabArgv` keys `engineForkArgv` on `tab.vendor`, so a fork tab pinned to `claudecpa` would have returned null and silently opened a plain tab. `addForkTab` now pins the user's pick as `engineCommand` and the resolved protocol as `vendor` — which is exactly what `EngineTab.engineCommand` already documents ("wins over `vendor` at spawn; `vendor` then carries the protocol kobe resolved for it"). The new tab still launches `claudecpa` (its zsh function passes `"$@"` through) and takes claude's session verbs.

Step 3 of the brief (persisting `engineProtocol.<preset>` from `protocolUpgradeFromLiveSession`) did **not** land — see below.

## Evidence

**Live, on the reporting machine** — real `state.json`, real `~/.claude` store, the real tab shape read out of `rove api get-task`:

```
state.json engineProtocol.claudecpa : (absent)
sessionProtocol('claudecpa')        : claudecpa

BEFORE (source = tab.vendor):
  {"kind":"no-session"}                      ← the toast

AFTER  (source = liveSourceProtocol) : claude
  {"kind":"fork","sessionId":"d710cde1-a409-47b5-97cd-3da0faf2541f"}

new tab   : {"engineCommand":"claudecpa","vendor":"claude"}
spawn argv: ["claudecpa","--resume","d710cde1-…","--fork-session","--session-id","fork-target-id"]
```

That last line is the `pty-sessions` spawn argv, computed by the real code from the real preset command — and it holds with `engineProtocol.claudecpa` still absent, which was the requirement.

**Harness screenshots were not usable and were not faked.** The visual fixture redirects `HOME`, so neither the `claudecpa` zsh function nor claude's auth exists inside it — a real wrapper session cannot run there. Instead of a synthetic stand-in shot, the UI half is pinned by a **render test driving the real keys through the real hook** (`test/render/new-chat-flow.test.tsx`), which is CI-enforced where a screenshot would not be.

## Tests

- `test/render/new-chat-flow.test.tsx` — real keypresses through the real `useTabDialogs`: a `claudecpa` tab with `liveVendor: "claude"` and a claude transcript on disk now forks instead of toasting, and the resulting tab's argv is `claudecpa --resume wrapped --fork-session`. The sandboxed `state.json` registers the preset **without** `engineProtocol`, so the fixture can't paper over the bug.
- `test/tui/continue-live-vendor.test.ts` — the resolver's three cases (resolves through the walk; never re-labels a declared protocol; stays put without evidence) plus the end-to-end plan → tab → argv, against a real claude transcript store via `CLAUDE_CONFIG_DIR`.

Mutation-verified at two different sites — reverting the resolver, and reverting the launch/protocol split — each fails the intended assertions in both suites, and only those.

## Not in this PR

`protocolUpgradeFromLiveSession` still refuses a task with no `command` (the reporting task's exact shape: `vendor=claudecpa`, `command` empty) and still only upgrades the task record, never writing `engineProtocol.<id>`. Persisting the walked protocol would fix this class once for every consumer — history, trust store, delivery mode — rather than per gesture, but it is a state write with its own correctness questions (when is walk evidence durable enough to persist, what invalidates it) and it belongs in its own change. Left out deliberately; this fix stands without it.