### PR TITLE
fix: round the Routines page's detail box

### DIFF
--- a/.changeset/routines-detail-box-rounded.md
+++ b/.changeset/routines-detail-box-rounded.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+The Routines page's detail box now draws the same rounded frame as every other framed surface; it was the last square-cornered box in the TUI.

--- a/packages/kobe/src/tui-react/component/automations-page.tsx
+++ b/packages/kobe/src/tui-react/component/automations-page.tsx
@@ -353,7 +353,7 @@ export function AutomationsPage(props: {
       {/* The detail frame is always mounted, even with nothing selected: a
           panel that appears and disappears makes the page jump, and the empty
           frame is where a first-time user reads what a routine even carries. */}
-      <box flexDirection="column" marginTop={1} border borderColor={theme.border} padding={1} flexShrink={0}>
+      <box flexDirection="column" marginTop={1} {...FRAME} borderColor={theme.border} padding={1} flexShrink={0}>
         {selected ? (
           <>
             <box flexDirection="row" justifyContent="space-between" gap={2}>

--- a/packages/kobe/test/render/automations-page-keys.test.tsx
+++ b/packages/kobe/test/render/automations-page-keys.test.tsx
@@ -164,7 +164,7 @@ test("the detail frame stays mounted with nothing selected", async () => {
   )
   await new Promise((r) => setTimeout(r, 120))
   const text = await frame()
-  expect(text).toContain("┌")
+  expect(text).toContain("╭")
   expect(text).toContain("A routine runs its prompt")
 })
 


### PR DESCRIPTION
Every other framed surface spreads `FRAME` from `ui/frame.ts`; this box wrote `border` by hand and stayed square after #794 rounded the composer's fields. It was the last square-cornered box in the TUI.

Before / after (harness, `ctrl+a 2`): `.scratch/dialog-unify/before-routines-page.png` → `.scratch/dialog-unify/after-routines-page.png` — the detail box corners are the only pixel difference.

coverage-exemption: packages/kobe/src/tui-react/component/automations-page.tsx — one prop spread swapped (border → {...FRAME}), no logic change