### PR TITLE
docs: generate the skill's flag reference from the verb specs

### DIFF
--- a/.agents/skills/kobe/SKILL.md
+++ b/.agents/skills/kobe/SKILL.md
@@ -3,7 +3,7 @@ name: rove
 description: Use when controlling Rove tasks, parallel coding attempts, hosted agent sessions, task lifecycle, or the daemon-owned issue tracker from a shell. Also the ONLY channel for messaging another agent session on this machine — `rove api send`, never a peer/MCP side channel.
 ---
 
-<!-- rove-skill-version: 40 — bump in lockstep with KOBE_SKILL_VERSION (src/lib/skill-install.ts). -->
+<!-- rove-skill-version: 41 — bump in lockstep with KOBE_SKILL_VERSION (src/lib/skill-install.ts). -->
 
 # Rove shell control
 
@@ -229,12 +229,22 @@ Four names that have actually been guessed wrong here: `add --vendor` is
 `--prompt` (`--text` belongs to `note`); `issue-list` has no `--state` at all
 — filter its JSON yourself.
 
-**[`references/api-flags.md`](references/api-flags.md) is every verb and flag**,
-including the groups this file leaves out on purpose: `routine-*` (scheduled
-prompts), `workitem-*` (GitHub issues via `gh`), `note`/`note-list` (the repo's
-durable field-note store), `read-output`/`digest`/`agent-turns`/`pty-list`, and
-the error-code table. Read it when you need a verb that is not above; reach for
-`schema` when the binary and that file disagree.
+**[`references/api-flags.md`](references/api-flags.md) is every verb and flag.**
+Find your section by what you were ASKED, not by Rove's noun for it:
+
+| You are asked to … | Read section |
+|---|---|
+| schedule / recur / cron / "every morning" / "keep messaging one window" / 定时 / 每天自动 | routines |
+| a GitHub issue, "file it upstream" / 提 issue | workitems |
+| track work in Rove's own backlog, move a kanban card | issues |
+| remember this for the repo, leave a field note / 记一笔 | drive |
+| what did the agent do, per-turn cost, read its screen | read |
+| make / rename / retarget / land / close a task | create / edit / lifecycle |
+| materialize or adopt a checkout | worktree |
+| which engines exist, send Rove product feedback | discover / feedback |
+| an error code came back, `nextCommandArgs` | Error codes |
+
+Reach for `schema` when the binary and that file disagree.
 
 ```bash
 rove api schema --verb add    # or --group create, --all

--- a/.agents/skills/kobe/references/api-flags.md
+++ b/.agents/skills/kobe/references/api-flags.md
@@ -9,6 +9,11 @@ Authoritative source is still the binary — `rove api schema --verb <name>` or
 `rove api <verb> --help`. Read that when this file and a rejection disagree;
 the CLI is what ships.
 
+Every fenced block below is GENERATED from the same verb specs `schema`
+serves (`bun scripts/gen-skill-api-flags.ts`); the prose between them is
+written by hand. Notation: `(REQ)` required, `(x)` the default when the flag is
+omitted, `{a|b}` the allowed values, `--a|--b` two spellings of one choice.
+
 Global: `--pretty` (readable JSON), `--help` (usage, exit).
 Every `--repo` resolves relative paths against `$PWD` and wants the git toplevel.
 
@@ -52,24 +57,32 @@ Seeing one of these in guidance means that guidance predates the rename —
 
 ## read
 
+<!-- generated:begin read -->
 ```text
-list          (none)                     every task
-get-task      --task-id(REQ)             one task + .tabs[] — the read before `send --tab`
-collect       --task-ids <csv> --repo    comparison snapshot across tasks
-inspect       --task-id                  daemon activity + pty walk + tab snapshots
-pty-list      (none)                     live hosted PTYs: key, alive, pid, command, OSC title
-read-output   --task-id --tab --source[auto|history|terminal] --cursor --limit
-digest        --repo(REQ) --since-days(7)
-agent-turns   --task-id --repo --since-days(7) --limit(200)
+list         (none)
+get-task     --task-id(REQ)
+pty-list     (none)
+collect      --task-ids <a,b,c> --group --repo
+digest       --repo(REQ) --since-days(7)
+agent-turns  --task-id --repo --since-days(7) --limit(200)
+inspect      --task-id
+read-output  --task-id --tab --source{auto|history|terminal}(auto) --cursor --limit(40)
 ```
+<!-- generated:end -->
+
+`get-task` is the read before `send --tab` — one task plus its `.tabs[]`.
+`collect` is the comparison snapshot across tasks: pass `--group <groupId>`
+(what `add --count` returned), a `--task-ids` csv, or a `--repo`; `inspect` is
+the wider diagnostic — daemon activity, a pty walk, and every tab snapshot.
 
 `pty-list` is what `NO_ENGINE_TAB`'s hint points at: when `.tabs[]` and reality
-disagree, it is the ground truth for what is actually alive.
+disagree, it is the ground truth for what is actually alive — key, alive, pid,
+command, OSC title.
 
-`read-output --limit` maxes at 50 (default 40). `--tab` is terminal-only —
-it cannot combine with `--source history`. The cursor is pinned to one
-source/session/tab; a moved target returns `SOURCE_CHANGED` rather than
-silently paging something else.
+`read-output --limit` maxes at 50. `--tab` is terminal-only — it cannot combine
+with `--source history`. The cursor is pinned to one source/session/tab; a
+moved target returns `SOURCE_CHANGED` rather than silently paging something
+else.
 
 `digest` and `agent-turns` are the measurement reads — `digest` aggregates a
 repo's recent task + routine activity, `agent-turns` is per-turn telemetry
@@ -78,24 +91,32 @@ needs numbers, not when you want to know what a task is doing.
 
 ## drive
 
+<!-- generated:begin drive -->
 ```text
-send        --prompt|--prompt-file(REQ) --task-id --tab --command --plain
-dispatch    --task-id(REQ) --prompt|--prompt-file(REQ) --tab
-note        --task-id(REQ) --text(REQ)
-note-list   --repo(REQ)
-pane-open   --command --task-id --tab --direction[right|down] --placement[split|tab] --title
-pane-close  --title(REQ) --task-id --tab
-tab-close   --task-id(REQ) --tab(REQ)
-notify      --title(REQ) --kind --task-id --source
-prompt      --title(REQ) --placeholder --initial --timeout
-set-active  --task-id | --none
+send           --task-id --prompt|--prompt-file(REQ) --tab --command --plain --allow-empty
+dispatch       --task-id(REQ) --prompt|--prompt-file(REQ) --tab
+note           --task-id(REQ) --text(REQ)
+note-list      --repo(REQ)
+pane-open      --task-id --tab --command --direction{right|down}(right)
+               --placement{split|tab}(split) --title
+pane-close     --task-id --title(REQ) --tab
+tab-close      --task-id(REQ) --tab(REQ)
+notify         --title(REQ) --kind(done) --task-id --source
+prompt         --title(REQ) --placeholder --initial --timeout
+engine-report  --task-id --kind(REQ) --engine --tab --detail
+set-active     --task-id --none
 ```
+<!-- generated:end -->
 
 **`note` is the repo's durable field-note store.** One line, a verified
 conclusion another session could act on — it is appended to the repo's notes
 (every future session on this repo starts with them) AND relayed to the
 dispatcher. Read them back with `note-list --repo`. This is the right home for
 a resolved gotcha; an issue is for work that still needs doing.
+
+`send --allow-empty` is the escape hatch for a `succeeded:` report from a task
+that legitimately produced no commits (an investigation, a review, a question
+answered); without it such a report is refused with `EMPTY_SUCCESS_REPORT`.
 
 `notify --kind` styles the toast: `done`, `needs_input`, `error` get severity
 treatment and an unread mark, anything else renders neutrally.
@@ -113,18 +134,36 @@ and ends that tab's hosted PTYs. It accepts engine, shell/command, and content
 tabs; closing the last tab leaves the task open with no session. A missing or
 already-closed id returns `TAB_NOT_FOUND` and points back to `get-task`.
 
+`engine-report` is the engine adapter's own channel for reporting a session
+event (`--kind`) back to the daemon — not a verb you reach for by hand.
+
+`set-active` takes one or the other: a `--task-id` to focus, or `--none` to
+clear the shared active task.
+
 ## create / edit / lifecycle
 
+<!-- generated:begin create,edit,lifecycle -->
 ```text
