### PR TITLE
fix: flush deferred prompts when the delivery check turns off

### DIFF
--- a/.changeset/flush-deferred-composer-off.md
+++ b/.changeset/flush-deferred-composer-off.md
@@ -4,4 +4,6 @@
 
 Flush queued peer and API prompts when the composer screen check is turned off.
 
-Rove now retries every deferred prompt in insertion order after the setting is durably disabled. Successful deliveries clear their Inbox entries; a busy, temporarily unavailable, or failed tab keeps its prompt queued and visible while later tabs continue. Explicitly closing a tab discards its queued prompt and clears the stale Inbox entry.
+Rove now retries every deferred prompt in insertion order after the setting is durably disabled. Each record is claimed before exact-engine-tab delivery, and a durable delivered marker prevents a failed Inbox cleanup from sending it twice. Concurrent flush, Inbox release, dismiss, and tab-close operations converge without duplicate delivery; expired records clean their Inbox pointers.
+
+A busy, temporarily unavailable, or failed tab stays queued while later tabs continue. Re-enabling the check synchronously cancels the remaining flush, an older daemon that lacks the flush verb produces an on-screen warning, and both attached-TUI and headless tab closing discard the tab's queued prompt.

--- a/.changeset/flush-deferred-composer-off.md
+++ b/.changeset/flush-deferred-composer-off.md
@@ -1,0 +1,7 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Flush queued peer and API prompts when the composer screen check is turned off.
+
+Rove now retries every deferred prompt in insertion order after the setting is durably disabled. Successful deliveries clear their Inbox entries; a busy, temporarily unavailable, or failed tab keeps its prompt queued and visible while later tabs continue. Explicitly closing a tab discards its queued prompt and clears the stale Inbox entry.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -327,9 +327,12 @@ The second one reads the engine's CURRENT on-screen layout, so a vendor
 redesign can make it wrong: it holds every message while reporting a composer
 you can see is empty. If that happens, turn the check off in **Settings → Dev
 → Check the composer before delivering**. Delivery then skips the screen read
-and relies on the keystroke-recency guard alone, which measures time instead
-of parsing a layout and so cannot go stale — a composer you are typing into
-right now stays protected either way.
+and immediately retries every queued prompt in its original order. A prompt
+that still cannot reach its exact tab stays in the Inbox; later tabs are still
+attempted, so one dead or recently typed-in tab cannot strand the rest. The
+keystroke-recency guard remains active and can keep a prompt queued until the
+10-second quiet period passes. Explicitly closing that tab discards its queued
+prompt, clears the stale Inbox entry, and records the discard in the daemon log.
 
 Leave it on otherwise. It is what stops an agent's message landing in the
 middle of a half-typed sentence.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -328,11 +328,17 @@ redesign can make it wrong: it holds every message while reporting a composer
 you can see is empty. If that happens, turn the check off in **Settings → Dev
 → Check the composer before delivering**. Delivery then skips the screen read
 and immediately retries every queued prompt in its original order. A prompt
-that still cannot reach its exact tab stays in the Inbox; later tabs are still
-attempted, so one dead or recently typed-in tab cannot strand the rest. The
+that still cannot reach its exact live engine tab stays in the Inbox; an alive
+PTY whose engine exited into its fallback shell is never used. Later tabs are
+still attempted, so one dead or recently typed-in tab cannot strand the rest. The
 keystroke-recency guard remains active and can keep a prompt queued until the
 10-second quiet period passes. Explicitly closing that tab discards its queued
 prompt, clears the stale Inbox entry, and records the discard in the daemon log.
+
+Turning the check back on cancels the remaining flush after its current item;
+both setting transitions are persisted synchronously. If the attached daemon
+is too old to support queue flushing, Settings shows an error dialog. Restart
+Rove to load the matching daemon, then toggle the setting again.
 
 Leave it on otherwise. It is what stops an agent's message landing in the
 middle of a half-typed sentence.

