### PR TITLE
fix: routines take --prompt-file like send and add

### DIFF
--- a/.agents/skills/kobe/references/api-flags.md
+++ b/.agents/skills/kobe/references/api-flags.md
@@ -233,10 +233,10 @@ it fires with no TUI attached.
 <!-- generated:begin routine -->
 ```text
 routine-list         (none)
-routine-create       --repo(REQ) --name(REQ) --prompt(REQ) --schedule(REQ)
+routine-create       --repo(REQ) --name(REQ) --prompt|--prompt-file(REQ) --schedule(REQ)
                      --vendor{claude|codex|copilot|kimi} --base-branch --precheck
                      --precheck-timeout(120) --grace(60) --persistent-session --disabled
-routine-update       --id(REQ) --name --prompt --schedule
+routine-update       --id(REQ) --name --prompt|--prompt-file --schedule
                      --vendor{claude|codex|copilot|kimi} --base-branch --precheck
                      --precheck-timeout(120) --grace(60) --persistent-session
 routine-set-enabled  --id(REQ) --enabled(REQ)

--- a/.changeset/routine-prompt-file.md
+++ b/.changeset/routine-prompt-file.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+`rove api routine-create` and `routine-update` take `--prompt-file` (`-` = stdin), the same escape hatch `send` and `add` have for a prompt with backticks, `$vars` or quotes. Optional `--prompt` flags no longer claim to be "required unless --prompt-file is given" in `--help`.

--- a/claude-plugin/skills/rove/references/api-flags.md
+++ b/claude-plugin/skills/rove/references/api-flags.md
@@ -233,10 +233,10 @@ it fires with no TUI attached.
 <!-- generated:begin routine -->
 ```text
 routine-list         (none)
-routine-create       --repo(REQ) --name(REQ) --prompt(REQ) --schedule(REQ)
+routine-create       --repo(REQ) --name(REQ) --prompt|--prompt-file(REQ) --schedule(REQ)
                      --vendor{claude|codex|copilot|kimi} --base-branch --precheck
                      --precheck-timeout(120) --grace(60) --persistent-session --disabled
-routine-update       --id(REQ) --name --prompt --schedule
+routine-update       --id(REQ) --name --prompt|--prompt-file --schedule
                      --vendor{claude|codex|copilot|kimi} --base-branch --precheck
                      --precheck-timeout(120) --grace(60) --persistent-session
 routine-set-enabled  --id(REQ) --enabled(REQ)