-add            --repo(REQ) + the hot-path flags above
-rename         --task-id(REQ) --title(REQ)
-set-branch     --task-id(REQ) --branch(REQ)
-set-command    --task-id(REQ) --command(REQ)      next launch only
-set-status     --task-id(REQ) --status(REQ)[backlog|in_progress|in_review|done|canceled|error]
-pin            --task-id(REQ) --pinned(true)
-land           --task-id(REQ) --strategy[merge|squash] --delete-branch --remove-worktree(true)
-delete         --task-id(REQ) --force --delete-branch
+add          --repo(REQ) --title --branch --base-branch --command --count
+             --agents <claude:2,codex:1>
+             --status{backlog|in_progress|in_review|done|canceled|error}(backlog) --pin
+             --activate(false) --prompt|--prompt-file
+rename       --task-id(REQ) --title(REQ)
+set-branch   --task-id(REQ) --branch(REQ)
+set-command  --task-id(REQ) --command(REQ)
+set-effort   --task-id(REQ) --level(REQ)
+set-status   --task-id(REQ)
+             --status{backlog|in_progress|in_review|done|canceled|error}(REQ)
+pin          --task-id(REQ) --pinned(true)
+land         --task-id(REQ) --strategy{merge|squash}(merge) --delete-branch
+             --remove-worktree(true)
+delete       --task-id(REQ) --force --delete-branch --wait
 ```
+<!-- generated:end -->
+
+`set-command` takes effect on the NEXT launch only. `set-effort --level` is
+engine-owned — the levels a vendor accepts come from its registry entry, so
+check `engine-list` rather than guessing.
 
 Task `--status` and issue `--status` are DIFFERENT enums — a task is
 `backlog|in_progress|in_review|done|canceled|error`, an issue is
@@ -135,22 +174,29 @@ ahead (`EMPTY_BRANCH`; `EMPTY_BRANCH_DIRTY_WORKTREE` when the worktree still
 holds the uncommitted work, with a send-back recovery path). Conflict aborts
 cleanly and returns the conflicted files.
 
+`delete --wait` is what turns "queued" into an answer — without it the call
+returns before the worktree is gone.
+
 ## worktree
 
+<!-- generated:begin worktree -->
 ```text
-ensure-worktree      --task-id(REQ)
-discover-adoptable   --repo(REQ)
-adopt                --repo(REQ) --worktree(REQ) --branch --title --command
+ensure-worktree     --task-id(REQ)
+discover-adoptable  --repo(REQ)
+adopt               --repo(REQ) --worktree(REQ) --branch --command --title
 ```
+<!-- generated:end -->
 
 ## issues (daemon-owned)
 
+<!-- generated:begin issues -->
 ```text
 issue-list        --repo(REQ)
 issue-create      --repo(REQ) --title(REQ) --body
-issue-update      --repo(REQ) --id(REQ,int) --title --body --task
-issue-set-status  --repo(REQ) --id(REQ,int) --status(REQ)[open|doing|hold|done]
+issue-set-status  --repo(REQ) --id(REQ) --status{open|doing|hold|done}(REQ)
+issue-update      --repo(REQ) --id(REQ) --title --body --task
 ```
+<!-- generated:end -->
 
 `--id` is an int, not the ULID a task uses. `issue-update --task <taskId>` is
 the kanban "move to In progress"; `--task none` unlinks. Kanban semantics are
@@ -161,15 +207,19 @@ in SKILL.md — do not move cards with `issue-set-status doing`.
 Read-only against the repo's real GitHub issues; nothing is copied into Rove's
 own store. These are the INBOUND user reports; Rove issues are the backlog.
 
+<!-- generated:begin workitems -->
 ```text
-workitem-list   --repo(REQ) --state[open|closed|all] --limit(20,max 50) --search --assignee --label
-workitem-start  --repo(REQ) --number(REQ,int) --vendor --base-branch
+workitem-list   --repo(REQ) --state{open|closed|all}(open) --limit(20) --search --assignee
+                --label
+workitem-start  --repo(REQ) --number(REQ) --vendor{claude|codex|copilot|kimi}
+                --base-branch
 ```
+<!-- generated:end -->
 
-`workitem-start` creates a worktree + engine whose first message carries the
-issue title, body, and URL, and keeps a link back to the issue. Note it takes
-`--vendor` (an engine enum), not `--command` — the one place the older
-vocabulary survives.
+`workitem-list --limit` caps at 50. `workitem-start` creates a worktree +
+engine whose first message carries the issue title, body, and URL, and keeps a
+link back to the issue. Note it takes `--vendor` (an engine enum), not
+`--command` — the one place the older vocabulary survives.
 
 ## routines (scheduled prompts)
 
@@ -180,18 +230,21 @@ turn of the same conversation (a Claude Code-style routine: one window, one
 vendor, messages keep arriving). An enabled routine holds the daemon alive so
 it fires with no TUI attached.
 
+<!-- generated:begin routine -->
 ```text
 routine-list         (none)
-routine-create       --repo(REQ) --name(REQ) --prompt|--prompt-file(REQ) --schedule(REQ)
-                     --vendor --base-branch --precheck --precheck-timeout(120) --grace(60)
-                     --persistent-session --disabled
-routine-update       --id(REQ) --name --prompt|--prompt-file --schedule --vendor --base-branch
-                     --precheck --precheck-timeout --grace --persistent-session
-routine-set-enabled  --id(REQ) --enabled(REQ,bool)
+routine-create       --repo(REQ) --name(REQ) --prompt(REQ) --schedule(REQ)
+                     --vendor{claude|codex|copilot|kimi} --base-branch --precheck
+                     --precheck-timeout(120) --grace(60) --persistent-session --disabled
+routine-update       --id(REQ) --name --prompt --schedule
+                     --vendor{claude|codex|copilot|kimi} --base-branch --precheck
+                     --precheck-timeout(120) --grace(60) --persistent-session
+routine-set-enabled  --id(REQ) --enabled(REQ)
 routine-delete       --id(REQ)
 routine-run-now      --id(REQ)
 routine-runs         --id(REQ)
 ```
+<!-- generated:end -->
 
 `--schedule` is five-field cron in the DAEMON HOST's local time
 (`'0 9 * * MON-FRI'`). `--precheck` is a shell command run in the repo before
@@ -212,9 +265,14 @@ is gone when the next firing arrives (an overnight gap usually means it is),
 the daemon respawns it in the SAME worktree — files and branch carry over, the
 conversation does not — and records that run as `revived`, not `dispatched`.
 
-`--prompt-file` (`-` = stdin) is the same escape hatch as `send`'s: a prompt
-with backticks, `$vars` or quotes goes through it, never a double-quoted
-`--prompt`.
+**Routines take `--prompt` only.** Unlike `send`/`add`/`dispatch` there is no
+`--prompt-file` here, so a prompt with backticks, `$vars` or quotes has no
+escape hatch — write it with single quotes and keep `$` out of it, or set it
+from the TUI.
+
+A bare `--enabled` means true, so pausing a routine is
+`routine-set-enabled --id <id> --enabled=false` (the same `=false` spelling
+`pin --pinned=false` uses).
 
 `routine-update --schedule` re-anchors the next run. `--precheck ''` clears it.
 `routine-run-now` skips the precheck deliberately (asking for it IS the answer)
@@ -228,11 +286,17 @@ prompt is queued in the Inbox, NOT lost), `skipped_precheck` (nothing to do),
 
 ## discover / feedback
 
+<!-- generated:begin discover,feedback -->
 ```text
