### PR TITLE
docs: remove history from comments in tui, state, types, lib, core, monitor

### DIFF
--- a/.changeset/comments-history-purge-tui-state.md
+++ b/.changeset/comments-history-purge-tui-state.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+comments: history removed from tui, state, types, lib, core and monitor; no code change.

--- a/packages/kobe/src/core/daemon-runtime.ts
+++ b/packages/kobe/src/core/daemon-runtime.ts
@@ -48,7 +48,7 @@ export const daemonRuntime: DaemonRuntimeAdapter = {
   isTaskStatus,
   isEngineActivityKind,
   affectsActivityState,
-  // The activity observer's foreground walk (issues #11/#16): ONE `ps`
+  // The activity observer's foreground walk: ONE `ps`
   // snapshot, then the same shallowest-engine walk `kobe api inspect` uses.
   async foregroundEngines(pids) {
     const rows = parsePsSnapshot(await psSnapshot())
@@ -60,10 +60,10 @@ export const daemonRuntime: DaemonRuntimeAdapter = {
     return out
   },
   titleTurnHint: engineTitleTurnHint,
-  // Tier-(b) protocol sniff (issue #31): the record upgrade for a generic
+  // Tier-(b) protocol sniff: the record upgrade for a generic
   // task identified by its live session — rules live with the sniffer.
   resolveProtocolUpgrade: protocolUpgradeFromLiveSession,
-  // Per-turn telemetry (issue #32) — delegated straight to the vendor's own
+  // Per-turn telemetry — delegated straight to the vendor's own
   // adapter; an engine without a turn reader simply reports none.
   readEngineTurns: async (vendor, transcriptPath) => (await engineEntry(vendor).readTurns?.(transcriptPath)) ?? [],
   checkLatestVersion,

--- a/packages/kobe/src/core/daemon-session-adapter.ts
+++ b/packages/kobe/src/core/daemon-session-adapter.ts
@@ -42,8 +42,8 @@ export async function ensureTaskSessionAdapter(link: DaemonRpcClient, taskId: st
   try {
     const opened = await ensureHostedEngine(host.rpc, worktreePath, launch)
     if (!opened.alive) throw new Error(`failed to start hosted engine session for ${taskId}`)
-    // Paste-delivery vendor (kimi — issue #25) with a repo init-prompt: the
-    // message rode outside the argv. Best-effort paste — the engine IS up,
+    // Paste-delivery vendor (kimi) with a repo init-prompt: the
+    // message rides outside the argv. Best-effort paste — the engine IS up,
     // so a missed paste leaves an idle prompt, not a failed session.
     if (launch.firstMessage) {
       const engineBin = engineLaunchArgv({ command: task.command, vendor: task.vendor, effort: task.modelEffort })[0]
@@ -81,14 +81,14 @@ export async function startTaskSessionWithPromptAdapter(
   // session it was observed from.
   await link.request("task.observeLanguage", { taskId, text: prompt }).catch(() => {})
   // "new-task", not "explicit": both callers (automation runner, work-item
-  // start) create the task right before this call, so the first prompt gets
+  // start) create the task immediately ahead of this call, so the first prompt gets
   // the branch-rename coda like every other new-worktree entry point.
   const launch = taskEngineLaunch(task, worktreePath, { kind: "new-task", prompt })
   const host = await ensureHostedSessionHost()
   try {
     const opened = await ensureHostedEngine(host.rpc, worktreePath, launch)
     if (!opened.alive) return false
-    // Paste-delivery vendor (kimi — issue #25): the prompt rode OUTSIDE the
+    // Paste-delivery vendor (kimi): the prompt rides OUTSIDE the
     // argv; deliver it once the engine process is up. A paste that never
     // lands means the prompt was not delivered — report false.
     if (launch.firstMessage) {
@@ -106,7 +106,7 @@ export async function startTaskSessionWithPromptAdapter(
 }
 
 function taskEngineLaunch(task: SerializedTask, worktreePath: string, promptIntent: PromptDeliveryIntent) {
-  // Pre-trust the worktree in the vendor's first-run store (issue #28).
+  // Pre-trust the worktree in the vendor's first-run store.
   trustEngineWorktree(task.vendor, worktreePath)
   return buildEngineSessionLaunch({
     task: { id: task.id, kind: task.kind, vendor: task.vendor, repo: task.repo },
@@ -120,7 +120,7 @@ function taskEngineLaunch(task: SerializedTask, worktreePath: string, promptInte
 export async function engineSpecAdapter(link: DaemonRpcClient, taskId: string) {
   const { task, worktreePath } = await ensureTaskWorktree(link, taskId)
   const launch = taskEngineLaunch(task, worktreePath, { kind: "repo-init" })
-  // Paste-delivery vendor (kimi — issue #25): the repo init-prompt rode
+  // Paste-delivery vendor (kimi): the repo init-prompt rides
   // OUTSIDE the argv; the web PTY sidecar pastes it after the fresh spawn
   // (the sidecar owns its own PTYs — the daemon's hosted paste can't reach
   // them). Without this the message would be silently dropped.
@@ -169,7 +169,7 @@ function tabIdFromHostedKey(key: string): string {
 /**
  * {@link deliverPromptToLiveEngineAdapter} reporting composer-busy as a VALUE.
  *
- * The routine runner (issue #91) must not drop a daily report the way
+ * The routine runner must not drop a daily report the way
  * quota-resume drops a continue nudge: a dropped report and a routine that
  * never ran look identical to the user. It needs the busy layer and the tab
  * to file a deferral, and the daemon cannot catch `ComposerBusyError` by type

--- a/packages/kobe/src/core/index.ts
+++ b/packages/kobe/src/core/index.ts
@@ -50,7 +50,7 @@ export async function createKobeCore(options: KobeCoreOptions = {}): Promise<Kob
   })
 
   // Heal the projects/savedRepos split (see backfillSavedReposFromProjects):
-  // rows minted before 2026-08-31 are in the sidebar but not the picker. Runs
+  // rows minted by an older kobe are in the sidebar but not the picker. Runs
   // once per daemon boot and is idempotent — after the first pass every row
   // is already saved and `addSavedRepo` reports nothing added.
   const backfilled = backfillSavedReposFromProjects(

--- a/packages/kobe/src/lib/error-message.ts
+++ b/packages/kobe/src/lib/error-message.ts
@@ -1,7 +1,7 @@
 /**
  * The message of an unknown thrown value — `Error#message` when it is a real
- * Error, else `String(err)`. The one shared spelling of a pattern that was
- * previously copied inline at ~50 call sites.
+ * Error, else `String(err)`. The one shared spelling of a pattern used at
+ * ~50 call sites.
  */
 export function errorMessage(err: unknown): string {
   return err instanceof Error ? err.message : String(err)

--- a/packages/kobe/src/lib/git-parsers.ts
+++ b/packages/kobe/src/lib/git-parsers.ts
@@ -273,7 +273,7 @@ export function parseNumstatRows(raw: string): NumstatRow[] {
       rows.push({ path: unquoteGitPath(pathField), added, deleted })
       i++
     } else {
-      // Rename: the next two fields are the old and new paths.
+      // Rename: the next two fields are the source and destination paths.
       if (i + 2 >= fields.length) break
       rows.push({
         path: unquoteGitPath(fields[i + 2] as string),

--- a/packages/kobe/src/lib/poll-scheduling.ts
+++ b/packages/kobe/src/lib/poll-scheduling.ts
@@ -1,6 +1,6 @@
 /**
- * Pure scheduling core for subprocess-backed background polling —
- * extracted from `src/tui/lib/background-poll.ts` (issue #6) so the
+ * Pure scheduling core for subprocess-backed background polling, kept out
+ * of `src/tui/lib/background-poll.ts` so the
  * daemon's worktree-changes collector can reuse the EXACT guards that
  * keep huge-repo `git status` off the event loop, without importing
  * UI state primitives into daemon code.

--- a/packages/kobe/src/lib/relative-time.ts
+++ b/packages/kobe/src/lib/relative-time.ts
@@ -3,12 +3,11 @@
  * millisecond delta, hours from minutes, days from hours. Both TUI consumers
  * (the Routines schedule preview's `formatRelative` and the Automations
  * page's `formatWhen`) derive their units from here so the two can't drift
- * apart again — they used to be independent copies, which is how one screen
- * ended up proposing floor while its neighbor rounded (PR #479).
+ * apart — independent copies are how one screen ends up flooring while its
+ * neighbor rounds.
  *
- * Every step uses Math.round — the behavior both consumers shipped with.
- * Floor-vs-round is a display-convention call the owner makes (PR #479
- * argues countdowns should floor so they never overstate headroom); when
+ * Every step uses Math.round. Floor-vs-round is a display-convention call
+ * (a countdown that floors never overstates headroom); when
  * that's decided, change it HERE so every consumer moves together.
  */
 export function relativeBuckets(absMs: number): { minutes: number; hours: number; days: number } {

--- a/packages/kobe/src/lib/skill-install.ts
+++ b/packages/kobe/src/lib/skill-install.ts
@@ -23,7 +23,7 @@
  * Absent skill → one-shot hint, never nags. Stale skill on an interactive
  * terminal → a yes / no / don't-notify-this-version prompt (runs before the
  * screen takeover); "no" re-asks next launch, "don't notify" mutes that
- * skill version, non-TTY falls back to the old one-shot hint.
+ * skill version, non-TTY falls back to the one-shot hint.
  */
 
 import { accessSync, existsSync, constants as fsConstants, readFileSync } from "node:fs"
@@ -173,7 +173,7 @@ export function npxMissingMessage(): string {
  *
  * Checks for `npx` FIRST: `Bun.spawn` THROWS on a missing binary (unlike
  * `spawnSync`, which returns `status: undefined`), and no caller on this path
- * catches — the throw used to escape all the way to `main().catch` and print
+ * catches — the throw would escape all the way to `main().catch` and print
  * `rove failed to start: Executable not found in $PATH: "npx"`. Returning
  * {@link NPX_MISSING_EXIT} keeps the callers' existing exit-code contract.
  */
@@ -281,11 +281,11 @@ function promptLine(): Promise<string> {
  *   - stale + interactive terminal → prompt: yes (install now) / no (ask
  *     again next launch) / don't notify for this version (persists
  *     `HINT_SEEN_KEY:vN`, so the next skill-version bump prompts again).
- *   - stale + non-TTY → the old one-shot stderr hint, gated per version.
+ *   - stale + non-TTY → the one-shot stderr hint, gated per version.
  * Safe to call on every startup.
  */
 export async function maybeHintSkillInstall(io: SkillHintIO = {}): Promise<void> {
-  // Plugin takeover (issue #37): when the Rove Claude Code plugin is enabled
+  // Plugin takeover: when the Rove Claude Code plugin is enabled
   // it BUNDLES the skill, and that copy versions with the plugin — not with
   // KOBE_SKILL_VERSION. Both the install nudge and the staleness prompt step
   // aside: nagging the user to `skill install` alongside the plugin's copy

--- a/packages/kobe/src/monitor/auto-title.ts
+++ b/packages/kobe/src/monitor/auto-title.ts
@@ -7,7 +7,7 @@
  * it back from the session transcript. We take the FIRST user message
  * of the task's origin session and truncate it via
  * `deriveTitleFromPrompt` (no model call — pure string work, the cheap
- * replacement for the old headless `claude -p` naming path).
+ * replacement for a headless `claude -p` naming call).
  *
  * Engine-aware via the registry: the task's `vendor` resolves an
  * `EngineHistoryReader` (claude-code's per-worktree `~/.claude/projects/*`

--- a/packages/kobe/src/monitor/pr-status.ts
+++ b/packages/kobe/src/monitor/pr-status.ts
@@ -152,10 +152,10 @@ export function samePrStatus(a: TaskPRStatus | undefined, b: TaskPRStatus | unde
 // ---------------------------------------------------------------------------
 // Failure classification + adaptive backoff (the "gh broke" vs "no PR" split).
 //
-// The poller used to collapse every non-success `gh pr view` — gh missing,
+// Collapsing every non-success `gh pr view` — gh missing,
 // unauthed, a network stall, a rate-limit, malformed JSON, no GitHub remote —
-// into the same "no PR" result, so a broken `gh` was indistinguishable from a
-// branch that simply has no PR yet and the user got no signal. These pure
+// into one "no PR" result makes a broken `gh` indistinguishable from a
+// branch that simply has no PR yet, and the user gets no signal. These pure
 // helpers split a failure into a genuine `empty` (gh ran, said no PR) vs a
 // typed transport/tooling `error`, and compute the next poll delay so a
 // persistent failure backs off (and a deterministic "no GitHub remote" settles

--- a/packages/kobe/src/monitor/status-rules.ts
+++ b/packages/kobe/src/monitor/status-rules.ts
@@ -1,7 +1,6 @@
 /**
- * Daemon-side status rules (docs/design/web-kanban.md M5, revised
- * 2026-06-11: the small-model judge was dropped in favor of rule + agent
- * self-report).
+ * Daemon-side status rules (docs/design/web-kanban.md M5): a pure rule plus
+ * the agent's own self-report, no small-model judge.
  *
  * The one rule that needs no judgment: an engine STARTING a turn on a
  * `backlog` task means work has begun — `turn-start` is unambiguous, so a

--- a/packages/kobe/src/state/auto-status.ts
+++ b/packages/kobe/src/state/auto-status.ts
@@ -1,6 +1,6 @@
 /**
- * The "auto status flow" opt-in (docs/design/web-kanban.md M5, revised
- * 2026-06-11): one switch gates BOTH halves of the flow —
+ * The "auto status flow" opt-in (docs/design/web-kanban.md M5):
+ * one switch gates BOTH halves of the flow —
  *
  *   - daemon rule: `turn-start` on a backlog task → `in_progress`
  *     (monitor/status-rules.ts), and

--- a/packages/kobe/src/state/composer-gate.ts
+++ b/packages/kobe/src/state/composer-gate.ts
@@ -6,11 +6,11 @@
  * message never lands in the middle of what someone is typing. That check
  * reads the engine's CURRENT layout through an `EngineScreenManifest`, which
  * is a rule about pixels an upstream vendor is free to change without telling
- * anyone. When Claude moved its composer behind three rows of status
- * furniture, the rule stopped matching and every delivery to every Claude task
- * was held (2026-09-01).
+ * anyone. A vendor moving its composer (Claude behind three rows of status
+ * furniture, say) stops the rule matching, and every delivery to every task
+ * on that engine is held.
  *
- * The detector is now conservative in the right direction — an unmatched
+ * The detector is conservative in the right direction — an unmatched
  * anchor answers "I can't see it" rather than "there is text" — but the
  * failure mode this switch exists for is the one that comes back: a vendor
  * moves, the gate is confidently wrong, and the user watches messages queue up

--- a/packages/kobe/src/state/last-active.ts
+++ b/packages/kobe/src/state/last-active.ts
@@ -1,6 +1,6 @@
 /**
- * `lastActive` — THE unified word for "what was focused last" (owner
- * naming, 2026-07-08). One global record of the last active task id,
+ * `lastActive` — THE unified word for "what was focused last".
+ * One global record of the last active task id,
  * persisted through `state/store.ts`'s read-merge-write transaction:
  * whichever process writes last wins, deliberately WITHOUT multi-TUI
  * coordination — opening kobe lands on whatever was focused most
@@ -21,7 +21,7 @@ export function readLastActiveTaskId(): string | null {
   return typeof value === "string" && value ? value : null
 }
 
-/** Persist the new focus. Clearing focus (null) keeps the old record —
+/** Persist the new focus. Clearing focus (null) keeps the existing record —
  *  "last active" means the last REAL focus, not the absence of one. */
 export function writeLastActiveTaskId(id: string): void {
   patchStateFile({ [LAST_ACTIVE_TASK_KEY]: id })

--- a/packages/kobe/src/state/layout-migration.ts
+++ b/packages/kobe/src/state/layout-migration.ts
@@ -240,7 +240,7 @@ function migrateLegacyPluginTree(env: NodeJS.ProcessEnv): StateLayoutMigrationRe
       if (!lstatIfExists(source) || lstatIfExists(destination)) continue
       renameSync(source, destination)
       moved += 1
-      // Leave the old path pointing at the new one: a `rove`/`kobe` binary
+      // Leave the former path pointing at the new one: a `rove`/`kobe` binary
       // predating the rename reads only `.kobe/plugins.json`, and finding it
       // empty reads as "you have no plugins", not as "look elsewhere".
       try {

--- a/packages/kobe/src/state/project-eligibility.ts
+++ b/packages/kobe/src/state/project-eligibility.ts
@@ -12,8 +12,8 @@
  * saved repos instead") while `rove remove` refuses a repo that was never in
  * `savedRepos`, which is precisely the set these rows belong to.
  *
- * `addSavedRepo` used to say validation was the caller's job. Eight callers,
- * one of which validated. So the rule lives here and the mutators apply it
+ * Validation is NOT the caller's job: of the eight call sites, exactly one
+ * would remember. So the rule lives here and the mutators apply it
  * themselves — a caller cannot forget a check it does not perform.
  *
  * Deliberately NOT a taste filter: "I'm not working on codefox right now" is

--- a/packages/kobe/src/state/repo-init.ts
+++ b/packages/kobe/src/state/repo-init.ts
@@ -38,7 +38,7 @@ export type FirstEngineMessageSource = "repo-init" | "explicit"
 export interface FirstEngineMessage {
   /** Text to paste into the engine composer as the first submitted message. */
   readonly text: string
-  /** Why this first message exists; used to keep priority rules explicit. */
+  /** Why this first message exists; keeps priority rules explicit. */
   readonly source: FirstEngineMessageSource
 }
 
@@ -71,8 +71,7 @@ export type PromptDeliveryIntent =
  * Lockfile → the directory its install step produces. A committed lockfile
  * with no install output means the worktree was never installed, so builds,
  * type-checks and tests there fail for reasons unrelated to the task — the
- * failure mode behind issue #35 (agents reporting install breakage as a
- * product regression).
+ * failure mode where agents report install breakage as a product regression.
  *
  * ponytail: a flat table, not a package-manager abstraction. Add a row when a
  * real repo needs one.

--- a/packages/kobe/src/state/repos.ts
+++ b/packages/kobe/src/state/repos.ts
@@ -1,7 +1,8 @@
 /**
  * Saved-repos persistence.
  *
- * The TUI's `KV` store (src/tui/context/kv.tsx) is a Solid-context wrapper
+ * The TUI's `KV` store (src/tui-react/context/kv.tsx) is a React-context
+ * wrapper
  * around `~/.config/rove/state.json`. Outside that context — e.g. from the
  * `kobe add` CLI subcommand — we can't use it. This module is the
  * non-reactive direct accessor for the same on-disk blob: load, mutate,
@@ -211,10 +212,10 @@ export interface AddSavedRepoOpts {
  * stores the repo root, not the subdir. The returned `path` is the
  * normalized form so callers report what was actually saved.
  *
- * VALIDATES (changed 2026-08-31): this used to document validation as the
- * caller's job. Of the eight call sites exactly one did it, and the other
- * seven put test fixtures and sandbox paths into the user's project list —
- * where nothing could remove them again. The gate now lives HERE, applied to
+ * VALIDATES here rather than leaving it to the caller: of the eight call
+ * sites exactly one would do it, and the other
+ * seven would put test fixtures and sandbox paths into the user's project
+ * list — where nothing could remove them again. The gate lives HERE, applied to
  * the normalized path, so no caller can skip it by forgetting; a refusal
  * comes back as `rejected` rather than an exception, because most callers
  * are opportunistic ("remember this repo while doing something else") and
@@ -247,11 +248,9 @@ export function addSavedRepo(absPath: string, opts: AddSavedRepoOpts = {}): AddR
  * Backfill `savedRepos` from the project rows that already exist.
  *
  * The sidebar's projects and the new-task picker's repos are meant to be the
- * same set, but until 2026-08-31 they were written by different paths: a row
- * minted by `createTask` on a fresh repo appeared in the sidebar while never
- * reaching `savedRepos`. On the owner's machine that was 6 of 8 projects —
- * visible, unpickable, and (once closing the last tab hides a project) not
- * recoverable.
+ * same set, but a row minted by an older kobe could reach the sidebar
+ * without ever reaching `savedRepos` — leaving it visible, unpickable, and
+ * (once closing the last tab hides a project) not recoverable.
  *
  * `mainRepos` is the caller's list of `kind:"main"` task repos; this module
  * cannot read the task index (the daemon owns it). Entries that fail the

--- a/packages/kobe/src/state/store.ts
+++ b/packages/kobe/src/state/store.ts
@@ -7,12 +7,12 @@
  * taken (the classic lost update). Every write therefore goes through
  * the read-merge-write transaction here.
  *
- * The fix is read-merge-write: every write re-reads the file fresh and
+ * Read-merge-write: every write re-reads the file fresh and
  * applies ONLY the keys the caller actually changed, then writes the
- * merged result atomically (tmp + rename, same crash-safety as before).
- * Concurrent writers touching DIFFERENT keys can no longer erase each
- * other; same-key writers remain last-write-wins, which is the documented
- * pre-existing semantics. There is still no flock — the merge shrinks the
+ * merged result atomically (tmp + rename).
+ * Concurrent writers touching DIFFERENT keys cannot erase each
+ * other; same-key writers are last-write-wins, which is the documented
+ * semantics. There is no flock — the merge shrinks the
  * race window to the read→rename span of a sync call, it does not
  * serialize writers. A true cross-process lock is the multi-instance
  * follow-up if same-key contention ever becomes real.
@@ -128,9 +128,9 @@ export function updateStateFile(mutate: (state: StateSnapshot) => boolean | unde
 
 /**
  * Merge a set of key changes into the file: fresh read, apply ONLY the
- * keys present in `patch` (an explicit `undefined` value DELETES the key —
- * matching the old whole-snapshot behavior where stringify dropped
- * undefined entries), atomic write. This is the multi-process-safe flush
+ * keys present in `patch` (an explicit `undefined` value DELETES the key,
+ * matching JSON stringify, which drops undefined
+ * entries), atomic write. This is the multi-process-safe flush
  * primitive: KVProvider passes just its dirty keys; `setPersisted*` passes
  * a single key. Keys this writer never touched pass through untouched.
  */

--- a/packages/kobe/src/state/tab-strip.ts
+++ b/packages/kobe/src/state/tab-strip.ts
@@ -22,7 +22,7 @@ export type TabStripMode = "always" | "multipleOnly" | "never"
 export const TAB_STRIP_MODES: readonly TabStripMode[] = ["always", "multipleOnly", "never"]
 
 /**
- * Off by default (owner call 2026-08-31, reverting the 2026-08-29 "always").
+ * Off by default.
  *
  * The sidebar tree already lists every worktree's tabs as rows, and the
  * active one is marked there — so the strip is a second copy of a list that
@@ -39,7 +39,7 @@ export const TAB_STRIP_HIDE_SINGLE_KEY = "chat.tabStrip.hideSingle"
  * Resolve the effective mode from stored values, honouring the legacy
  * boolean when the new key was never written.
  *
- * Migration reads rather than rewrites: a user who set the old toggle keeps
+ * Migration reads rather than rewrites: a user who set the legacy toggle keeps
  * their strip behaviour, and the moment they touch the new setting the new
  * key wins for good. Rewriting on read would need a kv write from a render
  * path, and there is nothing to gain from it.

--- a/packages/kobe/src/state/worktree-base.ts
+++ b/packages/kobe/src/state/worktree-base.ts
@@ -20,7 +20,7 @@
  * same file) and read FRESH on every worktree-path computation, so
  * changing it takes effect for the next task with no daemon restart.
  * Only NEW tasks move: existing tasks keep their persisted worktreePath,
- * and the old default root stays recognized for listing/slug allocation
+ * and the earlier default root stays recognized for listing/slug allocation
  * (see `managedWorktreeRootsFor`).
  *
  * Remote (SSH) projects are unaffected — their worktrees live on the

--- a/packages/kobe/src/tui/component/new-task-dialog/state.ts
+++ b/packages/kobe/src/tui/component/new-task-dialog/state.ts
@@ -46,8 +46,8 @@ import { DEFAULT_BASE_REF } from "../../lib/git-snapshot"
  *   - open — open `repo`'s OWN checkout (its `main` row) rather than
  *     branching a worktree off it. The only way back to a project the
  *     sidebar has hidden (`isClosedDownProject`): every other path through
- *     this dialog mints a `kind: "task"`, so picking the repo used to leave
- *     the user with an extra worktree and still no project row.
+ *     this dialog mints a `kind: "task"`, so picking the repo any other way
+ *     leaves the user with an extra worktree and still no project row.
  */
 export type NewTaskInput =
   | {
@@ -137,7 +137,7 @@ export type Field =
   | "tabs"
   | "engine"
   | "repo"
-  /** The Existing tab's task-vs-project selector (issue #90). Reachable only
+  /** The Existing tab's task-vs-project selector. Reachable only
    *  while it renders — see `nextField`. */
   | "intent"
   | "baseRef"
@@ -196,11 +196,11 @@ const PICKER_MIN_VISIBLE = 2
 /**
  * Visible picker rows for a viewport `height` rows tall.
  *
- * The cap used to be a flat 8 regardless of terminal height, so the dialog's
- * own height was a constant while the space for it was not: on a 24-row
- * terminal the card overran `maxCardHeight` and the bottom rows — the Create
- * button and, worse, `submitError` — were clipped away with nothing to
- * scroll them back. A failed create then looked like nothing happening at
+ * A flat cap regardless of terminal height would make the dialog's own
+ * height a constant while the space for it is not: on a 24-row
+ * terminal the card overruns `maxCardHeight` and the bottom rows — the Create
+ * button and, worse, `submitError` — are clipped away with nothing to
+ * scroll them back, so a failed create looks like nothing happening at
  * all. Shrinking the window is what gives those rows back; the list is
  * already windowed and scrolls under the cursor, so a shorter window costs
  * only how much is visible at once, never reachability.
@@ -419,7 +419,7 @@ export function resolveBaseRef(typed: string, filteredBranches: readonly string[
 }
 
 /* --------------------------------------------------------------------- */
-/*  Existing-tab intent (issue #90)                                       */
+/*  Existing-tab intent                                                   */
 /* --------------------------------------------------------------------- */
 
 /**

--- a/packages/kobe/src/tui/context/keybindings-chat.ts
+++ b/packages/kobe/src/tui/context/keybindings-chat.ts
@@ -54,9 +54,8 @@ export const CHAT_BINDINGS: readonly KobeBinding[] = [
   {
     id: "chat.tab.new",
     scope: "workspace",
-    // Direct-only (owner call 2026-07-11): tab management is
-    // high-frequency, so the single-press chord returned and the prefix
-    // stroke was dropped.
+    // Direct-only: tab management is high-frequency, so it gets a
+    // single-press chord rather than a prefix stroke.
     keys: ["ctrl+t"],
     category: "Workspace",
     description: "New chat tab",
@@ -68,13 +67,12 @@ export const CHAT_BINDINGS: readonly KobeBinding[] = [
     // (the keymap layer drops shift+ on letter keys, so ctrl+shift+t and
     // ctrl+t are indistinguishable).
     // `ctrl+e` mirrors the "engine" mnemonic the new-task dialog already
-    // uses for its own vendor cycle chord. Direct-only (owner call
-    // 2026-07-12): same reasoning as the tab-management rows above.
-    // Since issue #7 this opens the UNIFIED new-conversation dialog:
-    // default enter = the old "new tab with this engine", while in-dialog
-    // `tab` flips the destination (tab ⇄ fork a child task) and `ctrl+f`
-    // the context (fresh ⇄ continue) — owner sign-off 2026-08-10, see
-    // docs/design/keybinding-decisions.md.
+    // uses for its own vendor cycle chord. Direct-only, same reasoning as
+    // the tab-management rows above.
+    // Opens the UNIFIED new-conversation dialog: default enter = a new tab
+    // with this engine, while in-dialog `tab` flips the destination
+    // (tab ⇄ fork a child task) and `ctrl+f` the context (fresh ⇄ continue).
+    // See docs/design/keybinding-decisions.md.
     id: "chat.tab.chooseEngine",
     scope: "workspace",
     keys: ["ctrl+e"],
@@ -88,9 +86,9 @@ export const CHAT_BINDINGS: readonly KobeBinding[] = [
     // worktree that opens on this tab's history and then diverges
     // (claude `--resume … --fork-session`, `codex fork`). Sibling of
     // `chat.fork.new`, which forks the WORKTREE into a child task.
-    // Chord signed off 2026-08-10 (issue #7): prefix + `c` ("continue")
-    // is a PRESET entry into the unified `chat.tab.chooseEngine` dialog
-    // with the context toggle pre-flipped to "continue".
+    // prefix + `c` ("continue") is a PRESET entry into the unified
+    // `chat.tab.chooseEngine` dialog with the context toggle pre-flipped
+    // to "continue".
     id: "chat.tab.fork",
     scope: "workspace",
     keys: [],
@@ -103,10 +101,10 @@ export const CHAT_BINDINGS: readonly KobeBinding[] = [
     // Quick-fork: from a focused chat tab, spin up a child
     // task that inherits repo + branch + model from the source. The
     // dialog asks only for a prompt; the fork's first turn fires
-    // immediately. Since issue #7 a PRESET entry into the unified
+    // immediately. A PRESET entry into the unified
     // `chat.tab.chooseEngine` dialog with the destination toggle
     // pre-flipped to "fork a child task"; enter continues into the
-    // same QuickTaskComposer as before.
+    // QuickTaskComposer.
     id: "chat.fork.new",
     scope: "workspace",
     keys: [],
@@ -118,7 +116,7 @@ export const CHAT_BINDINGS: readonly KobeBinding[] = [
   {
     id: "chat.tab.close",
     scope: "workspace",
-    // Direct-only (owner call 2026-07-11), same as chat.tab.new.
+    // Direct-only, same as chat.tab.new.
     keys: ["ctrl+w"],
     category: "Workspace",
     description: "Close chat tab",
@@ -129,12 +127,12 @@ export const CHAT_BINDINGS: readonly KobeBinding[] = [
     // The other half of ctrl+w on a task's LAST tab: that close leaves the
     // task with no tabs, and the pane it leaves behind (`EmptyWorkspacePane`)
     // has no TerminalTabs mounted — so every workspace chord is unreachable
-    // there and the placeholder's own copy named keys that did nothing.
+    // there.
     //
     // Plain `return` is safe in this scope precisely because that pane holds
     // no input and no tab: there is nothing else for Enter to mean while it
-    // is on screen, and the binding is gated on it being on screen. Owner
-    // sign-off 2026-08-31, see docs/design/keybinding-decisions.md.
+    // is on screen, and the binding is gated on it being on screen.
+    // See docs/design/keybinding-decisions.md.
     id: "workspace.reopenSession",
     scope: "workspace",
     keys: ["return"],
@@ -161,14 +159,13 @@ export const CHAT_BINDINGS: readonly KobeBinding[] = [
     // `ctrl+]` cycles forward, `ctrl+[` cycles backward — bracket
     // pair mirrors the sidebar's `[/]` view switcher and the files
     // pane's `[/]` tab cycler so the bracket-pair pattern is
-    // consistent across panes. The earlier `ctrl+tab` /
-    // `ctrl+shift+tab` chord is dropped: `tab` is the global
-    // pane-cycle (focus.next) and the ctrl-prefixed variant felt
-    // collision-prone.
+    // consistent across panes. `ctrl+tab` / `ctrl+shift+tab` stay
+    // deliberately unbound: `tab` is the global pane-cycle (focus.next)
+    // and the ctrl-prefixed variant is collision-prone.
     id: "chat.tab.cycle-next",
     scope: "workspace",
-    // Direct-only (owner call 2026-07-11): cycling is a repeated action —
-    // a two-stroke prefix per hop is unusable.
+    // Direct-only: cycling is a repeated action — a two-stroke prefix per
+    // hop is unusable.
     keys: ["ctrl+]"],
     category: "Workspace",
     description: "Next chat tab",
@@ -178,7 +175,7 @@ export const CHAT_BINDINGS: readonly KobeBinding[] = [
   {
     id: "chat.tab.cycle-prev",
     scope: "workspace",
-    // Direct-only (owner call 2026-07-11), same as cycle-next.
+    // Direct-only, same as cycle-next.
     keys: ["ctrl+["],
     category: "Workspace",
     description: "Previous chat tab",
@@ -186,7 +183,7 @@ export const CHAT_BINDINGS: readonly KobeBinding[] = [
     presentation: "onePress",
   },
   {
-    // Splits inside the active workspace tab (issue #16).
+    // Splits inside the active workspace tab.
     // Deliberately CONTENT-NEUTRAL ids (`workspace.split.*`, not
     // chat/terminal): the split tree (`workspace/split-core.ts`) is
     // generic over leaf content — terminals today, other surfaces
@@ -194,8 +191,8 @@ export const CHAT_BINDINGS: readonly KobeBinding[] = [
     // RIGHT; `ctrl+=` reads as horizontal strokes → new leaf BELOW.
     // Both need the kitty keyboard protocol (legacy terminals can't
     // encode ctrl+=; ctrl+\ would be SIGQUIT) — see docs/KEYBINDINGS.md.
-    // Direct-only (owner call 2026-07-22): back off the prefix, same
-    // reasoning as the tab-management rows and ctrl+e.
+    // Direct-only: no prefix stroke, same reasoning as the tab-management
+    // rows and ctrl+e.
     id: "workspace.split.right",
     scope: "workspace",
     keys: ["ctrl+\\"],
@@ -244,9 +241,9 @@ export const CHAT_BINDINGS: readonly KobeBinding[] = [
   },
   {
     // Same chord as chat.tab.rename, contextual like workspace.split.close:
-    // while SPLIT, F2 renames the ACTIVE LEAF (owner semantics 2026-07-06 —
-    // the tab is the "group", each leaf has its own name: rename wins over
-    // the default basename of what it runs); unsplit tabs fall through the
+    // while SPLIT, F2 renames the ACTIVE LEAF (the tab is the "group", each
+    // leaf has its own name: rename wins over the default basename of what
+    // it runs); unsplit tabs fall through the
     // LIFO stack to rename-tab.
     id: "workspace.split.rename",
     scope: "workspace",
@@ -256,7 +253,5 @@ export const CHAT_BINDINGS: readonly KobeBinding[] = [
     hint: { keys: "f2" },
     presentation: "onePress",
   },
-  // The Solid-era AskUserQuestion picker rows (`chat.question.*`) are gone:
-  // the React TUI never registered them, so they were F1 noise advertising
-  // keys that did nothing. The engine CLI owns its own question UI.
+  // No AskUserQuestion picker rows: the engine CLI owns its own question UI.
 ]

--- a/packages/kobe/src/tui/context/keybindings-files.ts
+++ b/packages/kobe/src/tui/context/keybindings-files.ts
@@ -82,7 +82,7 @@ export const FILES_BINDINGS: readonly KobeBinding[] = [
   },
   {
     // `d` → open the current file's read-only diff in a workspace content
-    // tab (a content swap, does not steal focus — KOB-25). Enter still opens
+    // tab (a content swap, does not steal focus). Enter still opens
     // the editable editor tab; this is the non-focus-stealing diff view.
     id: "files.diff",
     scope: "files",
@@ -113,11 +113,9 @@ export const FILES_BINDINGS: readonly KobeBinding[] = [
   },
   {
     // Ops-pane action on the Changes tab: sends the PR prompt into the
-    // engine pane. prefix+p / prefix+P, no direct chord (owner call
-    // 2026-07-18): the old files-scoped ctrl+p was unreachable from the
-    // sidebar (ctrl+p = project filter there) and from the terminal
-    // (passes through to the engine) — the owner's muscle memory went
-    // straight to the prefix route, which was unbound. shift+p rides
+    // engine pane. prefix+p / prefix+P, no direct chord: a files-scoped
+    // ctrl+p is unreachable from the sidebar (ctrl+p = project filter there)
+    // and from the terminal (passes through to the engine). shift+p rides
     // along because "PR" reads uppercase: the capital press lands too.
     // Registered by the workspace host (host-keybindings.ts), not the
     // FileTree pane, so it fires from any pane focus.
@@ -129,7 +127,7 @@ export const FILES_BINDINGS: readonly KobeBinding[] = [
     description: "Ask the agent to create a PR from the current task",
   },
   // ─── Diff review (read-only diff content tab) ─────────────────────────
-  // Owner sign-off 2026-07-27: plain letters, diff-tab-scoped raw bindings
+  // Plain letters, diff-tab-scoped raw bindings
   // (registered by preview-review.tsx like the preview's `o`), inert
   // everywhere else so they can't shadow input or embedded terminals.
   // Rows here are documentation-only (`keys: []`) so F1 lists them.

--- a/packages/kobe/src/tui/context/keybindings-sidebar.ts
+++ b/packages/kobe/src/tui/context/keybindings-sidebar.ts
@@ -40,11 +40,9 @@ export const SIDEBAR_BINDINGS: readonly KobeBinding[] = [
     hint: { keys: "enter" },
   },
   {
-    // Owner call 2026-08-01: the tree has NO fold — every level is always
-    // expanded — so `l` is "go in" rather than "unfold": it opens the row
-    // under the cursor, and on a tab row (the last level) that means
-    // entering that tab's chat. `space` rides along from the original
-    // proposal; `h` was released with the fold it used to drive.
+    // The tree has NO fold — every level is always expanded — so `l` is "go
+    // in" rather than "unfold": it opens the row under the cursor, and on a
+    // tab row (the last level) that means entering that tab's chat.
     id: "sidebar.tree.open",
     scope: "sidebar",
     keys: ["l", "space"],
@@ -54,8 +52,7 @@ export const SIDEBAR_BINDINGS: readonly KobeBinding[] = [
   },
   {
     // Slot pair [top, bottom]: slot 0 (g) arms/completes the gg
-    // double-tap, slot 1 (shift+g) jumps to the bottom. Previously a
-    // single "g" row with an evt.shift gate (un-rebindable).
+    // double-tap, slot 1 (shift+g) jumps to the bottom.
     id: "sidebar.goto",
     scope: "sidebar",
     keys: ["g", "shift+g"],
@@ -71,9 +68,9 @@ export const SIDEBAR_BINDINGS: readonly KobeBinding[] = [
     hint: { keys: "r" },
   },
   {
-    // Explicit shift+m chord (matchKey mints `shift+m` from Shift+M) —
-    // previously keys: ["m"] with an evt.shift gate in the handler, which
-    // made the id un-rebindable (FIXED_BINDING_IDS).
+    // Explicit shift+m chord (matchKey mints `shift+m` from Shift+M). An
+    // evt.shift gate in the handler instead would make the id un-rebindable
+    // (FIXED_BINDING_IDS).
     id: "sidebar.localMerge",
     scope: "sidebar",
     keys: ["shift+m"],
@@ -82,10 +79,10 @@ export const SIDEBAR_BINDINGS: readonly KobeBinding[] = [
     hint: { keys: "M" },
   },
   {
-    // Capital P pins / unpins a managed task — an explicit shift+p chord
-    // (previously keys: ["p"] + an evt.shift gate, which kept the id in
-    // FIXED_BINDING_IDS). A mistyped lowercase `p` matches nothing, so it
-    // can't churn the flag. Pinned managed tasks float to the top of the
+    // Capital P pins / unpins a managed task — an explicit shift+p chord; an
+    // evt.shift gate instead would keep the id in FIXED_BINDING_IDS. A
+    // mistyped lowercase `p` matches nothing, so it can't churn the flag.
+    // Pinned managed tasks float to the top of the
     // sidebar's flat list, just below the saved-repo "main" rows.
     // `kind: "main"` rows ignore the chord — they're implicitly pinned.
     id: "sidebar.pin",
@@ -95,9 +92,6 @@ export const SIDEBAR_BINDINGS: readonly KobeBinding[] = [
     description: "Pin / unpin task at top (Shift+P)",
     hint: { keys: "P" },
   },
-  // `sidebar.view` ([/]) and `sidebar.archive` (a) retired with the archived
-  // view (issue #75) — the sidebar shows only the working set now; both chords
-  // are free again.
   {
     id: "sidebar.sort",
     scope: "sidebar",

--- a/packages/kobe/src/tui/context/keybindings-table.ts
+++ b/packages/kobe/src/tui/context/keybindings-table.ts
@@ -69,7 +69,7 @@ import { FILES_BINDINGS } from "./keybindings-files.ts"
 import { INBOX_BINDINGS } from "./keybindings-inbox.ts"
 import { SIDEBAR_BINDINGS } from "./keybindings-sidebar.ts"
 
-/** Pane scopes used to gate where a binding is active. */
+/** Pane scopes that gate where a binding is active. */
 export type KobeBindingScope = "global" | "sidebar" | "workspace" | "files" | "inbox" | "terminal"
 
 /**
@@ -130,8 +130,8 @@ export const KobeKeymap: readonly KobeBinding[] = [
     // Sidebar-only — single letter `n`. While focused on the chat
     // composer / files / terminal, `n` is just a letter you type;
     // ctrl+q jumps back to the sidebar where `n` opens the new-task
-    // dialog. Avoids the muscle-memory-vs-typing collision the old
-    // global `ctrl+n` had.
+    // dialog. A global `ctrl+n` would hit the muscle-memory-vs-typing
+    // collision instead.
     id: "task.new",
     scope: "sidebar",
     keys: ["n"],
@@ -147,13 +147,12 @@ export const KobeKeymap: readonly KobeBinding[] = [
     category: "Global",
     description: "Open active Task directory in editor",
   },
-  // The PROPOSED `prefix+t` Scratch-shell chord was REJECTED (owner
-  // 2026-08-16): Scratch entry lives in the ctrl+e new-conversation
-  // dialog as a trailing choice instead; no chord until frequency proves
-  // one out. See docs/design/keybinding-decisions.md.
+  // No Scratch-shell chord: Scratch entry lives in the ctrl+e
+  // new-conversation dialog as a trailing choice instead; no chord until
+  // frequency proves one out. See docs/design/keybinding-decisions.md.
   {
-    // PROPOSED chord (owner picked prefix+m 2026-07-16): global entry into
-    // the sidebar's move mode — focuses the sidebar, highlights the current
+    // Global entry into the sidebar's move mode — focuses the sidebar,
+    // highlights the current
     // selection, then j/k reorders saved projects; enter/esc exits.
     id: "task.moveMode",
     scope: "global",
@@ -195,12 +194,9 @@ export const KobeKeymap: readonly KobeBinding[] = [
     hint: { keys: "x" },
   },
   {
-    // Prefix-only `prefix+c` (owner call 2026-07-29, demoting the bare
-    // sidebar `c` it shipped with): the kanban is a step-back-and-look
-    // surface, not a per-task verb, so it doesn't earn a direct sidebar
     // The three sidebar-rail pages take prefix+1/2/3, matching the rail's
-    // own top-to-bottom order (owner call 2026-08-01) — the sidebar is the
-    // legend, so there is no mnemonic to remember. They swap only the content
+    // own top-to-bottom order — the sidebar is the legend, so there is no
+    // mnemonic to remember. They swap only the content
     // pane, so the prefix stays live behind them and 1→2→3 hops directly
     // between pages without an esc.
     id: "kanban.open",
@@ -242,9 +238,9 @@ export const KobeKeymap: readonly KobeBinding[] = [
   },
   {
     // "Back to tasks" chord. Plain `q` (sidebar scope) actually quits;
-    // ctrl+q is THE escape hatch out of any pane (direct-only again —
-    // owner call 2026-07-11, same as the tab-management rows: too
-    // load-bearing for a two-stroke prefix). Scope stays "workspace"
+    // ctrl+q is THE escape hatch out of any pane (direct-only, same as the
+    // tab-management rows: too load-bearing for a two-stroke prefix).
+    // Scope stays "workspace"
     // for override validation.
     id: "focus.sidebar",
     scope: "workspace",
@@ -257,13 +253,11 @@ export const KobeKeymap: readonly KobeBinding[] = [
 
   // ─── Navigation ───────────────────────────────────────────────────────
   {
-    // Relative pane cycling replaces the old four-slot absolute
-    // ctrl/prefix+h/j/k/l map (owner call 2026-07-14). Keeping previous
+    // Relative pane cycling, not a four-slot absolute map. Keeping previous
     // and next as separate ids lets users rebind either direction without
-    // preserving a positional slot contract. Direct ctrl+h/j/k/l remain
+    // preserving a positional slot contract. Direct ctrl+h/j/k/l stay
     // available to the embedded engine. prefix+h/l, not j/k — the three
-    // panes sit side by side, so the chords read left/right (owner call
-    // 2026-07-17).
+    // panes sit side by side, so the chords read left/right.
     id: "focus.previous",
     scope: "global",
     keys: [],
@@ -273,11 +267,11 @@ export const KobeKeymap: readonly KobeBinding[] = [
   },
   {
     // Forward pane move — walks sidebar → workspace → files, clamped at
-    // the ends (cursor semantics, owner call 2026-07-25 — no wrap).
+    // the ends (cursor semantics — no wrap).
     // `f4` stays the direct alias and sits in RESERVED_GLOBAL_CHORDS
     // (panes/terminal/keys-pure.ts), so it fires identically from inside
     // the embedded terminal; prefix+l is the relative navigation form.
-    // NOT `tab` (tried 2026-07-06, cut same day): the cycle path always
+    // NOT `tab`: the cycle path always
     // lands on the workspace terminal, which must keep tab as shell /
     // engine completion — so tab-cycling both trapped there every lap AND
     // typed a literal \t into the engine composer on arrival. NOT
@@ -310,12 +304,11 @@ export const KobeKeymap: readonly KobeBinding[] = [
     presentation: "onePress",
   },
   {
-    // Zen toggle (issue #18, pure-tui shape) — hides the Files column;
-    // the sidebar's ☯ ZEN chip is the click-based exit affordance, this is
-    // the keyboard one. Prefix-only `prefix+z` (owner call 2026-07-17,
-    // dropping the old f6 direct chord entirely — f6 now passes through
-    // to the embedded shell). Reachable from the terminal pane too since
-    // 2026-08-10: the prefix first stroke no longer passes through.
+    // Zen toggle — hides the Files column; the sidebar's ☯ ZEN chip is the
+    // click-based exit affordance, this is the keyboard one. Prefix-only
+    // `prefix+z`; f6 carries no chord and passes through to the embedded
+    // shell. Reachable from the terminal pane too, because the prefix first
+    // stroke does not pass through.
     id: "workspace.zenToggle",
     scope: "global",
     keys: [],
@@ -325,9 +318,9 @@ export const KobeKeymap: readonly KobeBinding[] = [
   },
   {
     // Doc-only: the chord is registered inline in Chat.tsx (gated on
-    // focused + streaming + no dialog). ESC no longer "detaches" focus
-    // back to the sidebar — that pulled focus out from under the user
-    // mid-edit. Use `ctrl+q` (`focus.sidebar`) for the explicit detach;
+    // focused + streaming + no dialog). ESC does NOT "detach" focus back to
+    // the sidebar — that would pull focus out from under the user mid-edit.
+    // Use `ctrl+q` (`focus.sidebar`) for the explicit detach;
     // ESC in chat is reserved for interrupting the current turn.
     id: "chat.interrupt",
     scope: "workspace",

--- a/packages/kobe/src/tui/context/theme-core.ts
+++ b/packages/kobe/src/tui/context/theme-core.ts
@@ -1,7 +1,6 @@
 /**
  * Framework-free theme core behind the React provider
- * (`src/tui-react/context/theme.tsx`). Extracted during the React
- * migration (issue #15, G2): JSON shape types, hex/def-ref/variant
+ * (`src/tui-react/context/theme.tsx`). JSON shape types, hex/def-ref/variant
  * resolution, and the display-time overlay (focus-accent slot +
  * transparent-background policy) all live here so the provider and
  * off-render consumers (`tui/lib/persisted-ui-prefs.ts`, tests) cannot

--- a/packages/kobe/src/tui/i18n/lookup.ts
+++ b/packages/kobe/src/tui/i18n/lookup.ts
@@ -1,8 +1,7 @@
 /**
  * Framework-free catalog lookup + interpolation behind the i18n runtime
- * (`./index.ts`, which `src/tui-react/i18n/index.ts` subscribes to).
- * Extracted during the React migration (issue #15, G2) so the resolution
- * rules live in exactly one place.
+ * (`./index.ts`, which `src/tui-react/i18n/index.ts` subscribes to), so the
+ * resolution rules live in exactly one place.
  */
 
 import type { Messages } from "./catalog"

--- a/packages/kobe/src/tui/i18n/messages/common.ts
+++ b/packages/kobe/src/tui/i18n/messages/common.ts
@@ -10,8 +10,8 @@ export const en = {
   /** Footer verb for a step that leads to another prompt. */
   create: "create",
   confirm: "Confirm",
-  /** Fallback shown when a pane's render tree throws, replacing the raw
-   *  shell the process used to drop to. */
+  /** Fallback shown when a pane's render tree throws, instead of dropping
+   *  the process to a raw shell. */
   paneCrash: {
     title: "This pane crashed",
     hint: "Reload it from the Tasks pane (the error was logged to client.log).",

--- a/packages/kobe/src/tui/i18n/messages/newTask.ts
+++ b/packages/kobe/src/tui/i18n/messages/newTask.ts
@@ -22,11 +22,11 @@ export const en = {
     folderName: "FOLDER NAME",
     baseBranch: "BASE BRANCH",
     adoptFilter: "FILTER (PATH GLOB)",
-    /** Existing tab: task vs project (issue #90) — only for a repo with a main row. */
+    /** Existing tab: task vs project — only for a repo with a main row. */
     opens: "OPENS",
   },
 
-  /** Existing-tab intent labels (issue #90). */
+  /** Existing-tab intent labels. */
   intent: {
     task: "a new task worktree",
     project: "the project itself",
@@ -51,7 +51,7 @@ export const en = {
     moreBelow: "↓ {count} more",
   },
 
-  /** "Open the project" failures (issue #90). {error} is the daemon's message. */
+  /** "Open the project" failures. {error} is the daemon's message. */
   open: {
     failed: "Couldn't open the project: {error}",
   },
@@ -113,11 +113,11 @@ export const zh: typeof en = {
     folderName: "文件夹名",
     baseBranch: "基准分支",
     adoptFilter: "过滤（路径 glob）",
-    /** Existing tab: task vs project (issue #90) — only for a repo with a main row. */
+    /** Existing tab: task vs project — only for a repo with a main row. */
     opens: "打开",
   },
 
-  /** Existing-tab intent labels (issue #90). */
+  /** Existing-tab intent labels. */
   intent: {
     task: "新建任务 worktree",
     project: "项目本身",
@@ -142,7 +142,7 @@ export const zh: typeof en = {
     moreBelow: "↓ 还有 {count} 项",
   },
 
-  /** "Open the project" failures (issue #90). {error} is the daemon's message. */
+  /** "Open the project" failures. {error} is the daemon's message. */
   open: {
     failed: "无法打开项目：{error}",
   },

--- a/packages/kobe/src/tui/i18n/messages/tasks.ts
+++ b/packages/kobe/src/tui/i18n/messages/tasks.ts
@@ -101,7 +101,7 @@ export const en = {
   moveChip: " move",
   /** Narrow mode's top-of-sidebar jump row back into the last-entered task */
   recentJump: "Recent: {title}",
-  /** The fold row standing in for a project's routine sessions (issue #91) */
+  /** The fold row standing in for a project's routine sessions */
   routinesRow: "{count} routine sessions",
   /** Empty-state messages */
   empty: {

--- a/packages/kobe/src/tui/i18n/messages/terminal.ts
+++ b/packages/kobe/src/tui/i18n/messages/terminal.ts
@@ -1,5 +1,5 @@
 /**
- * `terminal.*` messages — the embedded terminal pane (issue #16): the
+ * `terminal.*` messages — the embedded terminal pane: the
  * in-process PTY running the task's engine CLI (or a plain worktree
  * shell). English is the source of truth; `zh: typeof en` locks shapes.
  */
@@ -17,7 +17,7 @@ export const en = {
     renameField: "TAB TITLE",
     renameSubmit: "rename",
     chooseEngineHint: "←/→ or h/l choose, enter confirm, esc cancel",
-    // Unified new-conversation dialog (issue #7): the ctrl+e picker plus
+    // Unified new-conversation dialog: the ctrl+e picker plus
     // two footer toggles — tab flips the destination, ctrl+f the context.
     newChat: {
       title: "New conversation",

--- a/packages/kobe/src/tui/i18n/messages/update.ts
+++ b/packages/kobe/src/tui/i18n/messages/update.ts
@@ -9,8 +9,8 @@ export const en = {
   chip: "↑ {version}",
   current: "current",
   latest: "latest",
-  /** The registry check failed (offline, npm down, timeout). Distinct from
-   *  "you are up to date" — those two used to render identically. */
+  /** The registry check failed (offline, npm down, timeout). Must stay
+   *  distinct from "you are up to date". */
   latestUnknown: "unknown — could not reach the registry",
   releaseUrlUnavailable: "release URL unavailable",
   statusReleaseOpened: "Opened release page in your browser.",

--- a/packages/kobe/src/tui/i18n/messages/workspace.ts
+++ b/packages/kobe/src/tui/i18n/messages/workspace.ts
@@ -58,7 +58,7 @@ export const en = {
       running: "running",
       /** A dead engine PROCESS (pty exit record), not a failed turn. */
       dead: "engine exited",
-      /** A peer/API message accepted by the daemon but not yet pasted (issue #78). */
+      /** A peer/API message accepted by the daemon but not yet pasted. */
       promptDeferred: "message queued",
     },
     /** Rate-limited card's context line: when the armed auto-resume fires.
@@ -118,7 +118,7 @@ export const zh: typeof en = {
       rateLimited: "限流",
       running: "进行中",
       dead: "引擎已退出",
-      /** peer/API 消息已被 daemon 受理但尚未插入（issue #78）。 */
+      /** peer/API 消息已被 daemon 受理但尚未插入。 */
       promptDeferred: "消息已排队",
     },
     resumesAt: "{time} 恢复",

--- a/packages/kobe/src/tui/index.tsx
+++ b/packages/kobe/src/tui/index.tsx
@@ -1,10 +1,8 @@
 /**
  * kobe TUI bootstrap.
  *
- * Thin entry point: plain `kobe` starts the Workspace Host. The opentui outer monitor (`app.tsx`) and its
- * `KOBE_OUTER_MONITOR` / `KOBE_NO_DAEMON` escape hatches were retired —
- * see docs/design/app-retirement.md. Daemon recovery is `kobe daemon
- * restart`, not a daemon-less in-process Orchestrator.
+ * Thin entry point: plain `kobe` starts the Workspace Host. Daemon recovery
+ * is `kobe daemon restart`, not a daemon-less in-process Orchestrator.
  */
 
 import { ensureGlobalKobeHooks } from "../cli/hook-cmd.ts"
@@ -27,7 +25,6 @@ export async function startTui(): Promise<void> {
   // out of date. Best-effort — the reliable check is `kobe skill status`.
   await maybeHintSkillInstall()
 
-  // Hook installation used to live in the retired direct-tmux bootstrap.
   // Finish the idempotent local settings merge before the Workspace Host can
   // launch an engine, so its first activity events are observable too.
   await ensureGlobalKobeHooks()

--- a/packages/kobe/src/tui/lib/background-poll.ts
+++ b/packages/kobe/src/tui/lib/background-poll.ts
@@ -12,7 +12,7 @@
  * fire-and-forget — while `read(key)` stays a cheap reactive signal read.
  *
  * One poller instance owns a module-level entry map: per key (a repo /
- * worktree path), a Solid signal holding the last good value plus
+ * worktree path), a value cell holding the last good value plus
  * scheduling state. Three guards keep the child-process budget sane:
  *
  *   - **in-flight dedupe** — one run per key at a time; ticks that land
@@ -27,10 +27,10 @@
  * The guards themselves (the pure scheduling math + the abort/timeout run
  * wrapper + `spawnCapture`) live in the dependency-free
  * `src/lib/poll-scheduling.ts`, shared with the DAEMON's worktree-changes
- * collector (issue #6) — this module holds a per-key value cell that `poll`
+ * collector — this module holds a per-key value cell that `poll`
  * writes and `read` returns. Callers (the React panes) read imperatively on
  * their own render cadence; the re-exports below keep this module's public
- * API exactly what it was before the extraction.
+ * API stable for them.
  *
  * Failure contract: a run that throws, is aborted, or resolves after the
  * timeout never writes — `read` keeps returning the last good value (or

--- a/packages/kobe/src/tui/lib/event-loop-stall.ts
+++ b/packages/kobe/src/tui/lib/event-loop-stall.ts
@@ -1,8 +1,8 @@
 /**
- * Event-loop stall telemetry (incident 2026-07-07/08): when the TUI
- * "freezes" we could never tell after the fact whether the event loop was
- * blocked by JS (a kobe bug — sample would show the stack) or the whole
- * process was paged out under memory pressure (an OS-level stall — nothing
+ * Event-loop stall telemetry: when the TUI "freezes", nothing after the
+ * fact distinguishes an event loop blocked by JS (a kobe bug — `sample`
+ * would show the stack) from the whole
+ * process being paged out under memory pressure (an OS-level stall — nothing
  * in-process is at fault). A 1s heartbeat measures wall-clock drift; when a
  * beat arrives far later than scheduled, the gap IS the stall, and the log
  * line carries heap numbers so the next freeze report starts with ground

--- a/packages/kobe/src/tui/lib/git-snapshot.ts
+++ b/packages/kobe/src/tui/lib/git-snapshot.ts
@@ -56,9 +56,10 @@ function notAGitRepoReason(path: string): string {
 
 /**
  * `git` itself is missing from PATH. Distinct from {@link notAGitRepoReason}
- * because `spawnSync` reports BOTH as a non-zero `status` — the ENOENT case
- * used to fall through and tell the user to run `git init && git add -A &&
- * git commit`, three commands that would each also be `command not found`.
+ * because `spawnSync` reports BOTH as a non-zero `status` — without this the
+ * ENOENT case falls through and tells the user to run `git init && git add
+ * -A && git commit`, three commands that would each also be `command not
+ * found`.
  * Same wording as the WelcomePane's own (correct) probe so one machine can't
  * show two contradictory diagnoses.
  */

--- a/packages/kobe/src/tui/lib/help-groups.ts
+++ b/packages/kobe/src/tui/lib/help-groups.ts
@@ -1,5 +1,5 @@
 /**
- * Framework-free keymap DISPLAY seam (issue #15, G3): grouping for the help
+ * Framework-free keymap DISPLAY seam: grouping for the help
  * dialog plus the chord-cap resolution the Tasks-pane footer legend and the
  * help dialog share. `groupBindings` stays generic over the `category`
  * field; the cap helpers read the real keymap via `findBinding` (itself

--- a/packages/kobe/src/tui/lib/host-render-options.ts
+++ b/packages/kobe/src/tui/lib/host-render-options.ts
@@ -1,8 +1,8 @@
 /**
- * Framework-free host-boot pieces shared by the Solid pane host
- * (`./host-boot.tsx`) and the React one (`src/tui-react/lib/host-boot.tsx`,
- * issue #15 G3). Extracted so the render-option contract and the
- * exit-signal backstop cannot drift between the two boot paths.
+ * Framework-free host-boot pieces used by the pane host
+ * (`src/tui-react/lib/host-boot.tsx`), kept apart from it so the
+ * render-option contract and the exit-signal backstop cannot drift
+ * between boot paths.
  */
 
 /**
@@ -129,12 +129,11 @@ export function installPaneExitBackstop(): void {
 }
 
 /**
- * Orphan watchdog (issue #25) — the signal-FREE half of the leak defense.
+ * Orphan watchdog — the signal-FREE half of the leak defense.
  * The signal backstop above only fires when a signal actually arrives; when
- * the parent chain is SIGKILLed (2026-07-07: OOM killed the tmux server and
- * 41 pane hosts survived reparented to init, ~8.7GB RSS, which then fed the
- * next OOM), nothing is delivered and the host lives forever with a revoked
- * tty. A host's parent is always its tmux pane shell or the user's shell,
+ * the parent chain is SIGKILLed (an OOM kill takes the tmux server with it,
+ * reparenting every pane host to init), nothing is delivered and the host
+ * lives forever with a revoked tty, holding RSS that feeds the next OOM. A host's parent is always its tmux pane shell or the user's shell,
  * so PPID 1 can only mean "my pane/terminal is gone" — exit.
  *
  * Poll, don't listen: there is no parent-death event on macOS for an

--- a/packages/kobe/src/tui/lib/keybindings-starter.ts
+++ b/packages/kobe/src/tui/lib/keybindings-starter.ts
@@ -2,9 +2,8 @@
  * The starter `keybindings.yaml` Rove writes on request from Settings →
  * Keybindings.
  *
- * The section used to PRINT this example and leave the user to create the file
- * themselves — twelve dead lines on screen, a path that wrapped across two of
- * them, and a retyping job. The same text is worth more inside the file, where
+ * Rove writes the file rather than printing the example for the user to
+ * retype: the same text is worth more inside the file, where
  * it sits next to what you are actually writing.
  *
  * Everything is commented out, so creating the file cannot change behavior: an

--- a/packages/kobe/src/tui/lib/keymap-dispatch.ts
+++ b/packages/kobe/src/tui/lib/keymap-dispatch.ts
@@ -25,7 +25,7 @@ export type Binding = {
   key: string
   /** True when `key` is the second stroke of the PureTUI prefix. */
   prefix?: boolean
-  /** Terminal/shell input used to detect the PTY boundary. The configured prefix remains Kobe-owned. */
+  /** Terminal/shell input that marks the PTY boundary. The configured prefix remains Kobe-owned. */
   passthrough?: boolean
   /**
    * Owning KobeKeymap binding id (`tab.new`) — `bindByIds` fills it in so
@@ -94,9 +94,9 @@ export type RegisteredBinding = {
  * (LIFO, unchanged). A modal OWNER (barrier) is inserted BELOW the lowest
  * already-registered MEMBER of its scope, so members win over the barrier
  * and the barrier still cuts off everything older — regardless of whether
- * React committed the body's effects before or after the barrier's. This
- * is the explicit contract that used to be an effect-commit-order accident
- * (see tui-react/ui/dialog.tsx). O(n) only at mount/unmount, never on the
+ * React commits the body's effects before or after the barrier's. Making
+ * that ordering explicit here keeps it from being an effect-commit-order
+ * accident (see tui-react/ui/dialog.tsx). O(n) only at mount/unmount, never on the
  * per-keypress dispatch path.
  */
 export function insertRegistration(stack: RegisteredBinding[], reg: RegisteredBinding): void {
@@ -124,11 +124,11 @@ export function matchKey(evt: KeyEvent): string[] {
   if (name === "return") base.push("enter")
   if (name === "enter") base.push("return")
 
-  // Legacy C0 fallback (issue #192). Terminals without the kitty keyboard
+  // Legacy C0 fallback. Terminals without the kitty keyboard
   // protocol (macOS Terminal.app) send ctrl+h as raw 0x08 and ctrl+j as raw
   // 0x0a, which opentui's legacy parser surfaces as {name:"backspace"} /
   // {name:"linefeed"} with ctrl=false — so `ctrl+h`/`ctrl+j` chords (pane
-  // focus) were dead there while ctrl+k/ctrl+l (0x0b/0x0c) worked. Alias the
+  // focus) would be dead there while ctrl+k/ctrl+l (0x0b/0x0c) work. Alias the
   // two ambiguous bytes back to their chord names. The real Backspace key
   // sends 0x7f, so it never aliases; a terminal configured to "Backspace
   // sends ^H" trades deletion for pane focus, same as kitty-mode terminals.

--- a/packages/kobe/src/tui/lib/keymap-overrides.ts
+++ b/packages/kobe/src/tui/lib/keymap-overrides.ts
@@ -50,7 +50,7 @@ export type AppliedOverride = {
 /**
  * Ids whose event-shape or handler contract cannot be expressed by a rebind.
  * The four diff-review chords are raw literal bindings registered by
- * preview-review.tsx (owner sign-off 2026-07-27: fixed, docs/KEYBINDINGS.md
+ * preview-review.tsx (fixed bindings, docs/KEYBINDINGS.md
  * "Diff review") — the table rows exist so F1 lists them, but no handler
  * reads the keymap, so an override would apply cleanly and change nothing.
  * `applyKeymapOverrides` rejects any id listed here, and Settings →

--- a/packages/kobe/src/tui/lib/notify-state.ts
+++ b/packages/kobe/src/tui/lib/notify-state.ts
@@ -1,8 +1,7 @@
 /**
- * Framework-free notification state (issue #15, G3) — the pure map
+ * Framework-free notification state — the pure map
  * transforms + gating rules behind the per-ChatTab completion
- * notifications, shared by the Solid provider
- * (`src/tui/context/notifications.tsx`) and the React port
+ * notifications, consumed by the notification provider
  * (`src/tui-react/context/notifications.tsx`). Keeping the escalation
  * rule ("needs_input / error outrank done") and the "error toasts always
  * show" invariant in one place means both runtimes can't drift.
@@ -103,8 +102,8 @@ export function attentionKindFor(state: string): NotificationKind | null {
  */
 export function chipAttentionKind(turn: string): NotificationKind | null {
   if (turn === "done") return "done"
-  // `rate_limited` and `dead` split out of the chip's `error` in 2026-08-30;
-  // they stay attention edges here, matching `attentionKindFor`'s task-level
+  // `rate_limited` and `dead` are separate from the chip's `error`, but all
+  // three are attention edges here, matching `attentionKindFor`'s task-level
   // rule. The chip vocabulary distinguishes them so the GLYPH can; a toast
   // has only the three kinds, and all three mean "something needs you".
   if (turn === "error" || turn === "rate_limited" || turn === "dead") return "error"

--- a/packages/kobe/src/tui/lib/persisted-ui-prefs.ts
+++ b/packages/kobe/src/tui/lib/persisted-ui-prefs.ts
@@ -4,7 +4,7 @@
  * A kobe subcommand that renders in a tmux pane (the Ops pane today,
  * a full-width preview window soon) wants to match the outer app's
  * look: same theme, transparent-bg toggle, focus accent. It can't
- * share the outer TUI's Solid runtime (separate process), so it reads
+ * share the outer TUI's runtime (separate process), so it reads
  * the persisted prefs off disk instead.
  *
  * READ-ONLY by contract: the outer app owns `state.json`; a pane
@@ -49,7 +49,7 @@ export function readPersistedUiPrefs(
     const parsed = JSON.parse(readFileSync(kvStatePath(), "utf8")) as Record<string, unknown>
     const theme =
       typeof parsed.activeTheme === "string" && isKnownTheme(parsed.activeTheme) ? parsed.activeTheme : fallbackTheme
-    // Default-true (2026-07-12): only an explicit stored `false` opts out.
+    // Default-true: only an explicit stored `false` opts out.
     const transparent = parsed.transparentBackground !== false
     const focusAccent =
       typeof parsed.focusAccent === "string" && (FOCUS_ACCENT_SLOTS as readonly string[]).includes(parsed.focusAccent)

--- a/packages/kobe/src/tui/lib/prefix-hud.ts
+++ b/packages/kobe/src/tui/lib/prefix-hud.ts
@@ -12,7 +12,7 @@ import { type ReadableState, createStateCell } from "../../lib/external-store"
 /** How long a resolved line stays visible before the overlay flushes it. */
 export const PREFIX_HUD_TTL_MS = 4000
 
-/** Fast users finish before this; learners then get the complete command map. */
+/** Fast users finish inside this window; learners then get the complete command map. */
 export const PREFIX_GUIDE_DELAY_MS = 180
 
 const MAX_ENTRIES = 3

--- a/packages/kobe/src/tui/lib/task-actions.ts
+++ b/packages/kobe/src/tui/lib/task-actions.ts
@@ -1,9 +1,6 @@
 /**
- * Shared task-action flows — the ONE implementation behind the hosts
- * that expose task mutations. Today that's the in-session Tasks pane
- * (`tui/tasks-pane/host.tsx`); the deprecated outer monitor (`app.tsx`)
- * was the second host until its retirement (docs/design/app-retirement.md)
- * — consolidating here is what made that a pure deletion, not a port.
+ * Shared task-action flows — the ONE implementation behind every host
+ * that exposes task mutations.
  * Host differences are an explicit option or hook on {@link TaskActionContext},
  * never a second copy.
  *
@@ -137,10 +134,10 @@ async function stopHostedTask(taskId: string, logger: TaskActionLogger, logPrefi
 /**
  * True when `taskId` is the CURRENTLY active task, so delete should hand the
  * shared active-task focus to the next task. Deleting a BACKGROUND task must
- * not steal focus from whatever is active — the old unconditional
- * `setActiveTask(nextTask)` did exactly that (bug #6). Both real orchestrators
+ * not steal focus from whatever is active — an unconditional
+ * `setActiveTask(nextTask)` would do exactly that. Both real orchestrators
  * expose `activeTaskSignal()`; when it's absent (a bare test mock) we fall back
- * to `true` to preserve the pre-guard behavior rather than throw — real usage
+ * to `true` rather than throw — real usage
  * always resolves the active id and gets the guard.
  */
 function removedTaskIsActive(orch: KobeOrchestrator, taskId: string): boolean {
@@ -182,7 +179,7 @@ export async function deleteTaskFlow(ctx: TaskActionContext, taskId: string): Pr
   if (!task) return
   // A "project" row is a synthetic `kind: "main"` task projecting a saved
   // repo. It has no worktree of its own to destroy, and `deleteTask` refuses
-  // it (CannotDeleteMainTaskError) — pressing `d` on it used to just error.
+  // it (CannotDeleteMainTaskError), so `d` on it would just error.
   // Route it to forget-project instead: un-save the repo + drop the main row,
   // leaving the repo and any real tasks under it on disk.
   if (task.kind === "main") {
@@ -305,7 +302,7 @@ export async function renameBranchFlow(ctx: TaskActionContext, taskId: string): 
 /**
  * Cycle the task's engine vendor via `task.setVendor`.
  * Takes effect on the task's next enter: `ensureSession` rebuilds a session
- * whose `@kobe_vendor` tag no longer matches, launching the new engine.
+ * whose `@kobe_vendor` tag does not match, launching the new engine.
  *
  * Cycle over the SAME detected-built-ins + custom set the new-task dialog
  * offers (`availableEngineIds()` + `nextVendorWithin`), not the built-ins
@@ -316,9 +313,9 @@ export async function renameBranchFlow(ctx: TaskActionContext, taskId: string): 
 /**
  * Persist a task's engine and say so — the shared half of the two routes that
  * switch engines (`v` on a row, and the ctrl+e picker's "new tab in this
- * worktree"). Both need the same two toasts: the picker used to have neither,
- * so a rejected `setVendor` left a tab rendered under the NEW engine's label
- * while the task kept the old one — success and failure looked identical.
+ * worktree"). Both need the same two toasts: without them a rejected
+ * `setVendor` leaves a tab rendered under the NEW engine's label
+ * while the task keeps the previous one — success and failure look identical.
  *
  * Returns whether the write landed, so a caller can undo its optimistic UI.
  */
@@ -353,7 +350,7 @@ export async function applyVendorChange(
   }
   // Only for a change with nothing on screen to show it: the new vendor takes
   // effect on the task's NEXT enter (ensureSession rebuilds the pane when its
-  // `@kobe_vendor` tag no longer matches), so `v` on a row otherwise looks
+  // `@kobe_vendor` tag does not match), so `v` on a row otherwise looks
   // like a no-op.
   if (!opts.silentSuccess) ctx.notifyInfo?.(`Engine → ${engineDisplayName(next)} (applies on reopen)`)
   return true

--- a/packages/kobe/src/tui/lib/task-create-flow.ts
+++ b/packages/kobe/src/tui/lib/task-create-flow.ts
@@ -85,7 +85,7 @@ export async function createTaskFlow(ctx: CreateTaskContext): Promise<void> {
   const defaultRepo = ctx.cursorRepo() ?? repos[0] ?? process.cwd()
   const defaultVendor = ctx.lastVendor(defaultRepo) ?? DEFAULT_TASK_VENDOR
   const availableVendors = await availableEngineIds()
-  // First-run guard (#24): no built-in engine detected AND no custom engine
+  // First-run guard: no built-in engine detected AND no custom engine
   // configured. The dialog would still let the user pick a vendor, then the
   // missing binary surfaces only as a raw shell error inside the pane. Warn
   // up front but still allow proceeding (they may install it after picking).
@@ -98,7 +98,7 @@ export async function createTaskFlow(ctx: CreateTaskContext): Promise<void> {
     availableVendors,
     discoverAdoptable: orch ? (repo) => orch.discoverAdoptableWorktrees(repo) : undefined,
     // Which repos already own a project checkout — the Existing tab offers
-    // "open the project" only for these (issue #90). Read from the LIVE task
+    // "open the project" only for these. Read from the LIVE task
     // list rather than savedRepos: a saved repo with no main row has no
     // project to open, and the difference is exactly what the choice turns on.
     mainRepos: mainRepoSet(ctx.tasks()),
@@ -118,11 +118,11 @@ export async function createTaskFlow(ctx: CreateTaskContext): Promise<void> {
     ctx.notifyError?.(t("tasks.toast.noDaemonWorktree"))
     return
   }
-  // "Open the project" (issue #90) — the repo's OWN checkout, not a worktree
+  // "Open the project" — the repo's OWN checkout, not a worktree
   // branched off it. `ensureMainTask` is idempotent, so this both REVIVES a
-  // project the sidebar hid (its main row and savedRepos entry never went
-  // away — only the row did) and creates the row for a saved repo that has
-  // none yet. Deliberately ahead of the "Creating task…" toast: nothing is
+  // project the sidebar hid (its main task and savedRepos entry are both
+  // still there — only the row is hidden) and creates the row for a saved
+  // repo that has none yet. Deliberately ahead of the "Creating task…" toast: nothing is
   // being created, and claiming otherwise for what is really a navigation
   // would misreport the one path whose whole point is that it adds nothing.
   if (result.mode === "open") {

--- a/packages/kobe/src/tui/ops/activity-poll.ts
+++ b/packages/kobe/src/tui/ops/activity-poll.ts
@@ -3,7 +3,7 @@
  * into a standalone module because `host.tsx` imports `@opentui/*` render
  * assets (a `.scm` grammar file) that vitest can't load — so the backoff
  * curves live here, where they're directly unit-testable, and `host.tsx`
- * imports them. No IO, no Solid, no tmux: just numbers.
+ * imports them. No IO, no framework, no tmux: just numbers.
  */
 
 import type { ChatTabTurnState } from "@/engine/turn-detector"
@@ -40,7 +40,7 @@ export function nextActivityPollDelay(currentMs: number, idleStreak: number): nu
 
 /**
  * Next turn-status (capture-pane) poll delay in SHARED mode (the daemon
- * publishes transcript activity, so completion no longer comes from a local
+ * publishes transcript activity, so completion does not come from a local
  * JSONL read — only the tmux pane-quiescence hash does). Sibling of
  * {@link nextActivityPollDelay}.
  *

--- a/packages/kobe/src/tui/ops/pr-prompt.ts
+++ b/packages/kobe/src/tui/ops/pr-prompt.ts
@@ -32,7 +32,7 @@ Follow these steps to create a PR:
 If any of these steps fail, ask the user for help.`
 
 // Async spawn — `git status` is O(repo size), and this runs on the Ops
-// pane's render process. On a huge repo the old spawnSync blocked the
+// pane's render process. On a huge repo a spawnSync would block the
 // pane until the timeout; the async child costs nothing on the event
 // loop. Same timeout, SIGKILLed via AbortSignal.
 async function git(cwd: string, args: readonly string[]): Promise<string | null> {

--- a/packages/kobe/src/tui/ops/preview-syntax.ts
+++ b/packages/kobe/src/tui/ops/preview-syntax.ts
@@ -1,7 +1,6 @@
 /**
  * Theme → tree-sitter SyntaxStyle mapping for the ops preview window,
- * extracted from `tui/ops/host.tsx` and shared by the Solid and React
- * previews (issue #15, G3). Kept apart from `./preview-core` because it
+ * shared by the previews. Kept apart from `./preview-core` because it
  * imports `@opentui/core`, which vitest can't load.
  */
 

--- a/packages/kobe/src/tui/panes/filetree/keys-core.ts
+++ b/packages/kobe/src/tui/panes/filetree/keys-core.ts
@@ -1,10 +1,9 @@
 /**
  * Framework-free core of the file tree pane's key bindings — the tab
- * vocabulary plus the id → controller-action map that both the Solid hook
- * (`keys.ts`) and the React pane (`src/tui-react/panes/filetree/`) register
- * through their respective `useBindings` layers. Extracted from `keys.ts`
- * (issue #15, G3) so the slot-multiplexed dispatch — the property that makes
- * these chords user-rebindable — is single-sourced across both runtimes.
+ * vocabulary plus the id → controller-action map that the pane
+ * (`src/tui-react/panes/filetree/`) registers through its `useBindings`
+ * layer. Kept out of the component so the slot-multiplexed dispatch — the
+ * property that makes these chords user-rebindable — is single-sourced.
  *
  * `bindByIds` itself is framework-free (the React keybindings context
  * re-exports it from the same module), so the full `Binding[]` construction
@@ -33,7 +32,7 @@ export function tabLabelKey(tab: FileTreeTab): string {
 }
 
 /**
- * The controller surface the bindings drive. Plain thunks — a Solid
+ * The controller surface the bindings drive. Plain thunks — a
  * `Accessor` satisfies `currentTab` structurally, React passes closures
  * over the latest render (its `useBindings` re-reads config per keypress).
  */
@@ -64,7 +63,7 @@ export type FileTreeController = {
    *  scope. No-op on the All tab. */
   toggleScope?: () => void
   /** `d` — open the current file's read-only diff in a workspace content tab
-   *  (content swap, does not steal focus per KOB-25). */
+   *  (content swap, does not steal focus). */
   openDiff?: () => void
 }
 

--- a/packages/kobe/src/tui/panes/filetree/pane-core.ts
+++ b/packages/kobe/src/tui/panes/filetree/pane-core.ts
@@ -1,10 +1,9 @@
 /**
- * Framework-free pane logic for the file tree — extracted from the Solid
- * `FileTree.tsx` (issue #15, G3) so the React port shares the exact same
- * behavior instead of duplicating it. Everything here is pure functions
+ * Framework-free pane logic for the file tree, kept out of `FileTree.tsx`
+ * so every consumer shares the exact same behavior instead of duplicating
+ * it. Everything here is pure functions
  * over the `Row` model (plus one node-only fs.watch helper), unit-tested
- * in `test/tui-react/filetree-pane-core.test.ts`; the Solid component
- * keeps consuming these so the two runtimes cannot drift.
+ * in `test/tui-react/filetree-pane-core.test.ts`.
  */
 
 import { watch } from "node:fs"
@@ -41,7 +40,7 @@ export function statusToken(s: FileStatus): "warning" | "success" | "error" | "t
  * like `git ls-files ... (cwd=/foo) exited with code 128: fatal: not
  * a git repository`. Most users don't need the full args / exit
  * code; we surface the common cases and keep the rest generic.
- * `t` is the caller's translate fn — Solid and React each pass their
+ * `t` is the caller's translate fn — each caller passes its
  * own reactive one.
  */
 export function summarizeGitError(raw: string, t: (key: string) => string): string {
@@ -187,7 +186,7 @@ type EventedWatcher = ReturnType<typeof watch> & { on(event: "error", listener: 
  * recursive watcher can overwhelm the TUI process before the user does
  * anything.
  *
- * Known window, deliberately NOT closed (issue #61): macOS FSEvents arms
+ * Known window, deliberately NOT closed: macOS FSEvents arms
  * asynchronously, so a write landing right after this call may be dropped
  * before the stream is live. The daemon's single-file watchers close that
  * with a stat-poll, but stat-polling a whole worktree is disproportionate

--- a/packages/kobe/src/tui/panes/filetree/rows.ts
+++ b/packages/kobe/src/tui/panes/filetree/rows.ts
@@ -5,15 +5,15 @@
  *
  * The load-bearing export is {@link reconcileRows}: the Ops pane's
  * fs-watch refresh re-fetches `git ls-files` / `git status` and rebuilds
- * the row list from scratch, so every refresh used to produce ALL-NEW row
- * objects. Solid's `<For>` keys by object identity, which meant each
- * refresh destroyed and recreated every row's opentui renderables —
+ * the row list from scratch, so every refresh produces ALL-NEW row
+ * objects. List rendering keys by object identity, so each
+ * refresh would destroy and recreate every row's opentui renderables —
  * and @opentui/core 0.2.4 retains a small amount of native memory per
  * renderable create/destroy cycle (~300B; JS heap stays flat while RSS
  * climbs). A busy engine worktree refreshes thousands of times a day,
- * which is exactly the multi-GB Ops-pane growth observed in production.
+ * which is enough for multi-GB Ops-pane growth.
  * Reconciling by row key keeps the previous object whenever its fields
- * are unchanged, so `<For>` reuses the existing renderables and the
+ * are unchanged, so the list reuses the existing renderables and the
  * native churn drops to "rows that actually changed".
  */
 

--- a/packages/kobe/src/tui/panes/sidebar/git-head.ts
+++ b/packages/kobe/src/tui/panes/sidebar/git-head.ts
@@ -44,12 +44,12 @@ export const BRANCH_MIN_POLL_INTERVAL_MS = 1_500
  * a pure function of HEAD's content — a checkout rewrites the file, a
  * commit on a branch does not — so when HEAD's mtime+size haven't moved
  * since the last successful resolve, the cached name is returned without
- * spawning git at all. Before this gate, every visible project row cost
+ * spawning git at all. Without the gate every visible project row costs
  * one `git symbolic-ref` spawn per ~2s tick forever (5 projects ≈ 150
- * spawns/min steady-state, daemon-connected or not); now the steady state
- * is one ~µs `stat` per row per tick, with a spawn only on an actual HEAD
- * change. Repos where `.git/HEAD` isn't statable (a linked-worktree `.git`
- * FILE, permissions) skip the gate and keep the old always-spawn path.
+ * spawns/min steady-state, daemon-connected or not); with it the steady
+ * state is one ~µs `stat` per row per tick, with a spawn only on an actual
+ * HEAD change. Repos where `.git/HEAD` isn't statable (a linked-worktree
+ * `.git` FILE, permissions) skip the gate and always spawn.
  */
 const headCache = new Map<string, { fingerprint: string; value: string }>()
 

--- a/packages/kobe/src/tui/panes/sidebar/groups.ts
+++ b/packages/kobe/src/tui/panes/sidebar/groups.ts
@@ -1,8 +1,7 @@
 /**
  * Pure list-shaping helpers for the sidebar pane.
  *
- * Wave 4.5 dropped repo grouping; the archive view was removed in issue #75.
- * The sidebar is now a flat list of task rows showing the working set only.
+ * The sidebar is a flat list of task rows showing the working set only.
  * Repo / branch / worktree metadata for the SELECTED task is shown in the
  * topbar instead — see `src/tui/component/topbar.tsx`.
  *
@@ -18,9 +17,9 @@
  * already emits all `main` rows before any task row, the renderer only needs
  * the index of the first non-main row to place the divider.
  *
- * No reactivity here: pure functions over `readonly Task[]`. The Solid
- * component (`Sidebar.tsx`) wraps these in `createMemo` so they recompute
- * only when the upstream task signal changes.
+ * No reactivity here: pure functions over `readonly Task[]`. The Sidebar
+ * component memoizes them so they recompute only when the upstream task
+ * list changes.
  */
 
 import { reconcileStableRows } from "@/tui/lib/stable-rows"
@@ -58,7 +57,7 @@ export type SidebarRowSections = {
  * → regular ordering so users filtering inside a long list still see the
  * same predictable shape.
  *
- * `projectFilter` scopes BOTH sections to the one repo (owner 2026-07-17):
+ * `projectFilter` scopes BOTH sections to the one repo:
  * the filter label lives on the PROJECTS header, so the PROJECTS list must
  * agree with it — main rows outside the filtered repo are hidden along with
  * their tasks.
@@ -72,7 +71,7 @@ export type SidebarRowSections = {
  * handles the empty-state placeholder separately; we don't emit a
  * synthetic header for that.
  *
- * Pure: no Solid, no opentui. Component code calls this inside a memo;
+ * Pure: no framework, no opentui. Component code calls this inside a memo;
  * tests call it directly.
  */
 export function buildRows(
@@ -101,7 +100,7 @@ export function buildRows(
     if (t.pinned === true) pinnedRegular.push(t)
     else regular.push(t)
   }
-  // Projects keep their STORED order (owner 2026-07-16): tasks.json order =
+  // Projects keep their STORED order: tasks.json order =
   // save order, so a newly-added repo lands at the end and the list never
   // reshuffles on its own. Manual reordering goes through move mode
   // (`moveTask` covers main rows within the projects partition). `recent`
@@ -146,7 +145,7 @@ function taskTime(task: Task): number {
  *
  * Exported for the Sidebar's row renderer — main tasks display this
  * as the title (instead of `task.title`, which is a stored copy that
- * could drift if the user renamed the directory). Pure / no Solid.
+ * could drift if the user renamed the directory). Pure / framework-free.
  */
 export function repoBasename(repo: string): string {
   const segments = repo.split("/").filter(Boolean)
@@ -205,9 +204,9 @@ export function cursorIndexForProjectScope(rows: readonly SidebarRow[], projectF
 
 /**
  * Where the cursor should sit after the external selection or the flat id list
- * changed — the single owner of the "follow selection / clamp into range" policy
- * the Sidebar's sync effect used to inline. Returns the TARGET index (may equal
- * `cursor`, i.e. leave it put). Pure, so the edge cases that kept biting —
+ * changed — the single owner of the "follow selection / clamp into range"
+ * policy. Returns the TARGET index (may equal
+ * `cursor`, i.e. leave it put). Pure, so the edge cases that keep biting —
  * selection cleared, selected task vanished from another surface and the list
  * shrank, cursor left dangling past a shortened list — are unit-tested instead
  * of hand-traced. `cursor` is the current index (-1 when unset).
@@ -292,9 +291,9 @@ export function sameSidebarRowTask(a: Task, b: Task): boolean {
  * Why: every daemon `task.snapshot` push deserializes ALL-new Task
  * objects, so `buildRows` produces all-new `SidebarRow` wrappers even
  * when nothing the row renders changed (the common case: a
- * `setActiveTask` recency touch echoing back). Solid's `<For>` keys by
- * object identity, so without reconciliation each push destroyed and
- * recreated every row's opentui renderables — and @opentui/core 0.2.4
+ * `setActiveTask` recency touch echoing back). List rendering keys by
+ * object identity, so without reconciliation each push destroys and
+ * recreates every row's opentui renderables — and @opentui/core 0.2.4
  * retains ~300B of native memory per renderable create/destroy cycle.
  * A Tasks pane lives for days in every tmux session; task switches
  * happen constantly; multiply and that's unbounded native growth

--- a/packages/kobe/src/tui/panes/sidebar/hover-layout.ts
+++ b/packages/kobe/src/tui/panes/sidebar/hover-layout.ts
@@ -1,12 +1,11 @@
 import { approxCellWidth } from "../../../lib/display-width"
 
-// Cell measurement moved to the shared width module; re-exported so
-// existing importers (tests, panes) keep compiling.
+// Cell measurement lives in the shared width module; re-exported here so
+// importers (tests, panes) reach it from one place.
 export { approxCellWidth }
 
-// The hover TOOLTIP itself was cut with the flat sidebar's row cards
-// (2026-08-30): nothing feeds a SidebarHover anymore and no renderer
-// consumed one. What survives here is the placement math, reused by the
+// There is no hover TOOLTIP: nothing feeds a SidebarHover and no renderer
+// consumes one. This module owns only the placement math, reused by the
 // right-click ContextMenu — same "a box of text lines pinned near the
 // pointer" problem.
 export const SIDEBAR_HOVER_TOOLTIP_Z_INDEX = 2750

--- a/packages/kobe/src/tui/panes/sidebar/mock-fixtures.ts
+++ b/packages/kobe/src/tui/panes/sidebar/mock-fixtures.ts
@@ -1,5 +1,5 @@
 /**
- * Shared mock task fixtures for the sidebar smoke hosts (issue #15, G3).
+ * Shared mock task fixtures for the sidebar smoke hosts.
  * Framework-free, so the React mock hosts (e.g.
  * `src/tui-react/panes/sidebar/mock-host.tsx`) can render the same
  * synthetic task list without a daemon, tasks.json, or real worktrees.

--- a/packages/kobe/src/tui/panes/sidebar/nav-core.ts
+++ b/packages/kobe/src/tui/panes/sidebar/nav-core.ts
@@ -8,7 +8,7 @@
  * which is how you end up with an Archives tab sitting next to a Kanban tab
  * as if they were the same kind of thing.
  *
- * Vertical, one per line (owner call 2026-08-01): the rail is 24 cells wide,
+ * Vertical, one per line: the rail is 24 cells wide,
  * so three horizontal chips would truncate the moment a fourth arrives.
  */
 

--- a/packages/kobe/src/tui/panes/sidebar/row-view.ts
+++ b/packages/kobe/src/tui/panes/sidebar/row-view.ts
@@ -15,9 +15,9 @@ export interface SidebarRowView {
   readonly subtitleText: string
   readonly loading: boolean
   /**
-   * The row's status glyph. ONE vocabulary for project and task rows (owner
-   * call 2026-07-30) — a project used to fall back to `★`, which read as a
-   * different kind of thing rather than a different state of the same thing.
+   * The row's status glyph. ONE vocabulary for project and task rows — a
+   * project-only glyph like `★` reads as a different kind of thing rather
+   * than a different state of the same thing.
    */
   readonly stateGlyph: string
   readonly tone: SidebarTone
@@ -40,12 +40,9 @@ export interface SidebarRowView {
  * materializing worktree, a still-writing transcript) — `loading` otherwise
  * paints every such row `primary`.
  *
- * It used to return a WORD too ("rate limited" / "needs permission" /
- * "error") that replaced the branch in the subtitle. The subtitle went away
- * with the two-line cards: the tree row (`tree-rows.tsx`) is one cell and
- * renders the glyph plus the tab label, nothing else. The words were computed
- * on every row build, asserted by tests, and read by nobody — so they are
- * gone, and the glyph carries the state alone. That is the whole reason the
+ * No WORD accompanies the tone: the tree row (`tree-rows.tsx`) is one cell
+ * and renders the glyph plus the tab label, nothing else, so the glyph
+ * carries the state alone. That is the whole reason the
  * glyphs must stay distinct (`◷` vs `×` vs `†`): with no subtitle there is no
  * second channel to disambiguate them.
  */
@@ -98,14 +95,15 @@ export function prCheckChip(task: Task): { glyph: string; tone: SidebarTone } | 
 
 /**
  * The dim dot every row wears when it has no state to report. Three cases
- * converge on it deliberately (2026-08-15): a custom engine with no
+ * converge on it deliberately: a custom engine with no
  * transcript store the monitor can watch (`monitor/activity.ts`), a
  * non-agent tab (shell / command / content), and a row the daemon has
- * simply not observed yet. A dotted `◌` used to carry that last case as its
- * own "unknown" state, but it told the reader nothing they could act on —
- * both "idle" and "unknown" mean open it to find out — and U+25CC is absent
- * from several popular terminal fonts, so it fell back to a CJK face at 1.62
- * cells and overlapped the label beside it. `·` is in every font at one cell.
+ * simply not observed yet. That last case gets no separate "unknown"
+ * glyph: it would tell the reader nothing they could act on —
+ * both "idle" and "unknown" mean open it to find out — and a dotted `◌`
+ * (U+25CC) is absent from several popular terminal fonts, so it falls back
+ * to a CJK face at 1.62 cells and overlaps the label beside it. `·` is in
+ * every font at one cell.
  *
  * Exported so the tab rows share the constant rather than re-declaring it.
  */
@@ -124,9 +122,9 @@ const ERROR_GLYPH = "×"
  * Dead-engine glyph — the engine PROCESS is gone (killed, or exited under a
  * wrapper), from the pty-host's exit record. `†` (U+2020 DAGGER), not a
  * variant of `×`: an errored engine RAN and reported a failed turn, a dead one
- * is no longer there, and only one of the two can be answered by restarting.
+ * is gone, and only one of the two can be answered by restarting.
  * General Punctuation, so every monospace font has it at exactly one cell —
- * the constraint that retired `◌` (U+25CC fell back oversized) and `✕`.
+ * the same constraint that rules out `◌` (U+25CC renders oversized) and `✕`.
  */
 const DEAD_GLYPH = "†"
 
@@ -307,12 +305,12 @@ export function buildSidebarRowView(opts: {
     job: opts.job,
     transcript: opts.transcript,
   })
-  // One frame set for every engine (see `spinner-frames.ts` for why the
-  // per-vendor field went away). It must stay visually distinct from the
+  // One frame set for every engine (see `spinner-frames.ts`). It must stay
+  // visually distinct from the
   // STATIC badge glyphs below (`●` unseen-complete, `○` idle, `·` no state):
   // a spinner that borrows a badge glyph makes a RUNNING row read as a
-  // finished one. That collision is why the reduced-motion `●`/`·` pulse was
-  // removed (2026-07-30).
+  // finished one — which is also what rules out a reduced-motion `●`/`·`
+  // pulse.
   const spinnerFrames = DEFAULT_SPINNER_FRAMES
   const spinner = spinnerFrames[opts.spinnerFrame % spinnerFrames.length] ?? spinnerFrames[0]
   const tone = deleteFailed
@@ -365,7 +363,7 @@ export function buildSidebarRowView(opts: {
 /**
  * Overlay the LIVE spinner frame onto a row view built with a fixed
  * `spinnerFrame: 0`. The frame is passed as an ACCESSOR and read only
- * when the row is actually loading — inside a Solid memo that makes the
+ * when the row is actually loading — inside a memo that makes the
  * 10Hz frame signal a conditional dependency, so an idle row never
  * re-derives on the spinner tick (with N tasks and nothing running, the
  * tick has zero subscribers — no row rebuilds its view 10×/s). For a loading row this
@@ -381,9 +379,9 @@ export function withSpinnerFrame(view: SidebarRowView, frame: () => number): Sid
 }
 
 /**
- * herdr-style status circles (2026-07-27, ? for blocked-on-user since 07-29):
+ * herdr-style status circles (`?` for blocked-on-user):
  * ● turn done (not yet viewed), ○ idle. `completionSeen` is the herdr "seen"
- * bit — and seen means CONSUMED (owner 2026-08-02): a completion you have
+ * bit — and seen means CONSUMED: a completion you have
  * already looked at is simply over, so the badge drops back to the idle
  * circle rather than lingering as a ✓ the row would wear forever.
  */
@@ -395,7 +393,7 @@ function activityBadgeFor(
     case "rate_limited":
       return { glyph: "◷", tone: "warning" }
     // Needs-input reads as a literal question — the one state where the
-    // icon asks the user for something (owner call 2026-07-29).
+    // icon asks the user for something.
     case "permission_needed":
       return { glyph: "?", tone: "warning" }
     case "error":

--- a/packages/kobe/src/tui/panes/sidebar/tab-row-activity.ts
+++ b/packages/kobe/src/tui/panes/sidebar/tab-row-activity.ts
@@ -18,9 +18,9 @@
  * hook events with.
  *
  * Once ANY tab of the task has reported, the rollup means "whichever tab
- * moved last", and lending it to whichever tab happens to be active made a
- * switch inside a busy worktree light the tab you switched TO with its
- * sibling's spinner until its own state landed (owner report 2026-08-10).
+ * moved last", and lending it to whichever tab happens to be active would
+ * make a switch inside a busy worktree light the tab you switched TO with
+ * its sibling's spinner until its own state lands.
  */
 export function tabRowActivity<T>(args: {
   /** This tab's own entry, when the daemon has one. */

--- a/packages/kobe/src/tui/panes/sidebar/tree-core.ts
+++ b/packages/kobe/src/tui/panes/sidebar/tree-core.ts
@@ -1,10 +1,9 @@
 /**
  * Sidebar tree shaping — project → Task → Terminal Tab, as ONE flat row list.
  *
- * The owner's call (2026-08-01) retires the horizontal chattab strip: a
- * a Task's tabs become child rows under it in the sidebar, and the right
- * side is nothing but the active terminal. This module owns the shape; the
- * renderer owns the glyphs.
+ * There is no horizontal chattab strip: a Task's tabs are child rows under
+ * it in the sidebar, and the right side is nothing but the active terminal.
+ * This module owns the shape; the renderer owns the glyphs.
  *
  * Why flat rows with a `depth` instead of a nested structure: the entire
  * sidebar navigation model is a cursor over `flatTaskIds` (see
@@ -43,7 +42,7 @@ export interface TreeTab {
    *  Resolving precedence is the tab module's job, not the tree's. */
   readonly label: string
   /** The task's ACTIVE tab — the row that carries the session's state glyph
-   *  (owner call 2026-08-01: state lives on the chattab, not the worktree). */
+   *  (state lives on the chattab, not the worktree). */
   readonly active?: boolean
   /** A coding-agent tab. Shell/command/content tabs are outside the state
    *  vocabulary entirely — they always wear the plain dot. */
@@ -62,7 +61,7 @@ export type TreeRow =
     }
   | { readonly kind: "recent"; readonly id: typeof RECENT_ROW_ID; readonly task: Task; readonly depth: 1 }
   /**
-   * The routine count row (issue #91): one row standing in for a project's
+   * The routine count row: one row standing in for a project's
    * routine session tasks, which are background noise beside the handful of
    * tasks the user opened themselves — 7 daily routines are 49 rows a week.
    * Opening it reveals those tasks; they are never removed from the data.
@@ -78,7 +77,7 @@ export type TreeRow =
     }
 
 /**
- * Navigation id of the narrow-mode "↩ recent" jump row (issue #14, 2A).
+ * Navigation id of the narrow-mode "↩ recent" jump row.
  * Not a ULID and free of {@link TAB_ROW_SEPARATOR}, so `parseRowId` on it
  * yields a task id no task can have — cursor chords that don't special-case
  * it fall through to a lookup miss instead of acting on a real task.
@@ -86,7 +85,7 @@ export type TreeRow =
 export const RECENT_ROW_ID = "~recent"
 
 /**
- * Header id of the Scratch section (issue #33). Like {@link RECENT_ROW_ID},
+ * Header id of the Scratch section. Like {@link RECENT_ROW_ID},
  * not a repo path and free of the separator, so project-header consumers
  * (move mode, context menu, `mainTaskIdOfProject`) that look it up simply
  * miss — a Scratch header has no main task to move and no repo to file into.
@@ -94,12 +93,12 @@ export const RECENT_ROW_ID = "~recent"
 export const SCRATCH_SECTION_ID = "~scratch"
 
 /**
- * Navigation id of a project's routine count row (issue #91). Prefixed like
+ * Navigation id of a project's routine count row. Prefixed like
  * the other sentinels so it can never collide with a ULID, and carrying the
  * project key so two projects' rows stay distinct.
  *
- * This row is the ONE fold in a tree that otherwise has none (owner call
- * 2026-08-01, round 5 — see `tree-panel.tsx`). It is scoped deliberately: it
+ * This row is the ONE fold in a tree that otherwise has none (see
+ * `tree-panel.tsx`). It is scoped deliberately: it
  * folds only tasks a SCHEDULE created, never a task a human opened, so the
  * "everything under a project is always visible" promise still holds for
  * everything the user made themselves.
@@ -154,12 +153,12 @@ export function parseRowId(rowId: string): { taskId: string; tabId: string | nul
 export const PATH_LABEL_MAX = 24
 
 /**
- * What a worktree row is CALLED — the one derivation rule (issue #42):
+ * What a worktree row is CALLED — the one derivation rule:
  * a task with a branch is named by it; a branchless `dir` task (plain
  * `rove .` opens and scratch shells alike) by its tail-truncated
  * directory — the stored title is deliberately ignored there, because
- * dir-task titles are auto-generated noise (`jacksonc-xxxx`) and legacy
- * rows render by the new rule with no data migration. A regular task
+ * dir-task titles are auto-generated noise (`jacksonc-xxxx`) and existing
+ * rows render by this rule with no data migration. A regular task
  * before its worktree materialises (no branch yet, path not its own)
  * keeps its title, else the label falls back to the path and finally
  * "scratch" so a row is never blank.
@@ -208,7 +207,7 @@ export interface TreeInput {
   readonly tabsByTask: ReadonlyMap<string, readonly TreeTab[]>
   /** Task sort applied within each project group. Defaults to input order. */
   readonly sortMode?: import("./groups").TaskSortMode
-  /** Project keys whose routine count row is open (issue #91). Absent = all
+  /** Project keys whose routine count row is open. Absent = all
    *  closed, which is the resting state a fresh session starts in. */
   readonly expandedRoutines?: ReadonlySet<string>
 }
@@ -217,26 +216,26 @@ export interface TreeInput {
  * A project you closed down to nothing: its ONLY row is the repo's main
  * checkout (or a directory you opened), and that row's last tab is closed.
  *
- * Such a project is hidden from the tree (owner call 2026-08-31). Nothing is
+ * Such a project is hidden from the tree. Nothing is
  * deleted — the main task and the `savedRepos` entry both stay.
  *
  * The way BACK is the new-task dialog's Existing tab: pick the repo and
  * choose "the project itself" instead of a new task worktree, which submits
- * `mode: "open"` and routes to `ensureMainTask` (issue #90). That choice
+ * `mode: "open"` and routes to `ensureMainTask`. That choice
  * renders only for a repo that already has a main row — which is exactly the
- * set of repos this rule can hide. Until it existed the promise made here was
- * false: every submit path went through `createTask`, which always mints a
- * `kind: "task"`, so picking a hidden repo added a worktree beside the
- * project and still left no project row.
+ * set of repos this rule can hide. Without it every submit path goes through
+ * `createTask`, which always mints a
+ * `kind: "task"`, so picking a hidden repo would add a worktree beside the
+ * project and still leave no project row.
  *
  * This is the whole difference from Forget (`d` on the row →
  * `forgetProject`), which un-saves the repo: closing the last tab is a "I'm
  * done here for now" gesture, not a "remove this from my machine" one.
  *
- * A `dir` row folds the same way (owner call 2026-09-01). It has no
+ * A `dir` row folds the same way. It has no
  * picker entry to return through and does not need one: the way back is the
- * `rove .` that opened it in the first place, and a directory was never in
- * `savedRepos` to be lost from. Excluding it only made "close the last tab"
+ * `rove .` that opened it in the first place, and a directory is never in
+ * `savedRepos` to be lost from. Excluding it would make "close the last tab"
  * mean two different things depending on a row kind the user never chose —
  * the sidebar shows a folder and a checkout as the same shape of row.
  *
@@ -274,16 +273,16 @@ function isClosedDownProject(tasks: readonly Task[], tabsByTask: TreeInput["tabs
  * what lets "main" carry tabs like any other worktree.
  *
  * `dir` tasks (`kobe .` on an arbitrary directory) group under THEIR
- * DIRECTORY as the project header (owner 2026-08-02) — their `repo` IS the
+ * DIRECTORY as the project header — their `repo` IS the
  * directory, so the grouping rule is the same one every task uses. Emitting
- * them loose after the last project made them read as that project's rows.
+ * them loose after the last project would read as that project's rows.
  */
 export function buildTreeRows(input: TreeInput): TreeRow[] {
   const { tasks, tabsByTask } = input
   const sortMode = input.sortMode ?? "default"
   const byProject = new Map<string, { repo: string; tasks: Task[] }>()
 
-  // Scratch tasks (issue #33) never mint a project header: their cwd is
+  // Scratch tasks never mint a project header: their cwd is
   // unsettled by definition, so grouping them under their (temporary)
   // directory would name a home they don't have. They render in one
   // Scratch section ABOVE every project — the "unfiled live sessions" bench.
@@ -340,16 +339,16 @@ export function buildTreeRows(input: TreeInput): TreeRow[] {
   }
 
   const rows: TreeRow[] = []
-  // Scratch section first — above pinned and every project (issue #33): the
+  // Scratch section first — above pinned and every project: the
   // bench of unfiled live shells is what you reach for next.
   // The header reuses the project-row shape (id is a sentinel no repo path
   // can be — see SCRATCH_SECTION_ID); the renderer translates its label.
   if (scratchTasks.length > 0) {
     rows.push({ kind: "project", id: SCRATCH_SECTION_ID, repo: "", label: "Scratch", depth: 0 })
-    // A scratch task renders NO worktree row of its own (issue #41): its
+    // A scratch task renders NO worktree row of its own: its
     // auto-generated name is noise, and the shell IS the whole session — so
     // its tab rows hang directly under the section header. The task remains a
-    // real task in the data layer (#472's migration machinery is untouched);
+    // real task in the data layer;
     // only the render skips its middle row. When its tabs are unknown (never
     // mounted since restart) the worktree row stays as the only reachable
     // handle — a task with zero rows would be invisible AND unnavigable.
@@ -388,7 +387,7 @@ export function buildTreeRows(input: TreeInput): TreeRow[] {
       label: sidebarProjectLabel(entry.repo, projectRepos),
       depth: 0,
     })
-    // Routine sessions (issue #91) sort to the END of their project, behind
+    // Routine sessions sort to the END of their project, behind
     // one count row: they are a schedule's output, so they must never push
     // the tasks the user opened themselves down the pane.
     const routineTasks = entry.tasks.filter(isRoutineTask)

--- a/packages/kobe/src/tui/panes/sidebar/tree-menu.ts
+++ b/packages/kobe/src/tui/panes/sidebar/tree-menu.ts
@@ -17,13 +17,13 @@
  * row's branch / worktree path for another shell. When a chord lands, the
  * entry mirrors it like the rest.
  *
- * The new-conversation pair reads the same rule one pane over (owner ask
- * 2026-08-18): ctrl+e already opens the engine/shell picker for the task the
+ * The new-conversation pair reads the same rule one pane over:
+ * ctrl+e already opens the engine/shell picker for the task the
  * row points at, so the menu routes to THAT — the entry activates the row and
  * hands the request to its workspace, exactly like pressing the chord there.
  *
- * No Expand/Collapse entries anywhere: the tree has no fold (owner call
- * 2026-08-01) — every level always shows everything.
+ * No Expand/Collapse entries anywhere: the tree has no fold — every level
+ * always shows everything.
  *
  * Pure: labels are i18n KEYS, not text. The renderer runs them through `t()`
  * so the menu follows a language switch like everything else.
@@ -62,7 +62,7 @@ export interface TreeMenuItem {
 
 export interface TreeMenuContext {
   /** How many tabs the row's worktree has. Closing the LAST one is allowed
-   *  now (owner call 2026-08-31) — the task keeps its row and re-opens on
+   *  — the task keeps its row and re-opens on
    *  ⏎ / ctrl+e — so the entry shows for any tab that exists. */
   readonly tabCount?: number
 }
@@ -119,12 +119,11 @@ function taskVerbs(task: Task): TreeMenuItem[] {
 export function treeMenuItems(row: TreeRow, ctx: TreeMenuContext = {}): TreeMenuItem[] {
   if (row.kind === "project") {
     // `d` on a project row already forgets it (task-actions.ts routes main
-    // rows to `forgetProject` behind a confirm). The menu was missing the
-    // entry, which broke this module's own rule: a row's menu is what that
+    // rows to `forgetProject` behind a confirm), so the menu carries the
+    // entry too — this module's rule: a row's menu is what that
     // row's keyboard already does.
-    // Field notes are menu-only, like `setStatus` (no chord — a chord is the
-    // owner's call). Agents file them with `rove api note`; before this entry
-    // `rove api note-list` in a shell was the only reader.
+    // Field notes are menu-only, like `setStatus` (no chord). Agents file
+    // them with `rove api note`.
     return [
       { action: "newTask", labelKey: "tasks.menu.newTask" },
       { action: "fieldNotes", labelKey: "tasks.menu.fieldNotes" },
@@ -134,7 +133,7 @@ export function treeMenuItems(row: TreeRow, ctx: TreeMenuContext = {}): TreeMenu
   if (row.kind === "worktree") {
     return [{ action: "open", labelKey: "tasks.menu.open" }, ...newTabVerbs(), ...taskVerbs(row.task)]
   }
-  // The routine count row (issue #91) is a fold toggle, not a task — there is
+  // The routine count row is a fold toggle, not a task — there is
   // no task for any verb here to act on, and an entry that does nothing is
   // worse than no entry (the same rule `closeTab` follows above).
   if (row.kind === "routines") return []

--- a/packages/kobe/src/tui/panes/sidebar/view-core.ts
+++ b/packages/kobe/src/tui/panes/sidebar/view-core.ts
@@ -1,6 +1,5 @@
 /**
- * Framework-free view logic for the React sidebar (issue #15, G3; the Solid
- * original was removed 2026-07-07). Pure derivations only — no React, no
+ * Framework-free view logic for the React sidebar. Pure derivations only — no React, no
  * opentui: view-tab cycling, line budgets, the search-input keystroke
  * reducer, empty-state / label i18n-key selection, and small row helpers
  * (theme-core / lookup / message-core precedent).
@@ -10,8 +9,7 @@ import { charWidth, displayWidth } from "../../../lib/display-width"
 import { truncateEnd, truncateEndCells } from "../../lib/truncate"
 import type { SidebarTone } from "./row-view"
 
-/** Minimum width of the PureTUI task-list rail (32 → 26 → 24, owner calls
- * 2026-07-27/28 — the herdr-density pass kept shrinking it). Also the width
+/** Minimum width of the PureTUI task-list rail. Also the width
  * at and below ~144 cols, see {@link sidebarWidthFor}. */
 export const SIDEBAR_WIDTH = 24
 
@@ -29,9 +27,6 @@ export function sidebarWidthFor(terminalWidth: number): number {
 
 /** Polling interval for the per-main-row git branch refresh. */
 export const MAIN_BRANCH_POLL_MS = 2_000
-
-// VIEW_TABS / viewTabLabelKey / cycleViewTarget were retired with the
-// Archived sidebar view (issue #75): the sidebar always shows the working set.
 
 /**
  * Two-line card budgets. Line 1: selection marker (1) + badge (1) +

--- a/packages/kobe/src/tui/panes/sidebar/worktree-changes-poller.ts
+++ b/packages/kobe/src/tui/panes/sidebar/worktree-changes-poller.ts
@@ -8,7 +8,7 @@
  * per tick on a huge repo. The sync helper survives ONLY for one-shot
  * CLI use (`kobe api`); render paths must go through this poller.
  *
- * The scheduling core (per-key Solid signal, in-flight dedupe, adaptive
+ * The scheduling core (per-key value cell, in-flight dedupe, adaptive
  * cadence, timeout + hard backoff) is the generic
  * `src/tui/lib/background-poll.ts` — this module is the worktree-changes
  * binding: one async `git status --porcelain=v1` per worktree, parsed
@@ -18,9 +18,9 @@
  *
  * Deleted rows never call `poll()` at all (the Sidebar shows only live
  * tasks): a deleted task must not pay git-status for worktrees that no
- * longer matter — that's the exact original bug.
+ * longer matter.
  *
- * Since issue #6 this poller is the NO-DAEMON FALLBACK only: when a
+ * This poller is the NO-DAEMON FALLBACK only: when a
  * connected daemon advertises the `worktree.changes` channel (one
  * collector in the daemon, pushed counts), the Sidebar renders the pushes
  * and never calls `poll()` here — a pane spawns zero git processes while

--- a/packages/kobe/src/tui/panes/sidebar/worktree-changes.ts
+++ b/packages/kobe/src/tui/panes/sidebar/worktree-changes.ts
@@ -58,7 +58,7 @@ export function sameWorktreeChanges(a: WorktreeChanges, b: WorktreeChanges): boo
 
 /**
  * Pick the DAEMON-pushed counts for a row, or `null` when the local
- * poller must serve it (issue #6). A non-null `pushed` map means a
+ * poller must serve it. A non-null `pushed` map means a
  * daemon-side collector owns git polling for this process — a worktree
  * absent from the map (just-created task, deleted row, remote project)
  * reads as zeros (chip hidden), NEVER as "poll locally": the fallback is
@@ -105,9 +105,9 @@ export function readWorktreeChanges(worktreePath: string): WorktreeChanges {
  * rename resolution) is delegated to the shared {@link parsePorcelainRows};
  * this helper only classifies each row by its raw status pair: a `D` in
  * EITHER column counts as a deletion, everything else (M, A, R, C, T, U, ??)
- * as an addition. A rename is one porcelain row → one `added` event, as
- * before — the shared parser preserves the raw `x`/`y` chars so this
- * classification is byte-for-byte the same as the old inline scan.
+ * as an addition. A rename is one porcelain row → one `added` event; the
+ * shared parser preserves the raw `x`/`y` chars so this
+ * classification stays exact.
  */
 export function parsePorcelain(text: string): WorktreeChanges {
   let added = 0

--- a/packages/kobe/src/tui/panes/terminal/keys-pure.ts
+++ b/packages/kobe/src/tui/panes/terminal/keys-pure.ts
@@ -158,31 +158,29 @@ export const TRAPPED_KEYS = ["ctrl+pageup", "ctrl+pagedown"] as const
  *     `KobeKeymap` (keybindings-table.ts) stays the single source of truth
  *     and a user override never changes what the terminal swallows.
  *   - a chord literal — reserved even though no keymap row binds it
- *     directly anymore. #308 moved the workspace/chat management chords to
- *     prefix-only (`prefixKeys`), but the terminal passthrough kept
- *     swallowing their old direct chords on main; the literals preserve
- *     that behavior byte-for-byte until the prefix follow-up decides
+ *     directly. The workspace/chat management chords are prefix-only
+ *     (`prefixKeys`), but the terminal passthrough still swallows their
+ *     direct chords; the literals hold that behavior until the prefix
+ *     follow-up decides
  *     whether to release them to the PTY (and whether the configured
  *     prefix key itself must be reserved instead).
  *
  * `terminal-keys-pure.test.ts` pins the resolved set.
  */
 const RESERVED_SPEC: ReadonlyArray<string | { id: string }> = [
-  // The live keymap reference (owner call 2026-08-09): docs promise
-  // "F1 anywhere", the rest of the F-row (f2-f5, f7) was already
+  // The live keymap reference: docs promise
+  // "F1 anywhere", the rest of the F-row (f2-f5, f7) is
   // reserved, and the status-bar hint advertises F1 inside the terminal —
-  // leaving f1 passthrough made all three lie. No engine binds F1.
+  // leaving f1 passthrough would make all three lie. No engine binds F1.
   { id: "help.open" }, // f1
   // THE escape hatch out of the terminal: ctrl+q returns to the tasks
-  // list (direct chord restored 2026-07-11, same owner call as the tab
-  // rows below).
+  // list (a direct chord, same as the tab rows below).
   { id: "focus.sidebar" }, // ctrl+q
-  // Terminal tab management (the PTY chattab, issue #16) — parity with the
-  // tmux root key-table which also intercepted these. ctrl+w / f2 double
+  // Terminal tab management (the PTY chattab) — parity with the
+  // tmux root key-table, which intercepts these too. ctrl+w / f2 double
   // as `workspace.split.close` / `workspace.split.rename` when split —
-  // same chords, so one reservation covers both. Direct chords restored
-  // as dual aliases beside the prefix strokes (owner call 2026-07-11),
-  // so these derive from the table again.
+  // same chords, so one reservation covers both. Direct chords are dual
+  // aliases beside the prefix strokes, so these derive from the table.
   { id: "chat.tab.new" }, // ctrl+t
   { id: "chat.tab.close" }, // ctrl+w
   { id: "chat.tab.cycle-next" }, // ctrl+]
@@ -191,14 +189,14 @@ const RESERVED_SPEC: ReadonlyArray<string | { id: string }> = [
   // Engine picker / quick-fork (without the reservation the embedded
   // terminal forwards them to the engine CLI, e.g. emacs-style
   // forward-char on ctrl+f). ctrl+e is the unified new-conversation
-  // dialog's direct chord (issue #7); ctrl+f has no direct binding
-  // anymore (chat.fork.new is prefix-only since #308) but STAYS reserved
+  // dialog's direct chord; ctrl+f has no direct binding
+  // (chat.fork.new is prefix-only) but STAYS reserved
   // — it's the dialog's in-scope context toggle, and releasing it to the
   // PTY would make the byte mean different things per focus.
   "ctrl+e", // chat.tab.chooseEngine
-  "ctrl+f", // new-chat dialog context toggle (ex chat.fork.new direct)
-  // Split panes inside the tab (tmux % / "): direct chords restored
-  // (owner call 2026-07-22), so they derive from the table again.
+  "ctrl+f", // new-chat dialog context toggle
+  // Split panes inside the tab (tmux % / "): direct chords, so they
+  // derive from the table.
   // Reserving ctrl+\ costs the embedded shell SIGQUIT — accepted trade,
   // documented in docs/KEYBINDINGS.md.
   { id: "workspace.split.right" }, // ctrl+\
@@ -210,8 +208,8 @@ const RESERVED_SPEC: ReadonlyArray<string | { id: string }> = [
   { id: "focus.next" }, // f4
   // Terminal reset (confirm-gated).
   { id: "terminal.reset" }, // f5
-  // Zen toggle moved to prefix-only prefix+z (owner call 2026-07-17) —
-  // f6 is no longer reserved and passes through to the shell.
+  // Zen toggle is prefix-only (prefix+z) — f6 is not reserved and passes
+  // through to the shell.
   // Jump to the next waiting task. NOT ctrl+g (the engine/readline
   // abort-editing chord) — see docs/KEYBINDINGS.md.
   { id: "attention.next" }, // f7
@@ -229,8 +227,8 @@ export const RESERVED_GLOBAL_CHORDS: readonly string[] = [
 
 /**
  * Names opentui's keypress events use that we want forwarded to the
- * shell when the terminal pane is focused. Lives here (pure) so
- * `keys.ts` (Solid hook) and tests both consume the same source.
+ * shell when the terminal pane is focused. Lives here (pure) so the
+ * pane and its tests both consume the same source.
  */
 export const PASSTHROUGH_NAMES: readonly string[] = [
   // Letters

--- a/packages/kobe/src/tui/panes/terminal/pty-hosted-client.ts
+++ b/packages/kobe/src/tui/panes/terminal/pty-hosted-client.ts
@@ -74,9 +74,8 @@ const dispatchInstalled = new WeakSet<KobeDaemonClient>()
 /**
  * Install the single per-frame router on a shared client. Both `pty.data`
  * and `pty.exit` fan out to exactly one map lookup; unknown keys (a dead
- * handle's late frame, a key from another process) drop silently — the same
- * behavior the old per-handle `payload.key === this.taskId` guard gave, but
- * O(1) instead of O(open-tabs).
+ * handle's late frame, a key from another process) drop silently, in
+ * O(1) rather than the O(open-tabs) a per-handle key compare would cost.
  */
 function installDispatch(client: KobeDaemonClient): void {
   if (dispatchInstalled.has(client)) return

--- a/packages/kobe/src/tui/panes/terminal/pty-hosted.ts
+++ b/packages/kobe/src/tui/panes/terminal/pty-hosted.ts
@@ -150,7 +150,7 @@ export class HostedTaskPty extends XtermTaskPty {
       // any keystrokes the user queued while the socket opened.
       const fresh = HostedTaskPty.createdFresh(res)
       if (opts.initialInput && fresh) this.sendInput(opts.initialInput)
-      // Paste-delivery vendor (kimi — issue #25): the launch kept the first
+      // Paste-delivery vendor (kimi): the launch keeps the first
       // message OUT of its argv (the positional slot is a subcommand), so we
       // owe the session a paste once its engine process is up. Only on a
       // fresh spawn — a reattach already received (or never had) it.
@@ -190,7 +190,7 @@ export class HostedTaskPty extends XtermTaskPty {
         // WINCH at all (a plain shell). The data-wait alone is defeated by
         // an ACTIVELY-STREAMING child — its ordinary output frame lands ms
         // after the shrink and races the restore back into the coalescing
-        // ("input box gone", 2026-07-27) — so a floor keeps a real gap
+        // ("input box gone") — so a floor keeps a real gap
         // between the two TIOCSWINSZ (see WIGGLE_MIN_GAP_MS).
         await Promise.all([this.nextDataOrTimeout(500), new Promise((r) => setTimeout(r, WIGGLE_MIN_GAP_MS))])
         if (!this.killed) this.sendResize(this.cols, this.rows)
@@ -247,7 +247,7 @@ export class HostedTaskPty extends XtermTaskPty {
    * point of the backend. Called by `registry.detachAll()` on app exit.
    */
   /**
-   * Snapshot this handle's screen for a lossless wake (issue #29): the
+   * Snapshot this handle's screen for a lossless wake: the
    * SerializeAddon VT stream (~100-200KB) replaces the multi-MB emulator
    * while the tab is hidden. Null when we can't restore exactly — never
    * attached (no offset), already dead — so the park sweep still detaches
@@ -376,10 +376,9 @@ export class HostedTaskPty extends XtermTaskPty {
   /**
    * The shared dispatcher's `pty.exit` route. Applied only when the exit
    * belongs to OUR child: a kill()→reopen under the same key sends the
-   * old incarnation's exit frame ahead of our open response (socket
-   * FIFO), and blindly dying here closed the freshly-opened tab (the
-   * "editor tab twitches then exits" bug). Pre-pid hosts (no `pid` in
-   * the frame) keep the old die-on-any-exit behavior.
+   * previous incarnation's exit frame ahead of our open response (socket
+   * FIFO), and blindly dying here would close the freshly-opened tab.
+   * Pre-pid hosts (no `pid` in the frame) die on any exit.
    */
   remoteExited(pid: number | null | undefined): void {
     if (this.killed) return

--- a/packages/kobe/src/tui/panes/terminal/pty-types.ts
+++ b/packages/kobe/src/tui/panes/terminal/pty-types.ts
@@ -44,7 +44,7 @@ export type TaskPtyOpts = {
   initialInput?: string
   /**
    * First message to bracketed-paste once the engine process is up
-   * (paste-delivery vendors, issue #25 — their positional argv slot is a
+   * (paste-delivery vendors — their positional argv slot is a
    * subcommand, so the message can't ride `command`). Same fresh-spawn-only
    * rule as `initialInput`: a reattach must NOT redeliver it. Delivered by
    * the hosted backend (`pastePromptWhenEngineUp`); other backends ignore it.
@@ -53,7 +53,7 @@ export type TaskPtyOpts = {
   /** Engine binary name the first-message engine-up probe matches against. */
   engineBin?: string
   /**
-   * A previously parked screen to restore (issue #29). When the host
+   * A parked screen to restore. When the host
    * confirms the recorded byte offset is still inside its ring window,
    * the fresh emulator is primed with `serialized` and fed only the
    * delta written since park — bit-identical to never detaching. When

--- a/packages/kobe/src/tui/panes/terminal/registry.ts
+++ b/packages/kobe/src/tui/panes/terminal/registry.ts
@@ -25,21 +25,20 @@
  *   - It does not cap concurrency. Nothing else does either — there is
  *     no cap on simultaneous running tasks.
  *
- * PTY parking (issues #28/#29) — AUTOMATIC again since 2026-07-12: the
- * idle sweep detaches hidden tabs' xterm instances, but each handle now
+ * PTY parking is AUTOMATIC: the
+ * idle sweep detaches hidden tabs' xterm instances, but each handle
  * serializes its full screen first (`capturePark` → SerializeAddon VT
  * stream, ~100-200KB in `this.parked`) and the wake feeds that stream
  * plus the host's EXACT byte delta since park (`pty.open sinceOffset`)
- * into the fresh emulator — bit-identical to never detaching, which
- * removes the 2026-07-10 objection (the 512KB ring replay couldn't
- * rebuild a long session's screen). When the delta was trimmed away or
- * the child was respawned, the wake degrades to the old full-replay +
- * repaint-wiggle path.
+ * into the fresh emulator — bit-identical to never detaching. A 512KB
+ * ring replay alone cannot rebuild a long session's screen. When the
+ * delta has been trimmed away or the child was respawned, the wake
+ * degrades to the full-replay + repaint-wiggle path.
  *
  * Concurrency: every method is synchronous and JS is single-threaded,
  * so there's no race within a single registry. Two registries pointing
  * at the same task id return the same in-process shell handle. The
- * Solid component creates exactly one registry per app instance; tests
+ * host component creates exactly one registry per app instance; tests
  * stand up disposable registries inside a single `describe` block.
  */
 
@@ -110,9 +109,9 @@ export class PtyRegistry {
       if (since === null || now - since < idleMs) continue
       // Quiet gate: a hidden tab whose child is still streaming (claude
       // working in the background) keeps its emulator resident — parking
-      // it is exactly the "input box gone on wake" bug (2026-07-10 and
-      // again 2026-07-27): the delta outruns the 512KB host ring, and the
-      // degraded wake's repaint wiggle coalesces under an active stream.
+      // it produces the "input box gone on wake" failure: the delta outruns
+      // the 512KB host ring, and the degraded wake's repaint wiggle
+      // coalesces under an active stream.
       const lastOut = pty.lastOutputAtMs?.() ?? null
       if (lastOut !== null && now - lastOut < PARK_QUIET_MS) continue
       const screen = pty.capturePark?.() ?? null
@@ -139,7 +138,7 @@ export class PtyRegistry {
    * Return the existing PTY for `taskId`, or spawn a new one bound to
    * `cwd`. The `cwd` is only used on first acquisition; subsequent
    * acquires return the existing instance regardless of `cwd`. The
-   * Solid component is expected to `release()` and re-`acquire()` if
+   * host component is expected to `release()` and re-`acquire()` if
    * the task's worktree path actually changes — but in our data model
    * the worktree path is immutable for the lifetime of the task, so
    * that's a defensive contract not a runtime concern.
@@ -197,8 +196,8 @@ export class PtyRegistry {
 
   /**
    * Kill and forget every PTY whose id matches `predicate` — the
-   * task-scoped teardown for tab-keyed PTYs (`taskId::tabId`, issue
-   * #16): deleting a task must end every engine session it owns.
+   * task-scoped teardown for tab-keyed PTYs (`taskId::tabId`):
+   * deleting a task must end every engine session it owns.
    * Parked keys match too: their host sessions are ended by the delete
    * flow, and the screens must not outlive the task.
    */

--- a/packages/kobe/src/tui/panes/terminal/terminal-selection.ts
+++ b/packages/kobe/src/tui/panes/terminal/terminal-selection.ts
@@ -407,7 +407,7 @@ export function overlaySelection(
  *
  * Returns the input by reference when nothing moved, and `null` when line
  * numbering was RESET (a resize reflows history and bumps `epoch`): the
- * selection then addresses content that no longer exists under those ids and
+ * selection then addresses content that does not exist under those ids and
  * must be dropped, not silently mis-mapped.
  */
 export function followWindowShift(

--- a/packages/kobe/src/tui/panes/terminal/terminal-snapshot.ts
+++ b/packages/kobe/src/tui/panes/terminal/terminal-snapshot.ts
@@ -35,7 +35,7 @@ export function reconcileTerminalRows(previous: readonly TerminalRow[], next: Te
   return changed ? next : previous
 }
 
-/** Cursor objects are recreated on every probe; retain the old reference when their visible value is unchanged. */
+/** Cursor objects are recreated on every probe; retain the existing reference when their visible value is unchanged. */
 export function reconcileTerminalCursor(previous: CursorPos | null, next: CursorPos | null): CursorPos | null {
   if (previous === next) return previous
   if (previous && next && previous.x === next.x && previous.y === next.y) return previous

--- a/packages/kobe/src/tui/panes/terminal/xterm-chunks.ts
+++ b/packages/kobe/src/tui/panes/terminal/xterm-chunks.ts
@@ -238,9 +238,9 @@ export function xtermLineToChunks(
     }
     const chars = cell.getChars() || " "
     // Solid-block glyphs whose fg equals bg render as bg-only spaces: same
-    // pixels, but the HOST terminal's minimum-contrast feature (iTerm) can
-    // no longer darken the "glyph" half — the zebra-stripe fix for
-    // half-block renderers (carbonyl, the video plugin). Issue #1. The
+    // pixels, but the HOST terminal's minimum-contrast feature (iTerm)
+    // cannot darken the "glyph" half — the zebra-stripe fix for
+    // half-block renderers (carbonyl, the video plugin). The
     // decision lives in `paintsSamePixel`, shared with the comparator.
     buf += isSolidBlock(chars) && activeIsFill ? " " : chars
   }

--- a/packages/kobe/src/tui/workspace/interrupt-observer.ts
+++ b/packages/kobe/src/tui/workspace/interrupt-observer.ts
@@ -1,9 +1,10 @@
 /**
- * ESC-interrupt observer (issue #15) — framework-free.
+ * ESC-interrupt observer — framework-free.
  *
  * An ESC interrupt ends a turn without ANY hook: claude-code's abort path
- * returns before its stop hooks run, so the daemon's hook-driven `running`
- * badge sat lit until the ~10min lapse watchdog caught it. The one
+ * returns before its stop hooks run, so without this the daemon's
+ * hook-driven `running` badge stays lit until the ~10min lapse watchdog
+ * catches it. The one
  * event-grade signal an interrupt does produce is the engine's own OSC
  * title rewrite — the animated working frame (`⠂`/`⠐`, codex's braille)
  * flips back to the resting form the instant the turn stops

--- a/packages/kobe/src/tui/workspace/issue-chat-spawn.ts
+++ b/packages/kobe/src/tui/workspace/issue-chat-spawn.ts
@@ -36,8 +36,8 @@ export interface IssueChatBackgroundSpawn {
   readonly ptyKey: string
   readonly command: readonly string[]
   readonly initialInput?: string
-  /** Paste-delivery vendor's first message (kimi — issue #25): the story
-   *  prompt rode OUTSIDE the argv; the hosted PTY pastes it post-spawn. */
+  /** Paste-delivery vendor's first message (kimi): the prompt rides OUTSIDE
+   *  the argv; the hosted PTY pastes it post-spawn. */
   readonly firstMessage?: string
   /** Engine binary name for the first-message engine-up probe. */
   readonly engineBin?: string

--- a/packages/kobe/src/tui/workspace/live-engine.ts
+++ b/packages/kobe/src/tui/workspace/live-engine.ts
@@ -1,18 +1,15 @@
 /**
  * "Which engine is live in this tab right now" — the framework-free store
- * that replaced title sniffing as kobe's process-identity signal.
+ * that owns kobe's process-identity signal.
  *
- * Before: `vendorFromTerminalTitle` matched the OSC window title by
- * substring, so a claude session whose activity summary happened to
- * mention "codex" relabelled its tab codex and attached a Codex turn
- * detector. A window title is free-form text an engine writes for humans;
- * it was never identity.
- *
- * Now: one `ps` snapshot per tick serves every live PTY — each tab's
- * shell pid roots a process-tree walk (`engine/foreground.ts`). A tab is
- * "running claude" exactly while a claude process is alive under its
- * shell, and stops being so the moment that process exits (owner call
- * 2026-07-27: freeze the identity of what IS running; release it on exit).
+ * NOT the OSC window title: that is free-form text an engine writes for
+ * humans, so matching it by substring would relabel a claude session whose
+ * activity summary happens to mention "codex" and attach a Codex turn
+ * detector. Identity comes from the process tree instead — one `ps`
+ * snapshot per tick serves every live PTY, and each tab's shell pid roots a
+ * walk (`engine/foreground.ts`). A tab is "running claude" exactly while a
+ * claude process is alive under its shell, and stops being so the moment
+ * that process exits.
  *
  * Self-driving on purpose: it enumerates the PTY registry itself rather
  * than taking a caller-supplied key set, so the two consumers (turn-poll
@@ -42,7 +39,7 @@ export interface LiveEngineStore {
   resolve(key: string): VendorId | null | undefined
   /**
    * Auxiliary ptyKey → shell pid pairs to probe ALONGSIDE the local PTY
-   * registry (issue #33): the registry only knows PTYs this process
+   * registry: the registry only knows PTYs this process
    * attached, but the sidebar tree renders every task's hosted tabs — the
    * pty host's `pty.list` inventory carries their pids, and feeding them
    * here lights a shell-turned-agent row for tasks never opened in this
@@ -64,7 +61,7 @@ export type LiveEngineOpts = {
   /** Engines start and stop on human timescales — one `ps` every 2s. */
   intervalMs?: number
   /**
-   * Debounce for the OFF edge (issue #33): a lit identity goes dark only
+   * Debounce for the OFF edge: a lit identity goes dark only
    * after this many CONSECUTIVE engine-free walks. Engines briefly show an
    * empty tree mid-restart (claude relaunching after /login, a wrapper
    *  re-exec), and a 1-probe flicker would strobe the sidebar badge. The ON

--- a/packages/kobe/src/tui/workspace/pane-split.ts
+++ b/packages/kobe/src/tui/workspace/pane-split.ts
@@ -1,7 +1,7 @@
 /**
  * Plugin-pane placement (`tab.open` consumption): the DEFAULT is a split of
  * the currently-focused chattab — the pane joins the tab's split group
- * beside the engine (owner semantics 2026-07-29), exactly herdr's
+ * beside the engine, exactly herdr's
  * `placement = "split"`. `"tab"` opens a separate self-closing command tab
  * instead. An explicit `tabId` (`pane-open --tab`) hosts the split in THAT
  * tab instead of the focused one. Falls back to a tab when the host tab

--- a/packages/kobe/src/tui/workspace/scratch-adopt.ts
+++ b/packages/kobe/src/tui/workspace/scratch-adopt.ts
@@ -1,13 +1,13 @@
 /**
- * Scratch-task adoption decision (issues #33/#40) — pure. A scratch shell
+ * Scratch-task adoption decision — pure. A scratch shell
  * earns a project home when TWO facts line up: its live cwd resolved to a
  * git repo, and a coding harness is confirmed running in it (the foreground
  * walk's verdict — the same confidence bar the tab identity uses; a mere
  * `cd` into a repo is browsing, not working).
  *
  * Once that bar is met, the decision de-dupes against tasks that already
- * exist (issue #40 — migrating a shell parked in the kobe main checkout
- * used to mint a second sidebar row for the same directory):
+ * exist, so migrating a shell parked in the kobe main checkout does not
+ * mint a second sidebar row for the same directory:
  *
  *   1. cwd equal to or inside a MANAGED task's worktree → FOLD the shell
  *      into that task as a new terminal tab. Checked first because
@@ -44,7 +44,7 @@ export interface ScratchAdoptInput {
   readonly harnessLive: boolean
   /** Known project roots: savedRepos + every existing task's repo. */
   readonly knownRepos: ReadonlySet<string>
-  /** Candidate owners for the fold check (issue #40). */
+  /** Candidate owners for the fold check. */
   readonly ownerTasks: readonly ScratchOwnerTask[]
 }
 

--- a/packages/kobe/src/tui/workspace/split-core.ts
+++ b/packages/kobe/src/tui/workspace/split-core.ts
@@ -1,6 +1,6 @@
 /**
- * Pure, CONTENT-AGNOSTIC split-tree state for one workspace surface
- * (issue #16) — the tmux-pane layout idea, generic over what a leaf
+ * Pure, CONTENT-AGNOSTIC split-tree state for one workspace surface —
+ * the tmux-pane layout idea, generic over what a leaf
  * shows. Leaves carry an opaque `content` payload (today: a terminal
  * command, see `TerminalSplit.tsx`; later: any workspace surface);
  * groups lay their children out `row` (side-by-side, tmux's `%`) or
@@ -9,7 +9,7 @@
  * new group — arbitrary tmux-style layouts fall out of two chords.
  *
  * Framework-free on purpose, same architecture as `terminal-tabs-core.ts`:
- * the Solid renderer owns signals/UI, this module owns the transitions
+ * the renderer owns signals/UI, this module owns the transitions
  * so vitest can pin them. Nothing in here may know about terminals,
  * PTYs, or engines — content-specific keying (e.g. `splitLeafPtyKey`)
  * lives with the content adapter.
@@ -23,7 +23,7 @@ export interface SplitLeaf<T> {
   /** Opaque payload — what this leaf displays. Owned by the adapter. */
   readonly content: T
   /** User-set display name. Absent/null = the adapter's default name
-   *  (owner semantics 2026-07-06: the TAB is the "group"; every leaf
+   *  (the TAB is the "group"; every leaf
    *  inside carries its own name, tab-title naming-flow style). */
   readonly title?: string | null
 }

--- a/packages/kobe/src/tui/workspace/tabs-adopt.ts
+++ b/packages/kobe/src/tui/workspace/tabs-adopt.ts
@@ -2,7 +2,7 @@
  * Adopt live-but-unregistered pty sessions into a task's tab state.
  *
  * The pty host holds the truth about what is running; the tab snapshot is a
- * record of intent, and the two diverge (issue #20 — a canonical-spawn
+ * record of intent, and the two diverge (a canonical-spawn
  * fallback, a tab closed while its task was unmounted so the kill never
  * reached the host, an older kobe). The sidebar already SHOWS such sessions
  * as `⚠` rows, but a row that isn't in the tab state can't be opened,

--- a/packages/kobe/src/tui/workspace/terminal-tab-argv.ts
+++ b/packages/kobe/src/tui/workspace/terminal-tab-argv.ts
@@ -69,7 +69,7 @@ export function engineTabArgv(
 /**
  * Full spawn composition for an engine tab — {@link engineTabArgv} wrapped
  * in the user's shell (`shellSpawn`), plus the quick-fork initial
- * prompt policy (issue #17, verified delivery 12283c57): `prompt` rides the
+ * prompt policy: `prompt` rides the
  * argv as a positional arg ONLY on the first engine tab's FIRST spawn —
  * never on a later engine tab, an already-spawned tab, or one whose PTY is
  * still live (re-render churn), so the prompt can't re-deliver. Pure so
@@ -112,7 +112,7 @@ export function engineTabSpawnFor(
   // task's first tab: its id, worktree, and tab identity — so activity,
   // hooks, and a dead-reattach resume all belong to the story's task.
   const ref = tab.ptyTask
-  // Pre-trust the worktree in the vendor's first-run store (issue #28) — a
+  // Pre-trust the worktree in the vendor's first-run store — a
   // hosted session can't answer a trust dialog. The tab's pinned vendor wins.
   trustEngineWorktree(tab.vendor ?? opts.task.vendor, ref?.worktree ?? opts.worktreePath)
   const launch = buildEngineSessionLaunch({
@@ -123,7 +123,7 @@ export function engineTabSpawnFor(
     promptIntent,
     protocolGates: opts.protocolGates,
     // No firstMessageDelivery override: the registry contract applies, so a
-    // paste vendor's (kimi — issue #25) first message comes back as
+    // paste vendor's (kimi) first message comes back as
     // `launch.firstMessage` instead of riding the argv (its positional slot
     // is a subcommand — the text would kill the launch as an unknown
     // command). The hosted PTY backend pastes it post-spawn

--- a/packages/kobe/src/tui/workspace/terminal-tab-identity.ts
+++ b/packages/kobe/src/tui/workspace/terminal-tab-identity.ts
@@ -2,7 +2,7 @@
  * Live tab identity — the ONE transition that turns an engine tab back into
  * a shell tab when its engine exits.
  *
- * The model (owner 2026-08-10): every tab IS a shell. An engine is just a
+ * The model: every tab IS a shell. An engine is just a
  * process running inside it — `shellSpawn` types the CLI into the user's
  * shell, so exiting claude lands on a normal prompt with the PTY still very
  * much alive. `kind` therefore describes what the tab is running NOW, not

--- a/packages/kobe/src/tui/workspace/terminal-tab-shapes.ts
+++ b/packages/kobe/src/tui/workspace/terminal-tab-shapes.ts
@@ -56,7 +56,7 @@ export interface TabBase {
   /**
    * Frozen split layout for this tab (the "group"). Absent/null = unsplit
    * (the tab's own engine fills the whole body). Persisted WITH the tab so
-   * the layout survives restart (owner ask 2026-07-06): `leaf-1` is the
+   * the layout survives restart: `leaf-1` is the
    * tab's engine and resumes via the tab's sessionId exactly like an
    * unsplit tab; the other leaves are shells that respawn fresh. We freeze
    * the LAYOUT only — a shell the user ran `claude` inside comes back as a
@@ -100,7 +100,7 @@ export interface EngineTab extends TabBase {
   readonly sessionId?: string | null
   /**
    * True once this tab's PTY has actually spawned. Drives the restart
-   * story (issue #22): a persisted engine tab that already ran resumes
+   * story: a persisted engine tab that already ran resumes
    * its conversation (`--resume <sessionId>`) instead of opening a
    * blank session under the same id.
    */
@@ -148,9 +148,9 @@ export interface CommandTab extends TabBase {
 }
 
 /**
- * A read-only file view — the FileTree `d` action (issue #21): the preview
- * `<diff>`/`<code>` renderable, hosted as a tab instead of the removed
- * `kobe ops --preview` window. No PTY: it renders from a one-shot git read
+ * A read-only file view — the FileTree `d` action: the preview
+ * `<diff>`/`<code>` renderable, hosted as a tab.
+ * No PTY: it renders from a one-shot git read
  * (`loadPreviewData`), so it never spawns, resumes, or auto-closes on an
  * exit. Like the editor tab it's a FileTree-owned SINGLETON slot ({@link
  * openContentTab} replaces it in place), so repeatedly hitting `d` swaps the

--- a/packages/kobe/src/tui/workspace/terminal-tab-spawn.ts
+++ b/packages/kobe/src/tui/workspace/terminal-tab-spawn.ts
@@ -19,7 +19,7 @@ export interface TabSpawn {
   /**
    * First message the PTY layer must paste into the session once the engine
    * process is up (`TaskPtyOpts.firstMessage`) — paste-delivery vendors
-   * (kimi, issue #25) whose positional argv slot is a subcommand, so the
+   * (kimi) whose positional argv slot is a subcommand, so the
    * message can NOT ride {@link command}. Undefined when the message already
    * rode the argv or there is none.
    */

--- a/packages/kobe/src/tui/workspace/terminal-tab-split.ts
+++ b/packages/kobe/src/tui/workspace/terminal-tab-split.ts
@@ -84,8 +84,8 @@ export function splitLeafPtyKey(tabKey: string, leafId: string): string {
 }
 
 /**
- * Display names for a split tab's leaves, id → name (owner semantics
- * 2026-07-06: the TAB is the "group"; each leaf carries its OWN name).
+ * Display names for a split tab's leaves, id → name (the TAB is the
+ * "group"; each leaf carries its OWN name).
  * Naming flow mirrors tabs: a manual rename (`leaf.title`) always wins.
  *
  * The ENGINE leaf (`null` content = the tab's own command) reads the
@@ -140,7 +140,7 @@ export function splitLeafNames(
 }
 
 /**
- * Default tab names are "$process $ordinal" (owner naming 2026-07-07):
+ * Default tab names are "$process $ordinal":
  * a tab IS a terminal, so its name says what runs in it — "claude 3",
  * "shell 5", "vim 2" — never an opaque "tab N". `liveName` is the tab's
  * live foreground-process display name from `useTurnPolls().liveTitles`;
@@ -198,20 +198,16 @@ function isEngineDecoration(text: string, vendor: VendorId): boolean {
  * A tab's name for a surface that shows kobe's OWN state glyph beside it —
  * the sidebar tree.
  *
- * This used to DISCARD the recorded `lastTitle` for a status-owning engine
- * and fall through to the first-prompt summary or the vendor default,
- * because that recording was the engine's whole status line — `⠐ 利用自进化…`
- * still spinning on a row whose glyph said idle. Since the status prefix is
- * stripped where the title enters the app (`stripEngineStatusPrefix`), what
- * is recorded is the NAME, and throwing it away left every tree row reading
- * "claude 1" while the tab strip showed the real conversation title (owner
- * report 2026-08-10).
+ * The rule: strip the decoration, keep the name. The status prefix is
+ * stripped where the title enters the app (`stripEngineStatusPrefix`), so
+ * what `lastTitle` records is the NAME — discarding it for a status-owning
+ * engine would leave every tree row reading "claude 1" while the tab strip
+ * showed the real conversation title.
  *
- * So the rule is now: strip the decoration, keep the name. Titles recorded
- * BEFORE that fix still carry their prefix, so it is stripped again here —
- * display-side, so old snapshots heal without a migration (same approach as
- * `meaningfulAutoTitle`). A manual rename still wins: that is the user's
- * name, not the engine's.
+ * Snapshots written by an older kobe still carry their prefix, so it is
+ * stripped again here — display-side, so they heal without a migration
+ * (same approach as `meaningfulAutoTitle`). A manual rename still wins:
+ * that is the user's name, not the engine's.
  *
  * `liveTitle` is the pty host's CURRENT OSC title for this tab's session,
  * when the caller has one. `lastTitle` is a recording written only by the
@@ -239,12 +235,11 @@ export function tabTitleStable(
   }
   // Resolution order for "whose title is this": the live probe, then the
   // tab's own RECORDED identity, then an engine tab's creation pin. The
-  // recorded step matters for the flash (owner report 2026-08-10): clicking
-  // a tab writes `lastTitle` immediately, but the live probe is a ~2s ps
-  // walk, so for one render there is no live vendor — and without the
-  // recorded fallback this dropped to the raw-title branch below and flashed
-  // the engine's own status line ("⠐ Refactoring the parser") before
-  // settling back to "claude 1".
+  // recorded step matters for the flash: clicking a tab writes `lastTitle`
+  // immediately, but the live probe is a ~2s ps walk, so for one render
+  // there is no live vendor — and without the recorded fallback this drops
+  // to the raw-title branch below and flashes the engine's own status line
+  // ("⠐ Refactoring the parser") before settling back to "claude 1".
   const vendor =
     liveVendor ?? tab.liveVendor ?? (tab.kind === "engine" ? (tab.vendor ?? taskVendor) : undefined) ?? undefined
   // Cleaning the recorded title is NOT gated on `ownsStatus`: a status glyph
@@ -309,11 +304,11 @@ export function tabTitle(tab: TerminalTab, taskVendor: VendorId, liveName?: stri
   const sole = ls.length === 1 ? ls[0] : undefined
   if (sole && sole.id !== "leaf-1") return sole.title ?? `${liveName ?? SHELL_LEAF_NAME} ${tab.ordinal}`
   // The RUNNING process names the tab first (liveName — the OSC title
-  // stream, owner order 2026-07-09: rename > live process > first-prompt >
-  // vendor default). The first-prompt autoTitle and vendor derivation are
+  // stream; order is rename > live process > first-prompt > vendor default).
+  // The first-prompt autoTitle and vendor derivation are
   // only the pre-title fallback. Deriving from the task's CURRENT vendor
-  // relabelled every inherit-mode tab the moment a new tab switched the
-  // task engine, while their PTYs kept running the old one.
+  // instead would relabel every inherit-mode tab the moment a new tab
+  // switches the task engine, while their PTYs keep running the previous one.
   // A live title only names the tab when it IS a name: an engine that puts a
   // placeholder there (codex's thread id) must fall through to the rungs
   // below, which is where the conversation's first prompt lives.

--- a/packages/kobe/src/tui/workspace/terminal-tabs-core.ts
+++ b/packages/kobe/src/tui/workspace/terminal-tabs-core.ts
@@ -1,10 +1,9 @@
 /**
- * Pure tab-list state for the workspace terminal tabs (issue #16) — the
- * PTY-world successor of the tmux chattab concept. Same user contract:
+ * Pure tab-list state for the workspace terminal tabs. User contract:
  * new tab spawns the SAME engine command in the same worktree, the last
  * tab can't be closed, titles are user-renameable, bracket chords cycle.
  *
- * Framework-free on purpose: the Solid component owns signals/UI, this
+ * Framework-free on purpose: the component owns signals/UI, this
  * module owns the transitions so vitest can pin them. Tab PTYs are keyed
  * `${taskId}::${tabId}` into the existing PtyRegistry — no registry
  * changes; each tab is just another registry entry that survives task
@@ -50,9 +49,9 @@ export interface TabsState {
    * ({@link reopenTabs}). Only set when `tabs` is empty — a task with tabs
    * doesn't need it, and a stale value would outlive its meaning.
    *
-   * A snapshot written before this field existed simply lacks it, which is
-   * why {@link reopenTabs} treats absence as "use the default" rather than
-   * as an error: the whole point is that upgrading in place is silent.
+   * An older snapshot simply lacks the field, so {@link reopenTabs} treats
+   * absence as "use the default" rather than as an error: upgrading in place
+   * has to stay silent.
    */
   readonly reopenAs?: { readonly kind: "engine"; readonly vendor?: VendorId } | { readonly kind: "command" }
 }
@@ -102,7 +101,7 @@ export function reopenTabs(state: TabsState, shell: string): TabsState {
   }
 }
 
-/** A SCRATCH task's initial state (issue #33): one bare shell tab, active —
+/** A SCRATCH task's initial state: one bare shell tab, active —
  *  the task is the shell, an engine only appears when the user types one.
  *  Same shape the ctrl+e "shell" pick mints ({@link openCommandTab}). */
 export function initialShellTabs(shell: string): TabsState {
@@ -184,7 +183,7 @@ export function findContentTab(state: TabsState): ContentTab | undefined {
  * openEditorTab}. First time: insert after the active tab and focus it. Later
  * hits: retarget the existing tab to the new file/base in place (its render
  * re-reads on the prop change) and select it. Selecting is a content swap,
- * not a focus grab — the FileTree keeps keyboard focus (KOB-25); the host
+ * not a focus grab — the FileTree keeps keyboard focus; the host
  * wires it without a `focus.setFocused`.
  */
 export function openContentTab(state: TabsState, relPath: string, label: string, base?: string): TabsState {
@@ -210,8 +209,8 @@ export function openContentTab(state: TabsState, relPath: string, label: string,
 export function closeTab(
   state: TabsState,
   id: string,
-  /** Allow the task's LAST tab to close, leaving `tabs` empty (owner call
-   *  2026-08-31). Off by default: `closeActive`'s scratch branch reads a
+  /** Allow the task's LAST tab to close, leaving `tabs` empty.
+   *  Off by default: `closeActive`'s scratch branch reads a
    *  refusal as "this task is ending", so flipping this unconditionally would
    *  turn every scratch ctrl+w into a task teardown. */
   opts: { readonly allowEmpty?: boolean } = {},
@@ -301,9 +300,8 @@ export function setTabInitialPrompt(state: TabsState, id: string, prompt: string
  * An EMPTY title is also a no-op: this field exists so surfaces that render
  * a tab they don't host still know its name, and "the process has not
  * reported a title" must never erase the one it reported earlier. Recording
- * `""` renamed a live session to its vendor default a beat after the real
- * title appeared (owner report 2026-08-10) — and persisted that, so the tab
- * came back wrong on the next start too.
+ * `""` would rename a live session to its vendor default and persist that,
+ * so the tab would come back wrong on the next start too.
  */
 export function setTabLastTitle(state: TabsState, id: string, lastTitle: string): TabsState {
   if (lastTitle.length === 0) return state
@@ -364,24 +362,24 @@ export { type TabExitAction, engineTabArgv, engineTabSpawnFor, tabExitAction } f
 export { type TabSpawn, shellCommandLine, shellIdentityInput, shellSpawn } from "./terminal-tab-spawn"
 
 /**
- * Rehydrate a persisted tab snapshot (issue #22). A tab is a TERMINAL
- * (owner model 2026-07-07): claude/an editor are just processes that ran
- * in it, so EVERY tab survives restart. Engine tabs keep their identity
+ * Rehydrate a persisted tab snapshot. A tab is a TERMINAL: claude/an editor
+ * are just processes that ran in it, so EVERY tab survives restart. Engine
+ * tabs keep their identity
  * + sessionId so the host can `--resume` the conversation; command tabs
- * (a shell pick, a dead editor) come back running `shell` — their old
- * process is gone, and resurrecting a fresh engine
- * in its place was the "closed shell reopens as claude" bug. Same
+ * (a shell pick, a dead editor) come back running `shell` — their
+ * process is gone, and spawning a fresh engine
+ * in its place would reopen a closed shell as claude. Same
  * freeze-the-layout rule splitTree restore follows. Guards against a
  * corrupt/empty snapshot by falling back to `initialTabs()`; re-anchors
- * `activeId` if it pointed at a tab that no longer exists.
+ * `activeId` if it pointed at a tab that is absent.
  */
 export function rehydrateTabs(
   persisted: TabsState,
   shell: readonly string[],
-  /** Keep an intentionally-empty snapshot empty (owner call 2026-08-31).
+  /** Keep an intentionally-empty snapshot empty.
    *  Without this a task whose last tab you closed grows one back on the next
    *  mount, so the close never appears to take. Off by default so a CORRUPT
-   *  snapshot (the case this fallback was written for) still recovers. */
+   *  snapshot still recovers. */
   opts: { readonly allowEmpty?: boolean } = {},
 ): TabsState {
   const tabs = persisted.tabs.map(
@@ -418,7 +416,7 @@ export function cycleTab(state: TabsState, delta: 1 | -1): TabsState {
 
 /**
  * Move a tab up/down within its task's tab list (sidebar move mode, issue
- * #43). Edge-stops — moving the first tab up or the last down returns the
+ * Edge-stops — moving the first tab up or the last down returns the
  * SAME state object (no wrap), so callers persist nothing on a no-op. Tab
  * order IS the persisted `tabs` array order (`rehydrateTabs` keeps it), so
  * this needs no new persistence key.

--- a/packages/kobe/src/tui/workspace/turn-state-merge.ts
+++ b/packages/kobe/src/tui/workspace/turn-state-merge.ts
@@ -24,7 +24,7 @@ import type { ChatTabTurnState } from "../../engine/turn-detector.ts"
 export interface HookTabState {
   readonly state: TaskActivityState
   /** The state's stamp — the key the durable completion-seen mark is
-   *  recorded under (issue #23). Absent on the poll-only path. */
+   *  recorded under. Absent on the poll-only path. */
   readonly at?: number
 }
 

--- a/packages/kobe/src/tui/workspace/turn-target.ts
+++ b/packages/kobe/src/tui/workspace/turn-target.ts
@@ -1,11 +1,11 @@
 /**
- * Pure "what should this tab's turn detector track" resolution — extracted
- * out of `turn-polls.ts` (issue #16 React migration) so the Solid poll loop
- * and the React `use-turn-polls.ts` hook share ONE identity rule instead of
- * two hand-kept copies. Framework-free: no signals, no React state, just
+ * Pure "what should this tab's turn detector track" resolution, kept apart
+ * from `turn-polls.ts` so every consumer — including the
+ * `use-turn-polls.ts` hook — shares ONE identity rule instead of
+ * hand-kept copies. Framework-free: no signals, no React state, just
  * `TabsState` + a title lookup.
  *
- * Unified process-identity model (owner 2026-07-07): every tab is a shell;
+ * Unified process-identity model: every tab is a shell;
  * an engine is just a process running in it. A tab's turn detector target
  * is either the tab's OWN kobe-launched engine (by construction) or, for
  * any other tab, whatever its solo live PTY's OSC title says is running —
@@ -36,8 +36,8 @@ export function soloKey(taskId: string, tab: TerminalTab): string | null {
  *
  * `vendorOf` is the tri-state live process identity (`live-engine.ts`, a
  * process-tree walk): a vendor / null ("shell walked, no engine") /
- * undefined ("couldn't look"). The pin used to win unconditionally for
- * engine tabs, which kept a ctrl+C'd codex tab identified as codex forever —
+ * undefined ("couldn't look"). The pin must NOT win unconditionally for
+ * engine tabs: that keeps a ctrl+C'd codex tab identified as codex forever —
  * wrong detector, wrong persisted identity, wrong sidebar label. A confirmed
  * engine-free shell is a shell, whatever the tab was born as; and an engine
  * tab where the user then typed a DIFFERENT engine tracks that one.

--- a/packages/kobe/src/types/task.ts
+++ b/packages/kobe/src/types/task.ts
@@ -63,9 +63,9 @@ export type PRCheckState = "none" | "pending" | "passing" | "failing" | "unknown
 export type PRLifecycleState = "creating" | "open" | "ready_to_merge" | "merged" | "closed" | "unknown"
 
 /**
- * PR status persisted on Task. v0.6 keeps the shape (the monitor can
- * still display it) but the orchestrator no longer drives PR creation
- * itself; create-PR flows ask the active engine through Hosted PTY delivery.
+ * PR status persisted on Task. The monitor displays it; the orchestrator
+ * does NOT drive PR creation itself — create-PR flows ask the active engine
+ * through Hosted PTY delivery.
  */
 export interface TaskPRStatus {
   readonly provider: PRProviderId
@@ -160,7 +160,7 @@ export interface Task {
    */
   readonly kind?: "main" | "task" | "dir"
   /**
-   * A SCRATCH shell task (issue #33): a `kind: "dir"` task whose cwd is not
+   * A SCRATCH shell task: a `kind: "dir"` task whose cwd is not
    * settled yet — an ad-hoc shell opened to poke around, living in the
    * sidebar's Scratch section instead of a project group. Zero-ceremony
    * lifecycle: its shell exiting deletes the row outright. The flag CLEARS
@@ -170,8 +170,8 @@ export interface Task {
    */
   readonly scratch?: boolean
   /**
-   * The routine (`Automation`) this task is the standing session for
-   * (issue #91). A routine with `persistentSession` creates ONE task and
+   * The routine (`Automation`) this task is the standing session for.
+   * A routine with `persistentSession` creates ONE task and
    * re-delivers into it on every firing, instead of a fresh worktree per
    * run — so a daily check can read what it said yesterday.
    *
@@ -257,8 +257,8 @@ export interface Task {
   /**
    * The task brief: the full text of the prompt `add --prompt` delivered
    * into this task's engine, recorded on the delivery path. The engine's
-   * own transcript is NOT durable — a dead engine used to take the brief
-   * down with it, and the only recovery was the user re-pasting it. Stored
+   * own transcript is NOT durable — without this a dead engine takes the
+   * brief down with it, and the only recovery is the user re-pasting it. Stored
    * verbatim (never truncated: the constraints an agent needs most often
    * sit at the END of a long brief). Optional + additive: tasks created
    * without a prompt never get one.
@@ -303,7 +303,7 @@ export interface TaskLinkedWorkItem {
 /**
  * A persisted deletion marker. A concurrent writer that still holds the
  * deleted task dirty in memory must not write it back — the tombstone makes
- * the deletion visible to peers (issue #47). Pruned after a TTL at save time.
+ * the deletion visible to peers. Pruned after a TTL at save time.
  */
 export interface TaskTombstone {
   readonly id: string
@@ -316,8 +316,8 @@ export interface TaskIndex {
   readonly tasks: readonly Task[]
   /**
    * Deletion tombstones. Optional and absent when empty: builds that predate
-   * the field ignore it on read and drop it on write, degrading to the old
-   * last-write-wins behavior without corrupting anything (which is also why
+   * the field ignore it on read and drop it on write, degrading to plain
+   * last-write-wins without corrupting anything (which is also why
    * `version` stays 3 — older readers treat an unknown version as an empty
    * index, losing everything).
    */

--- a/packages/kobe/src/types/worktree.ts
+++ b/packages/kobe/src/types/worktree.ts
@@ -115,7 +115,7 @@ export interface WorktreeManager {
   create(repo: string, branch: string, path: string, baseRef?: string): Promise<WorktreeInfo>
 
   /**
-   * Remove a worktree previously created with {@link create}.
+   * Remove a worktree created with {@link create}.
    *
    * Guarantees: refuses to remove a dirty worktree unless `force` is
    * true. On success, the directory is gone, the worktree is

--- a/packages/kobe/test/core/daemon-session-adapter.test.ts
+++ b/packages/kobe/test/core/daemon-session-adapter.test.ts
@@ -79,8 +79,8 @@ describe("daemon session adapter", () => {
   })
 
   it("launches an explicit first prompt as a new-task intent (branch-rename coda)", async () => {
-    // Both callers (automation runner, work-item start) create the task right
-    // before this call, so the first prompt is a new-worktree entry (issue #8).
+    // Both callers (automation runner, work-item start) create the task
+    // immediately ahead of this call, so the first prompt is a new-worktree entry.
     await expect(startTaskSessionWithPromptAdapter(link(), "task-1", "do the thing")).resolves.toBe(true)
     expect(mocks.buildLaunch).toHaveBeenCalledWith(
       expect.objectContaining({ promptIntent: { kind: "new-task", prompt: "do the thing" } }),

--- a/packages/kobe/test/lib/display-width.test.ts
+++ b/packages/kobe/test/lib/display-width.test.ts
@@ -84,7 +84,7 @@ describe("charWidth", () => {
 
   it("counts the Enclosed Ideographic Supplement block as two cells", () => {
     // Whole block (U+1F200–U+1F2FF) is East-Asian-Width = Wide; it sits just
-    // below the emoji range and was previously counted as one cell.
+    // below the emoji range, which makes it easy to miscount as one cell.
     expect(charWidth(0x1f200)).toBe(2) // 🈀 square hiragana hoka
     expect(charWidth(0x1f21a)).toBe(2) // 🈚 squared CJK "no charge"
     expect(charWidth(0x1f22f)).toBe(2) // 🈯 squared CJK "reserved"

--- a/packages/kobe/test/lib/git-parsers.test.ts
+++ b/packages/kobe/test/lib/git-parsers.test.ts
@@ -9,7 +9,7 @@
  *     C-escaped string, and emits non-ASCII as three-digit OCTAL bytes
  *     (`\303\274` = the UTF-8 bytes of `ü`).
  *   - rename resolution: porcelain uses ` -> ` with each side quoted
- *     independently; numstat uses `-z` and emits the old and new paths as
+ *     independently; numstat uses `-z` and emits the source and destination paths as
  *     separate NUL-delimited fields, avoiding brace-compaction ambiguity.
  *   - the join: porcelain quotes a spaced path (`"a b.txt"`) while numstat
  *     with `-z` emits the raw path (`a b.txt\0`); unquoting BOTH yields one
@@ -144,7 +144,7 @@ describe("parseNumstatRows", () => {
   })
 
   test("resolves a same-directory rename", () => {
-    // `git diff --numstat -z` emits the old and new paths as separate fields.
+    // `git diff --numstat -z` emits the source and destination paths as separate fields.
     expect(parseNumstatRows("0\t0\t\0src/old.txt\0src/new.txt\0")).toEqual([
       numstat("src/new.txt", 0, 0, "src/old.txt"),
     ])
@@ -229,7 +229,7 @@ describe("porcelain ↔ numstat path coherence (the join the bug breaks)", () =>
 
   test("a move OUT of a subdirectory keys onto the same porcelain path", () => {
     // `git mv src/sub/a.txt src/a.txt`. Porcelain reports the full new path;
-    // numstat with `-z` emits the old and new paths as separate fields. Both
+    // numstat with `-z` emits the source and destination paths as separate fields. Both
     // must resolve to `src/a.txt` or the +/- counts orphan from the status row.
     const [p] = parsePorcelainRows("R  src/sub/a.txt -> src/a.txt")
     const [n] = parseNumstatRows("4\t2\t\0src/sub/a.txt\0src/a.txt\0")

--- a/packages/kobe/test/lib/path-glob.test.ts
+++ b/packages/kobe/test/lib/path-glob.test.ts
@@ -75,8 +75,8 @@ describe("matchPathGlob", () => {
   })
 
   it("matches a nested `**` filter against a worktree directly under the prefix", () => {
-    // Regression: `src/**/login` previously failed to match `/work/src/login`
-    // because the globstar required at least one intervening directory.
+    // A globstar that required at least one intervening directory would fail
+    // to match `/work/src/login`.
     expect(matchPathGlob("/work/**/login", "/work/login")).toBe(true)
     expect(matchPathGlob("/work/**/login", "/work/feature/login")).toBe(true)
   })

--- a/packages/kobe/test/lib/poll-scheduling.test.ts
+++ b/packages/kobe/test/lib/poll-scheduling.test.ts
@@ -147,7 +147,7 @@ describe("decodeCapturedChunks", () => {
     const buf = Buffer.from("文档", "utf8")
     const chunks = [buf.subarray(0, 2), buf.subarray(2)]
     expect(decodeCapturedChunks(chunks)).toBe("文档")
-    // Per-chunk decoding (the old `String(chunk)` path) would corrupt the split char.
+    // Per-chunk decoding (a bare `String(chunk)`) would corrupt the split char.
     expect(String(chunks[0]) + String(chunks[1])).not.toBe("文档")
   })
   test("accepts string chunks and preserves ASCII round-trips", () => {

--- a/packages/kobe/test/lib/relative-time.test.ts
+++ b/packages/kobe/test/lib/relative-time.test.ts
@@ -11,9 +11,9 @@ describe("relativeBuckets", () => {
   })
 
   test("each step ROUNDS — the behavior both consumers shipped with", () => {
-    // Pinned so the two callers can't drift apart again. Whether these should
-    // floor instead (a countdown that never overstates headroom — PR #479's
-    // argument) is an owner call; flipping it here moves every consumer.
+    // Pinned so the two callers can't drift apart. Whether these should
+    // floor instead (a countdown that never overstates headroom) is a
+    // display-convention call; flipping it here moves every consumer.
     expect(relativeBuckets(90 * MIN).hours).toBe(2) // 1h30m rounds up
     expect(relativeBuckets(89 * MIN).hours).toBe(1)
     expect(relativeBuckets(36 * 60 * MIN).days).toBe(2) // 1d12h rounds up

--- a/packages/kobe/test/lib/skill-install.test.ts
+++ b/packages/kobe/test/lib/skill-install.test.ts
@@ -205,7 +205,7 @@ describe("npx preflight", () => {
     }) as typeof process.stderr.write
     process.env.PATH = tempDir()
     try {
-      // Must RESOLVE, not reject — the old Bun.spawn path threw here.
+      // Must RESOLVE, not reject — a bare Bun.spawn throws here.
       await expect(runNpxSkillsInstall()).resolves.toBe(NPX_MISSING_EXIT)
       const said = stderr.join("")
       expect(said).toContain("npx")

--- a/packages/kobe/test/monitor/auto-title.test.ts
+++ b/packages/kobe/test/monitor/auto-title.test.ts
@@ -1,9 +1,9 @@
 /**
- * Auto-title behavior parity through the engine registry (KOB-233).
+ * Auto-title behavior parity through the engine registry.
  *
- * auto-title.ts used to pick its history reader with an inline vendor
- * if-ladder; it now resolves `engineEntry(vendor).history`. These tests
- * pin the behavior that must not have changed:
+ * auto-title.ts resolves its history reader through
+ * `engineEntry(vendor).history`, not an inline vendor if-ladder. These tests
+ * pin the behavior that must hold:
  *
  *  - claude: read the worktree's `~/.claude/projects/*` transcripts
  *    OLDEST-first and return the first user prompt, truncated;
@@ -92,8 +92,8 @@ describe("deriveTitleFromSession (claude, through the registry)", () => {
 
 describe("deriveTitleFromSession (custom vendor)", () => {
   it("returns '' instead of mis-reading claude's transcripts", async () => {
-    // A claude transcript EXISTS for the worktree — the old `else → claude`
-    // default would have read it; the registry's empty entry must not.
+    // A claude transcript EXISTS for the worktree — an `else → claude`
+    // default would read it; the registry's empty entry must not.
     await writeSession("aaaa-1111", [userLine("aaaa-1111", "claude-only prompt")], 1_000)
     await expect(deriveTitleFromSession(WORKTREE, "my-custom-engine")).resolves.toBe("")
   })

--- a/packages/kobe/test/state/issue-board.test.ts
+++ b/packages/kobe/test/state/issue-board.test.ts
@@ -52,7 +52,7 @@ describe("issueColumnKey", () => {
   // The defensive half of the link contract. The daemon unlinks an issue when
   // its task is deleted, so a live link resolves — but a store carried over
   // from a build that predates that cascade can hold one that doesn't, and
-  // such a card used to sit In progress with no gesture to get it out.
+  // such a card would sit In progress with no gesture to get it out.
   test("a link to a task that no longer exists reads as backlog", () => {
     const gone = () => false
     expect(issueColumnKey(issue({ id: 11, taskId: "01GONE" }), gone)).toBe("backlog")

--- a/packages/kobe/test/state/repo-init.test.ts
+++ b/packages/kobe/test/state/repo-init.test.ts
@@ -149,10 +149,10 @@ describe("resolveEngineLaunchInit", () => {
   })
 
   // Why: standing instructions for a worker — name your branch, report your
-  // outcome home — moved to the Rove agent skill, which the agent reads once.
-  // They used to be appended to EVERY new task's first prompt, which meant a
-  // user writing Chinese had their own words trailed by two English
-  // paragraphs, and the send-back half duplicated what SKILL.md already said.
+  // outcome home — live in the Rove agent skill, which the agent reads once.
+  // Appending them to EVERY new task's first prompt would trail a user
+  // writing Chinese with two English paragraphs, and duplicate what SKILL.md
+  // already says.
   //
   // What must survive: the user's prompt reaches the engine unchanged, and
   // the per-worktree FACTS (the missing-dependency warning below) still ride
@@ -175,7 +175,7 @@ describe("resolveEngineLaunchInit", () => {
   })
 })
 
-// Why: issue #35 — a fresh worktree with a committed lockfile but no install
+// Why: a fresh worktree with a committed lockfile but no install
 // output makes every build/test fail for reasons unrelated to the task, and
 // agents have reported that breakage as a product regression. Advice only:
 // installing belongs to `.rove/init.sh`, so a repo that configures one is

--- a/packages/kobe/test/state/store.test.ts
+++ b/packages/kobe/test/state/store.test.ts
@@ -2,10 +2,10 @@
  * Unit tests for `src/state/store.ts` — the single owner of
  * `~/.config/rove/state.json` I/O.
  *
- * The module exists to fix a multi-process lost-update bug: the TUI's
- * KVProvider used to debounce-write its ENTIRE in-memory snapshot, so a
+ * The module exists to prevent a multi-process lost update: a KVProvider
+ * that debounce-writes its ENTIRE in-memory snapshot silently reverts a
  * key another kobe process (Tasks pane, quick-task, a CLI command) wrote
- * in the meantime was silently reverted on the next flush. These tests
+ * in the meantime, on its next flush. These tests
  * pin the read-merge-write contract that prevents that, plus the
  * atomicity and corrupt-file behaviors carried over from the two former
  * writers.
@@ -113,7 +113,7 @@ describe("patchStateFile — the lost-update fix", () => {
 
     // Process A flushes its one dirty key. Its snapshot never contained
     // lastSelectedVendor — under whole-snapshot write-back this is the
-    // moment B's write used to be erased.
+    // moment B's write would be erased.
     patchStateFile({ activeTheme: "tokyonight" })
 
     expect(readDisk()).toEqual({

--- a/packages/kobe/test/state/tab-strip.test.ts
+++ b/packages/kobe/test/state/tab-strip.test.ts
@@ -2,10 +2,8 @@
  * Tab-strip visibility: the default, the legacy-boolean migration, and how a
  * mode turns into "does it render".
  *
- * The default is the load-bearing part. It has been flipped twice (off
- * 2026-08-01, on 2026-08-29, off again 2026-08-31) and nothing pinned it, so
- * a flip could ride along in an unrelated change and only be noticed on
- * screen.
+ * The default is the load-bearing part: with nothing pinning it, a flip
+ * rides along in an unrelated change and is only noticed on screen.
  */
 
 import { DEFAULT_TAB_STRIP_MODE, TAB_STRIP_MODES, resolveTabStripMode, tabStripVisible } from "@/state/tab-strip"
@@ -44,7 +42,7 @@ describe("resolveTabStripMode", () => {
   })
 
   it("lets the new key win once it exists", () => {
-    // Someone who set the old toggle and then touched the new setting keeps
+    // Someone who set the legacy toggle and then touched the new setting keeps
     // the new one — otherwise the legacy value would silently outrank it.
     expect(resolveTabStripMode("never", false)).toBe("never")
     expect(resolveTabStripMode("always", true)).toBe("always")

--- a/packages/kobe/test/tui/automation-composer.test.ts
+++ b/packages/kobe/test/tui/automation-composer.test.ts
@@ -15,7 +15,7 @@ const FULL: ComposerDraft = {
   schedule: "0 9 * * MON-FRI",
 }
 
-/** Fri 2026-07-31 10:00 local — the reference "now" for every preview test. */
+/** Friday 31 July 2026, 10:00 local — the reference "now" for every preview test. */
 const NOW = new Date(2026, 6, 31, 10, 0, 0).getTime()
 
 describe("field order", () => {

--- a/packages/kobe/test/tui/continue-live-vendor.test.ts
+++ b/packages/kobe/test/tui/continue-live-vendor.test.ts
@@ -1,5 +1,5 @@
 /**
- * "Continue this conversation" on a WRAPPER preset (owner report 2026-09-02).
+ * "Continue this conversation" on a WRAPPER preset.
  *
  * A custom engine registered before `engineProtocol.<id>` existed — the
  * `claudecpa` zsh function that ends up running the real claude binary — has

--- a/packages/kobe/test/tui/create-task-flow-open-project.test.ts
+++ b/packages/kobe/test/tui/create-task-flow-open-project.test.ts
@@ -1,15 +1,14 @@
 /**
- * The way BACK to a project the sidebar hid (issue #90).
+ * The way BACK to a project the sidebar hid.
  *
  * `isClosedDownProject` drops a project whose only row is its main checkout
- * once that checkout's last tab closes. Nothing is deleted, and the rule's
- * comment always claimed the repo was "still there in the new-task picker to
- * open again" — but every submit path went through `createTask`, which mints
- * a `kind: "task"`. Picking the hidden repo therefore added a worktree beside
- * the project and still produced no project row. The hiding rule had six
- * tests; the way back had none, which is why the gap shipped.
+ * once that checkout's last tab closes. Nothing is deleted, and the repo is
+ * meant to be "still there in the new-task picker to open again" — but a
+ * submit path through `createTask` mints a `kind: "task"`, so picking the
+ * hidden repo would add a worktree beside the project and still produce no
+ * project row.
  *
- * `mode: "open"` is that way back. These pin the half that was missing: the
+ * `mode: "open"` is the way back. These pin it: the
  * flow calls `ensureMainTask` (idempotent — it RESOLVES the existing main row
  * rather than creating a second one), lands on it, and creates no task.
  */
@@ -101,10 +100,9 @@ describe("createTaskFlow — opening a project instead of branching off it", () 
   })
 
   test("creates no task — that is the bug it exists to fix", async () => {
-    // Submitting the same repo through the default path is what used to
-    // happen, and it left the user with an extra worktree and still no
-    // project. Asserting the absence is the only thing that separates the
-    // fix from the bug: both end with a task selected.
+    // Submitting the same repo through the default path leaves the user with
+    // an extra worktree and still no project. Asserting the absence is the
+    // only thing that separates the two paths: both end with a task selected.
     const h = makeCtx({ submit: OPEN })
 
     await createTaskFlow(h.ctx)

--- a/packages/kobe/test/tui/event-loop-stall.test.ts
+++ b/packages/kobe/test/tui/event-loop-stall.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, it } from "vitest"
 import { STALL_HEARTBEAT_MS, STALL_THRESHOLD_MS, stallReport } from "../../src/tui/lib/event-loop-stall"
 
 // Why this matters: the stall report is the incident-forensics primitive for
-// "the TUI froze" reports (2026-07-07/08 — we could never tell OS paging
-// apart from an in-process block after the fact). The threshold branch and
+// "the TUI froze" reports — without it nothing tells OS paging
+// apart from an in-process block after the fact. The threshold branch and
 // the MB math are the whole contract; if either drifts, the log line lies.
 describe("stallReport", () => {
   const mem = { rss: 300 * 1048576, heapUsed: 120 * 1048576 }

--- a/packages/kobe/test/tui/filetree-git.test.ts
+++ b/packages/kobe/test/tui/filetree-git.test.ts
@@ -67,7 +67,7 @@ describe("parseNumstat", () => {
   })
 
   // ── Rename forms (the bug this file pins) ────────────────────────────────
-  // With `-z`, git emits the old and new paths as separate NUL-delimited
+  // With `-z`, git emits the source and destination paths as separate NUL-delimited
   // fields; the canonical NEW path must match what `git status --porcelain`
   // reports as the `R` row's path.
 

--- a/packages/kobe/test/tui/git-head-poller.test.ts
+++ b/packages/kobe/test/tui/git-head-poller.test.ts
@@ -81,7 +81,7 @@ describe("resolveBranchHead fingerprint gate", () => {
     expect(afterFirst).toBeGreaterThanOrEqual(1)
 
     // No fingerprint → nothing was cached → the next call resolves again
-    // (the old always-spawn behavior is preserved verbatim for this path).
+    // (this path always spawns).
     expect(await resolveBranchHead(missing, signal, spawn)).toBe("")
     expect(count()).toBeGreaterThan(afterFirst)
   })

--- a/packages/kobe/test/tui/interrupt-observer.test.ts
+++ b/packages/kobe/test/tui/interrupt-observer.test.ts
@@ -1,5 +1,5 @@
 /**
- * ESC-interrupt observer (issue #15) — the "打断后 sidebar 状态 N 秒内翻转"
+ * ESC-interrupt observer — the "打断后 sidebar 状态 N 秒内翻转"
  * behavior. An ESC interrupt runs NO hook (claude-code's abort path returns
  * before its stop hooks), so the observer reads the engine's own title
  * rewrite — working frame → resting form — against a hook-claimed `running`,

--- a/packages/kobe/test/tui/keymap-dispatch.test.ts
+++ b/packages/kobe/test/tui/keymap-dispatch.test.ts
@@ -255,8 +255,8 @@ describe("dispatchKeyEvent", () => {
   })
 
   // ─── Snapshot / re-entrancy stability ───────────────────────────────
-  // A matched handler's `cmd()` can synchronously mount/unmount components
-  // (Solid effects), which push/remove entries on the live binding stack
+  // A matched handler's `cmd()` can synchronously mount/unmount components,
+  // which push/remove entries on the live binding stack
   // mid-dispatch. The scan must run over a snapshot taken at entry so those
   // mutations can't skip or double-visit the in-flight scan, and the matched
   // binding must still fire exactly once.
@@ -331,7 +331,7 @@ describe("dispatchKeyEvent", () => {
     expect(fires).toBe(2)
   })
 
-  // ─── Legacy C0 fallback (issue #192) ─────────────────────────────────
+  // ─── Legacy C0 fallback ──────────────────────────────────────────────
   // Non-kitty terminals (macOS Terminal.app) deliver ctrl+h as raw 0x08 →
   // parsed {name:"backspace", raw:"\b"} and ctrl+j as 0x0a →
   // {name:"linefeed"}. matchKey aliases those back to the ctrl chords so
@@ -430,7 +430,7 @@ describe("dispatchKeyEvent", () => {
     expect(seen).toEqual([0])
   })
 
-  // The modal barrier (owner mandate 2026-07-08): a dialog must make the
+  // The modal barrier: a dialog must make the
   // WHOLE background unreachable structurally, not via per-pane gates.
   describe("modal barrier", () => {
     test("cuts off every binding below it without consuming the event", () => {
@@ -493,8 +493,8 @@ describe("dispatchKeyEvent", () => {
     })
 
     // Declared modal scope (insertRegistration): barrier-vs-body precedence
-    // used to be an accident of React committing the barrier's effect before
-    // the body's (sibling tree order). It is now declared data — the barrier
+    // is declared data, not an accident of React committing the barrier's
+    // effect before the body's (sibling tree order) — the barrier
     // carries `modalOwner`, body entries carry `modalMember`, and
     // insertRegistration slots the barrier BELOW its members. These tests pin
     // the invariant under BOTH registration orders.
@@ -603,8 +603,8 @@ describe("dispatchKeyEvent", () => {
   })
 
   // Why: the ctrl+w split-close bug — two ENABLED entries sharing a chord
-  // resolve by LIFO order, which React inverted vs Solid (ancestors on
-  // top), silently flipping the winner. The contract is mutual gating;
+  // resolve by LIFO order, and React stacks ancestors on top, so the
+  // winner flips silently. The contract is mutual gating;
   // dispatch (dev mode, KOBE_DEV=1) flags a second enabled match so the
   // violation is loud. Production skips the scan — it would break the
   // read-one-config-on-hit budget (perf-budgets.test.ts).

--- a/packages/kobe/test/tui/keymap-reload.test.ts
+++ b/packages/kobe/test/tui/keymap-reload.test.ts
@@ -21,9 +21,9 @@ describe("resetKeymapToDefaults", () => {
   })
 
   test("navigation keeps ctrl+q direct and uses only relative prefix h/l pane cycling", () => {
-    // Owner call 2026-07-14: release ctrl+h/j/k/l to the embedded engine
-    // and replace the four absolute prefix targets with relative cycling.
-    // Owner call 2026-07-17: h/l (left/right) — the panes sit side by side.
+    // ctrl+h/j/k/l belong to the embedded engine, and pane movement is
+    // relative cycling rather than four absolute prefix targets.
+    // h/l (left/right) — the panes sit side by side.
     expect(findBinding("focus.sidebar")?.keys).toEqual(["ctrl+q"])
     expect(findBinding("focus.sidebar")?.prefixKeys).toBeUndefined()
     expect(findBinding("focus.numeric")).toBeUndefined()

--- a/packages/kobe/test/tui/keymap-slot-parity.test.ts
+++ b/packages/kobe/test/tui/keymap-slot-parity.test.ts
@@ -13,8 +13,8 @@
  * layouts.
  *
  * These tests pin two invariants:
- *   1. with the DEFAULT keys, slot dispatch is byte-identical to the old
- *      name-based behavior (j/down → down, k/up → up, h/left → collapse,
+ *   1. with the DEFAULT keys, slot dispatch is byte-identical to plain
+ *      name-based dispatch (j/down → down, k/up → up, h/left → collapse,
  *      l/right → expand, [ → prev, ] → next);
  *   2. after a user override (and across the live-reload reset), the slot
  *      layout follows the new chords (`sidebar.nav: [w, s]` → w=down,

--- a/packages/kobe/test/tui/lib/git-snapshot.test.ts
+++ b/packages/kobe/test/tui/lib/git-snapshot.test.ts
@@ -74,11 +74,11 @@ describe("validateRepoPath", () => {
     expect(validateRepoPath(repo)).toBeNull()
   })
 
-  // A freshly `git init`ed repo passes `rev-parse --git-dir`, so the dialog
-  // used to accept it, prefill baseRef with DEFAULT_BASE_REF (getCurrentBranch
-  // returns null on an unborn HEAD), and only fail later inside ensureWorktree
+  // A freshly `git init`ed repo passes `rev-parse --git-dir`, so accepting it
+  // means prefilling baseRef with DEFAULT_BASE_REF (getCurrentBranch
+  // returns null on an unborn HEAD) and only failing later inside ensureWorktree
   // with `fatal: invalid reference: main` — on a path whose sole error handler
-  // is a console.error invisible under alt-screen. The user was left on a task
+  // is a console.error invisible under alt-screen, leaving the user on a task
   // row with an empty worktreePath telling them to select a task.
   it("rejects a repo with no commits, and says so", () => {
     const reason = validateRepoPath(emptyRepo)
@@ -96,10 +96,10 @@ describe("validateRepoPath", () => {
   })
 
   // git absent from PATH makes spawnSync return `status: null` + ENOENT, which
-  // used to satisfy `status !== 0` and produce the not-a-repo copy — telling a
-  // user with no git to run `git init && git add -A && git commit`, three
-  // commands that would each also be `command not found`. The WelcomePane's
-  // own probe already got this right; both surfaces now say the same thing.
+  // also satisfies `status !== 0` — a bare check there produces the not-a-repo
+  // copy, telling a user with no git to run `git init && git add -A && git
+  // commit`, three commands that would each also be `command not found`. This
+  // and the WelcomePane's own probe must say the same thing.
   it("says git is missing, not that the folder isn't a repo, when git is absent", () => {
     const realPath = process.env.PATH
     // An empty dir as the entire PATH: no `git` binary is reachable.

--- a/packages/kobe/test/tui/live-engine.test.ts
+++ b/packages/kobe/test/tui/live-engine.test.ts
@@ -1,7 +1,7 @@
 /**
- * The live-engine store is what replaced OSC-title sniffing as kobe's
- * process identity (a claude session whose summary said "codex" used to
- * relabel its tab codex). These lock the two properties the fix depends
+ * The live-engine store owns kobe's process identity, NOT OSC-title
+ * sniffing (a claude session whose summary says "codex" would
+ * relabel its tab codex). These lock the two properties it depends
  * on: identity comes from the tree under the tab's OWN shell pid, and it
  * is released the moment that process is gone.
  */

--- a/packages/kobe/test/tui/pty-dispatch-budget.test.ts
+++ b/packages/kobe/test/tui/pty-dispatch-budget.test.ts
@@ -149,7 +149,7 @@ describe("hosted pty inbound dispatch budget", () => {
     expect(feed.mock.instances[0]).toBe(ptys[3])
 
     // A frame for an unknown key touches NO handle (dropped by the map miss,
-    // same as the old per-handle key-compare rejecting) — and this holds no
+    // like a per-handle key-compare rejecting) — and this holds no
     // matter how many tabs are open, i.e. per-frame cost doesn't grow with N.
     feed.mockClear()
     host.push(dataFrame("nobody::tab"))

--- a/packages/kobe/test/tui/scratch-adopt.test.ts
+++ b/packages/kobe/test/tui/scratch-adopt.test.ts
@@ -1,8 +1,8 @@
 /**
- * Scratch adoption decision + the cwd read behind it (issues #33/#40). The
+ * Scratch adoption decision + the cwd read behind it. The
  * decision is the confidence gate: a repo alone (browsing) or a harness
  * alone (working in a non-repo) must both stay in Scratch. Once confident,
- * the fold check (#40) de-dupes against existing tasks so migrating a shell
+ * the fold check de-dupes against existing tasks so migrating a shell
  * parked in an already-tracked directory never mints a duplicate row.
  */
 
@@ -53,7 +53,7 @@ describe("decideScratchAdopt", () => {
     ).toEqual({ kind: "stay" })
   })
 
-  // --- issue #40: fold instead of minting a duplicate row -----------------
+  // --- fold instead of minting a duplicate row ----------------------------
 
   const mainTask: ScratchOwnerTask = { id: "T-main", kind: "main", dir: "/repos/rove" }
   const managed: ScratchOwnerTask = { id: "T-wt", kind: "task", dir: "/wt/kobe/feature-x" }

--- a/packages/kobe/test/tui/settings-rows.test.ts
+++ b/packages/kobe/test/tui/settings-rows.test.ts
@@ -4,11 +4,11 @@
  * Why these tests matter: the dialog's keyboard nav (j/k/enter), the
  * engines-section row-gated keys (r/x/d), and every section view's
  * cursor highlight all key off "a row's body index is its position in
- * the section's row list". Before the registry this was hand-chained
+ * the section's row list". The alternative is hand-chained
  * offset arithmetic (transparentRowIndex = themeCount, toastRowIndex =
- * themeCount+1+accentCount, ...) where one insertion shifted every
+ * themeCount+1+accentCount, ...) where one insertion shifts every
  * downstream index. These tests pin (a) the exact on-screen row ORDER
- * per section, (b) count parity with the old offset formulas for
+ * per section, (b) count parity with those offset formulas for
  * representative input sizes, and (c) the id-lookup helpers the views
  * use instead of arithmetic. If a row is added or reordered, the order
  * test here is the single place that must change with it.

--- a/packages/kobe/test/tui/sidebar-groups.test.ts
+++ b/packages/kobe/test/tui/sidebar-groups.test.ts
@@ -63,7 +63,7 @@ describe("sidebar task ordering", () => {
   })
 
   it("projects sit tight in recent mode — stored order, not reshuffled by use", () => {
-    // Projects render STORED order (save order; owner 2026-07-16): zeta was
+    // Projects render STORED order (save order): zeta was
     // saved first and used more recently, but neither recency nor alphabet
     // reshuffles the projects section — only move mode reorders it.
     const rows = buildRows(
@@ -254,12 +254,12 @@ describe("sidebar project filter cursor", () => {
  * Identity contract for the sidebar's row reconciler (docs/DESIGN.md §5.5).
  *
  * Why these matter: the Tasks pane lives for days in every tmux session,
- * Solid's `<For>` keys rows by OBJECT IDENTITY, and @opentui/core 0.2.4
+ * list rendering keys rows by OBJECT IDENTITY, and @opentui/core 0.2.4
  * retains ~300B of native memory per renderable create/destroy cycle.
  * Every daemon `task.snapshot` push deserializes ALL-new Task objects —
  * including the no-visual-change push from `setActiveTask`'s recency
  * touch on EVERY task switch — so without reconciliation each push
- * destroyed and recreated every row's renderables (the same leak class
+ * destroys and recreates every row's renderables (the same leak class
  * as the Ops-pane filetree, `test/tui/filetree-rows.test.ts`). The fix
  * is invisible to value-equality assertions: these tests pin identity
  * reuse with toBe — break it and the UI renders identically while the

--- a/packages/kobe/test/tui/sidebar-known-orphans.test.ts
+++ b/packages/kobe/test/tui/sidebar-known-orphans.test.ts
@@ -1,7 +1,7 @@
 /**
  * Scale guard for the sidebar tree's orphan backstop (`filterKnownOrphanTabs`
- * in orphan-tabs): orphan tabs are keyed by task id, and each orphan used to
- * prove its task still exists with a `tasks.some(...)` scan — O(orphans ×
+ * in orphan-tabs): orphan tabs are keyed by task id, and proving each orphan's
+ * task still exists with a `tasks.some(...)` scan would be O(orphans ×
  * tasks) on every poll tick, i.e. a few hundred scans of a few hundred
  * entries at real-install scale. The pure keeps ONE Set build for all
  * orphans; the instrumented array below fails the test on any per-orphan

--- a/packages/kobe/test/tui/sidebar-row-view.test.ts
+++ b/packages/kobe/test/tui/sidebar-row-view.test.ts
@@ -5,9 +5,8 @@
  * `buildSidebarRowView` over its whole input space — every activity state ×
  * seen bit × job × deletion phase × vendor × transcript, plus the spinner sets,
  * the completion grace window, subagent marks and subtitle truncation. Every
- * per-state assertion that used to live in this file was one sampled row of
- * that table, so those cases were removed rather than kept as a second, less
- * complete copy that could disagree with it.
+ * per-state assertion belongs in that table rather than here, as a second,
+ * less complete copy that could disagree with it.
  *
  * What stayed is what a table of outputs cannot say:
  *

--- a/packages/kobe/test/tui/sidebar-tree-core.test.ts
+++ b/packages/kobe/test/tui/sidebar-tree-core.test.ts
@@ -94,15 +94,15 @@ describe("buildTreeRows", () => {
   })
 
   test("every tab always renders — the tree has no fold", () => {
-    // Owner call 2026-08-01 round 5: no collapse anywhere, ever. The tree is
-    // a map; hiding rows made the map lie.
+    // No collapse anywhere, ever. The tree is
+    // a map; hiding rows makes the map lie.
     const tabs = new Map([["a", [tab("tab-1"), tab("tab-2")]]])
     const result = rows({ tasks: [task("a")], tabsByTask: tabs })
     expect(result.map((r) => r.id)).toEqual(["/repos/rove", "a", "a::tab-1", "a::tab-2"])
   })
 
   test("a dir task groups under its directory as the project header", () => {
-    // `kobe .` on an arbitrary directory (owner 2026-08-02): loose rows
+    // `kobe .` on an arbitrary directory: loose rows
     // after the last project read as THAT project's rows, so the directory
     // itself is the header — same grouping rule as every other task.
     const result = rows({ tasks: [task("d", { kind: "dir", repo: "/tmp/scratch" })] })
@@ -250,10 +250,10 @@ describe("mainTaskIdOfProject", () => {
   })
 })
 
-// `tabRowActivity` moved to the golden matrix
+// `tabRowActivity` is covered by the golden matrix
 // (`test/golden/sidebar-row-state.golden.txt`, "which entry a TAB row may
 // read"), which enumerates its whole truth table — tabActivity present/absent
-// x reportedTabCount 0/1/2 x active — instead of the five rows sampled here.
+// x reportedTabCount 0/1/2 x active — rather than a sample of it here.
 
 describe("withRecentRow", () => {
   test("prepends a navigable recent row whose id no task can own", () => {
@@ -439,10 +439,9 @@ describe("a project closed down to nothing (owner call 2026-08-31)", () => {
     expect(treeFlatIds(out)).toEqual([])
   })
 
-  // The half that shipped without a guard (issue #90): six tests pinned that
-  // the project GOES, none that it can come back. It could not — the dialog
-  // only ever minted `kind: "task"`. The way back is now `mode: "open"` →
-  // `ensureMainTask` (test/tui/create-task-flow-open-project.test.ts); what
+  // The other half of the guard: the tests above pin that the project GOES,
+  // and the way back is `mode: "open"` →
+  // `ensureMainTask` (test/tui/create-task-flow-open-project.test.ts). What
   // belongs HERE is the tree's side of that round trip.
   test("the hidden project returns as soon as its main has a tab again", () => {
     const tasks = [mainOf("/repos/codefox")]

--- a/packages/kobe/test/tui/sidebar-tree-menu-items.test.ts
+++ b/packages/kobe/test/tui/sidebar-tree-menu-items.test.ts
@@ -160,8 +160,8 @@ describe("treeMenuItems", () => {
 
   test("the LAST tab IS offered a close (owner call 2026-08-31)", () => {
     // Closing it leaves the task with no sessions; its sidebar row stays and
-    // re-opens on ⏎ / ctrl+e. The entry used to be withheld because closeTab
-    // refused the last tab, which is no longer true.
+    // re-opens on ⏎ / ctrl+e. The entry is NOT withheld — closeTab accepts
+    // the last tab.
     expect(actions(tabRow, { tabCount: 1 })).toContain("closeTab")
     expect(actions(tabRow, { tabCount: 1 })).toContain("newChat")
   })

--- a/packages/kobe/test/tui/split-core.test.ts
+++ b/packages/kobe/test/tui/split-core.test.ts
@@ -183,7 +183,7 @@ describe("split tree (content-agnostic)", () => {
     expect(splitLeafPtyKey("task::tab-1", "leaf-2")).toBe("task::tab-1::leaf-2")
   })
 
-  // Owner semantics 2026-07-06: the TAB is the "group"; each leaf carries
+  // The TAB is the "group"; each leaf carries
   // its OWN name — F2 rename wins, default = basename of what it runs,
   // duplicate defaults get a reading-order suffix so they stay tellable
   // apart. This pins the derivation the corner tags render from.
@@ -229,7 +229,7 @@ describe("split tree (content-agnostic)", () => {
     const live = new Map([["leaf-2", "vim"]])
     const named = splitLeafNames(leaves(s.root), ["claude"], "fix the resize race", live)
     expect(named.get("leaf-2")).toBe("vim")
-    // No live title yet → the generic default, same as before this existed.
+    // No live title yet → the generic default.
     expect(splitLeafNames(leaves(s.root), ["claude"], "fix the resize race").get("leaf-2")).toBe("shell")
     // A manual rename still wins over a live title.
     const renamed = splitLeafNames(leaves(renameLeaf(s, "leaf-2", "logs").root), ["claude"], null, live)
@@ -253,9 +253,9 @@ describe("split tree (content-agnostic)", () => {
 })
 
 // Why: tabTitle is the ONE naming rule for the strip label, the rename
-// dialog prefill, and notification titles (owner order 2026-07-09:
-// rename > live process > first-prompt > vendor default). Deriving from
-// anything else relabelled running tabs — pin the precedence and the
+// dialog prefill, and notification titles (order: rename > live process >
+// first-prompt > vendor default). Deriving from
+// anything else relabels running tabs — pin the precedence and the
 // split-tab branches ("group N" / a collapsed sole shell leaf).
 describe("tabTitle (tab naming policy)", () => {
   const engine = (over: Partial<EngineTab> = {}): EngineTab => ({

--- a/packages/kobe/test/tui/tab-close-scratch.test.ts
+++ b/packages/kobe/test/tui/tab-close-scratch.test.ts
@@ -1,8 +1,8 @@
 /**
  * ctrl+w on a task's ONLY tab: a scratch task tears down the whole task
- * (issue #42 — same zero-ceremony path as its shell exiting,
- * `onScratchExit`), while an ordinary task is simply left with no tabs
- * (owner call 2026-08-31): the row stays and re-opens on ⏎ / ctrl+e.
+ * (the same zero-ceremony path as its shell exiting,
+ * `onScratchExit`), while an ordinary task is simply left with no tabs:
+ * the row stays and re-opens on ⏎ / ctrl+e.
  */
 
 import { describe, expect, it, vi } from "vitest"
@@ -61,7 +61,7 @@ describe("closeActive on the only tab", () => {
   })
 
   it("ordinary task: closes it, leaving the task with no tabs", () => {
-    // Owner call 2026-08-31. The task and its worktree stay — its sidebar row
+    // The task and its worktree stay — its sidebar row
     // remains and re-opens on ⏎ / ctrl+e — so there is nothing to warn about.
     const { close, calls } = harness(initialShellTabs("/bin/zsh"))
     close.closeActive()
@@ -88,7 +88,7 @@ describe("closing down to zero tabs (owner call 2026-08-31)", () => {
   })
 
   it("records what the closed tab WAS, so re-entry reopens the same kind", () => {
-    // Owner ask 2026-08-31: re-entering an emptied task should bring back the
+    // Re-entering an emptied task must bring back the
     // kind of session that was there, not always an engine.
     const shellOnly: TabsState = {
       tabs: [{ kind: "command", id: "tab-1", title: null, ordinal: 1, command: ["/bin/zsh"] }],
@@ -120,12 +120,12 @@ describe("closing down to zero tabs (owner call 2026-08-31)", () => {
     expect(revived.tabs[0]?.kind).toBe("engine")
     expect(revived.tabs[0]).toMatchObject({ vendor: "codex" })
     // The session is NOT carried: that PTY died with the tab, so reviving it
-    // would resume a conversation that no longer has a process.
+    // would resume a conversation with no process behind it.
     expect(revived.tabs[0]).not.toHaveProperty("sessionId")
   })
 
   it("a snapshot written before reopenAs existed falls back to a default engine tab", () => {
-    // The upgrade path (owner ask): an install that emptied a task on an older
+    // The upgrade path: an install that emptied a task on an older
     // build has no `reopenAs`, and must still reopen rather than stay stuck.
     const legacy: TabsState = { tabs: [], activeId: "tab-1", nextOrdinal: 2 }
     const revived = reopenTabs(legacy, "/bin/zsh")

--- a/packages/kobe/test/tui/tab-last-title.test.ts
+++ b/packages/kobe/test/tui/tab-last-title.test.ts
@@ -43,11 +43,11 @@ describe("recorded live title (lastTitle)", () => {
     expect(tabTitle(renamed, "claude", "live")).toBe("my tab")
   })
 
-  // Regression (owner report 2026-08-10): "the chattab shows the right title
-  // for a second, then goes back to claude 7." The live-title store seeded a
-  // freshly-attached PTY with "" (nothing reported YET), the host recorded
-  // that over the real name, and the tab fell to its vendor default — then
-  // persisted, so it came back wrong on the next start too.
+  // Regression: "the chattab shows the right title
+  // for a second, then goes back to claude 7." Seeding a
+  // freshly-attached PTY with "" (nothing reported YET) lets the host record
+  // that over the real name, dropping the tab to its vendor default — and
+  // persisting it, so it comes back wrong on the next start too.
   it("an empty title never erases the recorded one", () => {
     const state = setTabLastTitle(initialTabs(), firstTab(initialTabs()).id, "✳ 运行本地Codex处理图片")
     const blanked = setTabLastTitle(state, firstTab(state).id, "")
@@ -65,8 +65,8 @@ describe("recorded live title (lastTitle)", () => {
 /**
  * Codex's OSC title is its THREAD ID until the thread is named, so the live
  * stream hands the ladder `01a00ee9-…` — an identifier, not a name. It must
- * lose to the tab's own first-prompt title (owner report 2026-08-17: "现在显示
- * 的是uuid"), which is what the naming pass derives from that very id.
+ * lose to the tab's own first-prompt title (otherwise the tab shows a uuid),
+ * which is what the naming pass derives from that very id.
  */
 describe("placeholder live titles (codex thread ids)", () => {
   const THREAD_ID = "01a00ee9-f0e9-7503-a11c-83b4eface0f6"

--- a/packages/kobe/test/tui/tab-title-stable.test.ts
+++ b/packages/kobe/test/tui/tab-title-stable.test.ts
@@ -5,13 +5,13 @@
  * renders tabs it does not host, so it has no live title stream and reads the
  * RECORDED `lastTitle`.
  *
- * That recording used to be the engine's whole status line (`⠐ 利用自进化…`),
- * so the rule threw it away — which left every row reading "claude 1" while
- * the tab strip showed the real conversation title (owner report
- * 2026-08-10). The status prefix is now stripped where the title enters the
- * app, so what is recorded is the NAME and the tree keeps it. Titles recorded
- * before that fix still carry their prefix and are stripped again here, so
- * old snapshots heal on display without a migration.
+ * The status prefix is stripped where the title enters the
+ * app, so what is recorded is the NAME and the tree keeps it. Throwing that
+ * recording away instead — as one must when it is the engine's whole status
+ * line (`⠐ 利用自进化…`) — leaves every row reading "claude 1" while
+ * the tab strip shows the real conversation title. Titles recorded by an
+ * older kobe still carry their prefix and are stripped again here, so
+ * those snapshots heal on display without a migration.
  */
 
 import { describe, expect, it } from "vitest"
@@ -47,7 +47,7 @@ describe("tabTitleStable", () => {
     expect(tabTitleStable(withAuto, "claude", "claude")).toBe("wire up the digest verb")
   })
 
-  // Regression (owner report 2026-08-10): a tab pinned to a user WRAPPER
+  // Regression: a tab pinned to a user WRAPPER
   // (`claudecpa` — a zsh function that ends up running real claude) is a
   // custom vendor and declares no glyph vocabulary, so its rows kept the
   // prefix. Cleaning is not gated on `ownsStatus` for exactly this reason.
@@ -93,9 +93,9 @@ describe("tabTitleStable", () => {
     expect(tabTitleStable(tab, "codex", "claude")).toBe("claude 1")
   })
 
-  // Regression (owner report 2026-08-10): quit kobe with `claude` running in
-  // a shell tab, restart, and the sidebar row read "shell N" — the rule only
-  // carried a resolved vendor through for tabs already born as engine tabs.
+  // Regression: quit kobe with `claude` running in
+  // a shell tab, restart, and the sidebar row reads "shell N" if the rule
+  // carries a resolved vendor through only for tabs born as engine tabs.
   it("names a shell tab after the engine running in it, not 'shell'", () => {
     const tab = {
       kind: "command",
@@ -111,10 +111,10 @@ describe("tabTitleStable", () => {
     expect(tabTitleStable(named, "claude", "claude")).toBe("wire up the digest verb 2")
   })
 
-  // Regression (owner report 2026-08-10): clicking into a tab flashed the
+  // Regression: clicking into a tab flashes the
   // engine's live status line before settling. The live vendor comes from a
   // ~2s ps walk, so for one render the probe answers `undefined` — without
-  // the RECORDED identity the rule dropped to the raw-title branch.
+  // the RECORDED identity the rule drops to the raw-title branch.
   it("falls back to the RECORDED vendor so the status line never flashes", () => {
     const tab = {
       kind: "command",
@@ -135,7 +135,7 @@ describe("tabTitleStable", () => {
 
   // Codex's OSC title is its thread ID until the thread is named, so the
   // recorded/live title on a codex row is `01a00ee9-…` — an identifier, not a
-  // name (owner report 2026-08-17).
+  // name.
   it("a codex thread id is not a name — the first prompt is", () => {
     const id = "01a00ee9-f0e9-7503-a11c-83b4eface0f6"
     const tab = engineTab({ vendor: "codex", lastTitle: id, autoTitle: "add a login form" })

--- a/packages/kobe/test/tui/task-actions-rename.test.ts
+++ b/packages/kobe/test/tui/task-actions-rename.test.ts
@@ -251,7 +251,7 @@ describe("cycleVendorFlow", () => {
 
 /**
  * The set-status flow. Its whole job is one RPC, so the tests name the FIELD
- * that RPC carries: dropping the `setStatus` call, or sending the old value,
+ * that RPC carries: dropping the `setStatus` call, or sending a stale value,
  * has to turn something red here.
  *
  * The cosmetic contract is asserted as an absence — no other orchestrator

--- a/packages/kobe/test/tui/tasks-legend-keys.test.ts
+++ b/packages/kobe/test/tui/tasks-legend-keys.test.ts
@@ -6,10 +6,10 @@
  * promises every surface follows the keymap: "one mutation re-points every
  * surface — chord, Help copy, and footer hint follow automatically
  * (overridden rows get their hint.keys refreshed; an unbound row loses its
- * hint)". The legend rows used to be a hardcoded literal array
- * (`{ k: "n" }`, `{ k: "a/d" }`, …) so an override / unbind in
- * ~/.kobe/settings/keybindings.yaml changed dispatch but NOT the advertised
- * cap — the legend lied. The fix derives each cap from `KobeKeymap` via
+ * hint)". A hardcoded literal array of legend rows
+ * (`{ k: "n" }`, `{ k: "a/d" }`, …) lets an override / unbind in
+ * ~/.kobe/settings/keybindings.yaml change dispatch but NOT the advertised
+ * cap, so the legend lies. Each cap is derived from `KobeKeymap` via
  * `legendCap` / `legendRowCap`, which live in the framework-free
  * `src/tui/lib/help-groups.ts` — imported here directly (no opentui in the
  * module graph), so this file tests the REAL helpers the footer legend

--- a/packages/kobe/test/tui/terminal-keys-pure.test.ts
+++ b/packages/kobe/test/tui/terminal-keys-pure.test.ts
@@ -47,9 +47,9 @@ describe("keyEventToShellBytes", () => {
   it("re-encodes kitty CSI-u keystrokes instead of trusting sequence", () => {
     // The host renderer runs with useKittyKeyboard, so on kitty-capable
     // terminals modifier chords arrive CSI-u encoded. Field shapes below
-    // were measured on the real wire (Bun PTY probe, 2026-07-06): for
+    // were measured on the real wire (Bun PTY probe): for
     // ctrl+c opentui puts the LOGICAL key ("c") in `sequence` — forwarding
-    // it verbatim typed a literal "c" instead of interrupting — while for
+    // it verbatim types a literal "c" instead of interrupting — while for
     // esc `sequence` carries the raw CSI-u bytes.
     expect(keyEventToShellBytes(evt({ name: "c", ctrl: true, sequence: "c", raw: "\x1b[99;5u" } as never))).toBe("\x03")
     expect(keyEventToShellBytes(evt({ name: "escape", sequence: "\x1b[27u", raw: "\x1b[27u" } as never))).toBe("\x1b")
@@ -68,9 +68,9 @@ describe("keyEventToShellBytes", () => {
   })
 
   it("keeps the typed uppercase for shift+letter keystrokes on both wire formats", () => {
-    // Regression (2026-07-18): shift+letter became a bindable chord and
-    // Shift+Z on kitty terminals typed lowercase "z" — the CSI-u path
-    // synthesized from `name` ("z"), dropping the shift. The parser puts
+    // Regression: shift+letter is a bindable chord, and
+    // Shift+Z on kitty terminals types lowercase "z" if the CSI-u path
+    // synthesizes from `name` ("z"), dropping the shift. The parser puts
     // the typed TEXT in `sequence` ("Z"); with no ctrl/alt that is the
     // byte to forward.
     expect(keyEventToShellBytes(evt({ name: "z", shift: true, sequence: "Z", raw: "\x1b[122:90;2u" } as never))).toBe(
@@ -95,19 +95,19 @@ describe("keyEventToShellBytes", () => {
 describe("key routing tables", () => {
   it("reserves ONLY the minimal kobe chords; the engine owns the rest", () => {
     expect(TRAPPED_KEYS).toEqual(["ctrl+pageup", "ctrl+pagedown"])
-    // Owner decision 2026-07-06: ctrl+q escape hatch + tab management +
+    // The reserved set: ctrl+q escape hatch + tab management +
     // splits + reset, plus f4 (focus.next pane cycle — the one cross-pane
     // chord besides ctrl+q reachable from inside the terminal). Anything
-    // beyond this list steals a chord from the engine CLI. f6 was the zen
-    // toggle 2026-07-07..17, released back to the shell when zen moved to
-    // prefix-only prefix+z; f7 (attention.next — jump to the next waiting
+    // beyond this list steals a chord from the engine CLI. f6 is NOT here —
+    // zen is prefix-only (prefix+z), so f6 belongs to the shell;
+    // f7 (attention.next — jump to the next waiting
     // task) same rationale as f4.
-    // NOT ctrl+g for attention.next: that's the engine's readline abort —
-    // it moved to f7 so ctrl+g passes through to the engine again.
-    // ctrl+<digit> joined 2026-07-29 (owner request): jump to the task
+    // NOT ctrl+g for attention.next: that's the engine's readline abort, so
+    // attention.next takes f7 and ctrl+g passes through to the engine.
+    // ctrl+<digit>: jump to the task
     // showing that digit, which only works if the digits don't reach the
     // engine. ctrl+1 is NOT here — the legacy terminal protocol can't
-    // encode it (verified on the owner's terminal), so the rows print
+    // encode it, so the rows print
     // 2…9,0 instead. The cost is the shell's ctrl+digit control bytes
     // (ctrl+3 = ESC, ctrl+8 = DEL); the real escape/backspace keys are
     // untouched.
@@ -131,9 +131,8 @@ describe("key routing tables", () => {
         "ctrl+w",
         "ctrl+\\",
         "ctrl+=",
-        // f1 joined 2026-08-09 (owner call): "F1 anywhere" is the docs'
-        // promise and the status-bar hint advertises it inside the
-        // terminal — no engine binds F1.
+        // f1: "F1 anywhere" is the docs' promise and the status-bar hint
+        // advertises it inside the terminal — no engine binds F1.
         "f1",
         "f2",
         "f3",

--- a/packages/kobe/test/tui/terminal-pty-park.test.ts
+++ b/packages/kobe/test/tui/terminal-pty-park.test.ts
@@ -1,9 +1,9 @@
 /**
- * PTY parking (issue #28) — the registry's idle sweep.
+ * PTY parking — the registry's idle sweep.
  *
- * Why this matters: every open tab used to keep a full @xterm/headless
- * instance (grid + scrollback) resident forever — the workspace host sat
- * at 250-300MB and was the first process killed under memory pressure.
+ * Why this matters: without it every open tab keeps a full @xterm/headless
+ * instance (grid + scrollback) resident forever — the workspace host sits
+ * at 250-300MB and is the first process killed under memory pressure.
  * The sweep detaches persistent-backend handles that have had no data
  * subscriber for the idle window; the child keeps running in the pty
  * host, and re-acquire reattaches + replays the host ring buffer (the

--- a/packages/kobe/test/tui/terminal-render.test.ts
+++ b/packages/kobe/test/tui/terminal-render.test.ts
@@ -27,8 +27,8 @@ describe("overlayCursor — cell-column aware", () => {
 
   it("lands on the right char when the row has wide (CJK) glyphs", () => {
     // "你好x": 你 = cells 0-1, 好 = cells 2-3, x = cell 4. `cursor.x` is a
-    // CELL column, so counting code points (你好x = 3) used to drift the
-    // cursor left by one column per wide char — this pins the fix.
+    // CELL column, so counting code points (你好x = 3) drifts the
+    // cursor left by one column per wide char — this pins against that.
     const rows = [[{ text: "你好x" } as Chunk]]
     expect(cursorCell(overlayCursor(rows, { x: 0, y: 0 }, COLORS), 0)?.text).toBe("你")
     expect(cursorCell(overlayCursor(rows, { x: 2, y: 0 }, COLORS), 0)?.text).toBe("好")

--- a/packages/kobe/test/tui/terminal-selection-trim.test.ts
+++ b/packages/kobe/test/tui/terminal-selection-trim.test.ts
@@ -60,7 +60,7 @@ const SCROLLBACK = 50
  * That is why a five-second budget still expired on CI while passing in 50ms
  * on every developer machine, and why raising it is the honest fix rather than
  * a papered-over race: nothing here is unordered, the work just takes as long
- * as it takes to win a scheduling slot (issue #94).
+ * as it takes to win a scheduling slot.
  */
 const SETTLE_MS = 30_000
 const settleUntil = (check: () => void): Promise<void> => vi.waitFor(check, { timeout: SETTLE_MS, interval: 10 })
@@ -69,7 +69,7 @@ type Frame = { snapshot: readonly TerminalRow[]; window: TerminalSnapshotWindow 
 
 describe("selection across a bounded-scrollback trim", () => {
   // The waits above may spend the full SETTLE_MS; vitest's default 5s test
-  // cap must not expire underneath them, or the budget is fiction (#94).
+  // cap must not expire underneath them, or the budget is fiction.
   it(
     "keeps the highlight on the content it selected while output streams",
     { timeout: SETTLE_MS + 5_000 },
@@ -104,7 +104,7 @@ describe("selection across a bounded-scrollback trim", () => {
         // and when it does the wait can only time out. That is this test's whole
         // flake history: it blocked four unrelated PRs and one release in a day
         // while passing in 50ms unloaded, because unloaded every refresh folds
-        // exactly one line (issue #94).
+        // exactly one line.
         //
         // `>=` is not a weaker assertion here. What the test is about is that a
         // selection follows the window it was taken in, and `followWindowShift`

--- a/packages/kobe/test/tui/terminal-selection.test.ts
+++ b/packages/kobe/test/tui/terminal-selection.test.ts
@@ -380,7 +380,7 @@ describe("bounded-scrollback trimming (snapshot window)", () => {
     expect(followWindowShift(state, { epoch: 1, startLine: 7 }, { epoch: 1, startLine: 7 }, 10, false)).toBe(state)
     // Alternate screen (no line numbering) is the other mechanism's business.
     expect(followWindowShift(state, null, null, 10, false)).toBe(state)
-    // A resize reflows history: those ids no longer mean anything.
+    // A resize reflows history: those ids mean nothing afterwards.
     expect(followWindowShift(state, { epoch: 1, startLine: 7 }, { epoch: 2, startLine: 0 }, 10, false)).toBeNull()
   })
 })

--- a/packages/kobe/test/tui/terminal-sgr-attrs.test.ts
+++ b/packages/kobe/test/tui/terminal-sgr-attrs.test.ts
@@ -122,8 +122,8 @@ describe("OSC 8 hyperlinks", () => {
   const URL = "https://example.com/s/quill-landing"
 
   // @xterm/headless underlines linked cells, so the production cell→chunk path
-  // reports ATTR.UNDERLINE for a link. This fallback parser used to DROP the
-  // OSC entirely, which made the mock pane render links unlike the real pane.
+  // reports ATTR.UNDERLINE for a link. A fallback parser that DROPS the
+  // OSC entirely makes the mock pane render links unlike the real pane.
   test("underlines the linked run and stops at the close (BEL-terminated)", () => {
     const { chunks } = parseAnsiLine(`pre \x1b]8;;${URL}\x07${URL}\x1b]8;;\x07 (round 2)`)
     expect(chunks.map((c) => c.text)).toEqual(["pre ", URL, " (round 2)"])

--- a/packages/kobe/test/tui/terminal-tab-fork-argv.test.ts
+++ b/packages/kobe/test/tui/terminal-tab-fork-argv.test.ts
@@ -170,7 +170,7 @@ describe("buildHandoffPrompt", () => {
 
 // Why: a handoff opens a LATER tab, so it can't ride the task-level prompt
 // (first-engine-tab only). It must fire exactly once — a replay on restart
-// would make the new engine re-read and re-announce the old session forever.
+// would make the new engine re-read and re-announce that session forever.
 describe("engineTabSpawnFor with a tab-owned handoff prompt", () => {
   const opts = {
     live: false,
@@ -193,7 +193,7 @@ describe("engineTabSpawnFor with a tab-owned handoff prompt", () => {
     const script = engineTabSpawnFor(state, handoff, ["codex"], opts).command[2]
     expect(script).toContain("read /r.jsonl")
     // A handoff opens on an EXISTING worktree — never a new-task first
-    // prompt, so the branch-rename coda must not ride along (issue #8).
+    // prompt, so the branch-rename coda must not ride along.
     expect(script).not.toContain("set-branch")
   })
 
@@ -207,7 +207,7 @@ describe("engineTabSpawnFor with a tab-owned handoff prompt", () => {
   })
 })
 
-// Why (issue #25): kimi's positional CLI slot is a SUBCOMMAND — a prompt in
+// Why: kimi's positional CLI slot is a SUBCOMMAND — a prompt in
 // the argv exits the engine `Unknown command` before it does any work. The
 // registry declares `firstMessageDelivery: "paste"` for kimi, so the TUI
 // spawn must keep the prompt OUT of the launch line and surface it as

--- a/packages/kobe/test/tui/terminal-tab-identity.test.ts
+++ b/packages/kobe/test/tui/terminal-tab-identity.test.ts
@@ -1,9 +1,9 @@
 /**
  * `demoteExitedEngine` — a tab is a SHELL; the engine is a process in it.
  *
- * The bug this pins (owner report 2026-08-10): a tab you exited claude in
- * kept `kind: "engine"`, so the sidebar row kept its agent state dot and
- * every keystroke marked an optimistic turn — while the row's own label had
+ * The bug this pins: a tab you exited claude in
+ * keeps `kind: "engine"`, so the sidebar row keeps its agent state dot and
+ * every keystroke marks an optimistic turn — while the row's own label has
  * already fallen back to `shell N`. Resetting the state at the exit is what
  * makes label, glyph and activity agree without a per-consumer guard.
  */

--- a/packages/kobe/test/tui/terminal-tabs-core.test.ts
+++ b/packages/kobe/test/tui/terminal-tabs-core.test.ts
@@ -117,7 +117,7 @@ describe("terminal tabs state", () => {
     expect(s.activeId).toBe("tab-2")
   })
 
-  // Regression (2026-07-10): FileTree opens share one File tab. Opening a
+  // Regression: FileTree opens share one File tab. Opening a
   // second file replaces and focuses that slot instead of growing one editor
   // tab per file forever.
   it("openEditorTab reuses the single editor slot", () => {
@@ -174,11 +174,11 @@ describe("terminal tabs state", () => {
     expect(after.tabs[1]).not.toHaveProperty("sessionId", "uuid-2")
   })
 
-  // Why: rehydrateTabs is the restart contract (issue #22, revised
-  // 2026-07-07) — a tab is a TERMINAL, so every tab survives: engine tabs
+  // Why: rehydrateTabs is the restart contract — a tab is a TERMINAL, so
+  // every tab survives: engine tabs
   // come back resumable, command tabs (a degraded shell, a dead editor)
-  // come back as plain shells. Dropping command tabs was the "closed
-  // shell reopens as claude" bug: a lone degraded tab fell through to
+  // come back as plain shells. Dropping command tabs reopens a closed
+  // shell as claude: a lone degraded tab falls through to
   // initialTabs(), resurrecting a fresh engine in the terminal's place.
   it("rehydrateTabs keeps every tab; command tabs respawn as shells", () => {
     let s = addTab(initialTabs(), "codex") // [1, 2*(codex)]
@@ -208,7 +208,7 @@ describe("terminal tabs state", () => {
     expect(rehydrateTabs({ tabs: [], activeId: "tab-1", nextOrdinal: 1 }, ["/bin/zsh"])).toEqual(initialTabs())
   })
 
-  // Why: the frozen split layout (owner ask 2026-07-06) must survive the
+  // Why: the frozen split layout must survive the
   // persist → rehydrate round-trip so a `claude | shell` group reopens
   // after restart. setTabSplit stores/clears the tree; rehydrateTabs keeps
   // it on the surviving engine tab. leaf-1 (null content = the tab's
@@ -267,10 +267,10 @@ describe("terminal tabs state", () => {
     expect(meaningfulAutoTitle(" fix the race ")).toBe("fix the race")
   })
 
-  // Why: the last-tab in-place recycle used to reset to bare initialTabs(),
-  // dropping title/autoTitle — the naming pass then derived a NEW name from
-  // the fresh session's first prompt, so the tab visibly renamed itself on
-  // every recycle. Carrying both fields keeps the name stable AND blocks
+  // Why: a last-tab in-place recycle that reset to bare initialTabs() would
+  // drop title/autoTitle — the naming pass would then derive a NEW name from
+  // the fresh session's first prompt, so the tab would visibly rename itself
+  // on every recycle. Carrying both fields keeps the name stable AND blocks
   // re-derivation (the pass only names tabs with neither field set).
   it("recycleTabs keeps the exited tab's title/autoTitle on the fresh tab", () => {
     let s = setTabAutoTitle(initialTabs(), "tab-1", "fix the resize race")
@@ -305,7 +305,7 @@ describe("terminal tabs state", () => {
     expect(hasEngineLeaf(engineClosed)).toBe(false) // only the shell survives
   })
 
-  // Why: this argv decision IS the restart-survival contract (issue #22) —
+  // Why: this argv decision IS the restart-survival contract —
   // `--resume` must fire ONLY for a tab that already conversed and has no
   // live PTY; a live PTY (re-render churn) or a never-spawned tab must
   // keep pinning the fresh id, or claude errors "no conversation found".
@@ -328,8 +328,8 @@ describe("terminal tabs state", () => {
     expect(engineTabArgv(tab({ sessionId: "u1", spawned: true }), base, false)).toEqual(["claude", "--resume", "u1"])
   })
 
-  // Why: the quick-fork initial prompt (issue #17, delivery verified in
-  // 12283c57) rides the argv as a positional arg ONLY on the first engine
+  // Why: the quick-fork initial prompt rides the argv as a positional arg
+  // ONLY on the first engine
   // tab's FIRST spawn — any wider and the prompt re-delivers on re-render
   // churn / restart / every new tab, replaying the fork message forever.
   it("engineTabSpawnFor: the initial prompt rides only the first engine tab's first spawn", () => {
@@ -348,8 +348,8 @@ describe("terminal tabs state", () => {
     const firstSpawn = engineTabSpawnFor(s, first, base, opts)
     expect(firstSpawn.command.slice(0, 2)).toEqual(["/bin/zsh", "-ilc"])
     expect(firstSpawn.command[2]).toContain("claude 'fix the bug")
-    // A quick-fork prompt is a fresh worktree task's FIRST prompt. It used to
-    // carry a branch-rename coda; that standing instruction now lives in the
+    // A quick-fork prompt is a fresh worktree task's FIRST prompt. It carries
+    // no branch-rename coda — that standing instruction lives in the
     // Rove agent skill, so the prompt reaches the engine as the user wrote it.
     expect(firstSpawn.command[2]).not.toContain("set-branch")
     // Second engine tab: never gets the prompt.
@@ -397,7 +397,7 @@ describe("terminal tabs state", () => {
     expect(tabExitAction({ ...engine, spawned: undefined }, true, false)).toBe("close") // never conversed
   })
 
-  // Why: shellSpawn is the vendor-launch contract (2026-07-10): the PTY
+  // Why: shellSpawn is the vendor-launch contract: the PTY
   // runs the user's SHELL and the engine command is TYPED into it, so the
   // session keeps rc-file context and exiting the vendor lands on a
   // prompt. Quoting must keep an argv with spaces/quotes ONE argument at

--- a/packages/kobe/test/tui/terminal-tabs-move.test.ts
+++ b/packages/kobe/test/tui/terminal-tabs-move.test.ts
@@ -1,5 +1,5 @@
 /**
- * Tab reorder within a task (sidebar move mode, issue #43): the pure
+ * Tab reorder within a task (sidebar move mode): the pure
  * `moveTab` core (edge-stop, no wrap) and the mounted-vs-background fork in
  * `moveTaskTab` — order must land in the module map AND the kv snapshot so
  * it survives restart (`rehydrateTabs` keeps array order).

--- a/packages/kobe/test/tui/workspace-task-selection.test.ts
+++ b/packages/kobe/test/tui/workspace-task-selection.test.ts
@@ -169,8 +169,8 @@ describe("pure-TUI workspace task activation", () => {
   })
 
   // Why: the SSH-reconnect "reopens on the oldest project" bug — a stale or
-  // freshly-respawned daemon replays a null/ancient focus, and the old
-  // fallback took tasks.json ARRAY order, which leads with the oldest saved
+  // freshly-respawned daemon replays a null/ancient focus, and a
+  // fallback on tasks.json ARRAY order leads with the oldest saved
   // repo's main task (wakey). Restore order must be: daemon focus →
   // persisted lastActive → newest updatedAt; never raw array position.
   test("selection restore prefers active → persisted lastActive → most recently updated", () => {

--- a/packages/kobe/test/tui/worktree-changes.test.ts
+++ b/packages/kobe/test/tui/worktree-changes.test.ts
@@ -26,7 +26,7 @@ describe("parsePorcelain", () => {
   })
 })
 
-// The sidebar's source-preference seam (issue #6): a non-null pushed map
+// The sidebar's source-preference seam: a non-null pushed map
 // means the daemon owns collection — including for rows ABSENT from the
 // map (remote / just-created), which must read as zeros, never
 // as "poll locally", or panes would re-grow git polls for exactly the

--- a/packages/kobe/test/tui/xterm-chunks.test.ts
+++ b/packages/kobe/test/tui/xterm-chunks.test.ts
@@ -121,10 +121,10 @@ describe("xtermLineMatchesChunks — allocation-free semantic check", () => {
  * A solid-block cell whose fg and bg are the SAME pixel color but declared
  * through different color modes — exactly what half-block renderers
  * (carbonyl, the ASCII video player) emit when they mix palette and
- * truecolor. The builder used to compare color KEYS (`pal:15` ≠
- * `rgb:16777215`) while the matcher compared resolved RGB (equal), so the
- * two disagreed on whether to substitute a bg-only space — the matcher
- * reported "changed" on every single compare and the pane re-rendered
+ * truecolor. A builder comparing color KEYS (`pal:15` ≠
+ * `rgb:16777215`) while the matcher compares resolved RGB (equal) makes the
+ * two disagree on whether to substitute a bg-only space — the matcher then
+ * reports "changed" on every single compare and the pane re-renders
  * forever (the visible "redraw keeps getting bumped").
  */
 function mixedModeBlockCell(chars: string) {


### PR DESCRIPTION
Comments in `tui`, `state`, `types`, `lib`, `core` and `monitor` now say what the code
does, not how it got here. Owner calls and dates, issue/PR/ticket refs, and past-state
narration are gone; where a real invariant, mechanism or deliberate refusal was buried in
the story, it was rewritten in the present tense rather than deleted.

**No code changed.** Not one token outside comments.

## Numbers

- **Worklist:** the `Done means` grep returned **353** hits across **142** files at the
  start; it returns **0** now over the whole slice.
- **Files touched:** 142 (+ 1 changeset). 748 deletions / 684 insertions — a net **64**
  comment lines removed, the rest rewritten in place.
- **esbuild proof: 142 / 142 byte-identical, 0 differing.**

### About the esbuild command

The command in RULES (`bun x esbuild <file> --format=esm --log-level=silent`) does **not**
strip comments in this codebase: esbuild preserves comments that sit inside object
literals and array elements, which is most of the keybinding tables. Run as written it
reports false differences on comment-only edits. The proof here adds
`--minify-whitespace`, which drops every comment while preserving all identifiers and
syntax, so a real code change would still show. Both sides are transpiled in one batch
run per side and compared with `diff -r`, because per-file `bun x` invocations
intermittently returned empty output and read as spurious diffs.

```
esbuild-identical: 142    differing: 0
```

## Gates

- `bun run lint` (repo root) — clean
- `bun run typecheck` — clean (all four workspace packages)
- `env -u ROVE_INVOKED_AS bun run test:fast` — **4185 passed, 4 failed**
- `bun run test:render` — 414 passed, 0 failed

The 4 failures are environmental, not from this branch: `test/state/project-eligibility.test.ts`
(2) and `test/cli/open-dir-cmd.test.ts` (2) classify by path shape, and this worktree lives
under `~/.rove/worktrees`, so the repo root reads as `roveInternal`. Neither test file is in
this diff. Proof: restoring the one touched source file (`src/state/project-eligibility.ts`)
to its `HEAD` content and re-running those two files fails the **same 4 tests**.

## Exemptions

coverage-exemption: packages/kobe/src/tui/index.tsx — comment-only change, esbuild output identical

Measured, not assumed: CI runs `coverage-gate.mjs` in render mode only, which gates
`src/**/*.tsx` plus `src/tui-react/**`. This diff contains exactly one `.tsx` and no
`tui-react` file, so `src/tui/index.tsx` is the only gated file. `bun run test:render`
puts it at 0% — it is the TUI bootstrap, never mounted by a render test.

file-size-exemption: packages/kobe/test/tui/keymap-dispatch.test.ts — comment-only change; the file was already over the cap and this commit removes lines rather than adding them

727 lines before this commit and 727 after (every edit in that file was an equal-line
rewrite). Not split here, per the rules. **The seam, since I am the one who has to name
it:** `describe("dispatchKeyEvent")` currently holds two unrelated jobs. Lines 51–434 are
chord matching and dispatch order (prefix sequences, passthrough, the C0 fallback,
snapshot re-entrancy). Lines 435+ are three self-contained concerns — `modal barrier`,
`shadowed-match warning (dev only)`, `shift+letter chords`. Splitting registration
precedence and the modal barrier into their own file leaves each half comfortably under
the cap.

## The three hardest judgment calls

**1. A comment that documented a chord the code does not have.**
`keybindings-table.ts` described `kanban.open` as `prefix+c` while the binding is
`prefixKeys: ["1"]`, and the sentence was truncated mid-clause:

> `// Prefix-only 'prefix+c' (owner call 2026-07-29, demoting the bare`
> `// sidebar 'c' it shipped with): the kanban is a step-back-and-look`
> `// surface, not a per-task verb, so it doesn't earn a direct sidebar`
> `// The three sidebar-rail pages take prefix+1/2/3, matching the rail's`

The first three lines are history *and* wrong. Deleted them; kept the rail-order rule,
which is the part that still describes the code:

> `// The three sidebar-rail pages take prefix+1/2/3, matching the rail's`
> `// own top-to-bottom order — the sidebar is the legend, so there is no`
> `// mnemonic to remember. They swap only the content pane, ...`

**2. Stale framework and file references the regex never saw.**
`solid-js` is not a dependency and `src/tui/panes/*/keys.ts`, `src/tui/lib/host-boot.tsx`,
`src/tui/context/notifications.tsx`, `src/tui/context/kv.tsx` and `app.tsx` do not exist —
so ~30 comments narrated a migration and pointed at deleted files. Those fail the "would
this still be true if git history were deleted?" test, so they went in the re-read pass:

> `// Framework-free core ... that both the Solid hook ('keys.ts') and the React pane ... register`
> → `// Framework-free core ... that the pane ('src/tui-react/panes/filetree/') registers`

I left the bare purity claims (`Pure: no Solid, no opentui`) alone in files I had no other
reason to touch — they assert what a module does *not* import, which is still true.

**3. Eleven regex hits that were not history at all.**
`used to gate`, `used to detect`, `before this` (a timing window), `the old and new paths`
(git's own rename vocabulary), `no longer exists` (about a dead process, not old code).
Deleting them would have lost real information, but the gate demands zero, so each was
rephrased to keep the meaning and drop the trigger word — e.g.
`/** Pane scopes used to gate where a binding is active. */` →
`/** Pane scopes that gate where a binding is active. */`, and
`// Rename: the next two fields are the old and new paths.` →
`// Rename: the next two fields are the source and destination paths.`

## One thing deliberately left

18 `it(...)` / `describe(...)` strings still carry an issue ref or an owner-call date, e.g.

```
test("the LAST tab IS offered a close (owner call 2026-08-31)", ...)
describe("worktreeRowLabel (issue #42)", ...)
```

RULES allow renaming a test name when the string itself is history, but a test name is
**code** — renaming these would break the byte-identity proof on 18 files and destroy the
signal that catches an accidental code edit. The default in that same rule is "otherwise
leave", so I left them and am flagging them instead. Happy to do them as a follow-up where
the esbuild proof is expected to differ; full list on request.