--- a/docs/ROUTINES.md
+++ b/docs/ROUTINES.md
@@ -66,6 +66,18 @@ rove api routine-run-now --id <id>          # fire it now, skipping the precheck
 rove api routine-runs --id <id>             # run history, newest first
 ```
 
+A prompt with backticks, `$vars` or quotes goes through `--prompt-file`
+(`-` reads stdin), the same escape hatch `send` and `add` have. Inside double
+quotes the shell runs a backticked command and ships its output instead of the
+words:
+
+```bash
+rove api routine-create --repo . --name "Morning reply" --schedule "0 9 * * *" \
+  --persistent-session --prompt-file - <<'EOF'
+Reply via `rove api send --task-id $ROVE_TASK_ID` with what changed overnight.
+EOF
+```
+
 Full flag list: `rove api schema --group routine`, or [rove api](API.md).
 
 ## Reading the page

--- a/packages/kobe/src/cli/api/flags.ts
+++ b/packages/kobe/src/cli/api/flags.ts
@@ -80,7 +80,7 @@ export const F = {
     type: "string",
     required,
     placeholder: "TEXT",
-    description: `${desc} Required unless --prompt-file is given.`,
+    description: required ? `${desc} Required unless --prompt-file is given.` : desc,
   }),
   /**
    * The escape hatch for a prompt the shell would mangle: backticks inside

--- a/packages/kobe/src/cli/api/verbs-automations.ts
+++ b/packages/kobe/src/cli/api/verbs-automations.ts
@@ -15,6 +15,7 @@
 
 import { F } from "./flags.ts"
 import { simpleRpc } from "./handler-helpers.ts"
+import { requirePromptText } from "./handlers-tasks.ts"
 import type { VerbSpec } from "./types.ts"
 
 const SCHEDULE_FLAG = {
@@ -88,6 +89,7 @@ export const ROUTINE_VERBS: readonly VerbSpec[] = [
       F.repo(),
       { name: "name", type: "string", required: true, placeholder: "N", description: "Routine name." },
       F.prompt(true, "Text delivered as the new session's first message."),
+      F.promptFile(),
       { ...SCHEDULE_FLAG, required: true },
       F.vendor(),
       {
@@ -105,7 +107,7 @@ export const ROUTINE_VERBS: readonly VerbSpec[] = [
       simpleRpc(ctx, "automation.create", {
         repo: ctx.args.requirePath("repo"),
         name: ctx.args.require("name"),
-        prompt: ctx.args.require("prompt"),
+        prompt: requirePromptText(ctx, "routine-create"),
         schedule: ctx.args.require("schedule"),
         ...(ctx.args.vendor() ? { vendor: ctx.args.vendor() } : {}),
         ...(ctx.args.str("base-branch") ? { baseRef: ctx.args.str("base-branch") } : {}),
@@ -123,6 +125,7 @@ export const ROUTINE_VERBS: readonly VerbSpec[] = [
       { name: "id", type: "string", required: true, placeholder: "ID", description: "Routine id." },
       { name: "name", type: "string", placeholder: "N", description: "New name." },
       F.prompt(false, "New prompt."),
+      F.promptFile(),
       SCHEDULE_FLAG,
       F.vendor(),
       { name: "base-branch", type: "string", placeholder: "B", description: "New base ref ('' to clear)." },
@@ -134,7 +137,7 @@ export const ROUTINE_VERBS: readonly VerbSpec[] = [
       simpleRpc(ctx, "automation.update", {
         id: ctx.args.require("id"),
         ...(ctx.args.str("name") !== undefined ? { name: ctx.args.str("name") } : {}),
-        ...(ctx.args.str("prompt") !== undefined ? { prompt: ctx.args.str("prompt") } : {}),
+        ...(ctx.args.promptText() !== undefined ? { prompt: ctx.args.promptText() } : {}),
         ...(ctx.args.str("schedule") !== undefined ? { schedule: ctx.args.str("schedule") } : {}),
         ...(ctx.args.vendor() ? { vendor: ctx.args.vendor() } : {}),
         // `--base-branch ''` clears the base ref (sends null); `present` keeps

--- a/packages/kobe/test/cli/api-routine-prompt-file.test.ts
+++ b/packages/kobe/test/cli/api-routine-prompt-file.test.ts
@@ -1,0 +1,57 @@
+/**
+ * `rove api routine-create` / `routine-update` prompt sourcing: the same
+ * `--prompt` / `--prompt-file` contract `send` and `add` have, pinned here so
+ * a scheduled prompt with backticks in it survives the shell. Same technique
+ * as api-handlers.test.ts: `invokeVerb` against a recording fake daemon.
+ */
+
+import { mkdtempSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { describe, expect, it } from "vitest"
+import { invokeVerb } from "../../src/cli/api-cmd.ts"
+import { FakeClient, expectApiError, stubRuntime } from "./api-handler-fixtures.ts"
+
+describe("routine verbs take --prompt-file", () => {
+  // A scheduled prompt that names its own reply command (`rove api send …`)
+  // has the same shell problem as `send`: backticks in a double-quoted
+  // --prompt are command substitution. The file route is the one that fits
+  // both verbs, so routines take it too.
+  it("routine-create ships the file's bytes verbatim", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "rove-routine-prompt-"))
+    const file = join(dir, "prompt.md")
+    const body = "each morning reply via `rove api send --task-id t1` and $(echo no)\n"
+    writeFileSync(file, body)
+    const client = new FakeClient({ "automation.create": () => ({ ok: true }) })
+    await invokeVerb(
+      "routine-create",
+      ["--repo", process.cwd(), "--name", "n", "--schedule", "0 9 * * *", "--prompt-file", file],
+      { client, runtime: stubRuntime() },
+    )
+    expect((client.requests[0]?.payload as { prompt: string }).prompt).toBe(body)
+  })
+
+  it("routine-update reads the file, and leaves the prompt alone when neither flag is given", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "rove-routine-prompt-"))
+    const file = join(dir, "prompt.md")
+    writeFileSync(file, "new `text`\n")
+    const client = new FakeClient({ "automation.update": () => ({ ok: true }) })
+    await invokeVerb("routine-update", ["--id", "r1", "--prompt-file", file], { client, runtime: stubRuntime() })
+    await invokeVerb("routine-update", ["--id", "r1", "--name", "renamed"], { client, runtime: stubRuntime() })
+    expect(client.requests.map((r) => r.payload)).toEqual([
+      { id: "r1", prompt: "new `text`\n" },
+      { id: "r1", name: "renamed" },
+    ])
+  })
+
+  it("routine-create with neither --prompt nor --prompt-file is MISSING_FLAG", async () => {
+    await expectApiError(
+      () =>
+        invokeVerb("routine-create", ["--repo", process.cwd(), "--name", "n", "--schedule", "0 9 * * *"], {
+          client: new FakeClient(),
+          runtime: stubRuntime(),
+        }),
+      "MISSING_FLAG",
+    )
+  })
+})


### PR DESCRIPTION
`routine-create` and `routine-update` only read `--prompt`, so a scheduled prompt with backticks had no way past the shell's command substitution (the gap #799 found while generating the reference). Both verbs now resolve the prompt through the same `promptText()` that `send` uses, so `--prompt` + `--prompt-file` together is `BAD_FLAG`, an empty file is `BAD_FLAG`, and neither on `routine-create` is `MISSING_FLAG`. `F.prompt` only claims the prompt-file fallback in `--help` when the flag is required (it was false on every optional `--prompt`).

Tests: `test/cli/api-routine-prompt-file.test.ts` (its own file: `api-handlers-more.test.ts` was at the 500-line cap; the seam is the verb group). Mutation: handler reverted to `require("prompt")` makes the verbatim-bytes test fail while the other two pass.

Generated skill reference regenerated (the new drift test caught it first). `docs/ROUTINES.md` shows the heredoc form.