-schema        --verb <name> | --group <g> | --all      (bare = compact index)
-engine-list   (none)                                   ids + RAW launch command + protocol
-feedback      --title(REQ) --body(REQ) --category(feedback)
+schema       --verb --group --all
+engine-list  (none)
+feedback     --title(REQ) --body(REQ) --category(feedback)
 ```
+<!-- generated:end -->
+
+Bare `schema` is the compact index; `--verb <name>` drills into one verb,
+`--group <g>` lists one group, `--all` dumps everything. `engine-list` is the
+ids + RAW launch command + protocol.
 
 `feedback` opens a GitHub Discussion in the Rove repo through `gh` — Rove's own
 product feedback channel, not a way to file work for another project (that is
@@ -249,6 +313,8 @@ Errors go to stderr as `{"error":{"message","code",...}}`. Most carry `hint`
 | `BAD_FLAG` | flag not on that verb | check the table above, then `schema --verb <v>` |
 | `TASK_NOT_FOUND` | id deleted or mistyped | `rove api list` |
 | `NO_ENGINE_TAB` | live tabs exist, none is an engine | `--tab tab-N` from `pty-list`, or `--tab new` |
+| `TAB_NOT_FOUND` | `--tab` names a closed/unknown tab | `get-task` for the live `.tabs[]` |
 | `DISPATCHER_UNREACHABLE` | bare `send` reply, dispatcher gone | nothing alive to reply to — never silently spawns |
+| `EMPTY_SUCCESS_REPORT` | `succeeded:` from a branch with 0 commits | commit first, or say so with `--allow-empty` |
 | `SOURCE_CHANGED` | `read-output` cursor's target moved | re-read without the cursor |
 | `EMPTY_BRANCH` | `land` on zero commits ahead | the worker committed nothing |

--- a/.changeset/generated-skill-verb-reference.md
+++ b/.changeset/generated-skill-verb-reference.md
@@ -1,0 +1,14 @@
+---
+"@sma1lboy/rove": patch
+---
+
+The agent skill's flag reference is generated from the verb specs
+
+`references/api-flags.md` was hand-written and had drifted from the CLI: it
+listed `--prompt-file` on `routine-create`/`routine-update`, where that flag
+does not exist, and omitted `set-effort`, `engine-report`, `collect --group`,
+`send --allow-empty` and `delete --wait` entirely. Its flag tables now come
+from the same verb specs `rove api schema` serves, with an architecture test
+that fails naming the stale verb, and SKILL.md points into the file by what a
+user asks for ("every morning", "file it upstream") rather than by Rove's own
+group names.

--- a/claude-plugin/skills/rove/SKILL.md
+++ b/claude-plugin/skills/rove/SKILL.md
@@ -3,7 +3,7 @@ name: rove
 description: Use when controlling Rove tasks, parallel coding attempts, hosted agent sessions, task lifecycle, or the daemon-owned issue tracker from a shell. Also the ONLY channel for messaging another agent session on this machine — `rove api send`, never a peer/MCP side channel.
 ---
 
-<!-- rove-skill-version: 40 — bump in lockstep with KOBE_SKILL_VERSION (src/lib/skill-install.ts). -->
+<!-- rove-skill-version: 41 — bump in lockstep with KOBE_SKILL_VERSION (src/lib/skill-install.ts). -->
 
 # Rove shell control
 
@@ -229,12 +229,22 @@ Four names that have actually been guessed wrong here: `add --vendor` is
 `--prompt` (`--text` belongs to `note`); `issue-list` has no `--state` at all
 — filter its JSON yourself.
 
-**[`references/api-flags.md`](references/api-flags.md) is every verb and flag**,
-including the groups this file leaves out on purpose: `routine-*` (scheduled
-prompts), `workitem-*` (GitHub issues via `gh`), `note`/`note-list` (the repo's
-durable field-note store), `read-output`/`digest`/`agent-turns`/`pty-list`, and
-the error-code table. Read it when you need a verb that is not above; reach for
-`schema` when the binary and that file disagree.
+**[`references/api-flags.md`](references/api-flags.md) is every verb and flag.**
+Find your section by what you were ASKED, not by Rove's noun for it:
+
+| You are asked to … | Read section |
+|---|---|
+| schedule / recur / cron / "every morning" / "keep messaging one window" / 定时 / 每天自动 | routines |
+| a GitHub issue, "file it upstream" / 提 issue | workitems |
+| track work in Rove's own backlog, move a kanban card | issues |
+| remember this for the repo, leave a field note / 记一笔 | drive |
+| what did the agent do, per-turn cost, read its screen | read |
+| make / rename / retarget / land / close a task | create / edit / lifecycle |
+| materialize or adopt a checkout | worktree |
+| which engines exist, send Rove product feedback | discover / feedback |
+| an error code came back, `nextCommandArgs` | Error codes |
+
+Reach for `schema` when the binary and that file disagree.
 
 ```bash
 rove api schema --verb add    # or --group create, --all

--- a/claude-plugin/skills/rove/references/api-flags.md
+++ b/claude-plugin/skills/rove/references/api-flags.md
@@ -9,6 +9,11 @@ Authoritative source is still the binary — `rove api schema --verb <name>` or
 `rove api <verb> --help`. Read that when this file and a rejection disagree;
 the CLI is what ships.
 
+Every fenced block below is GENERATED from the same verb specs `schema`
+serves (`bun scripts/gen-skill-api-flags.ts`); the prose between them is
+written by hand. Notation: `(REQ)` required, `(x)` the default when the flag is
+omitted, `{a|b}` the allowed values, `--a|--b` two spellings of one choice.
+
 Global: `--pretty` (readable JSON), `--help` (usage, exit).
 Every `--repo` resolves relative paths against `$PWD` and wants the git toplevel.
 
@@ -52,24 +57,32 @@ Seeing one of these in guidance means that guidance predates the rename —
 
 ## read
 
+<!-- generated:begin read -->
 ```text
-list          (none)                     every task
-get-task      --task-id(REQ)             one task + .tabs[] — the read before `send --tab`
-collect       --task-ids <csv> --repo    comparison snapshot across tasks
-inspect       --task-id                  daemon activity + pty walk + tab snapshots
-pty-list      (none)                     live hosted PTYs: key, alive, pid, command, OSC title
-read-output   --task-id --tab --source[auto|history|terminal] --cursor --limit
-digest        --repo(REQ) --since-days(7)
-agent-turns   --task-id --repo --since-days(7) --limit(200)
+list         (none)
+get-task     --task-id(REQ)
+pty-list     (none)
+collect      --task-ids <a,b,c> --group --repo
+digest       --repo(REQ) --since-days(7)
+agent-turns  --task-id --repo --since-days(7) --limit(200)
+inspect      --task-id
+read-output  --task-id --tab --source{auto|history|terminal}(auto) --cursor --limit(40)
 ```