--- a/packages/kobe-daemon/src/daemon/attention-inbox.ts
+++ b/packages/kobe-daemon/src/daemon/attention-inbox.ts
@@ -41,6 +41,8 @@ interface AttentionInboxFile {
  */
 export const MAX_EPISODES = 500
 
+export type AttentionInboxLane = "activity" | "prompt_deferred"
+
 export function defaultAttentionInboxPath(homeDir = readRoveEnv("HOME_DIR") ?? homedir()): string {
   return join(homeDir, ROVE_STATE_DIR_BASENAME, "attention-inbox.json")
 }
@@ -214,25 +216,35 @@ export class AttentionInboxStore {
    * (`deleteEpisode` via attention.dismiss). Kept for old clients whose
    * open still calls attention.markRead — treat it as the same resolve.
    */
-  async markRead(taskId: string, tabId: string | null, at: number): Promise<boolean> {
-    return await this.deleteEpisode(taskId, tabId, at)
+  async markRead(
+    taskId: string,
+    tabId: string | null,
+    at: number,
+    lane?: AttentionInboxLane,
+    deferredId?: string,
+  ): Promise<boolean> {
+    return await this.deleteEpisode(taskId, tabId, at, lane, deferredId)
   }
 
-  /** Nullable tabId addresses legacy task-level data only; new writes require a tab. */
-  async deleteEpisode(taskId: string, tabId: string | null, at?: number): Promise<boolean> {
+  /** Delete a matching episode; lane and deferredId narrow cross-store cleanup. */
+  async deleteEpisode(
+    taskId: string,
+    tabId: string | null,
+    at?: number,
+    lane?: AttentionInboxLane,
+    deferredId?: string,
+  ): Promise<boolean> {
     return await this.enqueue(async () => {
-      // Both lanes for this tab — the activity episode and any deferred-prompt
-      // one. Callers address a TAB ("I dealt with this"), not a lane; making
-      // them name the lane would leave whichever they forgot on screen.
-      const keys = [
-        attentionInboxItemKey({ taskId, tabId }),
-        attentionInboxItemKey({ taskId, tabId, state: "prompt_deferred" }),
-      ]
+      const activityKey = attentionInboxItemKey({ taskId, tabId })
+      const deferredKey = attentionInboxItemKey({ taskId, tabId, state: "prompt_deferred" })
+      const keys =
+        lane === "activity" ? [activityKey] : lane === "prompt_deferred" ? [deferredKey] : [activityKey, deferredKey]
       const next = new Map(this.items)
       let removed = false
       for (const key of keys) {
         const item = this.items.get(key)
         if (!item || (at !== undefined && item.at !== at)) continue
+        if (deferredId !== undefined && item.detail?.deferredPrompt?.id !== deferredId) continue
         next.delete(key)
         removed = true
       }

--- a/packages/kobe-daemon/src/daemon/deferred-prompts-store.ts
+++ b/packages/kobe-daemon/src/daemon/deferred-prompts-store.ts
@@ -29,6 +29,8 @@ export const DEFERRED_PROMPT_TTL_MS = 24 * 60 * 60 * 1000
 
 export type DeferredPromptLayer = "recent-human-write" | "composer-not-empty"
 
+export type DeferredPromptDiscardReason = "Inbox item dismissed" | "Inbox item read by legacy client" | "tab closed"
+
 /** One daemon-owned deferred prompt, awaiting a human's release from the Inbox. */
 export interface DeferredPromptRecord {
   /** Stable id — the inbox episode references the record by this. */
@@ -163,6 +165,27 @@ export class DeferredPromptsStore {
     return await this.enqueue(async () => (await readStore(this.path)).records.find((r) => r.id === id) ?? null)
   }
 
+  /**
+   * List every live record in insertion order. A flush is also a successful
+   * store operation, so it enforces the same TTL boundary as filing a prompt.
+   */
+  async list(): Promise<readonly DeferredPromptRecord[]> {
+    return await this.enqueue(async () => {
+      const now = this.now()
+      const store = await readStore(this.path)
+      const kept = store.records.filter((record) => {
+        if (now - record.at <= DEFERRED_PROMPT_TTL_MS) return true
+        logDaemonInfo(
+          SUBSYSTEM,
+          `expired deferred prompt ${record.id} for ${record.taskId}::${record.tabId} (age ${Math.round((now - record.at) / 1000)}s) — dropped`,
+        )
+        return false
+      })
+      if (kept.length !== store.records.length) await writeStore(this.path, kept)
+      return kept
+    })
+  }
+
   /** Remove one record (called after its prompt was inserted, or on dismiss). */
   async resolve(id: string): Promise<boolean> {
     return await this.enqueue(async () => {
@@ -171,6 +194,27 @@ export class DeferredPromptsStore {
       if (kept.length === store.records.length) return false
       await writeStore(this.path, kept)
       return true
+    })
+  }
+
+  /** Drop a tab's prompt after an explicit user/UI lifecycle action, with a log. */
+  async discardTab(
+    taskId: string,
+    tabId: string,
+    reason: DeferredPromptDiscardReason,
+  ): Promise<readonly DeferredPromptRecord[]> {
+    return await this.enqueue(async () => {
+      const store = await readStore(this.path)
+      const dropped = store.records.filter((record) => record.taskId === taskId && record.tabId === tabId)
+      if (dropped.length === 0) return []
+      for (const record of dropped) {
+        logDaemonInfo(SUBSYSTEM, `dropped deferred prompt ${record.id} for ${taskId}::${tabId} — ${reason}`)
+      }
+      await writeStore(
+        this.path,
+        store.records.filter((record) => record.taskId !== taskId || record.tabId !== tabId),
+      )
+      return dropped
     })
   }
 

--- a/packages/kobe-daemon/src/daemon/deferred-prompts-store.ts
+++ b/packages/kobe-daemon/src/daemon/deferred-prompts-store.ts
@@ -12,8 +12,8 @@
  * Retention is explicit and logged — a record never vanishes silently:
  * - at most ONE deferred prompt per (taskId, tabId) — the first writer keeps
  *   the slot until release, and a later writer gets an explicit rejection;
- * - records older than {@link DEFERRED_PROMPT_TTL_MS} are evicted during a
- *   successful file operation (also logged).
+ * - records older than {@link DEFERRED_PROMPT_TTL_MS} are returned to the
+ *   queue drainer for coordinated record + Inbox cleanup.
  */
 
 import { randomUUID } from "node:crypto"
@@ -46,7 +46,19 @@ export interface DeferredPromptRecord {
   readonly senderTaskId?: string
   /** Epoch ms of deferral. */
   readonly at: number
+  /** Persisted delivery tombstone: cleanup may retry, PTY delivery may not. */
+  readonly deliveredAt?: number
 }
+
+export interface DeferredPromptClaim {
+  readonly claimId: string
+  readonly record: DeferredPromptRecord
+}
+
+export type DeferredPromptClaimResult =
+  | { readonly kind: "claimed"; readonly claim: DeferredPromptClaim }
+  | { readonly kind: "in-flight" }
+  | { readonly kind: "missing" }
 
 /** A tab already has daemon-owned text, so a later prompt was not accepted. */
 export class DeferredPromptPendingError extends Error {
@@ -83,6 +95,9 @@ function normalizeRecord(value: unknown): DeferredPromptRecord | null {
     ...(typeof raw.senderLabel === "string" ? { senderLabel: raw.senderLabel } : {}),
     ...(typeof raw.senderTaskId === "string" ? { senderTaskId: raw.senderTaskId } : {}),
     at: raw.at,
+    ...(typeof raw.deliveredAt === "number" && Number.isFinite(raw.deliveredAt)
+      ? { deliveredAt: raw.deliveredAt }
+      : {}),
   }
 }
 
@@ -110,6 +125,7 @@ const SUBSYSTEM = "deferred-prompts"
 export class DeferredPromptsStore {
   private readonly tail: Promise<void> = Promise.resolve()
   private queue: Promise<void> = this.tail
+  private readonly claims = new Map<string, { claimId: string; done: Promise<void>; finish: () => void }>()
 
   constructor(
     private readonly path = defaultDeferredPromptsPath(),
@@ -128,7 +144,7 @@ export class DeferredPromptsStore {
 
   /**
    * Store one deferred prompt when its (taskId, tabId) slot is vacant, while
-   * evicting TTL-expired records when the new prompt is accepted. A live
+   * ignoring TTL-expired records when checking occupancy. A live
    * record wins over later writers, so a prompt the daemon already accepted
    * cannot disappear under a second send.
    * Returns the stored record (with its minted id).
@@ -141,10 +157,23 @@ export class DeferredPromptsStore {
       let occupied: DeferredPromptRecord | null = null
       for (const existing of store.records) {
         if (now - existing.at > DEFERRED_PROMPT_TTL_MS) {
-          logDaemonInfo(
-            SUBSYSTEM,
-            `expired deferred prompt ${existing.id} for ${existing.taskId}::${existing.tabId} (age ${Math.round((now - existing.at) / 1000)}s) — dropped`,
-          )
+          if (this.claims.has(existing.id)) {
+            if (existing.taskId === record.taskId && existing.tabId === record.tabId) {
+              throw new Error(`deferred prompt ${existing.id} expiry cleanup is in flight`)
+            }
+            kept.push(existing)
+            continue
+          }
+          if (existing.taskId === record.taskId && existing.tabId === record.tabId) {
+            logDaemonInfo(
+              SUBSYSTEM,
+              `expired deferred prompt ${existing.id} for ${existing.taskId}::${existing.tabId} replaced by a new deferral`,
+            )
+            continue
+          }
+          // Keep it until list() hands its identity to the daemon, which can
+          // delete the matching Inbox pointer before resolving the record.
+          kept.push(existing)
           continue
         }
         if (existing.taskId === record.taskId && existing.tabId === record.tabId) {
@@ -165,24 +194,110 @@ export class DeferredPromptsStore {
     return await this.enqueue(async () => (await readStore(this.path)).records.find((r) => r.id === id) ?? null)
   }
 
+  /** Claim one record for the whole delivery/cleanup transaction. */
+  async claim(id: string): Promise<DeferredPromptClaimResult> {
+    return await this.enqueue(async () => {
+      if (this.claims.has(id)) return { kind: "in-flight" }
+      const record = (await readStore(this.path)).records.find((candidate) => candidate.id === id)
+      if (!record) return { kind: "missing" }
+      const claimId = randomUUID()
+      let finish = () => {}
+      const done = new Promise<void>((resolve) => {
+        finish = resolve
+      })
+      this.claims.set(id, { claimId, done, finish })
+      return { kind: "claimed", claim: { claimId, record } }
+    })
+  }
+
+  /** Persist the no-redelivery boundary before cross-store Inbox cleanup. */
+  async markDelivered(claim: DeferredPromptClaim): Promise<DeferredPromptRecord> {
+    return await this.enqueue(async () => {
+      this.requireClaim(claim)
+      const store = await readStore(this.path)
+      const current = store.records.find((record) => record.id === claim.record.id)
+      if (!current) throw new Error(`deferred prompt ${claim.record.id} disappeared while claimed`)
+      const delivered = current.deliveredAt ? current : { ...current, deliveredAt: this.now() }
+      if (!current.deliveredAt) {
+        await writeStore(
+          this.path,
+          store.records.map((record) => (record.id === current.id ? delivered : record)),
+        )
+      }
+      return delivered
+    })
+  }
+
+  /** Finish a claimed record after its Inbox pointer is gone. */
+  async completeClaim(claim: DeferredPromptClaim): Promise<boolean> {
+    return await this.enqueue(async () => {
+      this.requireClaim(claim)
+      const store = await readStore(this.path)
+      const kept = store.records.filter((record) => record.id !== claim.record.id)
+      if (kept.length !== store.records.length) await writeStore(this.path, kept)
+      this.finishClaim(claim.record.id)
+      return kept.length !== store.records.length
+    })
+  }
+
+  /** Relinquish a failed/busy claim without changing the durable record. */
+  async releaseClaim(claim: DeferredPromptClaim): Promise<void> {
+    await this.enqueue(async () => {
+      this.requireClaim(claim)
+      this.finishClaim(claim.record.id)
+    })
+  }
+
+  private requireClaim(claim: DeferredPromptClaim): void {
+    if (this.claims.get(claim.record.id)?.claimId !== claim.claimId) {
+      throw new Error(`deferred prompt ${claim.record.id} claim is no longer owned`)
+    }
+  }
+
+  private finishClaim(id: string): void {
+    const active = this.claims.get(id)
+    this.claims.delete(id)
+    active?.finish()
+  }
+
+  private async waitForClaims(taskId: string, tabId?: string): Promise<void> {
+    for (;;) {
+      const waiting = await this.enqueue(async () => {
+        const records = (await readStore(this.path)).records.filter(
+          (record) => record.taskId === taskId && (tabId === undefined || record.tabId === tabId),
+        )
+        return records.flatMap((record) => {
+          const active = this.claims.get(record.id)
+          return active ? [active.done] : []
+        })
+      })
+      if (waiting.length === 0) return
+      await Promise.all(waiting)
+    }
+  }
+
   /**
    * List every live record in insertion order. A flush is also a successful
    * store operation, so it enforces the same TTL boundary as filing a prompt.
    */
-  async list(): Promise<readonly DeferredPromptRecord[]> {
+  async list(): Promise<{
+    readonly records: readonly DeferredPromptRecord[]
+    readonly expired: readonly DeferredPromptRecord[]
+  }> {
     return await this.enqueue(async () => {
       const now = this.now()
       const store = await readStore(this.path)
+      const expired: DeferredPromptRecord[] = []
       const kept = store.records.filter((record) => {
         if (now - record.at <= DEFERRED_PROMPT_TTL_MS) return true
+        expired.push(record)
         logDaemonInfo(
           SUBSYSTEM,
-          `expired deferred prompt ${record.id} for ${record.taskId}::${record.tabId} (age ${Math.round((now - record.at) / 1000)}s) — dropped`,
+          `expired deferred prompt ${record.id} for ${record.taskId}::${record.tabId} (age ${Math.round((now - record.at) / 1000)}s) — cleanup requested`,
         )
         return false
       })
-      if (kept.length !== store.records.length) await writeStore(this.path, kept)
-      return kept
+      return { records: kept, expired }
     })
   }
 
@@ -203,6 +318,7 @@ export class DeferredPromptsStore {
     tabId: string,
     reason: DeferredPromptDiscardReason,
   ): Promise<readonly DeferredPromptRecord[]> {
+    await this.waitForClaims(taskId, tabId)
     return await this.enqueue(async () => {
       const store = await readStore(this.path)
       const dropped = store.records.filter((record) => record.taskId === taskId && record.tabId === tabId)
@@ -225,6 +341,7 @@ export class DeferredPromptsStore {
 
   /** Task deletion drops its queued prompts — logged, never silent. */
   async deleteTask(taskId: string): Promise<void> {
+    await this.waitForClaims(taskId)
     await this.enqueue(async () => {
       const store = await readStore(this.path)
       const kept = store.records.filter((r) => r.taskId !== taskId)

--- a/packages/kobe-daemon/src/daemon/deferred-prompts-store.ts
+++ b/packages/kobe-daemon/src/daemon/deferred-prompts-store.ts
@@ -46,8 +46,10 @@ export interface DeferredPromptRecord {
   readonly senderTaskId?: string
   /** Epoch ms of deferral. */
   readonly at: number
-  /** Persisted delivery tombstone: cleanup may retry, PTY delivery may not. */
+  /** Confirmed PTY delivery; retained only while Inbox cleanup is pending. */
   readonly deliveredAt?: number
+  /** Persisted before the PTY write: an ambiguous attempt may clean up, never retry. */
+  readonly deliveryStartedAt?: number
 }
 
 export interface DeferredPromptClaim {
@@ -97,6 +99,9 @@ function normalizeRecord(value: unknown): DeferredPromptRecord | null {
     at: raw.at,
     ...(typeof raw.deliveredAt === "number" && Number.isFinite(raw.deliveredAt)
       ? { deliveredAt: raw.deliveredAt }
+      : {}),
+    ...(typeof raw.deliveryStartedAt === "number" && Number.isFinite(raw.deliveryStartedAt)
+      ? { deliveryStartedAt: raw.deliveryStartedAt }
       : {}),
   }
 }
@@ -210,7 +215,41 @@ export class DeferredPromptsStore {
     })
   }
 
-  /** Persist the no-redelivery boundary before cross-store Inbox cleanup. */
+  /** Persist the no-redelivery boundary before attempting a PTY write. */
+  async beginDelivery(claim: DeferredPromptClaim): Promise<DeferredPromptRecord> {
+    return await this.enqueue(async () => {
+      this.requireClaim(claim)
+      const store = await readStore(this.path)
+      const current = store.records.find((record) => record.id === claim.record.id)
+      if (!current) throw new Error(`deferred prompt ${claim.record.id} disappeared while claimed`)
+      const started = current.deliveryStartedAt !== undefined ? current : { ...current, deliveryStartedAt: this.now() }
+      if (current.deliveryStartedAt === undefined) {
+        await writeStore(
+          this.path,
+          store.records.map((record) => (record.id === current.id ? started : record)),
+        )
+      }
+      return started
+    })
+  }
+
+  /** Undo the boundary only when the runtime confirms no PTY write occurred. */
+  async resetDelivery(claim: DeferredPromptClaim): Promise<void> {
+    await this.enqueue(async () => {
+      this.requireClaim(claim)
+      const store = await readStore(this.path)
+      const current = store.records.find((record) => record.id === claim.record.id)
+      if (!current) throw new Error(`deferred prompt ${claim.record.id} disappeared while claimed`)
+      if (current.deliveryStartedAt === undefined) return
+      const { deliveryStartedAt: _deliveryStartedAt, ...reset } = current
+      await writeStore(
+        this.path,
+        store.records.map((record) => (record.id === current.id ? reset : record)),
+      )
+    })
+  }
+
+  /** Persist confirmed delivery before cross-store Inbox cleanup. */
   async markDelivered(claim: DeferredPromptClaim): Promise<DeferredPromptRecord> {
     return await this.enqueue(async () => {
       this.requireClaim(claim)
@@ -329,6 +368,29 @@ export class DeferredPromptsStore {
       await writeStore(
         this.path,
         store.records.filter((record) => record.taskId !== taskId || record.tabId !== tabId),
+      )
+      return dropped
+    })
+  }
+
+  /** Drop exactly one prompt referenced by an Inbox item, never its replacement. */
+  async discard(id: string, reason: DeferredPromptDiscardReason): Promise<DeferredPromptRecord | null> {
+    for (;;) {
+      const waiting = await this.enqueue(async () => this.claims.get(id)?.done)
+      if (!waiting) break
+      await waiting
+    }
+    return await this.enqueue(async () => {
+      const store = await readStore(this.path)
+      const dropped = store.records.find((record) => record.id === id)
+      if (!dropped) return null
+      logDaemonInfo(
+        SUBSYSTEM,
+        `dropped deferred prompt ${dropped.id} for ${dropped.taskId}::${dropped.tabId} — ${reason}`,
+      )
+      await writeStore(
+        this.path,
+        store.records.filter((record) => record.id !== id),
       )
       return dropped
     })

--- a/packages/kobe-daemon/src/daemon/handlers-attention.ts
+++ b/packages/kobe-daemon/src/daemon/handlers-attention.ts
@@ -10,18 +10,19 @@ async function discardMatchingDeferredPrompt(
   tabId: string | null,
   at: number | undefined,
   reason: DeferredPromptDiscardReason,
-): Promise<void> {
-  if (!tabId || !ctx.deferredPrompts) return
-  const matches = ctx.inbox
+): Promise<string | undefined> {
+  if (!tabId || !ctx.deferredPrompts) return undefined
+  const deferredId = ctx.inbox
     .snapshot()
-    .some(
+    .find(
       (item) =>
         item.taskId === taskId &&
         item.tabId === tabId &&
         item.state === "prompt_deferred" &&
         (at === undefined || item.at === at),
-    )
-  if (matches) await ctx.deferredPrompts.discardTab(taskId, tabId, reason)
+    )?.detail?.deferredPrompt?.id
+  if (deferredId) await ctx.deferredPrompts.discard(deferredId, reason)
+  return deferredId
 }
 
 export const ATTENTION_HANDLERS: readonly DaemonRequestHandler[] = [
@@ -31,8 +32,14 @@ export const ATTENTION_HANDLERS: readonly DaemonRequestHandler[] = [
       const taskId = requireString(payload, "taskId")
       const tabId = optionalString(payload, "tabId") ?? null
       const at = payload.at === undefined ? undefined : requireNumber(payload, "at")
-      await discardMatchingDeferredPrompt(ctx, taskId, tabId, at, "Inbox item dismissed")
-      const deleted = await ctx.inbox.deleteEpisode(taskId, tabId, at)
+      const deferredId = await discardMatchingDeferredPrompt(ctx, taskId, tabId, at, "Inbox item dismissed")
+      const deleted = await ctx.inbox.deleteEpisode(
+        taskId,
+        tabId,
+        at,
+        deferredId ? "prompt_deferred" : undefined,
+        deferredId,
+      )
       if (deleted) {
         ctx.plugins?.handleUiReport({
           kind: "attention.handled",
@@ -49,8 +56,14 @@ export const ATTENTION_HANDLERS: readonly DaemonRequestHandler[] = [
       const taskId = requireString(payload, "taskId")
       const tabId = optionalString(payload, "tabId") ?? null
       const at = requireNumber(payload, "at")
-      await discardMatchingDeferredPrompt(ctx, taskId, tabId, at, "Inbox item read by legacy client")
-      const updated = await ctx.inbox.markRead(taskId, tabId, at)
+      const deferredId = await discardMatchingDeferredPrompt(ctx, taskId, tabId, at, "Inbox item read by legacy client")
+      const updated = await ctx.inbox.markRead(
+        taskId,
+        tabId,
+        at,
+        deferredId ? "prompt_deferred" : undefined,
+        deferredId,
+      )
       if (updated) {
         ctx.plugins?.handleUiReport({
           kind: "attention.handled",

--- a/packages/kobe-daemon/src/daemon/handlers-attention.ts
+++ b/packages/kobe-daemon/src/daemon/handlers-attention.ts
@@ -1,7 +1,28 @@
 /** Durable attention-Inbox RPC handlers. */
 
+import type { DeferredPromptDiscardReason } from "./deferred-prompts-store.ts"
 import { optionalString, requireNumber, requireString } from "./handler-validators.ts"
-import type { DaemonRequestHandler } from "./handlers.ts"
+import type { DaemonHandlerContext, DaemonRequestHandler } from "./handlers.ts"
+
+async function discardMatchingDeferredPrompt(
+  ctx: DaemonHandlerContext,
+  taskId: string,
+  tabId: string | null,
+  at: number | undefined,
+  reason: DeferredPromptDiscardReason,
+): Promise<void> {
+  if (!tabId || !ctx.deferredPrompts) return
+  const matches = ctx.inbox
+    .snapshot()
+    .some(
+      (item) =>
+        item.taskId === taskId &&
+        item.tabId === tabId &&
+        item.state === "prompt_deferred" &&
+        (at === undefined || item.at === at),
+    )
+  if (matches) await ctx.deferredPrompts.discardTab(taskId, tabId, reason)
+}
 
 export const ATTENTION_HANDLERS: readonly DaemonRequestHandler[] = [
   {
@@ -10,6 +31,7 @@ export const ATTENTION_HANDLERS: readonly DaemonRequestHandler[] = [
       const taskId = requireString(payload, "taskId")
       const tabId = optionalString(payload, "tabId") ?? null
       const at = payload.at === undefined ? undefined : requireNumber(payload, "at")
+      await discardMatchingDeferredPrompt(ctx, taskId, tabId, at, "Inbox item dismissed")
       const deleted = await ctx.inbox.deleteEpisode(taskId, tabId, at)
       if (deleted) {
         ctx.plugins?.handleUiReport({
@@ -26,7 +48,9 @@ export const ATTENTION_HANDLERS: readonly DaemonRequestHandler[] = [
     async handle(payload, ctx) {
       const taskId = requireString(payload, "taskId")
       const tabId = optionalString(payload, "tabId") ?? null
-      const updated = await ctx.inbox.markRead(taskId, tabId, requireNumber(payload, "at"))
+      const at = requireNumber(payload, "at")
+      await discardMatchingDeferredPrompt(ctx, taskId, tabId, at, "Inbox item read by legacy client")
+      const updated = await ctx.inbox.markRead(taskId, tabId, at)
       if (updated) {
         ctx.plugins?.handleUiReport({
           kind: "attention.handled",

--- a/packages/kobe-daemon/src/daemon/handlers-deferred.ts
+++ b/packages/kobe-daemon/src/daemon/handlers-deferred.ts
@@ -55,6 +55,75 @@ async function fileWithInbox(
   return { kind, record }
 }
 
+type FlushRetained =
+  | { readonly id: string; readonly taskId: string; readonly tabId: string; readonly reason: "unavailable" }
+  | {
+      readonly id: string
+      readonly taskId: string
+      readonly tabId: string
+      readonly reason: "busy"
+      readonly layer: "recent-human-write" | "composer-not-empty"
+    }
+  | {
+      readonly id: string
+      readonly taskId: string
+      readonly tabId: string
+      readonly reason: "error"
+      readonly error: string
+    }
+
+async function flushDeferredPrompts(ctx: DaemonHandlerContext): Promise<{
+  delivered: string[]
+  retained: FlushRetained[]
+}> {
+  if (!ctx.deferredPrompts) throw new Error("deferred prompt store unavailable")
+  const delivered: string[] = []
+  const retained: FlushRetained[] = []
+  for (const record of await ctx.deferredPrompts.list()) {
+    const task = ctx.orch.getTask(record.taskId)
+    if (!task?.worktreePath) {
+      retained.push({ id: record.id, taskId: record.taskId, tabId: record.tabId, reason: "unavailable" })
+      continue
+    }
+    try {
+      const outcome = await ctx.runtime.deliverPromptToLiveEngineTabDetailed(
+        {
+          id: task.id,
+          tabId: record.tabId,
+          vendor: task.vendor,
+          command: task.command,
+          worktreePath: task.worktreePath,
+        },
+        record.prompt,
+      )
+      if (outcome.outcome === "delivered") {
+        await ctx.deferredPrompts.resolve(record.id)
+        await ctx.inbox.deleteEpisode(record.taskId, record.tabId)
+        delivered.push(record.id)
+      } else if (outcome.outcome === "busy") {
+        retained.push({
+          id: record.id,
+          taskId: record.taskId,
+          tabId: record.tabId,
+          reason: "busy",
+          layer: outcome.layer,
+        })
+      } else {
+        retained.push({ id: record.id, taskId: record.taskId, tabId: record.tabId, reason: "unavailable" })
+      }
+    } catch (error) {
+      retained.push({
+        id: record.id,
+        taskId: record.taskId,
+        tabId: record.tabId,
+        reason: "error",
+        error: error instanceof Error ? error.message : String(error),
+      })
+    }
+  }
+  return { delivered, retained }
+}
+
 export const DEFERRED_PROMPT_HANDLERS: readonly DaemonRequestHandler[] = [
   {
     // Socket-only (see deferredPrompt.get) — not on the pinned web allowlist.
@@ -102,6 +171,12 @@ export const DEFERRED_PROMPT_HANDLERS: readonly DaemonRequestHandler[] = [
       const removed = await ctx.deferredPrompts.resolve(id)
       if (record) await ctx.inbox.deleteEpisode(record.taskId, record.tabId)
       return { removed }
+    },
+  },
+  {
+    name: "deferredPrompt.flush",
+    async handle(_payload, ctx) {
+      return await flushDeferredPrompts(ctx)
     },
   },
 ]

--- a/packages/kobe-daemon/src/daemon/handlers-deferred.ts
+++ b/packages/kobe-daemon/src/daemon/handlers-deferred.ts
@@ -2,15 +2,22 @@
  * Deferred-prompt RPC handlers (issue #78 B-layer). The delivery gate ran in a
  * kobe (CLI) process and found the target composer busy; it calls
  * `deferredPrompt.file` to hand ownership to the daemon, which stores the text
- * and records a `prompt_deferred` inbox episode. The exit path reads the text
- * back (`get`), inserts it with a fresh A/C gate, then releases it (`resolve`).
+ * and records a `prompt_deferred` inbox episode. Release and bulk flush both
+ * claim the record, deliver through the exact-tab runtime, then durably mark
+ * delivery before the Inbox pointer is cleaned up.
  */
 
-import { DeferredPromptPendingError, type DeferredPromptRecord } from "./deferred-prompts-store.ts"
+import {
+  type DeferredPromptClaim,
+  DeferredPromptPendingError,
+  type DeferredPromptRecord,
+} from "./deferred-prompts-store.ts"
 import { optionalString, requireString } from "./handler-validators.ts"
 import type { DaemonHandlerContext, DaemonRequestHandler } from "./handlers.ts"
 
-type DeferredPromptInput = Omit<DeferredPromptRecord, "id" | "at"> & { readonly at: number }
+type DeferredPromptInput = Omit<DeferredPromptRecord, "id" | "at"> & {
+  readonly at: number
+}
 
 function deferredPromptInput(payload: Record<string, unknown>): DeferredPromptInput {
   const taskId = requireString(payload, "taskId")
@@ -36,7 +43,10 @@ function deferredPromptInput(payload: Record<string, unknown>): DeferredPromptIn
 async function fileWithInbox(
   input: DeferredPromptInput,
   ctx: DaemonHandlerContext,
-): Promise<{ readonly kind: "filed" | "occupied"; readonly record: DeferredPromptRecord }> {
+): Promise<{
+  readonly kind: "filed" | "occupied"
+  readonly record: DeferredPromptRecord
+}> {
   if (!ctx.orch.getTask(input.taskId)) throw new Error(`task not found: ${input.taskId}`)
   if (!ctx.deferredPrompts) throw new Error("deferred prompt store unavailable")
   let kind: "filed" | "occupied" = "filed"
@@ -56,7 +66,12 @@ async function fileWithInbox(
 }
 
 type FlushRetained =
-  | { readonly id: string; readonly taskId: string; readonly tabId: string; readonly reason: "unavailable" }
+  | {
+      readonly id: string
+      readonly taskId: string
+      readonly tabId: string
+      readonly reason: "unavailable"
+    }
   | {
       readonly id: string
       readonly taskId: string
@@ -71,57 +86,195 @@ type FlushRetained =
       readonly reason: "error"
       readonly error: string
     }
+  | {
+      readonly id: string
+      readonly taskId: string
+      readonly tabId: string
+      readonly reason: "in-flight"
+    }
+  | {
+      readonly id: string
+      readonly taskId: string
+      readonly tabId: string
+      readonly reason: "gate-enabled"
+    }
+
+interface DeliveryReport {
+  delivered: string[]
+  cleaned: string[]
+  expired: string[]
+  retained: FlushRetained[]
+  cleanupPending: Array<{
+    id: string
+    taskId: string
+    tabId: string
+    error: string
+  }>
+}
+
+function errorText(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+async function cleanupDeliveredClaim(
+  claim: DeferredPromptClaim,
+  ctx: DaemonHandlerContext,
+  report: DeliveryReport,
+): Promise<void> {
+  if (!ctx.deferredPrompts) throw new Error("deferred prompt store unavailable")
+  const { record } = claim
+  try {
+    await ctx.inbox.deleteEpisode(record.taskId, record.tabId)
+    await ctx.deferredPrompts.completeClaim(claim)
+    report.cleaned.push(record.id)
+  } catch (error) {
+    await ctx.deferredPrompts.releaseClaim(claim)
+    report.cleanupPending.push({
+      id: record.id,
+      taskId: record.taskId,
+      tabId: record.tabId,
+      error: errorText(error),
+    })
+  }
+}
+
+async function deliverClaim(
+  claim: DeferredPromptClaim,
+  ctx: DaemonHandlerContext,
+  report: DeliveryReport,
+): Promise<void> {
+  if (!ctx.deferredPrompts) throw new Error("deferred prompt store unavailable")
+  const { record } = claim
+  if (record.deliveredAt) {
+    await cleanupDeliveredClaim(claim, ctx, report)
+    return
+  }
+  const task = ctx.orch.getTask(record.taskId)
+  if (!task?.worktreePath) {
+    await ctx.deferredPrompts.releaseClaim(claim)
+    report.retained.push({
+      id: record.id,
+      taskId: record.taskId,
+      tabId: record.tabId,
+      reason: "unavailable",
+    })
+    return
+  }
+  try {
+    const outcome = await ctx.runtime.deliverPromptToLiveEngineTabDetailed(
+      {
+        id: task.id,
+        tabId: record.tabId,
+        vendor: task.vendor,
+        command: task.command,
+        worktreePath: task.worktreePath,
+      },
+      record.prompt,
+    )
+    if (outcome.outcome === "delivered") {
+      await ctx.deferredPrompts.markDelivered(claim)
+      report.delivered.push(record.id)
+      await cleanupDeliveredClaim(claim, ctx, report)
+    } else {
+      await ctx.deferredPrompts.releaseClaim(claim)
+      report.retained.push(
+        outcome.outcome === "busy"
+          ? {
+              id: record.id,
+              taskId: record.taskId,
+              tabId: record.tabId,
+              reason: "busy",
+              layer: outcome.layer,
+            }
+          : {
+              id: record.id,
+              taskId: record.taskId,
+              tabId: record.tabId,
+              reason: "unavailable",
+            },
+      )
+    }
+  } catch (error) {
+    await ctx.deferredPrompts.releaseClaim(claim).catch(() => {})
+    report.retained.push({
+      id: record.id,
+      taskId: record.taskId,
+      tabId: record.tabId,
+      reason: "error",
+      error: errorText(error),
+    })
+  }
+}
 
 async function flushDeferredPrompts(ctx: DaemonHandlerContext): Promise<{
   delivered: string[]
+  cleaned: string[]
+  expired: string[]
   retained: FlushRetained[]
+  cleanupPending: DeliveryReport["cleanupPending"]
 }> {
   if (!ctx.deferredPrompts) throw new Error("deferred prompt store unavailable")
-  const delivered: string[] = []
-  const retained: FlushRetained[] = []
-  for (const record of await ctx.deferredPrompts.list()) {
-    const task = ctx.orch.getTask(record.taskId)
-    if (!task?.worktreePath) {
-      retained.push({ id: record.id, taskId: record.taskId, tabId: record.tabId, reason: "unavailable" })
+  const report: DeliveryReport = {
+    delivered: [],
+    cleaned: [],
+    expired: [],
+    retained: [],
+    cleanupPending: [],
+  }
+  const listed = await ctx.deferredPrompts.list()
+  for (const expired of listed.expired) {
+    const claimed = await ctx.deferredPrompts.claim(expired.id)
+    if (claimed.kind !== "claimed") {
+      report.cleanupPending.push({
+        id: expired.id,
+        taskId: expired.taskId,
+        tabId: expired.tabId,
+        error: claimed.kind,
+      })
       continue
     }
     try {
-      const outcome = await ctx.runtime.deliverPromptToLiveEngineTabDetailed(
-        {
-          id: task.id,
-          tabId: record.tabId,
-          vendor: task.vendor,
-          command: task.command,
-          worktreePath: task.worktreePath,
-        },
-        record.prompt,
-      )
-      if (outcome.outcome === "delivered") {
-        await ctx.deferredPrompts.resolve(record.id)
-        await ctx.inbox.deleteEpisode(record.taskId, record.tabId)
-        delivered.push(record.id)
-      } else if (outcome.outcome === "busy") {
-        retained.push({
-          id: record.id,
-          taskId: record.taskId,
-          tabId: record.tabId,
-          reason: "busy",
-          layer: outcome.layer,
-        })
-      } else {
-        retained.push({ id: record.id, taskId: record.taskId, tabId: record.tabId, reason: "unavailable" })
-      }
+      await ctx.inbox.deleteEpisode(expired.taskId, expired.tabId)
+      await ctx.deferredPrompts.completeClaim(claimed.claim)
+      report.expired.push(expired.id)
     } catch (error) {
-      retained.push({
-        id: record.id,
-        taskId: record.taskId,
-        tabId: record.tabId,
-        reason: "error",
-        error: error instanceof Error ? error.message : String(error),
+      await ctx.deferredPrompts.releaseClaim(claimed.claim).catch(() => {})
+      report.cleanupPending.push({
+        id: expired.id,
+        taskId: expired.taskId,
+        tabId: expired.tabId,
+        error: errorText(error),
       })
     }
   }
-  return { delivered, retained }
+  for (const record of listed.records) {
+    if (record.deliveredAt) {
+      const claimed = await ctx.deferredPrompts.claim(record.id)
+      if (claimed.kind === "claimed") await cleanupDeliveredClaim(claimed.claim, ctx, report)
+      continue
+    }
+    if (ctx.runtime.composerGateEnabled()) {
+      report.retained.push({
+        id: record.id,
+        taskId: record.taskId,
+        tabId: record.tabId,
+        reason: "gate-enabled",
+      })
+      continue
+    }
+    const claimed = await ctx.deferredPrompts.claim(record.id)
+    if (claimed.kind === "in-flight") {
+      report.retained.push({
+        id: record.id,
+        taskId: record.taskId,
+        tabId: record.tabId,
+        reason: "in-flight",
+      })
+      continue
+    }
+    if (claimed.kind === "claimed") await deliverClaim(claimed.claim, ctx, report)
+  }
+  return report
 }
 
 export const DEFERRED_PROMPT_HANDLERS: readonly DaemonRequestHandler[] = [
@@ -152,11 +305,11 @@ export const DEFERRED_PROMPT_HANDLERS: readonly DaemonRequestHandler[] = [
     // these off the web allowlist is deliberate — the browser-reachable surface
     // is a pinned security contract (test/daemon/web-exposure.test.ts).
     name: "deferredPrompt.get",
-    async handle(payload, ctx) {
-      const id = requireString(payload, "id")
-      if (!ctx.deferredPrompts) throw new Error("deferred prompt store unavailable")
-      const record = await ctx.deferredPrompts.get(id)
-      return { record }
+    async handle() {
+      // A pre-claim client can race the daemon flusher after reading the text
+      // and paste the same record twice. Fail that mixed-version exit path
+      // loud; current clients use the atomic `release` verb below.
+      throw new Error("legacy deferred prompt release is unsafe; restart Rove to update the client")
     },
   },
   {
@@ -164,13 +317,43 @@ export const DEFERRED_PROMPT_HANDLERS: readonly DaemonRequestHandler[] = [
     async handle(payload, ctx) {
       const id = requireString(payload, "id")
       if (!ctx.deferredPrompts) throw new Error("deferred prompt store unavailable")
-      // Resolve means BOTH halves: the stored text AND the inbox episode that
-      // points at it. Read the record first (for its task/tab) so the episode
-      // can be dropped even though the record is about to go.
-      const record = await ctx.deferredPrompts.get(id)
-      const removed = await ctx.deferredPrompts.resolve(id)
-      if (record) await ctx.inbox.deleteEpisode(record.taskId, record.tabId)
-      return { removed }
+      // A legacy client can still finish an insert fetched before a daemon
+      // restart. Claim before trusting its resolve so it cannot erase a
+      // record that a concurrent flush owns.
+      const claimed = await ctx.deferredPrompts.claim(id)
+      if (claimed.kind !== "claimed") return { removed: false, kind: claimed.kind }
+      const report: DeliveryReport = { delivered: [], cleaned: [], expired: [], retained: [], cleanupPending: [] }
+      await ctx.deferredPrompts.markDelivered(claimed.claim)
+      await cleanupDeliveredClaim(claimed.claim, ctx, report)
+      return { removed: report.cleaned.includes(id), cleanupPending: report.cleanupPending }
+    },
+  },
+  {
+    name: "deferredPrompt.release",
+    async handle(payload, ctx) {
+      const id = requireString(payload, "id")
+      if (!ctx.deferredPrompts) throw new Error("deferred prompt store unavailable")
+      const report: DeliveryReport = {
+        delivered: [],
+        cleaned: [],
+        expired: [],
+        retained: [],
+        cleanupPending: [],
+      }
+      const claimed = await ctx.deferredPrompts.claim(id)
+      if (claimed.kind === "claimed") await deliverClaim(claimed.claim, ctx, report)
+      return { kind: claimed.kind, ...report }
+    },
+  },
+  {
+    name: "deferredPrompt.discardTab",
+    async handle(payload, ctx) {
+      const taskId = requireString(payload, "taskId")
+      const tabId = requireString(payload, "tabId")
+      if (!ctx.deferredPrompts) throw new Error("deferred prompt store unavailable")
+      const dropped = await ctx.deferredPrompts.discardTab(taskId, tabId, "tab closed")
+      if (dropped.length > 0) await ctx.inbox.deleteEpisode(taskId, tabId)
+      return { dropped: dropped.map((record) => record.id) }
     },
   },
   {

--- a/packages/kobe-daemon/src/daemon/handlers-deferred.ts
+++ b/packages/kobe-daemon/src/daemon/handlers-deferred.ts
@@ -3,8 +3,8 @@
  * kobe (CLI) process and found the target composer busy; it calls
  * `deferredPrompt.file` to hand ownership to the daemon, which stores the text
  * and records a `prompt_deferred` inbox episode. Release and bulk flush both
- * claim the record, deliver through the exact-tab runtime, then durably mark
- * delivery before the Inbox pointer is cleaned up.
+ * claim the record, persist a no-redelivery marker, then attempt exact-tab
+ * delivery and clean up the Inbox pointer.
  */
 
 import {
@@ -116,6 +116,10 @@ function errorText(error: unknown): string {
   return error instanceof Error ? error.message : String(error)
 }
 
+async function deleteDeferredInboxPointer(record: DeferredPromptRecord, ctx: DaemonHandlerContext): Promise<void> {
+  await ctx.inbox.deleteEpisode(record.taskId, record.tabId, undefined, "prompt_deferred", record.id)
+}
+
 async function cleanupDeliveredClaim(
   claim: DeferredPromptClaim,
   ctx: DaemonHandlerContext,
@@ -124,7 +128,7 @@ async function cleanupDeliveredClaim(
   if (!ctx.deferredPrompts) throw new Error("deferred prompt store unavailable")
   const { record } = claim
   try {
-    await ctx.inbox.deleteEpisode(record.taskId, record.tabId)
+    await deleteDeferredInboxPointer(record, ctx)
     await ctx.deferredPrompts.completeClaim(claim)
     report.cleaned.push(record.id)
   } catch (error) {
@@ -145,7 +149,7 @@ async function deliverClaim(
 ): Promise<void> {
   if (!ctx.deferredPrompts) throw new Error("deferred prompt store unavailable")
   const { record } = claim
-  if (record.deliveredAt) {
+  if (record.deliveredAt || record.deliveryStartedAt) {
     await cleanupDeliveredClaim(claim, ctx, report)
     return
   }
@@ -160,7 +164,10 @@ async function deliverClaim(
     })
     return
   }
+  let deliveryStarted = false
   try {
+    await ctx.deferredPrompts.beginDelivery(claim)
+    deliveryStarted = true
     const outcome = await ctx.runtime.deliverPromptToLiveEngineTabDetailed(
       {
         id: task.id,
@@ -176,6 +183,7 @@ async function deliverClaim(
       report.delivered.push(record.id)
       await cleanupDeliveredClaim(claim, ctx, report)
     } else {
+      await ctx.deferredPrompts.resetDelivery(claim)
       await ctx.deferredPrompts.releaseClaim(claim)
       report.retained.push(
         outcome.outcome === "busy"
@@ -196,13 +204,22 @@ async function deliverClaim(
     }
   } catch (error) {
     await ctx.deferredPrompts.releaseClaim(claim).catch(() => {})
-    report.retained.push({
-      id: record.id,
-      taskId: record.taskId,
-      tabId: record.tabId,
-      reason: "error",
-      error: errorText(error),
-    })
+    if (deliveryStarted) {
+      report.cleanupPending.push({
+        id: record.id,
+        taskId: record.taskId,
+        tabId: record.tabId,
+        error: errorText(error),
+      })
+    } else {
+      report.retained.push({
+        id: record.id,
+        taskId: record.taskId,
+        tabId: record.tabId,
+        reason: "error",
+        error: errorText(error),
+      })
+    }
   }
 }
 
@@ -234,7 +251,7 @@ async function flushDeferredPrompts(ctx: DaemonHandlerContext): Promise<{
       continue
     }
     try {
-      await ctx.inbox.deleteEpisode(expired.taskId, expired.tabId)
+      await deleteDeferredInboxPointer(expired, ctx)
       await ctx.deferredPrompts.completeClaim(claimed.claim)
       report.expired.push(expired.id)
     } catch (error) {
@@ -248,7 +265,7 @@ async function flushDeferredPrompts(ctx: DaemonHandlerContext): Promise<{
     }
   }
   for (const record of listed.records) {
-    if (record.deliveredAt) {
+    if (record.deliveredAt || record.deliveryStartedAt) {
       const claimed = await ctx.deferredPrompts.claim(record.id)
       if (claimed.kind === "claimed") await cleanupDeliveredClaim(claimed.claim, ctx, report)
       continue
@@ -352,7 +369,7 @@ export const DEFERRED_PROMPT_HANDLERS: readonly DaemonRequestHandler[] = [
       const tabId = requireString(payload, "tabId")
       if (!ctx.deferredPrompts) throw new Error("deferred prompt store unavailable")
       const dropped = await ctx.deferredPrompts.discardTab(taskId, tabId, "tab closed")
-      if (dropped.length > 0) await ctx.inbox.deleteEpisode(taskId, tabId)
+      for (const record of dropped) await deleteDeferredInboxPointer(record, ctx)
       return { dropped: dropped.map((record) => record.id) }
     },
   },

--- a/packages/kobe-daemon/src/daemon/handlers-ui.ts
+++ b/packages/kobe-daemon/src/daemon/handlers-ui.ts
@@ -86,7 +86,9 @@ export const UI_HANDLERS: readonly DaemonRequestHandler[] = [
         detail && typeof detail === "object" && !Array.isArray(detail) ? (detail as Record<string, unknown>) : undefined
       if (kind === "tab.closed" && taskId && typeof eventDetail?.tabId === "string" && ctx.deferredPrompts) {
         const dropped = await ctx.deferredPrompts.discardTab(taskId, eventDetail.tabId, "tab closed")
-        if (dropped.length > 0) await ctx.inbox.deleteEpisode(taskId, eventDetail.tabId)
+        for (const record of dropped) {
+          await ctx.inbox.deleteEpisode(taskId, eventDetail.tabId, undefined, "prompt_deferred", record.id)
+        }
       }
       ctx.plugins?.handleUiReport({
         kind: kind as import("../plugins/manifest.ts").PluginEventName,

--- a/packages/kobe-daemon/src/daemon/handlers-ui.ts
+++ b/packages/kobe-daemon/src/daemon/handlers-ui.ts
@@ -82,12 +82,16 @@ export const UI_HANDLERS: readonly DaemonRequestHandler[] = [
       }
       const taskId = optionalString(payload, "taskId")
       const detail = payload.detail
+      const eventDetail =
+        detail && typeof detail === "object" && !Array.isArray(detail) ? (detail as Record<string, unknown>) : undefined
+      if (kind === "tab.closed" && taskId && typeof eventDetail?.tabId === "string" && ctx.deferredPrompts) {
+        const dropped = await ctx.deferredPrompts.discardTab(taskId, eventDetail.tabId, "tab closed")
+        if (dropped.length > 0) await ctx.inbox.deleteEpisode(taskId, eventDetail.tabId)
+      }
       ctx.plugins?.handleUiReport({
         kind: kind as import("../plugins/manifest.ts").PluginEventName,
         ...(taskId ? { taskId } : {}),
-        ...(detail && typeof detail === "object" && !Array.isArray(detail)
-          ? { detail: detail as Record<string, unknown> }
-          : {}),
+        ...(eventDetail ? { detail: eventDetail } : {}),
       })
       return {}
     },

--- a/packages/kobe-daemon/src/daemon/protocol.ts
+++ b/packages/kobe-daemon/src/daemon/protocol.ts
@@ -308,11 +308,13 @@ export type DaemonRequestName =
   // Deferred prompts (issue #78 B-layer): the delivery gate accepted a prompt
   // it could not paste (composer busy) into daemon ownership. New clients use
   // `fileIfVacant`, whose distinct name makes old replace-on-file daemons fail
-  // loud. `get` reads one back; `resolve` drops it after insert or dismiss.
+  // loud. `get` reads one back; `resolve` drops it after insert or dismiss;
+  // `flush` retries the queue when the screen-based delivery check turns off.
   | "deferredPrompt.file"
   | "deferredPrompt.fileIfVacant"
   | "deferredPrompt.get"
   | "deferredPrompt.resolve"
+  | "deferredPrompt.flush"
 
 /**
  * Subscribe role (KOB) — distinguishes WHO is subscribing, so the daemon's

--- a/packages/kobe-daemon/src/daemon/protocol.ts
+++ b/packages/kobe-daemon/src/daemon/protocol.ts
@@ -308,12 +308,14 @@ export type DaemonRequestName =
   // Deferred prompts (issue #78 B-layer): the delivery gate accepted a prompt
   // it could not paste (composer busy) into daemon ownership. New clients use
   // `fileIfVacant`, whose distinct name makes old replace-on-file daemons fail
-  // loud. `get` reads one back; `resolve` drops it after insert or dismiss;
-  // `flush` retries the queue when the screen-based delivery check turns off.
+  // loud. `release` and `flush` claim records before exact-tab delivery;
+  // `get`/`resolve` remain only for loud legacy skew and pre-restart cleanup.
   | "deferredPrompt.file"
   | "deferredPrompt.fileIfVacant"
   | "deferredPrompt.get"
   | "deferredPrompt.resolve"
+  | "deferredPrompt.release"
+  | "deferredPrompt.discardTab"
   | "deferredPrompt.flush"
 
 /**

--- a/packages/kobe-daemon/src/daemon/runtime.ts
+++ b/packages/kobe-daemon/src/daemon/runtime.ts
@@ -187,6 +187,8 @@ export interface DaemonRuntimeAdapter {
         readonly layer: "recent-human-write" | "composer-not-empty"
       }
   >
+  /** Fresh persisted state, checked between deferred-queue deliveries. */
+  composerGateEnabled(): boolean
   settingsSnapshot(): Response
   settingsPatch(request: Request): Promise<Response>
   handleDiffRequest(request: Request, url: URL): Promise<Response | null>

--- a/packages/kobe-daemon/src/daemon/runtime.ts
+++ b/packages/kobe-daemon/src/daemon/runtime.ts
@@ -165,6 +165,28 @@ export interface DaemonRuntimeAdapter {
         readonly layer: "recent-human-write" | "composer-not-empty"
       }
   >
+  /**
+   * Deliver to one exact live tab. Used when draining daemon-owned deferred
+   * prompts: rerouting a queued tab-2 message into tab-1 would be data loss.
+   */
+  deliverPromptToLiveEngineTabDetailed(
+    target: {
+      readonly id: string
+      readonly tabId: string
+      readonly vendor?: VendorId
+      readonly command?: string
+      readonly worktreePath: string
+    },
+    prompt: string,
+  ): Promise<
+    | { readonly outcome: "delivered"; readonly tabId: string }
+    | { readonly outcome: "no-session" }
+    | {
+        readonly outcome: "busy"
+        readonly tabId: string
+        readonly layer: "recent-human-write" | "composer-not-empty"
+      }
+  >
   settingsSnapshot(): Response
   settingsPatch(request: Request): Promise<Response>
   handleDiffRequest(request: Request, url: URL): Promise<Response | null>

--- a/packages/kobe/src/cli/api/handlers-pane.ts
+++ b/packages/kobe/src/cli/api/handlers-pane.ts
@@ -143,6 +143,7 @@ export const TAB_CLOSE_VERB: VerbSpec = {
     const reply = await daemonOf(ctx).request<{ handled?: boolean }>("terminalTab.close", { taskId, tabId })
     if (reply.handled) return { ok: true, taskId, tabId, handledBy: "tui" }
     const result = await ctx.runtime.closeTerminalTab(taskId, tabId)
+    await daemonOf(ctx).request("deferredPrompt.discardTab", { taskId, tabId })
     return { ok: true, taskId, tabId, handledBy: "headless", ...result }
   },
 }

--- a/packages/kobe/src/cli/api/pty-delivery.ts
+++ b/packages/kobe/src/cli/api/pty-delivery.ts
@@ -14,7 +14,7 @@
 
 import type { PtyOpenResult } from "@sma1lboy/kobe-daemon/daemon/protocol"
 import type { PtySessionInfo } from "@sma1lboy/kobe-daemon/daemon/pty-host"
-import { type PsSnapshot, engineProcessIn, parsePsSnapshot, psSnapshot } from "../../engine/foreground.ts"
+import type { PsSnapshot } from "../../engine/foreground.ts"
 import {
   ComposerBusyError,
   type HostedSessionRpc,
@@ -33,39 +33,15 @@ import {
 } from "../../engine/hosted-session.ts"
 import { engineEntry } from "../../engine/registry.ts"
 import type { EngineScreenManifest } from "../../engine/screen-state.ts"
+import { sessionHasEngine } from "../../engine/session-engine-presence.ts"
 import type { EngineSessionLaunch } from "../../engine/session-launch.ts"
 import { readPersistedTerminalDefaultColors } from "../../tui/lib/terminal-colors.ts"
 import type { VendorId } from "../../types/vendor.ts"
 import { ApiError, type DeliveredPrompt, type PromptDeferralSink } from "./types.ts"
 
-/**
- * Foreground gate for delivery into an EXISTING session — is an agent still
- * the pane's foreground process, answered from the process tree? A session's
- * spawn argv says what WAS launched, not what is
- * running now — kobe's keepAlive drops an exited engine into a fallback
- * SHELL, where a pasted prompt executes as shell commands. Walk the PTY
- * child's descendants: any registered engine counts (cross-vendor send is
- * legitimate), `extraBin` additionally matches a custom engine's binary
- * name. False on no pid / ps failure — unverifiable is "not an engine".
- *
- * Known ceiling: during an engine's first ~1-2s (login shell still sourcing
- * rc, engine child not yet spawned) the gate reads "shell only" and refuses;
- * the typed error's hint makes the retry trivial. Watching the spawn argv
- * would close it but can't distinguish boot from the post-exit exec'd shell.
- */
-async function sessionHasEngine(
-  pid: number | null | undefined,
-  extraBin?: string,
-  snapshot: PsSnapshot = psSnapshot,
-): Promise<boolean> {
-  if (!pid) return false
-  try {
-    return engineProcessIn(parsePsSnapshot(await snapshot()), pid, extraBin)
-  } catch {
-    return false
-  }
-}
-
+// `sessionHasEngine` is the foreground gate for delivery into an existing
+// hosted session: an alive PTY may now be a fallback shell after the engine
+// exits, and pasting there would execute the prompt as shell commands.
 /**
  * The narrow pty-host surface this module needs: request/response RPC plus
  * cleanup. `KobeDaemonClient` satisfies it; tests inject a fake that
@@ -143,10 +119,10 @@ function outcomeFields(outcome: PromptWriteOutcome | null): {
  * session was created", never "delivered into an existing one".
  *
  * When alive tabs exist but none resolves as an engine, this THROWS
- * (NO_ENGINE_TAB) instead of spawning. A silent-spawn fallback boots an
- * unsandboxed `--dangerously-skip-permissions` engine — cwd'd at the MAIN
- * repo — while both sender and receiver believe the message was delivered.
- * A well-meaning fallback here is
+ * (NO_ENGINE_TAB) instead of spawning. Issue #19: the silent-spawn fallback
+ * booted an unsandboxed `--dangerously-skip-permissions` engine (in the
+ * incident, cwd'd at the MAIN repo) while both sender and receiver believed
+ * the message was delivered. A well-meaning fallback here is
  * indistinguishable from success on both sides — it must stay loud.
  */
 export async function deliverHostedPrompt(
@@ -241,7 +217,7 @@ export async function deliverHostedPrompt(
         delivered: false,
       }
     }
-    // Paste-delivery vendor (kimi): the launch spawned the bare
+    // Paste-delivery vendor (kimi — issue #25): the launch spawned the bare
     // engine and carried the first message OUTSIDE its argv; paste it once
     // the engine process is up. A paste that never lands is a failed start,
     // not a delivered prompt.
@@ -285,10 +261,10 @@ export async function deliverHostedPrompt(
     }
     // OUR launch carried the prompt in its argv, so no paste happened here.
     // The engine receives the prompt from its own command line — a delivery
-    // this code never observed, and must not claim to have confirmed.
-    // Hardcoding `delivered = true` here (and copying it into engineReady)
-    // is how a task that received nothing reports a clean success on all
-    // three fields.
+    // this code never observed, and must not claim to have confirmed. It
+    // used to hardcode `delivered = true` (and copy that into engineReady),
+    // which is how a task that received nothing still reported a clean
+    // success on all three fields.
     return {
       session: launch.key,
       pane: launch.key,
@@ -359,7 +335,7 @@ function resolveComposerManifest(vendor?: VendorId): EngineScreenManifest | unde
 }
 
 /**
- * Gate blocked the paste. With a deferral sink, try to
+ * Gate blocked the paste. With a deferral sink (issue #78 B-layer), try to
  * hand the prompt to daemon ownership. Report deferred success only when the
  * daemon accepts it; an occupied slot or failed handoff is an error. Without
  * a sink there is no queue, so surface the legacy typed error.

--- a/packages/kobe/src/client/remote-orchestrator-writes.ts
+++ b/packages/kobe/src/client/remote-orchestrator-writes.ts
@@ -184,6 +184,23 @@ export async function resolveDeferredPromptOp(client: KobeDaemonClient, id: stri
   return res.removed
 }
 
+export interface DeferredPromptFlushResult {
+  readonly delivered: readonly string[]
+  readonly retained: readonly {
+    readonly id: string
+    readonly taskId: string
+    readonly tabId: string
+    readonly reason: "busy" | "unavailable" | "error"
+    readonly layer?: "recent-human-write" | "composer-not-empty"
+    readonly error?: string
+  }[]
+}
+
+/** Retry every daemon-owned prompt after the screen-based gate turns off. */
+export async function flushDeferredPromptsOp(client: KobeDaemonClient): Promise<DeferredPromptFlushResult> {
+  return await client.request<DeferredPromptFlushResult>("deferredPrompt.flush", {})
+}
+
 /** Land a task's branch back into its base repo (`task.land`). Merge or
  *  squash; optionally delete the branch after. The daemon throws with a
  *  `LAND_CONFLICT`/`MAIN_CHECKOUT_DIRTY` sentinel in the message on the

--- a/packages/kobe/src/client/remote-orchestrator-writes.ts
+++ b/packages/kobe/src/client/remote-orchestrator-writes.ts
@@ -12,7 +12,6 @@
 
 import type { KobeDaemonClient } from "@sma1lboy/kobe-daemon/client"
 import type { Automation, AutomationRun } from "@sma1lboy/kobe-daemon/daemon/contracts"
-import type { DeferredPromptRecord } from "@sma1lboy/kobe-daemon/daemon/deferred-prompts-store"
 import type { RepoIssues } from "@sma1lboy/kobe-daemon/daemon/issues-store"
 import type { SerializedTask } from "@sma1lboy/kobe-daemon/daemon/protocol"
 import type { WorkItem } from "@sma1lboy/kobe-daemon/daemon/work-items"
@@ -52,7 +51,7 @@ export async function ensureMainTaskOp(client: KobeDaemonClient, repo: string): 
 }
 
 /** Open a directory as a `kind:"dir"` task; `scratch` marks a temp shell
- *  task for the sidebar's Scratch section. */
+ *  task for the sidebar's Scratch section (issue #33). */
 export async function openDirectoryTaskOp(
   client: KobeDaemonClient,
   input: { dir: string; scratch?: boolean },
@@ -61,7 +60,7 @@ export async function openDirectoryTaskOp(
   return deserializeTask(res.task)
 }
 
-/** Scratch → project migration: repoint + clear the flag. */
+/** Scratch → project migration (issue #33): repoint + clear the flag. */
 export async function adoptScratchRepoOp(client: KobeDaemonClient, id: TaskId | string, repo: string): Promise<void> {
   await client.request("task.adoptScratchRepo", { taskId: String(id), repo })
 }
@@ -77,7 +76,7 @@ export async function forgetProjectOp(client: KobeDaemonClient, repo: string): P
 
 /**
  * Fire-and-forget `turn-interrupted` report for a tab whose engine ended
- * its turn with NO hook of its own — an ESC interrupt (the TUI's
+ * its turn with NO hook of its own — an ESC interrupt (issue #15; the TUI's
  * `InterruptObserver` confirmed the engine's resting title against a
  * hook-claimed `running`). Same `engine.reportEvent` verb the `kobe hook`
  * processes use, so the daemon reduces + broadcasts it like any hook event.
@@ -111,7 +110,11 @@ export async function setCommandOp(
   command: string,
   vendor?: VendorId,
 ): Promise<void> {
-  await client.request("task.setCommand", { taskId: String(id), command, ...(vendor ? { vendor } : {}) })
+  await client.request("task.setCommand", {
+    taskId: String(id),
+    command,
+    ...(vendor ? { vendor } : {}),
+  })
 }
 
 export async function setPinnedOp(client: KobeDaemonClient, id: TaskId | string, pinned?: boolean): Promise<void> {
@@ -119,7 +122,10 @@ export async function setPinnedOp(client: KobeDaemonClient, id: TaskId | string,
 }
 
 export async function moveTaskOp(client: KobeDaemonClient, id: TaskId | string, delta: -1 | 1): Promise<void> {
-  await client.request("task.move", { taskId: String(id), direction: delta < 0 ? "up" : "down" })
+  await client.request("task.move", {
+    taskId: String(id),
+    direction: delta < 0 ? "up" : "down",
+  })
 }
 
 /** Record a task's brief (`task.setPrompt`). Second writer after the CLI
@@ -139,7 +145,11 @@ export async function deleteTaskOp(
   id: TaskId | string,
   opts?: { force?: boolean; deleteBranch?: boolean },
 ): Promise<void> {
-  await client.request("task.delete", { taskId: String(id), force: opts?.force, deleteBranch: opts?.deleteBranch })
+  await client.request("task.delete", {
+    taskId: String(id),
+    force: opts?.force,
+    deleteBranch: opts?.deleteBranch,
+  })
 }
 
 /** Explicitly delete one durable attention episode. */
@@ -172,25 +182,45 @@ export async function markAttentionReadOp(
   return res.updated
 }
 
-/** Read one deferred prompt back by id — the deferral exit path. */
-export async function getDeferredPromptOp(client: KobeDaemonClient, id: string): Promise<DeferredPromptRecord | null> {
-  const res = await client.request<{ record: DeferredPromptRecord | null }>("deferredPrompt.get", { id })
-  return res.record
-}
+export type DeferredPromptReleaseOutcome =
+  | "inserted"
+  | "deferred-again"
+  | "unavailable"
+  | "in-flight"
+  | "missing"
+  | "cleanup-pending"
 
-/** Release one deferred prompt after its text was inserted (or on dismiss). */
-export async function resolveDeferredPromptOp(client: KobeDaemonClient, id: string): Promise<boolean> {
-  const res = await client.request<{ removed: boolean }>("deferredPrompt.resolve", { id })
-  return res.removed
+/** Claim, deliver, and durably resolve one queued prompt inside the daemon. */
+export async function releaseDeferredPromptOp(
+  client: KobeDaemonClient,
+  id: string,
+): Promise<DeferredPromptReleaseOutcome> {
+  const res = await client.request<{
+    kind: "claimed" | "in-flight" | "missing"
+    delivered: readonly string[]
+    cleaned: readonly string[]
+    retained: readonly { reason: string }[]
+    cleanupPending: readonly unknown[]
+  }>("deferredPrompt.release", { id })
+  if (res.kind !== "claimed") return res.kind
+  if (res.cleanupPending.length > 0) return "cleanup-pending"
+  if (res.delivered.includes(id) || res.cleaned.includes(id)) return "inserted"
+  return res.retained[0]?.reason === "busy" ? "deferred-again" : "unavailable"
 }
 
 export interface DeferredPromptFlushResult {
   readonly delivered: readonly string[]
+  readonly cleaned: readonly string[]
+  readonly expired: readonly string[]
+  readonly cleanupPending: readonly {
+    readonly id: string
+    readonly error: string
+  }[]
   readonly retained: readonly {
     readonly id: string
     readonly taskId: string
     readonly tabId: string
-    readonly reason: "busy" | "unavailable" | "error"
+    readonly reason: "busy" | "unavailable" | "error" | "in-flight" | "gate-enabled"
     readonly layer?: "recent-human-write" | "composer-not-empty"
     readonly error?: string
   }[]
@@ -339,7 +369,14 @@ export async function deleteAutomationOp(client: KobeDaemonClient, id: string): 
  *  work-items page. `refresh` bypasses the daemon's 60s cache. */
 export async function listWorkItemsOp(
   client: KobeDaemonClient,
-  args: { repo: string; state?: string; limit?: number; search?: string; assignee?: string; refresh?: boolean },
+  args: {
+    repo: string
+    state?: string
+    limit?: number
+    search?: string
+    assignee?: string
+    refresh?: boolean
+  },
 ): Promise<{ items: WorkItem[] }> {
   return client.request<{ items: WorkItem[] }>("workitem.list", args)
 }
@@ -359,7 +396,9 @@ export async function startWorkItemOp(
  * pane + the outer monitor highlight the same task.
  */
 export async function setActiveTaskOp(client: KobeDaemonClient, id: TaskId | string | null): Promise<void> {
-  await client.request("task.setActive", { taskId: id === null ? null : String(id) })
+  await client.request("task.setActive", {
+    taskId: id === null ? null : String(id),
+  })
 }
 
 /**

--- a/packages/kobe/src/client/remote-orchestrator.ts
+++ b/packages/kobe/src/client/remote-orchestrator.ts
@@ -15,7 +15,6 @@
 import type { KobeDaemonClient } from "@sma1lboy/kobe-daemon/client"
 import { logClient, logClientError } from "@sma1lboy/kobe-daemon/client/client-log"
 import { ensureDaemonReachable } from "@sma1lboy/kobe-daemon/client/daemon-process"
-import type { DeferredPromptRecord } from "@sma1lboy/kobe-daemon/daemon/deferred-prompts-store"
 import type { RepoIssues } from "@sma1lboy/kobe-daemon/daemon/issues-store"
 import {
   type ChannelName,
@@ -87,7 +86,6 @@ import {
   ensureWorktreeOp,
   flushDeferredPromptsOp,
   forgetProjectOp,
-  getDeferredPromptOp,
   landTaskOp,
   listAutomationsOp,
   listFieldNotesOp,
@@ -98,10 +96,10 @@ import {
   moveTaskOp,
   mutateIssueOp,
   openDirectoryTaskOp,
+  releaseDeferredPromptOp,
   removeWorktreeOp,
   replyTabCloseOp,
   reportEngineInterruptOp,
-  resolveDeferredPromptOp,
   runAutomationNowOp,
   setActiveTaskOp,
   setAutomationEnabledOp,
@@ -433,8 +431,7 @@ export class RemoteOrchestrator {
     dismissAttentionOp(this.client, taskId, tabId, at)
   markAttentionRead = (taskId: TaskId | string, tabId: string | null, at: number): Promise<boolean> =>
     markAttentionReadOp(this.client, taskId, tabId, at)
-  getDeferredPrompt = (id: string): Promise<DeferredPromptRecord | null> => getDeferredPromptOp(this.client, id)
-  resolveDeferredPrompt = (id: string): Promise<boolean> => resolveDeferredPromptOp(this.client, id)
+  releaseDeferredPrompt = (id: string) => releaseDeferredPromptOp(this.client, id)
   flushDeferredPrompts = () => flushDeferredPromptsOp(this.client)
 
   /** Land a task's branch back into its base repo (`task.land`). Throws with a

--- a/packages/kobe/src/client/remote-orchestrator.ts
+++ b/packages/kobe/src/client/remote-orchestrator.ts
@@ -85,6 +85,7 @@ import {
   dismissAttentionOp,
   ensureMainTaskOp,
   ensureWorktreeOp,
+  flushDeferredPromptsOp,
   forgetProjectOp,
   getDeferredPromptOp,
   landTaskOp,
@@ -434,6 +435,7 @@ export class RemoteOrchestrator {
     markAttentionReadOp(this.client, taskId, tabId, at)
   getDeferredPrompt = (id: string): Promise<DeferredPromptRecord | null> => getDeferredPromptOp(this.client, id)
   resolveDeferredPrompt = (id: string): Promise<boolean> => resolveDeferredPromptOp(this.client, id)
+  flushDeferredPrompts = () => flushDeferredPromptsOp(this.client)
 
   /** Land a task's branch back into its base repo (`task.land`). Throws with a
    *  `LAND_CONFLICT` / `MAIN_CHECKOUT_DIRTY` sentinel in the message on the

--- a/packages/kobe/src/core/daemon-runtime.ts
+++ b/packages/kobe/src/core/daemon-runtime.ts
@@ -16,6 +16,7 @@ import { deriveTitleFromSession } from "../monitor/auto-title.ts"
 import { GH_PR_VIEW_FIELDS, classifyGhFailure, mapGhPrView, nextPrPoll, samePrStatus } from "../monitor/pr-status.ts"
 import { maybeAutoStart } from "../monitor/status-rules.ts"
 import { type Orchestrator, PLACEHOLDER_TASK_TITLE } from "../orchestrator/core.ts"
+import { composerGateEnabled } from "../state/composer-gate.ts"
 import { getPersistedString, getSavedRepos, setPersistedString } from "../state/repos.ts"
 import { parsePorcelain } from "../tui/panes/sidebar/worktree-changes.ts"
 import { DEFAULT_TASK_VENDOR, isTaskStatus } from "../types/task.ts"
@@ -97,6 +98,7 @@ export const daemonRuntime: DaemonRuntimeAdapter = {
   deliverPromptToLiveEngine: deliverPromptToLiveEngineAdapter,
   deliverPromptToLiveEngineDetailed: deliverPromptToLiveEngineDetailedAdapter,
   deliverPromptToLiveEngineTabDetailed: deliverPromptToLiveEngineTabDetailedAdapter,
+  composerGateEnabled,
   settingsSnapshot: daemonSettingsSnapshot,
   settingsPatch: daemonSettingsPatch,
   handleDiffRequest,

--- a/packages/kobe/src/core/daemon-runtime.ts
+++ b/packages/kobe/src/core/daemon-runtime.ts
@@ -28,6 +28,7 @@ import { handleThemesRequest } from "../web/themes.ts"
 import {
   deliverPromptToLiveEngineAdapter,
   deliverPromptToLiveEngineDetailedAdapter,
+  deliverPromptToLiveEngineTabDetailedAdapter,
   engineSpecAdapter,
   ensureTaskSessionAdapter,
   startTaskSessionWithPromptAdapter,
@@ -95,6 +96,7 @@ export const daemonRuntime: DaemonRuntimeAdapter = {
   vendorsWithQuotaProbe,
   deliverPromptToLiveEngine: deliverPromptToLiveEngineAdapter,
   deliverPromptToLiveEngineDetailed: deliverPromptToLiveEngineDetailedAdapter,
+  deliverPromptToLiveEngineTabDetailed: deliverPromptToLiveEngineTabDetailedAdapter,
   settingsSnapshot: daemonSettingsSnapshot,
   settingsPatch: daemonSettingsPatch,
   handleDiffRequest,

--- a/packages/kobe/src/core/daemon-session-adapter.ts
+++ b/packages/kobe/src/core/daemon-session-adapter.ts
@@ -209,6 +209,44 @@ export async function deliverPromptToLiveEngineDetailedAdapter(
   }
 }
 
+/** Exact-tab variant used by deferred queue draining. Never reroutes or spawns. */
+export async function deliverPromptToLiveEngineTabDetailedAdapter(
+  target: {
+    readonly id: string
+    readonly tabId: string
+    readonly vendor?: VendorId
+    readonly command?: string
+    readonly worktreePath: string
+  },
+  prompt: string,
+): Promise<
+  | { outcome: "delivered"; tabId: string }
+  | { outcome: "no-session" }
+  | { outcome: "busy"; tabId: string; layer: "recent-human-write" | "composer-not-empty" }
+> {
+  const host = await openHostedSessionHost()
+  if (!host) return { outcome: "no-session" }
+  try {
+    const key = `${target.id}::${target.tabId}`
+    const sessions = await listHostedSessions(host.rpc)
+    if (!sessions.some((session) => session.alive && session.key === key)) return { outcome: "no-session" }
+    const manifest = target.vendor ? engineEntry(target.vendor).screenManifest : undefined
+    try {
+      const delivered = await deliverToHostedKey(host.rpc, key, prompt, { screenManifest: manifest })
+      return delivered === null ? { outcome: "no-session" } : { outcome: "delivered", tabId: target.tabId }
+    } catch (err) {
+      if (err instanceof ComposerBusyError) {
+        return { outcome: "busy", tabId: target.tabId, layer: err.layer }
+      }
+      throw err
+    }
+  } catch {
+    return { outcome: "no-session" }
+  } finally {
+    host.close()
+  }
+}
+
 export async function tearDownTaskSessionAdapter(taskId: string): Promise<void> {
   const host = await openHostedSessionHost()
   if (!host) return

--- a/packages/kobe/src/core/daemon-session-adapter.ts
+++ b/packages/kobe/src/core/daemon-session-adapter.ts
@@ -292,14 +292,19 @@ export async function deliverPromptToLiveEngineTabDetailedAdapter(
   if (!host) return { outcome: "no-session" }
   try {
     const key = `${target.id}::${target.tabId}`
-    const sessions = await listHostedSessions(host.rpc)
+    let sessions: Awaited<ReturnType<typeof listHostedSessions>>
+    try {
+      sessions = await listHostedSessions(host.rpc)
+    } catch {
+      return { outcome: "no-session" }
+    }
     const session = sessions.find((candidate) => candidate.alive && candidate.key === key)
     if (!session) return { outcome: "no-session" }
-    const engineBin = engineLaunchArgv({
+    const engineArgv = engineLaunchArgv({
       command: target.command,
       vendor: target.vendor,
-    })[0]
-    if (!(await sessionHasEngine(session.pid, engineBin))) return { outcome: "no-session" }
+    })
+    if (!(await sessionHasEngine(session.pid, engineArgv))) return { outcome: "no-session" }
     const manifest = target.vendor ? engineEntry(target.vendor).screenManifest : undefined
     try {
       const delivered = await deliverToHostedKey(host.rpc, key, prompt, {
@@ -312,8 +317,6 @@ export async function deliverPromptToLiveEngineTabDetailedAdapter(
       }
       throw err
     }
-  } catch {
-    return { outcome: "no-session" }
   } finally {
     host.close()
   }

--- a/packages/kobe/src/core/daemon-session-adapter.ts
+++ b/packages/kobe/src/core/daemon-session-adapter.ts
@@ -15,6 +15,7 @@ import {
   pastePromptWhenEngineUp,
 } from "../engine/hosted-session.ts"
 import { engineEntry } from "../engine/registry.ts"
+import { sessionHasEngine } from "../engine/session-engine-presence.ts"
 import { buildEngineSessionLaunch } from "../engine/session-launch.ts"
 import { trustEngineWorktree } from "../engine/trust-worktree.ts"
 import { TaskDeletingError } from "../orchestrator/errors.ts"
@@ -22,7 +23,9 @@ import type { PromptDeliveryIntent } from "../state/repo-init.ts"
 import type { VendorId } from "../types/task.ts"
 
 async function getTask(link: DaemonRpcClient, taskId: string): Promise<SerializedTask> {
-  const { task } = await link.request<{ task: SerializedTask }>("task.get", { taskId })
+  const { task } = await link.request<{ task: SerializedTask }>("task.get", {
+    taskId,
+  })
   return task
 }
 
@@ -46,7 +49,11 @@ export async function ensureTaskSessionAdapter(link: DaemonRpcClient, taskId: st
     // message rides outside the argv. Best-effort paste — the engine IS up,
     // so a missed paste leaves an idle prompt, not a failed session.
     if (launch.firstMessage) {
-      const engineBin = engineLaunchArgv({ command: task.command, vendor: task.vendor, effort: task.modelEffort })[0]
+      const engineBin = engineLaunchArgv({
+        command: task.command,
+        vendor: task.vendor,
+        effort: task.modelEffort,
+      })[0]
       await pastePromptWhenEngineUp(host.rpc, launch.key, engineBin, launch.firstMessage, {
         initMarkerPath: launch.initMarkerPath,
         initTimeoutMs: launch.initTimeoutMs,
@@ -83,7 +90,10 @@ export async function startTaskSessionWithPromptAdapter(
   // "new-task", not "explicit": both callers (automation runner, work-item
   // start) create the task immediately ahead of this call, so the first prompt gets
   // the branch-rename coda like every other new-worktree entry point.
-  const launch = taskEngineLaunch(task, worktreePath, { kind: "new-task", prompt })
+  const launch = taskEngineLaunch(task, worktreePath, {
+    kind: "new-task",
+    prompt,
+  })
   const host = await ensureHostedSessionHost()
   try {
     const opened = await ensureHostedEngine(host.rpc, worktreePath, launch)
@@ -92,7 +102,11 @@ export async function startTaskSessionWithPromptAdapter(
     // argv; deliver it once the engine process is up. A paste that never
     // lands means the prompt was not delivered — report false.
     if (launch.firstMessage) {
-      const engineBin = engineLaunchArgv({ command: task.command, vendor: task.vendor, effort: task.modelEffort })[0]
+      const engineBin = engineLaunchArgv({
+        command: task.command,
+        vendor: task.vendor,
+        effort: task.modelEffort,
+      })[0]
       const outcome = await pastePromptWhenEngineUp(host.rpc, launch.key, engineBin, launch.firstMessage, {
         initMarkerPath: launch.initMarkerPath,
         initTimeoutMs: launch.initTimeoutMs,
@@ -109,10 +123,19 @@ function taskEngineLaunch(task: SerializedTask, worktreePath: string, promptInte
   // Pre-trust the worktree in the vendor's first-run store.
   trustEngineWorktree(task.vendor, worktreePath)
   return buildEngineSessionLaunch({
-    task: { id: task.id, kind: task.kind, vendor: task.vendor, repo: task.repo },
+    task: {
+      id: task.id,
+      kind: task.kind,
+      vendor: task.vendor,
+      repo: task.repo,
+    },
     worktreePath,
     shell: resolveLoginShell({ fallback: "/bin/zsh" }),
-    argv: engineLaunchArgv({ command: task.command, vendor: task.vendor, effort: task.modelEffort }),
+    argv: engineLaunchArgv({
+      command: task.command,
+      vendor: task.vendor,
+      effort: task.modelEffort,
+    }),
     promptIntent,
   })
 }
@@ -124,12 +147,19 @@ export async function engineSpecAdapter(link: DaemonRpcClient, taskId: string) {
   // OUTSIDE the argv; the web PTY sidecar pastes it after the fresh spawn
   // (the sidecar owns its own PTYs — the daemon's hosted paste can't reach
   // them). Without this the message would be silently dropped.
-  return { cwd: worktreePath, command: [...launch.command], firstMessage: launch.firstMessage }
+  return {
+    cwd: worktreePath,
+    command: [...launch.command],
+    firstMessage: launch.firstMessage,
+  }
 }
 
 export async function terminalSpecAdapter(link: DaemonRpcClient, taskId: string) {
   const { worktreePath } = await ensureTaskWorktree(link, taskId)
-  return { cwd: worktreePath, command: [resolveLoginShell({ fallback: "/bin/zsh" }), "-il"] }
+  return {
+    cwd: worktreePath,
+    command: [resolveLoginShell({ fallback: "/bin/zsh" }), "-il"],
+  }
 }
 
 /**
@@ -139,18 +169,30 @@ export async function terminalSpecAdapter(link: DaemonRpcClient, taskId: string)
  * "no alive engine" returns false and the schedule is dropped instead.
  */
 export async function deliverPromptToLiveEngineAdapter(
-  task: { readonly id: string; readonly vendor?: VendorId; readonly command?: string; readonly worktreePath: string },
+  task: {
+    readonly id: string
+    readonly vendor?: VendorId
+    readonly command?: string
+    readonly worktreePath: string
+  },
   prompt: string,
 ): Promise<boolean> {
   const host = await openHostedSessionHost()
   if (!host) return false
   try {
     const sessions = await listHostedSessions(host.rpc)
-    const engineBin = engineLaunchArgv({ command: task.command, vendor: task.vendor })[0]
+    const engineBin = engineLaunchArgv({
+      command: task.command,
+      vendor: task.vendor,
+    })[0]
     const key = findHostedEngineKey(sessions, task.id, engineBin)
     if (!key) return false
     const manifest = task.vendor ? engineEntry(task.vendor).screenManifest : undefined
-    return (await deliverToHostedKey(host.rpc, key, prompt, { screenManifest: manifest })) !== null
+    return (
+      (await deliverToHostedKey(host.rpc, key, prompt, {
+        screenManifest: manifest,
+      })) !== null
+    )
   } catch (err) {
     // Composer-busy is not a silent failure: let the quota-resume runner log
     // it instead of dropping the prompt without a trace.
@@ -176,27 +218,45 @@ function tabIdFromHostedKey(key: string): string {
  * across the package boundary — so the outcome crosses as data.
  */
 export async function deliverPromptToLiveEngineDetailedAdapter(
-  task: { readonly id: string; readonly vendor?: VendorId; readonly command?: string; readonly worktreePath: string },
+  task: {
+    readonly id: string
+    readonly vendor?: VendorId
+    readonly command?: string
+    readonly worktreePath: string
+  },
   prompt: string,
 ): Promise<
   | { outcome: "delivered"; tabId: string }
   | { outcome: "no-session" }
-  | { outcome: "busy"; tabId: string; layer: "recent-human-write" | "composer-not-empty" }
+  | {
+      outcome: "busy"
+      tabId: string
+      layer: "recent-human-write" | "composer-not-empty"
+    }
 > {
   const host = await openHostedSessionHost()
   if (!host) return { outcome: "no-session" }
   try {
     const sessions = await listHostedSessions(host.rpc)
-    const engineBin = engineLaunchArgv({ command: task.command, vendor: task.vendor })[0]
+    const engineBin = engineLaunchArgv({
+      command: task.command,
+      vendor: task.vendor,
+    })[0]
     const key = findHostedEngineKey(sessions, task.id, engineBin)
     if (!key) return { outcome: "no-session" }
     const manifest = task.vendor ? engineEntry(task.vendor).screenManifest : undefined
     try {
-      const delivered = await deliverToHostedKey(host.rpc, key, prompt, { screenManifest: manifest })
+      const delivered = await deliverToHostedKey(host.rpc, key, prompt, {
+        screenManifest: manifest,
+      })
       return delivered === null ? { outcome: "no-session" } : { outcome: "delivered", tabId: tabIdFromHostedKey(key) }
     } catch (err) {
       if (err instanceof ComposerBusyError) {
-        return { outcome: "busy", tabId: tabIdFromHostedKey(key), layer: err.layer }
+        return {
+          outcome: "busy",
+          tabId: tabIdFromHostedKey(key),
+          layer: err.layer,
+        }
       }
       throw err
     }
@@ -222,17 +282,29 @@ export async function deliverPromptToLiveEngineTabDetailedAdapter(
 ): Promise<
   | { outcome: "delivered"; tabId: string }
   | { outcome: "no-session" }
-  | { outcome: "busy"; tabId: string; layer: "recent-human-write" | "composer-not-empty" }
+  | {
+      outcome: "busy"
+      tabId: string
+      layer: "recent-human-write" | "composer-not-empty"
+    }
 > {
   const host = await openHostedSessionHost()
   if (!host) return { outcome: "no-session" }
   try {
     const key = `${target.id}::${target.tabId}`
     const sessions = await listHostedSessions(host.rpc)
-    if (!sessions.some((session) => session.alive && session.key === key)) return { outcome: "no-session" }
+    const session = sessions.find((candidate) => candidate.alive && candidate.key === key)
+    if (!session) return { outcome: "no-session" }
+    const engineBin = engineLaunchArgv({
+      command: target.command,
+      vendor: target.vendor,
+    })[0]
+    if (!(await sessionHasEngine(session.pid, engineBin))) return { outcome: "no-session" }
     const manifest = target.vendor ? engineEntry(target.vendor).screenManifest : undefined
     try {
-      const delivered = await deliverToHostedKey(host.rpc, key, prompt, { screenManifest: manifest })
+      const delivered = await deliverToHostedKey(host.rpc, key, prompt, {
+        screenManifest: manifest,
+      })
       return delivered === null ? { outcome: "no-session" } : { outcome: "delivered", tabId: target.tabId }
     } catch (err) {
       if (err instanceof ComposerBusyError) {

--- a/packages/kobe/src/engine/foreground.ts
+++ b/packages/kobe/src/engine/foreground.ts
@@ -49,6 +49,17 @@ function binaryName(token: string): string {
   return basename(token).replace(/\.(exe|js|mjs|cjs)$/, "")
 }
 
+/** Resolve the executable identity from launch argv, through known wrappers. */
+export function executableNameFromArgv(argv: readonly string[]): string | null {
+  for (const token of argv.slice(0, 8)) {
+    if (/^[A-Za-z_][A-Za-z0-9_]*=/.test(token)) continue
+    const name = binaryName(token)
+    if (WRAPPERS.has(name)) continue
+    return name || null
+  }
+  return null
+}
+
 /**
  * The vendor a command line IS, or null. Only the executable position
  * counts — scanning arguments is what made the title heuristic wrong
@@ -56,21 +67,16 @@ function binaryName(token: string): string {
  * is what identifies, and the tree walk finds that one).
  */
 export function vendorFromArgv(commandLine: string): VendorId | null {
-  for (const token of commandLine.trim().split(/\s+/).slice(0, 4)) {
-    // `env FOO=1 claude` — the assignments sit between wrapper and binary.
-    if (/^[A-Za-z_][A-Za-z0-9_]*=/.test(token)) continue
-    const name = binaryName(token)
-    if (WRAPPERS.has(name)) continue
-    // defaultCommand[0] is the launch binary; processNames covers engines
-    // that rewrite their process title post-launch (kimi → `kimi-co`).
-    return (
-      BUILTIN_VENDORS.find((v) => {
-        const entry = engineEntry(v)
-        return entry.defaultCommand[0] === name || entry.processNames?.includes(name) === true
-      }) ?? null
-    )
-  }
-  return null
+  const name = executableNameFromArgv(commandLine.trim().split(/\s+/))
+  if (!name) return null
+  // defaultCommand[0] is the launch binary; processNames covers engines
+  // that rewrite their process title post-launch (kimi → `kimi-co`).
+  return (
+    BUILTIN_VENDORS.find((v) => {
+      const entry = engineEntry(v)
+      return entry.defaultCommand[0] === name || entry.processNames?.includes(name) === true
+    }) ?? null
+  )
 }
 
 /** Parse `ps -A -o pid=,ppid=,args=` output; unparsable lines are skipped. */
@@ -144,20 +150,27 @@ export function foregroundEngineIn(rows: readonly ProcRow[], rootPid: number): F
  * so "session alive" never proves an engine is there — and pasting a prompt
  * into the fallback SHELL executes it as commands. Vendor-agnostic on
  * purpose: any engine may receive text (cross-vendor send is legitimate);
- * only a bare shell must not. `extraBin` matches a custom engine's launch
- * binary by name — a user-registered engine (aider etc.) is not a builtin,
- * so the argv walk alone can't see it.
+ * only a bare shell must not. `extraLaunch` supplies a custom engine's full
+ * launch argv; both it and the process row are normalized through the same
+ * wrapper/path parser before comparison.
  */
-export function engineProcessIn(rows: readonly ProcRow[], rootPid: number, extraBin?: string): boolean {
+export function engineProcessIn(
+  rows: readonly ProcRow[],
+  rootPid: number,
+  extraLaunch?: string | readonly string[],
+): boolean {
   if (foregroundEngineIn(rows, rootPid)) return true
-  if (!extraBin) return false
+  const expected = extraLaunch
+    ? executableNameFromArgv(typeof extraLaunch === "string" ? [extraLaunch] : extraLaunch)
+    : null
+  if (!expected) return false
   const kids = childrenIndex(rows)
   const queue = [...(kids.get(rootPid) ?? [])]
   while (queue.length > 0) {
     const row = queue.shift()
     if (!row) break
-    const argv0 = row.args.trim().split(/\s+/)[0] ?? ""
-    if (basename(argv0) === extraBin) return true
+    const executable = executableNameFromArgv(row.args.trim().split(/\s+/))
+    if (executable === expected) return true
     queue.push(...(kids.get(row.pid) ?? []))
   }
   return false

--- a/packages/kobe/src/engine/session-engine-presence.ts
+++ b/packages/kobe/src/engine/session-engine-presence.ts
@@ -7,12 +7,12 @@ import { type PsSnapshot, engineProcessIn, parsePsSnapshot, psSnapshot } from ".
  */
 export async function sessionHasEngine(
   pid: number | null | undefined,
-  extraBin?: string,
+  extraLaunch?: string | readonly string[],
   snapshot: PsSnapshot = psSnapshot,
 ): Promise<boolean> {
   if (!pid) return false
   try {
-    return engineProcessIn(parsePsSnapshot(await snapshot()), pid, extraBin)
+    return engineProcessIn(parsePsSnapshot(await snapshot()), pid, extraLaunch)
   } catch {
     return false
   }

--- a/packages/kobe/src/engine/session-engine-presence.ts
+++ b/packages/kobe/src/engine/session-engine-presence.ts
@@ -1,0 +1,19 @@
+import { type PsSnapshot, engineProcessIn, parsePsSnapshot, psSnapshot } from "./foreground.ts"
+
+/**
+ * A hosted PTY can remain alive after its engine exits because keepAlive drops
+ * it into a fallback shell. Delivery must therefore verify the current process
+ * tree instead of trusting the session's original launch command.
+ */
+export async function sessionHasEngine(
+  pid: number | null | undefined,
+  extraBin?: string,
+  snapshot: PsSnapshot = psSnapshot,
+): Promise<boolean> {
+  if (!pid) return false
+  try {
+    return engineProcessIn(parsePsSnapshot(await snapshot()), pid, extraBin)
+  } catch {
+    return false
+  }
+}

--- a/packages/kobe/src/state/composer-gate.ts
+++ b/packages/kobe/src/state/composer-gate.ts
@@ -46,12 +46,14 @@ export function toggleComposerGatePreference(
 ): "enabled" | "disabled" | "persist-failed" {
   const next = !composerGatePreferenceOn(store)
   store.set(COMPOSER_GATE_KEY, next)
-  if (next) return "enabled"
-  // KV writes are normally debounced. Flush before notifying the daemon so
-  // its fresh state.json read cannot race this transition and see the old ON.
-  if (!store.flush()) return "persist-failed"
-  onDisabled?.()
-  return "disabled"
+  // BOTH edges are synchronous: an in-progress daemon flush reads this value
+  // between records, so ON is its cancellation signal just as OFF starts it.
+  if (!store.flush()) {
+    store.set(COMPOSER_GATE_KEY, !next)
+    return "persist-failed"
+  }
+  if (!next) onDisabled?.()
+  return next ? "enabled" : "disabled"
 }
 
 /** Whether the screen-based composer check runs. Default true. */

--- a/packages/kobe/src/state/composer-gate.ts
+++ b/packages/kobe/src/state/composer-gate.ts
@@ -29,6 +29,31 @@ import { getPersistedBool } from "./store.ts"
 
 export const COMPOSER_GATE_KEY = "delivery.composerGate"
 
+export interface ComposerGatePreferenceStore {
+  get(key: string, fallback?: unknown): unknown
+  set(key: string, value: unknown): void
+  flush(): boolean
+}
+
+export function composerGatePreferenceOn(store: ComposerGatePreferenceStore): boolean {
+  return store.get(COMPOSER_GATE_KEY, true) !== false
+}
+
+/** Toggle the persisted gate and notify only after an on-to-off edge is durable. */
+export function toggleComposerGatePreference(
+  store: ComposerGatePreferenceStore,
+  onDisabled?: () => void,
+): "enabled" | "disabled" | "persist-failed" {
+  const next = !composerGatePreferenceOn(store)
+  store.set(COMPOSER_GATE_KEY, next)
+  if (next) return "enabled"
+  // KV writes are normally debounced. Flush before notifying the daemon so
+  // its fresh state.json read cannot race this transition and see the old ON.
+  if (!store.flush()) return "persist-failed"
+  onDisabled?.()
+  return "disabled"
+}
+
 /** Whether the screen-based composer check runs. Default true. */
 export function composerGateEnabled(): boolean {
   return getPersistedBool(COMPOSER_GATE_KEY, true)

--- a/packages/kobe/src/tui-react/component/settings-dialog/deferred-flush-feedback.ts
+++ b/packages/kobe/src/tui-react/component/settings-dialog/deferred-flush-feedback.ts
@@ -1,0 +1,24 @@
+import { errorMessage } from "@/lib/error-message"
+import { logClientError } from "@sma1lboy/kobe-daemon/client/client-log"
+import type { RemoteOrchestrator } from "../../../client/remote-orchestrator"
+import type { DialogContext } from "../../ui/dialog"
+import { DialogConfirm } from "../../ui/dialog-confirm"
+
+/** Surface old-daemon/missing-verb failures in the TUI, not only the log. */
+export async function flushDeferredPromptsWithFeedback(
+  remote: Pick<RemoteOrchestrator, "flushDeferredPrompts">,
+  dialog: DialogContext,
+): Promise<void> {
+  try {
+    await remote.flushDeferredPrompts()
+  } catch (error) {
+    const message = errorMessage(error)
+    logClientError("settings", `deferred prompt flush failed: ${message}`)
+    await DialogConfirm.show(
+      dialog,
+      "Deferred prompts were not flushed",
+      `${message}. Restart or update the daemon, then retry.`,
+      "cancel",
+    )
+  }
+}

--- a/packages/kobe/src/tui-react/component/settings-dialog/index.tsx
+++ b/packages/kobe/src/tui-react/component/settings-dialog/index.tsx
@@ -8,7 +8,6 @@
 import { errorMessage } from "@/lib/error-message"
 import { type BoxRenderable, type ScrollBoxRenderable, TextAttributes } from "@opentui/core"
 import { useRenderer } from "@opentui/react"
-import { logClientError } from "@sma1lboy/kobe-daemon/client/client-log"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { type KobeOrchestrator, RemoteOrchestrator, type UsageSnapshotMap } from "../../../client/remote-orchestrator"
 import { createStateCell } from "../../../lib/external-store"
@@ -33,6 +32,7 @@ import { useBindings } from "../../lib/keymap"
 import { useAccessor } from "../../lib/use-accessor"
 import { type DialogContext, useDialog, useDialogPaddingX } from "../../ui/dialog"
 import { confirmResetState, confirmRestartDaemon, hasRestartableDaemon } from "./actions"
+import { flushDeferredPromptsWithFeedback } from "./deferred-flush-feedback"
 import { SettingsCursorElContext } from "./rows"
 import { EngineSettingsSection } from "./sections-engines"
 import { GeneralSettingsSection, SettingsSectionSidebar } from "./sections-general"
@@ -73,15 +73,10 @@ export function SettingsDialog(props: SettingsDialogProps) {
   const hasDaemon = hasRestartableDaemon(props.orchestrator)
   const remote = props.orchestrator instanceof RemoteOrchestrator ? props.orchestrator : null
   const prefs = useSettingsPrefs(props.kv, dialog, () => {
-    if (!remote) return
-    void remote
-      .flushDeferredPrompts()
-      .catch((error) => logClientError("settings", `deferred prompt flush failed: ${errorMessage(error)}`))
+    if (remote) void flushDeferredPromptsWithFeedback(remote, dialog)
   })
   const engines = useEngineSettings(props.kv, dialog, (max) => setBodyRow((r) => Math.max(0, Math.min(r, max))))
-  // Daemon-pushed per-vendor quota snapshots (General's top-right dashboard).
-  // Only the RemoteOrchestrator has the channel; a local orchestrator (tests,
-  // direct mode) reads the empty fallback cell and the dashboard stays hidden.
+  // A local orchestrator has no daemon quota channel and uses the empty cell.
   const usage = useAccessor(remote ? remote.usageSnapshotSignal() : EMPTY_USAGE_SIGNAL)
 
   // Lazily-probed section data (accounts / plugins) — see ./use-section-data.

--- a/packages/kobe/src/tui-react/component/settings-dialog/index.tsx
+++ b/packages/kobe/src/tui-react/component/settings-dialog/index.tsx
@@ -8,6 +8,7 @@
 import { errorMessage } from "@/lib/error-message"
 import { type BoxRenderable, type ScrollBoxRenderable, TextAttributes } from "@opentui/core"
 import { useRenderer } from "@opentui/react"
+import { logClientError } from "@sma1lboy/kobe-daemon/client/client-log"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { type KobeOrchestrator, RemoteOrchestrator, type UsageSnapshotMap } from "../../../client/remote-orchestrator"
 import { createStateCell } from "../../../lib/external-store"
@@ -70,14 +71,17 @@ export function SettingsDialog(props: SettingsDialogProps) {
   const [feedbackStatus, setFeedbackStatus] = useState("")
   const themeNames = useMemo<readonly string[]>(() => themeCtx.all().slice().sort(), [themeCtx])
   const hasDaemon = hasRestartableDaemon(props.orchestrator)
-
-  const prefs = useSettingsPrefs(props.kv, dialog)
+  const remote = props.orchestrator instanceof RemoteOrchestrator ? props.orchestrator : null
+  const prefs = useSettingsPrefs(props.kv, dialog, () => {
+    if (!remote) return
+    void remote
+      .flushDeferredPrompts()
+      .catch((error) => logClientError("settings", `deferred prompt flush failed: ${errorMessage(error)}`))
+  })
   const engines = useEngineSettings(props.kv, dialog, (max) => setBodyRow((r) => Math.max(0, Math.min(r, max))))
-
   // Daemon-pushed per-vendor quota snapshots (General's top-right dashboard).
   // Only the RemoteOrchestrator has the channel; a local orchestrator (tests,
   // direct mode) reads the empty fallback cell and the dashboard stays hidden.
-  const remote = props.orchestrator instanceof RemoteOrchestrator ? props.orchestrator : null
   const usage = useAccessor(remote ? remote.usageSnapshotSignal() : EMPTY_USAGE_SIGNAL)
 
   // Lazily-probed section data (accounts / plugins) — see ./use-section-data.

--- a/packages/kobe/src/tui-react/component/settings-dialog/use-settings-prefs.ts
+++ b/packages/kobe/src/tui-react/component/settings-dialog/use-settings-prefs.ts
@@ -11,8 +11,9 @@
 
 import { accessSync, constants as fsConstants, mkdirSync } from "node:fs"
 import { errorMessage } from "@/lib/error-message"
+import { logClientError } from "@sma1lboy/kobe-daemon/client/client-log"
 import { AUTO_STATUS_KEY } from "../../../state/auto-status"
-import { COMPOSER_GATE_KEY } from "../../../state/composer-gate"
+import { composerGatePreferenceOn, toggleComposerGatePreference } from "../../../state/composer-gate"
 import { DISPATCHER_KEY } from "../../../state/dispatcher"
 import { DEFAULT_SCROLLBACK_ROWS, SCROLLBACK_ROWS_KEY, normalizeScrollbackRows } from "../../../state/scrollback"
 import { SPLIT_STYLE_KEY, type SplitStyle, normalizeSplitStyle } from "../../../state/split-style"
@@ -53,7 +54,7 @@ import type { DialogContext } from "../../ui/dialog"
 import { DialogConfirm } from "../../ui/dialog-confirm"
 import { RenameTaskDialog } from "../rename-task-dialog"
 
-export function useSettingsPrefs(kv: KVContext, dialog: DialogContext) {
+export function useSettingsPrefs(kv: KVContext, dialog: DialogContext, onComposerGateDisabled?: () => void) {
   const t = useT()
 
   function toastEnabled(): boolean {
@@ -143,10 +144,15 @@ export function useSettingsPrefs(kv: KVContext, dialog: DialogContext) {
   // ON by default (the only default-on switch here) — it is an escape hatch
   // for a gate that reads a vendor's screen layout, not a feature to opt into.
   function composerGateOn(): boolean {
-    return kv.get(COMPOSER_GATE_KEY, true) !== false
+    return composerGatePreferenceOn(kv)
   }
   function toggleComposerGate(): void {
-    kv.set(COMPOSER_GATE_KEY, !composerGateOn())
+    if (toggleComposerGatePreference(kv, onComposerGateDisabled) === "persist-failed") {
+      logClientError(
+        "settings",
+        "could not persist the disabled composer delivery check; deferred prompts were not flushed",
+      )
+    }
   }
 
   // Editor preference: which editor the file tree's `e` key launches.

--- a/packages/kobe/src/tui-react/workspace/deferred-prompt-insert.ts
+++ b/packages/kobe/src/tui-react/workspace/deferred-prompt-insert.ts
@@ -1,20 +1,17 @@
 /**
  * Exit path for a deferred prompt.
  *
- * Opening a `prompt_deferred` inbox item jumps to the tab AND inserts the
- * queued message — one action, reusing the existing open action (no new
- * chord). The insert RE-RUNS the A/C delivery gate: the human may be typing
+ * Opening a `prompt_deferred` inbox item jumps to the tab AND asks the daemon
+ * to release the queued message — one action, reusing the existing open action
+ * (no new chord). Release RE-RUNS the A/C delivery gate: the human may be typing
  * again at the moment they release the message, so an unconditional paste
  * would re-open the very bug this feature fixes. When the gate still blocks,
  * the message stays queued (episode + record untouched) and the caller toasts
- * "still queued"; on success the record and episode are resolved.
+ * "still queued". A daemon-side claim keeps release, flush, and dismiss from
+ * delivering the same record concurrently.
  */
 
 import type { RemoteOrchestrator } from "../../client/remote-orchestrator.ts"
-import { ComposerBusyError, deliverToHostedKey, openHostedSessionHost } from "../../engine/hosted-session.ts"
-import { engineEntry } from "../../engine/registry.ts"
-import type { EngineScreenManifest } from "../../engine/screen-state.ts"
-import type { VendorId } from "../../types/vendor.ts"
 
 export type DeferredInsertOutcome =
   /** Pasted + submitted; the record and episode are resolved. */
@@ -23,36 +20,16 @@ export type DeferredInsertOutcome =
   | "deferred-again"
   /** No reachable hosted session for the tab; kept queued for a later retry. */
   | "unavailable"
+  /** The record was already resolved or expired; caller should dismiss its stale Inbox pointer. */
+  | "missing"
 
 export async function insertDeferredPrompt(args: {
-  readonly orch: Pick<RemoteOrchestrator, "resolveDeferredPrompt">
-  readonly taskId: string
-  readonly tabId: string
-  readonly prompt: string
+  readonly orch: Pick<RemoteOrchestrator, "releaseDeferredPrompt">
   readonly deferredId: string
-  readonly manifest?: EngineScreenManifest
 }): Promise<DeferredInsertOutcome> {
-  const host = await openHostedSessionHost()
-  if (!host) return "unavailable"
-  try {
-    const key = `${args.taskId}::${args.tabId}`
-    let delivered: boolean
-    try {
-      delivered = (await deliverToHostedKey(host.rpc, key, args.prompt, { screenManifest: args.manifest })) !== null
-    } catch (err) {
-      if (err instanceof ComposerBusyError) return "deferred-again"
-      throw err
-    }
-    if (!delivered) return "unavailable"
-    await args.orch.resolveDeferredPrompt(args.deferredId)
-    return "inserted"
-  } finally {
-    host.close()
-  }
-}
-
-/** The composer-empty manifest for a task's vendor (undefined → C-layer skips,
- *  fail-open, A-layer still guards). */
-export function deferredManifestFor(vendor: VendorId | undefined): EngineScreenManifest | undefined {
-  return vendor ? engineEntry(vendor).screenManifest : undefined
+  const outcome = await args.orch.releaseDeferredPrompt(args.deferredId)
+  if (outcome === "inserted" || outcome === "deferred-again" || outcome === "unavailable") return outcome
+  if (outcome === "in-flight") return "deferred-again"
+  if (outcome === "missing") return "missing"
+  throw new Error(`deferred prompt ${args.deferredId} was delivered but cleanup is still pending`)
 }

--- a/packages/kobe/src/tui-react/workspace/terminal-tabs-close.ts
+++ b/packages/kobe/src/tui-react/workspace/terminal-tabs-close.ts
@@ -30,7 +30,13 @@ import {
 } from "../../tui/workspace/terminal-tabs-core"
 import { releaseSplitLeaves } from "./TerminalSplit"
 import { type TabsSnapshotKv, terminalTabsKey } from "./terminal-tabs-persist"
-import { requestTabClose, setTaskTabs, tabsByTask, takeUnclaimedTabClose } from "./terminal-tabs-shared"
+import {
+  reportTabsDelta,
+  requestTabClose,
+  setTaskTabs,
+  tabsByTask,
+  takeUnclaimedTabClose,
+} from "./terminal-tabs-shared"
 
 /**
  * Release a closing tab's PTYs — the split leaves plus the tab's own.
@@ -111,6 +117,7 @@ export function closeTaskTab(kv: TabsSnapshotKv, taskId: string, tabId: string):
   if (!closedId) return false
   setTaskTabs(taskId, next)
   kv.set(terminalTabsKey(taskId), next)
+  reportTabsDelta(taskId, state.tabs, next.tabs)
   releaseClosedTabPtys(taskId, closing, closedId)
   return true
 }

--- a/packages/kobe/src/tui-react/workspace/use-inbox-host.ts
+++ b/packages/kobe/src/tui-react/workspace/use-inbox-host.ts
@@ -13,7 +13,7 @@ import {
   partitionAttentionInboxAvailability,
   visitResolvedEpisodes,
 } from "./attention-inbox-core"
-import { deferredManifestFor, insertDeferredPrompt } from "./deferred-prompt-insert"
+import { insertDeferredPrompt } from "./deferred-prompt-insert"
 import { requestInboxItemOpen } from "./inbox-open-action"
 import { notifyInboxRpcFailure } from "./inbox-rpc-errors"
 import { writeInboxVisit } from "./inbox-visits"
@@ -97,32 +97,18 @@ export function useInboxHost(args: {
   }, [unavailableSignature, orch])
 
   /**
-   * Release a `prompt_deferred` episode. The text is
+   * Release a `prompt_deferred` episode (issue #78 B exit path). The text is
    * fetched from the daemon store (the episode carries only its id), inserted
    * with a FRESH A/C gate, and — only on success — resolved. The gate still
    * blocking means the human is typing again; the message stays queued.
    */
-  async function releaseDeferredPrompt(
-    item: AttentionInboxItem,
-    deferredId: string,
-    vendor: Task["vendor"],
-  ): Promise<void> {
+  async function releaseDeferredPrompt(item: AttentionInboxItem, deferredId: string): Promise<void> {
     try {
-      const record = await orch.getDeferredPrompt(deferredId)
-      if (!record) {
-        // The record was released or cleaned up after expiry — drop the stale
-        // episode so it doesn't point at a record that is gone.
+      const outcome = await insertDeferredPrompt({ orch, deferredId })
+      if (outcome === "missing") {
         notifyInboxRpcFailure(orch.dismissAttention(item.taskId, item.tabId, item.at), "dismiss", args.notifyError)
         return
       }
-      const outcome = await insertDeferredPrompt({
-        orch,
-        taskId: item.taskId,
-        tabId: item.tabId ?? "tab-1",
-        prompt: record.prompt,
-        deferredId,
-        manifest: deferredManifestFor(vendor),
-      })
       if (outcome === "deferred-again") args.notifyInfo(t("workspace.inbox.deferredStillQueued"))
       else if (outcome === "unavailable") args.notifyInfo(t("workspace.inbox.deferredUnavailable"))
       // "inserted" → the resolve RPC dropped both the record and the episode.
@@ -144,7 +130,7 @@ export function useInboxHost(args: {
       args.selectTask(item.taskId)
       requestTabActivation(item.taskId, item.tabId)
       args.focusWorkspace()
-      void releaseDeferredPrompt(item, deferredId, task?.vendor)
+      void releaseDeferredPrompt(item, deferredId)
       return
     }
 

--- a/packages/kobe/test/cli/api-tab-close.test.ts
+++ b/packages/kobe/test/cli/api-tab-close.test.ts
@@ -4,7 +4,9 @@ import { FakeClient, expectApiError, stubRuntime } from "./api-handler-fixtures.
 
 describe("tab-close handler", () => {
   it("uses the attached TUI's normal close path when it confirms the tab", async () => {
-    const client = new FakeClient({ "terminalTab.close": () => ({ ok: true, handled: true }) })
+    const client = new FakeClient({
+      "terminalTab.close": () => ({ ok: true, handled: true }),
+    })
     let headlessCalls = 0
     const result = await invokeVerb("tab-close", ["--task-id", "t1", "--tab", "tab-3"], {
       client,
@@ -17,11 +19,19 @@ describe("tab-close handler", () => {
     })
     expect(client.requests).toEqual([{ name: "terminalTab.close", payload: { taskId: "t1", tabId: "tab-3" } }])
     expect(headlessCalls).toBe(0)
-    expect(result).toEqual({ ok: true, taskId: "t1", tabId: "tab-3", handledBy: "tui" })
+    expect(result).toEqual({
+      ok: true,
+      taskId: "t1",
+      tabId: "tab-3",
+      handledBy: "tui",
+    })
   })
 
   it("falls back to the headless snapshot and PTY close path", async () => {
-    const client = new FakeClient({ "terminalTab.close": () => ({ ok: true, handled: false }) })
+    const client = new FakeClient({
+      "terminalTab.close": () => ({ ok: true, handled: false }),
+      "deferredPrompt.discardTab": () => ({ dropped: ["deferred-1"] }),
+    })
     const calls: string[][] = []
     const result = await invokeVerb("tab-close", ["--task-id", "t1", "--tab", "tab-2"], {
       client,
@@ -33,6 +43,13 @@ describe("tab-close handler", () => {
       }),
     })
     expect(calls).toEqual([["t1", "tab-2"]])
+    expect(client.requests).toEqual([
+      { name: "terminalTab.close", payload: { taskId: "t1", tabId: "tab-2" } },
+      {
+        name: "deferredPrompt.discardTab",
+        payload: { taskId: "t1", tabId: "tab-2" },
+      },
+    ])
     expect(result).toEqual({
       ok: true,
       taskId: "t1",
@@ -46,11 +63,19 @@ describe("tab-close handler", () => {
   it("requires both task and tab ids", async () => {
     const client = new FakeClient()
     await expectApiError(
-      () => invokeVerb("tab-close", ["--task-id", "t1"], { client, runtime: stubRuntime() }),
+      () =>
+        invokeVerb("tab-close", ["--task-id", "t1"], {
+          client,
+          runtime: stubRuntime(),
+        }),
       "MISSING_FLAG",
     )
     await expectApiError(
-      () => invokeVerb("tab-close", ["--tab", "tab-1"], { client, runtime: stubRuntime() }),
+      () =>
+        invokeVerb("tab-close", ["--tab", "tab-1"], {
+          client,
+          runtime: stubRuntime(),
+        }),
       "MISSING_FLAG",
     )
     expect(client.requestNames).toEqual([])

--- a/packages/kobe/test/core/daemon-session-adapter.test.ts
+++ b/packages/kobe/test/core/daemon-session-adapter.test.ts
@@ -10,6 +10,8 @@ const mocks = vi.hoisted(() => ({
   listSessions: vi.fn(async () => [{ key: "task-3::tab-1", alive: true }]),
   taskKeys: vi.fn(() => ["task-3::tab-1"]),
   killSessions: vi.fn(async () => {}),
+  deliver: vi.fn(async () => ({ bytes: 1 })),
+  sessionHasEngine: vi.fn(async () => true),
   buildLaunch: vi.fn((input: { task: { id: string } }): { key: string; command: string[]; firstMessage?: string } => ({
     key: `${input.task.id}::tab-1`,
     command: ["/bin/zsh", "-ilc", "claude 'repo prompt'"],
@@ -23,10 +25,13 @@ vi.mock("../../src/engine/hosted-session.ts", () => ({
   listHostedSessions: mocks.listSessions,
   hostedTaskKeys: mocks.taskKeys,
   killHostedSessions: mocks.killSessions,
+  deliverToHostedKey: mocks.deliver,
 }))
 vi.mock("../../src/engine/session-launch.ts", () => ({ buildEngineSessionLaunch: mocks.buildLaunch }))
+vi.mock("../../src/engine/session-engine-presence.ts", () => ({ sessionHasEngine: mocks.sessionHasEngine }))
 
 import {
+  deliverPromptToLiveEngineTabDetailedAdapter,
   engineSpecAdapter,
   ensureTaskSessionAdapter,
   startTaskSessionWithPromptAdapter,
@@ -162,5 +167,19 @@ describe("daemon session adapter", () => {
     await expect(engineSpecAdapter(deleting, "task-6")).rejects.toThrow("TASK_DELETING")
     await expect(terminalSpecAdapter(deleting, "task-6")).rejects.toThrow("TASK_DELETING")
     expect(mocks.ensureEngine).not.toHaveBeenCalled()
+  })
+
+  it("does not paste into an alive PTY after its engine exited to the fallback shell", async () => {
+    mocks.listSessions.mockResolvedValueOnce([{ key: "task-3::tab-1", alive: true, pid: 4242 } as never])
+    mocks.sessionHasEngine.mockResolvedValueOnce(false)
+
+    await expect(
+      deliverPromptToLiveEngineTabDetailedAdapter(
+        { id: "task-3", tabId: "tab-1", vendor: "claude", worktreePath: "/worktrees/story" },
+        "do not run this in zsh",
+      ),
+    ).resolves.toEqual({ outcome: "no-session" })
+    expect(mocks.sessionHasEngine).toHaveBeenCalledWith(4242, "claude")
+    expect(mocks.deliver).not.toHaveBeenCalled()
   })
 })

--- a/packages/kobe/test/core/daemon-session-adapter.test.ts
+++ b/packages/kobe/test/core/daemon-session-adapter.test.ts
@@ -188,7 +188,7 @@ describe("daemon session adapter", () => {
         "do not run this in zsh",
       ),
     ).resolves.toEqual({ outcome: "no-session" })
-    expect(mocks.sessionHasEngine).toHaveBeenCalledWith(4242, ["claude", "--dangerously-skip-permissions", "-c"])
+    expect(mocks.sessionHasEngine).toHaveBeenCalledWith(4242, expect.arrayContaining(["claude"]))
     expect(mocks.deliver).not.toHaveBeenCalled()
   })
 

--- a/packages/kobe/test/core/daemon-session-adapter.test.ts
+++ b/packages/kobe/test/core/daemon-session-adapter.test.ts
@@ -3,6 +3,14 @@ import { resolveLoginShell } from "@sma1lboy/kobe-daemon/daemon/platform-shell"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 const mocks = vi.hoisted(() => ({
+  ComposerBusyError: class extends Error {
+    constructor(
+      readonly layer: "recent-human-write" | "composer-not-empty",
+      readonly key: string,
+    ) {
+      super(`composer busy on ${key}: ${layer}`)
+    }
+  },
   close: vi.fn(),
   ensureHost: vi.fn(),
   openHost: vi.fn(),
@@ -19,6 +27,7 @@ const mocks = vi.hoisted(() => ({
 }))
 
 vi.mock("../../src/engine/hosted-session.ts", () => ({
+  ComposerBusyError: mocks.ComposerBusyError,
   ensureHostedSessionHost: mocks.ensureHost,
   openHostedSessionHost: mocks.openHost,
   ensureHostedEngine: mocks.ensureEngine,
@@ -179,7 +188,36 @@ describe("daemon session adapter", () => {
         "do not run this in zsh",
       ),
     ).resolves.toEqual({ outcome: "no-session" })
-    expect(mocks.sessionHasEngine).toHaveBeenCalledWith(4242, "claude")
+    expect(mocks.sessionHasEngine).toHaveBeenCalledWith(4242, ["claude", "--dangerously-skip-permissions", "-c"])
     expect(mocks.deliver).not.toHaveBeenCalled()
+  })
+
+  it("passes the custom engine's complete launch argv to the foreground gate", async () => {
+    mocks.listSessions.mockResolvedValueOnce([{ key: "task-3::tab-1", alive: true, pid: 4242 } as never])
+
+    await deliverPromptToLiveEngineTabDetailedAdapter(
+      {
+        id: "task-3",
+        tabId: "tab-1",
+        command: "env MODEL=sonnet /opt/tools/aider --yes",
+        worktreePath: "/worktrees/story",
+      },
+      "safe prompt",
+    )
+
+    expect(mocks.sessionHasEngine).toHaveBeenCalledWith(4242, ["env", "MODEL=sonnet", "/opt/tools/aider", "--yes"])
+  })
+
+  it("propagates an ambiguous delivery error after entering the PTY write", async () => {
+    mocks.listSessions.mockResolvedValueOnce([{ key: "task-3::tab-1", alive: true, pid: 4242 } as never])
+    mocks.deliver.mockRejectedValueOnce(new Error("transport lost after write"))
+
+    await expect(
+      deliverPromptToLiveEngineTabDetailedAdapter(
+        { id: "task-3", tabId: "tab-1", vendor: "claude", worktreePath: "/worktrees/story" },
+        "possibly written",
+      ),
+    ).rejects.toThrow("transport lost after write")
+    expect(mocks.close).toHaveBeenCalledOnce()
   })
 })

--- a/packages/kobe/test/daemon/attention-inbox.test.ts
+++ b/packages/kobe/test/daemon/attention-inbox.test.ts
@@ -99,6 +99,26 @@ describe("daemon attention inbox", () => {
     ])
   })
 
+  it("can delete only the deferred lane while preserving task activity", async () => {
+    let now = 100
+    const { store } = await create(() => now)
+    await store.record("task-1", "awaiting-input", { waiting: "permission" }, "tab-1")
+    now = 200
+    await store.recordPromptDeferred("task-1", "tab-1", "deferred-1", "composer-not-empty")
+
+    expect(await store.deleteEpisode("task-1", "tab-1", 200, "prompt_deferred")).toBe(true)
+    expect(store.snapshot()).toEqual([
+      {
+        taskId: "task-1",
+        tabId: "tab-1",
+        state: "permission_needed",
+        detail: { waiting: "permission" },
+        unread: true,
+        at: 100,
+      },
+    ])
+  })
+
   it("resolves an episode on open and ignores a stale open after a replacement", async () => {
     // Queue-drain model (owner 2026-07-16): opening REMOVES the episode
     // (markRead is a legacy alias for delete); a fresh event re-records at

--- a/packages/kobe/test/daemon/deferred-prompts-store.test.ts
+++ b/packages/kobe/test/daemon/deferred-prompts-store.test.ts
@@ -4,7 +4,7 @@ import { join } from "node:path"
 import { DEFERRED_PROMPT_TTL_MS, DeferredPromptsStore } from "@sma1lboy/kobe-daemon/daemon/deferred-prompts-store"
 import { afterEach, describe, expect, it, vi } from "vitest"
 
-/** Capture the daemon-log lines the store writes on expiry. */
+/** Capture the daemon-log lines the store writes on expiry or explicit discard. */
 function spyDaemonLog(): { lines: string[]; restore: () => void } {
   const lines: string[] = []
   const spy = vi.spyOn(process.stderr, "write").mockImplementation(((chunk: unknown) => {
@@ -84,6 +84,23 @@ describe("daemon deferred-prompts store (issue #78 B)", () => {
       expect(await store.get(a.id)).toBeNull()
       expect(await store.get(b.id)).toEqual(b)
       expect(log.lines.join("")).toContain("task-1 deleted")
+    } finally {
+      log.restore()
+    }
+  })
+
+  it("discardTab removes only that tab and logs why the prompt was dropped", async () => {
+    const { store } = await create()
+    const log = spyDaemonLog()
+    try {
+      const dropped = await store.file({ ...base, at: now })
+      const kept = await store.file({ ...base, tabId: "tab-2", at: now + 1 })
+
+      expect(await store.discardTab("task-1", "tab-1", "tab closed")).toEqual([dropped])
+      expect(await store.get(dropped.id)).toBeNull()
+      expect(await store.get(kept.id)).toEqual(kept)
+      expect(log.lines.join("")).toContain(`dropped deferred prompt ${dropped.id}`)
+      expect(log.lines.join("")).toContain("tab closed")
     } finally {
       log.restore()
     }

--- a/packages/kobe/test/daemon/deferred-prompts-store.test.ts
+++ b/packages/kobe/test/daemon/deferred-prompts-store.test.ts
@@ -58,19 +58,56 @@ describe("daemon deferred-prompts store (issue #78 B)", () => {
     expect(await store.get(first.id)).toEqual(first)
   })
 
-  it("evicts TTL-expired records on write, logging the drop", async () => {
+  it("returns TTL-expired records to the caller instead of silently dropping their Inbox identity", async () => {
     const { store } = await create()
     const log = spyDaemonLog()
     try {
       const old = await store.file({ ...base, taskId: "task-old", at: now })
       now += DEFERRED_PROMPT_TTL_MS + 1_000
-      await store.file({ ...base, taskId: "task-new", at: now })
+      const fresh = await store.file({ ...base, taskId: "task-new", at: now })
 
-      expect(await store.get(old.id)).toBeNull()
+      expect(await store.get(old.id)).toEqual(old)
+      expect(await store.list()).toEqual({ records: [fresh], expired: [old] })
       expect(log.lines.join("")).toContain("expired deferred prompt")
     } finally {
       log.restore()
     }
+  })
+
+  it("blocks same-tab replacement while expiry cleanup owns the record", async () => {
+    const { store } = await create()
+    const old = await store.file({ ...base, at: now })
+    now += DEFERRED_PROMPT_TTL_MS + 1
+    const claimed = await store.claim(old.id)
+    expect(claimed.kind).toBe("claimed")
+    await expect(store.file({ ...base, prompt: "new", at: now })).rejects.toThrow("cleanup is in flight")
+    if (claimed.kind !== "claimed") throw new Error("claim missing")
+    await store.completeClaim(claimed.claim)
+
+    const fresh = await store.file({ ...base, prompt: "new", at: now })
+    expect(await store.listForTask(base.taskId)).toEqual([fresh])
+  })
+
+  it("replaces an expired record in the same tab without leaving a duplicate cleanup target", async () => {
+    const { store } = await create()
+    const old = await store.file({ ...base, at: now })
+    now += DEFERRED_PROMPT_TTL_MS + 1_000
+
+    const fresh = await store.file({ ...base, prompt: "fresh", at: now })
+
+    expect(await store.get(old.id)).toBeNull()
+    expect(await store.list()).toEqual({ records: [fresh], expired: [] })
+  })
+
+  it("does not let an unrelated expired claim block filing another tab", async () => {
+    const { store } = await create()
+    const old = await store.file({ ...base, at: now })
+    now += DEFERRED_PROMPT_TTL_MS + 1_000
+    expect(await store.claim(old.id)).toMatchObject({ kind: "claimed" })
+
+    const fresh = await store.file({ ...base, tabId: "tab-2", prompt: "fresh", at: now })
+
+    expect(await store.get(fresh.id)).toEqual(fresh)
   })
 
   it("deleteTask drops the task's records with a log line", async () => {

--- a/packages/kobe/test/daemon/handler-test-context.ts
+++ b/packages/kobe/test/daemon/handler-test-context.ts
@@ -72,6 +72,7 @@ export function fakeCtx(orch: Record<string, unknown> = {}): {
       clearTask: (taskId: string) => rec.cleared.push(taskId),
     } as unknown as DaemonActivityRegistry,
     inbox: {
+      snapshot: () => (orch.inboxItems as unknown[] | undefined) ?? [],
       record: (taskId: string, kind: string, detail?: unknown, tabId?: string) => {
         rec.inboxRecords.push({ taskId, kind, detail, tabId })
         return Promise.resolve()

--- a/packages/kobe/test/daemon/handlers-deferred-races.test.ts
+++ b/packages/kobe/test/daemon/handlers-deferred-races.test.ts
@@ -1,0 +1,168 @@
+import { mkdtemp, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { AttentionInboxStore } from "@sma1lboy/kobe-daemon/daemon/attention-inbox"
+import type { DeferredPromptsStore } from "@sma1lboy/kobe-daemon/daemon/deferred-prompts-store"
+import { DeferredPromptsStore as Store } from "@sma1lboy/kobe-daemon/daemon/deferred-prompts-store"
+import { DaemonEventBus } from "@sma1lboy/kobe-daemon/daemon/event-bus"
+import type { DaemonRuntimeAdapter } from "@sma1lboy/kobe-daemon/daemon/runtime"
+import { afterEach, describe, expect, it } from "vitest"
+import { TASK, dispatch, fakeCtx } from "./handler-test-context.ts"
+
+describe("deferredPrompt RPC persistence races", () => {
+  let dir: string | null = null
+
+  afterEach(async () => {
+    if (dir) await rm(dir, { recursive: true, force: true })
+    dir = null
+  })
+
+  async function ctxWithRealStores(now: () => number = Date.now) {
+    const { ctx } = fakeCtx({
+      getTask: (id: string) => (id === TASK.id ? TASK : undefined),
+    })
+    dir = await mkdtemp(join(tmpdir(), "kobe-deferred-real-stores-"))
+    const deferredPath = join(dir, "deferred-prompts.json")
+    const store = new Store(deferredPath, now)
+    const inbox = new AttentionInboxStore(join(dir, "attention-inbox.json"), new DaemonEventBus(), now)
+    await inbox.init()
+    ;(ctx as { deferredPrompts?: DeferredPromptsStore }).deferredPrompts = store
+    ;(ctx as { inbox: AttentionInboxStore }).inbox = inbox
+    ;(ctx as { runtime: DaemonRuntimeAdapter }).runtime = {
+      ...ctx.runtime,
+      composerGateEnabled: () => false,
+    }
+    return { ctx, store, deferredPath, inbox }
+  }
+
+  it("does not redeliver an ambiguous PTY write after a daemon restart", async () => {
+    const { ctx, store, deferredPath } = await ctxWithRealStores()
+    const { id } = (await dispatch(
+      "deferredPrompt.fileIfVacant",
+      {
+        taskId: TASK.id,
+        tabId: "tab-1",
+        prompt: "at most once",
+        layer: "composer-not-empty",
+      },
+      ctx,
+    )) as { id: string }
+    let deliveries = 0
+    ;(ctx as { runtime: DaemonRuntimeAdapter }).runtime = {
+      ...ctx.runtime,
+      composerGateEnabled: () => false,
+      deliverPromptToLiveEngineTabDetailed: async () => {
+        deliveries++
+        throw new Error("transport lost after PTY write")
+      },
+    }
+
+    await expect(dispatch("deferredPrompt.flush", {}, ctx)).resolves.toMatchObject({
+      delivered: [],
+      cleanupPending: [{ id }],
+    })
+    expect((await store.get(id))?.deliveryStartedAt).toEqual(expect.any(Number))
+
+    const restarted = new Store(deferredPath)
+    ;(ctx as { deferredPrompts?: DeferredPromptsStore }).deferredPrompts = restarted
+    await expect(dispatch("deferredPrompt.flush", {}, ctx)).resolves.toMatchObject({ cleaned: [id], delivered: [] })
+    expect(deliveries).toBe(1)
+    expect(await restarted.get(id)).toBeNull()
+  })
+
+  it("delivery cleanup removes only the deferred Inbox lane", async () => {
+    let now = 100
+    const { ctx, inbox } = await ctxWithRealStores(() => now)
+    await inbox.record(TASK.id, "awaiting-input", { waiting: "permission" }, "tab-1")
+    now = 200
+    await dispatch(
+      "deferredPrompt.fileIfVacant",
+      {
+        taskId: TASK.id,
+        tabId: "tab-1",
+        prompt: "deliver",
+        layer: "composer-not-empty",
+      },
+      ctx,
+    )
+    ;(ctx as { runtime: DaemonRuntimeAdapter }).runtime = {
+      ...ctx.runtime,
+      composerGateEnabled: () => false,
+      deliverPromptToLiveEngineTabDetailed: async () => ({
+        outcome: "delivered",
+        tabId: "tab-1",
+      }),
+    }
+
+    await dispatch("deferredPrompt.flush", {}, ctx)
+
+    expect(inbox.snapshot()).toEqual([
+      expect.objectContaining({
+        state: "permission_needed",
+        taskId: TASK.id,
+        tabId: "tab-1",
+        at: 100,
+      }),
+    ])
+  })
+
+  it("does not discard a TTL replacement racing an old Inbox dismissal", async () => {
+    let now = Date.now()
+    const { ctx, store, inbox } = await ctxWithRealStores(() => now)
+    const old = (await dispatch(
+      "deferredPrompt.fileIfVacant",
+      {
+        taskId: TASK.id,
+        tabId: "tab-1",
+        prompt: "old",
+        layer: "composer-not-empty",
+      },
+      ctx,
+    )) as { id: string }
+    const oldAt = inbox.snapshot().find((item) => item.state === "prompt_deferred")?.at
+    expect(oldAt).toEqual(expect.any(Number))
+    const oldRecord = await store.get(old.id)
+    if (!oldRecord) throw new Error("old deferred prompt missing")
+    now = oldRecord.at + 24 * 60 * 60 * 1000 + 1
+
+    const recordPromptDeferred = inbox.recordPromptDeferred.bind(inbox)
+    let replacementStored = () => {}
+    const stored = new Promise<void>((resolve) => {
+      replacementStored = resolve
+    })
+    let finishPointer = () => {}
+    const pointerGate = new Promise<void>((resolve) => {
+      finishPointer = resolve
+    })
+    inbox.recordPromptDeferred = async (...args) => {
+      replacementStored()
+      await pointerGate
+      await recordPromptDeferred(...args)
+    }
+
+    const filing = dispatch(
+      "deferredPrompt.fileIfVacant",
+      {
+        taskId: TASK.id,
+        tabId: "tab-1",
+        prompt: "replacement",
+        layer: "recent-human-write",
+      },
+      ctx,
+    ) as Promise<{ id: string }>
+    await stored
+    await dispatch("attention.dismiss", { taskId: TASK.id, tabId: "tab-1", at: oldAt }, ctx)
+    finishPointer()
+    const replacement = await filing
+
+    expect(replacement.id).not.toBe(old.id)
+    expect((await store.get(replacement.id))?.prompt).toBe("replacement")
+    expect(inbox.snapshot()).toEqual([
+      expect.objectContaining({
+        detail: {
+          deferredPrompt: { id: replacement.id, layer: "recent-human-write" },
+        },
+      }),
+    ])
+  })
+})

--- a/packages/kobe/test/daemon/handlers-deferred.test.ts
+++ b/packages/kobe/test/daemon/handlers-deferred.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os"
 import { join } from "node:path"
 import type { DeferredPromptsStore } from "@sma1lboy/kobe-daemon/daemon/deferred-prompts-store"
 import { DeferredPromptsStore as Store } from "@sma1lboy/kobe-daemon/daemon/deferred-prompts-store"
+import type { DaemonRuntimeAdapter } from "@sma1lboy/kobe-daemon/daemon/runtime"
 import { afterEach, describe, expect, it } from "vitest"
 import { TASK, dispatch, fakeCtx } from "./handler-test-context.ts"
 
@@ -171,5 +172,154 @@ describe("deferredPrompt RPC handlers (issue #78 B)", () => {
 
     await dispatch("deferredPrompt.resolve", { id }, ctx)
     expect(rec.inboxDeleted).toEqual([{ taskId: TASK.id, tabId: "tab-1" }])
+  })
+
+  it("flush delivers every queued prompt in file order and resolves each episode", async () => {
+    const { ctx, rec, store } = await ctxWithStore()
+    const now = Date.now()
+    const first = await store.file({
+      taskId: TASK.id,
+      tabId: "tab-2",
+      prompt: "first",
+      layer: "composer-not-empty",
+      at: now,
+    })
+    const second = await store.file({
+      taskId: TASK.id,
+      tabId: "tab-1",
+      prompt: "second",
+      layer: "composer-not-empty",
+      at: now + 1,
+    })
+    const delivered: Array<{ tabId: string; prompt: string }> = []
+    ;(ctx as { runtime: DaemonRuntimeAdapter }).runtime = {
+      ...ctx.runtime,
+      deliverPromptToLiveEngineTabDetailed: async (target, prompt) => {
+        delivered.push({ tabId: target.tabId, prompt })
+        return { outcome: "delivered", tabId: target.tabId }
+      },
+    }
+
+    const result = await dispatch("deferredPrompt.flush", {}, ctx)
+
+    expect(delivered).toEqual([
+      { tabId: "tab-2", prompt: "first" },
+      { tabId: "tab-1", prompt: "second" },
+    ])
+    expect(result).toEqual({ delivered: [first.id, second.id], retained: [] })
+    expect(await store.get(first.id)).toBeNull()
+    expect(await store.get(second.id)).toBeNull()
+    expect(rec.inboxDeleted).toEqual([
+      { taskId: TASK.id, tabId: "tab-2" },
+      { taskId: TASK.id, tabId: "tab-1" },
+    ])
+  })
+
+  it("flush keeps a mid-queue failure visible and continues with later tabs", async () => {
+    const { ctx, rec, store } = await ctxWithStore()
+    const now = Date.now()
+    const first = await store.file({
+      taskId: TASK.id,
+      tabId: "tab-1",
+      prompt: "first",
+      layer: "composer-not-empty",
+      at: now,
+    })
+    const blocked = await store.file({
+      taskId: TASK.id,
+      tabId: "tab-2",
+      prompt: "blocked",
+      layer: "composer-not-empty",
+      at: now + 1,
+    })
+    const third = await store.file({
+      taskId: TASK.id,
+      tabId: "tab-3",
+      prompt: "third",
+      layer: "composer-not-empty",
+      at: now + 2,
+    })
+    const attempted: string[] = []
+    ;(ctx as { runtime: DaemonRuntimeAdapter }).runtime = {
+      ...ctx.runtime,
+      deliverPromptToLiveEngineTabDetailed: async (target) => {
+        attempted.push(target.tabId)
+        if (target.tabId === "tab-2") {
+          return { outcome: "busy", tabId: target.tabId, layer: "recent-human-write" }
+        }
+        return { outcome: "delivered", tabId: target.tabId }
+      },
+    }
+
+    const result = await dispatch("deferredPrompt.flush", {}, ctx)
+
+    expect(attempted).toEqual(["tab-1", "tab-2", "tab-3"])
+    expect(result).toEqual({
+      delivered: [first.id, third.id],
+      retained: [
+        {
+          id: blocked.id,
+          taskId: TASK.id,
+          tabId: "tab-2",
+          reason: "busy",
+          layer: "recent-human-write",
+        },
+      ],
+    })
+    expect(await store.get(first.id)).toBeNull()
+    expect(await store.get(blocked.id)).toEqual(blocked)
+    expect(await store.get(third.id)).toBeNull()
+    expect(rec.inboxDeleted).toEqual([
+      { taskId: TASK.id, tabId: "tab-1" },
+      { taskId: TASK.id, tabId: "tab-3" },
+    ])
+  })
+
+  it("discarding or closing a tab drops its stored prompt with its Inbox episode", async () => {
+    const { ctx, rec, store } = await ctxWithStore()
+    const now = Date.now()
+    const dismissed = await store.file({
+      taskId: TASK.id,
+      tabId: "tab-1",
+      prompt: "dismiss me",
+      layer: "composer-not-empty",
+      at: now,
+    })
+    const closed = await store.file({
+      taskId: TASK.id,
+      tabId: "tab-2",
+      prompt: "close me",
+      layer: "composer-not-empty",
+      at: now + 1,
+    })
+    ;(ctx.inbox as unknown as { snapshot: () => unknown[] }).snapshot = () => [
+      { taskId: TASK.id, tabId: "tab-1", state: "prompt_deferred", unread: true, at: now },
+    ]
+
+    await dispatch("attention.dismiss", { taskId: TASK.id, tabId: "tab-1", at: now }, ctx)
+    await dispatch("ui.reportEvent", { kind: "tab.closed", taskId: TASK.id, detail: { tabId: "tab-2" } }, ctx)
+
+    expect(await store.get(dismissed.id)).toBeNull()
+    expect(await store.get(closed.id)).toBeNull()
+    expect(rec.inboxDeleted).toContainEqual({ taskId: TASK.id, tabId: "tab-2" })
+  })
+
+  it("does not discard a newer deferred prompt for a stale Inbox dismissal", async () => {
+    const { ctx, store } = await ctxWithStore()
+    const now = Date.now()
+    const queued = await store.file({
+      taskId: TASK.id,
+      tabId: "tab-1",
+      prompt: "newer",
+      layer: "composer-not-empty",
+      at: now,
+    })
+    ;(ctx.inbox as unknown as { snapshot: () => unknown[] }).snapshot = () => [
+      { taskId: TASK.id, tabId: "tab-1", state: "prompt_deferred", unread: true, at: now + 1 },
+    ]
+
+    await dispatch("attention.dismiss", { taskId: TASK.id, tabId: "tab-1", at: now }, ctx)
+
+    expect(await store.get(queued.id)).toEqual(queued)
   })
 })

--- a/packages/kobe/test/daemon/handlers-deferred.test.ts
+++ b/packages/kobe/test/daemon/handlers-deferred.test.ts
@@ -1,8 +1,10 @@
 import { mkdtemp, rm } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
+import { AttentionInboxStore } from "@sma1lboy/kobe-daemon/daemon/attention-inbox"
 import type { DeferredPromptsStore } from "@sma1lboy/kobe-daemon/daemon/deferred-prompts-store"
 import { DeferredPromptsStore as Store } from "@sma1lboy/kobe-daemon/daemon/deferred-prompts-store"
+import { DaemonEventBus } from "@sma1lboy/kobe-daemon/daemon/event-bus"
 import type { DaemonRuntimeAdapter } from "@sma1lboy/kobe-daemon/daemon/runtime"
 import { afterEach, describe, expect, it } from "vitest"
 import { TASK, dispatch, fakeCtx } from "./handler-test-context.ts"
@@ -22,6 +24,19 @@ describe("deferredPrompt RPC handlers (issue #78 B)", () => {
     ;(ctx as { deferredPrompts?: DeferredPromptsStore }).deferredPrompts = store
     ;(ctx as { runtime: DaemonRuntimeAdapter }).runtime = { ...ctx.runtime, composerGateEnabled: () => false }
     return { ctx, rec, store }
+  }
+
+  async function ctxWithRealStores(now: () => number = Date.now) {
+    const { ctx } = fakeCtx({ getTask: (id: string) => (id === TASK.id ? TASK : undefined) })
+    dir = await mkdtemp(join(tmpdir(), "kobe-deferred-real-stores-"))
+    const deferredPath = join(dir, "deferred-prompts.json")
+    const store = new Store(deferredPath, now)
+    const inbox = new AttentionInboxStore(join(dir, "attention-inbox.json"), new DaemonEventBus(), now)
+    await inbox.init()
+    ;(ctx as { deferredPrompts?: DeferredPromptsStore }).deferredPrompts = store
+    ;(ctx as { inbox: AttentionInboxStore }).inbox = inbox
+    ;(ctx as { runtime: DaemonRuntimeAdapter }).runtime = { ...ctx.runtime, composerGateEnabled: () => false }
+    return { ctx, store, deferredPath, inbox }
   }
 
   it("file stores the text and records a prompt_deferred episode, returning the id", async () => {
@@ -369,6 +384,59 @@ describe("deferredPrompt RPC handlers (issue #78 B)", () => {
     expect(rec.inboxDeleted).toEqual([{ taskId: TASK.id, tabId: "tab-1" }])
   })
 
+  it("does not redeliver an ambiguous PTY write after a daemon restart", async () => {
+    const { ctx, store, deferredPath } = await ctxWithRealStores()
+    const { id } = (await dispatch(
+      "deferredPrompt.fileIfVacant",
+      { taskId: TASK.id, tabId: "tab-1", prompt: "at most once", layer: "composer-not-empty" },
+      ctx,
+    )) as { id: string }
+    let deliveries = 0
+    ;(ctx as { runtime: DaemonRuntimeAdapter }).runtime = {
+      ...ctx.runtime,
+      composerGateEnabled: () => false,
+      deliverPromptToLiveEngineTabDetailed: async () => {
+        deliveries++
+        throw new Error("transport lost after PTY write")
+      },
+    }
+
+    await expect(dispatch("deferredPrompt.flush", {}, ctx)).resolves.toMatchObject({
+      delivered: [],
+      cleanupPending: [{ id }],
+    })
+    expect((await store.get(id))?.deliveryStartedAt).toEqual(expect.any(Number))
+
+    const restarted = new Store(deferredPath)
+    ;(ctx as { deferredPrompts?: DeferredPromptsStore }).deferredPrompts = restarted
+    await expect(dispatch("deferredPrompt.flush", {}, ctx)).resolves.toMatchObject({ cleaned: [id], delivered: [] })
+    expect(deliveries).toBe(1)
+    expect(await restarted.get(id)).toBeNull()
+  })
+
+  it("delivery cleanup removes only the deferred Inbox lane", async () => {
+    let now = 100
+    const { ctx, inbox } = await ctxWithRealStores(() => now)
+    await inbox.record(TASK.id, "awaiting-input", { waiting: "permission" }, "tab-1")
+    now = 200
+    await dispatch(
+      "deferredPrompt.fileIfVacant",
+      { taskId: TASK.id, tabId: "tab-1", prompt: "deliver", layer: "composer-not-empty" },
+      ctx,
+    )
+    ;(ctx as { runtime: DaemonRuntimeAdapter }).runtime = {
+      ...ctx.runtime,
+      composerGateEnabled: () => false,
+      deliverPromptToLiveEngineTabDetailed: async () => ({ outcome: "delivered", tabId: "tab-1" }),
+    }
+
+    await dispatch("deferredPrompt.flush", {}, ctx)
+
+    expect(inbox.snapshot()).toEqual([
+      expect.objectContaining({ state: "permission_needed", taskId: TASK.id, tabId: "tab-1", at: 100 }),
+    ])
+  })
+
   it("cancels the remaining flush generation when the composer gate is re-enabled", async () => {
     const { ctx, store } = await ctxWithStore()
     const first = await store.file({
@@ -436,7 +504,14 @@ describe("deferredPrompt RPC handlers (issue #78 B)", () => {
       at: now + 1,
     })
     ;(ctx.inbox as unknown as { snapshot: () => unknown[] }).snapshot = () => [
-      { taskId: TASK.id, tabId: "tab-1", state: "prompt_deferred", unread: true, at: now },
+      {
+        taskId: TASK.id,
+        tabId: "tab-1",
+        state: "prompt_deferred",
+        detail: { deferredPrompt: { id: dismissed.id, layer: "composer-not-empty" } },
+        unread: true,
+        at: now,
+      },
     ]
 
     await dispatch("attention.dismiss", { taskId: TASK.id, tabId: "tab-1", at: now }, ctx)
@@ -464,5 +539,51 @@ describe("deferredPrompt RPC handlers (issue #78 B)", () => {
     await dispatch("attention.dismiss", { taskId: TASK.id, tabId: "tab-1", at: now }, ctx)
 
     expect(await store.get(queued.id)).toEqual(queued)
+  })
+
+  it("does not discard a TTL replacement racing an old Inbox dismissal", async () => {
+    let now = Date.now()
+    const { ctx, store, inbox } = await ctxWithRealStores(() => now)
+    const old = (await dispatch(
+      "deferredPrompt.fileIfVacant",
+      { taskId: TASK.id, tabId: "tab-1", prompt: "old", layer: "composer-not-empty" },
+      ctx,
+    )) as { id: string }
+    const oldAt = inbox.snapshot().find((item) => item.state === "prompt_deferred")?.at
+    expect(oldAt).toEqual(expect.any(Number))
+    const oldRecord = await store.get(old.id)
+    if (!oldRecord) throw new Error("old deferred prompt missing")
+    now = oldRecord.at + 24 * 60 * 60 * 1000 + 1
+
+    const recordPromptDeferred = inbox.recordPromptDeferred.bind(inbox)
+    let replacementStored = () => {}
+    const stored = new Promise<void>((resolve) => {
+      replacementStored = resolve
+    })
+    let finishPointer = () => {}
+    const pointerGate = new Promise<void>((resolve) => {
+      finishPointer = resolve
+    })
+    inbox.recordPromptDeferred = async (...args) => {
+      replacementStored()
+      await pointerGate
+      await recordPromptDeferred(...args)
+    }
+
+    const filing = dispatch(
+      "deferredPrompt.fileIfVacant",
+      { taskId: TASK.id, tabId: "tab-1", prompt: "replacement", layer: "recent-human-write" },
+      ctx,
+    ) as Promise<{ id: string }>
+    await stored
+    await dispatch("attention.dismiss", { taskId: TASK.id, tabId: "tab-1", at: oldAt }, ctx)
+    finishPointer()
+    const replacement = await filing
+
+    expect(replacement.id).not.toBe(old.id)
+    expect((await store.get(replacement.id))?.prompt).toBe("replacement")
+    expect(inbox.snapshot()).toEqual([
+      expect.objectContaining({ detail: { deferredPrompt: { id: replacement.id, layer: "recent-human-write" } } }),
+    ])
   })
 })

--- a/packages/kobe/test/daemon/handlers-deferred.test.ts
+++ b/packages/kobe/test/daemon/handlers-deferred.test.ts
@@ -1,10 +1,8 @@
 import { mkdtemp, rm } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
-import { AttentionInboxStore } from "@sma1lboy/kobe-daemon/daemon/attention-inbox"
 import type { DeferredPromptsStore } from "@sma1lboy/kobe-daemon/daemon/deferred-prompts-store"
 import { DeferredPromptsStore as Store } from "@sma1lboy/kobe-daemon/daemon/deferred-prompts-store"
-import { DaemonEventBus } from "@sma1lboy/kobe-daemon/daemon/event-bus"
 import type { DaemonRuntimeAdapter } from "@sma1lboy/kobe-daemon/daemon/runtime"
 import { afterEach, describe, expect, it } from "vitest"
 import { TASK, dispatch, fakeCtx } from "./handler-test-context.ts"
@@ -24,19 +22,6 @@ describe("deferredPrompt RPC handlers (issue #78 B)", () => {
     ;(ctx as { deferredPrompts?: DeferredPromptsStore }).deferredPrompts = store
     ;(ctx as { runtime: DaemonRuntimeAdapter }).runtime = { ...ctx.runtime, composerGateEnabled: () => false }
     return { ctx, rec, store }
-  }
-
-  async function ctxWithRealStores(now: () => number = Date.now) {
-    const { ctx } = fakeCtx({ getTask: (id: string) => (id === TASK.id ? TASK : undefined) })
-    dir = await mkdtemp(join(tmpdir(), "kobe-deferred-real-stores-"))
-    const deferredPath = join(dir, "deferred-prompts.json")
-    const store = new Store(deferredPath, now)
-    const inbox = new AttentionInboxStore(join(dir, "attention-inbox.json"), new DaemonEventBus(), now)
-    await inbox.init()
-    ;(ctx as { deferredPrompts?: DeferredPromptsStore }).deferredPrompts = store
-    ;(ctx as { inbox: AttentionInboxStore }).inbox = inbox
-    ;(ctx as { runtime: DaemonRuntimeAdapter }).runtime = { ...ctx.runtime, composerGateEnabled: () => false }
-    return { ctx, store, deferredPath, inbox }
   }
 
   it("file stores the text and records a prompt_deferred episode, returning the id", async () => {
@@ -384,59 +369,6 @@ describe("deferredPrompt RPC handlers (issue #78 B)", () => {
     expect(rec.inboxDeleted).toEqual([{ taskId: TASK.id, tabId: "tab-1" }])
   })
 
-  it("does not redeliver an ambiguous PTY write after a daemon restart", async () => {
-    const { ctx, store, deferredPath } = await ctxWithRealStores()
-    const { id } = (await dispatch(
-      "deferredPrompt.fileIfVacant",
-      { taskId: TASK.id, tabId: "tab-1", prompt: "at most once", layer: "composer-not-empty" },
-      ctx,
-    )) as { id: string }
-    let deliveries = 0
-    ;(ctx as { runtime: DaemonRuntimeAdapter }).runtime = {
-      ...ctx.runtime,
-      composerGateEnabled: () => false,
-      deliverPromptToLiveEngineTabDetailed: async () => {
-        deliveries++
-        throw new Error("transport lost after PTY write")
-      },
-    }
-
-    await expect(dispatch("deferredPrompt.flush", {}, ctx)).resolves.toMatchObject({
-      delivered: [],
-      cleanupPending: [{ id }],
-    })
-    expect((await store.get(id))?.deliveryStartedAt).toEqual(expect.any(Number))
-
-    const restarted = new Store(deferredPath)
-    ;(ctx as { deferredPrompts?: DeferredPromptsStore }).deferredPrompts = restarted
-    await expect(dispatch("deferredPrompt.flush", {}, ctx)).resolves.toMatchObject({ cleaned: [id], delivered: [] })
-    expect(deliveries).toBe(1)
-    expect(await restarted.get(id)).toBeNull()
-  })
-
-  it("delivery cleanup removes only the deferred Inbox lane", async () => {
-    let now = 100
-    const { ctx, inbox } = await ctxWithRealStores(() => now)
-    await inbox.record(TASK.id, "awaiting-input", { waiting: "permission" }, "tab-1")
-    now = 200
-    await dispatch(
-      "deferredPrompt.fileIfVacant",
-      { taskId: TASK.id, tabId: "tab-1", prompt: "deliver", layer: "composer-not-empty" },
-      ctx,
-    )
-    ;(ctx as { runtime: DaemonRuntimeAdapter }).runtime = {
-      ...ctx.runtime,
-      composerGateEnabled: () => false,
-      deliverPromptToLiveEngineTabDetailed: async () => ({ outcome: "delivered", tabId: "tab-1" }),
-    }
-
-    await dispatch("deferredPrompt.flush", {}, ctx)
-
-    expect(inbox.snapshot()).toEqual([
-      expect.objectContaining({ state: "permission_needed", taskId: TASK.id, tabId: "tab-1", at: 100 }),
-    ])
-  })
-
   it("cancels the remaining flush generation when the composer gate is re-enabled", async () => {
     const { ctx, store } = await ctxWithStore()
     const first = await store.file({
@@ -539,51 +471,5 @@ describe("deferredPrompt RPC handlers (issue #78 B)", () => {
     await dispatch("attention.dismiss", { taskId: TASK.id, tabId: "tab-1", at: now }, ctx)
 
     expect(await store.get(queued.id)).toEqual(queued)
-  })
-
-  it("does not discard a TTL replacement racing an old Inbox dismissal", async () => {
-    let now = Date.now()
-    const { ctx, store, inbox } = await ctxWithRealStores(() => now)
-    const old = (await dispatch(
-      "deferredPrompt.fileIfVacant",
-      { taskId: TASK.id, tabId: "tab-1", prompt: "old", layer: "composer-not-empty" },
-      ctx,
-    )) as { id: string }
-    const oldAt = inbox.snapshot().find((item) => item.state === "prompt_deferred")?.at
-    expect(oldAt).toEqual(expect.any(Number))
-    const oldRecord = await store.get(old.id)
-    if (!oldRecord) throw new Error("old deferred prompt missing")
-    now = oldRecord.at + 24 * 60 * 60 * 1000 + 1
-
-    const recordPromptDeferred = inbox.recordPromptDeferred.bind(inbox)
-    let replacementStored = () => {}
-    const stored = new Promise<void>((resolve) => {
-      replacementStored = resolve
-    })
-    let finishPointer = () => {}
-    const pointerGate = new Promise<void>((resolve) => {
-      finishPointer = resolve
-    })
-    inbox.recordPromptDeferred = async (...args) => {
-      replacementStored()
-      await pointerGate
-      await recordPromptDeferred(...args)
-    }
-
-    const filing = dispatch(
-      "deferredPrompt.fileIfVacant",
-      { taskId: TASK.id, tabId: "tab-1", prompt: "replacement", layer: "recent-human-write" },
-      ctx,
-    ) as Promise<{ id: string }>
-    await stored
-    await dispatch("attention.dismiss", { taskId: TASK.id, tabId: "tab-1", at: oldAt }, ctx)
-    finishPointer()
-    const replacement = await filing
-
-    expect(replacement.id).not.toBe(old.id)
-    expect((await store.get(replacement.id))?.prompt).toBe("replacement")
-    expect(inbox.snapshot()).toEqual([
-      expect.objectContaining({ detail: { deferredPrompt: { id: replacement.id, layer: "recent-human-write" } } }),
-    ])
   })
 })

--- a/packages/kobe/test/daemon/handlers-deferred.test.ts
+++ b/packages/kobe/test/daemon/handlers-deferred.test.ts
@@ -20,6 +20,7 @@ describe("deferredPrompt RPC handlers (issue #78 B)", () => {
     dir = await mkdtemp(join(tmpdir(), "kobe-deferred-handlers-"))
     const store = new Store(join(dir, "deferred-prompts.json"))
     ;(ctx as { deferredPrompts?: DeferredPromptsStore }).deferredPrompts = store
+    ;(ctx as { runtime: DaemonRuntimeAdapter }).runtime = { ...ctx.runtime, composerGateEnabled: () => false }
     return { ctx, rec, store }
   }
 
@@ -145,7 +146,7 @@ describe("deferredPrompt RPC handlers (issue #78 B)", () => {
     ).rejects.toThrow(/task not found/)
   })
 
-  it("get reads a record back by id (null once resolved)", async () => {
+  it("fails the legacy pre-claim read path loud and resolves a pre-restart insert through a claim", async () => {
     const { ctx, store } = await ctxWithStore()
     const { id } = (await dispatch(
       "deferredPrompt.file",
@@ -153,12 +154,11 @@ describe("deferredPrompt RPC handlers (issue #78 B)", () => {
       ctx,
     )) as { id: string }
 
-    const got = (await dispatch("deferredPrompt.get", { id }, ctx)) as { record: { prompt: string } | null }
-    expect(got.record?.prompt).toBe("queued")
+    await expect(dispatch("deferredPrompt.get", { id }, ctx)).rejects.toThrow(
+      "legacy deferred prompt release is unsafe",
+    )
 
-    await dispatch("deferredPrompt.resolve", { id }, ctx)
-    const after = (await dispatch("deferredPrompt.get", { id }, ctx)) as { record: unknown }
-    expect(after.record).toBeNull()
+    await expect(dispatch("deferredPrompt.resolve", { id }, ctx)).resolves.toMatchObject({ removed: true })
     expect(await store.get(id)).toBeNull()
   })
 
@@ -206,7 +206,13 @@ describe("deferredPrompt RPC handlers (issue #78 B)", () => {
       { tabId: "tab-2", prompt: "first" },
       { tabId: "tab-1", prompt: "second" },
     ])
-    expect(result).toEqual({ delivered: [first.id, second.id], retained: [] })
+    expect(result).toEqual({
+      delivered: [first.id, second.id],
+      cleaned: [first.id, second.id],
+      expired: [],
+      retained: [],
+      cleanupPending: [],
+    })
     expect(await store.get(first.id)).toBeNull()
     expect(await store.get(second.id)).toBeNull()
     expect(rec.inboxDeleted).toEqual([
@@ -256,6 +262,8 @@ describe("deferredPrompt RPC handlers (issue #78 B)", () => {
     expect(attempted).toEqual(["tab-1", "tab-2", "tab-3"])
     expect(result).toEqual({
       delivered: [first.id, third.id],
+      cleaned: [first.id, third.id],
+      expired: [],
       retained: [
         {
           id: blocked.id,
@@ -265,6 +273,7 @@ describe("deferredPrompt RPC handlers (issue #78 B)", () => {
           layer: "recent-human-write",
         },
       ],
+      cleanupPending: [],
     })
     expect(await store.get(first.id)).toBeNull()
     expect(await store.get(blocked.id)).toEqual(blocked)
@@ -273,6 +282,140 @@ describe("deferredPrompt RPC handlers (issue #78 B)", () => {
       { taskId: TASK.id, tabId: "tab-1" },
       { taskId: TASK.id, tabId: "tab-3" },
     ])
+  })
+
+  it("single-flights concurrent flush, release, and dismiss operations", async () => {
+    const { ctx, store } = await ctxWithStore()
+    const queued = await store.file({
+      taskId: TASK.id,
+      tabId: "tab-1",
+      prompt: "once",
+      layer: "composer-not-empty",
+      at: Date.now(),
+    })
+    let enterDelivery = () => {}
+    const entered = new Promise<void>((resolve) => {
+      enterDelivery = resolve
+    })
+    let finishDelivery = () => {}
+    const finish = new Promise<void>((resolve) => {
+      finishDelivery = resolve
+    })
+    let deliveries = 0
+    ;(ctx as { runtime: DaemonRuntimeAdapter }).runtime = {
+      ...ctx.runtime,
+      composerGateEnabled: () => false,
+      deliverPromptToLiveEngineTabDetailed: async () => {
+        deliveries++
+        enterDelivery()
+        await finish
+        return { outcome: "delivered", tabId: "tab-1" }
+      },
+    }
+    ;(ctx.inbox as unknown as { snapshot: () => unknown[] }).snapshot = () => [
+      { taskId: TASK.id, tabId: "tab-1", state: "prompt_deferred", unread: true, at: queued.at },
+    ]
+
+    const firstFlush = dispatch("deferredPrompt.flush", {}, ctx)
+    await entered
+    const competing = Promise.all([
+      dispatch("deferredPrompt.flush", {}, ctx),
+      dispatch("deferredPrompt.release", { id: queued.id }, ctx),
+      dispatch("attention.dismiss", { taskId: TASK.id, tabId: "tab-1", at: queued.at }, ctx),
+    ])
+    finishDelivery()
+    await Promise.all([firstFlush, competing])
+
+    expect(deliveries).toBe(1)
+    expect(await store.get(queued.id)).toBeNull()
+  })
+
+  it("persists delivery before Inbox cleanup and converges without redelivery after an injected fault", async () => {
+    const { ctx, rec, store } = await ctxWithStore()
+    const queued = await store.file({
+      taskId: TASK.id,
+      tabId: "tab-1",
+      prompt: "exactly once",
+      layer: "composer-not-empty",
+      at: Date.now(),
+    })
+    let deliveries = 0
+    ;(ctx as { runtime: DaemonRuntimeAdapter }).runtime = {
+      ...ctx.runtime,
+      composerGateEnabled: () => false,
+      deliverPromptToLiveEngineTabDetailed: async () => {
+        deliveries++
+        return { outcome: "delivered", tabId: "tab-1" }
+      },
+    }
+    const deleteEpisode = ctx.inbox.deleteEpisode.bind(ctx.inbox)
+    let failCleanup = true
+    ctx.inbox.deleteEpisode = async (...args) => {
+      if (failCleanup) {
+        failCleanup = false
+        throw new Error("inbox rename failed")
+      }
+      return await deleteEpisode(...args)
+    }
+
+    const first = await dispatch("deferredPrompt.flush", {}, ctx)
+    expect(first).toMatchObject({ delivered: [queued.id], cleanupPending: [{ id: queued.id }] })
+    expect((await store.get(queued.id))?.deliveredAt).toEqual(expect.any(Number))
+
+    const retry = await dispatch("deferredPrompt.flush", {}, ctx)
+    expect(retry).toMatchObject({ delivered: [], cleaned: [queued.id], cleanupPending: [] })
+    expect(deliveries).toBe(1)
+    expect(await store.get(queued.id)).toBeNull()
+    expect(rec.inboxDeleted).toEqual([{ taskId: TASK.id, tabId: "tab-1" }])
+  })
+
+  it("cancels the remaining flush generation when the composer gate is re-enabled", async () => {
+    const { ctx, store } = await ctxWithStore()
+    const first = await store.file({
+      taskId: TASK.id,
+      tabId: "tab-1",
+      prompt: "first",
+      layer: "composer-not-empty",
+      at: Date.now(),
+    })
+    const second = await store.file({
+      taskId: TASK.id,
+      tabId: "tab-2",
+      prompt: "second",
+      layer: "composer-not-empty",
+      at: Date.now() + 1,
+    })
+    let gateEnabled = false
+    ;(ctx as { runtime: DaemonRuntimeAdapter }).runtime = {
+      ...ctx.runtime,
+      composerGateEnabled: () => gateEnabled,
+      deliverPromptToLiveEngineTabDetailed: async (_target, _prompt) => {
+        gateEnabled = true
+        return { outcome: "delivered", tabId: "tab-1" }
+      },
+    }
+
+    const result = await dispatch("deferredPrompt.flush", {}, ctx)
+    expect(result).toMatchObject({
+      delivered: [first.id],
+      retained: [{ id: second.id, reason: "gate-enabled" }],
+    })
+    expect(await store.get(second.id)).toEqual(second)
+  })
+
+  it("returns TTL-pruned ids and removes their stale Inbox pointers", async () => {
+    const { ctx, rec, store } = await ctxWithStore()
+    const expired = await store.file({
+      taskId: TASK.id,
+      tabId: "tab-1",
+      prompt: "expired",
+      layer: "composer-not-empty",
+      at: Date.now() - 24 * 60 * 60 * 1000 - 1,
+    })
+
+    const result = await dispatch("deferredPrompt.flush", {}, ctx)
+    expect(result).toMatchObject({ expired: [expired.id], delivered: [] })
+    expect(rec.inboxDeleted).toEqual([{ taskId: TASK.id, tabId: "tab-1" }])
   })
 
   it("discarding or closing a tab drops its stored prompt with its Inbox episode", async () => {

--- a/packages/kobe/test/daemon/handlers.test.ts
+++ b/packages/kobe/test/daemon/handlers.test.ts
@@ -91,6 +91,7 @@ describe("daemon handler registry", () => {
       "deferredPrompt.fileIfVacant",
       "deferredPrompt.get",
       "deferredPrompt.resolve",
+      "deferredPrompt.flush",
     ]
     const registry = createDaemonHandlerRegistry()
     for (const name of rpcNames) expect(registry.get(name), name).toBeDefined()

--- a/packages/kobe/test/daemon/handlers.test.ts
+++ b/packages/kobe/test/daemon/handlers.test.ts
@@ -91,6 +91,8 @@ describe("daemon handler registry", () => {
       "deferredPrompt.fileIfVacant",
       "deferredPrompt.get",
       "deferredPrompt.resolve",
+      "deferredPrompt.release",
+      "deferredPrompt.discardTab",
       "deferredPrompt.flush",
     ]
     const registry = createDaemonHandlerRegistry()

--- a/packages/kobe/test/engine/foreground.test.ts
+++ b/packages/kobe/test/engine/foreground.test.ts
@@ -116,7 +116,23 @@ describe("engineProcessIn (delivery foreground gate)", () => {
 11 10 /usr/local/bin/aider --model gpt
 `)
     expect(engineProcessIn(rows, 10)).toBe(false)
-    expect(engineProcessIn(rows, 10, "aider")).toBe(true)
+    expect(engineProcessIn(rows, 10, ["aider"])).toBe(true)
+  })
+
+  it("matches custom launch argv through absolute paths and env wrappers", () => {
+    const absolute = parsePsSnapshot(`
+10 1 -zsh
+11 10 /usr/local/bin/aider --model gpt
+`)
+    expect(engineProcessIn(absolute, 10, ["/usr/local/bin/aider", "--model", "gpt"])).toBe(true)
+
+    const wrapped = parsePsSnapshot(`
+10 1 -zsh
+11 10 /usr/bin/env OPENAI_API_KEY=redacted /opt/tools/aider --model sonnet
+`)
+    expect(
+      engineProcessIn(wrapped, 10, ["env", "OPENAI_API_KEY=redacted", "/opt/tools/aider", "--model", "sonnet"]),
+    ).toBe(true)
   })
 })
 

--- a/packages/kobe/test/render/inbox-deferred-exit.test.tsx
+++ b/packages/kobe/test/render/inbox-deferred-exit.test.tsx
@@ -82,20 +82,19 @@ function deferredItem(at: number): AttentionInboxItem {
 
 interface OrchMock {
   orch: RemoteOrchestrator
-  /** Live counter — read `.resolveCalls` after the fact. */
-  state: { resolveCalls: number }
+  /** Live counter — read `.releaseCalls` after the fact. */
+  state: { releaseCalls: number }
   dismissed: Array<{ taskId: string; tabId: string | null; at: number }>
 }
 
-function orchMock(over: { deferredRecord?: unknown } = {}): OrchMock {
+function orchMock(over: { release?: "unavailable" | "missing" } = {}): OrchMock {
   const dismissed: Array<{ taskId: string; tabId: string | null; at: number }> = []
-  const state = { resolveCalls: 0 }
+  const state = { releaseCalls: 0 }
   const orch = {
     getTask: () => task("task-1"),
-    getDeferredPrompt: () => Promise.resolve(over.deferredRecord ?? null),
-    resolveDeferredPrompt: () => {
-      state.resolveCalls += 1
-      return Promise.resolve(true)
+    releaseDeferredPrompt: () => {
+      state.releaseCalls += 1
+      return Promise.resolve(over.release ?? "unavailable")
     },
     dismissAttention: (taskId: string, tabId: string | null, at: number) => {
       dismissed.push({ taskId, tabId, at })
@@ -136,9 +135,7 @@ test("opening a prompt_deferred item with no live host keeps it queued (no resol
   process.env.KOBE_HOME_DIR = home
   infoMessages = []
   try {
-    const { orch, state, dismissed } = orchMock({
-      deferredRecord: { id: "d1", taskId: "task-1", tabId: "tab-1", prompt: "hi", layer: "composer-not-empty", at: 1 },
-    })
+    const { orch, state, dismissed } = orchMock()
     const { destroy } = await renderComponent(<InboxProbe orch={orch} items={[deferredItem(1)]} />, {
       width: 80,
       height: 24,
@@ -150,7 +147,7 @@ test("opening a prompt_deferred item with no live host keeps it queued (no resol
     // Insert reached the hosted-PTY boundary; with no host socket the message
     // stays queued — surfaced via toast, not resolved, not dismissed.
     expect(infoMessages.length).toBeGreaterThan(0)
-    expect(state.resolveCalls).toBe(0)
+    expect(state.releaseCalls).toBe(1)
     expect(dismissed).toHaveLength(0)
     destroy()
   } finally {
@@ -166,7 +163,7 @@ test("opening a prompt_deferred item whose record is gone dismisses the stale ep
   process.env.KOBE_HOME_DIR = home
   infoMessages = []
   try {
-    const { orch, dismissed } = orchMock({ deferredRecord: null })
+    const { orch, dismissed } = orchMock({ release: "missing" })
     const { destroy } = await renderComponent(<InboxProbe orch={orch} items={[deferredItem(2)]} />, {
       width: 80,
       height: 24,

--- a/packages/kobe/test/tui-react/settings-composer-gate.test.ts
+++ b/packages/kobe/test/tui-react/settings-composer-gate.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from "vitest"
 import { composerGatePreferenceOn, toggleComposerGatePreference } from "../../src/state/composer-gate.ts"
 
 describe("composer delivery check setting", () => {
-  it("flushes only on the enabled-to-disabled transition", () => {
+  it("persists both transitions synchronously and drains only when disabled", () => {
     const values = new Map<string, unknown>()
     const calls: string[] = []
     const kv = {
@@ -27,17 +27,20 @@ describe("composer delivery check setting", () => {
     expect(toggleComposerGatePreference(kv, drain)).toBe("enabled")
     expect(composerGatePreferenceOn(kv)).toBe(true)
     expect(drain).toHaveBeenCalledTimes(1)
+    expect(calls).toEqual(["set:false", "flush", "drain", "set:true", "flush"])
   })
 
   it("does not drain when the disabled value could not be persisted", () => {
     const drain = vi.fn()
+    const values: unknown[] = []
     const kv = {
       get: () => true,
-      set: () => {},
+      set: (_key: string, value: unknown) => values.push(value),
       flush: () => false,
     }
 
     expect(toggleComposerGatePreference(kv, drain)).toBe("persist-failed")
     expect(drain).not.toHaveBeenCalled()
+    expect(values).toEqual([false, true])
   })
 })

--- a/packages/kobe/test/tui-react/settings-composer-gate.test.ts
+++ b/packages/kobe/test/tui-react/settings-composer-gate.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from "vitest"
+import { composerGatePreferenceOn, toggleComposerGatePreference } from "../../src/state/composer-gate.ts"
+
+describe("composer delivery check setting", () => {
+  it("flushes only on the enabled-to-disabled transition", () => {
+    const values = new Map<string, unknown>()
+    const calls: string[] = []
+    const kv = {
+      get: (key: string, fallback?: unknown) => values.get(key) ?? fallback,
+      set: (key: string, value: unknown) => {
+        values.set(key, value)
+        calls.push(`set:${String(value)}`)
+      },
+      flush: () => {
+        calls.push("flush")
+        return true
+      },
+    }
+    const drain = vi.fn(() => calls.push("drain"))
+
+    expect(composerGatePreferenceOn(kv)).toBe(true)
+    expect(toggleComposerGatePreference(kv, drain)).toBe("disabled")
+    expect(composerGatePreferenceOn(kv)).toBe(false)
+    expect(drain).toHaveBeenCalledTimes(1)
+    expect(calls).toEqual(["set:false", "flush", "drain"])
+
+    expect(toggleComposerGatePreference(kv, drain)).toBe("enabled")
+    expect(composerGatePreferenceOn(kv)).toBe(true)
+    expect(drain).toHaveBeenCalledTimes(1)
+  })
+
+  it("does not drain when the disabled value could not be persisted", () => {
+    const drain = vi.fn()
+    const kv = {
+      get: () => true,
+      set: () => {},
+      flush: () => false,
+    }
+
+    expect(toggleComposerGatePreference(kv, drain)).toBe("persist-failed")
+    expect(drain).not.toHaveBeenCalled()
+  })
+})

--- a/packages/kobe/test/tui-react/settings-deferred-flush-feedback.test.ts
+++ b/packages/kobe/test/tui-react/settings-deferred-flush-feedback.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it, vi } from "vitest"
+import { flushDeferredPromptsWithFeedback } from "../../src/tui-react/component/settings-dialog/deferred-flush-feedback.ts"
+import type { DialogContext } from "../../src/tui-react/ui/dialog.tsx"
+
+const mocks = vi.hoisted(() => ({ show: vi.fn().mockResolvedValue(undefined) }))
+vi.mock("../../src/tui-react/ui/dialog-confirm.tsx", () => ({ DialogConfirm: { show: mocks.show } }))
+
+describe("deferred queue settings feedback", () => {
+  it("shows an on-screen error when an older daemon lacks the flush verb", async () => {
+    const remote = {
+      flushDeferredPrompts: vi.fn().mockRejectedValue(new Error("unknown handler: deferredPrompt.flush")),
+    }
+
+    await flushDeferredPromptsWithFeedback(remote as never, {} as DialogContext)
+
+    expect(mocks.show).toHaveBeenCalledWith(
+      expect.anything(),
+      "Deferred prompts were not flushed",
+      expect.stringContaining("unknown handler: deferredPrompt.flush"),
+      "cancel",
+    )
+  })
+})


### PR DESCRIPTION
## Summary

Successor to #763, which GitHub auto-closed when its stack base (#745's branch) was deleted at merge — this is the same two commits rebased onto main (cherry-picked over the squash), now running the repo's real CI for the first time (the one gap independent verification flagged).

- Turning the composer delivery check off drains the deferred-prompt queue in order; a mid-flush failure retains the record + Inbox pointer.
- Draining is single-flight via a store claim covering flush / Inbox release / dismiss / tab close — concurrent paths deliver exactly once; delivery is gated on `sessionHasEngine` so a fallback shell (engine exited, PTY alive) can never receive a paste.
- Delivered records persist a tombstone before Inbox cleanup, so the delivered/retained report always matches reality; TTL pruning returns expired identities for Inbox cleanup; re-enabling the check mid-flush cancels the remainder (gate re-read per record); an old daemon missing the flush verb surfaces a visible Settings error; headless `rove api tab-close` discards the tab's record like the TUI path.

Adversarial review findings 4-9 (see #763 thread) all addressed; independently verified with mutation checks (claim guard, sessionHasEngine gate, tombstone ordering each break a test when reverted).

## Verification

Rebased head, local: `tsc --noEmit` ✓, `bun run lint` ✓, `KOBE_INCLUDE_SOCKET=1` deferred suites (24) ✓, settings-flush-feedback + pty-delivery-gates (6) ✓.


file-size-exemption: packages/kobe/src/client/remote-orchestrator.ts — pre-existing overage: main is already at 503 lines and this PR NET-REMOVES one line (502); the shrink is filed as daemon issue #24 rather than churning a hot file inside an in-review PR.
