### PR TITLE
docs: strip history from tui-react comments

### DIFF
--- a/.changeset/comments-history-tui-react.md
+++ b/.changeset/comments-history-tui-react.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+comments: history removed from tui-react; no code change

--- a/packages/kobe/src/tui-react/component/branch-picker-dialog.tsx
+++ b/packages/kobe/src/tui-react/component/branch-picker-dialog.tsx
@@ -2,7 +2,7 @@
 /**
  * Set-branch (re-branch) dialog — the sidebar `b` flow. Lists the task
  * repo's local branches with filter-as-you-type, matching the new-task
- * dialog's `fromBranch` picker (issue #10): reuses the same pure helpers
+ * dialog's `fromBranch` picker: reuses the same pure helpers
  * (`filterBranches` / `windowAround` / `clampCursor` / `resolveBaseRef`)
  * and the shared `PickerList`, so the two branch surfaces stay in lockstep.
  *

--- a/packages/kobe/src/tui-react/component/engine-picker-dialog.tsx
+++ b/packages/kobe/src/tui-react/component/engine-picker-dialog.tsx
@@ -3,16 +3,16 @@
  * Change-engine dialog — the tree menu's "Change engine" entry. The `v` chord
  * cycles blindly to the next available engine; a menu entry that did the same
  * would hide which engine the user is about to land on, so the menu offers a
- * pick instead (owner call 2026-09-01). Same shape as `status-picker-dialog`:
+ * pick instead. Same shape as `status-picker-dialog`:
  * a plain pick over a closed list, no free text — the list IS what
  * `availableEngineIds()` returned, and a name outside it cannot launch.
  *
  * Engines that DECLARE reasoning levels (`EngineRegistryEntry.effortLevels` —
  * codex today) get a second row under the list, so the level is settable on a
- * task that already exists; before this the only surface that could set one
- * was the web board's create-time picker, which left a codex task stuck on
- * whatever it launched with. Engines with no declared levels render no row at
- * all, matching the web picker's rule.
+ * task that already exists — otherwise the web board's create-time picker is
+ * the only surface that can set one, and a codex task is stuck on whatever it
+ * launched with. Engines with no declared levels render no row at all,
+ * matching the web picker's rule.
  *
  * Picking persists the task's vendor (and level) and nothing else; like `v`,
  * it takes effect on the task's next enter (`applyVendorChange` says so in

--- a/packages/kobe/src/tui-react/component/help-dialog.tsx
+++ b/packages/kobe/src/tui-react/component/help-dialog.tsx
@@ -1,18 +1,15 @@
 /** @jsxImportSource @opentui/react */
 /**
- * Help dialog (React port of `src/tui/component/help-dialog.tsx`, issue
- * #15 G3) — kobe's global keybindings, grouped by category via the shared
- * framework-free `src/tui/lib/help-groups.ts`. Each row prints the
+ * Help dialog — kobe's global keybindings, grouped by category via the
+ * shared framework-free `src/tui/lib/help-groups.ts`. Each row prints the
  * canonical chord (macOS glyphs via `formatChord`) plus the description;
- * alternate chords in a lighter color. Pane-local bindings are
- * intentionally not listed — this is the global-bindings registry only.
- * Full rationale (what was dropped in v0.6, why esc isn't re-bound here)
- * lives in the Solid header.
+ * alternate chords in a lighter color. Pane-local bindings are intentionally
+ * not listed — this is the global-bindings registry only.
  *
- * React deltas: the keymap table is mutated in place on keybindings.yaml
- * reloads, invisible to React — `useKeymapVersion()` subscribes this
- * component and invalidates the grouped rows; `useT()` subscribes it to
- * language changes so the non-reactive `tKeys` lookups re-run.
+ * The keymap table is mutated in place on keybindings.yaml reloads, which is
+ * invisible to React — `useKeymapVersion()` subscribes this component and
+ * invalidates the grouped rows; `useT()` subscribes it to language changes so
+ * the non-reactive `tKeys` lookups re-run.
  */
 
 import { type ScrollBoxRenderable, TextAttributes } from "@opentui/core"
@@ -167,7 +164,7 @@ export function HelpDialog(props: {
 
 /**
  * Convenience opener — pushes the help dialog onto the dialog stack.
- * Used by the global `?` binding. Static for parity with the Solid original.
+ * Used by the global `?` binding.
  */
 HelpDialog.show = (dialog: DialogContext, currentScope?: HelpSurface): void => {
   const reachability = currentBindingReachability()

--- a/packages/kobe/src/tui-react/component/issue-detail-parts.tsx
+++ b/packages/kobe/src/tui-react/component/issue-detail-parts.tsx
@@ -3,13 +3,9 @@
  * The story drawer's EVENTS feed — the last {@link EVENT_FEED_LIMIT} engine
  * lifecycle events of the story's linked task (docs/design/plugin-events.md).
  *
- * The drawer's section headers and chip buttons used to live here too; they
- * were the house dialog grammar wearing a story-drawer name, and moved to
- * `ui/dialog-parts.tsx` when the rest of the dialogs adopted them.
- *
  * The feed is a SNAPSHOT: one fetch when the drawer mounts, no polling and
  * no subscription. The daemon's ring is in-memory and capped at 100, so a
- * fresh daemon — or an id it no longer knows ("task not found") — simply
+ * fresh daemon — or an id it does not know ("task not found") — simply
  * reads as "no events", never as an error the user must act on.
  */
 

--- a/packages/kobe/src/tui-react/component/kanban-card.tsx
+++ b/packages/kobe/src/tui-react/component/kanban-card.tsx
@@ -62,11 +62,11 @@ export function KanbanCard(props: {
     success: theme.success,
   } as const
   // Transparent mode means transparent: the card drops its tinted surface and
-  // lets the host terminal through, like every other pane. It used to keep
+  // lets the host terminal through, like every other pane. Keeping
   // `backgroundElement` on the theory that a card is content rather than
-  // chrome — but a solid tile is the one thing on the board that cannot be
-  // seen through, so the exception read as the board ignoring the setting.
-  // Its border and the column's still separate it from the lane.
+  // chrome would make it the one thing on the board you cannot see through,
+  // which reads as the board ignoring the setting. Its border and the
+  // column's still separate it from the lane.
   // Horizontal padding only, plus a margin below. `padding={1}` was doing
   // three jobs at once — air inside the card, separation from the next card,
   // and a break between title and description — and paid two rows per card

--- a/packages/kobe/src/tui-react/component/kanban-page.tsx
+++ b/packages/kobe/src/tui-react/component/kanban-page.tsx
@@ -3,8 +3,8 @@
  * KanbanPage — the daemon-owned issue store as a Backlog / In progress /
  * Parked / Done board. One PROJECT at a time (tab/←/→ or click cycles the
  * rolling selector), four full-height bordered columns matching the workspace
- * host's border grammar. Full-page swap like WorktreesPage (issue #23
- * precedent): esc/ctrl+c closes, `r` refetches, plus a light poll so
+ * host's border grammar. Full-page swap like WorktreesPage: esc/ctrl+c
+ * closes, `r` refetches, plus a light poll so
  * agent-driven moves (`kobe api issue-update --task`) show up while open.
  *
  * The BOARD stays read-only (agents move cards via `kobe api issue-*`); the
@@ -135,7 +135,7 @@ export function KanbanPage(props: {
   }
 
   // ←/→ select cards when any exist; tab still cycles projects. On an empty
-  // board they fall through to project cycling (the old muscle memory).
+  // board they fall through to project cycling, the same thing tab does.
   function moveOrCycle(dir: "left" | "right"): void {
     if (columns.some((column) => column.issues.length > 0)) moveCursor(dir)
     else cycleProject(dir === "left" ? -1 : 1)

--- a/packages/kobe/src/tui-react/component/keyboard-hints.tsx
+++ b/packages/kobe/src/tui-react/component/keyboard-hints.tsx
@@ -112,7 +112,7 @@ export function useStatusKeyHintItems(opts?: { onOpenSettings?: () => void; comp
         ? prev
         : { tokens: nextTokens, modal: nextModal }
     })
-    // Dependencies, NOT a bare effect (React #185, 2026-08-31): this hook
+    // Dependencies, NOT a bare effect (React #185): this hook
     // renders in the workspace FOOTER, which wraps the whole pane tree, so its
     // setState re-renders every sidebar row — and each row's `useBindings`
     // bumps `stackVersion` on unmount/remount, which re-renders the footer.
@@ -128,14 +128,13 @@ export function useStatusKeyHintItems(opts?: { onOpenSettings?: () => void; comp
     // relies on is unchanged — an effect with dependencies still runs after
     // the commit that changed them.
     //
-    // `kv` is NOT among them, and that is the whole fix (React #185 again,
-    // this time on boot with the dependency array already in place).
-    // `KVProvider` rebuilds its context value from a `useMemo` keyed on the
-    // kv snapshot, so EVERY `kv.set` anywhere in the app — tab adoption
-    // writing a task's tab list, a pane marking a hint used — hands this hook
-    // a brand-new `kv` object. As a dependency that re-ran the effect on all
-    // of them, which is the same "runs on every render" the array was
-    // supposed to stop: setSnapshot -> footer re-render -> sidebar rows
+    // `kv` is deliberately NOT among them. `KVProvider` rebuilds its context
+    // value from a `useMemo` keyed on the kv snapshot, so EVERY `kv.set`
+    // anywhere in the app — tab adoption writing a task's tab list, a pane
+    // marking a hint used — hands this hook a brand-new `kv` object. As a
+    // dependency it re-runs the effect on all of them, which is the same
+    // "runs on every render" the array exists to stop (React #185):
+    // setSnapshot -> footer re-render -> sidebar rows
     // remount -> stackVersion bumps -> kv writes -> round again, 50 deep.
     // Only the enabled FLAG is read here, so depend on that boolean instead:
     // it changes when the user toggles hints, not when unrelated state lands.
@@ -152,7 +151,7 @@ export function useStatusKeyHintItems(opts?: { onOpenSettings?: () => void; comp
         sidebar: focus ? () => focus.setFocused("sidebar") : undefined,
         help: dialog ? () => HelpDialog.show(dialog, focus?.focused ?? "sidebar") : undefined,
       }
-  // Compact (narrow footer, issue #14): the chord caps alone — `⌃ A · F1` —
+  // Compact (narrow footer): the chord caps alone — `⌃ A · F1` —
   // still clickable, no verbs, and no [settings] segment below.
   const items: StatusKeyHintItem[] = snapshot.tokens.map((tok) => ({
     text: opts?.compact ? formatChord(tok.chord) : t(`hints.status.${tok.msg}`, { key: formatChord(tok.chord) }),
@@ -199,7 +198,7 @@ export function StatusKeyHintBar(props: { onOpenSettings?: () => void; compact?:
 
 /**
  * Extinguish a pane's first-use hint: call from the pane's own key handlers
- * (nav/select) — using the keys IS the proof the hint is no longer needed.
+ * (nav/select) — using the keys IS the proof the hint has done its job.
  * Writes once; safe to call per keypress.
  */
 export function usePaneHintMark(pane: HintPane): () => void {

--- a/packages/kobe/src/tui-react/component/mock-dialogs-host.tsx
+++ b/packages/kobe/src/tui-react/component/mock-dialogs-host.tsx
@@ -1,8 +1,8 @@
 /** @jsxImportSource @opentui/react */
 /**
- * React task-dialogs mock host (`bun run dev:mock-react-dialogs`) —
- * live-render proof for the ported NewTaskDialog + RenameTaskDialog
- * (issue #15, G3W2). Boots through the real React pane host, opens a
+ * Task-dialogs mock host (`bun run dev:mock-react-dialogs`) — live-render
+ * proof for NewTaskDialog + RenameTaskDialog. Boots through the real pane
+ * host, opens a
  * dialog on mount with fixture data (saved repos, adoptable worktrees,
  * a detected-vendor set), and leaves the full dialog interactive:
  * tab/←→/ctrl+[]/ctrl+e all run for real; esc closes; the last dialog

--- a/packages/kobe/src/tui-react/component/new-chat-dialog.tsx
+++ b/packages/kobe/src/tui-react/component/new-chat-dialog.tsx
@@ -1,9 +1,9 @@
 /** @jsxImportSource @opentui/react */
 /**
- * Unified new-conversation dialog (issue #7) — ONE entry for every "start a
- * new chat" shape. The default state is the old `chat.tab.chooseEngine`
- * (ctrl+e) picker verbatim: engine list (+ shell + plugin panes), ←/→
- * cycles, enter opens a fresh tab in this worktree. Two in-dialog toggles
+ * Unified new-conversation dialog — ONE entry for every "start a new chat"
+ * shape. The default state is the `chat.tab.chooseEngine` (ctrl+e) picker:
+ * engine list (+ shell + plugin panes), ←/→ cycles, enter opens a fresh tab
+ * in this worktree. Two in-dialog toggles
  * bend the outcome, with the footer always showing their live state:
  *
  *   - `tab`    — destination: new tab here ⇄ fork a child task worktree
@@ -29,8 +29,7 @@ import { type DialogContext, showDialog, useDialog, useDialogPaddingX } from "..
 import { ChoiceRow } from "./new-task-dialog/picker-list"
 
 /** What the picker can resolve to: an engine vendor, a plain shell tab, or
- *  a Scratch shell task (issue #33 — owner placement 2026-08-16: trailing
- *  choice, never a chord until frequency proves one out). With
+ *  a Scratch shell task (a trailing choice, never a chord). With
  *  `extraChoices`, an extra choice's `key` (e.g. a plugin pane) too. */
 export type EnginePick = VendorId | "shell" | "scratch" | (string & {})
 
@@ -50,10 +49,9 @@ export function NewChatDialogView(props: {
   defaultVendor: VendorId
   /** Offer a trailing "shell" choice (a plain terminal tab). */
   allowShell?: boolean
-  /** Offer the LAST-position "scratch" choice (a Scratch shell task — issue
-   *  #33). Tail placement is the owner's call (2026-08-16): the default
-   *  highlight and every existing choice's position stay untouched so
-   *  ctrl+e→enter muscle memory is preserved. */
+  /** Offer the LAST-position "scratch" choice (a Scratch shell task). Tail
+   *  placement keeps the default highlight and every other choice's position
+   *  where they are, so ctrl+e→enter muscle memory holds. */
   allowScratch?: boolean
   /** Trailing extra choices (plugin panes): `key` is returned, `label` shown. */
   extraChoices?: readonly { key: string; label: string }[]
@@ -80,7 +78,7 @@ export function NewChatDialogView(props: {
         ...vendors,
         ...(props.allowShell ? (["shell"] as const) : []),
         ...extras.map((e) => e.key),
-        // Scratch is LAST by owner placement — see allowScratch's doc.
+        // Scratch is LAST — see allowScratch's doc.
         ...(props.allowScratch ? (["scratch"] as const) : []),
       ]
     : vendors
@@ -141,8 +139,8 @@ export function NewChatDialogView(props: {
         <text
           fg={theme.textMuted}
           onMouseUp={() => {
-            // Cancel must also CLOSE — resolving the promise alone left the
-            // card on screen with its onClose already spent.
+            // Resolving the promise does not close the dialog; clear it
+            // explicitly.
             props.onCancel()
             dialog.clear()
           }}

--- a/packages/kobe/src/tui-react/component/new-task-dialog/dialog.tsx
+++ b/packages/kobe/src/tui-react/component/new-task-dialog/dialog.tsx
@@ -1,13 +1,11 @@
 /** @jsxImportSource @opentui/react */
 /**
- * The React new-task dialog JSX shell (issue #15, G3W2) — the
- * `src/tui/component/new-task-dialog/dialog.tsx` counterpart. Three
- * sibling sub-tabs share one frame (Existing / New Repo / Adopt),
- * switched with Ctrl+[ / Ctrl+] or ←/→ on the mode selector; the engine
- * selector cycles with ctrl+e. All state, effects, commit paths and key
- * bindings live in `./view-model.ts` (shared pure helpers from the Solid
- * side's `state.ts`/`clone.ts`); the tab bodies live in `./tab-*.tsx`.
- * Every user-visible string resolves through `useT()`.
+ * The new-task dialog's JSX shell. Three sibling sub-tabs share one frame
+ * (Existing / New Repo / Adopt), switched with Ctrl+[ / Ctrl+] or ←/→ on the
+ * mode selector; the engine selector cycles with ctrl+e. All state, effects,
+ * commit paths and key bindings live in `./view-model.ts` (pure helpers in
+ * `state.ts`/`clone.ts`); the tab bodies live in `./tab-*.tsx`. Every
+ * user-visible string resolves through `useT()`.
  */
 
 import { TextAttributes } from "@opentui/core"

--- a/packages/kobe/src/tui-react/component/new-task-dialog/index.tsx
+++ b/packages/kobe/src/tui-react/component/new-task-dialog/index.tsx
@@ -1,6 +1,6 @@
 /** @jsxImportSource @opentui/react */
 /**
- * New-task dialog entry point (issue #15, G3W2) — every call site opens
+ * New-task dialog entry point — every call site opens
  * the dialog through the `show(dialog, defaultRepo, savedRepos, options)`
  * contract. NewTaskDialog is THE canonical task-creation surface — this
  * is the full dialog (Existing / New Repo / Adopt tabs, engine selector,

--- a/packages/kobe/src/tui-react/component/new-task-dialog/picker-list.tsx
+++ b/packages/kobe/src/tui-react/component/new-task-dialog/picker-list.tsx
@@ -1,14 +1,14 @@
 /** @jsxImportSource @opentui/react */
 /**
- * Shared windowed picker list + field-label styling for the React
- * new-task dialog (issue #15, G3W2). The Solid shell repeats the
- * "↑ N more / rows / ↓ N more" block four times (repo, branch, clone
- * parent, adopt); the React port renders all four through this one
- * component — callers supply the pre-windowed row bodies and pick
- * handler, the list owns the cursor arrow, bold, and overflow lines.
- * Also home to {@link ChoiceRow}, the horizontal choose-one row shared by
- * the engine picker, the quick composer and the new-chat dialog. (The
- * new-task dialog now spends chips instead — docs/design/dialogs.md.)
+ * Shared windowed picker list + field-label styling for the new-task dialog.
+ * All four pickers (repo, branch, clone parent, adopt) render their
+ * "↑ N more / rows / ↓ N more" block through this one component — callers
+ * supply the pre-windowed row bodies and pick handler, the list owns the
+ * cursor arrow, bold, and overflow lines.
+ *
+ * Also home to {@link ChoiceRow}, the horizontal choose-one row shared by the
+ * engine picker, the quick composer and the new-chat dialog. The new-task
+ * dialog spends chips instead — docs/design/dialogs.md.
  */
 
 import { TextAttributes } from "@opentui/core"
@@ -115,12 +115,11 @@ export function PickerList(props: {
  * composer: choices side by side (`gap={2}`), the selected one primary +
  * bold (arrowed variants prefix `▸ ` / two spaces), click picks.
  *
- * Overflow (fixed 2026-07-30): a choice label is ATOMIC. Without
- * `wrapMode="none"` + `flexShrink={0}` Yoga compressed the cells and each
- * `<text>` wrapped INTERNALLY, so with enough engines installed a label like
- * `lazygit (split)` split mid-word across two lines and the row read as
- * garbage. The labels are now unbreakable and the ROW wraps instead, moving
- * whole choices onto the next line.
+ * Overflow: a choice label is ATOMIC. Without `wrapMode="none"` +
+ * `flexShrink={0}` Yoga compresses the cells and each `<text>` wraps
+ * INTERNALLY, so with enough engines installed a label like `lazygit (split)`
+ * splits mid-word across two lines and the row reads as garbage. Unbreakable
+ * labels make the ROW wrap instead, moving whole choices onto the next line.
  */
 export function ChoiceRow<T extends string>(props: {
   choices: readonly T[]

--- a/packages/kobe/src/tui-react/component/new-task-dialog/pure.ts
+++ b/packages/kobe/src/tui-react/component/new-task-dialog/pure.ts
@@ -1,12 +1,11 @@
 /**
- * Framework-free helpers for the React new-task dialog (issue #15, G3W2).
+ * Framework-free helpers for the new-task dialog.
  *
  * The bulk of the dialog's pure logic (field cycling, filters, windowing)
- * already lives in the shared `src/tui/component/new-task-dialog/state.ts`
- * and is consumed verbatim by both frameworks. This file holds only the
- * bits the Solid shell computes inline — extracted here so the React port
- * can unit-test them without mounting the dialog (`test/tui-react/
- * new-task-pure.test.ts`). No React, no Solid, no fs.
+ * lives in the shared `src/tui/component/new-task-dialog/state.ts`. This file
+ * holds the rest, kept out of the component so it is unit-testable without
+ * mounting the dialog (`test/tui-react/new-task-pure.test.ts`). No React,
+ * no fs.
  */
 
 import { DEFAULT_TASK_VENDOR } from "@/types/task"

--- a/packages/kobe/src/tui-react/component/new-task-dialog/tab-adopt.tsx
+++ b/packages/kobe/src/tui-react/component/new-task-dialog/tab-adopt.tsx
@@ -1,7 +1,6 @@
 /** @jsxImportSource @opentui/react */
 /**
- * Adopt tab of the React new-task dialog (issue #15, G3W2) —
- * discover existing git worktrees not yet linked to a task, filter by a
+ * Adopt tab of the new-task dialog — discover existing git worktrees not yet linked to a task, filter by a
  * path glob, multi-select, then import. Discovery + selection state live
  * in the view-model; this file is JSX only.
  */

--- a/packages/kobe/src/tui-react/component/new-task-dialog/tab-clone.tsx
+++ b/packages/kobe/src/tui-react/component/new-task-dialog/tab-clone.tsx
@@ -1,7 +1,6 @@
 /** @jsxImportSource @opentui/react */
 /**
- * Clone ("For New Repo") tab of the React new-task dialog (issue #15,
- * G3W2) — git URL, parent dir (with the same drill-down picker the
+ * Clone ("For New Repo") tab of the new-task dialog — git URL, parent dir (with the same drill-down picker the
  * existing tab uses), auto-derived folder name, base branch. The async
  * clone runs in the view-model; this file is JSX only.
  */

--- a/packages/kobe/src/tui-react/component/new-task-dialog/tab-existing.tsx
+++ b/packages/kobe/src/tui-react/component/new-task-dialog/tab-existing.tsx
@@ -1,10 +1,9 @@
 /** @jsxImportSource @opentui/react */
 /**
- * Existing tab of the React new-task dialog (issue #15, G3W2) — pick an
- * existing local repo path + base branch. Direct port of the Solid
- * shell's existing-tab body: unified free-text repo input with the
- * saved/browse smart dropdown, branch picker that augments the input.
- * All behavior lives in the view-model; this file is JSX only.
+ * Existing tab of the new-task dialog — pick an existing local repo path +
+ * base branch: a unified free-text repo input with the saved/browse smart
+ * dropdown, and a branch picker that augments the input. All behavior lives
+ * in the view-model; this file is JSX only.
  */
 
 import { type ExistingIntent, splitRepoRow } from "../../../tui/component/new-task-dialog/state"
@@ -80,11 +79,11 @@ export function ExistingTab({ vm }: { vm: NewTaskVm }) {
               //
               // Holding a NAME, there is a directory beside it and the row has
               // to divide: the input takes a fixed column and the directory is
-              // what gives way. `flexGrow` here is what CAUSED the bug this
-              // replaces — the input grew to the row, the directory then
-              // compressed it below the name's length, and an input narrower
-              // than its content scrolls to the cursor, so `fixture-repo`
-              // rendered as `ture-repo` with nothing to admit the cut.
+              // what gives way. NOT `flexGrow` — the input would grow to the
+              // row, the directory would then compress it below the name's
+              // length, and an input narrower than its content scrolls to the
+              // cursor, so `fixture-repo` renders as `ture-repo` with nothing
+              // to admit the cut.
               //
               // Holding a PATH (typed by hand, or a name too ambiguous to show)
               // nothing sits beside it and it takes the whole row: a path needs
@@ -108,7 +107,7 @@ export function ExistingTab({ vm }: { vm: NewTaskVm }) {
       {vm.field === "repo" && vm.activeList.length > 0 && !vm.repoPicked ? (
         <PickerList window={vm.activeWindow} cursor={vm.repoCursor} rows={repoRows} onPick={vm.selectRepoAt} />
       ) : null}
-      {/* Only for a repo that HAS a project checkout (issue #90). Everywhere
+      {/* Only for a repo that HAS a project checkout. Everywhere
           else this row would be a control whose second option does nothing,
           so it stays absent rather than disabled. */}
       {vm.canOpenProject ? (

--- a/packages/kobe/src/tui-react/component/new-task-dialog/use-adopt-state.ts
+++ b/packages/kobe/src/tui-react/component/new-task-dialog/use-adopt-state.ts
@@ -1,6 +1,6 @@
 /**
- * Adopt-tab state hook for the React new-task dialog (issue #15,
- * G3W2) — split out of `./view-model.ts`: worktree discovery (async
+ * Adopt-tab state hook for the new-task dialog — split out of
+ * `./view-model.ts`: worktree discovery (async
  * canon: useState + dependency-keyed effect with a disposed flag), glob
  * filter, windowed cursor, and the multi-select import commit.
  */

--- a/packages/kobe/src/tui-react/component/new-task-dialog/use-clone-state.ts
+++ b/packages/kobe/src/tui-react/component/new-task-dialog/use-clone-state.ts
@@ -1,6 +1,6 @@
 /**
- * Clone-tab state hook for the React new-task dialog (issue #15, G3W2) —
- * the "For New Repo" cluster split out of `./view-model.ts`: git URL,
+ * Clone-tab state hook for the new-task dialog — the "For New Repo" cluster
+ * split out of `./view-model.ts`: git URL,
  * parent-dir drill-down picker, auto-derived folder name, base branch,
  * and the async `git clone` commit path. All fs/spawn plumbing comes from
  * the shared `src/tui/component/new-task-dialog/clone.ts`.
@@ -116,8 +116,8 @@ export function useCloneState(args: {
     const targetReason = validateCloneTarget(cloneParent, cloneFolder)
     if (targetReason) {
       args.setSubmitError(targetReason)
-      // Blame the field actually at fault — same probe strategy as the
-      // Solid shell (see its commitClone for the full rationale).
+      // Blame the field actually at fault: probe which input is wrong rather
+      // than reporting the failure against the whole form.
       const folder = cloneFolder.trim()
       const folderStructurallyBad = !folder || folder.includes("/") || folder.includes("\\")
       const parentAtFault = !folderStructurallyBad && validateCloneTarget(cloneParent, "__kobe_probe__") != null

--- a/packages/kobe/src/tui-react/component/new-task-dialog/use-derived-dir.ts
+++ b/packages/kobe/src/tui-react/component/new-task-dialog/use-derived-dir.ts
@@ -1,5 +1,5 @@
 /**
- * Directory drill-down derivation (issue #15, G3W2) — memoized
+ * Directory drill-down derivation — memoized
  * split + readdir + filter over a typed path, shared by the existing
  * tab's browse-mode repo picker and the clone tab's parent-dir picker.
  * Pure plumbing from `src/tui/lib/path-helpers.ts`.

--- a/packages/kobe/src/tui-react/component/new-task-dialog/view-model.ts
+++ b/packages/kobe/src/tui-react/component/new-task-dialog/view-model.ts
@@ -1,20 +1,15 @@
 /**
- * View-model hook for the React new-task dialog (issue #15, G3W2) — the
- * state half of `src/tui/component/new-task-dialog/dialog.tsx`, with the
- * JSX stripped out. Every pure helper (field cycling, filters, windowing)
+ * View-model hook for the new-task dialog — the dialog's state, with the JSX
+ * in `./dialog.tsx`. Every pure helper (field cycling, filters, windowing)
  * comes from the SHARED `src/tui/component/new-task-dialog/state.ts` /
- * `clone.ts` / `src/tui/lib/git-snapshot.ts` / `path-helpers.ts` modules —
- * this file only translates Solid signals/memos/effects into React hooks.
+ * `clone.ts` / `src/tui/lib/git-snapshot.ts` / `path-helpers.ts` modules.
  * The clone and adopt clusters live in `./use-clone-state.ts` /
- * `./use-adopt-state.ts`; this hook owns the shared selectors, the
- * existing tab, the key bindings, and the commit dispatch.
+ * `./use-adopt-state.ts`; this hook owns the shared selectors, the existing
+ * tab, the key bindings, and the commit dispatch.
  *
- * Reactivity translation notes (vs the Solid original):
- *   - Solid's "reset cursor when the filtered list changes" effects become
- *     resets inside the input handlers (same pattern as the chat history
- *     palette) — typing is the only thing that changes those lists.
- *   - Error strings resolved at submit time use the module-level `t` —
- *     same non-reactive semantics as the Solid event handlers.
+ * Cursor resets live inside the input handlers rather than in an effect on
+ * the filtered lists: typing is the only thing that changes those lists.
+ * Error strings resolved at submit time use the module-level `t`.
  */
 
 import { type VendorId, nextVendorWithin, prevVendorWithin } from "@/types/vendor"
@@ -53,7 +48,7 @@ import { useAdoptState } from "./use-adopt-state"
 import { useCloneState } from "./use-clone-state"
 import { useDerivedDir } from "./use-derived-dir"
 
-/** Same prop surface as the Solid `NewTaskDialogView` — see its docs. */
+/** Prop surface of the dialog view. */
 export type NewTaskDialogProps = {
   onSubmit: (v: NewTaskInput) => void
   onCancel: () => void
@@ -109,9 +104,8 @@ export function useNewTaskViewModel(props: NewTaskDialogProps) {
   // Enter/click; typing resumes browsing.
   const [repoPicked, setRepoPicked] = useState(false)
   const [branchCursor, setBranchCursor] = useState(0)
-  // Existing-tab intent (issue #90). Defaults to "task" so the tab keeps
-  // doing what it always did; the choice only RENDERS when the picked repo
-  // already has a project checkout to open.
+  // Existing-tab intent. Defaults to "task"; the choice only RENDERS when the
+  // picked repo already has a project checkout to open.
   const [intent, setIntent] = useState<ExistingIntent>("task")
 
   // Validation error shown inline on submit; cleared on any input edit.
@@ -130,8 +124,9 @@ export function useNewTaskViewModel(props: NewTaskDialogProps) {
   // `repo` holds exactly what the field shows — a NAME once one is chosen,
   // free text while it is being typed. It is never a display derived from a
   // different underlying value: an opentui `<input>` adopts its `value` prop
-  // as its edit buffer, so a field showing one string while state held another
-  // wrote the shown one back on the next keystroke and the two oscillated.
+  // as its edit buffer, so a field showing one string while state holds
+  // another writes the shown one back on the next keystroke and the two
+  // oscillate.
   // One representation, resolved to a path at the boundaries instead.
   const repoResolution = resolveRepoInput(repo, repoOptions)
   // The directory the chosen NAME resolves to — muted, at the row's right
@@ -201,8 +196,9 @@ export function useNewTaskViewModel(props: NewTaskDialogProps) {
    * separately guarded on `canOpenProject` (derived from the CURRENT repo),
    * so this is about the row telling the truth, not about safety.
    *
-   * Three call sites used to write `setRepo` directly and skip it — typing
-   * reset the intent, picking the same repo from the dropdown did not.
+   * Every repo change routes through here — a call site writing `setRepo`
+   * directly would skip the reset and leave the row asserting the previous
+   * repo's intent.
    */
   function changeRepo(next: string): void {
     setRepo(next)
@@ -408,8 +404,7 @@ export function useNewTaskViewModel(props: NewTaskDialogProps) {
       { key: "up", cmd: () => moveCursor(-1) },
       { key: "down", cmd: () => moveCursor(1) },
       // ←/→/Enter ONLY while a selector is focused — an always-on binding
-      // would preventDefault the keys away from focused text inputs (same
-      // registration-gating rationale as the Solid shell).
+      // would preventDefault the keys away from focused text inputs.
       ...(field === "tabs" || field === "engine" || field === "intent"
         ? [
             {

--- a/packages/kobe/src/tui-react/component/prefix-hud.tsx
+++ b/packages/kobe/src/tui-react/component/prefix-hud.tsx
@@ -188,7 +188,7 @@ export function PrefixHud(props: { left: number; width: number }) {
     )
   }
 
-  // Narrow (issue #14): no sidebar column to sit over — go full width just
+  // Narrow mode: no sidebar column to sit over — go full width just
   // above the footer, where the bottom-most covered row is the workspace
   // frame's own border, not terminal content. NOT over the footer row
   // itself: the footer paints after the pane children, so an "overlay"

--- a/packages/kobe/src/tui-react/component/quick-task-bindings.ts
+++ b/packages/kobe/src/tui-react/component/quick-task-bindings.ts
@@ -3,7 +3,7 @@
  * `quick-task-composer.tsx` so the field-gating contract is
  * vitest-testable (the component file drags in `@opentui`).
  *
- * THE contract (regression: "type a prompt, hit enter" was dead): a
+ * THE contract, and what "type a prompt, hit enter" depends on: a
  * matched binding consumes its keypress — `dispatchKeyEvent` calls
  * `preventDefault()` on every hit, so the focused input never sees the
  * key. Field-dependent chords therefore must be gated at REGISTRATION:

--- a/packages/kobe/src/tui-react/component/quick-task-composer.tsx
+++ b/packages/kobe/src/tui-react/component/quick-task-composer.tsx
@@ -1,7 +1,6 @@
 /** @jsxImportSource @opentui/react */
 /**
- * Prompt-first quick-task composer (`<prefix> f`) — React port of
- * `src/tui/component/quick-task-composer.tsx`.
+ * Prompt-first quick-task composer (`<prefix> f`).
  *
  * The quick path is prompt-first: the PROMPT field is focused on open and
  * `enter` from it creates the task immediately. Engine and branch are right

--- a/packages/kobe/src/tui-react/component/rename-task-dialog.tsx
+++ b/packages/kobe/src/tui-react/component/rename-task-dialog.tsx
@@ -1,12 +1,9 @@
 /** @jsxImportSource @opentui/react */
 /**
- * React rename dialog (issue #15, G3W2) — the
- * `src/tui/component/rename-task-dialog/` counterpart, view + `show`
- * entry in one file (the Solid split exists only for its folder
- * convention). Same contract: single pre-filled input, Enter commits,
- * esc cancels via the dialog stack; `dialogTitle` / `fieldLabel` /
- * `submitLabel` overrides let it double for chat-tab renames, branch
- * names, launch commands, etc.
+ * Rename dialog — view + `show` entry in one file. Single pre-filled input,
+ * Enter commits, esc cancels via the dialog stack; `dialogTitle` /
+ * `fieldLabel` / `submitLabel` overrides let it double for chat-tab renames,
+ * branch names, launch commands, etc.
  *
  * `stripNewlines` / `isBlankText` come from the shared framework-free
  * `state.ts` — same sanitiser as the new-task dialog (opentui `<input>`

--- a/packages/kobe/src/tui-react/component/settings-dialog/actions.ts
+++ b/packages/kobe/src/tui-react/component/settings-dialog/actions.ts
@@ -1,7 +1,6 @@
 /**
- * Dev-section actions (React, issue #15 G3) — same flows as the Solid
- * `src/tui/component/settings-dialog/actions.ts`, sharing the framework-free
- * pieces (`actions-core.ts`); only the confirm-dialog wiring is React's.
+ * Dev-section actions. The flows themselves are framework-free
+ * (`actions-core.ts`); only the confirm-dialog wiring lives here.
  */
 
 import type { KobeOrchestrator } from "../../../client/remote-orchestrator"

--- a/packages/kobe/src/tui-react/component/settings-dialog/rows.tsx
+++ b/packages/kobe/src/tui-react/component/settings-dialog/rows.tsx
@@ -1,11 +1,9 @@
 /** @jsxImportSource @opentui/react */
 /**
- * Tiny presentational helpers shared by the React settings sections
- * (issue #15 G3). The Solid `sections.tsx` repeats the same row/box
- * markup per setting; the React port factors the repetition into `Row`
- * (one navigable/clickable line) and `SubSection` (BOLD title + muted
- * hint + rows) so each section file stays well under the size cap while
- * rendering the exact same boxes.
+ * Tiny presentational helpers shared by the settings sections: `Row` (one
+ * navigable/clickable line) and `SubSection` (BOLD title + muted hint +
+ * rows), so each section file stays well under the size cap instead of
+ * repeating the same row/box markup per setting.
  */
 
 import { type BoxRenderable, type RGBA, TextAttributes } from "@opentui/core"

--- a/packages/kobe/src/tui-react/component/settings-dialog/sections-engines.tsx
+++ b/packages/kobe/src/tui-react/component/settings-dialog/sections-engines.tsx
@@ -4,9 +4,9 @@
  * inspected. Each engine is a two-line card — the navigable line carries its
  * on/off switch, the ● default marker, its display name and launch command;
  * the muted line under it carries what detection found (the binary, and for
- * the built-ins whether an account is logged in). Accounts used to be its own
- * read-only section; splitting "which engines exist" from "do they work" only
- * made you hop between two lists of the same names.
+ * the built-ins whether an account is logged in). Accounts are NOT a section
+ * of their own: splitting "which engines exist" from "do they work" only makes
+ * you hop between two lists of the same names.
  */
 
 import { TextAttributes } from "@opentui/core"

--- a/packages/kobe/src/tui-react/component/settings-dialog/sections-general.tsx
+++ b/packages/kobe/src/tui-react/component/settings-dialog/sections-general.tsx
@@ -1,6 +1,6 @@
 /** @jsxImportSource @opentui/react */
 /**
- * Settings sections (issue #15 G3) — sidebar + General. Row indices come
+ * Settings sections — sidebar + General. Row indices come
  * from the shared framework-free row registry (`../../../tui/component/
  * settings-dialog/model`), so keyboard navigation and click targets stay
  * in lockstep with the dialog's key handlers. kv-backed prefs arrive as

--- a/packages/kobe/src/tui-react/component/settings-dialog/sections-misc.tsx
+++ b/packages/kobe/src/tui-react/component/settings-dialog/sections-misc.tsx
@@ -1,6 +1,6 @@
 /** @jsxImportSource @opentui/react */
 /**
- * Settings sections (issue #15 G3) — Feedback + Dev + Keybindings.
+ * Settings sections — Feedback + Dev + Keybindings.
  * Feedback-form design notes: the body is an UNCONTROLLED `<textarea>` so
  * pasted newlines survive; edits mirror back through `onContentChange`,
  * and an external reset clears the edit buffer through the ref.
@@ -153,8 +153,8 @@ export function DevSettingsSection(
     const row = rowIndex(rows, id)
     return (
       // Wrapped (not a fragment) so the gap lands BETWEEN experiments — each
-      // one is prose + its switch, and previously they ran together into a
-      // wall where the switches were invisible.
+      // one is prose + its switch, and without the gap they run together into
+      // a wall where the switches are invisible.
       <box flexDirection="column" gap={0} paddingTop={1}>
         <text fg={theme.textMuted} wrapMode="word">
           {t(hintKey)}
@@ -331,9 +331,8 @@ export function KeybindingsSettingsSection(
         </text>
       </box>
       {!report.exists ? (
-        // The example used to be printed here for the user to retype into a
-        // file they also had to create. It is now the CONTENT of that file,
-        // one keypress away — see `keybindings-starter.ts`.
+        // The example is the CONTENT of the starter file, one keypress away,
+        // rather than something to retype — see `keybindings-starter.ts`.
         <box flexDirection="column" gap={0}>
           <text fg={theme.textMuted} wrapMode="word">
             {t("settings.keybindings.createHint")}

--- a/packages/kobe/src/tui-react/component/settings-dialog/usage-core.ts
+++ b/packages/kobe/src/tui-react/component/settings-dialog/usage-core.ts
@@ -67,7 +67,7 @@ export function usageChips(usage: EngineQuotaUsage, nowMs: number): UsageChipVie
 }
 
 /**
- * Narrow-footer form (issue #14): ONE chip per vendor, pinned to the
+ * Narrow-footer form: ONE chip per vendor, pinned to the
  * session window — the "5h" rolling window every vendor reports as its
  * tightest budget — falling back to the vendor's first window when no
  * session window exists. Reset time is dropped; at 46 cols only the

--- a/packages/kobe/src/tui-react/component/settings-dialog/use-engine-settings.ts
+++ b/packages/kobe/src/tui-react/component/settings-dialog/use-engine-settings.ts
@@ -1,11 +1,10 @@
 /**
- * Engines-section state for the React settings dialog (issue #15, G3) — one
- * section's state in its own file, like `use-settings-prefs` / `use-section-data`,
- * so `./index.tsx` owns only the dialog's structure. This is the section with
- * real logic behind it: a custom-engine registry and the global default. Same
- * kv keys and flows
- * as the Solid `src/tui/component/settings-dialog.tsx`: per-vendor launch
- * command + display-name overrides (engineCommand.<id> / engineName.<id>),
+ * Engines-section state for the React settings dialog — one section's state
+ * in its own file, like `use-settings-prefs` / `use-section-data`, so
+ * `./index.tsx` owns only the dialog's structure. This is the section with
+ * real logic behind it: a custom-engine registry and the global default.
+ * Per-vendor launch command + display-name overrides
+ * (engineCommand.<id> / engineName.<id>),
  * the customEngineIds registry, and the GLOBAL default engine (the ●
  * marker — only this dialog writes it; per-project picks live in
  * state/vendor-prefs.ts).
@@ -159,7 +158,7 @@ export function useEngineSettings(
     kv.set(engineNameKey(vendor), "")
     if (isCustomEngine(vendor)) {
       // A removed preset must not leave its protocol behind: re-adding the
-      // same id later would silently inherit the old declaration.
+      // same id later would silently inherit the removed one's declaration.
       kv.set(engineProtocolKey(vendor), "")
       kv.set(
         "customEngineIds",
@@ -190,7 +189,7 @@ export function useEngineSettings(
     if (command === undefined) return
     // Declared ONCE, here: a custom engine is a named PRESET, and its
     // protocol is what makes every later `--command <id>` dispatch
-    // deterministic instead of sniffed (issue #30). Blank = the generic
+    // deterministic instead of sniffed. Blank = the generic
     // protocol — the engine still launches, it just gets no transcript
     // reader, trust pre-answer, or engine-specific delivery.
     const protocol = await RenameTaskDialog.show(dialog, "", {

--- a/packages/kobe/src/tui-react/component/settings-dialog/use-settings-prefs.ts
+++ b/packages/kobe/src/tui-react/component/settings-dialog/use-settings-prefs.ts
@@ -1,5 +1,5 @@
 /**
- * kv-backed preference helpers for the settings dialog (issue #15, G3) —
+ * kv-backed preference helpers for the settings dialog —
  * the General/Dev getter+toggle closures, kept apart from `./index.tsx` so the
  * dialog's structure (which sections, which is open) never mixes with the
  * per-preference kv keys and their normalizers. Adding a preference edits only
@@ -111,8 +111,8 @@ export function useSettingsPrefs(kv: KVContext, dialog: DialogContext) {
   }
 
   // Chat tab strip: never / only with 2+ tabs / always. Cycles rather than
-  // toggles — the sidebar tree made "off" the default, so the setting has
-  // three states instead of the old boolean (see state/tab-strip.ts).
+  // toggles — "off" is the default now that the sidebar tree lists tabs, so
+  // the setting has three states rather than a boolean (state/tab-strip.ts).
   function tabStripMode(): TabStripMode {
     return resolveTabStripMode(kv.get(TAB_STRIP_MODE_KEY, undefined), kv.get(TAB_STRIP_HIDE_SINGLE_KEY, undefined))
   }

--- a/packages/kobe/src/tui-react/component/toast-overlay.tsx
+++ b/packages/kobe/src/tui-react/component/toast-overlay.tsx
@@ -1,7 +1,6 @@
 /** @jsxImportSource @opentui/react */
 /**
- * Toast overlay (React port of `src/tui/component/toast-overlay.tsx`,
- * issue #15 G3) — bottom-right transient cards, newest at the bottom, up
+ * Toast overlay — bottom-right transient cards, newest at the bottom, up
  * to three visible, click to dismiss early. Each toast is a framed card:
  * a semantic-colored left accent bar (the Inbox selection-bar language,
  * not a full border frame), a title row with the status glyph, and an
@@ -38,7 +37,7 @@ export function ToastOverlay() {
   // the overlay sits on top of the layout without taking flow space;
   // `zIndex` keeps it above the panes but below the dialog backdrop (3000).
   const stackRows = visibleToasts.reduce((rows, toast) => rows + cardRows(toast), 0)
-  // On a terminal narrower than the card the stack used to poke left across
+  // On a terminal narrower than the card the stack would poke left across
   // the neighbouring pane — clamp to what actually fits.
   const cardWidth = Math.min(CARD_WIDTH, Math.max(12, dims.width - RIGHT_MARGIN * 2))
   const left = Math.max(0, dims.width - cardWidth - RIGHT_MARGIN)

--- a/packages/kobe/src/tui-react/component/update-page.tsx
+++ b/packages/kobe/src/tui-react/component/update-page.tsx
@@ -2,11 +2,10 @@
 /**
  * In-workspace update details page.
  *
- * `onClose` seam (daemon issue #23 remainder): `UpdatePage` now takes an
- * `{ onClose }` prop — same shape as `WorktreesPage` — so the pure-tui
- * workspace host mounts it as an in-place swap. The close
- * ("q"/esc/Ctrl+C/[Close] action)
- * path calls `onClose()` instead of `process.exit(0)`. The post-update
+ * `onClose` seam: `UpdatePage` takes an `{ onClose }` prop — same shape as
+ * `WorktreesPage` — so the pure-tui workspace host mounts it as an in-place
+ * swap. The close ("q"/esc/Ctrl+C/[Close] action) path calls `onClose()`
+ * instead of `process.exit(0)`. The post-update
  * self-replace exit is UNCHANGED: `runUpdater()` still destroys the
  * renderer and `process.exit(code)`s after the shell updater completes —
  * an embedded swap can't survive that, so it stays, with a status line

--- a/packages/kobe/src/tui-react/component/version-skew-banner.tsx
+++ b/packages/kobe/src/tui-react/component/version-skew-banner.tsx
@@ -4,23 +4,22 @@
  *
  * {@link VersionSkewBanner} — amber, a thin full-width strip (accent rule +
  * BOLD CAPS label + one-line action hint) that auto-hides once the condition
- * clears. The daemon answers fine, it is just an older BUILD than this process
- * (React port of `src/tui/component/version-skew-banner.tsx`, issue #15 G3).
+ * clears. The daemon answers fine, it is just running a different BUILD than
+ * this process.
  *
- * A red socket-disconnect banner shared this file and was removed: Rove keeps
- * working with the daemon down, and the reconnect loop recovers most drops in
- * under a second, so a full-width alert was interrupting with nothing to act
- * on. Skew is the opposite — it persists until someone restarts the daemon,
- * which is an action, which is why this one stayed.
+ * Do NOT add a red socket-disconnect banner here. Rove keeps working with the
+ * daemon down and the reconnect loop recovers most drops in under a second,
+ * so a full-width alert would interrupt with nothing to act on. Skew is the
+ * opposite — it persists until someone restarts the daemon, which is an
+ * action.
  *
  * {@link StaleInstallBanner} — red, the same strip, for the one condition
  * that never clears on its own: this process is running from an install that
- * has been deleted, so it can never start a daemon again. That earned a
- * banner on the same test the skew banner passed and the disconnect banner
- * failed — it persists until someone acts, and the action is reinstalling.
+ * has been deleted, so it can never start a daemon again. It passes the same
+ * test skew does — it persists until someone acts, and the action is
+ * reinstalling.
  *
- * Theme tokens only, engine-neutral copy. React canon: props are plain
- * values, not Accessors.
+ * Theme tokens only, engine-neutral copy.
  */
 
 import { TextAttributes } from "@opentui/core"
@@ -75,7 +74,7 @@ export function VersionSkewBanner(props: VersionSkewBannerProps) {
   const t = useT()
   if (!props.stale) return null
   // One-line action hint: terse + actionable, naming both versions and the
-  // two commands that fix it (same copy as the Solid `versionSkewHint`).
+  // two commands that fix it.
   const daemon = props.daemonVersion ? `v${props.daemonVersion}` : t("update.skew.olderBuild")
   return (
     <BannerStrip

--- a/packages/kobe/src/tui-react/component/worktrees-page.tsx
+++ b/packages/kobe/src/tui-react/component/worktrees-page.tsx
@@ -1,14 +1,13 @@
 /** @jsxImportSource @opentui/react */
 /**
- * WorktreesPage — React port of `src/tui/component/worktrees-page.tsx`
- * (issue #15/#23). Lists every git worktree across all locally-saved
- * projects (kobe-managed or not — see `worktree.list`'s handler), each row
- * flagging whether kobe manages it, its age, uncommitted-changes state, and
- * whether its branch has reached `origin`. Modeled on `tui-react/settings/
- * host.tsx` (standalone full-window surface, same close-key contract) and
- * the React new-task dialog's Adopt tab (cursor-navigable worktree list —
- * see `component/new-task-dialog/tab-adopt.tsx` for the row-grammar this
- * extends with badges).
+ * WorktreesPage — lists every git worktree across all locally-saved projects
+ * (kobe-managed or not — see `worktree.list`'s handler), each row flagging
+ * whether kobe manages it, its age, uncommitted-changes state, and whether
+ * its branch has reached `origin`. Modeled on `tui-react/settings/host.tsx`
+ * (standalone full-window surface, same close-key contract) and the new-task
+ * dialog's Adopt tab (cursor-navigable worktree list — see
+ * `component/new-task-dialog/tab-adopt.tsx` for the row grammar this extends
+ * with badges).
  *
  * Delete flow mirrors the daemon's own safety gate
  * (`GitWorktreeManager.remove`): a clean worktree deletes on a single
@@ -21,11 +20,10 @@
  * disappears the moment the user confirms and the daemon call runs in the
  * background. A failure (dirty refusal, or anything else) puts the row back.
  *
- * Solid→React deltas: the Solid `createResource` becomes THE ASYNC CANON
- * (`src/tui-react/history/host.tsx`) — `useState` + a `reloadTick`-keyed
- * `useEffect` whose stale completions are dropped by an effect-local
- * `disposed` flag; `refetch()` is just bumping `reloadTick`. `For`/`Show`
- * become plain `.map()`/ternaries.
+ * Loading follows THE ASYNC CANON (`src/tui-react/history/host.tsx`):
+ * `useState` + a `reloadTick`-keyed `useEffect` whose stale completions are
+ * dropped by an effect-local `disposed` flag; a refetch is just bumping
+ * `reloadTick`.
  */
 
 import { TextAttributes } from "@opentui/core"
@@ -87,7 +85,7 @@ export function WorktreesPage(props: { orchestrator: RemoteOrchestrator | null; 
   // (ls-remote + gh PR states, seconds when a remote is slow) swaps in when
   // it lands. `fullLanded` guards the rare inversion where the full pass
   // returns before the fast one — richer rows must not be overwritten.
-  // biome-ignore lint/correctness/useExhaustiveDependencies: reloadTick is a TRIGGER (the effect body doesn't read it) — matching the Solid refetch() re-run guard.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: reloadTick is a TRIGGER — the effect body doesn't read it.
   useEffect(() => {
     let disposed = false
     let fullLanded = false
@@ -117,8 +115,8 @@ export function WorktreesPage(props: { orchestrator: RemoteOrchestrator | null; 
         setRemovingPaths((paths) => paths.filter((p) => live.has(p)))
       })
       .catch(() => {
-        // Same boundary as the Solid resource: a failed read leaves the
-        // fast-pass rows (or the loading placeholder) rather than crashing.
+        // Failure boundary: a failed read leaves the fast-pass rows (or the
+        // loading placeholder) rather than crashing.
       })
     return () => {
       disposed = true
@@ -135,7 +133,7 @@ export function WorktreesPage(props: { orchestrator: RemoteOrchestrator | null; 
   const flatRows = flattenRows(visibleProjects)
 
   const [cursor, setCursor] = useState(0)
-  // Re-clamp whenever the row count changes — the Solid `createEffect` on `flatRows().length`.
+  // Re-clamp whenever the row count changes.
   useEffect(() => {
     setCursor((c) => clampCursor(c, flatRows.length))
   }, [flatRows.length])

--- a/packages/kobe/src/tui-react/context/focus.tsx
+++ b/packages/kobe/src/tui-react/context/focus.tsx
@@ -1,14 +1,8 @@
 /** @jsxImportSource @opentui/react */
 /**
- * Pane focus — global, single source of truth (React port of
- * `src/tui/context/focus.tsx`, issue #15 G2). Same responsibilities: pane
- * wrappers set focus on click, panes gate their keybindings on it, global
- * single-letter shortcuts gate on the workspace NOT being focused.
- *
- * API deltas from the Solid version, by design:
- *   - `focused` is a plain value (was `Accessor<PaneId>`).
- *   - `is(pane)` returns a boolean (was a memoized `Accessor<boolean>`);
- *     Solid call sites `is("sidebar")()` become `is("sidebar")`.
+ * Pane focus — global, single source of truth. Pane wrappers set focus on
+ * click, panes gate their keybindings on it, and global single-letter
+ * shortcuts gate on the workspace NOT being focused.
  */
 
 import { useRenderer } from "@opentui/react"
@@ -48,8 +42,8 @@ export function FocusProvider(props: { children?: ReactNode; initial?: PaneId })
   const focusedRef = useLatest(focused)
 
   /**
-   * Unified focus-change entry point (same contract as the Solid provider):
-   * on a real transition blur whatever opentui renderable holds native
+   * Unified focus-change entry point: on a real transition, blur whatever
+   * opentui renderable holds native
    * focus BEFORE flipping the pane state — removing the one-tick window
    * where a composer textarea keeps eating keystrokes after the user
    * chorded away from the workspace.

--- a/packages/kobe/src/tui-react/context/keybindings.ts
+++ b/packages/kobe/src/tui-react/context/keybindings.ts
@@ -1,5 +1,5 @@
 /**
- * React access to the kobe keymap (issue #15, G2). The data table, lookup
+ * React access to the kobe keymap. The data table, lookup
  * fns, and override machinery are the framework-free parts of
  * `src/tui/context/keybindings.ts` and are re-exported untouched; the only
  * React-specific piece is subscribing chord legends to live keymap reloads

--- a/packages/kobe/src/tui-react/context/kv-core.ts
+++ b/packages/kobe/src/tui-react/context/kv-core.ts
@@ -1,19 +1,19 @@
 /**
- * Framework-free KV core (issue #15, G3) — the data + persistence half of
- * the Solid `src/tui/context/kv.tsx` without the Solid store, consumed by
- * the React `KVProvider` and unit-testable under vitest (no @opentui).
+ * Framework-free KV core — the data + persistence half of the KV store,
+ * consumed by the React `KVProvider` and unit-testable under vitest
+ * (no @opentui).
  *
- * Semantics preserved from the Solid provider:
+ * Semantics:
  *   - Synchronous snapshot hydration from `state.json` at creation, so the
  *     first render already sees persisted values (no default flash).
  *     Snapshot-only reads — a key another process writes later is not
- *     picked up until restart (longstanding, accepted).
+ *     picked up until restart.
  *   - Writes are debounced (250ms) and DIRTY-KEY MERGED via
  *     `patchStateFile`: only keys THIS process changed since its last
  *     successful flush reach disk, so a concurrent kobe process's writes
  *     are never clobbered by a whole-snapshot write-back (the classic
- *     lost-update bug the Solid provider fixed). Dirty keys survive a
- *     failed flush and retry on the next one.
+ *     lost-update bug). Dirty keys survive a failed flush and retry on the
+ *     next one.
  *   - `clear()` is the one legitimate whole-file write
  *     (`replaceStateFile({})`): "reset UI state" means wipe EVERYTHING,
  *     including keys other processes wrote after we loaded.
@@ -94,10 +94,10 @@ export function createKvCore(): KvCore {
       // `undefined` DELETES: the key must leave the snapshot, not sit in it
       // as an enumerable `undefined` — `sweepOrphanTabsSnapshots` walks
       // `Object.keys` and re-deletes anything still present, and its effect
-      // re-runs on every kv identity change, so a spread-back key turned one
-      // sweep into an infinite setState loop (React #185, 2026-09-01). Disk
-      // already had delete semantics (patchStateFile drops explicit-undefined
-      // entries); this aligns the in-memory snapshot with it.
+      // re-runs on every kv identity change, so a spread-back key turns one
+      // sweep into an infinite setState loop (React #185). Disk already has
+      // delete semantics (patchStateFile drops explicit-undefined entries);
+      // this aligns the in-memory snapshot with it.
       store.update((s) => {
         if (value !== undefined) return { ...s, [key]: value }
         if (!(key in s)) return s // already absent — no snapshot churn

--- a/packages/kobe/src/tui-react/context/kv.tsx
+++ b/packages/kobe/src/tui-react/context/kv.tsx
@@ -1,17 +1,14 @@
 /** @jsxImportSource @opentui/react */
 /**
- * KV store provider — React port of `src/tui/context/kv.tsx` (issue #15,
- * G3). Persistence semantics (snapshot hydration, dirty-key merge flush,
- * whole-file clear) live in the framework-free `./kv-core`; this file owns
- * only the React reactivity: the provider subscribes to the core via
- * `useSyncExternalStore` and rebuilds the context value per snapshot, so
- * every consumer under the provider re-renders on any `kv.set`.
+ * KV store provider. Persistence semantics (snapshot hydration, dirty-key
+ * merge flush, whole-file clear) live in the framework-free `./kv-core`;
+ * this file owns only the React reactivity: the provider subscribes to the
+ * core via `useSyncExternalStore` and rebuilds the context value per
+ * snapshot, so every consumer under the provider re-renders on any `kv.set`.
  *
- * API parity with the Solid provider: `ready` / `store` / `signal` / `get`
- * / `set` / `flush` / `clear`. Delta by design: `signal` returns a plain
- * `[read, write]` tuple (Solid's `Setter` overload has no React
- * equivalent), and `store` is the immutable snapshot rather than a
- * fine-grained proxy.
+ * API: `ready` / `store` / `signal` / `get` / `set` / `flush` / `clear`.
+ * `signal` returns a plain `[read, write]` tuple, and `store` is the
+ * immutable snapshot rather than a fine-grained proxy.
  */
 
 import { type ReactNode, createContext, useContext, useEffect, useMemo, useState, useSyncExternalStore } from "react"
@@ -32,17 +29,16 @@ export type KVContext = {
 const Ctx = createContext<KVContext | null>(null)
 
 export function KVProvider(props: { children?: ReactNode }) {
-  // One core per provider instance, hydrated synchronously at first render
-  // (mirrors the Solid provider's init-time loadStateFile()).
+  // One core per provider instance, hydrated synchronously at first render.
   const [core] = useState<KvCore>(createKvCore)
   const snapshot = useSyncExternalStore(core.subscribe, core.snapshot, core.snapshot)
 
-  // Exit flush (issues #22/#23): writes are 250ms-debounced, and every quit
-  // path — the confirm chord, ctrl+c, the signal backstop, a page's bare
-  // `process.exit(0)` — ends the process synchronously, so a state change
-  // made inside that window never reached disk. Reading a completion and
-  // quitting straight after therefore relit the lamp on the next launch,
-  // the very bug the durable seen mark exists to prevent.
+  // Exit flush: writes are 250ms-debounced, and every quit path — the confirm
+  // chord, ctrl+c, the signal backstop, a page's bare `process.exit(0)` —
+  // ends the process synchronously, so without this a state change made
+  // inside that window never reaches disk. Reading a completion and quitting
+  // straight after would relight the lamp on the next launch, which is what
+  // the durable seen mark exists to prevent.
   //
   // Registered here rather than at the quit call sites: "exit" is the one
   // hook every path passes through (it fires on process.exit, unlike

--- a/packages/kobe/src/tui-react/context/notifications.tsx
+++ b/packages/kobe/src/tui-react/context/notifications.tsx
@@ -1,15 +1,13 @@
 /** @jsxImportSource @opentui/react */
 /**
- * Per-ChatTab completion notifications (React port of the Solid
- * NotificationsProvider, issue #15 G3). Same three signals (audible cue,
- * transient toast, unread tab mark) and the same gating — the pure state
- * transforms + the "error toasts always show" invariant live in the
- * shared `src/tui/lib/notify-state.ts` consumed by both runtimes.
+ * Per-ChatTab completion notifications: three signals (audible cue,
+ * transient toast, unread tab mark) and their gating. The pure state
+ * transforms + the "error toasts always show" invariant live in the shared
+ * framework-free `src/tui/lib/notify-state.ts`.
  *
- * The React KV provider is now ported, so sound/toast toggles are read
- * from it when a KVProvider is present. Render tests and the mock dialogs
- * host intentionally run without KV, so we fall back to a one-time
- * `state.json` snapshot in that case.
+ * Sound/toast toggles are read from KV when a KVProvider is present. Render
+ * tests and the mock dialogs host intentionally run without KV, so they fall
+ * back to a one-time `state.json` snapshot.
  */
 
 import { type ReactNode, createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from "react"
@@ -59,7 +57,7 @@ export function NotificationsProvider(props: { children?: ReactNode }) {
 
   // Toast auto-dismiss timers are provider-scoped: any still-pending timer
   // is cleared on unmount so `dismiss()` never fires against a torn-down
-  // tree (the Solid version's createManagedTimeouts, inlined).
+  // tree.
   const timers = useRef(new Set<ReturnType<typeof setTimeout>>())
   useEffect(
     () => () => {

--- a/packages/kobe/src/tui-react/context/theme.tsx
+++ b/packages/kobe/src/tui-react/context/theme.tsx
@@ -1,19 +1,16 @@
 /** @jsxImportSource @opentui/react */
 /**
- * Theme provider for kobe (React) — the `src/tui/context/theme.tsx`
- * counterpart for React panes (issue #15, G2). All theme SEMANTICS
- * (bundled registry, resolution, focus-accent + transparent overlay) come
- * from the shared framework-free `src/tui/context/theme-core.ts`; this file
- * owns only the React reactivity.
+ * Theme provider for kobe. All theme SEMANTICS (bundled registry,
+ * resolution, focus-accent + transparent overlay) come from the shared
+ * framework-free `src/tui/context/theme-core.ts`; this file owns only the
+ * React reactivity.
  *
- * Differences from the Solid provider, by design:
- *   - `useTheme().theme` is a PLAIN resolved object, not a Proxy. React
- *     components re-render via context when the theme changes, so
- *     per-property reactive reads have no equivalent — and a plain object
- *     keeps `theme.background` call sites source-compatible.
+ *   - `useTheme().theme` is a PLAIN resolved object, not a Proxy: React
+ *     components re-render via context when the theme changes, so there is
+ *     nothing for per-property reactive reads to do.
  *   - Module-level registry state lives in an external store (subscribed
- *     via useSyncExternalStore), matching the Solid module-store semantics:
- *     `addTheme`/`listThemes` work before or outside any provider.
+ *     via useSyncExternalStore), so `addTheme`/`listThemes` work before or
+ *     outside any provider.
  */
 
 import { RGBA } from "@opentui/core"
@@ -46,7 +43,7 @@ const store = createExternalStore<State>({
   themes: { ...BUNDLED_THEMES },
   active: DEFAULT_THEME,
   mode: "dark",
-  // Transparent by default (2026-07-12) — kobe sits on the terminal's own
+  // Transparent by default — kobe sits on the terminal's own
   // background unless the user explicitly turns transparency off.
   transparentBackground: true,
   focusAccent: "primary",
@@ -67,9 +64,8 @@ export function addTheme(name: string, theme: ThemeJson): boolean {
   return true
 }
 
-// Module-level accessors/setters, mirroring the Solid module's
-// store-outside-the-provider semantics. The React host-boot path (issue #15
-// G3) seeds persisted prefs through these BEFORE the first render (no
+// Module-level accessors/setters, usable outside the provider. The host-boot
+// path seeds persisted prefs through these BEFORE the first render (no
 // flash) and applies live daemon ui-prefs pushes without a hook scope; the
 // provider's context methods delegate to the same store.
 
@@ -141,10 +137,10 @@ function resolveActive(state: State): Theme {
 }
 
 export function ThemeProvider(props: { children?: ReactNode; mode?: "dark" | "light"; theme?: string }) {
-  // Seed once from props, mirroring the Solid provider's init block. Done
-  // during the first render (not an effect) so the very first paint already
-  // uses the requested theme; the store dedupes identical snapshots.
-  // biome-ignore lint/correctness/useExhaustiveDependencies: seed-once semantics, matching Solid's init.
+  // Seed once from props, during the first render (not an effect) so the very
+  // first paint already uses the requested theme; the store dedupes identical
+  // snapshots.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: seed-once semantics.
   useMemo(() => {
     store.update((s) => ({
       ...s,

--- a/packages/kobe/src/tui-react/lib/global-mouse-down.ts
+++ b/packages/kobe/src/tui-react/lib/global-mouse-down.ts
@@ -39,7 +39,7 @@ function dispatch(event: unknown): void {
 export function subscribeGlobalMouseDown(host: MouseDownHost, handler: (event: unknown) => void): () => void {
   subscribers.add(handler)
   // Re-point on a host swap (a test harness builds a fresh renderer per test):
-  // the old root is torn down, and its listener would never fire again.
+  // the previous root is torn down, and its listener would never fire again.
   if (installedHost !== host) {
     if (installedHost) installedHost.onMouseDown = undefined
     installedHost = host

--- a/packages/kobe/src/tui-react/lib/host-boot.tsx
+++ b/packages/kobe/src/tui-react/lib/host-boot.tsx
@@ -1,27 +1,22 @@
 /** @jsxImportSource @opentui/react */
 /**
- * Shared boot sequence for kobe's React pane hosts (issue #15, G3) — the
- * `src/tui/lib/host-boot.tsx` counterpart. Same responsibilities, same
- * boot order (log context → crash handlers → keybindings.yaml overlay →
- * user themes → prefs read → per-host setup → provider-wrapped render),
- * with the framework-free pieces (`applyUserKeybindings`, `loadUserThemes`,
- * `readPersistedUiPrefs`, `applyUiPrefs`, `hostRenderOptions`,
- * `installPaneExitBackstop`) imported from the shared modules.
+ * Shared boot sequence for kobe's pane hosts. Boot order: log context →
+ * crash handlers → keybindings.yaml overlay → user themes → prefs read →
+ * per-host setup → provider-wrapped render, with the framework-free pieces
+ * (`applyUserKeybindings`, `loadUserThemes`, `readPersistedUiPrefs`,
+ * `applyUiPrefs`, `hostRenderOptions`, `installPaneExitBackstop`) imported
+ * from the shared modules.
  *
- * Deliberate deltas from the Solid host:
  *   - Visual prefs are seeded into the module-level theme store BEFORE
- *     `createRoot().render()` (the Solid version applies them inside a
- *     sync component during first render) — the first painted frame is
- *     already styled, and no component needs render-time side effects.
+ *     `createRoot().render()`, so the first painted frame is already styled
+ *     and no component needs render-time side effects.
  *   - The live daemon subscription rides the client layer's framework-free
- *     store twins (`uiPrefsStore()` / `keybindingsRevStore()`) — Solid
- *     signals don't notify outside a reactive-solid runtime.
- *   - Error boundary is a small class component (React's only boundary
- *     primitive); crash logging + themed fallback match the Solid host.
- *   - Provider flags: `kv`, `focus`, and `notifications` are all portable
- *     now. Unlike the Solid host, `kv` defaults to FALSE here: every
- *     existing React pane opted in explicitly, so mounting KV implicitly
- *     would silently change them.
+ *     store twins (`uiPrefsStore()` / `keybindingsRevStore()`), which notify
+ *     outside any component.
+ *   - The error boundary is a small class component (React's only boundary
+ *     primitive), with crash logging + a themed fallback.
+ *   - Provider flags: `kv` defaults to FALSE — every pane opts in
+ *     explicitly, so mounting KV implicitly would silently change them.
  */
 
 import { createCliRenderer } from "@opentui/core"
@@ -71,7 +66,7 @@ import { DialogProvider } from "../ui/dialog"
 /** Theme used when `state.json` is missing/stale — kobe's brand default. */
 const FALLBACK_THEME = DEFAULT_THEME
 
-/** Same flag surface as the Solid host; see header for the un-ported one. */
+/** Provider flags; see the header for the defaults. */
 export interface HostProviderFlags {
   /** KVProvider (persisted UI state). Default false — see header. */
   readonly kv?: boolean
@@ -138,9 +133,8 @@ function UiPrefsSync() {
         return
       }
       orch = remote
-      // Framework-free store twins of the client layer's Solid signals —
-      // signals don't notify outside a reactive-solid runtime, stores
-      // notify everywhere. Deliver the current value eagerly (the
+      // Framework-free store twins of the client layer's values — they notify
+      // outside any component. Deliver the current value eagerly (the
       // subscribe-time channel replay may have landed before we attached).
       const applyPrefs = (payload: UiPrefsPayload | null) => {
         if (!payload) return
@@ -200,7 +194,7 @@ export function formatPaneCrashDiagnostic(error: unknown, info: ErrorInfo): stri
 /**
  * React's boundary primitive is still a class component. Catches render
  * errors from the host's view tree; fire-and-forget rejections are covered
- * by `installClientCrashHandlers`, same split as the Solid host.
+ * by `installClientCrashHandlers`.
  */
 export class PaneErrorBoundary extends Component<{ children?: ReactNode }, { error: unknown | null }> {
   override state: { error: unknown | null } = { error: null }
@@ -219,7 +213,7 @@ export class PaneErrorBoundary extends Component<{ children?: ReactNode }, { err
 /**
  * Boot a standalone React pane host: shared steps → prefs read + seed →
  * per-host `setup` → provider-wrapped `createRoot().render()`. Resolves
- * once the root is mounted, mirroring the Solid host's render-resolve.
+ * once the root is mounted.
  */
 export async function bootPaneHost(opts: BootPaneHostOpts): Promise<void> {
   if (opts.logContext) setClientLogContext(opts.logContext)
@@ -268,8 +262,8 @@ export async function bootPaneHost(opts: BootPaneHostOpts): Promise<void> {
       <PaneErrorBoundary>{screen.root()}</PaneErrorBoundary>
     </>
   )
-  // Same fixed nesting order as the Solid host:
-  // Theme > KV > Focus > Dialog > Notifications; only membership varies.
+  // Fixed nesting order: Theme > KV > Focus > Dialog > Notifications; only
+  // membership varies.
   const withNotifications = notifications ? <NotificationsProvider>{body}</NotificationsProvider> : body
   const withDialog = <DialogProvider>{withNotifications}</DialogProvider>
   const withFocus = focus ? <FocusProvider initial="sidebar">{withDialog}</FocusProvider> : withDialog

--- a/packages/kobe/src/tui-react/lib/keymap.ts
+++ b/packages/kobe/src/tui-react/lib/keymap.ts
@@ -1,25 +1,21 @@
 /**
- * React key-bindings layer (issue #15, G2) — the `src/tui/lib/keymap.tsx`
- * counterpart for React panes. The dispatcher core (LIFO stack walk, chord
- * matching, preventDefault-on-first-hit) is the shared framework-free
+ * React key-bindings layer. The dispatcher core (LIFO stack walk, chord matching,
+ * preventDefault-on-first-hit) is the shared framework-free
  * `src/tui/lib/keymap-dispatch.ts`; this file owns only registration.
  *
- * Contract parity with the Solid hook:
- *   - `config` is re-evaluated on EVERY keypress. The Solid version relies
- *     on closures over signals staying live; React closures go stale across
- *     renders, so the registered entry reads the LATEST config through a
- *     ref that every render refreshes.
+ * Contract:
+ *   - `config` is re-evaluated on EVERY keypress. React closures go stale
+ *     across renders, so the registered entry reads the LATEST config
+ *     through a ref that every render refreshes.
  *   - Bindings stack LIFO; only the topmost enabled match fires.
  *
- * Known ordering difference (documented, accepted for the migration): Solid
- * registers during component SETUP (parents before children → children end
- * up on top); React registers in mount EFFECTS (children before parents →
- * ancestors end up on top). Consequence: a parent and child sharing a chord
- * must resolve by GATING, not stack order — the parent's entry disables
- * itself when the child should win. Case today: TerminalTabs' ctrl+w/F2
- * (gate off while the active tab is split so TerminalSplit's leaf-level
- * close/rename fire). Modal barrier vs dialog body is NOT resolved by
- * order anymore — it's declared via `ModalScopeContext` + `modalOwner`
+ * Registration happens in mount EFFECTS, which run children before parents,
+ * so ANCESTORS end up on top of the stack. Consequence: a parent and child
+ * sharing a chord must resolve by GATING, not stack order — the parent's
+ * entry disables itself when the child should win. Live case: TerminalTabs'
+ * ctrl+w/F2 gate off while the active tab is split, so TerminalSplit's
+ * leaf-level close/rename fire. Modal barrier vs dialog body is not resolved
+ * by order at all — it is declared via `ModalScopeContext` + `modalOwner`
  * below and settled by `insertRegistration`.
  */
 
@@ -47,15 +43,15 @@ export { dispatchKeyEvent } from "../../tui/lib/keymap-dispatch"
  * every `useBindings` mounted inside is stamped as a MEMBER of that scope,
  * and the barrier declares OWNERSHIP via `useBindings`'s `modalOwner`
  * option. `insertRegistration` (keymap-dispatch.ts) then places the barrier
- * below its members no matter which effect committed first — the explicit
- * replacement for the old "sibling order is load-bearing" contract.
+ * below its members no matter which effect committed first, so sibling
+ * registration order is never load-bearing.
  */
 export const ModalScopeContext = createContext<symbol | null>(null)
 
 let nextId = 1
 const stack: RegisteredBinding[] = []
-// Same renderer-swap guard as the Solid layer: production runs one renderer
-// per process (no-op from the second call), but a test harness that creates
+// Renderer-swap guard: production runs one renderer per process (no-op from
+// the second call), but a test harness that creates
 // a fresh renderer per test in the same process must rebind the listener to
 // the new renderer's keyInput emitter.
 let installedRenderer: unknown = null
@@ -76,11 +72,11 @@ function ensureInstalled(renderer: ReturnType<typeof useRenderer>): void {
   if (supersededRenderers.has(renderer as object)) return
   if (installed && listener) installed.off("keypress", listener)
   if (installedRenderer) supersededRenderers.add(installedRenderer as object)
-  // New renderer → fresh stack. The old renderer's tree may be torn down
-  // without React cleanups (test harness destroy, hard renderer swap) —
+  // New renderer → fresh stack. The superseded renderer's tree may be torn
+  // down without React cleanups (test harness destroy, hard renderer swap) —
   // its entries would linger in the module-global stack forever. Harmless
   // once, but a lingering MODAL barrier (dialog open at teardown) would
-  // block every key of the next renderer. Late cleanups from the old tree
+  // block every key of the next renderer. Late cleanups from that tree
   // splice by id and no-op safely against the cleared array.
   stack.length = 0
   resetPrefixState()

--- a/packages/kobe/src/tui-react/lib/narrow-mode.ts
+++ b/packages/kobe/src/tui-react/lib/narrow-mode.ts
@@ -1,11 +1,11 @@
 /**
- * Narrow-layout breakpoint (issue #14 — phone SSH, ~46×70 cells).
+ * Narrow-layout breakpoint (phone SSH, ~46×70 cells).
  *
  * Below NARROW_BREAKPOINT cols the workspace collapses to a single-panel
  * layout (sidebar ⇄ workspace mutually exclusive, footer condensed). At or
- * above it the desktop three-pane layout must be byte-identical — issue
- * #11's golden stubs anchor that behavior, so every narrow consumer gates
- * on this one predicate rather than inventing its own threshold.
+ * above it the desktop three-pane layout must be byte-identical — the golden
+ * stubs anchor that behavior, so every narrow consumer gates on this one
+ * predicate rather than inventing its own threshold.
  *
  * Consumers derive the flag per render from `useTerminalDimensions().width`
  * — opentui re-renders on terminal resize, so the flag is live.

--- a/packages/kobe/src/tui-react/mock/dialogs-host.tsx
+++ b/packages/kobe/src/tui-react/mock/dialogs-host.tsx
@@ -1,7 +1,7 @@
 /** @jsxImportSource @opentui/react */
 /**
- * React dialogs/notifications mock host (`bun run dev:mock-react-dialogs`,
- * issue #15 G3) — the live render proof for the small-shared-dialogs slice:
+ * Dialogs/notifications mock host (`bun run dev:mock-react-dialogs`) — the
+ * live render proof for the small-shared-dialogs slice:
  * NotificationsProvider wired through `bootPaneHost` (providers:
  * notifications), VersionSkewBanner, ToastOverlay, and HelpDialog all on
  * one screen.

--- a/packages/kobe/src/tui-react/mock/host.tsx
+++ b/packages/kobe/src/tui-react/mock/host.tsx
@@ -1,7 +1,7 @@
 /** @jsxImportSource @opentui/react */
 /**
- * `dev:mock-react` — THE general mock scene (owner call 2026-07-09: one
- * bench, stuff everything in). Composes the real app shape without a
+ * `dev:mock-react` — THE general mock scene: one bench, everything in it.
+ * Composes the real app shape without a
  * daemon/orchestrator: the real Sidebar against the shared synthetic
  * fixtures (many projects + mixed-status tasks) next to real TerminalTabs
  * running throwaway shells, on the full provider stack (theme → focus →

--- a/packages/kobe/src/tui-react/ops/preview.tsx
+++ b/packages/kobe/src/tui-react/ops/preview.tsx
@@ -1,15 +1,11 @@
 /** @jsxImportSource @opentui/react */
 /**
- * React `kobe ops --preview <rel>` — the `src/tui/ops/preview.tsx`
- * counterpart (issue #15, G3). React is the default runtime since
- * 2026-07-07 (`uiFramework()` in `src/env.ts`); `KOBE_SOLID=1` is the
- * legacy escape hatch. Data + syntax-style
- * mapping are the shared `tui/ops/preview-core.ts` / `preview-syntax.ts`.
- * The Solid host's single `createResource` follows THE ASYNC CANON
- * (`src/tui-react/history/host.tsx`): `useState` + a dependency-keyed
+ * `kobe ops --preview <rel>`. Data + syntax-style mapping are the shared
+ * `tui/ops/preview-core.ts` / `preview-syntax.ts`. Loading follows THE ASYNC
+ * CANON (`src/tui-react/history/host.tsx`): `useState` + a dependency-keyed
  * `useEffect` whose stale completions are dropped by an effect-local
- * `disposed` flag. The read is one-shot (the preview window is immutable
- * for its lifetime), so there's no refresh tick.
+ * `disposed` flag. The read is one-shot (the preview window is immutable for
+ * its lifetime), so there's no refresh tick.
  */
 
 import type { DiffRenderable } from "@opentui/core"
@@ -62,7 +58,7 @@ export function PreviewScreen(props: OpsPreviewArgs) {
         if (!disposed) setData(d)
       })
       .catch(() => {
-        // Same boundary as the Solid resource: a failed read (worktree torn
+        // Failure boundary: a failed read (worktree torn
         // down mid-open) leaves the loading placeholder rather than crashing.
       })
     return () => {

--- a/packages/kobe/src/tui-react/panes/filetree/FileTree.tsx
+++ b/packages/kobe/src/tui-react/panes/filetree/FileTree.tsx
@@ -1,10 +1,9 @@
 /** @jsxImportSource @opentui/react */
 /**
- * React file tree pane — the `src/tui/panes/filetree/FileTree.tsx`
- * counterpart (issue #15, G3). Same behavior, same shared framework-free
- * logic (`git.ts`, `rows.ts`, `pane-core.ts`, `keys-core.ts`,
- * `open-external.ts`); this file owns only the React reactivity, following
- * THE ASYNC CANON from `src/tui-react/history/host.tsx`:
+ * File tree pane. The behavior lives in the shared framework-free logic
+ * (`git.ts`, `rows.ts`, `pane-core.ts`, `keys-core.ts`, `open-external.ts`);
+ * this file owns only the React reactivity, following THE ASYNC CANON from
+ * `src/tui-react/history/host.tsx`:
  *
  *   - each async git read is `useState` + a dependency-keyed `useEffect`;
  *   - the last resolved value stays visible while a refresh is in flight;
@@ -12,15 +11,11 @@
  *   - the opt-in fs watch bumps a `refreshTick` scalar the data effect
  *     refetches from, instead of owning its own fetch.
  *
- * Solid→React prop delta: `worktreePath` / `focused` are plain values here
- * (React re-renders on prop change), not Accessors.
- *
- * Fetch-effect shape mirrors the Solid original 1:1 — three effects on
- * worktree change (wipe + reload), tab change (cache-first + cursor
- * reset), and refresh tick (cursor-preserving reload). Content-equality
- * setters (`sameFileList` / `sameStatusEntries`) keep no-change refreshes
- * from re-rendering, the same renderable-churn guard the Solid pane
- * carries (rows.ts has the memory-leak story).
+ * Three fetch effects: worktree change (wipe + reload), tab change
+ * (cache-first + cursor reset), and refresh tick (cursor-preserving reload).
+ * Content-equality setters (`sameFileList` / `sameStatusEntries`) keep
+ * no-change refreshes from re-rendering — see rows.ts for why renderable
+ * churn matters here.
  */
 
 import { errorMessage } from "@/lib/error-message"
@@ -65,8 +60,7 @@ import { useLatest } from "../../lib/use-latest"
 import { FileTreeHeaderView } from "./header-view"
 import { FileTreeRowView } from "./row-view"
 
-/** Public props — the Solid `FileTreeProps` with plain values for the
- * reactive fields (see file header). Same field docs as the Solid pane. */
+/** Public props. */
 export type FileTreeProps = {
   /** Active task's worktree path; `null` renders the "No worktree" placeholder. */
   worktreePath: string | null
@@ -84,7 +78,7 @@ export type FileTreeProps = {
   onMention?: (relPath: string) => void
   /** `p` — request PR creation (workspace host only); also rendered as a chip. */
   onCreatePR?: () => void
-  /** Zen-mode chip left of Create PR (enter-only, see the Solid pane doc). */
+  /** Zen-mode chip left of Create PR (enter-only). */
   onZenToggle?: () => void
   /** Whether the pane has keyboard focus. Defaults to `true`. */
   focused?: boolean
@@ -123,7 +117,7 @@ export function FileTree(props: FileTreeProps) {
   const [expandedDirs, setExpandedDirs] = useState<ReadonlySet<string>>(() => new Set())
 
   // Latest-render mirrors for effect bodies that must read a value without
-  // depending on it (the Solid originals read these untracked inside `on(...)`).
+  // depending on it.
   const pathRef = useLatest(props.worktreePath)
   const tabRef = useLatest(tab)
   const allFilesRef = useLatest(allFiles)
@@ -183,7 +177,8 @@ export function FileTree(props: FileTreeProps) {
   )
 
   // Re-fetch when the worktree changes — wipe all caches first because the
-  // old cache no longer applies. Cleanup aborts the in-flight git read so
+  // previous worktree's cache does not apply. Cleanup aborts the in-flight
+  // git read so
   // rapid task-switches don't stack subprocesses. Scope resets to its
   // auto-fallback default (working, un-toggled) for the new task.
   useEffect(() => {
@@ -282,7 +277,7 @@ export function FileTree(props: FileTreeProps) {
 
   // Derived rows, reconciled against the previous list so unchanged rows
   // keep object identity (stable React keys + reference-equal memo output
-  // when nothing changed — same renderable-reuse story as the Solid pane).
+  // when nothing changed), so opentui reuses the renderables.
   const prevRows = useRef<readonly Row[]>([])
   const rows = useMemo<readonly Row[]>(() => {
     const next: Row[] = []

--- a/packages/kobe/src/tui-react/panes/filetree/header-view.tsx
+++ b/packages/kobe/src/tui-react/panes/filetree/header-view.tsx
@@ -1,7 +1,6 @@
 /** @jsxImportSource @opentui/react */
 /**
- * React view for the file tree pane's header chrome — the `src/tui/panes/
- * filetree/header-view.tsx` counterpart (issue #15, G3): the optional
+ * View for the file tree pane's header chrome: the optional
  * Zen / Create-PR action row, the All / Changes tab chips, and the
  * Changes-tab status legend. Pure render — tab state and actions stay in
  * the pane component.
@@ -44,10 +43,10 @@ export function FileTreeHeaderView(props: FileTreeHeaderProps) {
       {/* Action row — sits above the All / Changes tabs so it's reachable
          from both tabs. Zen toggle sits left of Create PR (prefix+p). */}
       {props.onZenToggle || props.onCreatePR ? (
-        // wrap, and chips flexShrink={0}: on a narrow pane Yoga used to
-        // squeeze the chips' inner gaps first ("[~]Zen"), and with shrink
-        // forbidden the row would overflow the pane border instead — wrapping
-        // stacks the chips right-aligned, both still whole.
+        // wrap, and chips flexShrink={0}: on a narrow pane Yoga squeezes the
+        // chips' inner gaps first ("[~]Zen"), and with shrink forbidden the
+        // row would overflow the pane border instead — wrapping stacks the
+        // chips right-aligned, both still whole.
         //
         // columnGap, NOT gap: Yoga's `gap` sets BOTH gutters, so the wrap this
         // row is designed around also inherited a 2-row vertical gutter — and

--- a/packages/kobe/src/tui-react/panes/filetree/mock-host.tsx
+++ b/packages/kobe/src/tui-react/panes/filetree/mock-host.tsx
@@ -1,7 +1,7 @@
 /** @jsxImportSource @opentui/react */
 /**
- * React file-tree mock host (`bun run dev:mock-react-filetree`) — the live
- * render proof for the ported pane. The pane reads real git, so the fixture
+ * File-tree mock host (`bun run dev:mock-react-filetree`) — the live render
+ * proof for the pane. The pane reads real git, so the fixture
  * is a throwaway `git init` repo in the OS tempdir with deterministic
  * `kobe-fixture-*` file names: the All tab lists them via
  * `git ls-files --others`, no commit required, and the smoke greps one of
@@ -25,8 +25,7 @@ function makeFixtureWorktree(): string {
   return dir
 }
 
-// Same minimal provider set as the Ops pane host that mounts the Solid
-// FileTree: Theme > Dialog only, no KV / Focus.
+// Minimal provider set: Theme > Dialog only, no KV / Focus.
 await bootPaneHost({
   logContext: "filetree-mock",
   providers: { kv: false, focus: false },

--- a/packages/kobe/src/tui-react/panes/filetree/row-view.tsx
+++ b/packages/kobe/src/tui-react/panes/filetree/row-view.tsx
@@ -1,9 +1,8 @@
 /** @jsxImportSource @opentui/react */
 /**
- * React view for a single file tree row — the `src/tui/panes/filetree/
- * row-view.tsx` counterpart (issue #15, G3). Pure render: all row math
- * (stat widths, path budget, status→token mapping) comes from the shared
- * framework-free `pane-core.ts`, so the two runtimes render identically.
+ * View for a single file tree row. Pure render: all row math (stat widths,
+ * path budget, status→token mapping) comes from the shared framework-free
+ * `pane-core.ts`.
  *
  * Cursor row treatment — shares the Sidebar's neutral left marker +
  * `backgroundElement` tint, NOT the pane-level focus accent or a solid

--- a/packages/kobe/src/tui-react/panes/sidebar/SidebarTree.tsx
+++ b/packages/kobe/src/tui-react/panes/sidebar/SidebarTree.tsx
@@ -1,20 +1,15 @@
 /** @jsxImportSource @opentui/react */
 /**
- * The tree sidebar (owner call 2026-08-01): project → Task → Terminal Tab, with
- * the right pane showing nothing but the active session's terminal.
+ * The tree sidebar: project → Task → Terminal Tab, with the right pane
+ * showing nothing but the active session's terminal. Tasks group under their
+ * project header and a worktree's tabs render as child rows beneath it.
  *
- * Round 2 (same day): the tree keeps the flat sidebar's design language —
- * the same brand header / nav rail / view tabs chrome, the same two-line
- * row cards, the same section-header grammar for project groups. What the
- * tree CHANGES is structure only: tasks group under their project header and
- * a worktree's tabs render as child rows beneath its card. Everything starts
- * expanded (owner call, round 4) — the collapse sets hold only what you folded
- * by hand, so a new worktree or a freshly-mounted tab needs no keystroke.
+ * Everything starts expanded — the collapse sets hold only what you folded by
+ * hand, so a new worktree or a freshly-mounted tab needs no keystroke.
  *
- * Navigation is deliberately the same machinery: the cursor indexes one flat
- * id list, so j/k/gg/enter come from the same `createSidebarController` the
- * flat sidebar uses, and a tab row is selectable by exactly the mechanism
- * that already selects tasks.
+ * The cursor indexes one flat id list, so j/k/gg/enter come from
+ * `createSidebarController` and a tab row is selectable by exactly the
+ * mechanism that selects tasks.
  */
 
 import type { Task } from "@/types/task"
@@ -50,9 +45,9 @@ export type SidebarTreeProps = SidebarProps & {
   /** Open a new conversation ("chat" — the ctrl+e picker) or a bare shell tab
    *  in any worktree — offered by the worktree/tab rows' menu. */
   onNewTab?: (taskId: string, kind: "chat" | "shell") => void
-  /** Move one tab within its task (move mode on a tab row, issue #43). */
+  /** Move one tab within its task (move mode on a tab row). */
   onMoveTabRequest?: (taskId: string, tabId: string, delta: -1 | 1) => void
-  /** Narrow mode's "↩ recent" jump target (issue #14, 2A) — renders as the
+  /** Narrow mode's "↩ recent" jump target — renders as the
    *  first navigable row; ⏎ re-enters that task's workspace. */
   recentTask?: Task | null
   /** Filled with a reader of the task under the cursor, so the host's
@@ -69,8 +64,8 @@ export function SidebarTree(props: SidebarTreeProps) {
   const focused = props.focused ?? true
   const dims = useTerminalDimensions()
 
-  // The same ~2s branch/changes poll tick the flat sidebar runs — the row
-  // cards' `useChanges`/`pollCurrentBranch` effects key on it.
+  // The ~2s branch/changes poll tick — the row cards'
+  // `useChanges`/`pollCurrentBranch` effects key on it.
   const [branchTick, setBranchTick] = useState(0)
   useEffect(() => {
     const timer = setInterval(() => setBranchTick((n) => n + 1), MAIN_BRANCH_POLL_MS)
@@ -95,8 +90,7 @@ export function SidebarTree(props: SidebarTreeProps) {
   }, [tree.flatIds])
 
   // Cursor: state + ref written together so key handlers between renders read
-  // the just-set index (React commits state later — same contract as the flat
-  // sidebar's cursor).
+  // the just-set index (React commits state later).
   const [cursorIndex, setCursorIndexState] = useState(-1)
   const cursorRef = useRef(cursorIndex)
   const setCursorIndex = useCallback((next: number): void => {
@@ -116,9 +110,8 @@ export function SidebarTree(props: SidebarTreeProps) {
   // Follow the active row when the selection moves from elsewhere (the F7
   // attention jump, the inbox). EDGE-triggered on the active row CHANGING —
   // not on every list identity churn: flatIds rebuilds on the 2s branch tick
-  // and every engine-state push, and re-anchoring then dragged the cursor
-  // back to the selected row while the user was j/k-walking the tree
-  // (prefix+h → move → yanked back, owner bug 2026-08-02). Clamps still run
+  // and every engine-state push, and re-anchoring then would drag the cursor
+  // back to the selected row while the user is j/k-walking the tree. Clamps run
   // on every list change so a shrunken list can't strand the cursor.
   const prevActiveRef = useRef<string | null>(null)
   // The row the cursor sat on LAST render — what move mode re-anchors to when
@@ -159,7 +152,7 @@ export function SidebarTree(props: SidebarTreeProps) {
   // Land the highlight on the top match on every search keystroke. Declared
   // AFTER the follow effect so it wins while a query is open — otherwise the
   // cursor would snap back to the active row you are trying to search away
-  // from. (Same ordering contract as the flat sidebar.)
+  // from.
   useEffect(() => {
     void search.query
     if (!search.active) return
@@ -175,7 +168,7 @@ export function SidebarTree(props: SidebarTreeProps) {
   const toggleRoutinesRow = tree.toggleRoutinesRow
   const activateRow = useCallback(
     (rowId: string): void => {
-      // The routine count row (issue #91) opens and closes instead of
+      // The routine count row opens and closes instead of
       // activating: it names no task, so `parseRowId` below would hand a
       // sentinel id to `onSelect` and land on nothing.
       if (toggleRoutinesRow(rowId)) return
@@ -206,7 +199,7 @@ export function SidebarTree(props: SidebarTreeProps) {
   const ctrl = controllerRef.current
 
   /**
-   * Move mode is SCOPE-AWARE (issue #43): the cursor row's level is what
+   * Move mode is SCOPE-AWARE: the cursor row's level is what
    * moves. A tab row moves within its task's tab list; a task/branch row
    * moves within its repo group (`moveTask` partitions by repo); a `main`
    * row — the repo's own checkout, the group's first row and the nearest
@@ -244,8 +237,8 @@ export function SidebarTree(props: SidebarTreeProps) {
   )
 
   // What wears the move chip: a main row drags its whole PROJECT, so the
-  // group header carries the chip (the pre-#43 rendering); any other row
-  // drags itself, so the chip sits on the row under the cursor.
+  // group header carries the chip; any other row drags itself, so the chip
+  // sits on the row under the cursor.
   const cursorRowId = tree.flatIds[cursorIndex]
   const cursorMove = useMemo((): { projectId: string | null; rowId: string | null } => {
     if (cursorRowId === undefined || cursorRowId === RECENT_ROW_ID) return { projectId: null, rowId: null }
@@ -290,8 +283,8 @@ export function SidebarTree(props: SidebarTreeProps) {
     markKeysUsed,
   })
 
-  // ctrl+<digit> jump — same contract as the flat sidebar: slot N is the Nth
-  // VISIBLE row, so it follows expansion state. Not gated on focus: the chord
+  // ctrl+<digit> jump: slot N is the Nth VISIBLE row, so it follows expansion
+  // state. Not gated on focus: the chord
   // exists to switch from inside the engine pane.
   useBindings(() => ({
     enabled: true,
@@ -305,8 +298,8 @@ export function SidebarTree(props: SidebarTreeProps) {
     }),
   }))
 
-  // Viewport follow — rowEls is keyed by flat index (the row cards' own
-  // registration convention), shared by cards and tab rows alike.
+  // Viewport follow — rowEls is keyed by flat index, the registration
+  // convention every row type shares.
   const scrollRef = useRef<ScrollBoxRenderable | null>(null)
   const rowElsRef = useRef<Map<number, BoxRenderable> | null>(null)
   if (rowElsRef.current === null) rowElsRef.current = new Map()
@@ -323,8 +316,7 @@ export function SidebarTree(props: SidebarTreeProps) {
   useEffect(() => {
     const el = outerRef.current
     if (!el) return
-    // opentui's width setter force-zeroes flexShrink — restore it here (see
-    // the flat Sidebar for the full story).
+    // opentui's width setter force-zeroes flexShrink — restore it here.
     el.width = effectiveWidth
     el.flexShrink = 1
     el.minHeight = 0
@@ -339,7 +331,7 @@ export function SidebarTree(props: SidebarTreeProps) {
     rowEls,
     onPress: (flatIndex, rowId) => {
       // Clicking a row while a menu is up dismisses it — otherwise the menu
-      // would hang over a row it no longer describes.
+      // would hang over a row it does not describe.
       menu.close()
       setCursorIndex(flatIndex)
       activateRow(rowId)

--- a/packages/kobe/src/tui-react/panes/sidebar/chrome.tsx
+++ b/packages/kobe/src/tui-react/panes/sidebar/chrome.tsx
@@ -1,9 +1,8 @@
 /** @jsxImportSource @opentui/react */
 /**
  * Shared sidebar chrome — the brand header, nav rail, view tabs, section
- * header, and zen chip, extracted from `panel.tsx` so the TREE sidebar
- * renders the exact same components instead of a lookalike (owner call
- * 2026-08-01: the tree keeps the flat sidebar's design language).
+ * header, and zen chip. One set of components, so every sidebar surface
+ * renders the same thing rather than a lookalike.
  */
 
 import { MouseButton, TextAttributes } from "@opentui/core"
@@ -75,9 +74,9 @@ export function SectionHeader(props: {
   )
 }
 
-/** The `/` query row. Shared by the flat sidebar and the tree so there is one
- *  search affordance rather than two lookalikes — the count suffix reads
- *  `matches/total` over whatever list the host is filtering. */
+/** The `/` query row — one search affordance for every list surface. The
+ *  count suffix reads `matches/total` over whatever list the host is
+ *  filtering. */
 export function SidebarSearchInput(props: { query: string; matchCount: number; totalCount: number }) {
   const { theme } = useTheme()
   const t = useT()
@@ -154,7 +153,7 @@ export function SidebarBrandHeader(props: {
 /** Persistent primary action for the sidebar. The full row is clickable and
  *  the keycap comes from the live keymap, so a rebound or disabled `task.new`
  *  binding never leaves stale instructions behind. The `+` trails the label
- *  next to the keycap (owner 2026-08-24) so the row reads label-first and the
+ *  next to the keycap so the row reads label-first and the
  *  affordance pair sits in the conventional right-hand shortcut column; the
  *  gap between them keeps `+ n` from reading as a literal `+n` chord. */
 export function SidebarCreateAction(props: { onAddTask?: () => void }) {
@@ -169,9 +168,9 @@ export function SidebarCreateAction(props: { onAddTask?: () => void }) {
     //
     // The left inset lives HERE and nowhere else. The inner box carries the
     // filled background, so it needs its own horizontal padding to keep the
-    // label off the fill's edge — and adding an inset on this wrapper too put
-    // the label at column 2 while every other sidebar element (the ROVE
-    // header, the nav rail, the tree rows, the ZEN chip) starts at column 1.
+    // label off the fill's edge. An inset on this wrapper too would put the
+    // label at column 2 while every other sidebar element (the ROVE header,
+    // the nav rail, the tree rows, the ZEN chip) starts at column 1.
     <box flexShrink={0} paddingRight={1}>
       <box
         position="relative"
@@ -200,7 +199,7 @@ export function SidebarCreateAction(props: { onAddTask?: () => void }) {
   )
 }
 
-/** Top-level rail: one destination per line (owner call 2026-08-01). The
+/** Top-level rail: one destination per line. The
  *  24-cell rail cannot fit three chips side by side — vertical scales. */
 export function SidebarNavRail(props: { nav: SidebarNav; setNav: (nav: SidebarNav) => void }) {
   const { theme } = useTheme()
@@ -219,8 +218,8 @@ export function SidebarNavRail(props: { nav: SidebarNav; setNav: (nav: SidebarNa
             paddingRight={1}
             onMouseUp={(e: { stopPropagation(): void }) => {
               // goToNav hands focus to the page; a bubbled sidebar
-              // focus-grab (the pane shell's onMouseUp) took it right back,
-              // so keys typed "into the page" fired sidebar chords (d!).
+              // focus-grab (the pane shell's onMouseUp) would take it right
+              // back, so keys typed "into the page" fire sidebar chords (d!).
               e.stopPropagation()
               props.setNav(item.nav)
             }}

--- a/packages/kobe/src/tui-react/panes/sidebar/orphan-tabs.ts
+++ b/packages/kobe/src/tui-react/panes/sidebar/orphan-tabs.ts
@@ -9,8 +9,8 @@
  *   - a session started by an older kobe, before the CLI wrote snapshots;
  *   - a snapshot reclaimed by the orphan sweep while its PTY lived on;
  *   - anything that opens a `<taskId>::<tabId>` session without going
- *     through either writer (issue #20: a canonical-spawn fallback ran a
- *     live engine for 1h44m that the sidebar never showed).
+ *     through either writer (a canonical-spawn fallback can run a live engine
+ *     for hours that the sidebar never shows).
  *
  * In every one of those the engine is alive and the sidebar showed either
  * nothing or a tab list missing the session. So: reconcile at TAB
@@ -31,7 +31,7 @@ export interface LiveSession {
   /** OSC window title of the live process, when the host observed one. */
   readonly title?: string | null
   /** Shell pid of the hosted session — roots the live-engine probe's
-   *  process-tree walk for tabs this TUI never attached (issue #33). */
+   *  process-tree walk for tabs this TUI never attached. */
   readonly pid?: number | null
 }
 
@@ -39,8 +39,8 @@ export interface LiveSession {
  * Group live sessions into UNREGISTERED tab rows per task, skipping every
  * exact `<taskId>::<tabId>` key in `registered` (a snapshot answered for
  * those tabs). Tab-granular on purpose: a task whose snapshot lists tab-2
- * while tab-1 is alive must still surface tab-1 — that divergence is issue
- * #20's invisible engine, and skipping whole tasks is what hid it.
+ * while tab-1 is alive must still surface tab-1 — that divergence is an
+ * invisible live engine, and skipping whole tasks is what hides it.
  *
  * The label is the live process title when the host has one, else the tab
  * id, prefixed ⚠ — the row exists because the snapshot does NOT know this

--- a/packages/kobe/src/tui-react/panes/sidebar/row-cards.tsx
+++ b/packages/kobe/src/tui-react/panes/sidebar/row-cards.tsx
@@ -1,22 +1,15 @@
 /** @jsxImportSource @opentui/react */
 /**
- * Shared per-row React hooks for the sidebar's rows.
- *
- * History: this file used to own the flat sidebar's two-line row cards
- * (`ProjectRowCard` / `TaskRowCard`). The flat sidebar is gone from the
- * product and those cards had zero callers — the hover-tooltip feed lived
- * in them, which is exactly what made the tooltip path unreachable — so
- * the cards were removed (2026-08-30). What survives is the seam the tree
- * sidebar's one-line rows import: the spinner-frame subscription, the
- * `+N −M` changes hook + chip, the unread-lamp "seen" bookkeeping, and the
- * (retired-print) jump-digit placeholder.
+ * Shared per-row React hooks for the sidebar's rows: the spinner-frame
+ * subscription, the `+N −M` changes hook + chip, the unread-lamp "seen"
+ * bookkeeping, and the jump-digit placeholder.
  *
  * Poller contract (async canon): the fire-and-forget `poll*` call lives in
  * an effect keyed on the Sidebar's `branchTick` (never in render), while
  * the cached `read` side (`worktreeChanges`) is a plain synchronous getter
  * read at render time. A finishing poll surfaces on the next tick
- * re-render (≤100ms via the spinner tick) instead of notifying — the Solid
- * signal's push is replaced by the tick's pull.
+ * re-render (≤100ms via the spinner tick) rather than notifying: the tick
+ * pulls, nothing pushes.
  */
 
 import type { TaskEngineState } from "@/client/remote-orchestrator"
@@ -35,8 +28,8 @@ const ZERO_FRAME = () => 0
 /**
  * Per-row spinner pulse — subscribes to the shared 10Hz frame store ONLY
  * while this row actually animates, so a frame tick re-renders the loading
- * rows and nothing else (the old component-level interval re-ran the whole
- * Sidebar per tick). Exported for the tree's one-line worktree rows.
+ * rows and nothing else — a component-level interval would re-run the whole
+ * Sidebar per tick. Exported for the tree's one-line worktree rows.
  */
 export function useSpinnerFrame(active: boolean): number {
   return useSyncExternalStore(
@@ -92,17 +85,17 @@ export function ChangeStats(props: { readonly changes: WorktreeChanges }) {
  * (selected while complete) — the herdr "seen" bit driving ● → ✓. Cleared the
  * moment that row's activity state moves off `turn_complete`.
  *
- * Process-scoped, and that used to be the whole record: the daemon's activity
- * registry outlives the TUI, so relaunching kobe re-lit every completion you
- * had already read (issue #22). The durable mark in `workspace/completion-seen`
- * is what survives the restart; this Set stays the same-render answer.
+ * Process-scoped, so it is only half the record: the daemon's activity
+ * registry outlives the TUI, and relaunching kobe would otherwise re-light
+ * every completion already read. The durable mark in
+ * `workspace/completion-seen` survives the restart; this Set is the
+ * same-render answer.
  *
  * Keyed per ROW (task, or task+tab in the tree), not per task: a task owns
  * several tab rows, and they render in the same pass. A sibling tab — which
- * legitimately passes `activityState: undefined` — took the clear branch and
- * wiped the bit the completed tab's row had just recorded. Symptom (owner
- * report 2026-08-10): open the tab, the lamp digests to ✓, and it flips back
- * to ● the moment you leave, forever.
+ * legitimately passes `activityState: undefined` — would take the clear
+ * branch and wipe the bit the completed tab's row just recorded, flipping the
+ * lamp ✓ → ● on every task switch.
  */
 const completionSeenIds = new Set<string>()
 
@@ -144,7 +137,7 @@ export function completionStampOf(activity: TaskEngineState | undefined): number
 }
 
 /**
- * Persisted half of the seen bit (issue #22): read the stored mark at render
+ * Persisted half of the seen bit: read the stored mark at render
  * time, and record this completion while you are looking at it.
  *
  * The write is an EFFECT on purpose — `kv.set` re-renders every KV consumer,
@@ -176,7 +169,7 @@ export function useDurableCompletionSeen(
  * nothing rather than a digit that jumps somewhere else. Keyed on the flat
  * index directly so the tree's rows (no SidebarRow wrapper) share it.
  */
-// ponytail: ctrl+<digit> jump chord still works, just no longer printed on the row.
+// ponytail: the ctrl+<digit> jump chord works; the digit is not printed on the row.
 export function JumpDigit(_props: { flatIndex: number; dim: boolean }) {
   return null
 }

--- a/packages/kobe/src/tui-react/panes/sidebar/tree-panel.tsx
+++ b/packages/kobe/src/tui-react/panes/sidebar/tree-panel.tsx
@@ -1,20 +1,16 @@
 /** @jsxImportSource @opentui/react */
 /**
- * The sidebar tree's body — one scrollbox of ONE-CELL rows (owner call
- * 2026-08-01, round 3). The chrome around it (brand header / nav rail / view
- * tabs / section-header grammar for project groups) stays the flat sidebar's
- * own components; inside the tree, density wins: worktree rows compress the
- * two-line card to one line, and tab rows start at the same column with the
- * state glyph carrying the hierarchy (issue #41).
+ * The sidebar tree's body — one scrollbox of ONE-CELL rows. Density wins
+ * inside the tree: a worktree row is one line, and tab rows start at the same
+ * column with the state glyph carrying the hierarchy.
  *
- * No fold anywhere (owner round 5) with ONE scoped exception: a project's
- * routine count row (issue #91), which folds only the standing sessions a
- * SCHEDULE created. Every project and every task a human opened still shows
- * everything under it — the promise that rule protects is intact.
+ * No fold anywhere with ONE scoped exception: a project's routine count row,
+ * which folds only the standing sessions a SCHEDULE created. Every project
+ * and every task a human opened still shows everything under it.
  *
- * One scrollbox, not the flat sidebar's two: a tree's whole point is that a
- * project and its worktrees scroll together, and the cursor indexes one flat
- * id list so one viewport is what "scroll the cursor into view" needs.
+ * ONE scrollbox: a tree's whole point is that a project and its worktrees
+ * scroll together, and the cursor indexes one flat id list, so one viewport
+ * is what "scroll the cursor into view" needs.
  */
 
 import type { ScrollBoxRenderable } from "@opentui/core"
@@ -46,14 +42,14 @@ export function SidebarTreeBody(props: {
       flexGrow={1}
       minHeight={0}
       stickyScroll={false}
-      // Scrollbar fully hidden (owner taste 2026-07-09): the cursor drives
+      // Scrollbar fully hidden: the cursor drives
       // scrolling, the thumb column is pure noise.
       verticalScrollbarOptions={{ visible: false }}
     >
       <box flexShrink={0} gap={0}>
         {props.rows.map((row, i) => {
           if (row.kind === "project") {
-            // The Scratch header (issue #33) reuses the project-row shape but
+            // The Scratch header reuses the project-row shape but
             // is a fixed section, not a repo: translated label, no context
             // menu (nothing to file, nothing to move).
             const isScratch = row.id === SCRATCH_SECTION_ID

--- a/packages/kobe/src/tui-react/panes/sidebar/tree-rows.tsx
+++ b/packages/kobe/src/tui-react/panes/sidebar/tree-rows.tsx
@@ -1,14 +1,12 @@
 /** @jsxImportSource @opentui/react */
 /**
- * One-line tree rows (owner call 2026-08-01, round 3): every row inside the
- * tree is ONE cell tall — project header flush, worktrees one cell in, and
- * tab rows at the SAME column as their worktree (issue #41: the state-circle
- * glyph carries the hierarchy; extra indent wasted the narrow rail's width).
- * The two-line cards remain the FLAT
- * sidebar's grammar; the tree's density is its point (a dozen worktrees ×
- * tabs must fit the rail), so a worktree row compresses the card to
- * `twisty · state glyph · title` plus the card's own right-edge cluster
- * (pin / PR chip / ±stats / jump digit) — same vocabulary, one line.
+ * One-line tree rows: every row inside the tree is ONE cell tall — project
+ * header flush, worktrees one cell in, and tab rows at the SAME column as
+ * their worktree (the state-circle glyph carries the hierarchy, so extra
+ * indent only costs the narrow rail width). Density is the point (a dozen
+ * worktrees × tabs must fit the rail), so a worktree row is
+ * `twisty · state glyph · title` plus the right-edge cluster
+ * (pin / PR chip / ±stats / jump digit).
  */
 
 import type { TaskEngineState, TaskJobState } from "@/client/remote-orchestrator"
@@ -42,8 +40,8 @@ import {
   useSpinnerFrame,
 } from "./row-cards"
 
-/** Cells of indent per depth level — one (owner round: the rail is narrow,
- *  and the glyph column already separates the levels visually). */
+/** Cells of indent per depth level — one: the rail is narrow, and the glyph
+ *  column already separates the levels visually. */
 const INDENT_CELLS = 1
 
 export type TreeRowShared = {
@@ -57,9 +55,9 @@ export type TreeRowShared = {
    *  keys on THIS (selected task + the tab's own active bit) rather than on
    *  `activeRowId`: that id needs the live tab map, which is cold right
    *  after a restart — and a lamp that ignores the session you are sitting
-   *  in is exactly the bug. */
+   *  in is wrong. */
   readonly selectedTaskId: string | null
-  /** The row being dragged in move mode (issue #43) — wears the move chip.
+  /** The row being dragged in move mode — wears the move chip.
    *  Null outside move mode, and while a `main` row drags its whole project
    *  (the group HEADER wears the chip then — `movingProjectId`). */
   readonly movingRowId?: string | null
@@ -101,7 +99,7 @@ function clusterCells(text: string): number {
   return cells
 }
 
-/** The move-mode chip a dragged ROW wears (issue #43) — same vocabulary as
+/** The move-mode chip a dragged ROW wears — same vocabulary as
  *  the project header's chip, so all three levels read identically. */
 function MoveChip(props: { readonly rowId: string; readonly shared: TreeRowShared }) {
   const { theme } = useTheme()
@@ -143,9 +141,9 @@ function RowShell(props: {
       onMouseUp={(evt: { button: number; x: number; y: number; stopPropagation(): void }) => {
         // Don't bubble to the pane box's focus-grab (the workspace host's
         // sidebar shell): activating a row hands focus to the CONTENT pane,
-        // and a bubbled sidebar re-grab overwrote it — the user typed into
-        // what looked like the terminal while the sidebar's letter chords
-        // (d!) were live. Same guard the ZEN chip carries.
+        // a bubbled sidebar re-grab would overwrite it, leaving the sidebar's
+        // letter chords (d!) live over what looks like the terminal. Same
+        // guard the ZEN chip carries.
         evt.stopPropagation()
         // Right-click opens the row's menu instead of activating it — the
         // terminal only forwards button 2 while mouse reporting is on, which
@@ -169,20 +167,18 @@ function RowShell(props: {
 }
 
 /**
- * A worktree row carries NO ENGINE state glyph (owner call 2026-08-01, round
- * 6): the session state belongs to the chattab that runs it, so that glyph
- * lives on the tab row below. What stays here is worktree-level fact — branch,
- * pin, PR chip, ±change stats — and a worktree being MATERIALIZED is the most
- * worktree-level fact there is.
+ * A worktree row carries NO ENGINE state glyph: the session state belongs to
+ * the chat tab that runs it, so that glyph lives on the tab row below. What
+ * stays here is worktree-level fact — branch, pin, PR chip, ±change stats —
+ * and a worktree being MATERIALIZED is the most worktree-level fact there is.
  *
  * Why the job spinner has to live here rather than on the tab row: during
  * `git worktree add` a freshly created task has no engine activity (the engine
  * has not started) and no tab rows at all (a tab is only recorded once
- * delivery succeeds). The tab row that renders the job today is therefore the
- * one row that does not yet exist, which is why `rove api add --count 5` on a
- * big repo showed five frozen `(new task)` rows for the whole minutes-long
- * materialization while the daemon published `task.jobs {phase:"running"}` the
- * entire time.
+ * delivery succeeds). The tab row that would render the job is therefore the
+ * one row that does not yet exist — without this, `rove api add --count 5` on
+ * a big repo leaves frozen `(new task)` rows for the whole minutes-long
+ * materialization while the daemon publishes `task.jobs {phase:"running"}`.
  *
  * It reads `taskJobs` DIRECTLY and nothing else — deliberately not through
  * `buildSidebarRowView`, whose `loading` also folds in engine activity. Taking
@@ -210,8 +206,8 @@ export function WorktreeTreeRow(props: {
   // fact) so a scan reads intent then evidence; they never share a glyph.
   const status = statusChip(task)
   // A worktree row is named by its BRANCH; branchless rows fall back to
-  // their tail-truncated path (the one derivation rule — `worktreeRowLabel`,
-  // issue #42). Which rows have to LOOK UP that branch is
+  // their tail-truncated path (the one derivation rule —
+  // `worktreeRowLabel`). Which rows have to LOOK UP that branch is
   // `rowLiveBranchPath`: main checkouts and directory/scratch tasks store
   // none and move freely, so they poll their own HEAD.
   const livePath = rowLiveBranchPath(task)
@@ -227,8 +223,8 @@ export function WorktreeTreeRow(props: {
   const materializing = shared.taskJobs?.get(task.id) !== undefined
   const frame = useSpinnerFrame(materializing)
   const reserved =
-    // The spinner column exists only while a job runs, so a quiet row's label
-    // budget and layout are byte-identical to before.
+    // The spinner column exists only while a job runs, so a quiet row spends
+    // none of its label budget on it.
     (materializing ? 2 : 0) +
     (task.pinned === true ? 2 : 0) +
     (chip ? 2 : 0) +
@@ -273,10 +269,9 @@ export function WorktreeTreeRow(props: {
 /**
  * The tab row's `buildSidebarRowView`, memoized on the real inputs so the
  * ~10Hz spinner tick (a fresh `shared` object every render) doesn't
- * re-derive idle tab rows. Same shape as the flat cards' `useRowCardChrome`
- * (row-cards.tsx) — non-loading rows come back as the same object and never
- * subscribe to the tick. Extracted + exported so the memo contract has a
- * direct test; TabTreeRow is the only caller.
+ * re-derive idle tab rows: non-loading rows come back as the same object and
+ * never subscribe to the tick. Exported so the memo contract has a direct
+ * test; TabTreeRow is the only caller.
  */
 export function useTabRowBaseView(args: {
   readonly task: Task
@@ -315,7 +310,7 @@ export function TabTreeRow(props: {
   const t = useT()
   const shared = props.shared
   const isCursor = shared.cursorIndex === props.flatIndex
-  // Glyph rule (owner round 7): an AGENT tab always wears the state circle
+  // Glyph rule: an AGENT tab always wears the state circle
   // vocabulary — `○` at rest, live state glyph when the daemon reports
   // activity for its session (the ACTIVE engine tab; activity is
   // task-scoped). A non-agent tab (shell/command/content) is outside the
@@ -323,8 +318,8 @@ export function TabTreeRow(props: {
   const isAgent = props.tab.engine === true
   // Prefer THIS tab's own activity over the task rollup. The daemon reports
   // both levels, but the task entry is last-event-wins across every tab — so
-  // a task whose live work is in tab-2 reads as whatever tab-N reported most
-  // recently, and a genuinely running row sat at `○` until you opened it.
+  // a task whose live work is in tab-2 would read as whatever tab-N reported
+  // most recently, leaving a genuinely running row at `○` until you open it.
   // Tab-level is the precise answer; the rollup stays the fallback for
   // sessions kobe didn't spawn as a tab (a hand-typed `claude` in a shell
   // reports task-level only — see the `engine-state` channel contract).
@@ -338,8 +333,8 @@ export function TabTreeRow(props: {
         active: props.tab.active === true,
       })
     : undefined
-  // One predicate now: "does this row have activity of its own". It used to
-  // also count "is the active tab", which is what let the rollup leak in.
+  // One predicate: "does this row have activity of its own". Also counting
+  // "is the active tab" is what lets the task rollup leak in.
   const carriesState = activity !== undefined
   // The unread lamp (herdr ● on turn_complete) is for sessions you are NOT
   // looking at — sitting in the tab digests it to ✓ on the same render.
@@ -352,7 +347,7 @@ export function TabTreeRow(props: {
   // Per-TAB seen bit: sibling tab rows of the same task render in this very
   // pass and would otherwise share (and clear) one task-wide mark. The
   // durable half survives a kobe restart, which the daemon's activity entry
-  // does too — without it every read completion came back ● (issue #22).
+  // does too — without it every already-read completion comes back ●.
   const durableSeen = useDurableCompletionSeen(
     props.task.id,
     props.tab.id,
@@ -375,14 +370,13 @@ export function TabTreeRow(props: {
   // sticky badge / a KNOWN-idle tombstone) the row wears the shared state
   // vocabulary — buildSidebarRowView rests at `○` for known-idle. With NO
   // signal at all (fresh daemon before its first observer pass, dead daemon
-  // lineage — issue #11) it rests at the same dim dot a non-agent tab wears.
-  // That case used to have its own dotted `◌` for "the daemon doesn't know",
-  // distinct from `○ idle` — dropped 2026-08-15 as a distinction without a
-  // difference: both readings send you into the tab to find out, and U+25CC
-  // is missing from common terminal fonts, so it fell back oversized and ran
+  // lineage) it rests at the same dim dot a non-agent tab wears. A separate
+  // dotted `◌` for "the daemon doesn't know" would be a distinction without a
+  // difference — both readings send you into the tab to find out — and U+25CC
+  // is missing from common terminal fonts, so it falls back oversized and runs
   // into the label. See NO_STATE_GLYPH.
   const glyph = isAgent && carriesState ? rowView.stateGlyph : NO_STATE_GLYPH
-  // depth 1, not 2 (issue #41): a tab row starts at the same column as its
+  // depth 1, not 2: a tab row starts at the same column as its
   // worktree row — the circle status glyph carries the hierarchy, and the
   // extra indent cell wasted width the narrow rail doesn't have.
   return (
@@ -415,7 +409,7 @@ export function TabTreeRow(props: {
 }
 
 /**
- * A project's routine count row (issue #91) — the one fold in this tree.
+ * A project's routine count row — the one fold in this tree.
  *
  * Standing routine sessions rest behind it because a schedule's output is
  * background noise beside the tasks the user opened themselves. ⏎ (or a
@@ -448,7 +442,7 @@ export function RoutinesTreeRow(props: {
 }
 
 /**
- * Narrow mode's "↩ Recent: <task>" jump row (issue #14, 2A) — the first
+ * Narrow mode's "↩ Recent: <task>" jump row — the first
  * navigable row of the narrow sidebar. ⏎ re-enters the named task's
  * workspace; it answers to nothing else (no menu, no per-task verbs).
  */

--- a/packages/kobe/src/tui-react/panes/sidebar/types.ts
+++ b/packages/kobe/src/tui-react/panes/sidebar/types.ts
@@ -1,10 +1,7 @@
 /**
- * React sidebar prop types (issue #15, G3). Ported from the Solid-era props
- * (removed 2026-07-07) with the idiomatic React translation: every
- * `Accessor<T>` prop became a plain `T` — the host re-renders the Sidebar
- * when the value changes, so per-read reactivity has no equivalent.
- * Callback props are unchanged. Shared data shapes (`WorktreeChanges`) are
- * the framework-free originals.
+ * React sidebar prop types. Values are plain `T`, never accessors — the host
+ * re-renders the Sidebar when one changes. Shared data shapes
+ * (`WorktreeChanges`) come from the framework-free modules.
  */
 
 import type { TaskEngineState, TaskJobState } from "@/client/remote-orchestrator"
@@ -22,7 +19,7 @@ export type SidebarTaskCallbacks = {
   onDeleteRequest?: (taskId: string) => void
   /** Shift+M — lowercase `m` is captured but ignored (shift dropped on letters). */
   onLocalMergeRequest?: (taskId: string) => void
-  /** Scope-aware reorder mode (issue #43): j/k move the cursor row's LEVEL
+  /** Scope-aware reorder mode: j/k move the cursor row's LEVEL
    *  — a tab within its task, a task within its repo group, a main row's
    *  whole project — instead of walking the cursor. */
   moveMode?: boolean
@@ -32,8 +29,8 @@ export type SidebarTaskCallbacks = {
   /**
    * Shift+P only. A bare `p` binds nothing — the registry row is an explicit
    * `shift+p` chord — so a mistyped press matches no binding and silently
-   * does nothing rather than churning the pin flag (same contract as the
-   * Solid era; see the sidebar.pin row in context/keybindings-sidebar.ts).
+   * does nothing rather than churning the pin flag (see the sidebar.pin row
+   * in context/keybindings-sidebar.ts).
    */
   onPinRequest?: (taskId: string) => void
   /**
@@ -56,7 +53,7 @@ export type SidebarTaskCallbacks = {
   /** Menu route of `b`: the branch picker/rename for the row's task. */
   onRenameBranchRequest?: (taskId: string) => void
   /** Menu route of `v`, as a picker over the available engines rather than
-   *  the chord's blind cycle (owner call 2026-09-01). */
+   *  the chord's blind cycle. */
   onChangeEngineRequest?: (taskId: string) => void
   /** Project row's "Field notes": read the repo's durable notes. Menu-only. */
   onFieldNotesRequest?: (repo: string) => void
@@ -77,7 +74,7 @@ export type SidebarProps = SidebarTaskCallbacks & {
   /** Keep a task-bound pane visually pinned to its own task after jump-away. */
   pinnedSelection?: boolean
   focused?: boolean
-  /** Presence (non-undefined) turns on the sort toggle, like the Solid accessor. */
+  /** Presence (non-undefined) turns on the sort toggle. */
   sortMode?: TaskSortMode
   /** Presence (non-undefined, null = "all") makes the filter host-controlled. */
   projectFilter?: string | null

--- a/packages/kobe/src/tui-react/panes/sidebar/use-sidebar-host-state.tsx
+++ b/packages/kobe/src/tui-react/panes/sidebar/use-sidebar-host-state.tsx
@@ -48,9 +48,9 @@ export interface SidebarHostState {
   readonly notifyInfo: (message: string) => void
   /**
    * The Sidebar's move-mode request (`shift+m`): select a row and toggle
-   * move mode. The tree then routes j/k by the cursor row's LEVEL (issue
-   * #43): a tab moves within its task, a task within its repo group, and a
-   * `main` row drags its whole project.
+   * move mode. The tree then routes j/k by the cursor row's LEVEL: a tab
+   * moves within its task, a task within its repo group, and a `main` row
+   * drags its whole project.
    */
   readonly onLocalMergeRequest: (id: string) => void
 }

--- a/packages/kobe/src/tui-react/panes/sidebar/use-tree-bindings.ts
+++ b/packages/kobe/src/tui-react/panes/sidebar/use-tree-bindings.ts
@@ -16,8 +16,8 @@
  *   3. Search-mode chords (registry ids).
  *   4. Menu-mode chords + menu escape.
  *
- * Registration order mirrors the old code (main → move → search → menu), so
- * the LIFO stack priority stays identical: menu > search > move > main.
+ * Registration order is main → move → search → menu, which gives the LIFO
+ * stack the priority menu > search > move > main.
  */
 
 import type { createSidebarController } from "../../../tui/panes/sidebar/controller"

--- a/packages/kobe/src/tui-react/panes/sidebar/use-tree-search.ts
+++ b/packages/kobe/src/tui-react/panes/sidebar/use-tree-search.ts
@@ -2,12 +2,11 @@
  * Tree-sidebar search state — the `/` query, its keystroke capture, and the
  * enter/exit transitions.
  *
- * Its own hook because it does something the rest of the tree does not: bypass
- * the component's normal key handling entirely. The mechanics are the flat
- * sidebar's (`Sidebar.tsx`) verbatim — a raw renderer keypress listener
- * rather than an opentui `<input>` (which misbehaved in the Solid original),
- * registered after the keymap dispatcher so chords that already
- * preventDefault'd never leak into the query.
+ * Its own hook because it does something the rest of the tree does not:
+ * bypass the component's normal key handling entirely. A raw renderer
+ * keypress listener rather than an opentui `<input>`, registered after the
+ * keymap dispatcher so chords that already preventDefault'd never leak into
+ * the query.
  */
 
 import type { KeyEvent } from "@opentui/core"

--- a/packages/kobe/src/tui-react/panes/sidebar/use-tree-state.ts
+++ b/packages/kobe/src/tui-react/panes/sidebar/use-tree-state.ts
@@ -6,13 +6,12 @@
  * loads it in Node — while this one is React state; the fold and expansion
  * rules below need that separation to stay testable as plain data.
  *
- * There is NO fold anywhere (owner call 2026-08-01, round 5) except one: a
- * project's routine count row (issue #91), which folds ONLY the standing
- * sessions a schedule created. Every project and every task a human opened
- * still shows everything under it. The tree is a map, not a filing cabinet —
- * hiding rows made the map lie, and the exception is scoped so it can't: a
- * folded routine stays findable by search, and openable from the Inbox and
- * the Routines page.
+ * There is NO fold anywhere except one: a project's routine count row, which
+ * folds ONLY the standing sessions a schedule created. Every project and every
+ * task a human opened still shows everything under it. The tree is a map, not
+ * a filing cabinet — hiding rows makes the map lie, and the exception is
+ * scoped so it can't: a folded routine stays findable by search, and openable
+ * from the Inbox and the Routines page.
  *
  * The expansion set is deliberately NOT persisted: it resets closed each
  * session, because the resting state that keeps the sidebar readable is the
@@ -88,7 +87,7 @@ export interface TreeState {
   readonly projectIdOfTask: (taskId: string) => string | null
   /** The task whose move reorders this project (its `main` checkout). */
   readonly mainTaskIdOfProject: (projectId: string) => string | null
-  /** Toggle a project's routine count row (issue #91). True when `rowId` was
+  /** Toggle a project's routine count row. True when `rowId` was
    *  one — the press is then consumed, and no task activation follows. */
   readonly toggleRoutinesRow: (rowId: string) => boolean
 }
@@ -98,7 +97,7 @@ export function useTreeState(opts: TreeStateOpts): TreeState {
   const query = opts.query ?? ""
   const searching = query.trim() !== ""
 
-  // Which projects' routine count rows are OPEN (issue #91). Session-scoped
+  // Which projects' routine count rows are OPEN. Session-scoped
   // on purpose: closed is the resting state worth returning to, so this
   // never reaches a store.
   const [expandedRoutines, setExpandedRoutines] = useState<ReadonlySet<string>>(() => new Set())
@@ -122,10 +121,10 @@ export function useTreeState(opts: TreeStateOpts): TreeState {
   // Live pty-host inventory, for tasks the snapshot can't answer for.
   const hostSessions = useHostSessions()
 
-  // Feed the host inventory's pids into the live-engine probe (issue #33):
-  // the local PTY registry only knows tabs THIS process attached, but the
-  // tree renders every task's hosted tabs — without the aux pids a `claude`
-  // typed into another task's shell tab never lit up until you visited it.
+  // Feed the host inventory's pids into the live-engine probe: the local PTY
+  // registry only knows tabs THIS process attached, but the tree renders every
+  // task's hosted tabs — without the aux pids a `claude` typed into another
+  // task's shell tab never lights up until you visit it.
   useEffect(() => {
     const pids = new Map<string, number>()
     for (const session of hostSessions) {
@@ -140,9 +139,9 @@ export function useTreeState(opts: TreeStateOpts): TreeState {
   // ptyKey → the host's LIVE OSC title. The host scans every session's
   // output whether or not anyone attached, so this answers for tabs whose
   // `TerminalTabs` is not mounted — the ones whose recorded `lastTitle`
-  // only moves when you click into them (owner report: the row's state glyph
-  // is live via the daemon's engine-state channel while its title sat frozen
-  // beside it). Empty titles are dropped: `""` is the host's "child has set
+  // only moves when you click into them, which leaves a row whose state glyph
+  // is live (daemon engine-state channel) sitting beside a frozen title.
+  // Empty titles are dropped: `""` is the host's "child has set
   // no title yet", not a name, and letting it through would blank a row that
   // has a perfectly good recorded one.
   const liveTitles = useMemo<ReadonlyMap<string, string>>(() => {
@@ -172,8 +171,8 @@ export function useTreeState(opts: TreeStateOpts): TreeState {
           // restart). Only the can't-look case falls back to the RECORDED
           // `liveVendor` (itself tri-state — the persisted twin); a confirmed
           // engine-free shell must not resurrect the identity of whatever ran
-          // there before (a ctrl+C'd codex kept its tab labelled "codex N"
-          // through the old `?? recorded` fallback).
+          // there before — a ctrl+C'd codex would keep its tab labelled
+          // "codex N" if the recorded value were a blanket fallback.
           const ptyKey = tabPtyKeyFor(task.id, tab)
           const probed = liveEngines.resolve(ptyKey)
           const live = probed === undefined ? tab.liveVendor : probed
@@ -206,8 +205,8 @@ export function useTreeState(opts: TreeStateOpts): TreeState {
 
   // Backstop: any LIVE pty session the snapshots don't answer for becomes an
   // explicit unregistered row — tab-granular, so a task whose snapshot lists
-  // tab-2 while tab-1 is alive still shows tab-1 (issue #20's invisible
-  // engine). See `orphan-tabs.ts`.
+  // tab-2 while tab-1 is alive still shows tab-1 rather than hiding a live
+  // engine. See `orphan-tabs.ts`.
   const orphansByTask = useMemo<ReadonlyMap<string, readonly TreeTab[]>>(() => {
     const registered = new Set<string>()
     for (const [taskId, tabs] of snapshotTabs) for (const tab of tabs) registered.add(tabRowId(taskId, tab.id))
@@ -220,8 +219,8 @@ export function useTreeState(opts: TreeStateOpts): TreeState {
   }, [snapshotTabs, hostSessions, tasks])
 
   // …and then it stops being unregistered: a row nobody can open or close is
-  // worse than the divergence it reports (the owner watched a live engine he
-  // could neither read nor end). Adoption writes the session into the task's
+  // worse than the divergence it reports — a live engine you can neither read
+  // nor end. Adoption writes the session into the task's
   // tab state, so the ⚠ row turns into an ordinary tab on the next tick —
   // idempotent, so the poll driving it costs nothing once reconciled.
   useEffect(() => {
@@ -250,7 +249,7 @@ export function useTreeState(opts: TreeStateOpts): TreeState {
   const recentTask = opts.recentTask ?? null
   const sortMode = opts.sortMode ?? "default"
   const { rows, totalCount } = useMemo(() => {
-    // A SEARCH builds the tree fully expanded (issue #91): folding the routine
+    // A SEARCH builds the tree fully expanded: folding the routine
     // sessions away at rest must not make them unfindable, and search is how
     // you reach one without opening the fold first. `filterTreeRows` then
     // drops the (now empty) count row itself.
@@ -310,7 +309,7 @@ export function useTreeState(opts: TreeStateOpts): TreeState {
     activeRowId,
     projectIdOfTask,
     mainTaskIdOfProject: mainTaskOfProject,
-    /** Open/close a project's routine count row (issue #91). Returns true when
+    /** Open/close a project's routine count row. Returns true when
      *  `rowId` WAS a routine row, so the caller knows the press was consumed
      *  and must not also try to activate a task by that id. */
     toggleRoutinesRow: useCallback(

--- a/packages/kobe/src/tui-react/panes/terminal/Terminal.tsx
+++ b/packages/kobe/src/tui-react/panes/terminal/Terminal.tsx
@@ -1,36 +1,23 @@
 /** @jsxImportSource @opentui/react */
 /**
- * Embedded terminal pane — React port of `tui/panes/terminal/Terminal.tsx`
- * (issue #16 React migration). Same seam: the PureTUI Workspace Host
- * mounts it as the center column running the task's real interactive
- * engine CLI (its `command` prop); it also works as a plain worktree
- * shell. Body: a headless xterm screen snapshot fed by the task PTY,
- * clipped via opentui's `overflow` + viewport slicing.
+ * Embedded terminal pane. The PureTUI Workspace Host mounts it as the center
+ * column running the task's real interactive engine CLI (its `command`
+ * prop); it also works as a plain worktree shell. Body: a headless xterm
+ * screen snapshot fed by the task PTY, clipped via opentui's `overflow` +
+ * viewport slicing.
  *
- * Shared framework-free logic (PTY backend, key encoding, SGR→StyledText,
- * viewport math, grid selection) is imported straight from the Solid
- * cluster `tui/panes/terminal/*` — this file (plus its `use-terminal-*`
- * hooks) owns only the React reactivity. See the Solid original for the
- * full lifecycle rationale (acquire/subscribe contract, never-kill-on-
- * unmount, dead-shell banner, F5 reset). Deltas below.
+ * Framework-free logic (PTY backend, key encoding, SGR→StyledText, viewport
+ * math, grid selection) comes from `tui/panes/terminal/*`; this file plus its
+ * `use-terminal-*` hooks own only the React reactivity. The lifecycle
+ * contract — acquire/subscribe, never-kill-on-unmount, the dead-shell banner,
+ * F5 reset — is documented on `use-terminal-pty.ts`.
  *
- * Solid→React translation notes:
- *   - `cwd`/`taskId`/`focused`/`resetToken` are plain values, not
- *     Accessors — React re-renders on prop change.
- *   - The Solid original's declaration-order comment ("selection memo
- *     BEFORE the render memos — cursorRows reads selection() during its
- *     EAGER first evaluation, a later declaration is a TDZ crash") is a
- *     Solid-specific hazard: `createMemo` evaluates eagerly at
- *     declaration time there. React's `useMemo` evaluates lazily off a
- *     dependency array during render, so no such ordering constraint
- *     exists — the hooks below are ordered for readability, not
- *     correctness.
- *   - Body-box measurement and the resize-push / host-cursor-anchor
- *     effects live in `use-terminal-geometry.ts` and
- *     `use-terminal-host-cursor.ts`. They receive the PTY handle and the
- *     computed viewport cursor after `useTerminalPty` has produced them,
- *     so the call order in this file remains the same and there is no
- *     chicken-and-egg hook-ordering hazard.
+ * Hook ORDER here is for readability, not correctness: `useMemo` evaluates
+ * lazily off a dependency array, so a memo may be declared after one it
+ * reads. Body-box measurement and the resize-push / host-cursor-anchor
+ * effects live in `use-terminal-geometry.ts` and `use-terminal-host-cursor.ts`
+ * — they receive the PTY handle and the computed viewport cursor after
+ * `useTerminalPty` has produced them.
  */
 
 import type { EngineTerminalPresentation } from "@/types/terminal-presentation"
@@ -107,7 +94,7 @@ export type TerminalProps = {
    */
   initialInput?: string
   /** Paste-delivery vendor's first message + the engine binary its up-probe
-   *  matches (`TaskPtyOpts.firstMessage`, issue #25): the hosted backend
+   *  matches (`TaskPtyOpts.firstMessage`): the hosted backend
    *  pastes it once the fresh-spawned engine is up; reattaches never
    *  redeliver it. */
   firstMessage?: string
@@ -261,14 +248,15 @@ export function Terminal(props: TerminalProps) {
     return overlayCursor(withSelection, cursorWhileUnselected, terminalColors)
   }, [visibleRows, selection.selection, visibleRange.start, bodyGeometry, focused, visibleCursor, terminalColors])
 
-  // Flatten every visible row into ONE `StyledText` — see the Solid
-  // original for why a single element (not per-row `<text>`s) is load-
-  // bearing for the cursor positioning math.
+  // Flatten every visible row into ONE `StyledText`. A single element (not
+  // per-row `<text>`s) is what makes the cursor positioning math work: the
+  // cursor is placed by offset into one text node.
   //
-  // `sealRowEndAttributes` is a local workaround for an opentui renderer bug
-  // (attributes open at a row's last column leak into the rest of the frame —
-  // the "wrapped URL underlines everything below it" report). Its doc comment
-  // has the full mechanism; drop this call once opentui resets per row.
+  // `sealRowEndAttributes` is a local workaround for an opentui renderer bug:
+  // attributes open at a row's last column leak into the rest of the frame,
+  // so a wrapped underlined URL underlines everything below it. Its doc
+  // comment has the full mechanism; drop this call once opentui resets per
+  // row.
   const styledSnapshot = useMemo(() => {
     const resolved = resolveInverseAttributes(cursorRows, terminalColors.foreground, terminalColors.background)
     const sealed = sealRowEndAttributes(

--- a/packages/kobe/src/tui-react/panes/terminal/keys.ts
+++ b/packages/kobe/src/tui-react/panes/terminal/keys.ts
@@ -1,17 +1,15 @@
 /**
- * Terminal pane key bindings — React hook layer, the
- * `tui/panes/terminal/keys.ts` counterpart (issue #16 React migration).
+ * Terminal pane key bindings — the React hook layer.
  *
- * Same passthrough contract as the Solid hook: when focused, every
- * keystroke the shell would expect (ctrl+c, ctrl+d, arrows, …) is
- * forwarded verbatim. The dynamically configured command prefix,
- * `RESERVED_GLOBAL_CHORDS`, and ctrl+pgup/pgdown scrollback chords stay
- * kobe-owned — see `keys-pure.ts` for the full rationale.
+ * Passthrough contract: when focused, every keystroke the shell would expect
+ * (ctrl+c, ctrl+d, arrows, …) is forwarded verbatim. The dynamically
+ * configured command prefix, `RESERVED_GLOBAL_CHORDS`, and ctrl+pgup/pgdown
+ * scrollback chords stay kobe-owned — see `keys-pure.ts` for the full
+ * rationale.
  *
- * Pure/runtime split preserved: `keys-pure.ts` (constants + the
- * side-effect-free byte encoder) is imported straight from the Solid
- * cluster; this file owns only the React registration (`useBindings` +
- * the raw keypress/paste listeners on the renderer).
+ * Pure/runtime split: `keys-pure.ts` holds the constants + the
+ * side-effect-free byte encoder; this file owns only the React registration
+ * (`useBindings` + the raw keypress/paste listeners on the renderer).
  */
 
 import { type KeyEvent, decodePasteBytes } from "@opentui/core"
@@ -88,10 +86,9 @@ export function useTerminalBindings(opts: TerminalBindingsOpts): void {
   }))
 
   // Catch-all input forwarder for IME/pinyin composition commits and any
-  // input whose `name` isn't in `PASSTHROUGH_NAMES` — see the Solid
-  // original for the full defaultPrevented rationale. Registered ONCE
-  // (empty deps) and reads the latest `opts` through a render-refreshed
-  // ref, so it doesn't re-subscribe to the renderer's emitter every render.
+  // input whose `name` isn't in `PASSTHROUGH_NAMES`. Registered ONCE (empty
+  // deps) and reads the latest `opts` through a render-refreshed ref, so it
+  // doesn't re-subscribe to the renderer's emitter every render.
   const renderer = useRenderer()
   useEffect(() => {
     if (!renderer) return

--- a/packages/kobe/src/tui-react/panes/terminal/mock-host.tsx
+++ b/packages/kobe/src/tui-react/panes/terminal/mock-host.tsx
@@ -1,8 +1,8 @@
 /** @jsxImportSource @opentui/react */
 /**
- * React terminal-pane mock host (`bun run dev:mock-react-terminal`) — the
- * live render proof for the ported pane (issue #16 React migration).
- * Backs the PTY with `MockTaskPty` (no real shell spawned) so the mount
+ * Terminal-pane mock host (`bun run dev:mock-react-terminal`) — the live
+ * render proof for the pane. Backs the PTY with `MockTaskPty` (no real shell
+ * spawned) so the mount
  * is deterministic: `feed()` pushes ANSI/text as if a shell had printed
  * it, proving the SGR→StyledText render path without a live process.
  *

--- a/packages/kobe/src/tui-react/panes/terminal/use-terminal-geometry.ts
+++ b/packages/kobe/src/tui-react/panes/terminal/use-terminal-geometry.ts
@@ -1,6 +1,5 @@
 /**
- * Body-box geometry measurement for the embedded terminal pane (React port of
- * the measurement half of the Solid original).
+ * Body-box geometry measurement for the embedded terminal pane.
  *
  * The seam is ordering, and the import graph pins it: this hook measures
  * BEFORE the PTY exists, so its `bodyGeometry` can feed `useTerminalPty`. The
@@ -15,10 +14,8 @@
  * stray standalone lines.
  *
  * `bodyEl` MUST be React state (not a plain ref) — the measurement effect
- * needs to re-run the instant the box ref is attached, mirroring the
- * Solid original's `bodyRef()` signal read (tracked, so setting the ref
- * re-fires the effect on first layout). A plain `useRef` would silently
- * skip that first measurement.
+ * needs to re-run the instant the box ref is attached, and a plain `useRef`
+ * would silently skip that first measurement.
  */
 
 import type { BoxRenderable } from "@opentui/core"
@@ -60,9 +57,9 @@ export function useTerminalGeometry(): UseTerminalGeometryResult {
     void dims
     void geomTick
     if (!bodyEl) return
-    // Pre-layout guard: before Yoga's first pass the box reports 0 (or
-    // junk) — flooring that into a "plausible" 20x4 and pushing it to an
-    // already-running PTY forced the engine CLI to redraw tiny.
+    // Pre-layout guard: before Yoga's first pass the box reports 0 (or junk)
+    // — flooring that into a "plausible" 20x4 and pushing it to an
+    // already-running PTY forces the engine CLI to redraw tiny.
     if (bodyEl.width <= 0 || bodyEl.height <= 0) return
     const cols = Math.max(20, bodyEl.width)
     const rows = Math.max(4, bodyEl.height)

--- a/packages/kobe/src/tui-react/panes/terminal/use-terminal-pty.ts
+++ b/packages/kobe/src/tui-react/panes/terminal/use-terminal-pty.ts
@@ -1,23 +1,17 @@
 /**
- * PTY acquire/subscribe lifecycle for the embedded terminal pane — React
- * port of `tui/panes/terminal/use-terminal-pty.ts` (issue #16 React
- * migration). Same contract as the Solid original:
+ * PTY acquire/subscribe lifecycle for the embedded terminal pane:
  *
  *   - When `cwd`/`taskId` resolve (and the body has measured), acquire a
  *     `TaskPty` from the registry; `acquire` reuses a live PTY for the
  *     same key — the "kept alive while in_progress" rule.
- *   - On a key change we DON'T kill the old PTY (the orchestrator owns
+ *   - On a key change we DON'T kill the outgoing PTY (the orchestrator owns
  *     release); we just resubscribe to the new one's data.
  *   - On unmount we drop our subscription and reference only.
  *
- * Solid→React prop delta: `cwd`/`taskId`/`command`/`resetToken`/
- * `bodyGeometry` are plain values here (React re-renders on prop change),
- * not Accessors. The Solid acquire effect deliberately tracks ONLY
- * `[cwd, taskId, bodyGeometryReady]` — `command` and the live geometry
- * value are read untracked at acquire time so a caller's prop swap alone
- * doesn't force a re-acquire (that's what `resetToken` is for). We
- * reproduce that by keeping `command`/`bodyGeometry` in refs and using
- * `[cwd, taskId, geometryReady]` as the effect's dependency array.
+ * The acquire effect depends ONLY on `[cwd, taskId, geometryReady]`.
+ * `command` and the live geometry value are kept in refs and read at acquire
+ * time, so a caller's prop swap alone does not force a re-acquire — that is
+ * what `resetToken` is for.
  */
 
 import { errorMessage } from "@/lib/error-message"
@@ -83,8 +77,7 @@ export function useTerminalPty(opts: UseTerminalPtyOpts): UseTerminalPtyResult {
   // F5 reset are the recovery path.
   const [exited, setExited] = useState(false)
 
-  // Latest-render mirrors read by effect bodies that must NOT depend on
-  // them (the Solid original's untracked reads inside `on(...)`).
+  // Latest-render mirrors read by effect bodies that must NOT depend on them.
   const commandRef = useLatest(opts.command)
   const initialInputRef = useLatest(opts.initialInput)
   const firstMessageRef = useLatest(opts.firstMessage)
@@ -213,7 +206,7 @@ export function useTerminalPty(opts: UseTerminalPtyOpts): UseTerminalPtyResult {
         onFreshPtyRef.current()
       } catch (err) {
         const message = errorMessage(err)
-        // `registry.reset()` kills the old PTY BEFORE the acquire half runs,
+        // `registry.reset()` kills the outgoing PTY BEFORE the acquire half runs,
         // so on failure there is no live handle left — clear the pane to the
         // error state (same shape as the acquire effect's failure path)
         // instead of leaving a dead snapshot up with the error invisible.
@@ -227,9 +220,9 @@ export function useTerminalPty(opts: UseTerminalPtyOpts): UseTerminalPtyResult {
     [],
   )
 
-  // External forced-reacquire (see `resetToken` on TerminalProps) —
-  // skipped on the initial mount (Solid's `defer: true`) so a fresh pane
-  // doesn't reset itself the instant it acquires its first PTY.
+  // External forced-reacquire (see `resetToken` on TerminalProps) — skipped
+  // on the initial mount so a fresh pane doesn't reset itself the instant it
+  // acquires its first PTY.
   const resetMountedRef = useRef(false)
   useEffect(() => {
     // Dependency-only invalidation key — this effect fires ONLY when

--- a/packages/kobe/src/tui-react/panes/terminal/use-terminal-selection.ts
+++ b/packages/kobe/src/tui-react/panes/terminal/use-terminal-selection.ts
@@ -1,8 +1,7 @@
 /**
- * Copy-on-select, GRID-based selection for the embedded terminal pane —
- * React port of the selection half of `tui/panes/terminal/Terminal.tsx`
- * (tmux convention; see `terminal-selection.ts` for why opentui's text-flow
- * selection can't work over this pane). Its own hook because selection is
+ * Copy-on-select, GRID-based selection for the embedded terminal pane (see
+ * `terminal-selection.ts` for why opentui's text-flow selection can't work
+ * over this pane). Its own hook because selection is
  * self-contained mouse state that the rest of the pane never reads — and,
  * per the two notes below, it is the part with the most non-obvious
  * re-render rules, which are easier to hold correct in one file.
@@ -11,8 +10,8 @@
  * survives every frame refresh and scrollback move. A ZERO-WIDTH selection
  * (a plain click, before any drag) resolves to `null` — rendering no
  * highlight and, more importantly, keeping `selection` reference-stable
- * across a click so the snapshot content isn't re-pushed for nothing (the
- * whole-pane twitch-on-click the Solid original called out).
+ * across a click so the snapshot content isn't re-pushed for nothing — a
+ * re-push twitches the whole pane.
  *
  * `isDragging` is a plain ref, not state: it flips on every mouse-move
  * during a drag, and mirroring that into React state would re-render the
@@ -305,7 +304,7 @@ export function useTerminalSelection(opts: UseTerminalSelectionOpts): UseTermina
       draggingRef.current,
     )
     // Line numbering was reset (a resize reflows history): the selection
-    // addresses content that no longer exists under those ids.
+    // addresses content that is gone from under those ids.
     if (!windowed) {
       clearSelectionState()
       return

--- a/packages/kobe/src/tui-react/ui/dialog-confirm.tsx
+++ b/packages/kobe/src/tui-react/ui/dialog-confirm.tsx
@@ -1,9 +1,8 @@
 /** @jsxImportSource @opentui/react */
 /**
- * Confirm dialog — yes/no prompt with focused buttons (React port of
- * `src/tui/ui/dialog-confirm.tsx`, issue #15 G3). Same contract:
- * left/right switch focus, enter commits, esc cancels via the dialog
- * stack; `DialogConfirm.show(dialog, title, message, label?)` resolves
+ * Confirm dialog — yes/no prompt with focused buttons. Left/right switch
+ * focus, enter commits, esc cancels via the dialog stack;
+ * `DialogConfirm.show(dialog, title, message, label?)` resolves
  * `boolean | undefined` (`undefined` = dismissed without an answer).
  */
 
@@ -68,8 +67,8 @@ export function DialogConfirm(props: DialogConfirmProps) {
     ],
   }))
 
-  // Tight vertical layout — same rationale as the Solid original: title
-  // row, message right under it, buttons row right under that.
+  // Tight vertical layout: title row, message right under it, buttons row
+  // right under that.
   return (
     <box paddingLeft={padX} paddingRight={padX} paddingBottom={1} gap={0}>
       <box flexDirection="row" justifyContent="space-between">

--- a/packages/kobe/src/tui-react/ui/dialog-parts.tsx
+++ b/packages/kobe/src/tui-react/ui/dialog-parts.tsx
@@ -3,15 +3,14 @@
  * The one dialog grammar, as components — see `docs/design/dialogs.md`.
  *
  * `ui/dialog.tsx` owns the CARD (size, placement, dimmer, esc barrier); this
- * file owns what goes inside it. Two grammars used to share that card: a
- * "form sheet" (New task, New routine, the pickers — lowercase labels, bare
- * inputs, `[ create ]` bottom-right) and a "story editor" (the kanban
- * drawer — caps labels, rounded field wells, chips, a key legend). Same
- * shell, two looks, and a dialog's appearance depended on which one its
- * author had open at the time.
+ * file owns what goes inside it. The card admits two looks — a "form sheet"
+ * (New task, New routine, the pickers — lowercase labels, bare inputs,
+ * `[ create ]` bottom-right) and a "story editor" (the kanban drawer — caps
+ * labels, rounded field wells, chips, a key legend) — and which one a dialog
+ * wears must not depend on what its author happened to have open.
  *
- * The pieces here are the story-editor half, extracted so a dialog gets the
- * grammar by composing rather than by remembering. In particular
+ * The pieces here are the story-editor half, so a dialog gets the grammar by
+ * composing rather than by remembering. In particular
  * {@link DialogField} spreads {@link FRAME}: a well is rounded because the
  * author used the shared component, not because they recalled that opentui
  * defaults `borderStyle` to square (`ui/frame.ts`).

--- a/packages/kobe/src/tui-react/ui/dialog.tsx
+++ b/packages/kobe/src/tui-react/ui/dialog.tsx
@@ -1,11 +1,8 @@
 /** @jsxImportSource @opentui/react */
 /**
- * Dialog stack (React port of `src/tui/ui/dialog.tsx`, issue #15 G2).
- * Public API preserved: `useDialog` → `{ replace, push, pop, clear, stack,
- * size, setSize }`, dialog bodies passed as THUNKS. The thunk contract
- * matters less in React (elements are plain objects, safe to create in key
- * handlers), but keeping it means Solid call sites port unchanged and the
- * body is created fresh per render of the provider.
+ * Dialog stack: `useDialog` → `{ replace, push, pop, clear, stack, size,
+ * setSize }`, dialog bodies passed as THUNKS so each body is created fresh
+ * per render of the provider.
  *
  * The provider dims its background subtree and puts the pointer-catching
  * overlay above it. Do not implement the dimmer as a translucent full-screen
@@ -23,7 +20,7 @@ import { isNarrowWidth } from "../lib/narrow-mode"
 import { useLatest } from "../lib/use-latest"
 
 /**
- * Horizontal padding for a dialog BODY's root box (issue #14, 3A): the
+ * Horizontal padding for a dialog BODY's root box: the
  * desktop's 2 cells halve to 1 below the narrow breakpoint, so a 44-cell
  * card keeps its columns for content. One hook so every dialog body agrees
  * — and follows a live resize.
@@ -51,15 +48,14 @@ export function Dialog(props: {
 
   const dismissRef = useRef(false)
   // Default-medium = 80 cols; small (50) is for tight yes/no prompts;
-  // large/xlarge get proportional bumps. Same rationale as the Solid
-  // original (wide help/settings cards need headroom, narrow PTYs cap
-  // at width-2 via maxWidth below).
+  // large/xlarge get proportional bumps: wide help/settings cards need
+  // headroom, narrow PTYs cap at width-2 via maxWidth below.
   const width = props.size === "xlarge" ? 140 : props.size === "large" ? 110 : props.size === "small" ? 50 : 80
 
   // Vertical headroom around the card so it never lands flush against
   // the terminal's top/bottom edge.
   const VERTICAL_MARGIN = 2
-  // Narrow (issue #14, 3A): every dialog is a centered clamp — the card's
+  // Narrow: every dialog is a centered clamp — the card's
   // maxWidth (width-2) already owns the width, and upper-fifth anchoring
   // gives away rows a 70-row phone screen doesn't have spare.
   const upperFifth = props.placement === "upper-fifth" && !isNarrowWidth(dimensions.width)
@@ -140,9 +136,9 @@ export type DialogContext = {
    */
   clear(options?: { refocus?: boolean }): void
   /**
-   * Replace the current dialog (if any) with a new one. The body stays a
-   * thunk for Solid-API parity; it is evaluated inside the provider's
-   * render, so hooks/contexts resolve normally.
+   * Replace the current dialog (if any) with a new one. The body is a thunk,
+   * evaluated inside the provider's render, so hooks/contexts resolve
+   * normally.
    */
   replace(thunk: () => ReactNode, onClose?: () => void): void
   push(thunk: () => ReactNode, onClose?: () => void): void
@@ -166,8 +162,7 @@ export function DialogProvider(props: { children?: ReactNode }) {
   const focusRef = useRef<Renderable | null>(null)
   const refocusTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
   // Cancel a pending deferred refocus on unmount so `.focus()` can't land
-  // on a renderable destroyed in the same tick (the Solid version used an
-  // owner-scoped managed timeout for this).
+  // on a renderable destroyed in the same tick.
   useEffect(
     () => () => {
       if (refocusTimer.current) clearTimeout(refocusTimer.current)
@@ -203,7 +198,7 @@ export function DialogProvider(props: { children?: ReactNode }) {
     // Opening the NEXT dialog in the same turn (addEngineFlow's chained
     // id → command → name prompts: each `clear()` is followed by the next
     // `replace()`) must cancel it, or that timer fires ~1ms later and pulls
-    // native focus off the new dialog's input — every Enter looked like it
+    // native focus off the new dialog's input — every Enter then reads as a
     // lost focus.
     if (refocusTimer.current) clearTimeout(refocusTimer.current)
     if (stackRef.current.length === 0) {
@@ -213,10 +208,10 @@ export function DialogProvider(props: { children?: ReactNode }) {
   }, [renderer])
 
   // escape and ctrl+c both dismiss the top dialog identically. A live text
-  // selection makes the FIRST press clear it and the next one close — the
-  // old version instead DISABLED the binding while a selection existed,
-  // which left esc permanently dead whenever a stale selection highlight
-  // (kept after a copy, cleared only on the next click) was still around.
+  // selection makes the FIRST press clear it and the next one close. Do NOT
+  // disable the binding while a selection exists: a stale selection highlight
+  // (kept after a copy, cleared only on the next click) then leaves esc
+  // permanently dead.
   const dismissTop = useCallback(() => {
     const selection = renderer?.getSelection()
     if (selection) {
@@ -277,8 +272,8 @@ export function DialogProvider(props: { children?: ReactNode }) {
     // reads stackRef. Consumers derive pane focus / binding gates from
     // `dialog.stack.length`; without a new context value on push/pop, a host
     // that happened to render while the modal was open could keep those
-    // gates disabled after Escape removed the barrier. A later pane click
-    // appeared to "fix" focus only because it forced that host to render.
+    // gates disabled after Escape removes the barrier — until some unrelated
+    // pane click forces that host to render again.
     [stack, size, placement, refocus, captureFocusIfFirst],
   )
 
@@ -318,9 +313,9 @@ const MODAL_SCOPE = Symbol("kobe.dialog.modal")
  * Mounted exactly while a dialog is up. Owns the esc/ctrl+c dismiss keys
  * AND the modal cut-off (`modal: true` — see keymap-dispatch.ts): any key
  * neither the dialog body nor this entry handles stops here instead of
- * reaching the panes behind the dialog. Structural fix for the "dialog is
- * open but keys still operate the background" bug class — background
- * bindings no longer rely on their own `dialog.stack.length === 0` gates.
+ * reaching the panes behind the dialog. This is what keeps keys from
+ * operating the background while a dialog is open, so background bindings
+ * need no `dialog.stack.length === 0` gates of their own.
  *
  * `modalOwner` (stack position: below the body's member registrations) and
  * `modal: true` (dispatch cut-off) together are the explicit contract —

--- a/packages/kobe/src/tui-react/ui/frame.ts
+++ b/packages/kobe/src/tui-react/ui/frame.ts
@@ -3,12 +3,10 @@
  *
  * opentui hard-codes `borderStyle: "single"` (square corners) as its Box
  * default and offers no global override, so every framed surface in the TUI
- * has to opt into rounded corners itself. That is a rule nobody can follow
- * reliably from memory: half the framed boxes in `tui-react` said `border`
- * and nothing else, and each shipped square until somebody noticed it looked
- * foreign beside its neighbours — the workspace pane, the files pane and the
- * tab strip were rounded while the kanban board, the prefix HUD, the context
- * menu and the story dialog were not.
+ * has to opt into rounded corners itself. A box that says `border` and
+ * nothing else silently opts OUT of the house style, and a square frame beside
+ * rounded neighbours reads as foreign — which is a rule nobody follows
+ * reliably from memory.
  *
  * Spread this instead of writing `border` by hand:
  *

--- a/packages/kobe/src/tui-react/ui/row-selection-chrome.ts
+++ b/packages/kobe/src/tui-react/ui/row-selection-chrome.ts
@@ -6,7 +6,7 @@
  * and tint, while a persistent selection remains visible after the cursor
  * moves without pretending the pane owns global focus.
  *
- * Transparent mode (owner call 2026-08-09): NO background fill at all — an
+ * Transparent mode: NO background fill at all — an
  * opaque tint block on top of the host wallpaper reads as a mismatched
  * patch, so the cursor signal moves entirely into the ▌ marker, which takes
  * the focus accent to stay visible against any wallpaper. Detected off the

--- a/packages/kobe/src/tui-react/ui/task-dialog-adapters.ts
+++ b/packages/kobe/src/tui-react/ui/task-dialog-adapters.ts
@@ -4,9 +4,9 @@
  * wire into the framework-free `CreateTaskContext` — the dialog surfacing
  * trio, the post-delete selection move, the repo-scoped vendor preference
  * pair, and the {@link buildBaseCreateTaskContext} base both hosts spread
- * before adding their divergences. Before this module each host carried its
- * own verbatim copy; the flows' behavior is defined in `tui/lib/task-actions`
- * + `tui/lib/task-create-flow`, so these adapters are pure wiring.
+ * before adding their divergences — one copy, so the two hosts cannot drift.
+ * The flows' behavior is defined in `tui/lib/task-actions` +
+ * `tui/lib/task-create-flow`, so these adapters are pure wiring.
  */
 
 import type { RemoteOrchestrator } from "../../client/remote-orchestrator.ts"

--- a/packages/kobe/src/tui-react/workspace/AttentionInboxPane.tsx
+++ b/packages/kobe/src/tui-react/workspace/AttentionInboxPane.tsx
@@ -37,8 +37,8 @@ import { activeTabIdFor, knownTaskTab, taskTabExists } from "./terminal-tabs-sha
 const MAX_VISIBLE_CARDS = 6
 const CARD_ROWS_WITH_GAP = 3
 // Title + hints + up to two 1-line section headers + two "+N more" lines,
-// each with the list's gap row — headers no longer charge a card slot, so
-// the chrome estimate carries them instead.
+// each with the list's gap row: headers do not charge a card slot, so the
+// chrome estimate carries them instead.
 const DIALOG_CHROME_ROWS = 12
 const AGE_REFRESH_MS = 30_000
 /** Identity keeps at least this many cells before the badge drops its label. */
@@ -371,10 +371,9 @@ export function AttentionInboxPane(props: {
             const title = task?.title ?? item.taskId
             // A rate-limited task usually has an auto-resume armed
             // (`Task.quotaResume`, persisted by the daemon's quota probe).
-            // Until 2026-08-30 that clock was written to disk and read by
-            // nothing, so "rate limited" gave a user no way to tell "back at
-            // 3:14, already scheduled" from "stuck, go do something". This
-            // card is where that belongs: the rail's tree row is one cell
+            // Surfacing that clock is what lets a user tell "back at 3:14,
+            // already scheduled" from "stuck, go do something". This card is
+            // where it belongs: the rail's tree row is one cell
             // wide, and the Inbox's whole job is what-needs-me / when.
             const resumeNote = quotaResumeNote(item.state, task, t)
             const project = task ? sidebarProjectLabel(task.repo, repos) : ""

--- a/packages/kobe/src/tui-react/workspace/TerminalSplit.tsx
+++ b/packages/kobe/src/tui-react/workspace/TerminalSplit.tsx
@@ -1,9 +1,8 @@
 /** @jsxImportSource @opentui/react */
 /**
- * TERMINAL adapter over the content-agnostic split tree (`tui/workspace/
- * split-core.ts`, reused unchanged) — React port of `tui/workspace/
- * TerminalSplit.tsx` (issue #16 React migration). The body of one
- * workspace terminal tab. Leaf content is `readonly string[] | null`: null
+ * TERMINAL adapter over the content-agnostic split tree
+ * (`tui/workspace/split-core.ts`). The body of one workspace terminal tab.
+ * Leaf content is `readonly string[] | null`: null
  * means "the tab's own command" (only ever `leaf-1`, whose PTY key IS the
  * tab key — `splitLeafPtyKey`), an argv means a split-created shell.
  *
@@ -17,22 +16,19 @@
  * `TerminalTabs.tsx` and persisted to state.json), passed down as the
  * `splitTree` prop and mutated back through `onSplitChange`.
  *
- * Solid→React deltas: `splitTree`/`cwd`/`focused`/`resetToken`/`engineTitle`
- * are plain values, not Accessors — the parent re-renders on change.
- * `activeLeaf` (local ephemeral focus, kept OUT of the persisted tree —
- * see the Solid header) is `useState`, re-seeded via a `useEffect` keyed on
- * `props.splitTree` identity (the Solid `createEffect(on(...))` twin). The
- * corner name-tag's live-title tracking is the shared framework-free
- * `useTitleSubscriptions` store (O18) — keyed on each leaf's globally-unique
- * `splitLeafPtyKey`, so an instance shared across tabs (this component mounts
- * without a key) can't bleed one tab's `leaf-1` title onto the next, and a
- * respawned leaf re-subscribes instead of freezing on the dead PTY's title.
- * `dividerProps` takes a resolved color value instead of a lazy accessor —
- * React re-evaluates the whole render on any prop/state change, so there is
- * no separate reactive-attribute path to preserve. The opentui borderColor
- * structural-absence trick (divider-less boxes must omit `borderColor`
- * entirely, not pass `undefined` — opentui's Box coerces `border: false` to
- * a full frame whenever any border styling lands) is preserved verbatim.
+ * `activeLeaf` (local ephemeral focus) is `useState`, kept OUT of the
+ * persisted tree so moving focus never reflows it, and re-seeded via a
+ * `useEffect` keyed on `props.splitTree` identity. The corner name-tag's
+ * live-title tracking is the shared framework-free `useTitleSubscriptions`
+ * store — keyed on each leaf's globally-unique `splitLeafPtyKey`, so an
+ * instance shared across tabs (this component mounts without a key) can't
+ * bleed one tab's `leaf-1` title onto the next, and a respawned leaf
+ * re-subscribes instead of freezing on the dead PTY's title.
+ *
+ * The opentui borderColor structural-absence rule holds throughout:
+ * divider-less boxes must omit `borderColor` ENTIRELY, not pass `undefined` —
+ * opentui's Box coerces `border: false` to a full frame whenever any border
+ * styling lands.
  */
 
 import type { EngineTerminalPresentation } from "@/types/terminal-presentation"
@@ -101,7 +97,7 @@ export function TerminalSplit(props: {
    *  (`TaskPtyOpts.initialInput`). Split-created shell leaves never get it. */
   initialInput?: string
   /** Paste-delivery vendor's first message for leaf-1's fresh spawn
-   *  (`TaskPtyOpts.firstMessage`, issue #25). Split leaves never get it. */
+   *  (`TaskPtyOpts.firstMessage`). Split leaves never get it. */
   firstMessage?: string
   /** Engine binary name for the first-message engine-up probe. */
   engineBin?: string
@@ -135,8 +131,8 @@ export function TerminalSplit(props: {
   const state = props.splitTree ?? UNSPLIT
 
   // FOCUS (local, ephemeral): which leaf has focus. Kept OUT of the
-  // persisted tree on purpose (see the Solid header's no-whole-tree-
-  // reflow rationale). Seeded from the persisted `activeLeafId` and
+  // persisted tree on purpose — moving focus must not reflow the whole
+  // tree. Seeded from the persisted `activeLeafId` and
   // re-seeded whenever the persisted tree changes identity (tab switch
   // or a structural edit).
   const [activeLeaf, setActiveLeaf] = useState<string>(state.activeLeafId)
@@ -257,8 +253,8 @@ export function TerminalSplit(props: {
   }, [props.tabKey, state])
   const liveTitles = useTitleSubscriptions(leafPtyKeys)
 
-  /** id → display name. Owner correction 2026-07-06: the TAB is the
-   *  "group" (its default title says so) — each leaf carries its OWN
+  /** id → display name. The TAB is the "group" (its default title says
+   *  so) — each leaf carries its OWN
    *  name: F2 rename wins, default = basename of what it runs
    *  ("claude", "zsh", "zsh 2"…). Derivation is pure (`splitLeafNames`). */
   const leafNames = splitLeafNames(leaves(state.root), props.command, props.engineTitle, liveTitles)
@@ -273,8 +269,8 @@ export function TerminalSplit(props: {
   // frame) whenever any border styling lands, both in the constructor
   // and in the `borderColor` setter, and the setter fires even for
   // undefined because parseColor mints a fresh RGBA every call. Hence the
-  // conditional spread. This coercion is what drew the phantom frames
-  // around the first leaf and the group.
+  // conditional spread — without it, phantom frames appear around the first
+  // leaf and the group.
   const dividerProps = (divider: "left" | "top" | undefined, color: RGBA) =>
     divider ? { border: [divider] as ("left" | "top")[], borderColor: color } : { border: false as const }
 
@@ -303,8 +299,8 @@ export function TerminalSplit(props: {
           }}
         />
         {/* Corner name tag — ONLY while there's more than one leaf to tell
-            apart (see the Solid header: a solo survivor already shows this
-            name on the tab strip). */}
+            apart: a solo survivor already shows this name on the tab
+            strip. */}
         {isSplit ? (
           <box position="absolute" right={0} top={0} zIndex={10} backgroundColor={theme.backgroundElement}>
             <text

--- a/packages/kobe/src/tui-react/workspace/TerminalTabs.tsx
+++ b/packages/kobe/src/tui-react/workspace/TerminalTabs.tsx
@@ -1,11 +1,10 @@
 /** @jsxImportSource @opentui/react */
 /**
- * Workspace terminal tabs (issue #16, React port). The PTY-world chattab:
- * a strip of engine-terminal tabs above the embedded Terminal pane; every tab
- * runs the user's SHELL in its own PTY (registry key `${taskId}::${tabId}`)
- * with the interactive engine command TYPED into it (`shellSpawn`), so ctrl+t
- * gives a parallel session in the same worktree exactly like the tmux
- * chattab did with windows. Plain ctrl+t opens the preferred engine
+ * Workspace terminal tabs. The PTY-world chattab: a strip of engine-terminal
+ * tabs above the embedded Terminal pane; every tab runs the user's SHELL in
+ * its own PTY (registry key `${taskId}::${tabId}`) with the interactive engine
+ * command TYPED into it (`shellSpawn`), so ctrl+t gives a parallel session in
+ * the same worktree. Plain ctrl+t opens the preferred engine
  * (`resolvePreferredVendor`); ctrl+e prompts for one instead
  * (`chat.tab.chooseEngine`), pins it to that tab via `TerminalTab.vendor`,
  * and records the pick as the project's new default.
@@ -18,21 +17,19 @@
  * task's tabs — their PTYs already survive via the registry's
  * acquire-reuse.
  *
- * Solid→React deltas (the load-bearing one): everything the Solid
- * component reads via the live `state()` accessor becomes a `stateRef`
- * that `update()` refreshes SYNCHRONOUSLY on every write. This matters
- * for the two places multiple `update()` calls land within one JS tick
- * without an intervening render — the restart-hydration `Promise.all` and
- * the naming-poll's per-candidate loop — where a plain destructured
- * `state` variable would go stale mid-loop and a later `update()` would
- * clobber an earlier one's change. `propsRef` gives the same freshness
- * to props read inside the two mount-only, forever-lived effects (the
- * naming-poll interval, the hydration verification) — both effects run
- * ONCE (`useEffect(..., [])`), so anything they read must come through a
- * ref, not a captured render-time value. Everywhere else reads the plain
- * `state`/`props` — recreated fresh every render, the guarantee Solid's
- * accessors gave for free. `onEditorTabReady`/`onEngineSendReady` hand
- * their callback to the parent once per mount, re-fired on remount.
+ * Freshness rule: `stateRef` mirrors the live state and `update()` refreshes
+ * it SYNCHRONOUSLY on every write. This matters for the two places multiple
+ * `update()` calls land within one JS tick without an intervening render —
+ * the restart-hydration `Promise.all` and the naming-poll's per-candidate
+ * loop — where a plain destructured `state` variable goes stale mid-loop and
+ * a later `update()` clobbers an earlier one's change. `propsRef` gives the
+ * same freshness to props read inside the two mount-only, forever-lived
+ * effects (the naming-poll interval, the hydration verification) — both run
+ * ONCE (`useEffect(..., [])`), so anything they read must come through a ref,
+ * not a captured render-time value. Everywhere else reads the plain
+ * `state`/`props`, recreated fresh every render.
+ * `onEditorTabReady`/`onEngineSendReady` hand their callback to the parent
+ * once per mount, re-fired on remount.
  */
 
 import type { TranscriptActivity } from "@/client/remote-orchestrator"
@@ -103,7 +100,7 @@ export interface TerminalTabsProps {
   worktree: string
   repo?: string
   taskKind?: "main" | "task" | "dir"
-  /** Scratch temp shell task (issue #33): tab-1 spawns as a BARE SHELL
+  /** Scratch temp shell task: tab-1 spawns as a BARE SHELL
    *  instead of an engine, and the last tab's shell exiting deletes the
    *  task outright (zero-ceremony lifecycle) via `onScratchExit` instead
    *  of recycling into a fresh engine tab. */
@@ -111,11 +108,11 @@ export interface TerminalTabsProps {
   /** The scratch task's last shell exited — the host deletes the task row. */
   onScratchExit?: () => void
   /** ctrl+e's trailing "scratch shell" choice — open a Scratch temp shell
-   *  task (issue #33; the entry point, chord rejected 2026-08-16). */
+   *  task. This menu entry is the only entry point; there is no chord. */
   onOpenScratch?: () => void
   command: readonly string[]
-  /** Task's current engine + effort — used to build a per-tab command when
-   *  a tab pins its own vendor via `chooseEngine`. */
+  /** Task's current engine + effort — builds a per-tab command when a tab
+   *  pins its own vendor via `chooseEngine`. */
   vendor: VendorId
   modelEffort?: string
   /** Best-effort: persist the picked vendor as the task's new default. */
@@ -129,10 +126,10 @@ export interface TerminalTabsProps {
   /** Paste-only sibling of `onEngineSendReady` (no submit) — the FileTree `a` @path mention. */
   onEnginePasteReady?: (paste: (text: string) => void) => void
   /** Hands the parent an imperative "open this file's read-only diff in a
-   *  content tab" function, once per mount — the FileTree `d` action (issue
-   *  #21). Opening is a content swap, not a focus grab (KOB-25). */
+   *  content tab" function, once per mount — the FileTree `d` action.
+   *  Opening is a content swap, not a focus grab. */
   onDiffTabReady?: (open: (relPath: string, label: string, base?: string) => void) => void
-  /** Quick-fork (issue #17): the composer submitted — parent creates the
+  /** Quick-fork: the composer submitted — parent creates the
    *  child task (in `repo`, the source task's main repo root) and jumps in. */
   onQuickFork?: (repo: string, result: QuickTaskResult) => void
   /** Quick-fork phase 2: a prompt auto-delivered to this task's first
@@ -150,7 +147,7 @@ export interface TerminalTabsProps {
   /** The user landed on a tab (switch or mount) — the host resolves any
    *  pending Inbox episode targeting it. */
   onTabVisited?: (tabId: string) => void
-  /** Confirmed ESC interrupt on a hook-running tab (issue #15) — the host
+  /** Confirmed ESC interrupt on a hook-running tab — the host
    *  reports `turn-interrupted` to the daemon. */
   onEngineInterrupt?: (tabId: string) => void
   focused: boolean
@@ -170,7 +167,7 @@ export function TerminalTabs(props: TerminalTabsProps): ReactNode {
   // effects below (see file header).
   const propsRef = useLatest(props)
 
-  /** Pin a fresh engine-session id on the just-created active engine tab (the tmux `@kobe_session_id` stash). */
+  /** Pin a fresh engine-session id on the just-created active engine tab. */
   const pinSession = (s: TabsState, vendor: VendorId | undefined): TabsState => {
     const base = vendor ? engineLaunchArgv({ vendor, effort: props.modelEffort }) : props.command
     const { sessionId } = withPinnedSessionId(base, vendor ?? props.vendor)
@@ -185,12 +182,12 @@ export function TerminalTabs(props: TerminalTabsProps): ReactNode {
   const initState = (): TabsState => {
     const existing = tabsByTask.get(props.taskId)
     if (existing) return existing
-    // Restart survival (issue #22): rehydrate the persisted tab snapshot
+    // Restart survival: rehydrate the persisted tab snapshot
     // before falling back to a fresh single tab.
     const saved = kv.get(persistKey, null) as TabsState | null
     const fromDisk = saved && Array.isArray(saved.tabs) ? rehydrateTabs(saved, [defaultShell()]) : null
     rehydratedRef.current = fromDisk !== null
-    // A scratch task's first tab is a BARE SHELL (issue #33) — the task IS
+    // A scratch task's first tab is a BARE SHELL — the task IS
     // the shell; an engine only appears if the user types one.
     const fresh =
       fromDisk ?? (props.scratch === true ? initialShellTabs(defaultShell()) : pinSession(initialTabs(), undefined))
@@ -227,7 +224,7 @@ export function TerminalTabs(props: TerminalTabsProps): ReactNode {
   const activeLeafSizeRef = useLatest(activeLeafSize)
 
   /** Engine-tab spawn: the composition (shell wrap + resume-vs-pin +
-   *  first-spawn initial prompt, issue #17) is pure — `engineTabSpawnFor`;
+   *  first-spawn initial prompt) is pure — `engineTabSpawnFor`;
    *  this closure only supplies the IO reads (registry liveness, props). */
   const engineTabSpawn = (tab: EngineTab): TabSpawn => {
     // A tab's own pinned command/protocol wins; otherwise it inherits the
@@ -257,7 +254,7 @@ export function TerminalTabs(props: TerminalTabsProps): ReactNode {
    *  see the `resetToken` doc on `Terminal.tsx`. */
   const [resetToken, setResetToken] = useState(0)
 
-  /* --------- restart resume verification (issue #22) — mount-only ------- */
+  /* --------- restart resume verification — mount-only ------------------- */
   const hydrating = useTabHydration(rehydratedRef.current, { stateRef, propsRef, update })
 
   // Parent handoffs — the once-per-mount work, in use-tab-handoffs.ts apart
@@ -281,7 +278,7 @@ export function TerminalTabs(props: TerminalTabsProps): ReactNode {
 
   const active = state.tabs.find((tab) => tab.id === state.activeId) ?? state.tabs[0]
 
-  /* --------- auto-naming + existence tracking (tmux naming pass), mount-only --- */
+  /* --------- auto-naming + existence tracking, mount-only --------------- */
   useTabNaming({ stateRef, propsRef, update })
 
   /* --------- per-tab turn state (hook-first, poll-fallback) --------- */
@@ -301,7 +298,7 @@ export function TerminalTabs(props: TerminalTabsProps): ReactNode {
   // Visiting a tab clears its unread mark (toast already auto-dismisses)
   // and reports the visit upstream — the host resolves any pending Inbox
   // episode targeting this tab (visited = handled, no explicit open needed).
-  // biome-ignore lint/correctness/useExhaustiveDependencies: fires only on a real activeId transition, matching the Solid `on(...)` guard; `notif`/`taskId` are stable for this component's lifetime.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: fires only on a real activeId transition; `notif`/`taskId` are stable for this component's lifetime.
   useEffect(() => {
     notif.markRead(props.taskId, state.activeId)
     propsRef.current.onTabVisited?.(state.activeId)
@@ -350,7 +347,7 @@ export function TerminalTabs(props: TerminalTabsProps): ReactNode {
   // through a ref rather than the one from its first render.
   const tabCloseRef = useLatest(tabClose)
 
-  // Rename + the unified new-conversation dialog (issue #7) — the flows that
+  // Rename + the unified new-conversation dialog — the flows that
   // ASK the user something (use-tab-dialogs.ts); per render for freshness.
   const { requestRename, requestNewChat } = useTabDialogs({
     dialog,
@@ -387,9 +384,9 @@ export function TerminalTabs(props: TerminalTabsProps): ReactNode {
   })
 
   /** What a plain ctrl+t tab should run — the full preference chain.
-   *  Always CONCRETE: the tab pins the vendor it actually spawns. The old
-   *  "inherit" mode (undefined when equal to the task engine) let a later
-   *  task-vendor switch relabel and re-target every earlier tab. */
+   *  Always CONCRETE: the tab pins the vendor it actually spawns. An
+   *  "inherit" mode (undefined when equal to the task engine) would let a
+   *  later task-vendor switch relabel and re-target every earlier tab. */
   const preferredTabVendor = (): VendorId => {
     try {
       return resolvePreferredVendor(resolveMainRepoRoot(props.worktree))
@@ -405,7 +402,7 @@ export function TerminalTabs(props: TerminalTabsProps): ReactNode {
         const preferred = preferredTabVendor()
         update(pinSession(addTab(state, preferred), preferred))
       },
-      // One dialog, three entries (issue #7): ctrl+e opens it pristine,
+      // One dialog, three entries: ctrl+e opens it pristine,
       // the prefix chords open it with a toggle pre-flipped — c dials
       // context to "continue this conversation", f dials destination to
       // "fork a child task worktree".
@@ -422,8 +419,7 @@ export function TerminalTabs(props: TerminalTabsProps): ReactNode {
   // run children-first — see keymap.ts), so these tab-level entries would
   // always shadow the split ones. Gate them off while the active tab is
   // actually split (>1 leaf) so the chords fall through the LIFO stack to
-  // the leaf bindings — the Solid-era precedence, restored by gating
-  // instead of ordering.
+  // the leaf bindings: precedence comes from the gate, not from mount order.
   const activeIsSplit = isTabSplit(active.splitTree)
   const spawn = activeSpawn()
   useBindings(() => ({
@@ -455,7 +451,7 @@ export function TerminalTabs(props: TerminalTabsProps): ReactNode {
           <text fg={theme.textMuted}>{t("terminal.restoring")}</text>
         </box>
       ) : active.kind === "content" ? (
-        // Read-only diff/preview tab (issue #21) — the shared PreviewScreen,
+        // Read-only diff/preview tab — the shared PreviewScreen,
         // no PTY. `onClose` (q/esc) closes THIS tab instead of exiting the
         // process (the standalone entrypoint keeps the process.exit default).
         <PreviewScreen

--- a/packages/kobe/src/tui-react/workspace/attention-inbox-core.ts
+++ b/packages/kobe/src/tui-react/workspace/attention-inbox-core.ts
@@ -32,9 +32,8 @@ export function visitResolvedEpisodes(
  * list could not be read at all (this process has never mounted that task's
  * TerminalTabs, so its KV snapshot is absent). Callers treat unavailable
  * episodes as garbage and DELETE them from the daemon, so answering "gone"
- * for "don't know" destroyed live episodes — the owner-reported "two tabs
- * are unread but the Inbox only lists one" (2026-08-10). Unknown keeps the
- * episode.
+ * for "don't know" destroys live episodes: two tabs read as unread while the
+ * Inbox lists one. Unknown keeps the episode.
  */
 export function isAttentionInboxItemAvailable(
   item: AttentionInboxItem,

--- a/packages/kobe/src/tui-react/workspace/completion-seen.ts
+++ b/packages/kobe/src/tui-react/workspace/completion-seen.ts
@@ -2,11 +2,10 @@
  * Durable "I already looked at this completion" record — the persisted half
  * of the sidebar's unread lamp (● turn done, not yet viewed).
  *
- * The lamp's seen bit used to live ONLY in a process-local Set, so quitting
- * kobe threw the fact away while the daemon kept publishing the very same
- * `turn_complete` (its activity registry is daemon-lived, not TUI-lived).
- * Every completion you had already read came back unread on the next launch
- * — owner report 2026-08-12, issue #22.
+ * A process-local Set alone is not enough: quitting kobe throws the fact away
+ * while the daemon keeps publishing the very same `turn_complete` (its
+ * activity registry is daemon-lived, not TUI-lived), so every completion you
+ * had already read comes back unread on the next launch.
  *
  * The mark is the completion's own timestamp: `turn_complete` is a STICKY
  * activity state, so its `at` is stamped once by the reporting event and
@@ -31,7 +30,7 @@ export type CompletionSeenKv = {
 }
 
 /** Row identity of a seen mark: a task's own rollup, or one of its tabs.
- *  Same NUL-joined shape the session Set has always used. */
+ *  Same NUL-joined shape the session Set uses. */
 export function completionSeenKey(taskId: string, tabId?: string): string {
   return tabId === undefined ? taskId : `${taskId}\0${tabId}`
 }
@@ -91,13 +90,13 @@ export function markCompletionSeen(kv: CompletionSeenKv, key: string, at: number
 
 /**
  * The subset of `stamps` whose completion the persisted record already
- * covers — the tab strip's half of the same bit (issue #23).
+ * covers — the tab strip's half of the same bit.
  *
- * The strip used to read a purely in-process unread map, so it lost the
- * fact on every relaunch: a tab that finished while you were away came
- * back looking read. Folding the SAME (task, tab) → seen-at record the
- * sidebar lamp uses keeps the two surfaces telling one story across
- * restarts. A tab with no stamp (`undefined` — the poll-only path, where
+ * A purely in-process unread map loses the fact on every relaunch, so a tab
+ * that finished while you were away comes back looking unread. Folding the
+ * SAME (task, tab) → seen-at record the sidebar lamp uses keeps the two
+ * surfaces telling one story across restarts. A tab with no stamp
+ * (`undefined` — the poll-only path, where
  * no hook ever reported a completion timestamp) is never "seen": there is
  * nothing to key a mark on.
  */

--- a/packages/kobe/src/tui-react/workspace/deferred-prompt-insert.ts
+++ b/packages/kobe/src/tui-react/workspace/deferred-prompt-insert.ts
@@ -1,5 +1,5 @@
 /**
- * Exit path for a deferred prompt (issue #78 B-layer, hard constraint #1+#3).
+ * Exit path for a deferred prompt.
  *
  * Opening a `prompt_deferred` inbox item jumps to the tab AND inserts the
  * queued message — one action, reusing the existing open action (no new

--- a/packages/kobe/src/tui-react/workspace/empty-workspace-pane.tsx
+++ b/packages/kobe/src/tui-react/workspace/empty-workspace-pane.tsx
@@ -8,12 +8,12 @@
  * this state: they are all registered inside that component. Entering the
  * task from the sidebar revives it (`reviveEmptiedTabs`), but this pane is
  * also reached WITHOUT an activation — restart restore, or a task emptied
- * while already on screen — and there the placeholder used to name two keys
- * that had no handler at all.
+ * while already on screen — so a placeholder that only NAMES the keys would
+ * name two chords with no handler at all.
  *
  * So the placeholder owns them itself. Both chords do the same thing (revive
  * this task's session), because from here there is only one thing to do:
- *   - `workspace.reopenSession` (⏎) — owner sign-off 2026-08-31.
+ *   - `workspace.reopenSession` (⏎).
  *   - `chat.tab.chooseEngine` (ctrl+e) — the SAME id `TerminalTabs` binds.
  *     Registering it here is not a second chord, it is the one chord staying
  *     answerable in the state where its usual owner is unmounted.

--- a/packages/kobe/src/tui-react/workspace/fork-chat-tab.ts
+++ b/packages/kobe/src/tui-react/workspace/fork-chat-tab.ts
@@ -28,7 +28,8 @@ import {
 export type ChatForkPlan =
   /** Same engine, native fork: it reopens its own conversation and branches. */
   | { readonly kind: "fork"; readonly sessionId: string }
-  /** Different engine: it starts fresh, briefed to read the old transcript. */
+  /** Different engine: it starts fresh, briefed to read the source
+   *  transcript. */
   | { readonly kind: "handoff"; readonly prompt: string }
   /** Nothing to continue from — this tab has no conversation yet. */
   | { readonly kind: "no-session" }
@@ -43,9 +44,9 @@ export type ChatForkPlan =
  * A custom preset registered without `engineProtocol.<id>` (the shape every
  * pre-`engineProtocol` preset has on disk) resolves to the empty custom
  * registry entry: no transcript reader, no fork verb — so a `claudecpa` tab
- * that has been talking to claude all along reported "nothing to continue"
- * (owner report 2026-09-02). The process-tree walk already answered this
- * question and recorded it as `EngineTab.liveVendor`; this is the join.
+ * that has been talking to claude all along would report "nothing to
+ * continue". The process-tree walk already answers this question and records
+ * it as `EngineTab.liveVendor`; this is the join.
  *
  * Evidence, never a default. A declared protocol (built-in, contrib, or a
  * preset that named one) is authoritative and wins; a live vendor that names
@@ -84,7 +85,7 @@ export async function planChatContinuation(
 }
 
 /**
- * "Continue this conversation" for the FORK destination (issue #7): the
+ * "Continue this conversation" for the FORK destination: the
  * child task runs in a NEW worktree, and engine-native session forks are
  * keyed to the source cwd — so this is ALWAYS a handoff (or a refusal),
  * never `{ kind: "fork" }`. The brief names the source worktree, which is

--- a/packages/kobe/src/tui-react/workspace/host-banner.tsx
+++ b/packages/kobe/src/tui-react/workspace/host-banner.tsx
@@ -6,8 +6,8 @@
  * Its own module because the host renders the result in THREE places — the
  * settings page, a full-window page, and `WorkspaceFrame` all wrap it — while
  * the choice between the two banners is one question with one answer. The
- * WIRING is what has historically been wrong here (both banners were correct
- * components nobody mounted), so `host-version-skew-banner.test.tsx` drives
+ * WIRING is the fragile part — a correct banner component nobody mounts looks
+ * exactly like a working one — so `host-version-skew-banner.test.tsx` drives
  * these signals through the real `WorkspaceRoot` rather than through this hook.
  */
 
@@ -29,24 +29,22 @@ export interface HostBanner {
 }
 
 /**
- * The skew banner's problem, and its fix. `daemonStaleSignal()` has been
- * accurate since it was written and its ONLY reader was the mock workbench —
- * so the state it names was invisible in the product the whole time. That
- * state is not an edge case: Rove ships several times a day and the daemon is
- * a long-lived process that outlives an `npm i -g`, which makes "new binary,
- * old daemon" the ordinary result of updating.
+ * What `daemonStaleSignal()` names is not an edge case: Rove ships several
+ * times a day and the daemon is a long-lived process that outlives an
+ * `npm i -g`, which makes "new binary, stale daemon" the ordinary result of
+ * updating. It persists until someone restarts the daemon, which is why it
+ * gets a banner.
  *
- * Skew only. A daemon-disconnect banner used to sit in front of this one: a
- * full-width red alert on every socket drop. It was the wrong weight — the
- * reconnect loop recovers most drops in under a second, and Rove keeps working
- * through the ones it doesn't, so the alert interrupted to announce something
- * with nothing to act on. Skew is different: it persists until someone
- * restarts the daemon, which is why it kept its banner.
+ * Skew only — do NOT add a daemon-disconnect banner beside it. A full-width
+ * alert on every socket drop is the wrong weight: the reconnect loop recovers
+ * most drops in under a second, and Rove keeps working through the ones it
+ * doesn't, so the alert would interrupt to announce something with nothing to
+ * act on.
  *
  * The one condition that outranks skew: this process's install was deleted, so
- * it cannot start a daemon at all. It used to be invisible — the client just
- * looked like it was reconnecting, for two days (issue #96). Latched, never
- * cleared: only a reinstall fixes it.
+ * it cannot start a daemon at all. Without its own state that reads as an
+ * ordinary reconnect, indefinitely. Latched, never cleared: only a reinstall
+ * fixes it.
  */
 export function useHostBanner(orch: RemoteOrchestrator, width: number): HostBanner {
   const daemonStale = useAccessor(orch.daemonStaleSignal())

--- a/packages/kobe/src/tui-react/workspace/host-keybindings.ts
+++ b/packages/kobe/src/tui-react/workspace/host-keybindings.ts
@@ -1,19 +1,17 @@
 /**
- * Workspace-host keybinding registration — React port of `tui/workspace/
- * host-keybindings.ts` (issue #16 React migration). Owns the four
- * `useBindings` blocks the native workspace needs, plus the quit/exit and
- * pane-cycle helpers only those bindings use.
+ * Workspace-host keybinding registration. Owns the four `useBindings` blocks
+ * the native workspace needs, plus the quit/exit and pane-cycle helpers only
+ * those bindings use.
  *
  * Pure wiring: every handler is a closure the host passes in; this module
  * adds no state of its own beyond the renderer handle `exitApp` needs. See
  * `docs/KEYBINDINGS.md` for the scope/boundary rules these rows follow.
  *
- * Solid→React deltas: `settingsOpen`/`worktreesOpen`/`searchActive`/
- * `selectedId` are plain values (the host re-renders on change), not
- * Accessors — `useBindings`'s config function is re-evaluated on every
- * keypress via a render-refreshed ref (`tui-react/lib/keymap.ts`), so a
- * plain closure over these params is exactly as fresh as the Solid
- * Accessor calls were.
+ * `settingsOpen`/`worktreesOpen`/`searchActive`/`selectedId` are plain values
+ * (the host re-renders on change), and `useBindings`'s config function is
+ * re-evaluated on every keypress via a render-refreshed ref
+ * (`tui-react/lib/keymap.ts`) — so a plain closure over these params reads
+ * the current value, not the one from its registering render.
  */
 
 import { useRenderer } from "@opentui/react"
@@ -100,7 +98,7 @@ export function useWorkspaceKeybindings(deps: WorkspaceKeybindingDeps): void {
     if (ok) exitApp()
   }
 
-  // Cursor semantics, not a ring (owner call 2026-07-25): focus movement
+  // Cursor semantics, not a ring: focus movement
   // clamps at both ends — sidebar ← workspace → files — instead of
   // wrapping, so "previous" from the sidebar never jumps to files.
   function cyclePane(delta: 1 | -1): void {
@@ -131,7 +129,7 @@ export function useWorkspaceKeybindings(deps: WorkspaceKeybindingDeps): void {
         // f4 — reserved from terminal passthrough, so the cycle behaves
         // identically from every pane including inside the terminal.
         "focus.next": prefixAction(() => cyclePane(1)),
-        // prefix+z only (owner call 2026-07-17). The configured prefix is
+        // prefix+z only. The configured prefix is
         // Kobe-global, so this remains reachable inside the terminal pane.
         "workspace.zenToggle": prefixAction(() => deps.toggleZen()),
         // f7 — reserved from terminal passthrough too, so "jump to the
@@ -143,8 +141,8 @@ export function useWorkspaceKeybindings(deps: WorkspaceKeybindingDeps): void {
         "workItems.open": prefixAction(() => deps.pages.openWorkItems()),
         "task.moveMode": prefixAction(() => deps.enterMoveMode()),
         // prefix+, — the global companion to the sidebar's bare `s`. The
-        // row shipped in the table (and docs) without a handler here, so
-        // the chord was dead outside the sidebar.
+        // row exists in the table (and docs); without a handler here the
+        // chord is dead outside the sidebar.
         "settings.open": prefixAction(() => deps.pages.openSettings()),
         "files.createPR": prefixAction(() => deps.createPR()),
         // Global scope, so it acts on the active task — except while the
@@ -182,7 +180,7 @@ export function useWorkspaceKeybindings(deps: WorkspaceKeybindingDeps): void {
       "tasks.update": () => deps.pages.openUpdate(),
     }),
   }))
-  // Task-lifecycle chords (issue #20 — the tmux Tasks pane's n/b/v set).
+  // Task-lifecycle chords — the n/b/v set.
   // d/a/r/pin/move fire from the Sidebar's OWN keys via the Request props;
   // these three are host-scoped in both hosts. Gated on sidebar focus + no
   // dialog + search inactive (typing `n` into the search box must not open

--- a/packages/kobe/src/tui-react/workspace/host-pages.tsx
+++ b/packages/kobe/src/tui-react/workspace/host-pages.tsx
@@ -234,8 +234,8 @@ export interface UseHostPagesRenderResult {
  *
  * `pageDeps`, the full-window/content-page render calls, the narrow-mode
  * surface decision, and the settings standalone page all serve one concern:
- * deciding which surface occupies the workspace. Keeping them together means
- * `host.tsx` no longer has to thread every dependency through `pageDeps`.
+ * deciding which surface occupies the workspace. Keeping them together is
+ * what spares `host.tsx` from threading every dependency through `pageDeps`.
  */
 export function useHostPagesRender(opts: UseHostPagesRenderOpts): UseHostPagesRenderResult {
   const {

--- a/packages/kobe/src/tui-react/workspace/host-sidebar.tsx
+++ b/packages/kobe/src/tui-react/workspace/host-sidebar.tsx
@@ -71,7 +71,7 @@ export interface HostSidebarProps {
   readonly zenActive: boolean
   readonly onZenClick: () => void
   readonly onFocusRequest: () => void
-  /** Narrow mode's "↩ recent" jump row target (issue #14, 2A). */
+  /** Narrow mode's "↩ recent" jump row target. */
   readonly recentTask?: Task | null
   /** Global task sort mode driven by the `t` chord. */
   readonly sortMode?: TaskSortMode
@@ -90,7 +90,7 @@ export function HostSidebar(props: HostSidebarProps) {
   // where that fork lives; a failure surfaces as a toast rather than a silent
   // no-op. Closing the LAST tab is not a failure (it empties the list and the
   // row is revived on re-entry), so the only false left is a tab the tree
-  // still lists but the state no longer has — a stale row, not a refusal.
+  // still lists but the state does not have — a stale row, not a refusal.
   const closeTab = useCallback(
     (taskId: string, tabId: string): void => {
       if (!closeTaskTab(kv, taskId, tabId))
@@ -98,7 +98,7 @@ export function HostSidebar(props: HostSidebarProps) {
     },
     [kv, notif, t],
   )
-  // Tab reorder is tab close's sibling (move mode on a tab row, issue #43):
+  // Tab reorder is tab close's sibling (move mode on a tab row):
   // same mounted-vs-background fork, same "who owns this task's state"
   // question — `moveTaskTab` is where that fork lives. An edge-stop (first
   // tab up / last down) is a silent no-op, not an error.
@@ -108,8 +108,8 @@ export function HostSidebar(props: HostSidebarProps) {
     },
     [kv],
   )
-  // "New conversation" / "New shell" from a row's menu (owner ask
-  // 2026-08-18). Unlike close/move there is no background path: the picker is
+  // "New conversation" / "New shell" from a row's menu. Unlike close/move
+  // there is no background path: the picker is
   // a dialog and a shell tab needs its PTY where the tabs render, so this
   // ENTERS the task first and the request is claimed by its workspace — on
   // the spot when it is already mounted, on first mount otherwise.

--- a/packages/kobe/src/tui-react/workspace/host-task-actions.ts
+++ b/packages/kobe/src/tui-react/workspace/host-task-actions.ts
@@ -1,22 +1,17 @@
 /**
- * Workspace-host task-action wiring — React port of `tui/workspace/
- * host-task-actions.ts` (issue #16 React migration). Builds the
- * `CreateTaskContext` the shared `tui/lib/task-actions` flows run on (the
- * SAME framework-free flows the Solid host and the tmux Tasks pane use —
- * confirm copy, DIRTY_WORKTREE force-delete branch, error handling all
- * live there so no host drifts) and returns the host's action callbacks.
+ * Workspace-host task-action wiring. Builds the `CreateTaskContext` the
+ * shared `tui/lib/task-actions` flows run on — confirm copy, DIRTY_WORKTREE
+ * force-delete branch and error handling all live there, so no host drifts —
+ * and returns the host's action callbacks.
  *
  * Only this host's genuine divergences are wired here: dialog surfacing
- * (the React `DialogConfirm`/`RenameTaskDialog`/`NewTaskDialog`), toast
- * notifications and selection. No `openCreateSurface` (the in-pane NewTaskDialog IS the
+ * (`DialogConfirm`/`RenameTaskDialog`/`NewTaskDialog`), toast notifications
+ * and selection. No `openCreateSurface` (the in-pane NewTaskDialog IS the
  * surface), no `reload` (this host is fully render-driven).
  *
- * Solid→React deltas: every accessor prop (`tasks`, `selectedId`,
- * `selectedTask`) becomes a plain getter closure over the latest render's
- * value — callers pass `() => tasks` / `() => selectedId` etc. from the
- * host, same shape the flows already expect (`TaskActionContext.tasks` is
- * `() => readonly Task[]`), so this file's body is otherwise unchanged
- * from the Solid original.
+ * `tasks` / `selectedId` / `selectedTask` are passed as getter closures over
+ * the latest render's value (`() => tasks`), the shape the flows expect
+ * (`TaskActionContext.tasks` is `() => readonly Task[]`).
  */
 
 import { errorMessage } from "@/lib/error-message"
@@ -52,7 +47,7 @@ export type WorkspaceTaskActionDeps = {
   setSelectedId: (id: string | null) => void
   selectedTask: () => Task | undefined
   activateTask: (id: string) => Promise<void>
-  /** Reclaim a deleted task's terminal-tab snapshot (O19). */
+  /** Reclaim a deleted task's terminal-tab snapshot. */
   forgetTaskTabs: (taskId: string) => void
 }
 
@@ -109,7 +104,7 @@ export function useWorkspaceTaskActions(deps: WorkspaceTaskActionDeps): Workspac
     // renderer, which is the half that reaches the user's machine over SSH).
     copyText: (text) => copyTextToSystemClipboard(text, (payload) => renderer?.copyToClipboardOSC52(payload)),
     onTaskDeleted: (() => {
-      // Reclaim the deleted task's terminal-tab snapshot (O19), THEN move the
+      // Reclaim the deleted task's terminal-tab snapshot, THEN move the
       // host cursor off it (the shared selection move — the base's bare
       // `selectNextAfterDelete` overridden with this wrapper).
       const moveSelection = selectNextAfterDelete({
@@ -140,7 +135,7 @@ export function useWorkspaceTaskActions(deps: WorkspaceTaskActionDeps): Workspac
 
   // Set-branch (`b`): pick from the repo's local branches (filter-as-you-type)
   // or type a new name — the shared `renameBranchFlow`'s bare text prompt
-  // replaced by the branch-listing dialog (issue #10). `setBranch` no-ops on
+  // replaced by the branch-listing dialog. `setBranch` no-ops on
   // an unchanged name and rejects main/dir rows, so we guard/notify here:
   // opening the picker for a task whose branch can't be set would send the
   // user through a choice that only ever ends in the error toast.
@@ -175,8 +170,8 @@ export function useWorkspaceTaskActions(deps: WorkspaceTaskActionDeps): Workspac
     })
     if (!pick) return
     // Not `pick.vendor === current` — re-picking the same engine at a
-    // different reasoning level is a real change, and the early return used
-    // to eat it.
+    // different reasoning level is a real change, which that comparison
+    // would swallow.
     if (pick.vendor === current && (pick.effort === undefined || pick.effort === (task.modelEffort ?? ""))) return
     await applyVendorChange(taskActions, id, pick.vendor, { effort: pick.effort })
   }
@@ -190,7 +185,7 @@ export function useWorkspaceTaskActions(deps: WorkspaceTaskActionDeps): Workspac
     pickVendor,
     // The ctrl+e picker's engine pick. Silent on success: the tab it just
     // opened IS the new engine, so a toast saying the change "applies on
-    // reopen" contradicted what the user was already looking at. Failures
+    // reopen" would contradict what the user is looking at. Failures
     // still toast — see applyVendorChange.
     setVendor: async (id, vendor) => {
       await applyVendorChange(taskActions, id, vendor, { silentSuccess: true })

--- a/packages/kobe/src/tui-react/workspace/host.tsx
+++ b/packages/kobe/src/tui-react/workspace/host.tsx
@@ -47,7 +47,7 @@ import { useZenMode } from "./use-zen-mode"
 
 /** Exported for the render track: the banner wiring can only be proven by
  *  mounting the REAL host — a test against the banner component alone stays
- *  green when the mount is deleted, which is the exact bug being fixed. */
+ *  green even when the mount is deleted. */
 export function WorkspaceRoot(props: { orchestrator: RemoteOrchestrator }) {
   const { theme } = useTheme()
   const inactiveBorder = theme.borderActive
@@ -115,8 +115,8 @@ export function WorkspaceRoot(props: { orchestrator: RemoteOrchestrator }) {
   })
   const worktree = selectedTask?.worktreePath || null
 
-  // Toasts + global sort pref + move-mode — the wiring shared with the tmux
-  // Tasks pane, extracted to the hook next to the Sidebar itself.
+  // Toasts + global sort pref + move-mode — the sidebar-adjacent wiring,
+  // extracted to the hook next to the Sidebar itself.
   const { sortMode, toggleSortMode, moveMode, setMoveMode, notifyError, notifyInfo, onLocalMergeRequest } =
     useSidebarHostState({ kv, notif, tasks, selectedId, setSelectedId })
 
@@ -133,7 +133,7 @@ export function WorkspaceRoot(props: { orchestrator: RemoteOrchestrator }) {
     notifyInfo,
   })
 
-  // Cross-task attention (P0): rising-edge notify for non-selected tasks +
+  // Cross-task attention: rising-edge notify for non-selected tasks +
   // the global chord's jump-to-next handler. State is engine-owned/neutral.
   const { jumpToNextAttention } = useAttention({
     tasks,
@@ -179,14 +179,14 @@ export function WorkspaceRoot(props: { orchestrator: RemoteOrchestrator }) {
   // Imperative tab handles: refs handed by TerminalTabs + FileTree/PR actions.
   const editor = useEditorHandles({ orchestrator: orch, worktree, selectedId, focus, notifyError })
 
-  // Quick-fork (issue #17, ctrl+f): composer → create+enter → hand the
+  // Quick-fork (ctrl+f): composer → create+enter → hand the
   // prompt to the new task's TerminalTabs mount (phase 2). Wiring lives in
   // `quick-fork.ts` because the create/enter/pending-prompt shape is identical
   // regardless of host — the other caller is TerminalTabs, and both must stay
   // one implementation.
   const quickFork = useQuickFork(orch, { selectTask: setSelectedId, enterTask: activateTask, notifyError })
 
-  // Scratch temp shell tasks (issue #33) — open gesture, exit deletion, and
+  // Scratch temp shell tasks — open gesture, exit deletion, and
   // the quiet adoption loop all live in the hook.
   const scratch = useScratchShell({
     orchestrator: orch,
@@ -200,7 +200,7 @@ export function WorkspaceRoot(props: { orchestrator: RemoteOrchestrator }) {
     notifyInfo,
   })
 
-  /* --------- zen mode (issue #18, pure-tui shape) ----------------------- */
+  /* --------- zen mode ---------------------------------------------------- */
   const { zen, toggleZen } = useZenMode({ kv, focus })
 
   // Tab open/close (and editor-file close) edges report as plugin events
@@ -213,8 +213,6 @@ export function WorkspaceRoot(props: { orchestrator: RemoteOrchestrator }) {
   // Which surface the workspace shows — settings/worktrees/update full swaps
   // plus the rail's one-at-a-time nav. State + rationale in host-pages.tsx.
   const pages = useHostPagesState(focus)
-  // Sidebar layout: the tree lists each worktree's tabs as rows (the strip is
-  // off by default to match); `flat` restores the PROJECTS / TASKS list.
   // The selected task's active tab — the tree marks that exact row as live.
   // Read from the module map rather than threaded through TerminalTabs: the
   // sidebar renders tabs for tasks whose TerminalTabs is not mounted, so the
@@ -275,8 +273,8 @@ export function WorkspaceRoot(props: { orchestrator: RemoteOrchestrator }) {
     createPR: () => void editor.onCreatePR(),
     // prefix+m — global entry into the sidebar's move mode: focus the
     // sidebar, highlight the selection (falling back to the first task),
-    // then j/k reorders the cursor row's level (tab/task/project — issue
-    // #43) and enter/esc exits.
+    // then j/k reorders the cursor row's level (tab/task/project) and
+    // enter/esc exits.
     enterMoveMode: () => {
       const target = selectedId ?? tasks[0]?.id
       if (!target) return
@@ -335,13 +333,12 @@ export function WorkspaceRoot(props: { orchestrator: RemoteOrchestrator }) {
             pages.setNav("terminal")
             void activateTask(id)
           }}
-          // Picking a TAB is entering that session (owner 2026-08-01): focus
-          // moves to the terminal, same as activate — a click that leaves the
-          // sidebar's letter chords (d!) live under your typing is how issues
-          // got mis-deleted. Re-clicking the tab you are ALREADY in flips focus
-          // back to the sidebar (owner 2026-08-09): the first click entered the
-          // session, so a second click on the same row means "give me the
-          // sidebar". Keyboard enter is exempt (sidebar already focused —
+          // Picking a TAB is entering that session: focus moves to the
+          // terminal, same as activate — a click that leaves the sidebar's
+          // letter chords (d!) live under your typing is how a task gets
+          // deleted by accident. Re-clicking the tab you are ALREADY in flips
+          // focus back to the sidebar: the first click entered the session, so
+          // a second click on the same row means "give me the sidebar". Keyboard enter is exempt (sidebar already focused —
           // enter always means enter the session), as is a click that brings
           // the terminal back from a rail page.
           onSelectTab={(taskId, tabId) => {
@@ -361,7 +358,7 @@ export function WorkspaceRoot(props: { orchestrator: RemoteOrchestrator }) {
           worktreeChanges={worktreeChanges}
           transcriptActivity={transcriptActivity}
           focused={activePane === "sidebar"}
-          // Task lifecycle (issue #20): the Sidebar's own d/r/p/m keys
+          // Task lifecycle: the Sidebar's own d/r/p/m keys
           // fire these; the flows are the shared lib/task-actions bodies.
           onAddTask={() => void createTask()}
           onDeleteRequest={(id) => void deleteTask(id)}
@@ -448,12 +445,11 @@ export function WorkspaceRoot(props: { orchestrator: RemoteOrchestrator }) {
         />
       ) : null}
 
-      {/* Cross-task attention toasts (issue #15). `useAttention` above fires
-          `notif.notify()` on unfocused-task state changes, but the main app
-          never mounted the overlay that renders them (only the standalone
-          `kobe tasks` pane did) — so the bottom-right toast silently never
-          appeared. Absolute-positioned overlay, under the
-          host's NotificationsProvider. */}
+      {/* Cross-task attention toasts. `useAttention` above fires
+          `notif.notify()` on unfocused-task state changes; without this
+          overlay mounted, nothing renders them and the bottom-right toast
+          silently never appears. Absolute-positioned, under the host's
+          NotificationsProvider. */}
       <ToastOverlay />
       {/* Prefix sequence HUD — bottom-left over the Tasks sidebar (the
           terminal column is off-limits: it collided with the engine's own

--- a/packages/kobe/src/tui-react/workspace/inbox-item-view.ts
+++ b/packages/kobe/src/tui-react/workspace/inbox-item-view.ts
@@ -6,8 +6,8 @@
  *
  * One rule holds the four together: the Inbox's vocabulary must MATCH the
  * sidebar rail's (`row-view.ts`) and the tab strip's (`tab-strip.tsx`). Three
- * surfaces describing one tab in three vocabularies is how a rate limit and a
- * crash ended up looking identical.
+ * surfaces describing one tab in three vocabularies is what makes a rate
+ * limit and a crash look identical.
  */
 
 import type { Task } from "@/types/task"
@@ -27,10 +27,10 @@ export function itemColor(state: AttentionInboxItem["state"], theme: ThemeColors
 export function itemGlyph(state: AttentionInboxItem["state"]): string {
   if (state === "permission_needed") return "?"
   if (state === "turn_complete") return "✓"
-  // `◷`, the sidebar's rate-limited glyph, not the `⌛` this used to show:
-  // U+231B carries the Unicode Emoji property, so macOS resolved it to
-  // AppleColorEmoji — a 2.13-cell colour glyph in a 1-cell column, which
-  // both overflowed and broke the pane's monochrome ink (2026-08-15).
+  // `◷`, the sidebar's rate-limited glyph, deliberately not `⌛`: U+231B
+  // carries the Unicode Emoji property, so macOS resolves it to
+  // AppleColorEmoji — a 2.13-cell colour glyph in a 1-cell column, which both
+  // overflows and breaks the pane's monochrome ink.
   if (state === "rate_limited") return "◷"
   // `†` — the engine PROCESS is gone, the sidebar rail's DEAD_GLYPH.
   if (state === "dead") return "†"
@@ -52,10 +52,9 @@ export function itemStateKey(state: AttentionInboxItem["state"]): string {
 /**
  * "resumes 3:14 PM" for a rate-limited task whose auto-resume is armed, in the
  * viewer's locale clock. The daemon persists `Task.quotaResume.resumeAt` when
- * the engine's quota probe answers when the window clears (quota-resume.ts) —
- * and until 2026-08-30 that timestamp was written to disk and read by NOTHING,
- * so "rate limited" gave a user no way to tell "back at 3:14, already
- * scheduled" from "stuck, go do something else".
+ * the engine's quota probe answers when the window clears (quota-resume.ts).
+ * Showing it is what lets a user tell "back at 3:14, already scheduled" from
+ * "stuck, go do something else".
  *
  * Null unless the state is `rate_limited` (the only state the schedule
  * describes), the task carries a schedule, and its stamp parses — a garbage

--- a/packages/kobe/src/tui-react/workspace/inbox-open-action.ts
+++ b/packages/kobe/src/tui-react/workspace/inbox-open-action.ts
@@ -5,7 +5,7 @@ type InboxOpenRpc = Pick<RemoteOrchestrator, "dismissAttention">
 
 /**
  * Opening an item RESOLVES it: the item is removed from the Inbox
- * (no read/unread lifecycle — owner call 2026-07-16). A fresh event on the
+ * (there is no read/unread lifecycle). A fresh event on the
  * same Task and Terminal Tab records a new item at the latest position.
  * Unavailable items are stale UI state and resolve the same way.
  */

--- a/packages/kobe/src/tui-react/workspace/inbox-visits.ts
+++ b/packages/kobe/src/tui-react/workspace/inbox-visits.ts
@@ -6,10 +6,10 @@
  * has to answer "where was I lately". This records the visits themselves:
  * one entry per (task, TAB), newest first, capped.
  *
- * Per-tab, not per-task (owner report 2026-08-10): switching among a task's
- * chat tabs is the most common way to move around, and a task-keyed log
- * collapsed all of it into one entry — so the tabs you just left never
- * showed up and RECENT listed unrelated tasks instead.
+ * Per-tab, not per-task: switching among a task's chat tabs is the most
+ * common way to move around, and a task-keyed log collapses all of it into
+ * one entry — the tabs you just left never show up, and RECENT lists
+ * unrelated tasks instead.
  *
  * Framework-free so the pane, the host, and unit tests share one rule; the
  * KV layer just persists the array.

--- a/packages/kobe/src/tui-react/workspace/keybinding-gates.ts
+++ b/packages/kobe/src/tui-react/workspace/keybinding-gates.ts
@@ -63,7 +63,7 @@ export type CyclePaneId = (typeof PANE_CYCLE)[number]
  * unmounted pane strands the cursor on nothing, so it drops out of the cycle
  * rather than being clamped against.
  *
- * Cursor semantics, not a ring (owner call 2026-07-25): movement clamps at
+ * Cursor semantics, not a ring: movement clamps at
  * both ends instead of wrapping, so "previous" from the sidebar never jumps
  * to files. Returns null when focus should not move.
  */

--- a/packages/kobe/src/tui-react/workspace/mock-host.tsx
+++ b/packages/kobe/src/tui-react/workspace/mock-host.tsx
@@ -1,7 +1,7 @@
 /** @jsxImportSource @opentui/react */
 /**
- * `dev:mock-react-workspace` — the ported `TerminalTabs` cluster (tab
- * strip, terminal split, engine picker, rename dialog, turn polls) against
+ * `dev:mock-react-workspace` — the `TerminalTabs` cluster (tab strip,
+ * terminal split, engine picker, rename dialog, turn polls) against
  * REAL in-process PTYs, no daemon/orchestrator/engine involved — same
  * "prove the seam live, no fake" convention as `tui/mock/terminal-host.tsx`
  * (`dev:mock-terminal`). `getDefaultPtyRegistry()` has no injectable mock

--- a/packages/kobe/src/tui-react/workspace/optimistic-activity.ts
+++ b/packages/kobe/src/tui-react/workspace/optimistic-activity.ts
@@ -12,13 +12,13 @@
  * - `interrupted` (esc) is a FACT ABOUT THE PAST — "at time T the user
  *   interrupted". Every authoritative state stamped BEFORE T is therefore
  *   stale evidence, and stays suppressed until a genuinely newer event
- *   arrives. It never decays back into the old state; its TTL is only a
- *   memory bound.
+ *   arrives. It never decays back into the state it suppressed; its TTL is
+ *   only a memory bound.
  *
- * That asymmetry is what kills the recurring class of bug: an engine that
- * never reports a terminal state (esc during `/compact` sends no
- * post-compact and no Stop hook) used to leave a `running` entry that
- * resurfaced the moment any suppression expired.
+ * That asymmetry is what handles an engine that never reports a terminal
+ * state: esc during `/compact` sends no post-compact and no Stop hook, so a
+ * decaying suppression would let the stale `running` entry resurface the
+ * moment it expired.
  *
  * No label text is ever derived from a mark — this feeds the ICON only.
  */
@@ -166,9 +166,9 @@ export function mergeAnsweredTabs(
     // Downgrade, never delete. An ABSENT tab entry does not read as "nothing
     // to show" downstream — `tabRowActivity` hands the row no activity at all,
     // and the sidebar then draws the dim `·` it reserves for "the daemon has
-    // never reported this tab". So deleting the entry blanked the row of an
-    // engine that was visibly working, for as long as the 30min mark lived
-    // (owner report 2026-08-25). `idle` is the honest claim: we know the tab
+    // never reported this tab". So deleting the entry would blank the row of
+    // an engine that is visibly working, for as long as the 30min mark lives.
+    // `idle` is the honest claim: we know the tab
     // stopped waiting on the user, we just don't know what it is doing now —
     // which is exactly what the resting `○` says.
     const nextTabs = new Map(perTab)

--- a/packages/kobe/src/tui-react/workspace/quick-fork.ts
+++ b/packages/kobe/src/tui-react/workspace/quick-fork.ts
@@ -1,7 +1,7 @@
 /**
- * Quick-fork (issue #17, KOB-74) — resolve the composer's seed defaults from
- * the active task, and drive `orch.createTask` with the same tmux-parity
- * side effects `quick-task/host.tsx` and the shared `createTaskFlow`
+ * Quick-fork — resolve the composer's seed defaults from the active task,
+ * and drive `orch.createTask` with the same side effects
+ * `quick-task/host.tsx` and the shared `createTaskFlow`
  * (`tui/lib/task-actions.ts`) both perform: `addSavedRepo` + `setRepoLastActiveVendor`
  * before create, `selectTask`/`enterTask` after. Also owns the phase-2
  * first-prompt handoff (`useQuickFork`): the composer resolves on the
@@ -10,7 +10,7 @@
  *
  * Its own module because BOTH `TerminalTabs.tsx` and `host.tsx` drive this
  * gesture: the create/enter/pending-prompt shape must not exist twice, or the
- * two entry points diverge on the tmux-parity side effects above.
+ * two entry points diverge on the side effects above.
  */
 
 import { errorMessage } from "@/lib/error-message"
@@ -62,7 +62,7 @@ export interface QuickForkOrchestrator {
 }
 
 /**
- * Create the forked task and apply the same tmux-parity side effects
+ * Create the forked task and apply the same side effects
  * `createTaskFlow`/`quick-task/host.tsx` apply on submit: remember the
  * picked vendor as the repo's new default and auto-save the repo.
  */
@@ -83,7 +83,7 @@ export async function createQuickForkTask(
  * `createTaskFlow` ends on. Errors are reported via `notifyError`, never
  * thrown. Returns the created task's id (undefined on failure) so the
  * caller can hand its first-prompt delivery to the new task's TerminalTabs
- * mount (phase 2, issue #17).
+ * mount (phase 2).
  */
 export async function runQuickFork(
   orch: QuickForkOrchestrator,
@@ -111,9 +111,8 @@ export async function runQuickFork(
  * Re-fire a task's stored brief as a NEW task ("Run again", row menu).
  *
  * Rove records the delivered `add --prompt` text on the task (`task.prompt`)
- * precisely so an attempt that went wrong can be re-run clean; before this the
- * only route was `get-task | jq -r .task.prompt` piped back into `add`. The
- * child is a quick-fork with the SOURCE's own inputs — same repo, same engine,
+ * precisely so an attempt that went wrong can be re-run clean. The child is a
+ * quick-fork with the SOURCE's own inputs — same repo, same engine,
  * cut from the base ref the source was cut from — so the only difference
  * between the two runs is the worktree.
  *
@@ -171,8 +170,8 @@ export interface UseQuickForkResult {
  * Host-level quick-fork wiring: runs the create+enter flow, then holds the
  * prompt for the ONE render cycle it takes `ShowWorkspace` to remount
  * `TerminalTabs` on the new task (a plain `{ taskId, prompt } | null`, not
- * a Map — `runQuickFork`'s `enterTask` already lands `selectedTask` on the
- * new task before this resolves, so there's only ever one pending prompt).
+ * a Map — `runQuickFork`'s `enterTask` lands `selectedTask` on the new task
+ * first, so at most one prompt is ever pending).
  */
 export function useQuickFork(
   orch: QuickForkOrchestrator,

--- a/packages/kobe/src/tui-react/workspace/scratch-fold.ts
+++ b/packages/kobe/src/tui-react/workspace/scratch-fold.ts
@@ -1,8 +1,8 @@
 /**
- * Fold a scratch shell into the task that already owns its cwd (issue #40)
- * — the execution half of `decideScratchAdopt`'s `fold` verdict. Instead of
- * repointing the scratch row at the repo (which minted a duplicate sidebar
- * row for a directory some task already names), the shell's HOSTED sessions
+ * Fold a scratch shell into the task that already owns its cwd — the
+ * execution half of `decideScratchAdopt`'s `fold` verdict. Repointing the
+ * scratch row at the repo instead would mint a duplicate sidebar row for a
+ * directory some task already names, so the shell's HOSTED sessions
  * are re-keyed under the owning task's next free tab ids (`pty.rename` — the
  * child keeps running, engine and all) and the tab records are adopted
  * through the ordinary orphan-adoption write (`adoptTaskTabs`), which never
@@ -75,8 +75,8 @@ export async function foldScratchShell(
     next++
     // The local handle still keyed to `from` is NOT released here: the
     // scratch row's deletion (the caller's next step) runs the ordinary
-    // task-PTY sweep, whose `pty.kill` on the old key is a host-side no-op
-    // after the rename — the moved session survives, the handle dies.
+    // task-PTY sweep, whose `pty.kill` on the pre-rename key is a host-side
+    // no-op — the moved session survives, the handle dies.
   }
   if (folded.length === 0) return null
   adoptTaskTabs(io.kv, targetTaskId, folded)

--- a/packages/kobe/src/tui-react/workspace/show-workspace.tsx
+++ b/packages/kobe/src/tui-react/workspace/show-workspace.tsx
@@ -1,6 +1,6 @@
 /** @jsxImportSource @opentui/react */
 /**
- * The workspace center column — the terminal-in-the-middle seam (issue #16):
+ * The workspace center column — the terminal-in-the-middle seam:
  * either the empty "select a task" placeholder or the selected worktree's
  * TerminalTabs (keyed per task so tasks sharing a directory never share
  * component state) — the host composes the workspace's regions, and this
@@ -31,14 +31,14 @@ export function ShowWorkspace(props: {
   onEngineSendReady: (send: (text: string) => void) => void
   /** Paste-only sibling of `onEngineSendReady` (no submit) — the FileTree `a` @path mention.
    *  Required like its sibling: optional here, dropping the host's wire would
-   *  silently make the `a` key dead again instead of failing the typecheck. */
+   *  silently make the `a` key dead instead of failing the typecheck. */
   onEnginePasteReady: (paste: (text: string) => void) => void
   onDiffTabReady: (open: (relPath: string, label: string, base?: string) => void) => void
   onQuickFork: (repo: string, result: QuickTaskResult) => void
   initialPrompt?: string
   /** The user landed on a tab of the selected task — resolve its episodes. */
   onTabVisited?: (taskId: string, tabId: string) => void
-  /** A scratch task's last shell exited — the host deletes the row (issue #33). */
+  /** A scratch task's last shell exited — the host deletes the row. */
   onScratchExit?: (taskId: string) => void
   /** ctrl+e's trailing "scratch shell" choice — open a Scratch task. */
   onOpenScratch?: () => void
@@ -52,9 +52,10 @@ export function ShowWorkspace(props: {
   // requirement — no provider simply means "tabs unknown", which mounts.
   const kv = useOptionalKV()
   // Subscribe to the tab map's revision counter. `knownTaskTabs` reads a
-  // module-level Map, which React cannot see on its own: closing a task's
-  // last tab used to change the answer below without re-rendering, leaving
-  // TerminalTabs mounted over an empty tab list it is not built to survive.
+  // module-level Map, which React cannot see on its own: without the
+  // subscription, closing a task's last tab changes the answer below with no
+  // re-render, leaving TerminalTabs mounted over an empty tab list it is not
+  // built to survive.
   useAccessor(tabsRevision)
   const transcriptActivity = useAccessor(props.orchestrator.transcriptActivityStore())
   const engineTabStates = useAccessor(props.orchestrator.engineTabStatesSignal())
@@ -88,13 +89,13 @@ export function ShowWorkspace(props: {
     return <EmptyWorkspacePane taskId={String(props.task.id)} focused={props.focused} />
   }
   return (
-    // The terminal-in-the-middle seam (issue #16): the center column IS
+    // The terminal-in-the-middle seam: the center column IS
     // the engine — an in-process PTY (Bun.spawn terminal) running the
     // real interactive CLI, so kobe never re-renders the engine's own
     // TUI. Keyed by TASK, not worktree: two tasks can share a directory
     // (a project-main task + a dir task on the same checkout), and a
-    // path key reused the component across them — the stale task's
-    // TabsState got written under the new task's persistKey, cloning its
+    // path key would reuse the component across them — the stale task's
+    // TabsState then lands under the new task's persistKey, cloning its
     // tabs into the other task. PTY reuse on switch-back is unaffected:
     // the registry keys are `taskId::tabId`, not React keys.
     <TerminalTabs
@@ -122,9 +123,9 @@ export function ShowWorkspace(props: {
               const taskId = props.task?.id
               if (!taskId) return
               // The tab is added to LOCAL state first and renders under the new
-              // engine's label, so a rejected write looked exactly like a
-              // success while the task kept its old vendor. Same two toasts the
-              // `v` row-chord raises — see applyVendorChange.
+              // engine's label, so a rejected write looks exactly like a
+              // success while the task keeps its previous vendor. Same two
+              // toasts the `v` row-chord raises — see applyVendorChange.
               void props.onEngineChosen?.(taskId, vendor)
             }
           : undefined
@@ -137,8 +138,8 @@ export function ShowWorkspace(props: {
       onDiffTabReady={props.onDiffTabReady}
       onQuickFork={props.onQuickFork}
       initialPrompt={props.initialPrompt}
-      // This worktree's slice of the daemon transcript.activity push
-      // (issue #24) — flips the tab turn-status loops to shared mode.
+      // This worktree's slice of the daemon transcript.activity push —
+      // flips the tab turn-status loops to shared mode.
       sharedActivity={transcriptActivity?.get(path) ?? null}
       // This task's slice of the hook-driven per-tab engine state — the
       // sub-second chip/notification source (poll stays as fallback).
@@ -149,7 +150,7 @@ export function ShowWorkspace(props: {
         if (taskId) props.onTabVisited?.(taskId, tabId)
       }}
       // A confirmed ESC interrupt (hook still claims running, live title
-      // says the engine rested — issue #15) is reported as the
+      // says the engine rested) is reported as the
       // `turn-interrupted` the engine's abort path never fires itself.
       onEngineInterrupt={(tabId) => {
         const taskId = props.task?.id

--- a/packages/kobe/src/tui-react/workspace/tab-strip.tsx
+++ b/packages/kobe/src/tui-react/workspace/tab-strip.tsx
@@ -1,7 +1,6 @@
 /** @jsxImportSource @opentui/react */
 /**
- * Workspace tab strip — React port of `tui/workspace/tab-strip.tsx` (issue
- * #16 React migration). The row of engine/command tabs above the embedded
+ * Workspace tab strip — the row of engine/command tabs above the embedded
  * terminal. Owns the per-tab turn chip and the turn-complete pulse: when a
  * tab's turn flips running→done, the chip and title flash emphasized for a
  * few frames before settling — a landing cue for work that finished while
@@ -41,8 +40,8 @@ export const TURN_GLYPHS: Record<ChatTabTurnState, string> = {
   error: "!",
   // Borrowed verbatim from the sidebar rail (row-view.ts) so the strip and
   // the rail never say different things about the same tab: `◷` a limit that
-  // clears itself, `†` an engine process that is gone. Both were `!` until
-  // 2026-08-30 — three states, one glyph, opposite required actions.
+  // clears itself, `†` an engine process that is gone. Distinct glyphs on
+  // purpose: they demand opposite actions, so one shared `!` would hide that.
   rate_limited: "◷",
   dead: "†",
   // Hook-only "blocked on the user" state — same ?/warning pairing as the
@@ -78,11 +77,10 @@ export function TabStrip(props: {
   turnVendors: ReadonlyMap<string, VendorId>
   /**
    * Tabs whose CURRENT completion the user has already looked at, from the
-   * durable `(task, tab) → seen-at` record the sidebar lamp reads (issue
-   * #23). Their `done` chip digests to the resting `○` — a finished turn
-   * you have read is simply over, the same "seen means consumed" rule the
-   * rail follows. Omitted (render tests, hosts without kv) = nothing seen,
-   * the pre-#23 behaviour.
+   * durable `(task, tab) → seen-at` record the sidebar lamp reads. Their
+   * `done` chip digests to the resting `○` — a finished turn you have read is
+   * simply over, the same "seen means consumed" rule the rail follows.
+   * Omitted (render tests, hosts without kv) = nothing seen.
    */
   seenTabs?: ReadonlySet<string>
 }) {
@@ -90,7 +88,7 @@ export function TabStrip(props: {
   const { theme } = themeCtx
   const kv = useKV()
   const dims = useTerminalDimensions()
-  // Off by default (owner call 2026-08-31): the sidebar tree already lists
+  // Off by default: the sidebar tree already lists
   // every worktree's tabs and marks the active one, so the strip is a second
   // copy of a list that is already on screen. Settings → General → Terminal
   // turns it back on.
@@ -99,7 +97,7 @@ export function TabStrip(props: {
     kv.get(TAB_STRIP_MODE_KEY, undefined),
     kv.get(TAB_STRIP_HIDE_SINGLE_KEY, undefined),
   )
-  // Narrow (issue #14) overrides the mode: the sidebar tree is not on screen
+  // Narrow mode overrides the setting: the sidebar tree is not on screen
   // beside a narrow workspace, so the condensed strip is the only tab
   // affordance there.
   const narrow = isNarrowWidth(dims.width)
@@ -158,11 +156,10 @@ export function TabStrip(props: {
     const nativeStatusVisible = visibleNativeStatus(tab, props.vendor, props.turnVendors.get(tab.id), liveTitle)
     const chipShown = !nativeStatusVisible && turn !== "unknown" && props.turnStates.has(tab.id)
     // Cap a single tab at the pane it lives in. Without this a long shell
-    // name (`a-very-long-shell-name…`) drew past the strip: the box is
-    // `overflow: hidden`, so the frame's right edge was clipped away and the
-    // title ran to the last column with no ellipsis — nothing on screen said
-    // it had been cut. The narrow form has always truncated; this is the same
-    // rule for the wide one.
+    // name (`a-very-long-shell-name…`) draws past the strip: the box is
+    // `overflow: hidden`, so the frame's right edge is clipped away and the
+    // title runs to the last column with no ellipsis — nothing on screen says
+    // it was cut. Same rule the narrow form follows.
     //
     // Truncating HERE, before `cells`, is what keeps the scroll math honest:
     // the offset is computed from these widths, so measuring the untruncated
@@ -172,7 +169,7 @@ export function TabStrip(props: {
       Math.max(MIN_TAB_TITLE_CELLS, dims.width - TAB_CHROME_CELLS - (chipShown ? 2 : 0)),
       approxCharCells,
     )
-    // Every tab is a bordered box now (2 cells of frame + 2 of padding) —
+    // Every tab is a bordered box (2 cells of frame + 2 of padding) —
     // the scroll math must see the same width it draws.
     const active = tab.id === props.activeId
     return { tab, turn, chipShown, title, cells: 4 + (chipShown ? 2 : 0) + displayWidth(title) }
@@ -204,7 +201,7 @@ export function TabStrip(props: {
 
   if (hidden) return null
 
-  /* --------- narrow condensed form (issue #14) --------------------------
+  /* --------- narrow condensed form -------------------------------------
    * At phone-SSH widths a row of tabs cannot fit: show only the ACTIVE
    * tab — turn chip + title truncated to the pane — with a right-stuck
    * `2/3` position counter. Tab-switching chords are unchanged; the

--- a/packages/kobe/src/tui-react/workspace/terminal-tabs-move.ts
+++ b/packages/kobe/src/tui-react/workspace/terminal-tabs-move.ts
@@ -1,5 +1,5 @@
 /**
- * Move a tab of ANY task — mounted or not (sidebar move mode, issue #43).
+ * Move a tab of ANY task — mounted or not (sidebar move mode).
  *
  * Same two routes as `closeTaskTab`, for the same reason: the sidebar tree
  * names tabs of tasks whose `TerminalTabs` may or may not be mounted, and the

--- a/packages/kobe/src/tui-react/workspace/terminal-tabs-persist.ts
+++ b/packages/kobe/src/tui-react/workspace/terminal-tabs-persist.ts
@@ -1,12 +1,11 @@
 /**
- * Persisted terminal-tab snapshot reclamation (O19) — the `terminalTabs.*` kv
- * keys `TerminalTabs.tsx` writes on every tab mutation (the whole splitTree +
- * pinned sessionId per task) were WRITE-ONLY: nothing ever deleted them, so a
- * high-churn build/delete workflow (fan-out is the product's basic move) grew
- * one orphan snapshot per deleted task forever, and because kv-core reads and
- * rewrites the whole file, every leftover key taxed every later tab write.
- * The web side already does the symmetric cleanup (kobe-web tabs.ts), so this
- * is a TUI-side gap, not a design choice.
+ * Persisted terminal-tab snapshot reclamation — the `terminalTabs.*` kv keys
+ * `TerminalTabs.tsx` writes on every tab mutation (the whole splitTree +
+ * pinned sessionId per task). Without a deleter they are WRITE-ONLY: a
+ * high-churn build/delete workflow (fan-out is the product's basic move)
+ * grows one orphan snapshot per deleted task forever, and because kv-core
+ * reads and rewrites the whole file, every leftover key taxes every later tab
+ * write. The web side does the symmetric cleanup (kobe-web tabs.ts).
  *
  * Two pure operations over a minimal kv surface (`set(key, undefined)` deletes
  * — kv-core's explicit-undefined serialization). Framework-free so both live

--- a/packages/kobe/src/tui-react/workspace/terminal-tabs-shared.ts
+++ b/packages/kobe/src/tui-react/workspace/terminal-tabs-shared.ts
@@ -25,10 +25,10 @@ import { type TabsSnapshotKv, forgetTaskTabsSnapshot, terminalTabsKey } from "./
  *
  *  WRITE THROUGH `setTaskTabs` / `deleteTaskTabs`, never `.set` / `.delete`
  *  directly: a plain Map mutation is invisible to React, and `ShowWorkspace`
- *  decides whether to mount `TerminalTabs` at all from this map. Closing a
- *  task's last tab wrote here and re-rendered nothing, so the component that
- *  owns the now-empty tab list stayed mounted and kept dereferencing an
- *  `active` tab that no longer existed. */
+ *  decides whether to mount `TerminalTabs` at all from this map. A raw
+ *  mutation when a task's last tab closes re-renders nothing, leaving the
+ *  component that owns the now-empty tab list mounted and dereferencing an
+ *  `active` tab that is gone. */
 export const tabsByTask = new Map<string, TabsState>()
 
 /** Bumped on every `tabsByTask` write — the subscribable half of the map, so
@@ -45,11 +45,10 @@ export function setTaskTabs(taskId: string, state: TabsState): void {
 /**
  * Revive a task whose last tab was closed, returning true when it did.
  *
- * Selecting the task is the affordance (owner call 2026-08-31): the sidebar
- * row IS the button, so entering an emptied task reopens the kind of tab that
- * was there rather than landing on a pane with nothing to press. A snapshot
- * from before `reopenAs` existed reopens the default engine tab — see
- * {@link reopenTabs}.
+ * Selecting the task is the affordance: the sidebar row IS the button, so
+ * entering an emptied task reopens the kind of tab that was there rather than
+ * landing on a pane with nothing to press. A snapshot carrying no `reopenAs`
+ * reopens the default engine tab — see {@link reopenTabs}.
  *
  * No-op for every other state: a task with tabs, and a task that has never
  * opened any (`null`, not empty — TerminalTabs mounts and mints its own).
@@ -101,12 +100,10 @@ export function knownTaskTab(kv: TabsSnapshotKv, taskId: string, tabId: string):
  *
  * The distinction is load-bearing because callers DELETE episodes that read
  * as unavailable. `knownTaskTab(...) !== undefined` collapses "don't know"
- * into "gone" and destroys live episodes — the owner-reported "two tabs are
- * unread but the Inbox only lists one" (40641c01). That fix converted the
- * host but left the dialog, its per-row badge, and the F7 jump on the binary
- * form, so the badge counted episodes the list hid and opening such a row
- * silently dismissed it instead of navigating. Route every availability
- * question through here.
+ * into "gone" and destroys live episodes: the list hides episodes the badge
+ * still counts, and opening such a row silently dismisses it instead of
+ * navigating. The host, the dialog, its per-row badge and the F7 jump must
+ * all route their availability question through here.
  */
 export function taskTabExists(kv: TabsSnapshotKv | null, taskId: string, tabId: string): boolean | undefined {
   const known = knownTaskTabs(kv, taskId)
@@ -183,7 +180,7 @@ export function requestTabOpen(
 
 /**
  * Cross-component "add a session to this task" request — the sidebar tree's
- * right-click "New conversation" / "New shell" (owner ask 2026-08-18).
+ * right-click "New conversation" / "New shell".
  *
  * Twin of {@link requestTabActivation}, not of {@link requestTabClose}: both
  * kinds need the task's OWN workspace (the picker is a dialog; a shell tab
@@ -289,8 +286,8 @@ export function takeUnclaimedTabAdopt(): { taskId: string; tabIds: readonly stri
 }
 
 /**
- * Cross-component "move this tab up/down" request (sidebar move mode, issue
- * #43) — same claim protocol as {@link requestTabClose}: the sidebar can name
+ * Cross-component "move this tab up/down" request (sidebar move mode) —
+ * same claim protocol as {@link requestTabClose}: the sidebar can name
  * a tab of a task whose TerminalTabs is not mounted, so an unclaimed request
  * is written in the background (`moveTaskTabRow`).
  */
@@ -377,7 +374,7 @@ export function reportTabsDelta(taskId: string, prev: readonly TerminalTab[], ne
 }
 
 /**
- * Reclaim a DELETED task's in-process + persisted tab state (O19): drop its
+ * Reclaim a DELETED task's in-process + persisted tab state: drop its
  * `tabsByTask` entry (module-level, otherwise only-grows) and its
  * `terminalTabs.*` kv snapshot. Call from the task-DELETE flow only. Its PTYs
  * are released separately by the host's deleting-task sweep / the tab's own

--- a/packages/kobe/src/tui-react/workspace/title-subscriptions.ts
+++ b/packages/kobe/src/tui-react/workspace/title-subscriptions.ts
@@ -1,43 +1,38 @@
 /**
  * Framework-free live-title subscription store — the ONE "ptyKey → live
  * foreground-process display title" reconciler shared by the workspace
- * terminal surfaces (O18). Before this, `use-turn-polls.ts` Pass 1 and
- * `TerminalSplit.tsx` each hand-wrote a lazy-attach-with-retry title
- * subscription pass, and they had DRIFTED apart: turn-polls compared PTY
- * INSTANCES (release + respawn at the same key drops the dead PTY's stale
- * title), while TerminalSplit only did a `has(id)` existence check keyed on
- * the bare leaf id — so a split leaf that respawned kept a subscription
- * pinned to the dead PTY (frozen title), and because TerminalSplit mounts
- * without a React key its instance survives tab switches while every tab's
- * leaves start at `leaf-1`, so a subscription from one tab's `leaf-1` bled
- * its title onto the next tab's `leaf-1`. Both bugs vanish once the reconcile
- * is instance-compared and keyed on the GLOBALLY-UNIQUE registry ptyKey
- * (`splitLeafPtyKey(tabKey, id)` / `soloKey(...)`), which is exactly what
- * this store does.
+ * terminal surfaces. Two properties are load-bearing, and a hand-written
+ * subscription pass tends to miss both:
  *
- * The correct reconcile logic is lifted verbatim from `use-turn-polls.ts`
- * Pass 1 (the already-verified writing): for each requested ptyKey, resolve
- * the registry PTY, (re)subscribe when the instance at that key changed, and
- * drop subscriptions whose key is no longer requested or whose PTY died.
+ *   - INSTANCE-compared, not `has(key)`: release + respawn at the same key
+ *     must re-subscribe, or the leaf keeps a subscription pinned to the dead
+ *     PTY and freezes on its last title.
+ *   - keyed on the GLOBALLY-UNIQUE registry ptyKey
+ *     (`splitLeafPtyKey(tabKey, id)` / `soloKey(...)`), not on the bare leaf
+ *     id: TerminalSplit mounts without a React key, so its instance survives
+ *     tab switches while every tab's leaves start at `leaf-1` — a bare-id
+ *     subscription bleeds one tab's title onto the next tab's `leaf-1`.
  *
- * The STORE keeps titles raw — the OSC stream IS the label (owner
- * 2026-08-01: "don't waste the OSC name"). It once collapsed an engine's
- * title to its binary ("✳ Claude Code" → "claude") via the live-engine
- * vendor, which (a) threw away the one line of live status the engine writes
- * and (b) FLICKERED: the ps-walk probe transiently loses a vendor mid-turn,
- * so labels flapped raw ↔ collapsed every probe tick. Identity (which
- * detector to attach) still comes from the process tree; display no longer
- * does.
+ * Reconcile is therefore: for each requested ptyKey, resolve the registry
+ * PTY, (re)subscribe when the instance at that key changed, and drop
+ * subscriptions whose key is unrequested or whose PTY died.
+ *
+ * The STORE keeps titles raw — the OSC stream IS the label. Collapsing an
+ * engine's title to its binary ("✳ Claude Code" → "claude") via the
+ * live-engine vendor would (a) throw away the one line of live status the
+ * engine writes and (b) FLICKER: the ps-walk probe transiently loses a vendor
+ * mid-turn, so labels would flap raw ↔ collapsed every probe tick. Identity
+ * (which detector to attach) comes from the process tree; display does not.
  *
  * What the RENDER projections below (and use-turn-polls' twin) do strip is
  * the engine's leading STATUS decoration — claude's `✳`/`⠂`/`⠐`, codex's
  * spinner frame — because kobe draws that state in its own glyph column and
- * showing both says it twice (owner 2026-08-10). That is a display concern,
+ * showing both says it twice. That is a display concern,
  * so it lives in the projection, not in the store, and the vocabulary is
  * declared per engine (`terminalTitle.statusPrefixes`). The name itself is
  * still never rewritten.
  *
- * No React, no Solid, no @opentui — plain closures over Maps, unit-testable
+ * No React, no @opentui — plain closures over Maps, unit-testable
  * under vitest. Callers own the tick that drives `reconcile()` (a PTY spawns
  * asynchronously after its Terminal mounts, so the attach must retry).
  */
@@ -87,7 +82,7 @@ export function createTitleSubscriptions(
       const wanted = new Set(ptyKeys)
       let changed = false
 
-      // Drop subscriptions no longer wanted OR whose PTY instance changed
+      // Drop subscriptions that are unwanted OR whose PTY instance changed
       // (release + respawn) — the dead PTY's title must not linger.
       for (const [key, sub] of subs) {
         const cur = wanted.has(key) ? lookup(key) : null
@@ -109,7 +104,7 @@ export function createTitleSubscriptions(
         // "this tab's live title is empty" instead of "nothing reported
         // yet", and the host records that over the tab's real `lastTitle`
         // (use-tab-turn-state), wiping the name to the vendor default a beat
-        // after the correct one rendered (owner report 2026-08-10).
+        // after the correct one rendered.
         const entry: Entry = { pty, unsub: () => {}, title: undefined }
         entry.unsub = pty.onTitleChange((raw) => {
           if (entry.title === raw) return
@@ -198,7 +193,7 @@ export function useTitleSubscriptions(ptyKeys: ReadonlyMap<string, string>): Rea
   // Title-change pushes (not caused by a reconcile) re-project the view.
   // Deferred one microtask (coalesced): a fresh subscription seeds its title
   // SYNCHRONOUSLY inside the store's reconcile loop, which must never be
-  // re-entered — the old setState tick got this asynchrony for free from React.
+  // re-entered.
   useEffect(() => {
     let active = true
     let scheduled = false

--- a/packages/kobe/src/tui-react/workspace/use-attention.ts
+++ b/packages/kobe/src/tui-react/workspace/use-attention.ts
@@ -1,5 +1,5 @@
 /**
- * Cross-task attention wiring for the native workspace host (P0):
+ * Cross-task attention wiring for the native workspace host:
  *
  *  1. Rising-edge notify — diff the previous vs current daemon activity each
  *     render and fire `notify()` for any NON-selected task that just crossed
@@ -10,13 +10,13 @@
  *
  *     The diff runs over the PER-TAB map, not the task-level one. The task
  *     entry is a last-event-wins rollup across every tab, and an edge only
- *     fires on a value CHANGE — so two tabs of one task finishing in a row
- *     left the rollup sitting at `turn_complete` and the second one never
- *     announced itself. Two agents finished, you heard about one. The daemon
- *     already keys its Inbox episodes `(taskId, tabId)`, so F7 was right the
- *     whole time; only the toast was lossy. Tasks whose engine reports no tab
- *     identity at all (a `claude` typed into a plain shell — no KOBE_TAB_ID)
- *     have no per-tab entry, so they keep notifying off the rollup.
+ *     fires on a value CHANGE — so diffing the rollup would leave it sitting
+ *     at `turn_complete` when two tabs of one task finish in a row, and the
+ *     second one would never announce itself. The daemon keys its Inbox
+ *     episodes `(taskId, tabId)`, so the per-tab map is the matching grain.
+ *     Tasks whose engine reports no tab identity at all (a `claude` typed
+ *     into a plain shell — no KOBE_TAB_ID) have no per-tab entry, so they
+ *     keep notifying off the rollup.
  *  2. Jump-to-next — F7 walks available pending items in the daemon-owned
  *     durable Inbox. Opening or visiting the target resolves the item and
  *     removes it from the queue.
@@ -55,8 +55,8 @@ export type NotifyTarget = { readonly taskId: string; readonly tabId: string }
  * keeps its task-level rollup entry. Never both: the rollup mirrors whichever
  * tab moved last, so emitting it alongside the tabs double-counts.
  *
- * Pure, so the edge behaviour that actually broke — two tabs of one task
- * finishing in a row — is testable without mounting the host.
+ * Pure, so the load-bearing edge — two tabs of one task finishing in a row —
+ * is testable without mounting the host.
  */
 export function notifyTargetStates(
   engineState: ReadonlyMap<string, TaskEngineState>,
@@ -66,8 +66,8 @@ export function notifyTargetStates(
   const targets = new Map<string, NotifyTarget>()
   for (const [taskId, es] of engineState) {
     const tabs = engineTabState?.get(taskId)
-    // Idle entries are KNOWN-idle tombstones (issue #11 — the accumulator
-    // keeps them so the sidebar can tell idle from unknown). They carry no
+    // Idle entries are KNOWN-idle tombstones (the accumulator keeps them so
+    // the sidebar can tell idle from unknown). They carry no
     // attention and must not make a task look "tab-covered": a task whose
     // only tab entries are tombstones still notifies from its rollup (an
     // untagged external session reports task-level only).
@@ -124,9 +124,8 @@ export function useAttention(args: {
     prevStates.current = next
     if (kv.get(CROSS_TASK_KEY, true) === false) return
     const repos = [...new Set(tasks.map((t) => t.repo))]
-    // One O(n) index build instead of a per-edge `tasks.find` scan: with a
-    // few hundred tasks and one edge each, the loop used to re-scan the
-    // whole array for every notification.
+    // One O(n) index build instead of a per-edge `tasks.find` scan, which
+    // re-scans the whole array once per notification.
     const taskById = new Map<string, Task>(tasks.map((task) => [task.id, task]))
     for (const { key, kind } of edges) {
       const target = targets.get(key)
@@ -148,7 +147,7 @@ export function useAttention(args: {
     }
   }, [engineState, engineTabState, selectedId, tasks, kv, notif])
 
-  // Deferred-prompt toast (issue #78 B): a `prompt_deferred` episode is
+  // Deferred-prompt toast: a `prompt_deferred` episode is
   // inbox-ONLY — the engine reported no activity (the blocked prompt never
   // reached it), so the engine-state rising-edge above never fires for it.
   // Diff the inbox episodes on their (task, tab, at) identity instead. Unlike
@@ -194,7 +193,7 @@ export function useAttention(args: {
         taskId: selectedId,
         tabId: selectedId ? activeTabIdFor(selectedId) : null,
       },
-      // Tri-state — a binary check made F7 skip episodes whose task simply
+      // Tri-state — a binary check makes F7 skip episodes whose task simply
       // hasn't mounted here and toast "nothing needs you".
       (item) =>
         isAttentionInboxItemAvailable(

--- a/packages/kobe/src/tui-react/workspace/use-editor-handles.tsx
+++ b/packages/kobe/src/tui-react/workspace/use-editor-handles.tsx
@@ -56,18 +56,18 @@ export function mentionAction(pasteToEngineFn: {
 export function useEditorHandles(opts: UseEditorHandlesOpts): UseEditorHandlesResult {
   const { orchestrator, worktree, selectedId, focus, notifyError } = opts
 
-  // Imperative handle from the currently-mounted TerminalTabs (issue #16):
-  // a ref, since FileTree's "open" only READS it at click time and
+  // Imperative handle from the currently-mounted TerminalTabs: a ref, since
+  // FileTree's "open" only READS it at click time and
   // TerminalTabs re-hands it on every mount (task/worktree switch).
   const openEditorTabFn = useRef<((command: readonly string[], label: string) => void) | null>(null)
   const sendToEngineFn = useRef<((text: string) => void) | null>(null)
   // Paste-only sibling of sendToEngineFn (no submit) — the FileTree `a` @path
   // mention, handed up through the same TerminalTabs mount-once contract.
   const pasteToEngineFn = useRef<((text: string) => void) | null>(null)
-  // Read-only diff tab opener (issue #21) — same ref pattern as the editor
-  // tab: TerminalTabs re-hands it per mount, FileTree's `d` reads it at
-  // keypress. Opening is a content swap; the host does NOT focus the
-  // workspace here (KOB-25 — a read-only open must not pull focus).
+  // Read-only diff tab opener — same ref pattern as the editor tab:
+  // TerminalTabs re-hands it per mount, FileTree's `d` reads it at keypress.
+  // Opening is a content swap; the host does NOT focus the workspace here — a
+  // read-only open must not pull focus.
   const openDiffTabFn = useRef<((relPath: string, label: string, base?: string) => void) | null>(null)
 
   // Identity guard for the async actions below: after an await, the selected

--- a/packages/kobe/src/tui-react/workspace/use-file-open-actions.ts
+++ b/packages/kobe/src/tui-react/workspace/use-file-open-actions.ts
@@ -49,7 +49,8 @@ export function useFileOpenActions(deps: {
       return opened("external")
     }
     // Stale continuation: the user switched tasks while the editor resolved —
-    // the file belongs to the old worktree, not whatever tab mount is live now.
+    // the file belongs to the worktree it was resolved against, not whatever
+    // tab mount is live now.
     if (selectedWorktreeRef.current !== wt || openEditorTabFn.current !== openEditorTab) return
     openEditorTab?.(["sh", "-c", launch.command], launch.label)
     opened("editor")
@@ -57,7 +58,7 @@ export function useFileOpenActions(deps: {
   }
 
   // Deliberately NO `focus.setFocused` — a read-only open is a content swap,
-  // not a navigation (KOB-25), so the FileTree keeps keyboard focus.
+  // not a navigation, so the FileTree keeps keyboard focus.
   function openDiff(relPath: string, base?: string): void {
     const label = pathLeaf(relPath)
     openDiffTabFn.current?.(relPath, label, base)

--- a/packages/kobe/src/tui-react/workspace/use-inbox-host.ts
+++ b/packages/kobe/src/tui-react/workspace/use-inbox-host.ts
@@ -97,7 +97,7 @@ export function useInboxHost(args: {
   }, [unavailableSignature, orch])
 
   /**
-   * Release a `prompt_deferred` episode (issue #78 B exit path). The text is
+   * Release a `prompt_deferred` episode. The text is
    * fetched from the daemon store (the episode carries only its id), inserted
    * with a FRESH A/C gate, and — only on success — resolved. The gate still
    * blocking means the human is typing again; the message stays queued.
@@ -111,7 +111,7 @@ export function useInboxHost(args: {
       const record = await orch.getDeferredPrompt(deferredId)
       if (!record) {
         // The record was released or cleaned up after expiry — drop the stale
-        // episode so it doesn't point at a record that no longer exists.
+        // episode so it doesn't point at a record that is gone.
         notifyInboxRpcFailure(orch.dismissAttention(item.taskId, item.tabId, item.at), "dismiss", args.notifyError)
         return
       }

--- a/packages/kobe/src/tui-react/workspace/use-issue-chat.ts
+++ b/packages/kobe/src/tui-react/workspace/use-issue-chat.ts
@@ -18,8 +18,8 @@
  *                         (the viewport tab is active).
  *   - `project`         — no worktree: a NEW chattab appended to the main
  *                         workspace, running on the project checkout with
- *                         the story prompt riding its spawn (a busy tab-1
- *                         can no longer swallow the prompt). Jump = enter
+ *                         the story prompt riding its spawn, so a busy tab-1
+ *                         cannot swallow it. Jump = enter
  *                         the project workspace.
  *
  * Image references need no side channel — `images[N]: /path` placeholder

--- a/packages/kobe/src/tui-react/workspace/use-scratch-adopt.ts
+++ b/packages/kobe/src/tui-react/workspace/use-scratch-adopt.ts
@@ -1,12 +1,12 @@
 /**
- * Scratch-task adoption loop (issues #33/#40) — the React binding over the
+ * Scratch-task adoption loop — the React binding over the
  * pure `decideScratchAdopt`. Every poll tick it asks, for each scratch task
  * with an attached live shell: where has the shell settled (live cwd → repo
  * main root), and is a coding harness confirmed running in it (the
  * live-engine store's walk — same confidence bar as tab identity). Both
  * true → the pure decision picks one of two moves:
  *
- *   - `fold` (issue #40): the cwd already belongs to an existing task —
+ *   - `fold`: the cwd already belongs to an existing task —
  *     the shell (engine session and all) becomes that task's new terminal
  *     tab via `foldScratchShell`, and the emptied scratch row is deleted.
  *     No new task is minted, so the sidebar never grows a duplicate row

--- a/packages/kobe/src/tui-react/workspace/use-scratch-shell.ts
+++ b/packages/kobe/src/tui-react/workspace/use-scratch-shell.ts
@@ -1,8 +1,8 @@
 /**
- * Scratch temp shell tasks (issue #33) — the host-side lifecycle wiring:
+ * Scratch temp shell tasks — the host-side lifecycle wiring:
  *
- *   - `openScratchShell` (ctrl+e dialog's trailing "scratch shell" choice —
- *     the prefix+t chord was rejected, owner 2026-08-16): create a scratch
+ *   - `openScratchShell` (the ctrl+e dialog's trailing "scratch shell" choice,
+ *     the only entry point — there is no chord): create a scratch
  *     dir task rooted at $HOME and enter it. The task's tab-1 spawns as a
  *     bare shell (TerminalTabs' scratch mode); the row lives in the
  *     sidebar's Scratch section.
@@ -12,7 +12,7 @@
  *     UNFORCED: `kind: "dir"` already skips the dirty gate and never removes
  *     the directory, so `force` here would only be a standing licence to
  *     destroy a real worktree if the row's kind ever changed.
- *   - the fold finish (issue #40): the adoption loop moved the shell's
+ *   - the fold finish: the adoption loop moved the shell's
  *     sessions under an existing task — quietly re-point selection to the
  *     folded tab (ONLY when the scratch row was the selected one; a
  *     background fold must not move the user), then delete the emptied
@@ -34,7 +34,7 @@ import { useScratchAdopt } from "./use-scratch-adopt"
 
 /** Task ids whose scratch teardown already started — module-level so the
  *  guard survives the hook being rebuilt every render. Never cleared: a
- *  torn-down scratch task's id is retired with it. */
+ *  torn-down scratch task's id stays in the set for the process's life. */
 const scratchTeardowns = new Set<string>()
 
 export function useScratchShell(deps: {
@@ -54,7 +54,7 @@ export function useScratchShell(deps: {
   const { orchestrator, enterTask, forgetTaskTabs, notifyError } = deps
 
   // The quiet cwd+harness adoption loop rides along: one hook is the whole
-  // scratch lifecycle from the host's perspective. Fold (issue #40) hands
+  // scratch lifecycle from the host's perspective. The fold hands
   // back here for the selection follow-up + row deletion.
   useScratchAdopt({
     tasks: deps.tasks,
@@ -70,9 +70,9 @@ export function useScratchShell(deps: {
       }
       // No `force`: a scratch row is `kind: "dir"`, and BOTH deletion gates
       // already special-case that kind (the dirty check is skipped, and
-      // `finish()` never removes a dir task's directory). So `force` bought
-      // nothing here — it only stood ready to authorise a real destructive
-      // removal if this row ever stopped being a dir task.
+      // `finish()` never removes a dir task's directory). So `force` would
+      // buy nothing here — it would only stand ready to authorise a real
+      // destructive removal if this row ever stopped being a dir task.
       await orchestrator.deleteTask(scratchTaskId)
       forgetTaskTabs(scratchTaskId)
     },
@@ -88,7 +88,7 @@ export function useScratchShell(deps: {
   }
 
   const onScratchExit = (taskId: string): void => {
-    // Idempotence: ctrl+w on the last tab (issue #42) kills the live PTY,
+    // Idempotence: ctrl+w on the last tab kills the live PTY,
     // whose exit event re-enters this teardown before the delete lands —
     // the second call would surface a spurious "task not found" toast.
     if (scratchTeardowns.has(taskId)) return

--- a/packages/kobe/src/tui-react/workspace/use-tab-close.ts
+++ b/packages/kobe/src/tui-react/workspace/use-tab-close.ts
@@ -8,10 +8,10 @@
  *
  * The four exits a tab has, and why they differ:
  *
- *   - `closeActive`   — ctrl+w. Closes the last tab too (owner call
- *     2026-08-31), leaving the task with none: its sidebar row stays and
- *     re-opens on ⏎ / ctrl+e. On a scratch task the last tab still tears the
- *     task down instead (issue #42) — its whole life IS that one shell.
+ *   - `closeActive`   — ctrl+w. Closes the last tab too, leaving the task
+ *     with none: its sidebar row stays and re-opens on ⏎ / ctrl+e. On a
+ *     scratch task the last tab tears the task down instead — its whole life
+ *     IS that one shell.
  *   - `closeById`     — a close named from OUTSIDE the component (the sidebar
  *     tree's menu). Same semantics as ctrl+w minus the toast.
  *   - `closeExited`   — the tab's process ended. No viewport carve-out is
@@ -50,11 +50,11 @@ export interface TabCloseDeps {
    *  they survive this hook being rebuilt every render. */
   readonly resumeTriedRef: { readonly current: Set<string> }
   /** Surface a refused close. Reachable only on a scratch task whose
-   *  teardown hook is missing — an ordinary task's last tab now closes. */
+   *  teardown hook is missing — an ordinary task's last tab closes. */
   readonly notifyCannotCloseLast: (tabId: string) => void
-  /** Scratch task (issue #33): the LAST tab going away — its shell exiting
-   *  OR ctrl+w on it (issue #42) — ends the task itself (the host deletes
-   *  the row) instead of recycling/refusing. Absent on ordinary tasks. */
+  /** Scratch task: the LAST tab going away — its shell exiting OR ctrl+w on
+   *  it — ends the task itself (the host deletes the row) instead of
+   *  recycling/refusing. Absent on ordinary tasks. */
   readonly onScratchExit?: () => void
 }
 
@@ -68,7 +68,7 @@ export interface TabClose {
 export function useTabClose(deps: TabCloseDeps): TabClose {
   const taskId = (): string => deps.propsRef.current.taskId
 
-  /** Auto-close (issue #16): a tab closes itself when its process exits and
+  /** Auto-close: a tab closes itself when its process exits and
    *  releases its PTY. Reads the FRESH state — exit events can arrive from a
    *  stale render (see `handleActiveExit`). */
   function closeExited(id: string): void {
@@ -89,10 +89,9 @@ export function useTabClose(deps: TabCloseDeps): TabClose {
   function closeById(id: string): void {
     const current = deps.stateRef.current
     const closing = current.tabs.find((tab) => tab.id === id)
-    // A task may be closed down to zero tabs (owner call 2026-08-31): its
-    // sidebar row stays and re-opens on ⏎ / ctrl+e. Scratch tasks keep the
-    // old shape — their last tab going away ends the task, which
-    // `closeActive` routes through `onScratchExit`.
+    // A task may be closed down to zero tabs: its sidebar row stays and
+    // re-opens on ⏎ / ctrl+e. Scratch tasks differ — their last tab going
+    // away ends the task, which `closeActive` routes through `onScratchExit`.
     const { state: next, closedId } = closeTab(current, id, { allowEmpty: deps.onScratchExit === undefined })
     // Refused: nothing named `id`, or a scratch task's last tab.
     if (!closedId) return
@@ -111,7 +110,7 @@ export function useTabClose(deps: TabCloseDeps): TabClose {
         ? closeTab(current, current.activeId, { allowEmpty: true })
         : closeActiveTab(current)
     if (!closedId) {
-      // Scratch task (issue #42): ctrl+w on its only tab tears down the
+      // Scratch task: ctrl+w on its only tab tears down the
       // whole task — same zero-ceremony semantics (and same path) as the
       // shell exiting on its own. Ordinary tasks keep the refusal toast.
       if (deps.onScratchExit) {
@@ -131,8 +130,8 @@ export function useTabClose(deps: TabCloseDeps): TabClose {
     // An exit event can be the echo of an intentional ctrl+w: closing kills
     // the PTY, which fires onExit into a STALE render before React swaps the
     // Terminal. If the tab is already gone from the fresh state there is
-    // nothing to do — acting on the stale snapshot resurrected the closed tab
-    // (the "ctrl+w needs two presses" bug).
+    // nothing to do — acting on the stale snapshot resurrects the closed tab,
+    // which reads as "ctrl+w needs two presses".
     if (!deps.stateRef.current.tabs.some((tab) => tab.id === active.id)) return
     // Policy is pure (`tabExitAction`): a live exit means the tab's SHELL
     // ended (engines run inside it — `shellSpawn`), so the tab closes; a
@@ -150,7 +149,7 @@ export function useTabClose(deps: TabCloseDeps): TabClose {
       closeExited(active.id)
       return
     }
-    // Scratch task (issue #33): the last shell exiting IS the end of the
+    // Scratch task: the last shell exiting IS the end of the
     // task — zero ceremony, the row disappears. No recycle: a scratch task
     // has no engine to respawn into.
     if (deps.onScratchExit) {
@@ -160,7 +159,7 @@ export function useTabClose(deps: TabCloseDeps): TabClose {
     }
     // Last tab: the strip can never be empty — recycle it in place as a fresh
     // engine tab (new session) instead of freezing on the exit banner.
-    // `recycleTabs` carries the old tab's title/autoTitle so the recycle does
+    // `recycleTabs` carries the outgoing tab's title/autoTitle so the recycle does
     // not visibly rename the tab.
     getDefaultPtyRegistry().release(tabPtyKeyFor(taskId(), active))
     deps.resumeTriedRef.current.clear()

--- a/packages/kobe/src/tui-react/workspace/use-tab-dialogs.ts
+++ b/packages/kobe/src/tui-react/workspace/use-tab-dialogs.ts
@@ -1,20 +1,19 @@
 /**
  * Tab-strip dialog flows: rename (F2) and the unified new-conversation dialog
- * (issue #7) — the places the component ASKS the user something, kept apart
- * from the places it acts. Pure composition over the injected deps: no state
- * of its own, so every closure reads the CURRENT
- * render's `state`/`active` (the caller re-creates this hook's return every
- * render, same freshness contract as the inline originals).
+ * — the places the component ASKS the user something, kept apart from the
+ * places it acts. Pure composition over the injected deps: no state of its
+ * own, so every closure reads the CURRENT render's `state`/`active` (the
+ * caller re-creates this hook's return every render).
  *
- * `requestNewChat` replaces the old separate choose-engine / chat-fork /
- * quick-fork flows: one dialog (`NewChatDialog`), two toggles, four combos:
+ * `requestNewChat` is the single entry: one dialog (`NewChatDialog`), two
+ * toggles, four combos:
  *
- *   destination=tab  + context=fresh    → new tab here (old ctrl+e enter,
+ *   destination=tab  + context=fresh    → new tab here (ctrl+e enter,
  *                                         incl. shell / plugin panes)
  *   destination=tab  + context=continue → fork/handoff sibling tab
- *                                         (old `ctrl+a c`)
+ *                                         (`ctrl+a c`)
  *   destination=fork + context=fresh    → QuickTaskComposer child task
- *                                         (old `ctrl+a f`)
+ *                                         (`ctrl+a f`)
  *   destination=fork + context=continue → composer, first prompt led by the
  *                                         transcript handoff brief
  */
@@ -74,7 +73,7 @@ export function useTabDialogs(deps: {
   activeLeafSize: () => { cols: number; rows: number } | null
   onChooseEngine?: (vendor: VendorId) => void
   onQuickFork?: (repo: string, result: QuickTaskResult) => void
-  /** The dialog's trailing "scratch shell" choice (issue #33): open a
+  /** The dialog's trailing "scratch shell" choice: open a
    *  Scratch temp shell task. Absent = the choice isn't offered. */
   onOpenScratch?: () => void
   /** Toast for the "nothing to continue from" refusals. */
@@ -106,7 +105,7 @@ export function useTabDialogs(deps: {
     )
 
   /** destination=tab: land the picked engine as a sibling tab — fresh
-   *  (plain `addTab`) or continuing (fork/handoff, old `ctrl+a c`).
+   *  (plain `addTab`) or continuing (fork/handoff, `ctrl+a c`).
    *  `tabVendor` is the id the active tab was LAUNCHED under, `source` the
    *  protocol it speaks; picking that same id is "continue here", so it
    *  continues under the same protocol rather than reading as a handoff to a
@@ -130,8 +129,8 @@ export function useTabDialogs(deps: {
     }
   }
 
-  /** destination=fork: the QuickTaskComposer child-task flow (old
-   *  `ctrl+a f`), seeded from THIS task's repo/branch and the dialog's
+  /** destination=fork: the QuickTaskComposer child-task flow (`ctrl+a f`),
+   *  seeded from THIS task's repo/branch and the dialog's
    *  engine pick. With context=continue the created task's first prompt
    *  opens on the transcript handoff brief, then the user's own prompt. */
   const forkChildTask = async (
@@ -170,8 +169,8 @@ export function useTabDialogs(deps: {
       const tabVendor = (active.kind === "engine" ? active.vendor : undefined) ?? deps.vendor
       const source = liveSourceProtocol(active, tabVendor)
       const available = await availableEngineIds()
-      // Installed plugin panes ride the same picker (owner ask 2026-07-29):
-      // ctrl+e is "what runs in this tab", and a pane is exactly that. Reads
+      // Installed plugin panes ride the same picker: ctrl+e is "what runs in
+      // this tab", and a pane is exactly that. Reads
       // the local registry synchronously — a handful of small files. Only
       // offered in the default combo (the dialog filters otherwise).
       let panes: PaneLaunch[] = []
@@ -212,9 +211,8 @@ export function useTabDialogs(deps: {
         update(openCommandTab(state, [defaultShell()], null))
         return
       }
-      // "scratch" = a whole Scratch temp shell TASK, not a tab of this one
-      // (issue #33 — owner entry point 2026-08-16, replacing the rejected
-      // prefix+t chord).
+      // "scratch" = a whole Scratch temp shell TASK, not a tab of this one.
+      // This menu entry is its only entry point; there is no chord.
       if (choice.pick === "scratch") {
         deps.onOpenScratch?.()
         return

--- a/packages/kobe/src/tui-react/workspace/use-tab-handoffs.ts
+++ b/packages/kobe/src/tui-react/workspace/use-tab-handoffs.ts
@@ -44,7 +44,7 @@ export interface TabHandoffIO {
 type EnginePtyIO = Pick<TabHandoffIO, "stateRef" | "propsRef" | "engineTabSpawnRef">
 
 /** The engine tab's live PTY — the active tab when it's an engine, else the
- *  first engine tab; a parked background tab (issue #28) is re-acquired
+ *  first engine tab; a parked background tab is re-acquired
  *  (reattach + replay, then the paste lands). Reads everything through the
  *  latest-render refs, so one closure stays valid for the mount's life. */
 function resolveEnginePty(io: EnginePtyIO): ReturnType<ReturnType<typeof getDefaultPtyRegistry>["get"]> | null {
@@ -119,10 +119,10 @@ export function useTabHandoffs(io: TabHandoffIO): {
     })
   }, [])
 
-  // Read-only diff/preview tab (issue #21): the FileTree `d` action. A
-  // content swap, NOT a focus grab — `openContentTab` selects the tab but
-  // the host never calls `focus.setFocused` here (KOB-25), so keyboard focus
-  // stays on the FileTree that opened it.
+  // Read-only diff/preview tab: the FileTree `d` action. A content swap, NOT
+  // a focus grab — `openContentTab` selects the tab but the host never calls
+  // `focus.setFocused` here, so keyboard focus stays on the FileTree that
+  // opened it.
   // biome-ignore lint/correctness/useExhaustiveDependencies: mount-once handoff; the callback reads propsRef/stateRef for freshness.
   useEffect(() => {
     propsRef.current.onDiffTabReady?.((relPath, label, base) => {

--- a/packages/kobe/src/tui-react/workspace/use-tab-lifecycle.ts
+++ b/packages/kobe/src/tui-react/workspace/use-tab-lifecycle.ts
@@ -1,6 +1,6 @@
 /**
- * Mount-once tab-lifecycle effects: restart-resume verification (issue #22)
- * and the tab auto-naming poll (the tmux naming pass) — grouped with
+ * Mount-once tab-lifecycle effects: restart-resume verification and the tab
+ * auto-naming poll — grouped with
  * `use-tab-handoffs.ts` by lifetime, not by topic: what these have in common
  * is running once per mount and living forever. Both are mount-only, forever-
  * lived effects — everything they read comes through the caller's
@@ -22,7 +22,7 @@ import {
   setTabSpawned,
 } from "../../tui/workspace/terminal-tabs-core"
 
-/** Cadence of the tab auto-naming pass (tmux ran its pass on the monitor tick). */
+/** Cadence of the tab auto-naming pass. */
 const NAMING_POLL_MS = 5000
 
 /**
@@ -41,7 +41,7 @@ export interface TabLifecycleIO {
 }
 
 /**
- * Restart resume verification (issue #22): rehydrated tabs' `spawned`
+ * Restart resume verification: rehydrated tabs' `spawned`
  * flags are up to 5s stale and must be re-verified against the real
  * transcripts before anything spawns. Returns the `hydrating` gate —
  * while true, the caller must not mount anything that spawns.
@@ -73,8 +73,8 @@ export function useTabHydration(rehydrated: boolean, io: TabLifecycleIO): boolea
             }
             // Ask whether the session is RECORDED, not whether kobe can
             // parse its messages: `readHistory` is empty for engines that
-            // ship no message parser (kimi), so the old check reported
-            // every kimi session as absent and the tab respawned blank.
+            // ship no message parser (kimi), so a parse-based check reports
+            // every kimi session as absent and the tab respawns blank.
             const exists = await engineSessionExists(vendor, worktree, tab.sessionId)
             if (cancelled) return
             io.update(setTabSpawned(io.stateRef.current, tab.id, exists))
@@ -91,7 +91,7 @@ export function useTabHydration(rehydrated: boolean, io: TabLifecycleIO): boolea
   return hydrating
 }
 
-/** Auto-naming + existence tracking (the tmux naming pass), mount-only. */
+/** Auto-naming + existence tracking, mount-only. */
 export function useTabNaming(io: TabLifecycleIO): void {
   // biome-ignore lint/correctness/useExhaustiveDependencies: mount-once interval; reads propsRef/stateRef for freshness.
   useEffect(() => {
@@ -103,7 +103,7 @@ export function useTabNaming(io: TabLifecycleIO): void {
      * id the engine reports in its OWN live title — codex writes its thread
      * UUID there until the thread is named, and that thread is exactly the
      * rollout holding the first prompt. Without the second source a codex tab
-     * had no session to name itself from and wore `codex N` forever.
+     * has no session to name itself from and wears `codex N` forever.
      */
     const namingSessionId = (tab: EngineTab): string | null =>
       tab.sessionId ?? engineSessionIdFromTitle(vendorOf(tab), tab.lastTitle ?? "")

--- a/packages/kobe/src/tui-react/workspace/use-tab-turn-state.ts
+++ b/packages/kobe/src/tui-react/workspace/use-tab-turn-state.ts
@@ -4,20 +4,19 @@
  * quiescence poll, still the source for `liveTitles`/`turnVendors` and the
  * no-hooks fallback) and merges the daemon's hook-driven per-tab engine
  * state over it (`turn-state-merge.ts`, hook-wins per tabId). Also owns the
- * per-tab background-attention notifications that used to live inline in
- * `TerminalTabs`: a rising edge into done/error/needs_input on a NON-active
+ * per-tab background-attention notifications: a rising edge into
+ * done/error/needs_input on a NON-active
  * tab fires `notif.notify` (toast + unread). Edge detection is the shared
  * framework-free `attentionEdges` (seed rule inside — a fresh mount's
  * replayed sticky `turn_complete` paints the ✓ chip but never re-fires a
  * toast; `TerminalTabs` remounts per worktree via `key={path}`, so task
  * switches re-seed).
  *
- * Also owns the strip's half of the DURABLE seen bit (issue #23). The chip
- * used to be backed by a purely in-process unread map, so a completion you
- * had already read came back looking fresh after a restart while the
- * sidebar lamp — persisted since issue #22 — said otherwise. Both surfaces
- * now read and write the one `(task, tab) → seen-at` record in
- * `completion-seen.ts`; the strip must keep its own write because the rail
+ * Also owns the strip's half of the DURABLE seen bit. A purely in-process
+ * unread map would make a completion you already read look fresh again after
+ * a restart while the persisted sidebar lamp said otherwise, so both surfaces
+ * read and write the one `(task, tab) → seen-at` record in
+ * `completion-seen.ts`. The strip must keep its own write because the rail
  * is not always mounted (narrow layout hides it behind the workspace, which
  * is exactly where the strip is the only tab affordance).
  */
@@ -55,9 +54,9 @@ export function useTabTurnState(deps: {
   /** Task title — the toast's context line under the tab label. */
   taskTitle?: string
   notif: NotificationsContext
-  /** Tab-state writer — used to RECORD each tab's latest live title. */
+  /** Tab-state writer — RECORDS each tab's latest live title. */
   update?: (next: TabsState) => void
-  /** Confirmed ESC interrupt on a hook-running tab (issue #15) — the host
+  /** Confirmed ESC interrupt on a hook-running tab — the host
    *  reports it to the daemon as a `turn-interrupted` engine event. */
   onEngineInterrupt?: (tabId: string) => void
 }): {
@@ -71,7 +70,7 @@ export function useTabTurnState(deps: {
 
   const turnStates = useMemo(() => mergeTurnStates(deps.hookTabStates, pollStates), [deps.hookTabStates, pollStates])
 
-  // ESC-interrupt watch (issue #15): a hook-claimed `running` tab whose RAW
+  // ESC-interrupt watch: a hook-claimed `running` tab whose RAW
   // live title flipped to the engine's resting form ended its turn without
   // any hook (claude-code's abort path runs none). The observer owns the
   // Stop-race debounce; both callbacks read LIVE state through refs so a
@@ -128,8 +127,8 @@ export function useTabTurnState(deps: {
       // The engine this tab was running is gone (vendor → confirmed null):
       // reset the tab to the shell it always was, BEFORE recording the new
       // identity. `kind` describes what runs here now — leaving it at
-      // "engine" is what kept a dot on the sidebar row and made every
-      // keystroke mark an optimistic turn for a session that had exited.
+      // "engine" keeps a dot on the sidebar row and makes every keystroke
+      // mark an optimistic turn for a session that has exited.
       const tab = next.tabs.find((t) => t.id === tabId)
       const demoted = tab ? demoteExitedEngine(tab, tab.liveVendor, live, [defaultShell()]) : undefined
       if (tab && demoted && demoted !== tab) {
@@ -177,14 +176,13 @@ export function useTabTurnState(deps: {
 }
 
 /**
- * Read + record the durable completion-seen marks for this task's tabs
- * (issue #23) — the strip's counterpart to the sidebar row's
- * `useDurableCompletionSeen`.
+ * Read + record the durable completion-seen marks for this task's tabs — the
+ * strip's counterpart to the sidebar row's `useDurableCompletionSeen`.
  *
  * Only a HOOK-reported completion carries the stamp the mark is keyed on;
  * the quiescence poll infers `done` with no timestamp, so a poll-only tab
- * simply never digests (the pre-#23 behaviour) rather than being marked
- * seen against a stamp we made up. The write is an effect for the same
+ * simply never digests rather than being marked seen against a stamp we made
+ * up. The write is an effect for the same
  * reason the rail's is: `kv.set` re-renders every KV consumer.
  */
 export function useDurableTabSeen(

--- a/packages/kobe/src/tui-react/workspace/use-task-selection.ts
+++ b/packages/kobe/src/tui-react/workspace/use-task-selection.ts
@@ -72,10 +72,10 @@ export async function activateWorkspaceTask(opts: ActivateWorkspaceTaskOptions, 
  * freshly-respawned daemon can replay a null/ancient focus while disk still
  * knows the truth) → the most recently UPDATED live task. Raw array order is
  * never used as a tiebreak — tasks.json leads with the oldest saved repo's
- * main task, which is how every SSH reconnect used to land on an untouched
- * project instead of the one being worked on.
+ * main task, so array order lands every SSH reconnect on an untouched project
+ * instead of the one being worked on.
  *
- * The recency fallback SKIPS a routine's standing session (issue #91): a
+ * The recency fallback SKIPS a routine's standing session: a
  * schedule that fired at 03:00 makes it the most recently updated task in the
  * install, but it is the least likely thing you meant to open — and its
  * sidebar row is folded away, so booting onto it would leave the cursor on a

--- a/packages/kobe/src/tui-react/workspace/use-turn-polls.ts
+++ b/packages/kobe/src/tui-react/workspace/use-turn-polls.ts
@@ -1,22 +1,21 @@
 /**
- * Per-tab turn-state polling for the workspace terminal tabs — React port
- * of `tui/workspace/turn-polls.ts` (issue #16 React migration). Same
- * `startTurnStatusPoll` loop the Ops pane runs, with PTY IO in place of
- * tmux capture-pane; shared mode when the host passes the daemon's
- * transcript.activity slice, local fixed-cadence fallback otherwise.
+ * Per-tab turn-state polling for the workspace terminal tabs. The same
+ * `startTurnStatusPoll` loop the Ops pane runs, reading PTY output; shared
+ * mode when the host passes the daemon's transcript.activity slice, local
+ * fixed-cadence fallback otherwise.
  *
- * Unified process-identity model (owner 2026-07-07): every tab is a shell;
+ * Unified process-identity model: every tab is a shell;
  * an engine is just a process running in it. A tab gets a turn detector
  * attached whenever its foreground process IS an engine — kobe-launched
  * (an engine tab with a live engine leaf) OR user-typed (`claude` in a
  * plain shell, detected from the PTY's OSC window title via
  * `vendorFromTerminalTitle`), detaching again the moment the title stops
- * matching. `targetFor`/`soloKey` (identity resolution) are the shared
- * framework-free `turn-target.ts` — the Solid original and this hook use
- * the exact same rule. The same title stream feeds `liveTitles` — the tab
- * strip's dynamic "$process $ordinal" default names.
+ * matching. `targetFor`/`soloKey` (identity resolution) live in the shared
+ * framework-free `turn-target.ts`, so every surface resolves identity by one
+ * rule. The same title stream feeds `liveTitles` — the tab strip's dynamic
+ * "$process $ordinal" default names.
  *
- * Solid→React deltas: the reconcile pass is a STABLE callback reading its
+ * Freshness rules: the reconcile pass is a STABLE callback reading its
  * changing inputs through latest-render refs; a `useEffect` keyed on
  * `[taskId, worktree, vendor, state]` re-runs it whenever the tabs snapshot
  * changes, and the 2s lazy-attach tick + title-store pushes call it
@@ -27,8 +26,8 @@
  * mirroring `ops/host.tsx`'s `sharedMapRef` convention. The `turnPolls` Map
  * lives in a ref so it persists across renders without becoming React state
  * churn; the per-tab live-title tracking is the shared framework-free
- * `TitleSubscriptions` store (O18) — the same instance-compared reconcile
- * this hook used to hand-write, now shared with `TerminalSplit.tsx`.
+ * `TitleSubscriptions` store, whose instance-compared reconcile
+ * `TerminalSplit.tsx` uses too.
  */
 
 import { useCallback, useEffect, useRef, useState } from "react"
@@ -171,7 +170,7 @@ export function useTurnPolls(deps: {
           // Marker-less engines (copilot/kimi-without-hooks) classify the
           // capture declaratively instead of publishing "unknown".
           ...(entry.screenManifest ? { screenManifest: entry.screenManifest } : {}),
-          // Shared mode (issue #24): the daemon's transcript.activity push
+          // Shared mode: the daemon's transcript.activity push
           // supplies completion reads + drives the adaptive capture
           // cadence; null (no daemon data) falls back to fixed-cadence
           // local polling — the Ops pane's exact contract.
@@ -199,7 +198,7 @@ export function useTurnPolls(deps: {
       attached.add(tabId)
     }
 
-    // Tabs whose process is no longer an engine (closed, degraded, or the
+    // Tabs whose process is not an engine any more (closed, degraded, or the
     // user-typed engine exited back to the prompt) stop polling.
     for (const [id, poll] of turnPolls) {
       if (attached.has(id)) continue
@@ -227,8 +226,7 @@ export function useTurnPolls(deps: {
   // identity — re-evaluate attach/detach the moment a user-typed engine
   // announces itself, not on the next slow tick. Deferred one microtask
   // (coalesced): a fresh subscription seeds its title SYNCHRONOUSLY inside
-  // the store's reconcile loop, which must never be re-entered — the old
-  // setState tick got this asynchrony for free from React.
+  // the store's reconcile loop, which must never be re-entered.
   useEffect(() => {
     let active = true
     let scheduled = false

--- a/packages/kobe/src/tui-react/workspace/use-workspace-selection.ts
+++ b/packages/kobe/src/tui-react/workspace/use-workspace-selection.ts
@@ -71,7 +71,7 @@ export function useWorkspaceSelection(args: {
         return
       }
     }
-    // Boot lands IN the restored session (owner 2026-08-09): reopening kobe
+    // Boot lands IN the restored session: reopening kobe
     // resumes where you quit, so the content pane — not the sidebar — should
     // hold focus. One-shot, only while the user hasn't picked anything yet;
     // a boot with no restorable task leaves the sidebar focused (cold-start
@@ -80,23 +80,23 @@ export function useWorkspaceSelection(args: {
       bootFocusRef.current = true
       args.focusWorkspace()
     }
-    // A deleting task is NOT a valid selection (issue #34): the snapshot
-    // still contains it, but its sidebar row is gone (#473) and the PTY sweep
-    // below kills its sessions — leaving selection on it kept its Terminal
-    // mounted, which answered the kill with a dead-on-attach RESUME.
+    // A deleting task is NOT a valid selection: the snapshot still contains
+    // it, but its sidebar row is gone and the PTY sweep below kills its
+    // sessions — leaving selection on it keeps its Terminal mounted, which
+    // answers the kill with a dead-on-attach RESUME.
     if (selectedId && tasks.some((task) => task.id === selectedId && !task.deletion)) return
     // Fallback carries the persisted lastActive record too — a stale or
     // freshly-respawned daemon can replay a null focus while disk still
-    // knows the real one (the "reopens on the oldest project" bug).
+    // knows the real one, which lands the boot on an arbitrary project.
     setSelectedId(firstSelectableTask(tasks, activeTaskId, readLastActiveTaskId())?.id ?? null)
   }, [tasks, activeTaskId, selectedId, args.focusWorkspace])
 
-  // Orphan sweep (O19): clear `terminalTabs.*` snapshots whose task no longer
-  // exists. Runs on EVERY task-list identity change, not once per session:
-  // a sibling client (`rove api` / web board) deleting a task only lands here
-  // as a changed list — forgetTaskTabs is wired to THIS client's delete flow
-  // alone, so a once-per-session sweep left those orphans taxing every later
-  // kv write until the next launch. The sweep itself is idempotent and cheap
+  // Orphan sweep: clear `terminalTabs.*` snapshots whose task is gone. Runs
+  // on EVERY task-list identity change, not once per session: a sibling
+  // client (`rove api` / web board) deleting a task only lands here as a
+  // changed list — forgetTaskTabs is wired to THIS client's delete flow
+  // alone, so a once-per-session sweep would leave those orphans taxing every
+  // later kv write until the next launch. The sweep itself is idempotent and cheap
   // (one Set lookup per snapshot key), so re-running it on every list echo
   // costs nothing: a live task's id is always in the list, so its snapshots
   // can never be swept by a re-run.
@@ -119,7 +119,7 @@ export function useWorkspaceSelection(args: {
     )
   }, [tasks, kv])
 
-  // PTY lifecycle (issue #16): deleting a task must end every engine session
+  // PTY lifecycle: deleting a task must end every engine session
   // it owns — its tab PTYs are keyed `taskId::tabId` in the default registry,
   // invisible to the pane once unmounted. Watch the task snapshot and release
   // the corpses; the pane never kills (registry docs), so this is the one
@@ -140,20 +140,20 @@ export function useWorkspaceSelection(args: {
       if (!next.has(id)) registry.releaseWhere((key) => key === id || key.startsWith(`${id}::`))
     }
     liveTaskIdsRef.current = next
-    // Chattabs die WITH their worktree (owner call 2026-08-01): removing a
-    // task's worktree (worktrees page / web / a sibling client) clears its
-    // `worktreePath` but keeps the task — without this, its tab rows stayed
-    // in the tree, its snapshot would respawn them, and their PTYs kept
-    // shells alive in a deleted directory. A non-empty → empty transition
+    // Chattabs die WITH their worktree: removing a task's worktree (worktrees
+    // page / web / a sibling client) clears its `worktreePath` but keeps the
+    // task — without this its tab rows stay in the tree, its snapshot
+    // respawns them, and their PTYs keep shells alive in a deleted directory.
+    // A non-empty → empty transition
     // is the observable edge; task deletion itself is already covered by
     // the delete flow's forgetTaskTabs + the live-task sweep above.
     //
     // ANNOUNCE IT. This destroys every tab of a task the user did NOT delete,
     // triggered by something that happened somewhere else (another client, a
-    // web action, another agent's `rove api`) — and it did it silently, which
-    // is how "the tab I was working in just vanished" reached the owner with
-    // nothing to look at (2026-08-29). The toast is deliberately not a
-    // confirm: the worktree is ALREADY gone by the time this runs, so there is
+    // web action, another agent's `rove api`); silently is how a tab vanishes
+    // out from under someone with nothing to look at. The toast is
+    // deliberately not a confirm: the worktree is ALREADY gone by the time
+    // this runs, so there is
     // nothing left to consent to, and a modal here would interrupt for a
     // decision the user cannot make. Telling them what happened, and that the
     // branch survives, is the whole remedy.
@@ -182,9 +182,9 @@ export function useWorkspaceSelection(args: {
     if (selectedId === id) {
       // Entering the already-selected task must still publish it as active:
       // a fresh home boots with a fallback-selected task but a null active
-      // record, and without this the first Enter never wrote lastActive —
+      // record, and without this the first Enter never writes lastActive —
       // so narrow mode's "↩ recent" row (and every lastActive consumer)
-      // stayed empty until the user switched tasks once.
+      // stays empty until the user switches tasks once.
       // Focus bookkeeping, not a user gesture — the pane has already switched
       // locally, so the only casualty is the lastActive record. A toast would
       // report a failure the user just watched succeed.
@@ -206,8 +206,8 @@ export function useWorkspaceSelection(args: {
   const activationGenerationRef = useRef(0)
   async function activateTask(id: string): Promise<void> {
     const generation = ++activationGenerationRef.current
-    // Entering a task whose last tab was closed reopens one (owner call
-    // 2026-08-31). Before the worktree await, so the revived tab is published
+    // Entering a task whose last tab was closed reopens one. Before the
+    // worktree await, so the revived tab is published
     // by the time selection lands and the workspace never paints the blank
     // frame `show-workspace` renders for an empty tab list.
     reviveEmptiedTabs(kv, id, defaultShell())

--- a/packages/kobe/src/tui-react/workspace/use-zen-mode.ts
+++ b/packages/kobe/src/tui-react/workspace/use-zen-mode.ts
@@ -1,5 +1,5 @@
 /**
- * Zen mode state for the PureTUI workspace (issue #18): the layout collapses
+ * Zen mode state for the PureTUI workspace: the layout collapses
  * to the engine pane, hiding files and terminal (and the Tasks rail too, when
  * `zen.keepTasks` is off).
  *

--- a/packages/kobe/test/render/attention-deferred-toast.test.tsx
+++ b/packages/kobe/test/render/attention-deferred-toast.test.tsx
@@ -1,6 +1,6 @@
 /** @jsxImportSource @opentui/react */
 /**
- * The B-layer deferral toast (issue #78): a `prompt_deferred` inbox episode is
+ * The B-layer deferral toast: a `prompt_deferred` inbox episode is
  * inbox-ONLY (no engine activity), so `useAttention` diffs the inbox episodes
  * themselves and toasts on a fresh one. Render-track proof that the wiring
  * fires — the toast is the user-visible half of accept-and-defer.

--- a/packages/kobe/test/render/automations-page-keys.test.tsx
+++ b/packages/kobe/test/render/automations-page-keys.test.tsx
@@ -34,8 +34,8 @@ const ONLINE = createStateCell("online")
 
 function orchestrator(automations: unknown[] = []) {
   return {
-    // The page no longer reads this; kept so a re-added reader can't
-    // silently crash the test.
+    // The page does not read this; kept so a re-added reader can't silently
+    // crash the test.
     connectionStateSignal: () => ONLINE,
     listAutomations: async () => ({ automations, keepsDaemonAlive: automations.length > 0 }),
     automationRuns: async () => ({ runs: [] }),
@@ -55,8 +55,8 @@ test("n opens the create flow", async () => {
 })
 
 test("esc closes the create flow", async () => {
-  // The composer used to bind escape itself and only resolve the promise —
-  // as a modal MEMBER it outranked the barrier, so the card never popped.
+  // A composer that binds escape itself and only resolves the promise is a
+  // modal MEMBER outranking the barrier, so the card never pops.
   const { frame, mockInput } = await renderComponent(
     <AutomationsPage orchestrator={orchestrator()} focused={true} onClose={() => {}} />,
     { width: 60, height: 16, providers: { dialog: true, notifications: true } },
@@ -89,8 +89,8 @@ test("esc closes the page", async () => {
 })
 
 test("keys stay dead while another pane holds focus", async () => {
-  // The sidebar binds `n` too (new task). Both are live at once now that rail
-  // pages no longer disable the workspace chords, so the page must yield.
+  // The sidebar binds `n` too (new task), and rail pages do not disable the
+  // workspace chords, so both are live at once and the page must yield.
   const { frame, mockInput } = await renderComponent(
     <AutomationsPage orchestrator={orchestrator()} focused={false} onClose={() => {}} />,
     { width: 60, height: 16, providers: { dialog: true, notifications: true } },

--- a/packages/kobe/test/render/dialog-confirm-danger.test.tsx
+++ b/packages/kobe/test/render/dialog-confirm-danger.test.tsx
@@ -1,8 +1,8 @@
 /** @jsxImportSource @opentui/react */
 /**
- * DialogConfirm danger contract (owner report 2026-08-30): destructive
- * confirms used to open with focus on the confirm button, so one stray
- * Enter destroyed uncommitted work. `danger` must (1) land initial focus
+ * DialogConfirm danger contract. A destructive confirm that opens with focus
+ * on the confirm button loses uncommitted work to one stray Enter, so
+ * `danger` must (1) land initial focus
  * on Cancel, (2) draw the confirm button in the error color — the same
  * `danger` → `theme.error` convention ContextMenuEntry uses — while plain
  * confirms keep confirm-first focus for one-keystroke dismissal.
@@ -44,7 +44,7 @@ async function mountConfirm(props: { danger?: boolean; initialActive?: "confirm"
 let reshow: (() => void) | undefined
 function ShowDriver(props: { onResult: (result: DialogConfirmResult) => void }) {
   const dialog = useDialog()
-  // biome-ignore lint/correctness/useExhaustiveDependencies: mount-once, matching the Solid setup semantics.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: mount-once setup.
   useEffect(() => {
     reshow = () => {
       void DialogConfirm.show(
@@ -65,8 +65,8 @@ describe("DialogConfirm danger", () => {
   it("opens with focus on Cancel — a stray Enter deletes nothing", async () => {
     const { mockInput, spans, commits } = await mountConfirm({ danger: true })
 
-    // The regression: Enter on a freshly opened destructive confirm must NOT
-    // commit the destructive action.
+    // Enter on a freshly opened destructive confirm must NOT commit the
+    // destructive action.
     act(() => mockInput.pressEnter())
     await settle()
     expect(commits.confirm).toBe(0)

--- a/packages/kobe/test/render/dialog-narrow.test.tsx
+++ b/packages/kobe/test/render/dialog-narrow.test.tsx
@@ -1,6 +1,6 @@
 /** @jsxImportSource @opentui/react */
 /**
- * Narrow dialog clamp (issue #14, M5/3A): body padding halves below the
+ * Narrow dialog clamp: body padding halves below the
  * breakpoint (one shared hook, live on resize), the card width clamps to
  * terminal−2, and the new-chat footer hint wraps to a second line instead
  * of clipping. Content itself is unchanged.

--- a/packages/kobe/test/render/dialog-stack.test.tsx
+++ b/packages/kobe/test/render/dialog-stack.test.tsx
@@ -16,7 +16,7 @@ function Driver(props: { onMount: (dialog: ReturnType<typeof useDialog>) => void
   const dialog = useDialog()
   // Imperative stack mutations run once after mount — calling them during
   // render would setState the provider mid-render (React render loop).
-  // biome-ignore lint/correctness/useExhaustiveDependencies: mount-once, matching the Solid setup semantics.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: mount-once setup.
   useEffect(() => props.onMount(dialog), [])
   return <text>base content</text>
 }
@@ -81,9 +81,9 @@ describe("DialogProvider", () => {
     expect(centeredRow).toBeGreaterThan(Math.floor(height / 5))
   })
 
-  // Regression (owner report 2026-07-09): the translucent full-screen
-  // backdrop erased wide glyphs from the pane behind a dialog while leaving
-  // adjacent ASCII visible. Keep mixed CJK/ASCII background text intact so
+  // A translucent full-screen backdrop erases wide glyphs from the pane
+  // behind a dialog while leaving adjacent ASCII visible. Keep mixed
+  // CJK/ASCII background text intact so
   // opening a modal only dims it; it must not punch character-shaped holes.
   it("keeps wide glyphs in background text while a dialog is open", async () => {
     const background = "设置 split horizon 和 vertical 深度限制"
@@ -157,11 +157,10 @@ describe("DialogProvider", () => {
     expect(dialogRef.current?.stack.length).toBe(0)
   })
 
-  // Regression (owner report 2026-07-08): a stale text selection — the
-  // terminal keeps the highlight after a copy until the next click — used
-  // to DISABLE the esc/ctrl+c binding entirely, leaving esc dead while a
-  // dialog was up. Contract now: first esc clears the selection (dialog
-  // stays), second esc closes.
+  // A stale text selection — the terminal keeps the highlight after a copy
+  // until the next click — must not DISABLE the esc/ctrl+c binding, which
+  // would leave esc dead while a dialog is up. Contract: first esc clears the
+  // selection (dialog stays), second esc closes.
   it("esc clears a stale selection first, then closes on the next press", async () => {
     const dialogRef: { current?: ReturnType<typeof useDialog> } = {}
     const { frame, mockInput, renderer } = await renderComponent(
@@ -196,7 +195,7 @@ describe("DialogProvider", () => {
     expect(dialogRef.current?.stack.length).toBe(0)
   })
 
-  // Structural modal guarantee (owner mandate 2026-07-08): while ANY
+  // Structural modal guarantee: while ANY
   // dialog is up, bindings registered by the UI behind it must be
   // unreachable — no per-pane `dialog.stack.length === 0` gate required.
   it("blocks background bindings while a dialog is open, restores them after", async () => {
@@ -244,11 +243,11 @@ describe("DialogProvider", () => {
     expect(background).toBe(2)
   })
 
-  // Regression (owner report 2026-07-16): if the workspace host rendered
-  // while a dialog was open, it cached dialogOpen=true into its pane-focus
-  // and shortcut gates. Escape removed the modal barrier, but the unchanged
-  // DialogContext value did not render consumers again; clicking a pane was
-  // the only thing that woke the shortcuts back up.
+  // A workspace host that renders while a dialog is open caches
+  // dialogOpen=true into its pane-focus and shortcut gates. Escape removes the
+  // modal barrier, but an unchanged DialogContext value would not render
+  // consumers again, leaving clicking a pane as the only way to wake the
+  // shortcuts back up.
   it("rerenders dialog consumers after escape so pane gates recover without a click", async () => {
     let background = 0
     let rerenderWhileOpen: (() => void) | undefined
@@ -345,11 +344,11 @@ describe("DialogProvider", () => {
     expect(dialogRef.current?.stack.length).toBe(0)
   })
 
-  // Regression (owner report 2026-08-10): Settings → Engines → "+ Add
-  // engine" chains three prompts, each closing (clear → deferred refocus of
-  // the pane behind) before the next opens. The pending timer landed ~1ms
-  // into the NEXT prompt and yanked native focus back to the pane, so every
-  // Enter looked like it lost focus. Opening a dialog must cancel it.
+  // Settings → Engines → "+ Add engine" chains three prompts, each closing
+  // (clear → deferred refocus of the pane behind) before the next opens. The
+  // pending timer lands ~1ms into the NEXT prompt and yanks native focus back
+  // to the pane, so every Enter reads as a lost focus. Opening a dialog must
+  // cancel it.
   it("a chained dialog keeps focus when the previous one's refocus is still pending", async () => {
     const dialogRef: { current?: ReturnType<typeof useDialog> } = {}
     let paneInput: Renderable | null = null

--- a/packages/kobe/test/render/empty-workspace-pane.test.tsx
+++ b/packages/kobe/test/render/empty-workspace-pane.test.tsx
@@ -1,12 +1,13 @@
 /** @jsxImportSource @opentui/react */
 /**
- * The keys the no-sessions placeholder advertises (issue #90).
+ * The keys the no-sessions placeholder advertises.
  *
- * The copy has always read "press ⏎ or ctrl+e to start one", and neither key
- * did anything: both are registered inside `TerminalTabs`, which this state
- * deliberately does NOT mount (its `active` tab is non-null by construction,
- * so mounting over an empty list would mint a replacement and the close would
- * never appear to take). The placeholder named an affordance nothing backed.
+ * The copy reads "press ⏎ or ctrl+e to start one", and both keys are normally
+ * registered inside `TerminalTabs`, which this state deliberately does NOT
+ * mount (its `active` tab is non-null by construction, so mounting over an
+ * empty list would mint a replacement and the close would never appear to
+ * take). Without the placeholder's own bindings it names an affordance
+ * nothing backs.
  *
  * So the pane binds them itself, and these pin that: a press REVIVES the
  * task's tabs. Asserting on `tabsByTask` rather than the frame is deliberate —

--- a/packages/kobe/test/render/engine-settings-protocol.test.tsx
+++ b/packages/kobe/test/render/engine-settings-protocol.test.tsx
@@ -1,6 +1,6 @@
 /** @jsxImportSource @opentui/react */
 /**
- * Settings → Engines writes a custom engine's PROTOCOL (issue #30).
+ * Settings → Engines writes a custom engine's PROTOCOL.
  *
  * A custom engine is a named preset, and `engineProtocol.<id>` is the field
  * that makes every later `--command <id>` dispatch deterministic instead of
@@ -74,13 +74,13 @@ function Driver(props: { onReady: (api: ReturnType<typeof useEngineSettings>, kv
 
 /**
  * Fresh $KOBE_HOME_DIR + a mounted hook, with `run` driven from OUTSIDE the
- * component and fully awaited before this resolves.
+ * component and fully awaited before the returned promise resolves.
  *
- * Deliberately not "fire it inside the mount effect and hope": that made the
- * flow depend on effect timing, and a `run` that started after the caller's
- * `script.restore()` would reach the REAL `RenameTaskDialog.show`, which
- * awaits a dialog nobody can answer — a hang that reproduces only on a slow
- * runner. Awaiting a ready-promise makes the order deterministic.
+ * Deliberately not "fire it inside the mount effect and hope": that makes the
+ * flow depend on effect timing, and a `run` starting after the caller's
+ * `script.restore()` reaches the REAL `RenameTaskDialog.show`, which awaits a
+ * dialog nobody can answer — a hang that shows up only on a slow runner.
+ * Awaiting a ready-promise makes the order deterministic.
  */
 async function withEngineSettings(
   run: (api: ReturnType<typeof useEngineSettings>) => void | Promise<void>,

--- a/packages/kobe/test/render/failure-toast.test.tsx
+++ b/packages/kobe/test/render/failure-toast.test.tsx
@@ -1,18 +1,17 @@
 /** @jsxImportSource @opentui/react */
 /**
- * Failed mutations must be VISIBLE — the regression this branch fixes:
+ * Failed mutations must be VISIBLE, and there are two ways for them not to be:
  *
- *   - Kanban issue create/delete logged to the daemon log only; under the
- *     alternate screen a bare `console.error` is invisible, so the card just
- *     stayed on the board.
- *   - Automations / Work-items failures rendered as a muted `textMuted`
+ *   - a Kanban issue create/delete that only logs — under the alternate screen
+ *     a bare `console.error` is invisible, so the card just stays on the board;
+ *   - an Automations / Work-items failure rendered as a muted `textMuted`
  *     inline line — reads as a hint, not a failure.
  *
- * All three pages now push failures through the shared toast queue. Each
- * test mounts the REAL page plus the REAL `ToastOverlay` and drives the REAL
- * keys (down/d/enter, e, return) against a rejecting orchestrator mock, then
+ * All three pages push failures through the shared toast queue. Each test
+ * mounts the REAL page plus the REAL `ToastOverlay` and drives the REAL keys
+ * (down/d/enter, e, return) against a rejecting orchestrator mock, then
  * asserts the error toast painted on the frame — the "✕" glyph the toast
- * overlay draws, which no pre-fix rendering produced.
+ * overlay draws, which neither silent rendering produces.
  */
 import { expect, test } from "bun:test"
 import { createStateCell } from "../../src/lib/external-store"
@@ -36,7 +35,7 @@ async function coloredSpans(spans: () => Promise<import("@opentui/core").Capture
 /**
  * The failure is a TOAST, not the page's muted notice line: some span must
  * carry the "✕" toast glyph, and the span carrying `message` must not paint
- * with the same color as `mutedNeedle`'s span (the pre-fix `textMuted` look).
+ * with the same color as `mutedNeedle`'s span (the muted-notice look).
  */
 async function expectErrorToast(
   frame: string,
@@ -140,7 +139,7 @@ const AUTOMATION = {
   updatedAt: "2026-07-01T00:00:00Z",
 }
 
-/** The page no longer reads the connection signal, but the fake orchestrator
+/** The page does not read the connection signal, but the fake orchestrator
  *  still answers it so a re-added reader can't silently crash this test.
  *  Hoisted so `useSyncExternalStore` sees one stable store identity. */
 const ONLINE = createStateCell("online")

--- a/packages/kobe/test/render/filetree-cjk-overflow.test.tsx
+++ b/packages/kobe/test/render/filetree-cjk-overflow.test.tsx
@@ -4,11 +4,11 @@
  * the real frame, in cells, with a real Chinese path.
  *
  * Rove defaults to Simplified Chinese, so a CJK path is the ordinary case,
- * not an exotic one. The row's budget (`computePathBudget`) has always been
- * in CELLS, but it used to be SPENT by a code-point counter: a 26-cell budget
- * "fitted" `文档/设计/终端渲染说明书笔记.md` at 18 code points and drew its 31
- * cells, five of them through the border and onto the workspace pane, taking
- * the `+N`/`−N` stat columns with it.
+ * not an exotic one. The row's budget (`computePathBudget`) is in CELLS, and
+ * spending it with a code-point counter is the trap: a 26-cell budget "fits"
+ * `文档/设计/终端渲染说明书笔记.md` at 18 code points and draws its 31 cells,
+ * five of them through the border and onto the workspace pane, taking the
+ * `+N`/`−N` stat columns with it.
  *
  * Asserting the truncated STRING would not catch that — the string is the
  * same either way until you ask what it costs. So the assertion is on the
@@ -93,7 +93,7 @@ test("the All tab shows a CJK filename, not git's octal escaping", async () => {
 })
 
 test("an ASCII path of the same length is unchanged", async () => {
-  // The desktop-layout guard: 1 cell per glyph spends what it always did.
+  // The desktop-layout guard: 1 cell per glyph, so cells and code points agree.
   const text = await changesFrame(repoWith("docs/design/terminal-notes.md"), "terminal-notes")
   expect(text).toContain("terminal-notes.md")
   for (const line of text.split("\n")) {

--- a/packages/kobe/test/render/focus-provider.test.tsx
+++ b/packages/kobe/test/render/focus-provider.test.tsx
@@ -3,8 +3,7 @@
  * FocusProvider — pane focus context (src/tui-react/context/focus.tsx). Imports
  * @opentui/react (useRenderer) so it can't run under vitest at all; this is its
  * only coverage. Drives the real `focused`/`is`/`cycle`/`setFocused` surface
- * every pane wrapper reads. API delta from Solid: `focused`/`is()` are plain
- * values, not accessors.
+ * every pane wrapper reads.
  */
 import { describe, expect, it } from "bun:test"
 import { FocusProvider, type PaneId, useFocus } from "../../src/tui-react/context/focus"

--- a/packages/kobe/test/render/harness.tsx
+++ b/packages/kobe/test/render/harness.tsx
@@ -129,8 +129,8 @@ export function settle(ms = 60): Promise<void> {
  * command guide, which only opens PREFIX_GUIDE_DELAY_MS after the tap — must
  * pass a `timeoutMs` anchored to that product constant, not a bare estimate:
  * the deadline has to cover the delay plus frame latency on a loaded CI
- * runner, or the test flakes at random on unrelated PRs (issue #82: a 1s
- * budget failed at ~1.1s of test wall-clock on a slow runner).
+ * runner, or the test flakes at random on unrelated changes — a 1s budget is
+ * not enough for ~1.1s of test wall-clock on a slow runner.
  */
 export async function waitForFrameText(
   frame: () => Promise<string>,

--- a/packages/kobe/test/render/host-files-pane-border.test.tsx
+++ b/packages/kobe/test/render/host-files-pane-border.test.tsx
@@ -1,9 +1,9 @@
 /** @jsxImportSource @opentui/react */
 /**
- * Render coverage for the files-pane chrome (2026-08-29 redesign): a
- * rounded border whose color follows pane focus — `focusAccent` when the
- * files pane holds the focus, the (now brighter) `borderActive` when it
- * does not. The tree inside is FileTree's own contract (see
+ * Render coverage for the files-pane chrome: a rounded border whose color
+ * follows pane focus — `focusAccent` when the files pane holds the focus,
+ * `borderActive` when it does not. The tree inside is FileTree's own contract
+ * (see
  * `host-sidebar-filetree.test.tsx`); here it only proves the pane mounts
  * through its real git read so the border frames actual content.
  */

--- a/packages/kobe/test/render/host-files-pane-header.test.tsx
+++ b/packages/kobe/test/render/host-files-pane-header.test.tsx
@@ -1,7 +1,6 @@
 /** @jsxImportSource @opentui/react */
 /**
- * The Files pane's header row — both halves of the owner's 2026-09-02
- * screenshot.
+ * The Files pane's header row.
  *
  * 1. The Zen and Create-PR chips ALWAYS wrap: `[~] Zen` + `[^ A P] Ask agent
  *    to create PR` is 40 cells against the pane's 22-34 cell width clamp

--- a/packages/kobe/test/render/host-version-skew-banner.test.tsx
+++ b/packages/kobe/test/render/host-version-skew-banner.test.tsx
@@ -2,17 +2,16 @@
 /**
  * The version-skew banner's MOUNT, not its rendering.
  *
- * `VersionSkewBanner` has been correct since it was written and its only
- * caller was the mock workbench — the component was fine, the product never
- * mounted it. So a test against the component alone stays green with the
- * wiring deleted, which is exactly the bug: this file mounts the REAL
+ * A correct `VersionSkewBanner` whose only caller is the mock workbench looks
+ * exactly like a working one, so a test against the component alone stays
+ * green with the product wiring deleted. This file mounts the REAL
  * `WorkspaceRoot` and drives `daemonStaleSignal()`, the cell the `hello`
  * handshake writes.
  *
  * Why it matters here specifically: Rove ships several times a day and the
  * daemon is a long-lived process that outlives an `npm i -g`, so "new binary,
- * old daemon" is the ordinary outcome of updating — the one state the user is
- * most likely to be in and least likely to be told about.
+ * stale daemon" is the ordinary outcome of updating — the one state the user
+ * is most likely to be in and least likely to be told about.
  */
 
 import { afterAll, afterEach, beforeAll, expect, test } from "bun:test"
@@ -108,9 +107,9 @@ async function mountHost(orchestrator: RemoteOrchestrator) {
 }
 
 test("the host mounts the skew banner and drives it from the daemon signal", async () => {
-  // The wiring IS the fix: a banner fed by a hand-set prop reproduces the bug
-  // instead of catching it, so the skew has to arrive the way it does in
-  // production — through the cell the handshake writes.
+  // The wiring is the whole claim: a banner fed by a hand-set prop reproduces
+  // the failure instead of catching it, so the skew has to arrive the way it
+  // does in production — through the cell the handshake writes.
   const { orchestrator, stale, daemonVersion } = fakeOrchestrator()
   const { frame } = await mountHost(orchestrator)
   expect(await frame()).not.toContain("DAEMON OUT OF DATE")
@@ -137,13 +136,11 @@ test("the host mounts the skew banner and drives it from the daemon signal", asy
 })
 
 test("a socket disconnect paints no banner of its own", async () => {
-  // This used to assert precedence between two banners: a red DAEMON
-  // DISCONNECTED strip took the slot from the amber skew one. The red banner
-  // is gone — Rove keeps working with the daemon down and the socket usually
-  // returns within a second, so it interrupted with nothing to act on. What
-  // is left to pin is that its removal did not take the skew banner with it:
-  // a stale build is still worth saying while the socket is down, because
-  // restarting the daemon is what fixes BOTH.
+  // There is no DAEMON DISCONNECTED strip: Rove keeps working with the daemon
+  // down and the socket usually returns within a second, so it would interrupt
+  // with nothing to act on. What this pins is that its absence does not take
+  // the skew banner with it — a stale build is still worth saying while the
+  // socket is down, because restarting the daemon is what fixes BOTH.
   const { orchestrator, stale, daemonVersion, connection } = fakeOrchestrator()
   const { frame } = await mountHost(orchestrator)
   await act(async () => {
@@ -158,12 +155,11 @@ test("a socket disconnect paints no banner of its own", async () => {
 })
 
 /**
- * Issue #96, the surfacing half. A GUI running from a deleted install can
- * never start a daemon, and until now that state had no picture at all: the
- * client looked like it was reconnecting, for two days on the owner's
- * machine. Mounted through the real host and driven from the cell the
- * reconnect loop writes, for the same reason as the skew test above — a
- * banner fed a hand-set prop would pass with the wiring deleted.
+ * The surfacing half. A GUI running from a deleted install can never start a
+ * daemon, and with no picture for that state the client just looks like it is
+ * reconnecting, indefinitely. Mounted through the real host and driven from
+ * the cell the reconnect loop writes, for the same reason as the skew test
+ * above — a banner fed a hand-set prop would pass with the wiring deleted.
  */
 test("the host mounts the stale-install banner and drives it from the orchestrator", async () => {
   const { orchestrator, staleInstall } = fakeOrchestrator()

--- a/packages/kobe/test/render/inbox-deferred-exit.test.tsx
+++ b/packages/kobe/test/render/inbox-deferred-exit.test.tsx
@@ -1,6 +1,6 @@
 /** @jsxImportSource @opentui/react */
 /**
- * The B-layer exit path (issue #78): opening a `prompt_deferred` inbox item
+ * The B-layer exit path: opening a `prompt_deferred` inbox item
  * jumps AND inserts the queued message, re-running the A/C gate. Render-track
  * proof of the wiring — the inbox half of accept-and-defer.
  *

--- a/packages/kobe/test/render/inbox-glyph-width.test.tsx
+++ b/packages/kobe/test/render/inbox-glyph-width.test.tsx
@@ -10,10 +10,9 @@
  * cells, overrunning the text beside it. Nothing upstream can see that; the
  * width table is not wrong, the font is just missing the glyph.
  *
- * This pane shipped `⌛` (U+231B) for rate-limited. U+231B carries the Unicode
- * Emoji property, so macOS resolved it to AppleColorEmoji at 2.13 cells — a
- * colour glyph in a monochrome pane, overflowing its column (2026-08-15, the
- * same sweep that removed the sidebar's oversized `◌` and `✕`).
+ * `⌛` (U+231B) is the trap this pane avoids for rate-limited: U+231B carries
+ * the Unicode Emoji property, so macOS resolves it to AppleColorEmoji at 2.13
+ * cells — a colour glyph in a monochrome pane, overflowing its column.
  *
  * So the assertion is on the CELL, not on the character: mount the real pane,
  * capture the real frame, and require each badge to sit in one cell of the

--- a/packages/kobe/test/render/inbox-window.test.tsx
+++ b/packages/kobe/test/render/inbox-window.test.tsx
@@ -2,9 +2,9 @@
 /**
  * The Inbox window and its cell budgets, read off real frames:
  *
- *  - clipped cards are SAID ("+N more"), not silently cut — the old window
- *    charged section headers a full card slot, so a trailing RECENT header
- *    dangled with every row under it hidden and nothing saying so;
+ *  - clipped cards are SAID ("+N more"), not silently cut — charging section
+ *    headers a full card slot leaves a trailing RECENT header dangling with
+ *    every row under it hidden and nothing saying so;
  *  - clipped labels end in `…` (the sidebar's round-one truncation rule) —
  *    Yoga's bare hard cut reads as the full name;
  *  - when the identity line gets too tight, the state badge drops its label

--- a/packages/kobe/test/render/kanban-columns.test.tsx
+++ b/packages/kobe/test/render/kanban-columns.test.tsx
@@ -1,12 +1,12 @@
 /** @jsxImportSource @opentui/react */
 /**
- * What the board actually RENDERS for the two routing rules this branch
- * added, against the real component rather than the pure column math that
+ * What the board actually RENDERS for its two routing rules, against the real
+ * component rather than the pure column math that
  * `test/state/issue-board.test.ts` already covers:
  *
  *   - a `hold` story lands under Parked even though it is linked to a task
- *     (before, the link alone pushed it into In progress, where more than a
- *     dozen shelved stories sat pretending to be active work);
+ *     (routing on the link alone puts shelved stories in In progress,
+ *     pretending to be active work);
  *   - a card whose linked engine is blocked leads its column, and the header
  *     says how many need you.
  */
@@ -81,12 +81,12 @@ test("a blocked card's column header reports how many need you", async () => {
 })
 
 /**
- * A link the task index cannot resolve reads as unlinked. The daemon now
- * unlinks an issue when its task is deleted, so this is the belt to that
- * braces: a store carried over from a build without the cascade still holds
- * dead links, and In progress used to be a one-way door for them — the
- * drawer swapped Start for "open the linked session", which jumped at
- * nothing. In Backlog the card is startable again.
+ * A link the task index cannot resolve reads as unlinked. The daemon unlinks
+ * an issue when its task is deleted, so this is the belt to that braces: a
+ * store carried over from a build without the cascade still holds dead links,
+ * and In progress would be a one-way door for them — the drawer swaps Start
+ * for "open the linked session", which jumps at nothing. In Backlog the card
+ * is startable again.
  */
 test("a card linked to a task the index does not have renders in Backlog", async () => {
   const text = await board([issue(1, { taskId: "T1" }), issue(2, { taskId: "GONE" })], undefined, [
@@ -124,7 +124,7 @@ test("a card's title sits against its own top border, with a blank lane row afte
   expect(second).toBeGreaterThan(first)
 
   // Directly above the title is the card's own top border, not a padded row:
-  // the two rows the old `padding={1}` spent are what this buys back.
+  // the two rows a `padding={1}` would spend are what this buys back.
   expect(lines[first - 1] ?? "").toContain("╭")
 
   // Between the cards, exactly one row carrying no card chrome — the lane
@@ -146,7 +146,7 @@ test("a card's title sits against its own top border, with a blank lane row afte
  *
  * Pinned against the frame because opentui's default is SQUARE: a box that
  * says `border` and nothing else silently opts out of the house style, which
- * is how the board shipped as the one page framed in `┌┐└┘`. Asserting the
+ * would leave the board the one page framed in `┌┐└┘`. Asserting the
  * absence of square glyphs is what makes this test fail if either box loses
  * its `borderStyle` again — a corner-count assertion alone would pass on the
  * default.
@@ -217,8 +217,9 @@ test("a card is see-through in transparent mode and solid outside it", async () 
 
 /**
  * The board's keys are live, not decoration: `r` refetches. A page whose
- * bindings silently do nothing renders identically to a working one, which is
- * exactly how the Automations page once shipped with every key dead.
+ * bindings silently do nothing renders identically to a working one — a
+ * `Binding[]` passed as an object literal is enough to kill every key on a
+ * page and change nothing on screen.
  */
 test("r refetches the board", async () => {
   let fetches = 0
@@ -260,8 +261,8 @@ test("an empty column renders its placeholder", async () => {
 /**
  * Below the narrow breakpoint the board renders ONE full-width lane under a
  * strip of every lane's count — four side-by-side columns at phone width
- * were one-word-per-line strips. The off-lane cards must NOT render: their
- * presence is exactly what the old layout got wrong.
+ * were one-word-per-line strips. The off-lane cards must NOT render — their
+ * presence is the whole failure mode.
  */
 test("narrow board shows a lane strip and only the selected lane's cards", async () => {
   const { frame } = await renderComponent(

--- a/packages/kobe/test/render/keyboard-hints.test.tsx
+++ b/packages/kobe/test/render/keyboard-hints.test.tsx
@@ -141,8 +141,8 @@ function withGuideKvHome(): void {
 
 // The which-key guide is a deliberate delayed reveal: PrefixHud only opens it
 // PREFIX_GUIDE_DELAY_MS after the tap, so the poll budget must cover that
-// product delay plus frame latency on a loaded CI runner (same flake as
-// issue #82 in shortcut-reveal).
+// product delay plus frame latency on a loaded CI runner (same flake
+// shortcut-reveal guards against).
 const GUIDE_REVEAL_TIMEOUT_MS = PREFIX_GUIDE_DELAY_MS + 5_000
 
 async function waitForGuideText(frame: () => Promise<string>, text: string): Promise<string> {

--- a/packages/kobe/test/render/narrow-mode-resize.test.tsx
+++ b/packages/kobe/test/render/narrow-mode-resize.test.tsx
@@ -1,6 +1,6 @@
 /** @jsxImportSource @opentui/react */
 /**
- * Narrow-mode breakpoint under a REAL opentui renderer (issue #14, M1):
+ * Narrow-mode breakpoint under a REAL opentui renderer:
  * proves the flag consumers derive from `useTerminalDimensions().width`
  * flips live when the terminal resizes across the 70-col boundary — the
  * same reactive path the workspace host will branch its layout on.
@@ -20,7 +20,7 @@ test("narrow flag flips live on resize across the breakpoint", async () => {
   const { frame, resize } = await renderComponent(<NarrowProbe />, { width: 80, height: 24 })
   expect(await frame()).toContain("layout:wide")
 
-  // Phone-SSH target viewport (issue #14: ~46×70 cells).
+  // Phone-SSH target viewport (~46×70 cells).
   await act(async () => {
     resize(46, 70)
   })

--- a/packages/kobe/test/render/new-chat-dialog.test.tsx
+++ b/packages/kobe/test/render/new-chat-dialog.test.tsx
@@ -1,8 +1,8 @@
 /** @jsxImportSource @opentui/react */
 /**
- * Unified new-conversation dialog (issue #7) — REAL keypresses against the
- * mounted view: enter in the pristine state must reproduce the old ctrl+e
- * result exactly, `tab` / `ctrl+f` flip the destination / context toggles
+ * Unified new-conversation dialog — REAL keypresses against the mounted view:
+ * enter in the pristine state must reproduce the plain ctrl+e result exactly,
+ * `tab` / `ctrl+f` flip the destination / context toggles
  * (footer reflects them live), shell-only choices clamp onto an engine when
  * a toggle leaves the default combo, and preset props open pre-flipped.
  */

--- a/packages/kobe/test/render/new-chat-flow.test.tsx
+++ b/packages/kobe/test/render/new-chat-flow.test.tsx
@@ -1,6 +1,6 @@
 /** @jsxImportSource @opentui/react */
 /**
- * Unified new-conversation DISPATCH (issue #7) — the four toggle combos must
+ * Unified new-conversation DISPATCH — the four toggle combos must
  * land in four different places, driven by REAL keypresses through the real
  * `useTabDialogs` hook:
  *
@@ -13,10 +13,10 @@
  * Every `requestNewChat` open is gated on an ASYNC engine probe
  * (`availableEngineIds()` → `findClaudeBinary()` &c., a `which` + `stat` per
  * vendor) that runs before `NewChatDialog.show`. A fixed `settle()` is a bet
- * that probe finishes inside 60ms; it took 38ms on an idle Mac, and lost that
- * bet on a loaded CI runner (v0.9.72 attempt 1 — the assertion read the
- * pre-dialog frame, which is blank because `Driver` renders `null`). Wait for
- * the dialog's own text with `waitForFrameText` instead.
+ * that probe finishes inside 60ms; it takes ~38ms on an idle Mac and loses
+ * that bet on a loaded CI runner, where the assertion reads the pre-dialog
+ * frame — blank, because `Driver` renders `null`. Wait for the dialog's own
+ * text with `waitForFrameText` instead.
  *
  * Engine history reads and kobe state writes are both sandboxed to a
  * tmpdir via their real env seams (`CLAUDE_CONFIG_DIR` / `CODEX_HOME` /
@@ -163,24 +163,24 @@ describe("requestNewChat dispatch", () => {
     expect(captured.errors).toEqual(["No conversation in this tab to fork yet"])
   })
 
-  // Why (owner report 2026-09-02): `claudecpa` is a zsh function that ends up
-  // running the real claude binary. Registered with no `engineProtocol`, its id
-  // resolves to the empty custom registry entry — no transcript reader, no fork
-  // verb — so this gesture refused with the "nothing to continue" toast on a tab
-  // that had been talking to claude all along. The walk already recorded the
-  // truth as `liveVendor`; this drives the same keys the owner did.
+  // Why: `claudecpa` is a zsh function that ends up running the real claude
+  // binary. Registered with no `engineProtocol`, its id resolves to the empty
+  // custom registry entry — no transcript reader, no fork verb — so this
+  // gesture would refuse with the "nothing to continue" toast on a tab that has
+  // been talking to claude all along. The process walk records the truth as
+  // `liveVendor`; this drives the real keys against it.
   test("tab+continue forks through a wrapper preset's LIVE engine (issue: claudecpa)", async () => {
     const projectDir = path.join(process.env.CLAUDE_CONFIG_DIR as string, "projects", encodeCwd(worktree))
     fs.mkdirSync(projectDir, { recursive: true })
     fs.writeFileSync(path.join(projectDir, "wrapped.jsonl"), "{}\n")
-    // A wrapper preset registered the way every pre-`engineProtocol` one is on
-    // disk: a command and a name, NO `engineProtocol.claudecpa`. That absence is
-    // the bug under test, so the fixture must not paper over it.
+    // A wrapper preset registered the way one without `engineProtocol` sits on
+    // disk: a command and a name, NO `engineProtocol.claudecpa`. That absence
+    // is the case under test, so the fixture must not paper over it.
     //
     // Scoped to THIS test, not the file: custom engines are always offered, so
     // a registration left standing changes what the picker highlights for
-    // everyone else — and on a runner with no claude binary it becomes the only
-    // entry, which is how it broke the two neighbours that assert on "claude".
+    // everyone else — and on a runner with no claude binary it becomes the
+    // only entry, breaking the two neighbours that assert on "claude".
     const statePath = path.join(process.env.KOBE_HOME_DIR as string, ".config", "rove", "state.json")
     fs.mkdirSync(path.dirname(statePath), { recursive: true })
     fs.writeFileSync(
@@ -247,8 +247,7 @@ describe("requestNewChat dispatch", () => {
     act(() => mockInput.pressEnter())
     // `forkChildTask` resolves the handoff plan asynchronously before opening
     // the QuickTaskComposer. Wait for the composer (or a refusal toast) instead
-    // of relying on a fixed settle window — issue #77 was the composer not
-    // having rendered when the assertion ran.
+    // of relying on a fixed settle window, which races the composer's render.
     await waitFor(async () => {
       const f = await frame()
       return f.includes("Quick task") || captured.errors.length > 0

--- a/packages/kobe/test/render/new-task-open-project.test.tsx
+++ b/packages/kobe/test/render/new-task-open-project.test.tsx
@@ -1,6 +1,6 @@
 /** @jsxImportSource @opentui/react */
 /**
- * The Existing tab's "open the project" choice (issue #90), through the real
+ * The Existing tab's "open the project" choice, through the real
  * dialog entry point.
  *
  * The flow-level tests (`test/tui/create-task-flow-open-project.test.ts`) pin
@@ -86,7 +86,7 @@ test("a repo with no project checkout does not", async () => {
 })
 
 test("omitting mainRepos entirely leaves the tab as it was", async () => {
-  // Every caller that has not been taught about the option keeps the old tab.
+  // A caller that passes no `mainRepos` gets the tab unchanged.
   const dir = repo()
   const { frame } = await mount(dir)
   const text = await frame()

--- a/packages/kobe/test/render/new-task-repo-name-field.test.tsx
+++ b/packages/kobe/test/render/new-task-repo-name-field.test.tsx
@@ -1,8 +1,8 @@
 /** @jsxImportSource @opentui/react */
 /**
  * The Existing tab's repo field shows a NAME, with the directory demoted to
- * muted text at the row's right edge (owner report 2026-09-01) — while the
- * value it submits stays a full path.
+ * muted text at the row's right edge — while the value it submits stays a
+ * full path.
  *
  * The split is only worth having if both halves hold at once, and the two
  * halves fail in opposite directions:

--- a/packages/kobe/test/render/pty-delivery-size.test.ts
+++ b/packages/kobe/test/render/pty-delivery-size.test.ts
@@ -1,12 +1,12 @@
 /**
- * Issue #18 — `kobe api send` delivery must not resize the pane's PTY.
+ * `kobe api send` delivery must not resize the pane's PTY.
  *
- * The attached TUI opens a session at its real pane size; a headless
- * delivery client used to reattach via `pty.open {cols:80, rows:24}`,
- * which the host treats as last-attach-wins → the engine got SIGWINCH,
- * repainted at 80 cols, and the pane garbled (content wrapped into the
- * left half, right half blank). The anchored property: after a delivery,
- * the child's terminal size still equals the attached client's pane size.
+ * The attached TUI opens a session at its real pane size; a headless delivery
+ * client that reattaches via `pty.open {cols:80, rows:24}` hits the host's
+ * last-attach-wins rule → the engine gets SIGWINCH, repaints at 80 cols, and
+ * the pane garbles (content wrapped into the left half, right half blank).
+ * The anchored property: after a delivery, the child's terminal size still
+ * equals the attached client's pane size.
  *
  * Runs against a real Bun PTY child (`/bin/sh`, probed with `stty size`),
  * like pty-host.test.ts — the spawn/terminal plumbing is production's.

--- a/packages/kobe/test/render/pty-host.test.ts
+++ b/packages/kobe/test/render/pty-host.test.ts
@@ -213,9 +213,9 @@ describe("PtyHost", () => {
     expect(host.list()).toMatchObject([{ key: "live-task::tab1", alive: true }])
   })
 
-  // Why: issue #40 — folding a scratch shell into the task that owns its cwd
-  // re-keys the RUNNING session instead of respawning it, so the engine
-  // inside survives the move and the sweep now judges it by its new owner.
+  // Why: folding a scratch shell into the task that owns its cwd re-keys the
+  // RUNNING session instead of respawning it, so the engine inside survives
+  // the move and the sweep judges it by its new owner.
   test("rename re-keys a running session; sweep and reattach see the new owner", async () => {
     const host = makeHost()
     const a = collector()
@@ -225,7 +225,7 @@ describe("PtyHost", () => {
 
     expect(host.rename("scratch::tab-1", "owner::tab-3")).toBe(true)
     expect(host.list()).toMatchObject([{ key: "owner::tab-3", alive: true }])
-    // The old key is gone: killing it is a no-op, the session lives on.
+    // The pre-rename key is gone: killing it is a no-op, the session lives on.
     await host.kill("scratch::tab-1")
     host.sweepTasks(new Set(["owner"]))
     expect(host.list()).toMatchObject([{ key: "owner::tab-3", alive: true }])
@@ -252,9 +252,9 @@ describe("PtyHost", () => {
     expect(host.list()).toMatchObject([{ key: "t1::tab1", alive: false }])
   })
 
-  // Why: issue #9 — a crashed engine used to leave "session exited" with no
-  // cause anywhere. The real Bun child is what production runs, so this is
-  // the end-to-end proof the exit code survives the driver seam.
+  // Why: without the exit code, a crashed engine leaves "session exited" with
+  // no cause anywhere. The real Bun child is what production runs, so this is
+  // the end-to-end proof the code survives the driver seam.
   test("a real child's non-zero exit code lands in list(), the exit frame, and the death record", async () => {
     const deaths: Array<{ key: string; exit: { code: number | null }; tail: string }> = []
     const host = makeHost({ onSessionExit: (info) => deaths.push(info) })
@@ -298,8 +298,8 @@ describe("PtyHost", () => {
     expect(host.open("t1::tab1", SPEC, {}, collector().sink).created).toBe(false)
   })
 
-  // Why: the warm slot is the "pre-initialized shell" ask (2026-07-10) —
-  // an engine tab must adopt the ALREADY-RUNNING spare (same pid) instead
+  // Why: the warm slot is the pre-initialized shell — an engine tab must
+  // adopt the ALREADY-RUNNING spare (same pid) instead
   // of paying shell startup, a replacement must be warmed right away, and
   // the spare must never pin the host open (liveCount) or show in list().
   test("warm shell: adopted by a matching open, invisible otherwise", async () => {
@@ -398,8 +398,8 @@ describe("PtyHost", () => {
 // (instead of through a real PTY) is the only way to pin CROSS-CHUNK carry:
 // a real child's writes don't split at chosen byte boundaries, yet a PTY
 // read boundary can fall anywhere — including inside a title's terminator.
-// Regression pin for b8737857, whose introducer-anchored carry was lost in
-// the #334 extraction to pty-observability.ts.
+// The introducer-anchored carry is the part an extraction to
+// pty-observability.ts is most likely to drop, so it is pinned directly.
 describe("foldOscTitle", () => {
   const ESC = "\x1b"
   const BEL = "\x07"

--- a/packages/kobe/test/render/pty-hosted.test.ts
+++ b/packages/kobe/test/render/pty-hosted.test.ts
@@ -139,11 +139,11 @@ describe("HostedTaskPty over a real pty-host socket", () => {
   })
 
   test("kill() + immediate same-key reopen survives the old child's exit frame", async () => {
-    // The editor-tab file swap (and F5 reset): release the old vim and
+    // The editor-tab file swap (and F5 reset): release the running vim and
     // acquire a new PTY under the SAME key in the same tick. The host's
-    // pty.exit for the OLD child races the new handle's open over the
-    // key-routed dispatcher — pre-fix it marked the NEW handle dead, so
-    // the tab closed itself and the file needed a second click.
+    // pty.exit for the DYING child races the new handle's open over the
+    // key-routed dispatcher; marking the NEW handle dead closes the tab and
+    // the file needs a second click.
     const a = new HostedTaskPty({ taskId: "smoke::t7", ...OPTS })
     a.write("old-file\n")
     await until(() => text(a).includes("old-file"), "first session streams")
@@ -157,7 +157,7 @@ describe("HostedTaskPty over a real pty-host socket", () => {
       rows: 12,
     })
     await until(() => text(b).includes("new-file"), "respawned session streams")
-    // Let the old incarnation's exit frame land — it must not kill us.
+    // Let the dying incarnation's exit frame land — it must not kill us.
     await new Promise((r) => setTimeout(r, 300))
     expect(b.killed).toBe(false)
     expect(b.deadOnAttach).toBe(false)
@@ -190,11 +190,11 @@ describe("HostedTaskPty over a real pty-host socket", () => {
   })
 
   test("an actively-streaming reattach keeps a real gap between the wiggle's resizes", async () => {
-    // Regression (2026-07-27 "input box gone"): a streaming child's ordinary
-    // output frame lands milliseconds after the shrink and resolved the
-    // data-wait, so the restore raced back into zero-gap coalescing — one
-    // SIGWINCH at the unchanged size, no repaint. The floor must hold the
-    // two resizes apart even when data arrives instantly.
+    // "Input box gone": a streaming child's ordinary output frame lands
+    // milliseconds after the shrink and resolves the data-wait, so the restore
+    // races back into zero-gap coalescing — one SIGWINCH at the unchanged
+    // size, no repaint. The floor must hold the two resizes apart even when
+    // data arrives instantly.
     const cmd = ["/bin/sh", "-c", "echo ready; while :; do echo tick; sleep 0.02; done"]
     const a = new HostedTaskPty({ taskId: "smoke::t3-stream", cwd: dir, command: cmd, cols: 60, rows: 12 })
     await until(() => text(a).includes("ready"), "streaming session starts")
@@ -216,10 +216,10 @@ describe("HostedTaskPty over a real pty-host socket", () => {
   })
 
   test("waits 500ms for a delayed repaint before restoring the reattach size", async () => {
-    // Regression for 052e57e: a macOS repaint can arrive after the old
-    // 200ms bound. This deterministic delayed-repaint handle holds the
-    // shrink stage for 300ms, so the test both pins the 500ms contract and
-    // proves the original size is restored only after that repaint settles.
+    // A macOS repaint can arrive more than 200ms late. This deterministic
+    // delayed-repaint handle holds the shrink stage for 300ms, so the test
+    // both pins the 500ms contract and proves the original size is restored
+    // only after that repaint settles.
     const a = new HostedTaskPty({ taskId: "smoke::t3-delayed", ...OPTS })
     a.write("ready\n")
     await until(() => text(a).includes("ready"), "first delayed-repaint attach sees output")
@@ -321,7 +321,7 @@ describe("HostedTaskPty over a real pty-host socket", () => {
     const woken = new HostedTaskPty({ taskId: key, ...OPTS_P, restore: screen ?? undefined })
     await until(() => text(woken).includes("WAKE-MARKER"), "woken handle sees the while-parked delta")
     // Full-screen equality against the never-parked oracle — scrollback,
-    // colors, and the pre-park content the 512KB-ring path used to lose.
+    // colors, and the pre-park content a bounded 512KB ring would lose.
     expect(text(woken)).toBe(text(oracle))
     expect(text(woken)).toContain("pre-park line 0")
     expect(woken.captureCursor()).toEqual(oracle.captureCursor())

--- a/packages/kobe/test/render/pty-large-prompt.test.ts
+++ b/packages/kobe/test/render/pty-large-prompt.test.ts
@@ -20,8 +20,8 @@
  * announce bracketed paste, drain stdin to a file) so the test owns timing
  * a real engine only offers by luck. Real-engine measurements behind the
  * numbers: claude announces DECSET 2004 at ~258ms, codex ~321ms, kimi
- * ~1953ms — kimi lands AFTER the old hardcoded 1500ms settle, which is
- * exactly why kimi was the vendor that lost prompts.
+ * ~1953ms — kimi lands AFTER a hardcoded 1500ms settle would expire, which is
+ * exactly why a fixed window loses kimi's prompts.
  */
 
 import { afterEach, describe, expect, test } from "bun:test"
@@ -99,7 +99,7 @@ describe("large prompt delivery into a cold engine", () => {
     const host = new PtyHost({})
     hosts.push(host)
     const sink = join(scratch(), "got.txt")
-    // Cold for 1.6s: past the old hardcoded 1500ms settle, like kimi.
+    // Cold for 1.6s: past a 1500ms fixed settle, like kimi.
     spawnFakeEngine(host, "t1::tab-1", sink, 1_600)
 
     const bytes = await writeHostedPrompt(deliveryRpc(host), "t1::tab-1", BIG_PROMPT)
@@ -123,7 +123,7 @@ describe("large prompt delivery into a cold engine", () => {
     const waited = Date.now() - start
 
     expect(ready).toBe(true)
-    // The old code wrote at ~1500ms and lost the prompt; this must not.
+    // A fixed ~1500ms write loses the prompt; this must not.
     expect(waited).toBeGreaterThan(1_500)
   }, 30_000)
 
@@ -133,8 +133,9 @@ describe("large prompt delivery into a cold engine", () => {
     const sink = join(scratch(), "lost.txt")
     spawnFakeEngine(host, "t3::tab-1", sink, 1_600)
 
-    // Reproduce the OLD behaviour exactly: write immediately, no readiness
-    // wait. The control that proves the fix is what does the work.
+    // The control: write immediately, no readiness wait. This is the shape
+    // that loses the prompt, and it is what makes the test above mean
+    // something.
     await settle(200)
     host.write("t3::tab-1", `\x1b[200~${BIG_PROMPT}\x1b[201~`)
     await settle(2_500)

--- a/packages/kobe/test/render/rail-pages-baseline.test.tsx
+++ b/packages/kobe/test/render/rail-pages-baseline.test.tsx
@@ -1,11 +1,11 @@
 /** @jsxImportSource @opentui/react */
 /**
  * Rail-page visual baseline: Kanban / Routines / Issues swap the SAME
- * content panel, so switching between them must not move the text. The
- * 2026-08-30 visual audit found the three pages each picked their own left
- * inset (padding 1 / 2 / 3, so the body jumped sideways on every switch)
- * and two of the three painted their static page titles with the accent
- * hue, which on the default claude palette IS the focus orange.
+ * content panel, so switching between them must not move the text. Left to
+ * themselves the three pages each pick their own inset (padding 1 / 2 / 3, so
+ * the body jumps sideways on every switch) and paint their static page titles
+ * with the accent hue, which on the default claude palette IS the focus
+ * orange.
  *
  * Contract pinned here, against the real render:
  *   - every rail page's content starts at exactly x=2 (the inset the other
@@ -103,9 +103,9 @@ const RAIL_PAGES: readonly RailPage[] = [
 for (const page of RAIL_PAGES) {
   test(`rail page ${page.title} starts its title at x=2`, async () => {
     const { line } = await renderPage(page.title, page.overrides)
-    // Exactly two leading cells before the title — the shared inset. The old
-    // per-page choices were 1 (Issues), 2 (Routines), 3 (Kanban), and the
-    // whole body jumped sideways on every page switch.
+    // Exactly two leading cells before the title — the shared inset. Per-page
+    // choices (1 / 2 / 3) make the whole body jump sideways on every page
+    // switch.
     expect(line.startsWith(`  ${page.title}`)).toBe(true)
   })
 
@@ -121,7 +121,7 @@ for (const page of RAIL_PAGES) {
   test(`rail page ${page.title} starts its BODY at x=2 too`, async () => {
     // The title row alone is not the contract — a page can pad its root to 2
     // and still inset its own body children (Kanban's project selector and
-    // board each carried their own paddingLeft). Pin every content region,
+    // board each easily carry their own paddingLeft). Pin every content region,
     // so a partial revert of the per-child insets fails here.
     const { text } = await renderPage(page.title, page.overrides)
     for (const anchor of page.body) {

--- a/packages/kobe/test/render/settings-keybindings-create.test.tsx
+++ b/packages/kobe/test/render/settings-keybindings-create.test.tsx
@@ -1,8 +1,8 @@
 /** @jsxImportSource @opentui/react */
 /**
- * Settings → Keybindings used to print a YAML example and leave you to create
- * the file yourself. The page now writes it: one keypress, and the section
- * flips from "not created yet" to a real config it can report on.
+ * Settings → Keybindings WRITES the starter YAML rather than printing an
+ * example for you to retype: one keypress, and the section flips from "not
+ * created yet" to a real config it can report on.
  */
 
 import { expect, test } from "bun:test"

--- a/packages/kobe/test/render/settings-narrow-width.test.tsx
+++ b/packages/kobe/test/render/settings-narrow-width.test.tsx
@@ -31,7 +31,7 @@ async function generalAt(width: number): Promise<string> {
 
 test("at 46 columns the label renders whole instead of being cut mid-word", async () => {
   const text = await generalAt(46)
-  // The longest General label, previously clipped by its own padding.
+  // The longest General label — the one its own padding would clip.
   expect(text).toContain("Show keyboard hints")
   // Its inline hint is dropped rather than rendered as a clipped fragment.
   expect(text).not.toContain("re-enabling relights")

--- a/packages/kobe/test/render/shortcut-reveal.test.tsx
+++ b/packages/kobe/test/render/shortcut-reveal.test.tsx
@@ -49,8 +49,8 @@ function tempHome(mode?: "local" | "guide"): string {
 
 // The complete guide is a deliberate delayed reveal: PrefixHud only opens it
 // PREFIX_GUIDE_DELAY_MS after the tap, so the poll budget must cover that
-// product delay plus frame latency on a loaded CI runner (issue #82: a bare
-// 1s budget flaked at ~1.1s test wall-clock).
+// product delay plus frame latency on a loaded CI runner — a bare 1s budget
+// flakes at ~1.1s test wall-clock.
 const GUIDE_REVEAL_TIMEOUT_MS = PREFIX_GUIDE_DELAY_MS + 5_000
 
 async function waitForGuideText(frame: () => Promise<string>, text: string): Promise<string> {

--- a/packages/kobe/test/render/sidebar-completion-seen.test.ts
+++ b/packages/kobe/test/render/sidebar-completion-seen.test.ts
@@ -27,11 +27,10 @@ describe("completionSeenFor", () => {
     expect(completionSeenFor(task, "turn_complete", false)).toBe(false)
   })
 
-  // Regression (owner report 2026-08-10): "I go in and it shows read, but as
-  // soon as I leave it goes back to unread." A task's tab rows all render in
-  // one pass; a sibling tab legitimately carries no activity, and with a
-  // task-wide key its clear branch wiped the bit the completed tab had just
-  // recorded — so the ✓ never survived leaving the row.
+  // "Read while I'm in it, unread the moment I leave." A task's tab rows all
+  // render in one pass; a sibling tab legitimately carries no activity, and
+  // with a task-wide key its clear branch wipes the bit the completed tab just
+  // recorded, so the ✓ never survives leaving the row.
   it("a sibling tab of the same task does not wipe the completed tab's seen bit", () => {
     const task = "task-seen-3"
     expect(completionSeenFor(task, "turn_complete", true, "tab-1")).toBe(true)
@@ -48,10 +47,10 @@ describe("completionSeenFor", () => {
     expect(completionSeenFor(task, "turn_complete", false, "tab-1")).toBe(true)
   })
 
-  // Regression (owner report 2026-08-12, issue #22): quitting kobe empties
-  // this Set while the DAEMON keeps reporting the same `turn_complete`, so a
-  // relaunch re-lit every completion already read. A fresh process is exactly
-  // this: nothing in the Set, and the persisted mark as the only witness.
+  // Quitting kobe empties this Set while the DAEMON keeps reporting the same
+  // `turn_complete`, so a relaunch relights every completion already read. A
+  // fresh process is exactly this: nothing in the Set, and the persisted mark
+  // as the only witness.
   it("a completion the persisted mark covers is read on a fresh process", () => {
     const task = "task-seen-5"
     expect(completionSeenFor(task, "turn_complete", false, "tab-1", true)).toBe(true)

--- a/packages/kobe/test/render/sidebar-recent-row.test.tsx
+++ b/packages/kobe/test/render/sidebar-recent-row.test.tsx
@@ -1,6 +1,6 @@
 /** @jsxImportSource @opentui/react */
 /**
- * Narrow mode's "↩ Recent" jump row (issue #14, M4/2A): renders as the
+ * Narrow mode's "↩ Recent" jump row: renders as the
  * FIRST navigable row of the sidebar tree, and ⏎ on it activates the recent
  * task — real keys, real tree cursor, no new chord.
  */

--- a/packages/kobe/test/render/sidebar-routine-fold.test.tsx
+++ b/packages/kobe/test/render/sidebar-routine-fold.test.tsx
@@ -1,6 +1,6 @@
 /** @jsxImportSource @opentui/react */
 /**
- * The sidebar's routine fold (issue #91), against real captured frames.
+ * The sidebar's routine fold, against real captured frames.
  *
  * Asserted on the FRAME, not on `buildTreeRows`' output: the thing that has to
  * be true is that a routine session's row is not on screen at rest, and a pure

--- a/packages/kobe/test/render/sidebar-row-chords-cursor.test.tsx
+++ b/packages/kobe/test/render/sidebar-row-chords-cursor.test.tsx
@@ -2,8 +2,8 @@
 /**
  * The sidebar's `b` / `v` / `o` chords target the CURSOR row, not the active
  * task. `j`/`k` move the cursor without selecting (only enter selects), so
- * after one `j` the two differ — and before this contract `b` renamed the
- * ACTIVE task's git branch while the highlight sat on another row. Same shape
+ * after one `j` the two differ, and a chord bound to the active task would
+ * rename a git branch while the highlight sits on another row. Same shape
  * as sidebar-sort-key.test.tsx: the real host binding hook mounted next to
  * the real tree, keys pressed through the mock input.
  */

--- a/packages/kobe/test/render/sidebar-sort-key.test.tsx
+++ b/packages/kobe/test/render/sidebar-sort-key.test.tsx
@@ -123,7 +123,7 @@ test("t flips the sidebar between default and recent sort", async () => {
   expect(orderOf(await frame())).toBeLessThan(0)
 
   // `t` — the sidebar-scoped chord the F1 keymap advertises — flips to
-  // recency: zzz (touched 2026-08-20) jumps above aaa (2026-08-01).
+  // recency: zzz (touched later) jumps above aaa.
   mockInput.typeText("t")
   await new Promise((r) => setTimeout(r, SETTLE))
   expect(orderOf(await frame())).toBeGreaterThan(0)

--- a/packages/kobe/test/render/sidebar-tab-row-view-memo.test.tsx
+++ b/packages/kobe/test/render/sidebar-tab-row-view-memo.test.tsx
@@ -3,8 +3,7 @@
  * The tab row's view derivation must be memoized on its real inputs
  * (`useTabRowBaseView` in tree-rows.tsx). The sidebar re-renders on the
  * ~10Hz spinner tick with a fresh `shared` object every render, and without
- * the memo every idle tab row re-ran `buildSidebarRowView` each tick — the
- * flat cards fixed the same thing in `useRowCardChrome` (row-cards.tsx).
+ * the memo every idle tab row re-runs `buildSidebarRowView` each tick.
  * This probe mounts the hook with CONSTANT inputs, forces re-renders the
  * way the tick does, and pins the returned view to ONE object identity.
  */

--- a/packages/kobe/test/render/sidebar-tree-materializing.test.tsx
+++ b/packages/kobe/test/render/sidebar-tree-materializing.test.tsx
@@ -6,13 +6,14 @@
  * a minutes-long `git worktree add`.
  *
  * The rows the user stares at during that minute are WORKTREE rows, and the
- * one row that used to carry the materializing spinner — the task's active tab
- * row — does not exist yet, because a tab is only recorded once delivery
- * succeeds. So the whole fan-out sat frozen on N identical `(new task)` rows.
+ * task's active TAB row — the natural place for a materializing spinner —
+ * does not exist yet, because a tab is only recorded once delivery succeeds.
+ * Put the spinner there and the whole fan-out sits frozen on N identical
+ * `(new task)` rows.
  *
  * A real mount here rather than a pure assertion on purpose: the claim is
- * "the spinner reaches the frame", and the previous bug was precisely a signal
- * that arrived everywhere except the cells.
+ * "the spinner reaches the frame", and the failure mode is a signal that
+ * arrives everywhere except the cells.
  */
 import { expect, test } from "bun:test"
 import { DEFAULT_SPINNER_FRAMES } from "../../src/engine/spinner-frames"
@@ -110,7 +111,7 @@ test("only the tasks WITH a job spin — a sibling that finished stops", async (
 })
 
 test("a job does NOT leak the task-level activity rollup onto sibling tabs", async () => {
-  // The guard on the fix: the worktree row reads `taskJobs` directly and must
+  // The guard: the worktree row reads `taskJobs` directly and must
   // not start routing task-level ENGINE activity onto rows that have no tab
   // identity — that rollup leak is what `carriesState` exists to stop.
   // A task-level `running` entry with no job in flight must light nothing.

--- a/packages/kobe/test/render/sidebar-tree-menu.test.tsx
+++ b/packages/kobe/test/render/sidebar-tree-menu.test.tsx
@@ -130,9 +130,9 @@ test("right-click on a project header offers the project's own actions", async (
   const after = await frame()
   expect(after).toContain("New task")
   // Forget mirrors `d` on the project's row (task-actions.ts sends a main row
-  // to `forgetProject` behind a confirm) — the menu was missing it.
+  // to `forgetProject` behind a confirm).
   expect(after).toContain("Remove project")
-  // The repo's durable note store had no in-product reader before this entry.
+  // This entry is the only in-product reader of the repo's durable notes.
   expect(after).toContain("Field notes")
   // A project is not a checkout — no per-task verbs on its header.
   expect(after).not.toContain("Rename")

--- a/packages/kobe/test/render/sidebar-tree.test.tsx
+++ b/packages/kobe/test/render/sidebar-tree.test.tsx
@@ -1,17 +1,14 @@
 /** @jsxImportSource @opentui/react */
 /**
- * The frame goldens (`test/render/golden/*.frame.txt`) now lock what this
- * sidebar RENDERS — the project header, the per-level indent, the resting and
- * live state glyphs, the pruned search tree — as whole captured frames rather
- * than as substring probes that say nothing about the cells they don't name.
- * The cases that asserted those things were removed here rather than kept as
- * a weaker duplicate.
+ * The frame goldens (`test/render/golden/*.frame.txt`) lock what this sidebar
+ * RENDERS — the project header, the per-level indent, the resting and live
+ * state glyphs, the pruned search tree — as whole captured frames rather than
+ * as substring probes that say nothing about the cells they don't name.
  *
- * What remains is this file's original reason to exist, which no frame can
- * cover: pressing a real key and proving the CALLBACK fired. The Automations
- * page once shipped with every one of its keys dead (a `Binding[]` passed as
- * an object literal) and a frame-only test stayed green through it — a tree
- * whose j/k/enter silently do nothing looks exactly like a tree that renders
+ * This file covers what no frame can: pressing a real key and proving the
+ * CALLBACK fired. A `Binding[]` passed as an object literal is enough to kill
+ * every key on a page while a frame-only test stays green — a tree whose
+ * j/k/enter silently do nothing looks exactly like a tree that renders
  * correctly.
  */
 import { expect, test } from "bun:test"
@@ -82,8 +79,8 @@ test("enter on a tab row activates that tab, not just its task", async () => {
 })
 
 test("l on a tab row enters that tab's chat — there is no fold", async () => {
-  // Owner call 2026-08-01 round 5: the tree never folds, so `l` is "go in".
-  // On the last level (a tab row) that means entering the tab.
+  // The tree never folds, so `l` is "go in". On the last level (a tab row)
+  // that means entering the tab.
   seedTabs("a", ["tab-1", "tab-2"])
   const picked: Array<[string, string]> = []
   const { frame, mockInput } = await renderComponent(
@@ -179,7 +176,7 @@ test("escape leaves search and restores the full tree", async () => {
   expect(text).not.toContain("/bravo")
 })
 
-// ─── Move mode is scope-aware (issue #43): the cursor row's LEVEL moves ───
+// ─── Move mode is scope-aware: the cursor row's LEVEL moves ───
 
 test("move mode on a TASK row moves the task itself within its repo group", async () => {
   tabsByTask.clear()
@@ -209,7 +206,7 @@ test("move mode on a TASK row moves the task itself within its repo group", asyn
 
 test("move mode on a MAIN row drags the whole project", async () => {
   // Project order is the mains' stored order, so moving the main IS moving
-  // the group — the pre-#43 behavior, now scoped to the main row.
+  // the group. Scoped to the main row: no other row drags its project.
   tabsByTask.clear()
   const moves: Array<[string, number]> = []
   const tasks = [MAIN, task("a")]

--- a/packages/kobe/test/render/sidebar-unread-restart.test.tsx
+++ b/packages/kobe/test/render/sidebar-unread-restart.test.tsx
@@ -1,6 +1,7 @@
 /** @jsxImportSource @opentui/react */
 /**
- * Issue #22 at the render boundary: a completion this process has never seen
+ * The durable seen mark at the render boundary: a completion this process has
+ * never seen
  * — the state a relaunched kobe is in — must still draw as read when the
  * persisted mark covers it.
  *

--- a/packages/kobe/test/render/sidebar-update-chip.test.tsx
+++ b/packages/kobe/test/render/sidebar-update-chip.test.tsx
@@ -3,8 +3,8 @@
  * The brand-row update chip — the passive half of the update surface. The
  * daemon's npm poll lands in `updateSignal`; this pins that a `hasUpdate`
  * payload renders a right-aligned, clickable chip on the ROVE brand row and
- * that no chip renders otherwise (regression: the consumer was lost with the
- * tmux runtime in #313 and the poll went nowhere for months).
+ * that no chip renders otherwise — with no consumer, the poll runs and its
+ * result goes nowhere, silently.
  */
 
 import { expect, test } from "bun:test"

--- a/packages/kobe/test/render/silent-failure-toasts.test.tsx
+++ b/packages/kobe/test/render/silent-failure-toasts.test.tsx
@@ -84,18 +84,18 @@ test("kanban: a rejected detail-drawer edit shows an error toast, not the stale 
 })
 
 /**
- * The terminal's acquire-failure state used to be a dead end.
+ * The terminal's acquire-failure state must not be a dead end.
  *
  * `terminal.exited` names its recovery key ("process exited — F5 restarts
- * it"), and F5 is documented as THE terminal recovery chord. But
- * `requestReset` began `if (!pty) return`, and a failed acquire runs
- * `setPty(null)` — so in the one state that most needs recovery, F5 did
- * nothing at all. The only escape was switching tasks away and back, which
+ * it"), and F5 is documented as THE terminal recovery chord. But a
+ * `requestReset` that begins `if (!pty) return` does nothing after a failed
+ * acquire, which runs `setPty(null)` — so in the one state that most needs
+ * recovery, F5 is dead. The only escape is switching tasks away and back, which
  * the screen never mentioned.
  *
  * This drives the real chord through the real pane against a registry whose
- * first spawn throws, and asserts BOTH halves of the fix: the hint naming F5
- * is on screen, and pressing F5 actually brings the terminal up.
+ * first spawn throws, and asserts BOTH halves: the hint naming F5 is on
+ * screen, and pressing F5 actually brings the terminal up.
  */
 test("terminal: F5 recovers a failed acquire, and the pane says so", async () => {
   let attempt = 0
@@ -135,16 +135,16 @@ test("terminal: F5 recovers a failed acquire, and the pane says so", async () =>
 })
 
 /**
- * Enter on a task whose worktree can't be materialized used to be a TOTAL
- * no-op: `activateWorkspaceTask` correctly refused to move the selection and
- * called `reportError`, but the host wired `reportError` to a bare
- * `console.error`. Under the alternate screen that reaches the daemon log
- * only, so the row didn't move, no toast appeared, and the user could press
- * Enter forever with identical results.
+ * Enter on a task whose worktree can't be materialized must not be a TOTAL
+ * no-op. `activateWorkspaceTask` correctly refuses to move the selection and
+ * calls `reportError`; wiring `reportError` to a bare `console.error` sends it
+ * to the daemon log only under the alternate screen, so the row does not move,
+ * no toast appears, and the user can press Enter forever with identical
+ * results.
  *
  * The unit tests next door cover the error→copy MAPPING. This one covers the
- * WIRING — that the mapped string actually reaches the toast surface. Reverting
- * either half must fail something, and mapping alone passed the old test suite.
+ * WIRING — that the mapped string actually reaches the toast surface.
+ * Reverting either half must fail something; a mapping-only suite would pass.
  */
 function SelectionHarness(props: { orch: never; notifyError: (m: string) => void }) {
   const selection = useWorkspaceSelection({

--- a/packages/kobe/test/render/stale-daemon-reads.test.tsx
+++ b/packages/kobe/test/render/stale-daemon-reads.test.tsx
@@ -2,16 +2,14 @@
 /**
  * What the daemon-fed pages claim when a read fails.
  *
- * These outlived the daemon-disconnect banner they were written for. That
- * banner was removed — Rove keeps working with the daemon down and the socket
- * usually returns within a second, so a full-width red alert interrupted with
- * nothing to act on. What the banner was covering for is still real and still
- * needs guarding: a page must not turn a failed read into a confident green
- * claim, which is the failure this file exists to catch. The banner never fixed
- * that; it only sat on top of it.
+ * There is no daemon-disconnect banner to lean on: Rove keeps working with
+ * the daemon down and the socket usually returns within a second, so a
+ * full-width red alert would interrupt with nothing to act on. Each page has
+ * to hold the line itself — a page must not turn a failed read into a
+ * confident green claim, which is the failure this file catches.
  *
- * The remaining case in the removal's blast radius is the routines page's
- * daemon-hold chip — see the last test.
+ * The sharpest case is the routines page's daemon-hold chip — see the last
+ * test.
  */
 
 import { expect, test } from "bun:test"
@@ -116,16 +114,16 @@ test("the routines page keeps its rows when a poll fails", async () => {
   // The one place the removed banner was load-bearing: `keepsDaemonAlive`
   // comes off the last SUCCESSFUL read, so with the daemon gone the green
   // "keeping the daemon awake" chip is a claim about a process that is not
-  // answering. It used to be overridden by a red "daemon unreachable"; now it
-  // just goes stale. Deliberate — the row data beside it is equally stale, the
+  // answering. It simply goes stale rather than being overridden by a red
+  // "daemon unreachable". Deliberate — the row data beside it is equally stale, the
   // 5s poll heals both the moment the daemon answers, and `rove doctor`
   // already names a dead daemon. This pins the swallow-and-keep behavior so a
   // future refactor can't turn a failed poll into an empty list instead.
   const { orchestrator, connection, failReads } = fakeOrchestrator({ automations: [AUTOMATION] })
   const { frame, mockInput } = await renderComponent(
     <AutomationsPage orchestrator={orchestrator} focused={true} onClose={() => {}} />,
-    // notifications: the page reports failed MUTATIONS as toasts (#651), so
-    // it calls useNotifications() on every render.
+    // notifications: the page reports failed MUTATIONS as toasts, so it calls
+    // useNotifications() on every render.
     { width: 74, height: 20, providers: { dialog: true, notifications: true } },
   )
   await settle(150)

--- a/packages/kobe/test/render/status-hints-kv-identity.test.tsx
+++ b/packages/kobe/test/render/status-hints-kv-identity.test.tsx
@@ -3,15 +3,15 @@
  * The status hint effect must not re-run because unrelated state was
  * persisted.
  *
- * React #185 again, on BOOT this time, with #702's dependency array already
- * in place: `kv` was one of those dependencies, and `KVProvider` rebuilds
- * its context value from a `useMemo` keyed on the kv snapshot. Every
- * `kv.set` anywhere in the app — tab adoption recording a task's tab list,
- * a pane marking its hint used — therefore handed the hook a NEW `kv`
- * object and re-ran the effect, which is the same "runs on every render"
- * the array was added to stop. setSnapshot re-renders the footer, the
- * sidebar rows under it remount, `useBindings` bumps the stack version, the
- * rows write kv again, and the workspace crashed 50 nested updates later.
+ * React #185 on BOOT, with a dependency array already in place: listing `kv`
+ * among those dependencies is enough to defeat it. `KVProvider` rebuilds its
+ * context value from a `useMemo` keyed on the kv snapshot, so every `kv.set`
+ * anywhere in the app — tab adoption recording a task's tab list, a pane
+ * marking its hint used — hands the hook a NEW `kv` object and re-runs the
+ * effect, which is the same "runs on every render" the array exists to stop.
+ * setSnapshot re-renders the footer, the sidebar rows under it remount,
+ * `useBindings` bumps the stack version, the rows write kv again, and the
+ * workspace crashes 50 nested updates later.
  *
  * `status-hints-no-loop.test.tsx` mounts WITHOUT a KV provider, so `kv` is
  * null there and stays referentially stable — which is why it stayed green

--- a/packages/kobe/test/render/status-hints-no-loop.test.tsx
+++ b/packages/kobe/test/render/status-hints-no-loop.test.tsx
@@ -2,7 +2,7 @@
 /**
  * The status hint row must not re-run its snapshot effect on every render.
  *
- * React error #185 ("Maximum update depth exceeded") crashed the workspace
+ * React error #185 ("Maximum update depth exceeded") crashes the workspace
  * while deleting tasks in a burst. `useStatusKeyHintItems` renders in the
  * workspace FOOTER, which wraps the whole pane tree, so its `setState`
  * re-renders every sidebar row — and each row's `useBindings` bumps the
@@ -96,10 +96,10 @@ test("deleting rows in a burst settles instead of looping", async () => {
 })
 
 test("a render that changes no hint input does not re-run the snapshot", async () => {
-  // The regression guard proper. Without a dependency array this effect ran
-  // on EVERY render, which is the precondition for the loop above; the
-  // compare-and-set only hid it. Here the tree re-renders with the same
-  // focus, same bindings, same keymap — the effect must stay quiet.
+  // The guard proper. Without a dependency array this effect runs on EVERY
+  // render, which is the precondition for the loop above; a compare-and-set
+  // only hides it. Here the tree re-renders with the same focus, same
+  // bindings, same keymap — the effect must stay quiet.
   const { frame, mockInput } = await renderComponent(<App />, { width: 80, height: 12 })
   await act(async () => {})
 

--- a/packages/kobe/test/render/tab-session-discovery.test.tsx
+++ b/packages/kobe/test/render/tab-session-discovery.test.tsx
@@ -85,7 +85,7 @@ function lifecycleIO(state: TabsState, wt: string): TabLifecycleIO & { state: ()
 test("a rehydrated kimi tab adopts the session its worktree already has", async () => {
   await seedKimiSession()
   const state: TabsState = {
-    // No sessionId — exactly how every kimi tab persisted before this change.
+    // No sessionId — exactly how a kimi tab persists.
     tabs: [{ kind: "engine", id: "tab-1", title: null, ordinal: 1, vendor: "kimi" }],
     activeId: "tab-1",
     nextOrdinal: 2,

--- a/packages/kobe/test/render/tab-strip-boxed.test.tsx
+++ b/packages/kobe/test/render/tab-strip-boxed.test.tsx
@@ -1,6 +1,6 @@
 /** @jsxImportSource @opentui/react */
 /**
- * Boxed tab strip (2026-08-29 design): every tab is a closed rounded box;
+ * Boxed tab strip: every tab is a closed rounded box;
  * the ACTIVE tab omits its bottom edge so the frame reads as a notch opening
  * into the pane below (claude-squad's `activeTabBorder`). Tabs sit flush —
  * the frames are the gutter — and the one-row viewport scrolls per cell to
@@ -25,7 +25,7 @@ import { TURN_GLYPHS, TabStrip } from "../../src/tui-react/workspace/tab-strip"
 import type { TerminalTab } from "../../src/tui/workspace/terminal-tabs-core"
 import { renderComponent } from "./harness"
 
-// The strip is OFF by default (2026-08-31) — the sidebar tree already lists
+// The strip is OFF by default — the sidebar tree already lists
 // these tabs. This file is about what it DRAWS when asked for, so the mode is
 // pinned to `always` for every test here.
 process.env.KOBE_HOME_DIR ??= mkdtempSync(join(tmpdir(), "kobe-tab-strip-boxed-"))
@@ -66,11 +66,11 @@ function StripDriver(props: { tabs: readonly TerminalTab[]; start: string; width
 /**
  * A title longer than the pane is truncated, not drawn past the strip.
  *
- * The strip is `overflow: hidden`, so an over-long title did not merely spill
- * — it pushed the tab's own right frame off the edge and ran to the last
- * column with no ellipsis, so nothing on screen said the name had been cut.
- * The narrow form (`tab-strip-narrow.test.tsx`) always truncated; this is the
- * same rule for the wide one.
+ * The strip is `overflow: hidden`, so an over-long title does not merely spill
+ * — it pushes the tab's own right frame off the edge and runs to the last
+ * column with no ellipsis, leaving nothing on screen to say the name was cut.
+ * The narrow form (`tab-strip-narrow.test.tsx`) truncates; this is the same
+ * rule for the wide one.
  *
  * Truncation happens before the width each entry reports, so this also guards
  * the scroll math: measuring an untruncated title would scroll the viewport by
@@ -102,8 +102,8 @@ test("a title wider than the pane is ellipsised inside its own frame", async () 
   const titleRow = (await frame()).split("\n").find((line) => line.includes("a-very-long-shell")) ?? ""
   // Cut, and visibly so.
   expect(titleRow).toContain("…")
-  // The tab's own right frame survived: both verticals are on the row, which
-  // is exactly what an over-long title used to push off the edge.
+  // The tab's own right frame survives: both verticals are on the row, which
+  // is exactly what an over-long title pushes off the edge when unclamped.
   expect(count(titleRow, "│")).toBe(2)
 })
 

--- a/packages/kobe/test/render/tab-strip-narrow.test.tsx
+++ b/packages/kobe/test/render/tab-strip-narrow.test.tsx
@@ -1,6 +1,6 @@
 /** @jsxImportSource @opentui/react */
 /**
- * Narrow condensed tab strip (issue #14, M3): below the breakpoint the
+ * Narrow condensed tab strip: below the breakpoint the
  * strip shows only the ACTIVE tab plus a `2/3` position counter — narrow
  * overrides the mode gate, because the sidebar tree is not on screen beside
  * a narrow workspace, so the condensed strip is the only tab affordance
@@ -56,7 +56,7 @@ test("narrow strip shows the active tab truncated with a position counter", asyn
 })
 
 test("desktop renders the boxed strip when the mode is `always`", async () => {
-  // Explicit, because `never` is the default (2026-08-31): the sidebar tree
+  // Explicit, because `never` is the default: the sidebar tree
   // already lists these tabs. This pins what the strip DRAWS when asked for.
   process.env.KOBE_HOME_DIR = mkdtempSync(join(tmpdir(), "kobe-tab-strip-always-"))
   mkdirSync(join(process.env.KOBE_HOME_DIR, ".config", "rove"), { recursive: true })

--- a/packages/kobe/test/render/tab-strip-state-glyphs.test.ts
+++ b/packages/kobe/test/render/tab-strip-state-glyphs.test.ts
@@ -7,8 +7,8 @@
  * Mutation target is the WIRE between the two vocabularies, not either table
  * alone: reverting `activityTurnState`'s `rate_limited → error` fold turns
  * this red, and so does reverting `TURN_GLYPHS`. Asserting only one of the
- * two would stay green through a revert of the other — and the bug was
- * precisely that the two halves disagreed.
+ * two would stay green through a revert of the other, and the failure mode is
+ * precisely the two halves disagreeing.
  */
 import { describe, expect, it } from "bun:test"
 import type { TaskActivityState } from "../../src/engine/hook-events"
@@ -36,7 +36,7 @@ describe("tab strip glyphs agree with the sidebar rail", () => {
 
   it("still raises an attention notification for all three", () => {
     // Splitting the chip vocabulary must not silently drop the toast that
-    // `rate_limited` used to get by riding on `error`.
+    // `rate_limited` gets by riding on `error`.
     for (const state of ["rate_limited", "error", "dead"] as const) {
       expect(chipAttentionKind(activityTurnState(state) ?? "")).toBe("error")
     }

--- a/packages/kobe/test/render/tab-strip-unread-restart.test.tsx
+++ b/packages/kobe/test/render/tab-strip-unread-restart.test.tsx
@@ -1,15 +1,15 @@
 /** @jsxImportSource @opentui/react */
 /**
- * Issue #23 at the render boundary: the tab strip's completion chip must
- * consult the SAME durable `(task, tab) → seen-at` record the sidebar lamp
- * reads (issue #22), so a completion you had already looked at does not come
- * back wearing a fresh ✓ after a restart.
+ * The durable seen bit at the render boundary: the tab strip's completion
+ * chip must consult the SAME `(task, tab) → seen-at` record the sidebar lamp
+ * reads, so a completion you had already looked at does not come back wearing
+ * a fresh ✓ after a restart.
  *
  * A relaunched kobe is exactly this state — no in-process history, and the
  * daemon still publishing the same sticky `turn_complete`. So the strip is
  * mounted through the REAL hook (`useDurableTabSeen`) against a seeded
- * state.json, not handed a precomputed set: the wiring is the thing that
- * broke, and `test/tui-react/completion-seen.test.ts` already owns the fold.
+ * state.json, not handed a precomputed set: the wiring is what this file
+ * owns, and `test/tui-react/completion-seen.test.ts` already owns the fold.
  *
  * The rail's counterpart lives in `sidebar-unread-restart.test.tsx`.
  */

--- a/packages/kobe/test/render/terminal-drag-autoscroll.test.tsx
+++ b/packages/kobe/test/render/terminal-drag-autoscroll.test.tsx
@@ -135,7 +135,7 @@ test("dragging sideways along the top row does not scroll", async () => {
  * cannot move. Claude Code is exactly this case, so without it a drag-select
  * at the edge of an engine tab does nothing at all.
  *
- * And forwarding alone is not the fix (issue #54): the app scrolls, the
+ * And forwarding alone is not enough: the app scrolls, the
  * content shifts, but the snapshot row numbers stay put — so the SELECTION
  * must follow the measured content shift, not stay a screen-fixed rectangle.
  * The drag here is held at the edge while the scripted app scrolls itself;

--- a/packages/kobe/test/render/terminal-selection-mouse-gate.test.tsx
+++ b/packages/kobe/test/render/terminal-selection-mouse-gate.test.tsx
@@ -2,7 +2,7 @@
 /**
  * The pane's own selection yields the screen to an app that owns the mouse.
  *
- * #785 already keeps the pane out of a mouse-aware app on the PRESS — the
+ * The press-time gate already keeps the pane out of a mouse-aware app: the
  * click is forwarded and no selection starts. What it cannot cover is the app
  * arriving AFTER the selection: `vim` typed at a prompt where text is still
  * highlighted, or launched mid-drag. Both highlights then paint on the same
@@ -116,7 +116,7 @@ test("a selection is cleared when the app takes the mouse under it", async () =>
 })
 
 /**
- * The shift bypass (#785's iTerm/kitty escape hatch) is how text still gets
+ * The shift bypass (the iTerm/kitty escape hatch) is how text still gets
  * pulled out of a mouse-aware app, so a selection begun while the app ALREADY
  * owned the mouse is a deliberate override — it keeps its highlight.
  */

--- a/packages/kobe/test/render/terminal-tabs-close.test.ts
+++ b/packages/kobe/test/render/terminal-tabs-close.test.ts
@@ -91,12 +91,10 @@ test("a listener for a DIFFERENT task does not claim it", () => {
 })
 
 test("the last tab closes, leaving the task empty", () => {
-  // A task's last tab may go (owner call 2026-08-31): the row stays and is
-  // revived on re-entry. This file used to assert the opposite — the older
-  // rule, when an emptied task had no way back — and that stale expectation
-  // is why the background path kept refusing after the mounted one stopped:
-  // the two routes are the SAME gesture from the tree, and only one of them
-  // was updated.
+  // A task's last tab may go: the row stays and is revived on re-entry. The
+  // mounted and background routes are the SAME gesture from the tree, so both
+  // have to allow it — a refusal left on either one is invisible from the
+  // other.
   tabsByTask.clear()
   tabsByTask.set("t1", state(["tab-1"]))
   expect(closeTaskTab(fakeKv(), "t1", "tab-1")).toBe(true)

--- a/packages/kobe/test/render/workspace-orphan-sweep.test.tsx
+++ b/packages/kobe/test/render/workspace-orphan-sweep.test.tsx
@@ -1,12 +1,11 @@
 /** @jsxImportSource @opentui/react */
 /**
- * Orphan-sweep timing in useWorkspaceSelection (O19 follow-up): the sweep of
- * `terminalTabs.*` snapshots whose task no longer exists must run on EVERY
- * task-list identity change, not once per session. forgetTaskTabs only fires
- * for THIS client's delete flow — a sibling client (`rove api` / web board)
- * removing a task lands here purely as a changed list, and the old
- * once-per-session ref left those orphans on disk until the next launch,
- * taxing every later kv write. This probe seeds two snapshots, then removes
+ * Orphan-sweep timing in useWorkspaceSelection: the sweep of `terminalTabs.*`
+ * snapshots whose task is gone must run on EVERY task-list identity change,
+ * not once per session. forgetTaskTabs only fires for THIS client's delete
+ * flow — a sibling client (`rove api` / web board) removing a task lands here
+ * purely as a changed list, and a once-per-session ref leaves those orphans on
+ * disk until the next launch, taxing every later kv write. This probe seeds two snapshots, then removes
  * a task from the list the way a foreign delete does, and pins the sweep to
  * follow THAT change — plus the load-bearing `tasks.length === 0` guard.
  */

--- a/packages/kobe/test/render/workspace-selection-lastactive.test.tsx
+++ b/packages/kobe/test/render/workspace-selection-lastactive.test.tsx
@@ -1,10 +1,10 @@
 /** @jsxImportSource @opentui/react */
 /**
  * selectTask must publish the active task even when the id is already the
- * local selection (issue #14 follow-up): a fresh home boots with a
- * fallback-selected task but a NULL active record, and the old early-return
- * meant the first Enter never called setActiveTask — so lastActive stayed
- * unwritten and narrow mode's "↩ recent" row never appeared.
+ * local selection: a fresh home boots with a fallback-selected task but a
+ * NULL active record, so an early return on "already selected" means the first
+ * Enter never calls setActiveTask — lastActive stays unwritten and narrow
+ * mode's "↩ recent" row never appears.
  */
 
 import { describe, expect, it } from "bun:test"
@@ -93,7 +93,7 @@ describe("selectTask on a fresh home", () => {
     expect(selectedId).toBe("alpha")
     expect(published).toEqual([])
 
-    // Entering that pre-selected task must publish it (the fix).
+    // Entering that pre-selected task must publish it.
     act(() => selectTask?.("alpha"))
     await settle()
     expect(published).toEqual(["alpha"])

--- a/packages/kobe/test/render/workspace-worktree-gone-notice.test.tsx
+++ b/packages/kobe/test/render/workspace-worktree-gone-notice.test.tsx
@@ -2,9 +2,9 @@
 /**
  * A task whose worktree disappears out-of-band (another client, the worktrees
  * page, another agent's `rove api`) has ALL of its terminal tabs dropped — its
- * PTYs released and its persisted snapshot deleted. That was silent, which is
- * how "the tab I was working in just vanished" reached the owner with nothing
- * to look at (2026-08-29). It must announce itself.
+ * PTYs released and its persisted snapshot deleted. Silently, that reads as
+ * "the tab I was working in just vanished" with nothing to look at. It must
+ * announce itself.
  *
  * Deliberately NOT a confirm dialog: the worktree is already gone by the time
  * this runs, so there is nothing left to consent to.

--- a/packages/kobe/test/render/worktrees-page-delete.test.tsx
+++ b/packages/kobe/test/render/worktrees-page-delete.test.tsx
@@ -4,9 +4,9 @@
  * daemon.
  *
  * `git worktree remove` on a worktree with a populated `node_modules` is
- * seconds of real filesystem work; the page used to `await` it before
- * refetching, so the row sat there looking hung. These tests pin the
- * optimistic behavior: gone on confirm, back on failure.
+ * seconds of real filesystem work, so `await`ing it before refetching leaves
+ * the row sitting there looking hung. These tests pin the optimistic
+ * behavior: gone on confirm, back on failure.
  */
 
 import { expect, test } from "bun:test"

--- a/packages/kobe/test/tui-react/attention-notify-targets.test.ts
+++ b/packages/kobe/test/tui-react/attention-notify-targets.test.ts
@@ -18,10 +18,10 @@ const tabLevel = (
     ]),
   )
 
-// The cross-task notifier used to diff the TASK-level map, which the daemon
-// writes as a last-event-wins rollup. An edge only fires on a value change, so
-// the second of two tabs finishing found the rollup already at turn_complete
-// and never announced itself — two agents done, one toast.
+// Diffing the TASK-level map is not enough: the daemon writes it as a
+// last-event-wins rollup, and an edge only fires on a value change, so the
+// second of two tabs finishing finds the rollup already at turn_complete and
+// never announces itself — two agents done, one toast.
 describe("cross-task notify targets", () => {
   test("gives each reporting tab its own entry", () => {
     const { states, targets } = notifyTargetStates(
@@ -49,7 +49,7 @@ describe("cross-task notify targets", () => {
     expect([...states.keys()]).toEqual(["a:tab-1"])
   })
 
-  // The regression itself.
+  // The case the per-tab grain exists for.
   test("a second tab finishing still fires an edge", () => {
     const rollup = "turn_complete"
     const before = notifyTargetStates(
@@ -64,7 +64,7 @@ describe("cross-task notify targets", () => {
       { key: "a:tab-2", kind: "done" },
     ])
 
-    // Task-level only — what the old code diffed — sees no change at all.
+    // Task-level only sees no change at all.
     const oldBefore = new Map([["a", rollup]])
     const oldAfter = new Map([["a", rollup]])
     expect(attentionEdges(oldBefore, oldAfter, null, attentionKindFor)).toEqual([])

--- a/packages/kobe/test/tui-react/completion-seen.test.ts
+++ b/packages/kobe/test/tui-react/completion-seen.test.ts
@@ -23,9 +23,9 @@ function fakeKv(seed?: unknown) {
   }
 }
 
-// Issue #22 (owner report 2026-08-12): the sidebar's unread lamp only knew
-// what THIS process had seen, so relaunching kobe re-lit every completion
-// the daemon still reported. The durable mark is what crosses the restart.
+// An unread lamp that only knows what THIS process has seen relights every
+// completion the daemon still reports on relaunch. The durable mark is what
+// crosses the restart.
 describe("durable completion-seen marks", () => {
   test("a mark covers its own completion and every older one", () => {
     const kv = fakeKv()
@@ -78,10 +78,9 @@ describe("durable completion-seen marks", () => {
   })
 })
 
-// Issue #23: the tab strip's chip used to sit on a process-local unread map,
-// so a completion you had read came back looking fresh after a restart while
-// the sidebar lamp (persisted since #22) disagreed. Both now fold the SAME
-// record.
+// A process-local unread map under the tab strip's chip would make a
+// completion you had read look fresh again after a restart, while the
+// persisted sidebar lamp disagreed. Both fold the SAME record.
 describe("seenCompletionTabs (tab strip's half of the mark)", () => {
   test("only tabs whose current completion the record covers come back seen", () => {
     const kv = fakeKv({

--- a/packages/kobe/test/tui-react/file-open-actions.test.ts
+++ b/packages/kobe/test/tui-react/file-open-actions.test.ts
@@ -5,7 +5,7 @@
  * run under vitest directly. What's pinned here is the resolution ORDER
  * (plugin > editor tab > OS opener), the stale-continuation guard that keeps a
  * slow editor resolve from delivering into whatever task the user switched to,
- * and KOB-25's rule that a read-only diff must not steal focus.
+ * and the rule that a read-only diff must not steal focus.
  */
 
 import { beforeEach, describe, expect, test, vi } from "vitest"
@@ -117,7 +117,7 @@ describe("openDiff", () => {
     expect(openDiffTab).toHaveBeenCalledWith("src/deep/a.ts", "a.ts", "main")
   })
 
-  // KOB-25: a read-only open is a content swap, not a navigation.
+  // A read-only open is a content swap, not a navigation.
   test("does not pull focus", () => {
     const { actions, setFocused } = setup()
     actions.openDiff("a.ts")

--- a/packages/kobe/test/tui-react/filetree-pane-core.test.ts
+++ b/packages/kobe/test/tui-react/filetree-pane-core.test.ts
@@ -1,12 +1,9 @@
 /**
- * pane-core — the framework-free file-tree logic extracted for the React
- * port (issue #15, G3). Both runtimes drive their cursor / expansion /
- * stat-column behavior through these functions, so this suite is the single
- * behavioral pin for hierarchy navigation (`h`/`l` semantics), the
- * Changes-tab stat alignment math, git-error summarization, and the
- * fs-watch event filter. A regression here misbehaves identically in the
- * Solid pane and the React pane — which is exactly the point of the
- * extraction.
+ * pane-core — the framework-free file-tree logic. The pane drives its cursor
+ * / expansion / stat-column behavior through these functions, so this suite
+ * is the single behavioral pin for hierarchy navigation (`h`/`l` semantics),
+ * the Changes-tab stat alignment math, git-error summarization, and the
+ * fs-watch event filter.
  */
 
 import { describe, expect, test } from "vitest"

--- a/packages/kobe/test/tui-react/help-groups.test.ts
+++ b/packages/kobe/test/tui-react/help-groups.test.ts
@@ -1,7 +1,6 @@
 /**
- * Invariants for the shared help-dialog grouping (issue #15, G3) — consumed
- * by BOTH the Solid and React HelpDialogs. Declaration order is the visible
- * contract: the F1 help lists categories in the order the keymap declares
+ * Invariants for the shared help-dialog grouping. Declaration order is the
+ * visible contract: the F1 help lists categories in the order the keymap declares
  * them, and every binding must land in exactly one group (a dropped row is
  * an invisible keybinding).
  */

--- a/packages/kobe/test/tui-react/history-message-core.test.ts
+++ b/packages/kobe/test/tui-react/history-message-core.test.ts
@@ -1,7 +1,6 @@
 /**
- * Pins the framework-free history transcript formatting shared by the Solid and
- * React panes. Renderer-bound TSX stays out of vitest; this file covers the
- * extracted pure logic only.
+ * Pins the framework-free history transcript formatting. Renderer-bound TSX
+ * stays out of vitest; this file covers the extracted pure logic only.
  */
 
 import { describe, expect, it } from "vitest"
@@ -24,9 +23,9 @@ describe("history message core", () => {
   })
 
   it("cuts long summaries by code point — never bisects a surrogate pair", () => {
-    // Each 🎉 is one code point but two UTF-16 units; the old
-    // `.slice(0, 119)` by UTF-16 length could cut mid-pair and emit a lone
-    // surrogate (→ �). truncateEnd counts code points instead.
+    // Each 🎉 is one code point but two UTF-16 units, so slicing by UTF-16
+    // length can cut mid-pair and emit a lone surrogate (→ �). truncateEnd
+    // counts code points instead.
     const out = toolInputSummary({ command: "🎉".repeat(200) })
     expect(out).toBe(`${"🎉".repeat(119)}…`)
   })

--- a/packages/kobe/test/tui-react/inbox-open-action.test.ts
+++ b/packages/kobe/test/tui-react/inbox-open-action.test.ts
@@ -10,7 +10,7 @@ const item: AttentionInboxItem = {
   at: 123,
 }
 
-// Opening RESOLVES the episode (queue-drain model, owner 2026-07-16): both
+// Opening RESOLVES the episode (queue-drain model): both
 // the available and the unavailable path dismiss it from the daemon store;
 // only navigation differs (an unavailable target can't be jumped to).
 describe("requestInboxItemOpen", () => {

--- a/packages/kobe/test/tui-react/inbox-visits.test.ts
+++ b/packages/kobe/test/tui-react/inbox-visits.test.ts
@@ -33,9 +33,9 @@ describe("inbox visit log", () => {
     expect(log).toEqual([visit("b", "tab-2", 3), visit("a", "tab-1", 1)])
   })
 
-  // Owner report 2026-08-10: entries are keyed by (task, TAB). A task-keyed
-  // log collapsed a whole session of chat-tab switching into one row, so the
-  // tabs you'd just left never appeared in RECENT.
+  // Entries are keyed by (task, TAB). A task-keyed log collapses a whole
+  // session of chat-tab switching into one row, so the tabs you just left
+  // never appear in RECENT.
   test("keeps a separate entry per tab of the same task", () => {
     const log = recordInboxVisit([visit("a", "tab-1", 1)], visit("a", "tab-2", 2))
     expect(log).toEqual([visit("a", "tab-2", 2), visit("a", "tab-1", 1)])

--- a/packages/kobe/test/tui-react/keybinding-gates.test.ts
+++ b/packages/kobe/test/tui-react/keybinding-gates.test.ts
@@ -2,9 +2,9 @@
  * Pins the workspace-host gating contract (workspace/keybinding-gates.ts):
  * an open dialog or full-page swap disables every workspace chord group,
  * and the ONE deliberate exemption — the settings page's own close keys —
- * is live exactly while settings is open with no sub-dialog above it.
- * Previously these were inline `dialog.stack.length === 0 && …` expressions
- * in host-keybindings.ts with no test.
+ * is live exactly while settings is open with no sub-dialog above it. One
+ * named predicate per group, rather than inline `dialog.stack.length === 0 && …`
+ * expressions scattered through host-keybindings.ts with nothing testing them.
  */
 
 import { describe, expect, test } from "vitest"
@@ -80,8 +80,7 @@ describe("nextFocusedPane", () => {
   })
 
   test("clamps at both ends rather than wrapping", () => {
-    // Cursor semantics, owner call 2026-07-25: "previous" from the sidebar
-    // must never jump to files.
+    // Cursor semantics: "previous" from the sidebar must never jump to files.
     expect(nextFocusedPane("sidebar", -1, withFiles)).toBeNull()
     expect(nextFocusedPane("files", 1, withFiles)).toBeNull()
   })

--- a/packages/kobe/test/tui-react/kv-core.test.ts
+++ b/packages/kobe/test/tui-react/kv-core.test.ts
@@ -1,7 +1,6 @@
 /**
- * Framework-free KV core (src/tui-react/context/kv-core.ts) — the React
- * KVProvider's persistence half. These tests pin the semantics the Solid
- * provider fought for and the React port must not regress:
+ * Framework-free KV core (src/tui-react/context/kv-core.ts) — the
+ * KVProvider's persistence half. These tests pin its semantics:
  *
  *   - DIRTY-KEY MERGE on flush: only keys THIS core `set()` reach disk; a
  *     key another process wrote after hydration passes through untouched
@@ -92,13 +91,13 @@ describe("createKvCore", () => {
   })
 
   it("set(key, undefined) removes the key from the in-memory snapshot", () => {
-    // React #185 (2026-09-01): the spread `{ ...s, [key]: undefined }` kept
-    // the deleted key ENUMERABLE in the snapshot, so the orphan sweep
+    // A spread `{ ...s, [key]: undefined }` would keep the deleted key
+    // ENUMERABLE in the snapshot, so the orphan sweep
     // (`sweepOrphanTabsSnapshots`, which walks Object.keys and re-deletes)
-    // re-set it on every task-list change — each set a new snapshot identity,
+    // re-sets it on every task-list change — each set a new snapshot identity,
     // each identity a re-run of the sweep effect: an infinite setState loop
-    // that crashed the workspace whenever a stale `terminalTabs.*` key
-    // existed. Deletion must actually shrink Object.keys.
+    // (React #185) that crashes the workspace whenever a stale
+    // `terminalTabs.*` key exists. Deletion must actually shrink Object.keys.
     isolatedHome({ "terminalTabs.dead": { tabs: [] }, kept: 1 })
     const kv = createKvCore()
     kv.set("terminalTabs.dead", undefined)
@@ -159,8 +158,8 @@ describe("createKvCore", () => {
     expect(readState(home)).toEqual({ k: "v" })
   })
 
-  // Issues #22/#23: the debounce is a real data-loss window — a state change
-  // made inside it is gone if the process exits before the timer fires. The
+  // The debounce is a real data-loss window — a state change made inside it
+  // is gone if the process exits before the timer fires. The
   // KVProvider's "exit" hook calls flush() for exactly this; these pin that
   // flush actually beats the pending timer rather than racing it.
   it("flush() persists a write still inside the debounce window", () => {
@@ -205,9 +204,9 @@ describe("createKvCore", () => {
     const kv = createKvCore()
     kv.set("nested", { a: 1, b: [1, 2] })
     expect(kv.flush()).toBe(true)
-    // The file is rewritten whole on EVERY flush and read only by machines;
-    // `null, 2` used to triple its bytes. Round-tripping through parse must
-    // reproduce the exact bytes — the cheapest compactness invariant.
+    // The file is rewritten whole on EVERY flush and read only by machines,
+    // so it is serialized compactly (`null, 2` would triple its bytes).
+    // Round-tripping through parse must reproduce the exact bytes.
     const raw = readFileSync(statePath(home), "utf8")
     expect(raw).toBe(JSON.stringify(JSON.parse(raw)))
   })

--- a/packages/kobe/test/tui-react/new-task-pure.test.ts
+++ b/packages/kobe/test/tui-react/new-task-pure.test.ts
@@ -1,10 +1,9 @@
 /**
- * Unit tests for the React new-task dialog's extracted pure helpers
- * (`src/tui-react/component/new-task-dialog/pure.ts`). These were inline
- * in the Solid shell; the React port pulls them out so the vendor-set
- * fallback, initial-vendor clamping, and adopt multi-select semantics
- * are pinned without mounting the dialog (no @opentui import here —
- * vitest never loads the renderer).
+ * Unit tests for the new-task dialog's extracted pure helpers
+ * (`src/tui-react/component/new-task-dialog/pure.ts`): the vendor-set
+ * fallback, initial-vendor clamping, and adopt multi-select semantics,
+ * pinned without mounting the dialog (no @opentui import here — vitest never
+ * loads the renderer).
  *
  * Why these matter: the vendor fallback is what guarantees the engine
  * selector is never empty (task creation must never be blocked by a

--- a/packages/kobe/test/tui-react/notify-state.test.ts
+++ b/packages/kobe/test/tui-react/notify-state.test.ts
@@ -1,7 +1,7 @@
 /**
- * Invariants for the shared notification state (issue #15, G3) — the pure
- * transforms behind BOTH the Solid and React NotificationsProviders. The
- * escalation rule (needs_input/error outrank done) and the "error toasts
+ * Invariants for the shared notification state — the pure transforms behind
+ * the NotificationsProvider. The escalation rule (needs_input/error outrank
+ * done) and the "error toasts
  * always show" gate are behavior users notice the moment they regress
  * (a red unread dot silently downgraded to green, or a failure toast
  * suppressed by the completion-toast preference), so they're pinned here

--- a/packages/kobe/test/tui-react/ops-activity-monitor.test.ts
+++ b/packages/kobe/test/tui-react/ops-activity-monitor.test.ts
@@ -1,12 +1,10 @@
 /**
  * The Ops pane's framework-free turn-status poll loop
- * (`tui/ops/activity-monitor.ts`), extracted from the Solid host so the
- * React port (issue #15, G3) runs the SAME loop body. Why these tests
- * matter: the loop was previously component-internal and untestable
- * (host.tsx pulls @opentui render assets); the extraction makes the
- * teardown-race swallow and the ChatTab done rule ("new completion id +
- * quiescent pane") directly checkable with fake IO and fake timers —
- * regressions here silently report "done" for a sibling window's turn.
+ * (`tui/ops/activity-monitor.ts`). Kept out of the component (host.tsx pulls
+ * @opentui render assets) so the teardown-race swallow and the ChatTab done
+ * rule ("new completion id + quiescent pane") are checkable with fake IO and
+ * fake timers — a regression here silently reports "done" for a sibling
+ * window's turn.
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"

--- a/packages/kobe/test/tui-react/ops-preview-core.test.ts
+++ b/packages/kobe/test/tui-react/ops-preview-core.test.ts
@@ -1,10 +1,9 @@
 /**
- * Data half of the ops preview window (`tui/ops/preview-core.ts`), shared
- * by the Solid and React previews (issue #15, G3). Why these tests matter:
+ * Data half of the ops preview window (`tui/ops/preview-core.ts`).
  * `loadPreviewData` decides which renderable the preview mounts — a dirty
  * file MUST render as a `<diff>` vs HEAD and a clean/untracked one as its
- * `<code>` content — and `filetypeOf` picks the tree-sitter grammar; both
- * were previously locked inside the untestable host.tsx.
+ * `<code>` content — and `filetypeOf` picks the tree-sitter grammar. Both
+ * live here rather than inside the untestable host.tsx.
  */
 
 import { execFileSync } from "node:child_process"

--- a/packages/kobe/test/tui-react/revive-emptied-tabs.test.ts
+++ b/packages/kobe/test/tui-react/revive-emptied-tabs.test.ts
@@ -1,11 +1,11 @@
 /**
  * Re-entering a task whose last tab you closed must give it a tab back.
  *
- * `closeTab({ allowEmpty })` (owner call 2026-08-31) lets the last tab go, and
- * `show-workspace` deliberately renders nothing for an empty tab list — mounting
- * TerminalTabs over one would mint a replacement it cannot control. That left
- * the task reachable but dead: its row was still in the sidebar, and selecting
- * it landed on a blank pane with no way out.
+ * `closeTab({ allowEmpty })` lets the last tab go, and `show-workspace`
+ * deliberately renders nothing for an empty tab list — mounting TerminalTabs
+ * over one would mint a replacement it cannot control. Without a revive that
+ * leaves the task reachable but dead: its row is still in the sidebar, and
+ * selecting it lands on a blank pane with no way out.
  *
  * `reviveEmptiedTabs` is the missing half, and this pins the states it must and
  * must NOT act on. `terminal-tabs-core.test`-adjacent coverage

--- a/packages/kobe/test/tui-react/scratch-fold.test.ts
+++ b/packages/kobe/test/tui-react/scratch-fold.test.ts
@@ -1,9 +1,9 @@
 /**
- * Fold execution (issue #40): the scratch shell's hosted sessions move
- * under the owning task's next free tab ids and get adopted into its tab
- * state — quietly (adoption never steals the target's active tab), and
- * only when the host actually re-keyed something (an old host or a dead
- * session must NOT delete the scratch row over nothing).
+ * Fold execution: the scratch shell's hosted sessions move under the owning
+ * task's next free tab ids and get adopted into its tab state — quietly
+ * (adoption never steals the target's active tab), and only when the host
+ * actually re-keyed something (a host without rename support, or a dead
+ * session, must NOT delete the scratch row over nothing).
  */
 
 import { afterEach, describe, expect, it } from "vitest"

--- a/packages/kobe/test/tui-react/settings-label-layout.test.ts
+++ b/packages/kobe/test/tui-react/settings-label-layout.test.ts
@@ -2,11 +2,11 @@
  * The General section's label column is a budget, not a constant.
  *
  * Its rows are `overflow="hidden"` + `wrapMode="none"`, so overspending is a
- * silent hard cut — no ellipsis says it happened. The column used to be a
- * flat 30 cells regardless of terminal width, which did the most damage
- * exactly where there was least room: `docs/TUI.md` promises phone SSH down
- * to 46 columns, and at 46 the row owns 26 cells, so the padding alone
- * overran it and took the label with it.
+ * silent hard cut — no ellipsis says it happened. A flat 30-cell column
+ * regardless of terminal width does the most damage exactly where there is
+ * least room: `docs/TUI.md` promises phone SSH down to 46 columns, and at 46
+ * the row owns 26 cells, so the padding alone overruns it and takes the label
+ * with it.
  */
 
 import { describe, expect, test } from "vitest"
@@ -22,8 +22,8 @@ describe("generalLabelLayout", () => {
   })
 
   test("46 columns (phone SSH, narrow padding): drops the hint, stops padding", () => {
-    // The regression. 46 − 2 − 14 − 2 − 2 = 26 cells for the whole row, so a
-    // 30-cell pad overran it by 4 before any hint text existed.
+    // 46 − 2 − 14 − 2 − 2 = 26 cells for the whole row, so a 30-cell pad
+    // overruns it by 4 before any hint text exists.
     expect(rowCells(46, 1)).toBe(26)
     const { labelColumn, showHint } = generalLabelLayout(46, 1)
     expect(showHint).toBe(false)
@@ -31,7 +31,7 @@ describe("generalLabelLayout", () => {
   })
 
   test("50 columns: the width where a 30-cell pad consumed the budget exactly", () => {
-    // rowCells === 30 here, so the old code left the hint structurally
+    // rowCells === 30 here, so a flat 30-cell pad leaves the hint structurally
     // unreachable — never clipped, never rendered.
     expect(rowCells(50, 1)).toBe(30)
     expect(generalLabelLayout(50, 1).showHint).toBe(false)

--- a/packages/kobe/test/tui-react/sidebar-orphan-tabs.test.ts
+++ b/packages/kobe/test/tui-react/sidebar-orphan-tabs.test.ts
@@ -4,10 +4,10 @@
  *
  *   - a task with NO snapshot at all (headless start before the CLI wrote
  *     snapshots) — the original hole-filling case;
- *   - a task WITH a snapshot that is missing the session's tab (issue #20:
- *     the canonical-spawn fallback ran a live engine for 1h44m while the
- *     sidebar rendered only the snapshot's tab-2 — a writable engine the UI
- *     never showed).
+ *   - a task WITH a snapshot that is missing the session's tab (a
+ *     canonical-spawn fallback can run a live engine for hours while the
+ *     sidebar renders only the snapshot's tab-2 — a writable engine the UI
+ *     never shows).
  *
  * The rule these pin: reconciliation is TAB-granular. A registered tab keeps
  * its snapshot projection (titles, ordinals, kinds); an unregistered live

--- a/packages/kobe/test/tui-react/sidebar-view-core.test.ts
+++ b/packages/kobe/test/tui-react/sidebar-view-core.test.ts
@@ -1,9 +1,8 @@
 /**
  * Unit tests for `src/tui/panes/sidebar/view-core.ts` — the framework-free
- * view logic extracted for the React sidebar port (issue #15, G3; the Solid
- * original was removed 2026-07-07). These pin the shared derivations (tab
- * cycle, budgets, empty-state key selection, the `/`-search keystroke
- * reducer, and the small row helpers).
+ * sidebar view logic. These pin the shared derivations (tab cycle, budgets,
+ * empty-state key selection, the `/`-search keystroke reducer, and the small
+ * row helpers).
  */
 
 import { describe, expect, it } from "vitest"

--- a/packages/kobe/test/tui-react/terminal-tabs-persist.test.ts
+++ b/packages/kobe/test/tui-react/terminal-tabs-persist.test.ts
@@ -1,5 +1,5 @@
 /**
- * Locks the O19 reclamation contract: a DELETED task's `terminalTabs.*`
+ * Locks the snapshot-reclamation contract: a DELETED task's `terminalTabs.*`
  * snapshot is dropped, and the one-time orphan sweep drops only keys whose
  * task id is absent from the live set. Uses a fake kv mirroring kv-core's
  * explicit-undefined delete.

--- a/packages/kobe/test/tui-react/theme-core.test.ts
+++ b/packages/kobe/test/tui-react/theme-core.test.ts
@@ -46,7 +46,7 @@ describe("applyDisplayOverlay", () => {
 
     it("guards host-backed warning without changing warning on opaque surfaces", () => {
       const out = applyDisplayOverlay(base, "primary", true, lightHost)
-      // The regression: these sit directly on the host terminal background.
+      // These sit directly on the host terminal background.
       expect(contrastRatio(out.text, lightHost)).toBeGreaterThanOrEqual(4.5)
       expect(contrastRatio(out.textMuted, lightHost)).toBeGreaterThanOrEqual(4.5)
       expect(out.warningOnHost).toBeDefined()

--- a/packages/kobe/test/tui-react/title-subscriptions.test.ts
+++ b/packages/kobe/test/tui-react/title-subscriptions.test.ts
@@ -1,11 +1,12 @@
 /**
- * Locks the O18 title-subscription store's two correctness properties that
- * the two hand-written copies had drifted on: (1) instance-compared reconcile
- * — a release + respawn at the SAME ptyKey drops the dead PTY's stale title
- * and re-subscribes to the fresh one (the old TerminalSplit `has(id)` check
- * froze here), and (2) subscription is keyed by the GLOBALLY-UNIQUE ptyKey, so
- * two keys that would collide as bare leaf ids stay isolated (the cross-tab
- * bleed). Drives a fake PTY set through the injectable `PtyLookup`.
+ * Locks the title-subscription store's two correctness properties, both of
+ * which a hand-written subscription pass tends to miss: (1) instance-compared
+ * reconcile — a release + respawn at the SAME ptyKey drops the dead PTY's
+ * stale title and re-subscribes to the fresh one, where a `has(id)` existence
+ * check freezes; and (2) subscription is keyed by the GLOBALLY-UNIQUE ptyKey,
+ * so two keys that would collide as bare leaf ids stay isolated instead of
+ * bleeding one tab's title into another. Drives a fake PTY set through the
+ * injectable `PtyLookup`.
  */
 
 import { describe, expect, it } from "vitest"
@@ -67,8 +68,8 @@ describe("createTitleSubscriptions", () => {
 
   // Identity now comes from the process tree (`live-engine.ts`), never from
   // the title, so with no live engine every title passes through RAW —
-  // including one that merely mentions an engine name. That collision
-  // ("✳ …codex…" in a claude session) was the old title-matching bug.
+  // including one that merely mentions an engine name — the collision
+  // ("✳ …codex…" in a claude session) that title-matching identity produces.
   it("passes titles through raw when no live engine claims the pty", () => {
     for (const raw of ["✳ Claude Code", "claude", "fixing the codex tab bug", "vim", "zsh"]) {
       const pty = fakePty(raw)
@@ -90,11 +91,10 @@ describe("createTitleSubscriptions", () => {
     expect(store.get("b")).toBe("codex") // untouched
   })
 
-  // Regression (owner report 2026-08-10): a PTY that has not reported a title
-  // YET must read as undefined, not "". The host records get()'s value onto
-  // the tab (`setTabLastTitle`), so an empty string overwrote the tab's real
-  // recorded name and the chattab fell back to "claude N" a beat after the
-  // correct title had rendered.
+  // A PTY that has not reported a title YET must read as undefined, not "".
+  // The host records get()'s value onto the tab (`setTabLastTitle`), so an
+  // empty string overwrites the tab's real recorded name and the chattab falls
+  // back to "claude N" a beat after the correct title rendered.
   it("a PTY with no title yet reads as undefined, never an empty string", () => {
     const pty = fakePty() // attached, nothing reported
     const store = createTitleSubscriptions(() => pty)


### PR DESCRIPTION
Comment-only pass over `packages/kobe/src/tui-react/**` and its `test/render/**` + `test/tui-react/**` tests, per `.scratch/comment-purge/RULES.md`. Dates, issue/PR/ticket references, owner attributions, and "how it used to work" narratives are gone; the load-bearing ones were rewritten into present-tense invariants and mechanisms rather than deleted.

## Worklist

The "Done means" grep over this slice returned **406 lines across 179 files** on `origin/main`. It now returns **0**.

A second manual pass caught history the regex misses — dangling `Solid`/"React port of"/`tmux` references to modules and a framework that no longer exist, bare ticket ids (`KOB-25`, `O18`, `O19`, `#43`, `#785`, `#334`, `#651`, `#702`), and "used to / once shipped / was removed / this branch" narratives. React error `#185` and a hex colour are the only `#N` tokens left, and both are current facts.

## Proof: no code changed

`bun x esbuild <file> --format=esm` is NOT a comment stripper — it preserves comments that sit inside object literals (verified on `context/theme.tsx`). The proof therefore uses `--minify-whitespace`, which does strip them, with `--tsconfig-raw` pinned identically on both sides so tsconfig discovery cannot differ between the two trees:

```
bun x esbuild <311 files> --loader:.ts=ts --loader:.tsx=tsx --format=esm \
  --minify-whitespace --tsconfig-raw='{...}' --outdir=... --outbase=packages/kobe
```

**311 files compared, 311 byte-identical.** (Every `.ts`/`.tsx` in the slice, not just the touched ones.)

Second, independent proof: the full `git diff origin/main...HEAD` contains no line outside a comment body or the changeset — filtering the diff for lines that are not blank, not `//`, `*`, `/*`, `{/*`, or `*/` leaves only JSX comment continuation lines and `.changeset/`.

Two test-name strings and two local identifiers were rewritten during the pass and then reverted, because a string literal is code and the proof must stay clean.

## Gates

- `env -u ROVE_INVOKED_AS bun run test:fast` — 4176 pass, 4 fail. Both failing files (`test/state/project-eligibility.test.ts`, `test/cli/open-dir-cmd.test.ts`) are untouched by this PR and fail for an environment reason: this worktree lives under `~/.rove/worktrees`, and their `REPO_ROOT` (`new URL("../..", import.meta.url)`) is therefore classified `roveInternal`. Nothing in the slice is imported by either file, and no code changed anywhere.
- `bun test test/render` — 414 pass, 0 fail.
- `bun run lint` (repo root) — clean, 1340 files.
- `bun x tsc --noEmit` (packages/kobe) — clean.
- file-size-cap — passes; five touched files sit in the near-cap warning band (492/496/485/481/471), all shrunk by this PR. No seam named: this is comment removal only.

## Coverage exemptions

Measured with `bun run test:render` + `KOBE_RENDER_COVERAGE=1 bun scripts/coverage-gate.mjs`: 72 touched files clear the 50% floor, 15 do not. The gate judges any touched file regardless of direction, and these percentages are `origin/main`'s — the esbuild proof above shows the executable content is unchanged.

coverage-exemption: packages/kobe/src/tui-react/component/mock-dialogs-host.tsx — comment-only change, esbuild output identical (0%)
coverage-exemption: packages/kobe/src/tui-react/lib/host-boot.tsx — comment-only change, esbuild output identical (33.1%)
coverage-exemption: packages/kobe/src/tui-react/mock/dialogs-host.tsx — comment-only change, esbuild output identical (0%)
coverage-exemption: packages/kobe/src/tui-react/mock/host.tsx — comment-only change, esbuild output identical (0%)
coverage-exemption: packages/kobe/src/tui-react/ops/preview.tsx — comment-only change, esbuild output identical (9.2%)
coverage-exemption: packages/kobe/src/tui-react/panes/filetree/mock-host.tsx — comment-only change, esbuild output identical (0%)
coverage-exemption: packages/kobe/src/tui-react/panes/terminal/mock-host.tsx — comment-only change, esbuild output identical (0%)
coverage-exemption: packages/kobe/src/tui-react/workspace/mock-host.tsx — comment-only change, esbuild output identical (0%)
coverage-exemption: packages/kobe/src/tui-react/workspace/TerminalSplit.tsx — comment-only change, esbuild output identical (6.5%)
coverage-exemption: packages/kobe/src/tui-react/workspace/TerminalTabs.tsx — comment-only change, esbuild output identical (34.2%)
coverage-exemption: packages/kobe/src/tui-react/workspace/title-subscriptions.ts — comment-only change, esbuild output identical (5.1%)
coverage-exemption: packages/kobe/src/tui-react/workspace/use-file-open-actions.ts — comment-only change, esbuild output identical (33.3%)
coverage-exemption: packages/kobe/src/tui-react/workspace/use-scratch-adopt.ts — comment-only change, esbuild output identical (31.8%)
coverage-exemption: packages/kobe/src/tui-react/workspace/use-tab-handoffs.ts — comment-only change, esbuild output identical (35.5%)
coverage-exemption: packages/kobe/src/tui-react/workspace/use-tab-turn-state.ts — comment-only change, esbuild output identical (19.9%)
coverage-exemption: packages/kobe/src/tui-react/workspace/use-turn-polls.ts — comment-only change, esbuild output identical (3.8%)