+<!-- generated:end -->
+
+`get-task` is the read before `send --tab` — one task plus its `.tabs[]`.
+`collect` is the comparison snapshot across tasks: pass `--group <groupId>`
+(what `add --count` returned), a `--task-ids` csv, or a `--repo`; `inspect` is
+the wider diagnostic — daemon activity, a pty walk, and every tab snapshot.
 
 `pty-list` is what `NO_ENGINE_TAB`'s hint points at: when `.tabs[]` and reality
-disagree, it is the ground truth for what is actually alive.
+disagree, it is the ground truth for what is actually alive — key, alive, pid,
+command, OSC title.
 
-`read-output --limit` maxes at 50 (default 40). `--tab` is terminal-only —
-it cannot combine with `--source history`. The cursor is pinned to one
-source/session/tab; a moved target returns `SOURCE_CHANGED` rather than
-silently paging something else.
+`read-output --limit` maxes at 50. `--tab` is terminal-only — it cannot combine
+with `--source history`. The cursor is pinned to one source/session/tab; a
+moved target returns `SOURCE_CHANGED` rather than silently paging something
+else.
 
 `digest` and `agent-turns` are the measurement reads — `digest` aggregates a
 repo's recent task + routine activity, `agent-turns` is per-turn telemetry
@@ -78,23 +91,32 @@ needs numbers, not when you want to know what a task is doing.
 
 ## drive
 
+<!-- generated:begin drive -->
 ```text
-send        --prompt|--prompt-file(REQ) --task-id --tab --command --plain
-dispatch    --task-id(REQ) --prompt|--prompt-file(REQ) --tab
-note        --task-id(REQ) --text(REQ)
-note-list   --repo(REQ)
-pane-open   --command --task-id --tab --direction[right|down] --placement[split|tab] --title
-pane-close  --title(REQ) --task-id --tab
-notify      --title(REQ) --kind --task-id --source
-prompt      --title(REQ) --placeholder --initial --timeout
-set-active  --task-id | --none
+send           --task-id --prompt|--prompt-file(REQ) --tab --command --plain --allow-empty
+dispatch       --task-id(REQ) --prompt|--prompt-file(REQ) --tab
+note           --task-id(REQ) --text(REQ)
+note-list      --repo(REQ)
+pane-open      --task-id --tab --command --direction{right|down}(right)
+               --placement{split|tab}(split) --title
+pane-close     --task-id --title(REQ) --tab
+tab-close      --task-id(REQ) --tab(REQ)
+notify         --title(REQ) --kind(done) --task-id --source
+prompt         --title(REQ) --placeholder --initial --timeout
+engine-report  --task-id --kind(REQ) --engine --tab --detail
+set-active     --task-id --none
 ```
+<!-- generated:end -->
 
 **`note` is the repo's durable field-note store.** One line, a verified
 conclusion another session could act on — it is appended to the repo's notes
 (every future session on this repo starts with them) AND relayed to the
 dispatcher. Read them back with `note-list --repo`. This is the right home for
 a resolved gotcha; an issue is for work that still needs doing.
+
+`send --allow-empty` is the escape hatch for a `succeeded:` report from a task
+that legitimately produced no commits (an investigation, a review, a question
+answered); without it such a report is refused with `EMPTY_SUCCESS_REPORT`.
 
 `notify --kind` styles the toast: `done`, `needs_input`, `error` get severity
 treatment and an unread mark, anything else renders neutrally.
@@ -106,18 +128,42 @@ treatment and an unread mark, anything else renders neutrally.
 `pane-open --command` runs through the login shell's `-ilc`, so pipes and
 your rc's PATH work.
 
+`tab-close` names one exact Terminal Tab from `get-task .tabs[].id`. Unlike
+`pane-close`, it also works headless: it removes the persisted tab snapshot
+and ends that tab's hosted PTYs. It accepts engine, shell/command, and content
+tabs; closing the last tab leaves the task open with no session. A missing or
+already-closed id returns `TAB_NOT_FOUND` and points back to `get-task`.
+
+`engine-report` is the engine adapter's own channel for reporting a session
+event (`--kind`) back to the daemon — not a verb you reach for by hand.
+
+`set-active` takes one or the other: a `--task-id` to focus, or `--none` to
+clear the shared active task.
+
 ## create / edit / lifecycle
 
+<!-- generated:begin create,edit,lifecycle -->
 ```text
-add            --repo(REQ) + the hot-path flags above
-rename         --task-id(REQ) --title(REQ)
-set-branch     --task-id(REQ) --branch(REQ)
-set-command    --task-id(REQ) --command(REQ)      next launch only
-set-status     --task-id(REQ) --status(REQ)[backlog|in_progress|in_review|done|canceled|error]
-pin            --task-id(REQ) --pinned(true)
-land           --task-id(REQ) --strategy[merge|squash] --delete-branch --remove-worktree(true)
-delete         --task-id(REQ) --force --delete-branch
+add          --repo(REQ) --title --branch --base-branch --command --count
+             --agents <claude:2,codex:1>
+             --status{backlog|in_progress|in_review|done|canceled|error}(backlog) --pin
+             --activate(false) --prompt|--prompt-file
+rename       --task-id(REQ) --title(REQ)
+set-branch   --task-id(REQ) --branch(REQ)
+set-command  --task-id(REQ) --command(REQ)
+set-effort   --task-id(REQ) --level(REQ)
+set-status   --task-id(REQ)
+             --status{backlog|in_progress|in_review|done|canceled|error}(REQ)
+pin          --task-id(REQ) --pinned(true)
+land         --task-id(REQ) --strategy{merge|squash}(merge) --delete-branch
+             --remove-worktree(true)
+delete       --task-id(REQ) --force --delete-branch --wait
 ```
+<!-- generated:end -->
+
+`set-command` takes effect on the NEXT launch only. `set-effort --level` is
+engine-owned — the levels a vendor accepts come from its registry entry, so
+check `engine-list` rather than guessing.
 
 Task `--status` and issue `--status` are DIFFERENT enums — a task is
 `backlog|in_progress|in_review|done|canceled|error`, an issue is
@@ -128,22 +174,29 @@ ahead (`EMPTY_BRANCH`; `EMPTY_BRANCH_DIRTY_WORKTREE` when the worktree still
 holds the uncommitted work, with a send-back recovery path). Conflict aborts
 cleanly and returns the conflicted files.
 
+`delete --wait` is what turns "queued" into an answer — without it the call
+returns before the worktree is gone.
+
 ## worktree
 
+<!-- generated:begin worktree -->
 ```text
-ensure-worktree      --task-id(REQ)
-discover-adoptable   --repo(REQ)
-adopt                --repo(REQ) --worktree(REQ) --branch --title --command
+ensure-worktree     --task-id(REQ)
+discover-adoptable  --repo(REQ)
+adopt               --repo(REQ) --worktree(REQ) --branch --command --title
 ```
+<!-- generated:end -->
 
 ## issues (daemon-owned)
 
+<!-- generated:begin issues -->
 ```text
 issue-list        --repo(REQ)
 issue-create      --repo(REQ) --title(REQ) --body
-issue-update      --repo(REQ) --id(REQ,int) --title --body --task
-issue-set-status  --repo(REQ) --id(REQ,int) --status(REQ)[open|doing|hold|done]
+issue-set-status  --repo(REQ) --id(REQ) --status{open|doing|hold|done}(REQ)
+issue-update      --repo(REQ) --id(REQ) --title --body --task
 ```
+<!-- generated:end -->
 
 `--id` is an int, not the ULID a task uses. `issue-update --task <taskId>` is
 the kanban "move to In progress"; `--task none` unlinks. Kanban semantics are
@@ -154,15 +207,19 @@ in SKILL.md — do not move cards with `issue-set-status doing`.
 Read-only against the repo's real GitHub issues; nothing is copied into Rove's
 own store. These are the INBOUND user reports; Rove issues are the backlog.
 
+<!-- generated:begin workitems -->
 ```text
-workitem-list   --repo(REQ) --state[open|closed|all] --limit(20,max 50) --search --assignee --label
-workitem-start  --repo(REQ) --number(REQ,int) --vendor --base-branch
+workitem-list   --repo(REQ) --state{open|closed|all}(open) --limit(20) --search --assignee
+                --label
+workitem-start  --repo(REQ) --number(REQ) --vendor{claude|codex|copilot|kimi}
+                --base-branch
 ```
+<!-- generated:end -->
 
-`workitem-start` creates a worktree + engine whose first message carries the
-issue title, body, and URL, and keeps a link back to the issue. Note it takes
-`--vendor` (an engine enum), not `--command` — the one place the older
-vocabulary survives.
+`workitem-list --limit` caps at 50. `workitem-start` creates a worktree +
+engine whose first message carries the issue title, body, and URL, and keeps a
+link back to the issue. Note it takes `--vendor` (an engine enum), not
+`--command` — the one place the older vocabulary survives.
 
 ## routines (scheduled prompts)
 
@@ -173,18 +230,21 @@ turn of the same conversation (a Claude Code-style routine: one window, one
 vendor, messages keep arriving). An enabled routine holds the daemon alive so
 it fires with no TUI attached.
 
+<!-- generated:begin routine -->
 ```text
 routine-list         (none)
-routine-create       --repo(REQ) --name(REQ) --prompt|--prompt-file(REQ) --schedule(REQ)
-                     --vendor --base-branch --precheck --precheck-timeout(120) --grace(60)
-                     --persistent-session --disabled
-routine-update       --id(REQ) --name --prompt|--prompt-file --schedule --vendor --base-branch
-                     --precheck --precheck-timeout --grace --persistent-session
-routine-set-enabled  --id(REQ) --enabled(REQ,bool)
+routine-create       --repo(REQ) --name(REQ) --prompt(REQ) --schedule(REQ)
+                     --vendor{claude|codex|copilot|kimi} --base-branch --precheck
+                     --precheck-timeout(120) --grace(60) --persistent-session --disabled
+routine-update       --id(REQ) --name --prompt --schedule
+                     --vendor{claude|codex|copilot|kimi} --base-branch --precheck
+                     --precheck-timeout(120) --grace(60) --persistent-session
+routine-set-enabled  --id(REQ) --enabled(REQ)
 routine-delete       --id(REQ)
 routine-run-now      --id(REQ)
 routine-runs         --id(REQ)
 ```
+<!-- generated:end -->
 
 `--schedule` is five-field cron in the DAEMON HOST's local time
 (`'0 9 * * MON-FRI'`). `--precheck` is a shell command run in the repo before
@@ -205,9 +265,14 @@ is gone when the next firing arrives (an overnight gap usually means it is),
 the daemon respawns it in the SAME worktree — files and branch carry over, the
 conversation does not — and records that run as `revived`, not `dispatched`.
 
-`--prompt-file` (`-` = stdin) is the same escape hatch as `send`'s: a prompt
-with backticks, `$vars` or quotes goes through it, never a double-quoted
-`--prompt`.
+**Routines take `--prompt` only.** Unlike `send`/`add`/`dispatch` there is no
+`--prompt-file` here, so a prompt with backticks, `$vars` or quotes has no
+escape hatch — write it with single quotes and keep `$` out of it, or set it
+from the TUI.
+
+A bare `--enabled` means true, so pausing a routine is
+`routine-set-enabled --id <id> --enabled=false` (the same `=false` spelling
+`pin --pinned=false` uses).
 
 `routine-update --schedule` re-anchors the next run. `--precheck ''` clears it.
 `routine-run-now` skips the precheck deliberately (asking for it IS the answer)
@@ -221,11 +286,17 @@ prompt is queued in the Inbox, NOT lost), `skipped_precheck` (nothing to do),
 
 ## discover / feedback
 
+<!-- generated:begin discover,feedback -->
 ```text
-schema        --verb <name> | --group <g> | --all      (bare = compact index)
-engine-list   (none)                                   ids + RAW launch command + protocol
-feedback      --title(REQ) --body(REQ) --category(feedback)
+schema       --verb --group --all
+engine-list  (none)
+feedback     --title(REQ) --body(REQ) --category(feedback)
 ```
+<!-- generated:end -->
+
+Bare `schema` is the compact index; `--verb <name>` drills into one verb,
+`--group <g>` lists one group, `--all` dumps everything. `engine-list` is the
+ids + RAW launch command + protocol.
 
 `feedback` opens a GitHub Discussion in the Rove repo through `gh` — Rove's own
 product feedback channel, not a way to file work for another project (that is
@@ -242,6 +313,8 @@ Errors go to stderr as `{"error":{"message","code",...}}`. Most carry `hint`
 | `BAD_FLAG` | flag not on that verb | check the table above, then `schema --verb <v>` |
 | `TASK_NOT_FOUND` | id deleted or mistyped | `rove api list` |
 | `NO_ENGINE_TAB` | live tabs exist, none is an engine | `--tab tab-N` from `pty-list`, or `--tab new` |
+| `TAB_NOT_FOUND` | `--tab` names a closed/unknown tab | `get-task` for the live `.tabs[]` |
 | `DISPATCHER_UNREACHABLE` | bare `send` reply, dispatcher gone | nothing alive to reply to — never silently spawns |
+| `EMPTY_SUCCESS_REPORT` | `succeeded:` from a branch with 0 commits | commit first, or say so with `--allow-empty` |
 | `SOURCE_CHANGED` | `read-output` cursor's target moved | re-read without the cursor |
 | `EMPTY_BRANCH` | `land` on zero commits ahead | the worker committed nothing |

--- a/packages/kobe/src/cli/api/read-output.ts
+++ b/packages/kobe/src/cli/api/read-output.ts
@@ -415,6 +415,7 @@ export const READ_OUTPUT_VERB: VerbSpec = {
       name: "limit",
       type: "int",
       placeholder: "N",
+      default: String(DEFAULT_PAGE_MESSAGES),
       description: `History messages per page (default ${DEFAULT_PAGE_MESSAGES}, max ${MAX_PAGE_MESSAGES}).`,
     },
   ],

--- a/packages/kobe/src/cli/api/verbs-automations.ts
+++ b/packages/kobe/src/cli/api/verbs-automations.ts
@@ -36,7 +36,8 @@ const PRECHECK_FLAGS = [
     name: "precheck-timeout",
     type: "int",
     placeholder: "SEC",
-    description: "Seconds before the precheck is killed and the run skipped (default 120).",
+    default: "120",
+    description: "Seconds before the precheck is killed and the run skipped.",
   },
 ] as const
 
@@ -44,8 +45,9 @@ const GRACE_FLAG = {
   name: "grace",
   type: "int",
   placeholder: "MIN",
+  default: "60",
   description:
-    "How late a missed occurrence may still run when the daemon was down (default 60). Only the most recent missed occurrence is ever run.",
+    "How late a missed occurrence may still run when the daemon was down. Only the most recent missed occurrence is ever run.",
 } as const
 
 const PERSISTENT_FLAG = {

--- a/packages/kobe/src/cli/api/verbs-work-items.ts
+++ b/packages/kobe/src/cli/api/verbs-work-items.ts
@@ -21,7 +21,7 @@ export const WORK_ITEM_VERBS: readonly VerbSpec[] = [
     flags: [
       F.repo(),
       { name: "state", type: "enum", values: WORK_ITEM_STATES, default: "open", description: "Issue state filter." },
-      { name: "limit", type: "int", placeholder: "N", description: "Max items (1-50, default 20)." },
+      { name: "limit", type: "int", placeholder: "N", default: "20", description: "Max items (1-50, max 50)." },
       { name: "search", type: "string", placeholder: "Q", description: "Free-text search passed to `gh --search`." },
       {
         name: "assignee",

--- a/packages/kobe/src/lib/skill-install.ts
+++ b/packages/kobe/src/lib/skill-install.ts
@@ -44,7 +44,7 @@ import { getPersistedString, setPersistedString } from "../state/repos.ts"
  * didn't, so we prompt the developer to re-run the active CLI's
  * `skill install` command.
  */
-export const KOBE_SKILL_VERSION = 40
+export const KOBE_SKILL_VERSION = 41
 
 /**
  * Where an installed kobe skill can be FOUND, relative to a home/project

--- a/packages/kobe/test/architecture/claude-plugin.test.ts
+++ b/packages/kobe/test/architecture/claude-plugin.test.ts
@@ -76,11 +76,18 @@ describe("claude-plugin hooks.json mirrors the Claude hook adapter", () => {
 })
 
 describe("claude-plugin bundle integrity", () => {
-  test("bundled SKILL.md is byte-identical to the canonical skill", () => {
-    const canonical = readFileSync(join(ROOT, ".agents", "skills", "kobe", "SKILL.md"), "utf8")
-    const bundled = readFileSync(join(PLUGIN, "skills", "rove", "SKILL.md"), "utf8")
-    expect(bundled).toBe(canonical)
-  })
+  // Every file of the skill, not just SKILL.md: the reference under
+  // `references/` had already drifted between the two copies (a `tab-close`
+  // row and its prose existed canonically and not in the bundle) while this
+  // test watched SKILL.md alone and stayed green.
+  test.each(["SKILL.md", join("references", "api-flags.md")])(
+    "bundled %s is byte-identical to the canonical skill",
+    (file) => {
+      const canonical = readFileSync(join(ROOT, ".agents", "skills", "kobe", file), "utf8")
+      const bundled = readFileSync(join(PLUGIN, "skills", "rove", file), "utf8")
+      expect(bundled).toBe(canonical)
+    },
+  )
 
   test("plugin.json points at hooks.json and names the plugin rove", () => {
     const manifest = JSON.parse(readFileSync(join(PLUGIN, ".claude-plugin", "plugin.json"), "utf8")) as {

--- a/packages/kobe/test/architecture/skill-api-reference.test.ts
+++ b/packages/kobe/test/architecture/skill-api-reference.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Drift guard for the agent skill's SECOND layer — `references/api-flags.md`.
+ *
+ * The skill is progressive on purpose: SKILL.md carries the hot verbs, this
+ * reference carries the rest, `rove api schema` is the third layer. The middle
+ * layer was hand-written and drifted — `routine-create --persistent-session`
+ * and `routine-runs`' `revived`/`deferred` statuses shipped with the reference
+ * listing none of them, so an agent reading the skill concluded routines can
+ * only spawn a task per run. Layering does not stop that; deriving the tables
+ * from the verb specs does, and this test is what makes the derivation binding.
+ *
+ * It also guards the two things a generator cannot own: that every group the
+ * binary serves has a SECTION here at all, that SKILL.md signposts each section
+ * by user intent, and that the hand-written error-code table names codes the
+ * source actually throws.
+ */
+
+import { readFileSync, readdirSync } from "node:fs"
+import { join } from "node:path"
+import { fileURLToPath } from "node:url"
+import { describe, expect, test } from "vitest"
+import { REFERENCE_PATHS, describeStale, regenerate, sectionsByGroup } from "../../../../scripts/gen-skill-api-flags.ts"
+import { VERB_GROUP_IDS } from "../../src/cli/api/types.ts"
+
+const ROOT = fileURLToPath(new URL("../../../../", import.meta.url))
+const FIX = "bun scripts/gen-skill-api-flags.ts"
+
+const reference = () => readFileSync(REFERENCE_PATHS[0], "utf8")
+const skill = () => readFileSync(join(ROOT, ".agents", "skills", "kobe", "SKILL.md"), "utf8")
+
+describe("api-flags.md flag tables are generated from the verb specs", () => {
+  test("no generated block is stale", () => {
+    const { stale } = regenerate(reference())
+    expect(
+      stale,
+      `api-flags.md no longer matches the verb specs:\n${describeStale(stale)}\nRegenerate with: ${FIX}`,
+    ).toEqual([])
+  })
+
+  test("regenerating is idempotent", () => {
+    const once = regenerate(reference()).text
+    expect(regenerate(once).text).toBe(once)
+  })
+
+  test("every verb group the binary serves has a section", () => {
+    const sections = sectionsByGroup(reference())
+    for (const group of VERB_GROUP_IDS) {
+      expect(sections.get(group), `verb group "${group}" has no <!-- generated:begin --> region in api-flags.md`) //
+        .toBeTruthy()
+    }
+  })
+})
+
+describe("SKILL.md signposts the reference by intent", () => {
+  /** The right-hand column of the "Read section" lookup table. */
+  function signpostedSections(): Set<string> {
+    const rows = skill()
+      .split("\n")
+      .filter((l) => l.trim().startsWith("|") && l.trim().endsWith("|"))
+      .map((l) => l.trim().slice(1, -1).split("|"))
+      .filter((cells) => cells.length === 2)
+    return new Set(rows.map((cells) => cells[1].trim()))
+  }
+
+  test("every section of api-flags.md is reachable from a signpost row", () => {
+    const signposted = signpostedSections()
+    for (const [group, section] of sectionsByGroup(reference())) {
+      expect(
+        signposted.has(section),
+        `verb group "${group}" lives in api-flags.md's "${section}" section, but no SKILL.md signpost row points there — an agent asked for it in the user's own words will never open the file`,
+      ).toBe(true)
+    }
+  })
+})
+
+describe("the error-code table names codes the source throws", () => {
+  /**
+   * The table stays hand-written: its value is the "Means"/"Recover" prose,
+   * and the codes themselves are string literals scattered across handlers
+   * with no registry to generate from. So guard the half that CAN rot — a
+   * renamed or deleted code — without inventing one.
+   */
+  test("every documented code appears as a literal in the source", () => {
+    const source = ["src/cli", "src/orchestrator"]
+      .map((dir) => readTsSources(join(ROOT, "packages", "kobe", dir)))
+      .join("\n")
+    const codes = reference()
+      .split("\n")
+      .filter((l) => /^\| `[A-Z][A-Z0-9_]+` \|/.test(l))
+      .map((l) => l.split("`")[1])
+    expect(codes.length).toBeGreaterThan(4)
+    for (const code of codes) {
+      expect(source.includes(`"${code}"`), `api-flags.md documents error code ${code}, which no source file throws`) //
+        .toBe(true)
+    }
+  })
+})
+
+/** Concatenate every `.ts` under `dir` — cheaper to read than to shell out. */
+function readTsSources(dir: string): string {
+  const out: string[] = []
+  for (const entry of readdirSync(dir, { withFileTypes: true, recursive: true })) {
+    if (entry.isFile() && entry.name.endsWith(".ts")) {
+      out.push(readFileSync(join(entry.parentPath ?? dir, entry.name), "utf8"))
+    }
+  }
+  return out.join("\n")
+}

--- a/scripts/gen-skill-api-flags.ts
+++ b/scripts/gen-skill-api-flags.ts
@@ -1,0 +1,234 @@
+#!/usr/bin/env bun
+/**
+ * Render the flag tables in the agent skill's `references/api-flags.md` from
+ * the verb specs the binary itself serves through `rove api schema`.
+ *
+ * The second layer of the skill (SKILL.md → this reference → `schema`) used to
+ * be a hand-written table, and it drifted: `routine-create --persistent-session`
+ * and `routine-runs`' `revived`/`deferred` statuses shipped for weeks with the
+ * reference listing none of them, so an agent reading the skill concluded
+ * routines can only spawn a task per run. Layering does not fix that; deriving
+ * does.
+ *
+ * Only the fenced blocks between `<!-- generated:begin <groups> -->` and
+ * `<!-- generated:end -->` are owned here — the prose around them stays
+ * authored, because "what `--precheck` is FOR" is not in any spec. Each
+ * marker names the {@link VerbGroup} ids that section covers, so the
+ * section↔group mapping lives in the document instead of in a second table
+ * here that could disagree with it.
+ *
+ *   bun scripts/gen-skill-api-flags.ts            # rewrite both skill copies
+ *   bun scripts/gen-skill-api-flags.ts --check    # exit 1 if stale (CI/test)
+ */
+
+import { readFileSync, writeFileSync } from "node:fs"
+import { join } from "node:path"
+import { fileURLToPath } from "node:url"
+import type { FlagSpec, VerbGroup, VerbSpec } from "../packages/kobe/src/cli/api/types.ts"
+import { VERB_GROUP_IDS } from "../packages/kobe/src/cli/api/types.ts"
+import { VERBS } from "../packages/kobe/src/cli/api/verbs.ts"
+
+const ROOT = fileURLToPath(new URL("..", import.meta.url))
+
+/** Canonical skill first; every other path is a byte copy of it. */
+export const REFERENCE_PATHS = [
+  join(ROOT, ".agents/skills/kobe/references/api-flags.md"),
+  join(ROOT, "claude-plugin/skills/rove/references/api-flags.md"),
+]
+
+/** The command a stale check tells the reader to run. */
+const FIX_COMMAND = "bun scripts/gen-skill-api-flags.ts"
+
+const BEGIN = /^<!-- generated:begin (.+?) -->$/
+const END = "<!-- generated:end -->"
+
+/** Where a wrapped flag list resumes, and the column budget it wraps at. */
+const WRAP_COLS = 90
+
+/**
+ * Flag pairs that are ONE choice, not two flags. `--prompt` is marked required
+ * on the spec but `--prompt-file` satisfies it, so rendering them as separate
+ * tokens would tell an agent to pass both. This is the only such pair on the
+ * surface; a second one belongs here rather than in a general rule, because
+ * nothing in `FlagSpec` distinguishes "alternate" from "also allowed".
+ */
+const ALTERNATES: ReadonlyArray<readonly [string, string]> = [["prompt", "prompt-file"]]
+
+/**
+ * `--name{a|b}(REQ)` / `--name(default)` / `--name <a,b,c>` — the reference's
+ * notation. Metavar placeholders (PATH, ID, TEXT…) are dropped: the flag name
+ * already says what they say, and printing them on all ~90 flags is the noise
+ * the hand-written table was avoiding. A placeholder that carries SYNTAX
+ * rather than a type — it contains a separator, e.g. `claude:2,codex:1` —
+ * survives, because that shape is not guessable from the name.
+ */
+function renderFlag(f: FlagSpec): string {
+  const values = f.type === "enum" && f.values ? `{${f.values.join("|")}}` : ""
+  const marker = f.required ? "(REQ)" : f.default !== undefined ? `(${f.default})` : ""
+  const shape = f.placeholder && /[,:]/.test(f.placeholder) ? ` <${f.placeholder}>` : ""
+  return `--${f.name}${values}${marker}${shape}`
+}
+
+function renderFlags(verb: VerbSpec): string[] {
+  const byName = new Map(verb.flags.map((f) => [f.name, f]))
+  const fused = new Map<string, string>()
+  const dropped = new Set<string>()
+  for (const [primary, secondary] of ALTERNATES) {
+    const a = byName.get(primary)
+    if (!a || !byName.has(secondary)) continue
+    fused.set(primary, `--${primary}|--${secondary}${a.required ? "(REQ)" : ""}`)
+    dropped.add(secondary)
+  }
+  return verb.flags.filter((f) => !dropped.has(f.name)).map((f) => fused.get(f.name) ?? renderFlag(f))
+}
+
+/** One `verb  flags…` line, wrapped at {@link WRAP_COLS} with continuations
+ *  indented to the flag column so a long verb still reads as one row. */
+function renderVerb(verb: VerbSpec, column: number): string[] {
+  const tokens = renderFlags(verb)
+  if (tokens.length === 0) return [verb.name.padEnd(column) + "(none)"]
+  const indent = " ".repeat(column)
+  const lines: string[] = []
+  let current = verb.name.padEnd(column)
+  let started = false
+  for (const token of tokens) {
+    if (started && current.length + 1 + token.length > WRAP_COLS) {
+      lines.push(current)
+      current = indent + token
+    } else {
+      current = started ? `${current} ${token}` : current + token
+    }
+    started = true
+  }
+  lines.push(current)
+  return lines
+}
+
+/** The fenced block for one section — every verb in the named groups, in the
+ *  canonical {@link VERBS} order so this listing agrees with `schema`'s. */
+export function renderGroups(groups: readonly VerbGroup[]): string {
+  const verbs = VERBS.filter((v) => groups.includes(v.group))
+  if (verbs.length === 0) throw new Error(`no verbs in group(s): ${groups.join(", ")}`)
+  const column = Math.max(...verbs.map((v) => v.name.length)) + 2
+  const body = verbs.flatMap((v) => renderVerb(v, column))
+  return ["```text", ...body, "```"].join("\n")
+}
+
+function parseGroups(raw: string): VerbGroup[] {
+  return raw.split(",").map((part) => {
+    const id = part.trim()
+    if (!(VERB_GROUP_IDS as readonly string[]).includes(id)) {
+      throw new Error(`unknown verb group "${id}" in a generated:begin marker`)
+    }
+    return id as VerbGroup
+  })
+}
+
+/**
+ * group id → the section that documents it, named the way SKILL.md's signpost
+ * table cites it: the `## ` heading with any parenthetical stripped, so
+ * `## issues (daemon-owned)` is cited as `issues`. Derived from the same
+ * markers the blocks are, which is what lets a test assert that every group
+ * the binary serves has a row an agent can find it by.
+ */
+export function sectionsByGroup(source: string): Map<VerbGroup, string> {
+  const map = new Map<VerbGroup, string>()
+  let heading = ""
+  for (const line of source.split("\n")) {
+    if (line.startsWith("## ")) heading = line.slice(3).replace(/\s*\(.*$/, "").trim()
+    const match = BEGIN.exec(line)
+    if (match) for (const group of parseGroups(match[1])) map.set(group, heading)
+  }
+  return map
+}
+
+/** One drifted region, described the way a reader needs to act on it. */
+export interface StaleRegion {
+  /** The marker's group list, e.g. `create,edit,lifecycle`. */
+  readonly groups: string
+  /** Lines the file has that the specs do not — usually a renamed verb. */
+  readonly stray: string[]
+  /** Lines the specs have that the file does not — the missing flags. */
+  readonly missing: string[]
+}
+
+/** Human-readable: names the group AND the verb lines that moved. */
+export function describeStale(regions: readonly StaleRegion[]): string {
+  return regions
+    .map((r) => [`[${r.groups}]`, ...r.stray.map((l) => `  - ${l}`), ...r.missing.map((l) => `  + ${l}`)].join("\n"))
+    .join("\n")
+}
+
+export interface RegenResult {
+  readonly text: string
+  /** Regions whose block changed, for the stale message. */
+  readonly stale: StaleRegion[]
+  /** Every group id claimed by a marker, so callers can assert coverage. */
+  readonly covered: VerbGroup[]
+}
+
+/** Replace each generated region in place; everything else survives byte-for-byte. */
+export function regenerate(source: string): RegenResult {
+  const lines = source.split("\n")
+  const out: string[] = []
+  const stale: StaleRegion[] = []
+  const covered: VerbGroup[] = []
+  for (let i = 0; i < lines.length; i++) {
+    const match = BEGIN.exec(lines[i])
+    if (!match) {
+      out.push(lines[i])
+      continue
+    }
+    const raw = match[1]
+    const groups = parseGroups(raw)
+    covered.push(...groups)
+    const close = lines.indexOf(END, i + 1)
+    if (close === -1) throw new Error(`unclosed generated region "${raw}"`)
+    const fresh = renderGroups(groups)
+    const had = lines.slice(i + 1, close)
+    const want = fresh.split("\n")
+    if (had.join("\n") !== fresh) {
+      stale.push({
+        groups: raw,
+        stray: had.filter((l) => !want.includes(l)),
+        missing: want.filter((l) => !had.includes(l)),
+      })
+    }
+    out.push(lines[i], ...fresh.split("\n"), END)
+    i = close
+  }
+  return { text: out.join("\n"), stale, covered }
+}
+
+function main(): void {
+  const check = process.argv.includes("--check")
+  const canonical = readFileSync(REFERENCE_PATHS[0], "utf8")
+  const { text, stale, covered } = regenerate(canonical)
+
+  const missing = VERB_GROUP_IDS.filter((g) => !covered.includes(g))
+  if (missing.length > 0) {
+    console.error(`api-flags.md has no section for verb group(s): ${missing.join(", ")}`)
+    console.error(`Add a "## <section>" with a <!-- generated:begin ${missing[0]} --> region.`)
+    process.exit(1)
+  }
+
+  const drifted = REFERENCE_PATHS.filter((p) => readFileSync(p, "utf8") !== text)
+  if (check) {
+    if (stale.length > 0) {
+      console.error(`api-flags.md no longer matches the verb specs:\n${describeStale(stale)}`)
+      console.error(`Regenerate with: ${FIX_COMMAND}`)
+      process.exit(1)
+    }
+    if (drifted.length > 1) {
+      console.error(`skill copies disagree: ${drifted.join(", ")}\nRegenerate with: ${FIX_COMMAND}`)
+      process.exit(1)
+    }
+    console.log("api-flags.md is up to date")
+    return
+  }
+
+  for (const path of REFERENCE_PATHS) writeFileSync(path, text)
+  console.log(stale.length > 0 ? `regenerated:\n${describeStale(stale)}` : "no changes")
+}
+
+if (import.meta.main) main()


### PR DESCRIPTION
The agent skill is progressive on purpose — SKILL.md carries the hot verbs,
`references/api-flags.md` carries the rest, `rove api schema` is the third
layer. The middle layer was hand-written, and it drifted. Layering does not
fix that; deriving does.

## 1. The flag tables are generated

`scripts/gen-skill-api-flags.ts` renders each `<!-- generated:begin <groups> -->`
region from the same `VERBS` specs `schema` serves. Prose between the regions
stays authored — "what `--precheck` is FOR" is in no spec. The marker names the
verb groups its section covers, so the section↔group mapping lives in the
document rather than in a second table that could disagree with it.

`packages/kobe/test/architecture/skill-api-reference.test.ts` fails on drift,
naming the group *and* the verb line, with the regenerate command:

```
api-flags.md no longer matches the verb specs:
[worktree]
  - ensure-worktree     --task-id(REQ)
  + ensure-worktree     --task-id(REQ) --mutant
Regenerate with: bun scripts/gen-skill-api-flags.ts
```

### What the hand table had wrong or missing

This list is the proof the generator earns its keep.

**Documented a flag that does not exist** (an agent following it gets `BAD_FLAG`):

- `routine-create --prompt-file` and `routine-update --prompt-file` — routine
  verbs take `--prompt` only, and their handlers read `require("prompt")`, not
  `promptText()`. A whole paragraph of prose promised the `send` escape hatch.
  Corrected in the docs; see the flag gap noted at the bottom.

**Verbs missing entirely:** `set-effort`, `engine-report`.

**Flags missing:** `collect --group`, `send --allow-empty`, `delete --wait`
(all three documented in SKILL.md, absent from the reference), and `add`'s real
flag list — it said "`--repo(REQ)` + the hot-path flags above".

**Defaults and enums missing:** `read-output --source(auto)`,
`notify --kind(done)`, `pane-open --direction(right) --placement(split)`,
`land --strategy(merge)`, `add --status(backlog) --activate(false)`,
`workitem-list --state(open)`, and the `{claude|codex|copilot|kimi}` values on
every `--vendor`.

**Four defaults the spec under-declared** — the hand table knew them, the
binary's own `--help` did not. Declared them on the `FlagSpec` instead of
dropping them from the docs, so `schema` and `--help` now tell the truth too:
`read-output --limit(40)`, `workitem-list --limit(20)`,
`routine-* --precheck-timeout(120)`, `routine-* --grace(60)`.

**The two skill copies had already drifted:** `claude-plugin/skills/rove/references/api-flags.md`
was missing the `tab-close` row and its prose. The existing mirror test only
checked `SKILL.md` and stayed green through it; it now covers every file of the
skill, and the generator writes both copies.

Everything else in the diff is notation (`[a|b]` → `{a|b}`, matching the CLI's
own `--help`) or ordering (now the canonical `VERBS` order, so this listing
agrees with `schema`'s). Trailing annotation columns moved into prose.

## 2. SKILL.md signposts by intent

The old sentence named Rove's nouns: an agent thinking "message one window
every morning" never maps that to the word `routine` and never opens the file.
It is now a lookup table keyed on user phrasing, including the Chinese ones.
SKILL.md 29,971 → 30,422 bytes (+451).

The right-hand column is **authored**, not generated — but a test asserts every
verb group's section is reachable from a row, and the generator refuses to run
if a group has no section at all. So a new verb group cannot ship without a
signpost, while the phrasings stay human.

## Verification

- Idempotent: two runs, no diff. Deleting `routine-runs --id(REQ)` from the
  checked-in file fails `--check` and the test naming `[routine]`; regenerating
  restores it byte-identically.
- Mutation: a fake `--mutant` flag on `ensure-worktree` fails naming that verb;
  regenerate passes; reverted.
- `bun run lint` (root), `bun x tsc --noEmit`, `vitest run test/lib test/cli/skill test/architecture` — 285 passed.
- `bun run test:fast` — 4182 passed, 4 failed: `project-eligibility` /
  `open-dir-cmd`, which reject this checkout by path shape because it lives
  under `~/.rove/worktrees`. Pre-existing and environmental; the diff touches
  neither file.

## Seam named, not hacked around

The **error-code table stays authored.** Codes are string literals scattered
across handlers with no registry, and the table's value is its Means/Recover
prose, which no generator can write. Building a registry is a bigger change
than this PR. What is guarded instead: a test asserts every code the table
names appears as a literal in the source, so a renamed or deleted code fails.

## For the owner, not fixed here

Routines have no `--prompt-file`, so a scheduled prompt with backticks or
`$vars` has no escape hatch that `send`/`add`/`dispatch` all have. It is a
two-part gap (the flag *and* the handler reading it), so it is a behavior
decision rather than part of this docs PR. The shared `F.prompt` helper also
bakes "Required unless --prompt-file is given" into every verb's `--help`,
which is false for routines.
