### PR TITLE
chore: remove history from comments in engine, cli, web, orchestrator, client and kobe-web

### DIFF
--- a/.changeset/comments-history-purge-engine-cli-web.md
+++ b/.changeset/comments-history-purge-engine-cli-web.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+comments: history removed from engine, cli, web, orchestrator, client, worktree, exec and kobe-web; no code change.

--- a/packages/kobe-web/src/components/AppShell.tsx
+++ b/packages/kobe-web/src/components/AppShell.tsx
@@ -130,8 +130,8 @@ export function AppShell() {
   const { settingsOpen } = useGlobalUiState()
   const [adoptOpen, setAdoptOpen] = useState(false)
   // The right tools rail is a fixed column at lg+, and a slide-in drawer on
-  // narrow windows (where it used to vanish entirely, making rename/changes
-  // unreachable on a phone).
+  // narrow windows — without the drawer it vanishes entirely there, putting
+  // rename/changes out of reach on a phone.
   const [toolsOpen, setToolsOpen] = useState(false)
 
   useEffect(() => {

--- a/packages/kobe-web/src/components/Board.tsx
+++ b/packages/kobe-web/src/components/Board.tsx
@@ -17,8 +17,8 @@
  * exception: once a quickStart resolves with a taskId we optimistically flip
  * that issue into the In progress column (lib/use-issue-actions.ts) so the
  * board reflects the start before the snapshot's `taskId` link lands. There is
- * NO per-card live engine / worktree / task.snapshot subscription — that was
- * the old unified board's lag source and is gone. Column rendering lives in
+ * NO per-card live engine / worktree / task.snapshot subscription — that is
+ * the board's main lag source. Column rendering lives in
  * BoardColumns.tsx.
  */
 

--- a/packages/kobe-web/src/components/ChatTerminal.tsx
+++ b/packages/kobe-web/src/components/ChatTerminal.tsx
@@ -86,12 +86,12 @@ const TERMINAL_FONT_FAMILIES = [
 /**
  * Warm every family in the stack, not just the first.
  *
- * `document.fonts.load()` resolves one family at a time, and awaiting only
- * JetBrains Mono left the Nerd Fonts to load lazily — i.e. after the first
- * frame that needed them. Interactively nobody notices; a scripted capture
- * screenshots the frame in between and photographs missing-glyph boxes where
- * the icons belong, which is how `docs/assets/workspace.png` shipped with
- * `▯▯` in place of `▶▶`. Each family is settled independently so an absent
+ * `document.fonts.load()` resolves one family at a time, so awaiting only
+ * JetBrains Mono leaves the Nerd Fonts to load lazily — i.e. after the first
+ * frame that needs them. Interactively nobody notices; a scripted capture
+ * screenshots the frame in between and photographs missing-glyph boxes (`▯▯`
+ * in place of `▶▶`) where the icons belong. Each family is settled
+ * independently so an absent
  * one (a machine without Nerd Fonts) cannot block the others.
  */
 async function loadTerminalFont(): Promise<void> {
@@ -181,7 +181,7 @@ export function ChatTerminal({
   const [draft, setDraft] = useState(() =>
     mode === "engine" ? (consumePendingPrompt(taskId) ?? "") : "",
   )
-  // Shell-like prompt recall: ↑/↓ walk previously-sent prompts (newest-first).
+  // Shell-like prompt recall: ↑/↓ walk already-sent prompts (newest-first).
   const [history, setHistory] = useState<string[]>(() =>
     mode === "engine" ? loadHistory(taskId) : [],
   )

--- a/packages/kobe-web/src/components/IssuePeek.tsx
+++ b/packages/kobe-web/src/components/IssuePeek.tsx
@@ -1,6 +1,6 @@
 /**
  * IssuePeek — the unified Board's wide story-detail drawer onto one issue, and
- * the owner-specified START surface for turning a story into a task. It rides
+ * the START surface for turning a story into a task. It rides
  * the shared {@link SlideOver} chrome in its `wide` two-column shell
  * (right-docked, slide-in, focus-trapped, Esc/backdrop close) and splits into:
  *
@@ -14,7 +14,7 @@
  *     created date, a "running" line for a linked issue, and the engine-owned
  *     {@link EngineEffortPicker}. Its bottom holds the start actions.
  *
- * Start actions (owner-explicit): an un-started, startable issue gets TWO
+ * Start actions: an un-started, startable issue gets TWO
  * buttons — "Start in background" (spawn + stay on the board) and "Start &
  * watch" (spawn + open the live session). A linked issue swaps both for a single
  * "Open session". A done story has nothing to start.

--- a/packages/kobe-web/src/components/NotesPanel.tsx
+++ b/packages/kobe-web/src/components/NotesPanel.tsx
@@ -83,7 +83,7 @@ export function NotesPanel({
     // Repoint the ref BEFORE flushing so the outgoing task's queued save can't
     // reflect a stale "saved" onto the incoming task (the flush is target-
     // guarded on this ref). The flush persists an edit made in the last
-    // <debounce ms — the old clearTimeout here silently dropped it.
+    // <debounce ms, which a bare clearTimeout here would silently drop.
     loadedTaskRef.current = taskId
     flushPendingSave()
     setSaveState("idle")

--- a/packages/kobe-web/src/components/TaskRail.tsx
+++ b/packages/kobe-web/src/components/TaskRail.tsx
@@ -56,8 +56,8 @@ export function TaskRail({
     perRowEngineLabel(engines, task, mixedEngines)
 
   // Module store, not useState — the `/` → /task/$taskId nav remounts AppShell
-  // (different route trees), which used to wipe these on the first task open
-  // (issue #7). In-memory only: survives route nav, resets on full reload.
+  // (different route trees), which would wipe local useState on the first
+  // task open. In-memory only: survives route nav, resets on full reload.
   const { query, statusFilter, sortMode } = useRailState()
   const listRef = useRef<HTMLDivElement>(null)
   const filterRef = useRef<HTMLInputElement>(null)
@@ -75,7 +75,7 @@ export function TaskRail({
   // kobe session re-sorts this rail too. The local toggle still works between
   // pref pushes — there's no prefs.set RPC yet, so web-side toggles are local.
   // applyPrefSort is rising-edge (store-tracked), so a remount replaying the
-  // same pref no longer stomps a local toggle.
+  // same pref does not stomp a local toggle.
   const prefSort = uiPrefs?.sortMode
   useEffect(() => {
     applyPrefSort(prefSort)
@@ -263,7 +263,7 @@ export function TaskRail({
               // low-frequency clutter. All (see everything) + Needs (the
               // attention spine wired to the tab badge + `n` nav) carry the
               // value. The "working"/"changes" buckets still exist in triage for
-              // the Board; the rail just no longer offers them as quick filters.
+              // the Board; the rail just does not offer them as quick filters.
             ] as Array<{ key: Bucket | "all"; label: string; title: string }>
           ).map((c) => (
             <button

--- a/packages/kobe-web/src/lib/board-state.ts
+++ b/packages/kobe-web/src/lib/board-state.ts
@@ -1,11 +1,11 @@
 /**
  * Board view state that must survive route changes — a module store (the
  * tabs.ts pattern), NOT component useState, so navigating board → task →
- * board keeps the filter (the issue #7 lesson: route-local state resets on
- * the first navigation because the view unmounts).
+ * board keeps the filter — route-local state resets on the first navigation,
+ * because the view unmounts.
  *
  * The board is issues-only and non-optimistic (the daemon issue.snapshot is
- * truth), so there's no optimistic-override layer here any more — just the two
+ * truth), so there is no optimistic-override layer here — just the two
  * display filters. Deliberately not persisted to localStorage: a filter that
  * outlives the browser session is surprising on a fresh load.
  */

--- a/packages/kobe-web/src/lib/board.ts
+++ b/packages/kobe-web/src/lib/board.ts
@@ -18,9 +18,9 @@ import type { Issue, RepoIssues } from "./types.ts"
 
 /**
  * One card on the board: always an issue, carrying its source `repo` so
- * project-grouping can key it. (The board used to be a unified task+issue
- * board; tasks were dropped — the lag came from per-card live engine/worktree
- * subscriptions, and tasks still live in the Workspace view.)
+ * project-grouping can key it. Tasks are deliberately not cards: per-card
+ * live engine/worktree subscriptions are where the lag comes from, and tasks
+ * have the Workspace view.
  */
 export interface BoardCard {
   repo: string

--- a/packages/kobe-web/src/lib/composer-history.ts
+++ b/packages/kobe-web/src/lib/composer-history.ts
@@ -1,6 +1,6 @@
 /**
  * Per-task prompt history for the engine composer — a shell-like recall ring so
- * ↑/↓ walk your previously-sent prompts. Persisted in localStorage per task so
+ * ↑/↓ walk the prompts you already sent. Persisted in localStorage per task so
  * it survives reloads. `navigateHistory` is pure (the cursor math); load/push
  * touch localStorage.
  */

--- a/packages/kobe-web/src/lib/issues.ts
+++ b/packages/kobe-web/src/lib/issues.ts
@@ -313,9 +313,9 @@ export function resolveIssueRepoSelection(
  * through the pty sidecar's spawn-on-send path, which materializes the worktree
  * + engine.
  *
- * The task no longer reverse-references the issue: `Task.issueId` was dropped,
- * so `task.create` carries no `issueId` — `Issue.taskId` (set by `linkIssue`)
- * is the only link, and the daemon's done-mirror is a reverse lookup over it.
+ * The link is ONE-WAY: `task.create` carries no `issueId`, so `Issue.taskId`
+ * (set by `linkIssue`) is the only link, and the daemon's done-mirror is a
+ * reverse lookup over it.
  *
  * `vendor` is the engine chosen in the drawer; when omitted it falls back to
  * the shared Settings default. `effort` is the engine's reasoning/effort level

--- a/packages/kobe-web/src/lib/rail-state.ts
+++ b/packages/kobe-web/src/lib/rail-state.ts
@@ -1,10 +1,10 @@
 /**
- * Task-rail filter state — module store (issue #7). The `/` route renders
- * <AppShell/> directly while /task/$taskId wraps it in <TaskRoute>, so the
- * first task-open from home unmounts+remounts AppShell and used to wipe the
- * rail's local useState (text query, status chip, sort) on
- * its most common trigger. Holding the state at module level (same pattern as
- * tabs.ts/toast.ts) makes it survive the remount.
+ * Task-rail filter state — module store. The `/` route renders <AppShell/>
+ * directly while /task/$taskId wraps it in <TaskRoute>, so the first
+ * task-open from home unmounts+remounts AppShell, wiping any local useState
+ * (text query, status chip, sort) on its most common trigger. Holding the
+ * state at module level (same pattern as tabs.ts/toast.ts) makes it survive
+ * the remount.
  *
  * Persistence semantics (deliberate): in-memory ONLY — state survives route
  * navigation but resets on a full page reload. A text query or status filter
@@ -30,8 +30,8 @@ const initial: RailState = {
 
 const store = createExternalStore(initial)
 /** Last ui-prefs sortMode applied — lets applyPrefSort fire only on a CHANGED
- *  pref (rising edge), so an AppShell remount with the same pref no longer
- *  stomps a local sort toggle the way the old mount-effect reset did. */
+ *  pref (rising edge), so an AppShell remount with the same pref does not
+ *  stomp a local sort toggle the way a plain mount-effect reset would. */
 let lastAppliedPrefSort: TaskSortMode | null = null
 
 function set(next: Partial<RailState>): void {

--- a/packages/kobe-web/src/lib/store.ts
+++ b/packages/kobe-web/src/lib/store.ts
@@ -75,7 +75,7 @@ function set(next: Partial<AppState>): void {
   for (const l of listeners) l()
 }
 
-/** Drop per-task entries whose task no longer exists in the snapshot. Returns
+/** Drop per-task entries whose task is absent from the snapshot. Returns
  *  the SAME reference when nothing changed (so React skips a needless update).
  *  Exported for tests. */
 export function pruneByTask<T>(
@@ -89,8 +89,8 @@ export function pruneByTask<T>(
 }
 
 /** A delete publishes task.snapshot (task gone) THEN a trailing idle
- *  engine-state for the same id. An idle state for a task that no longer
- *  exists is that orphan — drop it so the badge map stays clean. A NON-idle
+ *  engine-state for the same id. An idle state for a task the snapshot does
+ *  not list is that orphan — drop it so the badge map stays clean. A NON-idle
  *  state for an unknown task is a mid-creation race, not an orphan, so it's
  *  kept. Exported for tests. */
 export function isOrphanIdleEngineState(
@@ -128,7 +128,7 @@ function applyIssueSnapshotEvent(
 
 /** A task.snapshot is the authoritative task list — sweep every per-task
  *  side table (engine badges, jobs, workspace tabs + their PTYs) for tasks
- *  that no longer exist, so a delete in ANY surface (TUI, api, another
+ *  the list does not name, so a delete in ANY surface (TUI, api, another
  *  browser) cleans this one up too. */
 function applyTaskList(tasks: Task[]): void {
   const live = new Set(tasks.map((t) => t.id))
@@ -248,10 +248,10 @@ let reconnectTimer: ReturnType<typeof setTimeout> | null = null
 
 /** A stream is "live enough" to reuse when its EventSource exists and hasn't
  *  reached CLOSED — CONNECTING (the browser's own retry) and OPEN both count.
- *  Once CLOSED, the source is dead and must be replaced; the old code's bare
- *  `if (source) return` left a CLOSED source assigned, so after a daemon
- *  restart every later subscribe()/ensureStream() early-returned and the
- *  dashboard wedged on "connecting…" until a full browser refresh. */
+ *  Once CLOSED, the source is dead and must be replaced; a bare
+ *  `if (source) return` would leave a CLOSED source assigned, so after a
+ *  daemon restart every later subscribe()/ensureStream() early-returns and
+ *  the dashboard wedges on "connecting…" until a full browser refresh. */
 function isStreamReusable(s: EventSource | null): boolean {
   return s !== null && s.readyState !== EventSource.CLOSED
 }

--- a/packages/kobe-web/src/lib/tab-kinds.ts
+++ b/packages/kobe-web/src/lib/tab-kinds.ts
@@ -1,12 +1,10 @@
 /**
  * tab-kinds — the single registry of workspace tab kinds.
  *
- * A tab's kind drives two cross-cutting facts that were previously string-matched
- * in many places: whether it owns a server-side PTY (so closing or pruning the
- * tab must tear that PTY down) and how a fresh tab of the kind is titled. Both
- * lived as scattered `kind === "vendor" || kind === "terminal"` guards (three
- * copies) and count-based title strings spread across five tab-mutation helpers.
- * They live here now, so adding or changing a kind is one registry entry and the
+ * A tab's kind drives two cross-cutting facts: whether it owns a server-side
+ * PTY (so closing or pruning the tab must tear that PTY down) and how a fresh
+ * tab of the kind is titled. Both are declared here rather than string-matched
+ * at each site, so adding or changing a kind is one registry entry and the
  * rules are unit-tested in isolation.
  *
  * Pure + React-free: the per-kind RENDER (a component) stays in WorkspaceTabs'

--- a/packages/kobe-web/src/lib/tabs.ts
+++ b/packages/kobe-web/src/lib/tabs.ts
@@ -117,8 +117,8 @@ export function withTaskTab(next: TabsState, taskId: string): TabsState {
 
 /**
  * Migrate one stored tab object to a current {@link WorkspaceTab}. Stale
- * localStorage can carry retired kinds — `notes` (the old right-rail tab,
- * now an empty chooser) and `chat` (renamed to `vendor`); anything without a
+ * localStorage can carry kinds this build does not have — `notes` (an empty
+ * chooser now) and `chat` (spelled `vendor`); anything without a
  * recognized kind defaults to `vendor`. Pure (a `notes` migration mints a
  * fresh empty tab id); exported for tests.
  *
@@ -239,11 +239,11 @@ export function resetLayout(): void {
 }
 
 /**
- * Sweep tab state for tasks that no longer exist (deleted in the TUI, via
- * `kobe api`, or by another browser). Kills the dead tasks' PTYs server-side
- * — without this, a deleted task's engine kept running in the pty sidecar,
- * orphaned and invisible (same bug class as the tmux orphan `kobe api delete`
- * had). Call ONLY with an authoritative live-daemon task list.
+ * Sweep tab state for tasks the daemon does not list (deleted in the TUI,
+ * via `kobe api`, or by another browser). Kills the dead tasks' PTYs
+ * server-side — without this a deleted task's engine keeps running in the pty
+ * sidecar, orphaned and invisible. Call ONLY with an authoritative
+ * live-daemon task list.
  */
 export function pruneMissingTasks(liveTaskIds: ReadonlySet<string>): void {
   // A vendor tab pinned to a dead engine task is equally orphaned even though

--- a/packages/kobe-web/src/lib/toast.ts
+++ b/packages/kobe-web/src/lib/toast.ts
@@ -1,7 +1,7 @@
 /**
- * Toast store — the web UI's one error/notice surface. RPC failures used to
- * be swallowed (`.catch(() => {})`) so a failed rename/create looked
- * like nothing happened; every mutation path now reports here instead.
+ * Toast store — the web UI's one error/notice surface. A swallowed RPC
+ * failure (`.catch(() => {})`) makes a failed rename/create look like nothing
+ * happened, so every mutation path reports here instead.
  * Module-level external store, same persistence semantics as store.ts/tabs.ts.
  */
 

--- a/packages/kobe-web/src/lib/use-repo-issues.ts
+++ b/packages/kobe-web/src/lib/use-repo-issues.ts
@@ -1,7 +1,7 @@
 /**
- * use-repo-issues — the issue-snapshot data plumbing extracted from the old
- * IssuesPage so the unified Board can render a repo's issues without
- * re-deriving the fetch/seq/live-push machinery.
+ * use-repo-issues — the issue-snapshot data plumbing, held apart from any one
+ * page so the Board can render a repo's issues without re-deriving the
+ * fetch/seq/live-push machinery.
  *
  * Two truth sources, merged per repo into one cache:
  *   1. an initial `/api/issues` GET per repo (and on demand via `refresh`);

--- a/packages/kobe-web/src/lib/vendor.ts
+++ b/packages/kobe-web/src/lib/vendor.ts
@@ -2,12 +2,12 @@
  * vendor — the SPA's vendor-identity rules, in one place.
  *
  * "Which engine does a task run, what do we call it, and does this workspace
- * mix engines?" used to be split three ways: `engines.ts` owned the label
- * lookup, `task-list.ts` owned the vendor aggregations, and the per-row
- * "label only when mixed" rule was inlined in AppShell — each independently
- * coalescing an unset `task.vendor` to the literal `"claude"`. This module owns
- * all of it, so the unset-vendor default lives in ONE place ({@link
- * DEFAULT_VENDOR}) and the rules are unit-testable without rendering a row.
+ * mix engines?" is answered here and nowhere else: the label lookup, the
+ * vendor aggregations, and the per-row "label only when mixed" rule. Split
+ * across modules, each would coalesce an unset `task.vendor` to the literal
+ * `"claude"` on its own; here the unset-vendor default lives in ONE place
+ * ({@link DEFAULT_VENDOR}) and the rules are unit-testable without rendering
+ * a row.
  *
  * `engines.ts` keeps ONLY its job: fetching the engine-owned list from the
  * bridge (`useEngines` + {@link EngineOption}). This module takes that list as

--- a/packages/kobe-web/test/board.test.ts
+++ b/packages/kobe-web/test/board.test.ts
@@ -354,7 +354,7 @@ describe("buildBoardView — the whole board view-model", () => {
       "/u/kobe",
       "/u/web",
     ])
-    // Only issue #1 matches "auth", so one shown card, one project board.
+    // Only the id-1 issue matches "auth", so one shown card, one project board.
     expect(view.shownCount).toBe(1)
     expect(view.projectBoards.map((b) => b.repo)).toEqual(["/u/kobe"])
     expect(view.hasAnyCard).toBe(true)

--- a/packages/kobe-web/test/repo-key.test.ts
+++ b/packages/kobe-web/test/repo-key.test.ts
@@ -7,9 +7,9 @@ import {
 } from "../src/lib/repo-key.ts"
 
 /**
- * repo-key is the single home for the issue-snapshot aliasing contract that
- * used to be copy-pasted across store.ts, daemon-link.ts, and use-repo-issues.ts.
- * These tests pin the contract so the three consumers can't silently diverge.
+ * repo-key is the single home for the issue-snapshot aliasing contract shared
+ * by store.ts, daemon-link.ts, and use-repo-issues.ts. These tests pin the
+ * contract so the three consumers can't silently diverge.
  */
 
 describe("normalizeRepoPath", () => {

--- a/packages/kobe-web/test/tabs-migrate.test.ts
+++ b/packages/kobe-web/test/tabs-migrate.test.ts
@@ -2,8 +2,9 @@ import { describe, expect, it } from "vitest"
 import { migrateStoredTab } from "../src/lib/tabs.ts"
 
 /**
- * Stale localStorage from older builds can carry retired tab kinds. The
- * migration must coerce them to current kinds so the SPA never renders an
+ * Stale localStorage from older builds can carry tab kinds this build does
+ * not have. The migration must coerce them to current kinds so the SPA never
+ * renders an
  * unknown tab (or crashes) on load.
  */
 

--- a/packages/kobe/src/cli/api-cmd.ts
+++ b/packages/kobe/src/cli/api-cmd.ts
@@ -76,11 +76,11 @@ import { type DaemonSession, openDaemonSession } from "./daemon-session.ts"
 import type { DaemonRpc } from "./daemon-session.ts"
 
 function emit(value: unknown, pretty: boolean): void {
-  // A verb that refused an UNVERIFIED $ROVE_TASK_ID (issue #24) degraded
-  // quietly — the create/send succeeded, it just recorded no dispatcher. Ride
-  // the notice on the result object so an agent sees it: stderr is reserved
-  // for the one JSON error envelope (docs/API.md), and a silent degrade is
-  // exactly what made the wrong reply address invisible for weeks.
+  // A verb that refuses an UNVERIFIED $ROVE_TASK_ID degrades quietly — the
+  // create/send succeeds, it just records no dispatcher. Ride the notice on
+  // the result object so an agent sees it: stderr is reserved for the one
+  // JSON error envelope (docs/API.md), and a silent degrade makes a wrong
+  // reply address invisible.
   const warning = takeIdentityWarning()
   // Objects only — spreading an array would flatten it into numeric keys.
   const mergeable = warning && value && typeof value === "object" && !Array.isArray(value)
@@ -153,9 +153,9 @@ export function toApiError(err: unknown): ApiError {
  *   - new CLI × old daemon — the daemon predates the verb.
  *   - old CLI × new daemon — the daemon dropped a verb this CLI still ships.
  *
- * Untyped, this is the incident that motivated the mapping: an agent asked
- * `schema --verb archive`, got a full spec and exit 0, ran `archive`, and got
- * a bare `RPC_ERROR` 200ms later. Schema is how an agent discovers a
+ * Untyped, the failure looks like this: an agent asks `schema --verb archive`,
+ * gets a full spec and exit 0, runs `archive`, and gets a bare `RPC_ERROR`
+ * 200ms later. Schema is how an agent discovers a
  * capability, so a `RPC_ERROR` there reads as "this call failed, retry" rather
  * than "this binary and that daemon disagree about what exists".
  */

--- a/packages/kobe/src/cli/api/branch-signals.ts
+++ b/packages/kobe/src/cli/api/branch-signals.ts
@@ -8,7 +8,7 @@
  * The base ref comes from the TASK RECORD first: `add --base-branch` is
  * persisted on the task at create time, so a task cut from `release/2.x`
  * is measured against `release/2.x`, not against a guess. Records that
- * predate the field (or whose recorded ref no longer resolves) fall back
+ * predate the field (or whose recorded ref does not resolve) fall back
  * to the re-resolution the worktrees page uses: `origin/HEAD` →
  * `origin/main` → `origin/master` → local `main`/`master`. All reads are
  * lock-free (`GIT_OPTIONAL_LOCKS=0`) and best-effort — a repo with no
@@ -56,7 +56,7 @@ export function resolveBaseRef(worktreePath: string): string | null {
 /**
  * The base to measure against: the task's RECORDED fork point when present
  * and still resolvable, else the {@link resolveBaseRef} guess for records
- * that predate the persisted field. A recorded ref that no longer resolves
+ * that predate the persisted field. A recorded ref that stops resolving
  * (base branch deleted, remote renamed) falls back too — an honest guess
  * beats a stale certainty.
  */

--- a/packages/kobe/src/cli/api/dispatcher.ts
+++ b/packages/kobe/src/cli/api/dispatcher.ts
@@ -1,12 +1,11 @@
 /**
- * Dispatcher provenance — the collaboration loop's reply address (issue #21).
+ * Dispatcher provenance — the collaboration loop's reply address.
  *
  * A task created from inside another kobe engine tab records WHO dispatched
  * it (`dispatcher: {taskId, tabId}`), and a bare `send` from that task
- * replies to exactly that tab. Completion has always been designed to flow
- * back through `send` into the dispatching chat tab (the `report`/`await`
- * verbs were removed in 55c990f34 in favour of it); this module is the
- * missing address that makes the route computable instead of hand-relayed.
+ * replies to exactly that tab. Completion flows back through `send` into the
+ * dispatching chat tab; this module is the address that makes that route
+ * computable instead of hand-relayed.
  *
  * Both halves live here rather than in `handler-helpers.ts` so the stamping
  * (create-side) and the routing (send-side) stay one readable concern.
@@ -61,12 +60,12 @@ async function realProbe(): Promise<SelfSessionProbe> {
  * The caller's OWN kobe session identity — `$KOBE_TASK_ID`/`$KOBE_TAB_ID`
  * cross-checked against the pty host, or `null` when it doesn't hold up.
  *
- * The env alone is NOT identity (issue #24). It is an ordinary variable and
- * inherits down the entire process tree, so a Claude Code background daemon
- * forked out of an engine tab carries that tab's ids for as long as it
- * lives — and every task IT later creates recorded a dispatcher pointing at
- * a stranger's session, which is where finished workers reported to. Two
- * things have to be true for the env to be believed:
+ * The env alone is NOT identity. It is an ordinary variable and inherits
+ * down the entire process tree, so a Claude Code background daemon forked
+ * out of an engine tab carries that tab's ids for as long as it lives — and
+ * every task IT creates would record a dispatcher pointing at a stranger's
+ * session, which is where finished workers would report. Two things have to
+ * be true for the env to be believed:
  *
  *   1. `<taskId>::<tabId>` is a session the pty host lists as ALIVE, and
  *   2. that session's shell pid is an ANCESTOR of this process.
@@ -122,7 +121,7 @@ async function resolveSelfSession(env: NodeJS.ProcessEnv, probe?: SelfSessionPro
   } catch {
     /* unreadable host/ps — fall through to the refusal below */
   }
-  // Never a SILENT degrade (issue #24's fallback rule): the caller believes
+  // Never a SILENT degrade: the caller believes
   // it is a kobe session and its dispatcher/peer fields just vanished. stderr
   // carries exactly one JSON error envelope by contract (docs/API.md), so the
   // notice rides the verb's own stdout result instead — see `takeIdentityWarning`.
@@ -176,22 +175,21 @@ export async function readOwnDispatcher(daemon: DaemonRpc): Promise<Dispatcher |
  * Pick the tab a dispatcher-defaulted `send` lands on: the exact tab the
  * work was dispatched from first, the dispatcher task's canonical live
  * engine tab when that tab has died, and NEVER a silent spawn — with
- * nothing alive the send fails loud with a typed error, per the 2026-08-12
- * collaboration-verb design principle (a fallback must not impersonate
- * success). `undefined` means "the canonical tab", the delivery layer's own
+ * nothing alive the send fails loud with a typed error: a fallback must not
+ * impersonate success. `undefined` means "the canonical tab", the delivery layer's own
  * spelling for it.
  */
 export async function resolveDispatcherTab(runtime: ApiRuntime, dispatcher: Dispatcher): Promise<string | undefined> {
   const { tabs, running } = await runtime.taskTabs(dispatcher.taskId)
   // The dispatched-from tab first, addressed only when it reads ALIVE: the
-  // tab join now also lists live sessions the persisted snapshot never
-  // registered (issue #20), so "present and alive" is the honest liveness
+  // tab join also lists live sessions the persisted snapshot never
+  // registered, so "present and alive" is the honest liveness
   // test and a tab that is merely gone from the snapshot still gets the
   // canonical fallback below instead of a TAB_NOT_FOUND at delivery.
   if (tabs.some((t) => t.id === dispatcher.tabId && t.alive)) return dispatcher.tabId
   // Dead dispatcher tab → the task's canonical live engine, gated on a live
   // engine tab existing. The canonical path legitimately COLD-STARTS an
-  // engine for a task with no alive session at all (issue #19) — correct for
+  // engine for a task with no alive session at all — correct for
   // a first prompt, wrong for a reply: it would boot an engine nobody asked
   // for and address it as if it were the agent that dispatched the work.
   if (running) return undefined
@@ -211,18 +209,18 @@ export async function resolveDispatcherTab(runtime: ApiRuntime, dispatcher: Disp
  * messaging another, and the receiver needs what a bare paste never carries —
  * who is talking and how to answer.
  *
- * Both delivery verbs wear it. `send` always did; `add --prompt` did not, and
- * that gap is why a dispatched task finished its work and then sat waiting:
- * `add` records the sender as `dispatcher` on the task ROW, which a receiver
- * would have to think to go read (`rove api get-task`) and has no reason to
- * suspect exists. A task's opening brief is exactly the moment the reply
- * address matters, since every report it will ever send flows back through
- * it (2026-09-01: issue #92's survey completed and was never delivered). Same convention as field
+ * Both delivery verbs wear it, `add --prompt` included. Without it on the
+ * opening brief the sender is recorded only as `dispatcher` on the task ROW,
+ * which a receiver would have to think to go read (`rove api get-task`) and
+ * has no reason to suspect exists — so a dispatched task finishes its work
+ * and then sits waiting. A task's opening brief is exactly the moment the
+ * reply address matters, since every report it will ever send flows back
+ * through it. Same convention as field
  * notes (`[ROVE FIELD NOTE] from "<label>" (task <id>)`), plus the reply
  * command so a peer conversation is symmetric without any coordinator.
  * Sender identity is the VERIFIED $KOBE_TASK_ID/$KOBE_TAB_ID pair, not the
  * raw env: an unverified one names a stranger's session as the sender and
- * bakes their tab into the reply command (issue #24). A send from a plain
+ * bakes their tab into the reply command. A send from a plain
  * shell, an unverified process, or to yourself stays untouched.
  */
 export async function withPeerProvenance(daemon: DaemonRpc, targetTaskId: string, prompt: string): Promise<string> {
@@ -238,8 +236,8 @@ export async function withPeerProvenance(daemon: DaemonRpc, targetTaskId: string
   }
   const api = kobeApiInvocation()
   // The baked-in reply command carries the sender's TAB, not just its task
-  // (issue #21): task-granular replies land on canonical-tab resolution,
-  // which is exactly the link that breaks (#19) — tab-precise addressing is
+  // task-granular replies land on canonical-tab resolution, which is exactly
+  // the link that breaks — tab-precise addressing is
   // the loop's durable route home. $KOBE_TAB_ID is exported into every
   // engine tab alongside $KOBE_TASK_ID (session-launch.ts).
   const replyTarget = `--task-id ${senderId} --tab ${self.tabId}`
@@ -248,13 +246,12 @@ export async function withPeerProvenance(daemon: DaemonRpc, targetTaskId: string
   // "--skill first" trick) — a pointer, not a curriculum, since every peer
   // message pays for this prefix in context. Loading the skill is REQUIRED,
   // not suggested: a receiver that replies from the raw prefix alone
-  // improvises verbs and side-channels (2026-08-10: a peer coordination
-  // round-trip fell back to a human relay because neither side had the
-  // skill's contract in context).
+  // improvises verbs and side-channels, and the round-trip falls back to a
+  // human relay.
   // The sender's text goes LAST, whole, after a blank line — never as the
   // object of this English sentence. A model generates in the language of
   // the tokens nearest its turn, so wrapping a Chinese prompt in an English
-  // clause pulled replies into English; ending on the sender's own words
+  // clause pulls replies into English; ending on the sender's own words
   // removes that pull without changing what the prefix says.
   return `[ROVE PEER] from "${label}" (task ${senderId} — load the Rove agent skill FIRST (registered as /rove; legacy /kobe installs still work), then reply: \`${api} send ${replyTarget} --prompt "<text>"\`; verb reference: \`${api} schema\`)\n\n${prompt}`
 }

--- a/packages/kobe/src/cli/api/handlers-add.ts
+++ b/packages/kobe/src/cli/api/handlers-add.ts
@@ -1,13 +1,12 @@
 /**
  * The `add` verb — the one create path, single or parallel.
  *
- * `fan-out` used to be a separate verb for "N tasks of one prompt"; it was
- * the same create-then-deliver loop with a count, and having two verbs meant
- * an agent had to know which one to reach for before it knew how many
- * attempts it wanted. `add --count N` (and `--agents claude:2,codex:1`) is
- * that verb folded back in: `--count` absent = exactly one task, and the
- * whole parallel contract (shared `groupId`, `#i/N` titles, per-sibling
- * failure rows, PARTIAL_FANOUT) applies unchanged from N=2 up.
+ * There is deliberately no separate "N tasks of one prompt" verb: it is the
+ * same create-then-deliver loop with a count, and two verbs would make an
+ * agent choose one before it knows how many attempts it wants. `--count`
+ * absent = exactly one task, and the whole parallel contract (shared
+ * `groupId`, `#i/N` titles, per-sibling failure rows, PARTIAL_FANOUT) applies
+ * from N=2 up.
  *
  * Its own module rather than living beside `send` in `handlers-tasks.ts`: the
  * handlers there act on a task that already exists, while everything here is
@@ -81,7 +80,7 @@ export async function add(ctx: VerbContext): Promise<unknown> {
 async function addOne(ctx: VerbContext, repo: string): Promise<unknown> {
   const daemon = daemonOf(ctx)
   const { args } = ctx
-  // Record who dispatched this create (issue #21) — the reply address a
+  // Record who dispatched this create — the reply address a
   // sub-task's bare `send` routes its outcome back to.
   const choice = await engineChoice(ctx, repo)
   const payload: Record<string, string> = { repo, ...(await dispatcherEnvPayload()), ...enginePayload(choice) }
@@ -132,7 +131,7 @@ async function addOne(ctx: VerbContext, repo: string): Promise<unknown> {
   )
   // A prompt that never confirmed AND was not deferred is a failure — but the
   // task IS created, so carry the taskId in the error so a script can find it.
-  // Deferred (issue #78 B-layer) is a SUCCESS: the daemon owns the message now.
+  // A deferred prompt is a SUCCESS: the daemon owns the message now.
   if (!delivered.delivered && !delivered.deferred) {
     throw new ApiError(
       `task ${taskId} created but the prompt was not delivered (paste did not land)`,
@@ -166,8 +165,8 @@ async function addOne(ctx: VerbContext, repo: string): Promise<unknown> {
 /**
  * `--count N` / `--agents e:2,f:1`: N sibling tasks of ONE prompt, each in
  * its own worktree + branch. Every sibling of this round shares one groupId,
- * so the grouping outlives this CLI call (the JSON output used to be its only
- * record). Siblings share the prompt, so bare titles would converge onto the
+ * so the grouping outlives this CLI call rather than living only in the JSON
+ * output. Siblings share the prompt, so bare titles would converge onto the
  * SAME name — an explicit --title gets its `#i/N` ordinal here; placeholder-
  * titled siblings get theirs appended by the daemon's auto-title pass (keyed
  * on groupId) when the prompt-derived name lands.
@@ -241,7 +240,7 @@ async function addParallel(
   // can retry or delete them instead of double-spawning.
   const created: Array<{ taskId: string; vendor: VendorId; task: SerializedTask }> = []
   let createFailure: { vendor: VendorId; error: { message: string; code: string } } | null = null
-  // Every sibling records the same dispatcher (issue #21) — the reply
+  // Every sibling records the same dispatcher — the reply
   // address each worker's bare `send` routes its outcome back to.
   const dispatcher = await dispatcherEnvPayload()
   for (const [i, vendor] of plan.entries()) {
@@ -295,7 +294,7 @@ async function addParallel(
   settled.forEach((r, i) => {
     const { taskId, vendor } = created[i]
     if (r.status === "fulfilled" && (r.value.delivered || r.value.deferred)) {
-      // Deferred (issue #78 B-layer) is a SUCCESS, exactly as `addOne`/`send`
+      // A deferred prompt is a SUCCESS, exactly as `addOne`/`send`
       // treat it: the daemon took ownership of the prompt and queued an inbox
       // episode, so the caller must NOT retry (the tab stays occupied until
       // that deferred prompt is released, dismissed, or expires). It

--- a/packages/kobe/src/cli/api/handlers-agent-turns.ts
+++ b/packages/kobe/src/cli/api/handlers-agent-turns.ts
@@ -1,5 +1,5 @@
 /**
- * `agent-turns` — the read end of per-turn agent telemetry (issue #32).
+ * `agent-turns` — the read end of per-turn agent telemetry.
  *
  * The records are produced by each engine's own adapter (the turn's model,
  * timings, and token usage come from that vendor's transcript) and joined to

--- a/packages/kobe/src/cli/api/handlers-digest.ts
+++ b/packages/kobe/src/cli/api/handlers-digest.ts
@@ -9,8 +9,8 @@
  * it can move, so the ruler ships before anything that claims to learn.
  *
  * Task OUTCOMES are deliberately absent: completion flows back to the
- * spawning agent's chat tab (`send`), not into Rove state — the stored
- * `workerReport` channel was removed because nothing read it.
+ * spawning agent's chat tab (`send`), not into Rove state. There is
+ * deliberately no stored `workerReport` channel: nothing would read it.
  */
 
 import type { Automation, AutomationRun, AutomationRunStatus } from "@sma1lboy/kobe-daemon/daemon/contracts"

--- a/packages/kobe/src/cli/api/handlers-fanout.ts
+++ b/packages/kobe/src/cli/api/handlers-fanout.ts
@@ -1,9 +1,8 @@
 /**
  * Verb handlers for `collect` and `feedback` — grouped separately from
- * `handlers-tasks.ts` since they don't touch single-task CRUD. The
- * `fan-out` handler that named this file folded into `add --count`
- * (`handlers-add.ts`, issue #30); the file keeps its name so its git
- * history stays traceable.
+ * `handlers-tasks.ts` since they don't touch single-task CRUD. The parallel
+ * create path this file is named for lives in `handlers-add.ts`, behind
+ * `add --count`.
  */
 
 import type { SerializedTask } from "@sma1lboy/kobe-daemon/daemon/protocol"
@@ -82,7 +81,7 @@ export async function collect(ctx: VerbContext): Promise<unknown> {
       vendor: task.vendor,
       status: task.status,
       ...(task.groupId ? { groupId: task.groupId } : {}),
-      // Lineage read (issue #21): who dispatched this task, so a parallel
+      // Lineage read: who dispatched this task, so a parallel
       // round's parent is programmatically discoverable.
       ...(task.dispatcher ? { dispatcher: task.dispatcher } : {}),
       running,

--- a/packages/kobe/src/cli/api/handlers-inspect.ts
+++ b/packages/kobe/src/cli/api/handlers-inspect.ts
@@ -119,7 +119,7 @@ async function sessionExitsSection(taskId: string | undefined): Promise<unknown>
 
 /**
  * Persisted tab snapshots (what the sidebar tree names its rows from),
- * RECONCILED against the live session inventory (issue #20): each task also
+ * RECONCILED against the live session inventory: each task also
  * reports `unregistered` — alive `<taskId>::tab-N` sessions its snapshot
  * does not list — and a task with live sessions but no snapshot at all still
  * gets an entry. A live engine must never be invisible in this read.

--- a/packages/kobe/src/cli/api/handlers-tasks.ts
+++ b/packages/kobe/src/cli/api/handlers-tasks.ts
@@ -195,8 +195,8 @@ export async function send(ctx: VerbContext): Promise<unknown> {
     text,
   )
   // A prompt that never landed AND was not deferred is a delivery FAILURE the
-  // script must see — non-zero exit, not a phantom `ok:true`. Deferred
-  // (issue #78 B-layer) is a SUCCESS: the daemon owns the message and queued
+  // script must see — non-zero exit, not a phantom `ok:true`. A deferred
+  // prompt is a SUCCESS: the daemon owns the message and queued
   // an inbox episode. The caller must NOT retry — a retry would stack a
   // duplicate of the same message in the deferred queue.
   if (!delivered.delivered && !delivered.deferred) {
@@ -305,7 +305,7 @@ export async function deleteTask(ctx: VerbContext): Promise<unknown> {
   const deleteBranch = ctx.args.bool("delete-branch") ?? false
   // Deleting somebody else's task destroys their worktree and every tab in
   // it, so the daemon's audit line has to name WHO asked. Same verified
-  // identity `send`/`add` use (never the bare env — issue #24): unverifiable
+  // identity `send`/`add` use, never the bare env: unverifiable
   // stays unattributed rather than blaming a stranger's session.
   const self = await verifiedSelfSession()
   const res = (await daemon.request("task.delete", {
@@ -370,12 +370,12 @@ export async function land(ctx: VerbContext): Promise<unknown> {
       // Left UNDEFINED when the flag is absent so the orchestrator's default
       // (remove it) applies; only an explicit `--remove-worktree=false` keeps
       // the worktree. Coercing undefined to false here would pin the CLI to
-      // the old opt-in behaviour.
+      // an opt-in it does not have.
       removeWorktree: ctx.args.bool("remove-worktree"),
       // Sent on EVERY land: the daemon refuses to remove the worktree the
       // caller is running from, and it can only know where that is if we tell
-      // it. Since removal is now the default rather than an opt-in flag, an
-      // agent landing its own task would otherwise delete its own cwd.
+      // it. Removal is the default, so an agent landing its own task would
+      // otherwise delete its own cwd.
       callerCwd: process.cwd(),
     })
   } catch (err) {

--- a/packages/kobe/src/cli/api/pty-delivery.ts
+++ b/packages/kobe/src/cli/api/pty-delivery.ts
@@ -39,9 +39,9 @@ import type { VendorId } from "../../types/vendor.ts"
 import { ApiError, type DeliveredPrompt, type PromptDeferralSink } from "./types.ts"
 
 /**
- * Foreground gate for delivery into an EXISTING session (herdr's
- * "agent is no longer the pane foreground process" check, ported to the
- * process tree): a session's spawn argv says what WAS launched, not what is
+ * Foreground gate for delivery into an EXISTING session — is an agent still
+ * the pane's foreground process, answered from the process tree? A session's
+ * spawn argv says what WAS launched, not what is
  * running now — kobe's keepAlive drops an exited engine into a fallback
  * SHELL, where a pasted prompt executes as shell commands. Walk the PTY
  * child's descendants: any registered engine counts (cross-vendor send is
@@ -143,10 +143,10 @@ function outcomeFields(outcome: PromptWriteOutcome | null): {
  * session was created", never "delivered into an existing one".
  *
  * When alive tabs exist but none resolves as an engine, this THROWS
- * (NO_ENGINE_TAB) instead of spawning. Issue #19: the silent-spawn fallback
- * booted an unsandboxed `--dangerously-skip-permissions` engine (in the
- * incident, cwd'd at the MAIN repo) while both sender and receiver believed
- * the message was delivered. A well-meaning fallback here is
+ * (NO_ENGINE_TAB) instead of spawning. A silent-spawn fallback boots an
+ * unsandboxed `--dangerously-skip-permissions` engine — cwd'd at the MAIN
+ * repo — while both sender and receiver believe the message was delivered.
+ * A well-meaning fallback here is
  * indistinguishable from success on both sides — it must stay loud.
  */
 export async function deliverHostedPrompt(
@@ -241,7 +241,7 @@ export async function deliverHostedPrompt(
         delivered: false,
       }
     }
-    // Paste-delivery vendor (kimi — issue #25): the launch spawned the bare
+    // Paste-delivery vendor (kimi): the launch spawned the bare
     // engine and carried the first message OUTSIDE its argv; paste it once
     // the engine process is up. A paste that never lands is a failed start,
     // not a delivered prompt.
@@ -285,10 +285,10 @@ export async function deliverHostedPrompt(
     }
     // OUR launch carried the prompt in its argv, so no paste happened here.
     // The engine receives the prompt from its own command line — a delivery
-    // this code never observed, and must not claim to have confirmed. It
-    // used to hardcode `delivered = true` (and copy that into engineReady),
-    // which is how a task that received nothing still reported a clean
-    // success on all three fields.
+    // this code never observed, and must not claim to have confirmed.
+    // Hardcoding `delivered = true` here (and copying it into engineReady)
+    // is how a task that received nothing reports a clean success on all
+    // three fields.
     return {
       session: launch.key,
       pane: launch.key,
@@ -359,7 +359,7 @@ function resolveComposerManifest(vendor?: VendorId): EngineScreenManifest | unde
 }
 
 /**
- * Gate blocked the paste. With a deferral sink (issue #78 B-layer), try to
+ * Gate blocked the paste. With a deferral sink, try to
  * hand the prompt to daemon ownership. Report deferred success only when the
  * daemon accepts it; an occupied slot or failed handoff is an error. Without
  * a sink there is no queue, so surface the legacy typed error.

--- a/packages/kobe/src/cli/api/read-output.ts
+++ b/packages/kobe/src/cli/api/read-output.ts
@@ -26,7 +26,7 @@
  *   - Strictly read-only: never spawns, attaches, resizes, or mutates
  *     task/engine lifecycle (terminal reads go through `pty.peek`).
  *
- * Tab precision (2026-08-16): the default terminal read resolves the
+ * Tab precision: the default terminal read resolves the
  * task's CANONICAL engine tab; `--tab tab-N` reads exactly that hosted
  * session instead (the API's smallest unit is one tab, same as
  * `send --tab`). A tab read is terminal-only — history is

--- a/packages/kobe/src/cli/api/runtime.ts
+++ b/packages/kobe/src/cli/api/runtime.ts
@@ -96,7 +96,7 @@ async function deliverHosted(
       engineLaunchArgv({ command: launchCommand, vendor: launchVendor, effort: target.modelEffort }),
       launchVendor,
     )
-    // Pre-trust the worktree in the protocol's first-run store (issue #28) —
+    // Pre-trust the worktree in the protocol's first-run store —
     // a hosted session can't answer a trust dialog. A generic protocol has
     // no store kobe knows how to pre-answer, and trustEngineWorktree no-ops.
     trustEngineWorktree(launchVendor, worktree)
@@ -121,16 +121,16 @@ async function deliverHosted(
       },
     )
     // `started && !delivered` is the real failure: the session was created but
-    // the prompt never reached it. `engineReady` no longer stands in for that
-    // — it is now an independent readiness observation, and an engine that
-    // never announced bracketed paste can still have been written to.
+    // the prompt never reached it. `engineReady` does NOT stand in for that —
+    // it is an independent readiness observation, and an engine that never
+    // announced bracketed paste can still have been written to.
     if (result.started && !result.delivered && !result.deferred) {
       throw new ApiError(`failed to start hosted engine session for ${target.id}`, "SESSION_FAILED")
     }
     // Make the session visible to the sidebar tree, which lists a worktree's
-    // tabs from the task's persisted snapshot — a CLI-started session used to
-    // run live with no snapshot, so the tree showed the worktree with no tabs
-    // under it at all. Write-once (a --tab new spawn already appended its tab
+    // tabs from the task's persisted snapshot. Without this a CLI-started
+    // session runs live with no snapshot, so the tree shows the worktree with
+    // no tabs under it at all. Write-once (a --tab new spawn already appended its tab
     // in mintCliTab); see `tab-snapshot.ts`. When THIS delivery started the
     // session, record the pinned session id + spawned flag too, so a later
     // dead-reattach resumes the conversation (see engineTabArgv).
@@ -219,11 +219,11 @@ export async function deliverPrompt(
     await client.request("task.observeLanguage", { taskId: target.id, text: prompt }).catch(() => {})
   }
 
-  // The deferral sink hands a composer-busy prompt to daemon ownership
-  // (issue #78 B-layer): the daemon stores the text and queues an inbox
-  // episode, and this send reports accepted-but-deferred. The distinct verb
-  // is the rolling-upgrade guard: an old replace-on-file daemon rejects it,
-  // so the caller fails instead of losing the prompt it previously accepted.
+  // The deferral sink hands a composer-busy prompt to daemon
+  // ownership: the daemon stores the text and queues an inbox episode, and
+  // this send reports accepted-but-deferred. The distinct verb is the
+  // rolling-upgrade guard: a replace-on-file daemon rejects it, so the caller
+  // fails instead of losing a prompt it has already accepted.
   const defer: PromptDeferralSink = {
     defer: async (info) => {
       const result = await client.request<unknown>("deferredPrompt.fileIfVacant", info)
@@ -256,7 +256,7 @@ export const defaultApiRuntime: ApiRuntime = {
         host.close()
       }
     }
-    // Live foreground-walk verdicts per session (issue #33): ONE ps snapshot,
+    // Live foreground-walk verdicts per session: ONE ps snapshot,
     // the same shallowest-engine walk inspect/live-engine run — so get-task's
     // `liveVendor` reflects what runs NOW, not what a mounted TUI last
     // recorded. Best-effort: a failed ps just keeps the recorded values.

--- a/packages/kobe/src/cli/api/schema.ts
+++ b/packages/kobe/src/cli/api/schema.ts
@@ -81,7 +81,7 @@ export function schemaIndex(): unknown {
 /**
  * The verbs in ONE group (compact). Every group here has verbs and every verb
  * is in a group — both sides come from the same `VerbSpec.group` field, so the
- * listing can no longer disagree with the `group` an agent read off the index.
+ * listing cannot disagree with the `group` an agent read off the index.
  */
 export function groupSchema(group: string): unknown {
   const verbs = VERBS.filter((v) => v.group === group)

--- a/packages/kobe/src/cli/api/tab-snapshot.ts
+++ b/packages/kobe/src/cli/api/tab-snapshot.ts
@@ -43,13 +43,13 @@ export interface TaskTabRow {
   readonly autoTitle: string | null
   readonly alive: boolean
   /** How the tab's session died — ABNORMAL exits only (clean exit 0 stays
-   *  null, per issue #9's no-noise rule); null while alive/unknown. Joined
+   *  null, by the no-noise rule); null while alive/unknown. Joined
    *  from the live host when present, else the durable exit records —
    *  `tail` (the exit-time output lines the durable record keeps) rides
    *  along whenever the record describes the same death. */
   readonly exit: (PtySessionExit & { tail?: readonly string[] }) | null
   /** Present (true) only on rows derived from a LIVE pty session the
-   *  persisted snapshot does not list — issue #20's invisible engine. The
+   *  persisted snapshot does not list — an otherwise invisible engine. The
    *  snapshot is a record of intent; the pty host holds the truth, and a
    *  divergence must render as a row, not vanish. */
   readonly unregistered?: true
@@ -102,7 +102,7 @@ const aliveKeysOf = (sessions: readonly TaskSessionRow[]): Set<string> =>
 
 /**
  * Tab ids with a LIVE `<taskId>::<tabId>` pty session the snapshot does not
- * list — the reconciliation read behind issue #20 (a canonical-spawn
+ * list — the reconciliation read for an invisible engine (a canonical-spawn
  * fallback, an older kobe, any future path that opens a session without
  * writing the snapshot). Split leaves (`::leaf-N` suffix) belong to their
  * tab and never count on their own, matching `joinTaskTabs`' exact-key rule.
@@ -136,7 +136,7 @@ const abnormalExit = (exit: PtySessionExit | null | undefined): PtySessionExit |
  * key) answers "how did it die" after the host itself is gone; a live host's
  * in-memory exit wins when both exist.
  *
- * `liveVendors` (issue #33) is a fresh foreground-walk verdict per session
+ * `liveVendors` is a fresh foreground-walk verdict per session
  * key — the same tri-state the TUI's live-engine store speaks: a vendor =
  * that engine runs under the session's shell NOW, null = walked and
  * engine-free, absent = couldn't look. Where it answers it overrides the

--- a/packages/kobe/src/cli/api/types.ts
+++ b/packages/kobe/src/cli/api/types.ts
@@ -86,9 +86,9 @@ export type VerbHandler = (ctx: VerbContext) => Promise<unknown>
  * purpose: a verb's group is a REQUIRED field on {@link VerbSpec}, so a new
  * verb does not compile until it is grouped, and `VERB_GROUPS` is derived from
  * the specs instead of being hand-maintained beside them. There is
- * deliberately no `other`: the old fallback let an ungrouped verb report a
- * group name that `--group` then rejected as unknown — invisible until an
- * agent actually browsed by group.
+ * deliberately no `other`: such a fallback lets an ungrouped verb report a
+ * group name that `--group` then rejects as unknown — invisible until an
+ * agent actually browses by group.
  */
 export const VERB_GROUP_IDS = [
   "discover",
@@ -165,17 +165,16 @@ export interface DeliveredPrompt {
    * The engine had its tty in raw mode and was READING when we wrote —
    * observed via DECSET 2004 in the session ring, not inferred from the
    * process table. This is the field that decides whether a large prompt
-   * can survive: a write before this is true is silently truncated to the
-   * tty's 1024-byte canonical buffer.
+   * can survive: a write made while this is false is silently truncated to
+   * the tty's 1024-byte canonical buffer.
    *
-   * It used to be a literal copy of {@link delivered}, which made it a
-   * second voice repeating one guess rather than an independent signal.
+   * Never a copy of {@link delivered} — that would be a second voice
+   * repeating one guess rather than an independent signal.
    */
   readonly engineReady: boolean
   /**
    * The prompt was written to the engine's pty AFTER it was confirmed
-   * reading. This is a real observation now — previously the spawn path
-   * hardcoded `true` without checking anything.
+   * reading. A real observation, never a hardcoded `true`.
    *
    * It does NOT promise the engine's composer rendered the text; that is
    * {@link promptEcho}. Delivery is byte-level truth, echo is UI-level
@@ -191,7 +190,7 @@ export interface DeliveredPrompt {
   readonly bytes?: number
   /**
    * Whether the prompt's tail was seen echoed back on capture — the capture
-   * confirmation `delivered` used to claim in its docs but never performed.
+   * confirmation that {@link delivered} deliberately does not make.
    *
    * `"confirmed"` is positive proof. `"unconfirmed"` is INCONCLUSIVE, not
    * failure: engines that collapse a big paste into a placeholder never echo
@@ -200,7 +199,7 @@ export interface DeliveredPrompt {
   readonly promptEcho?: "confirmed" | "unconfirmed"
   /**
    * Present when the delivery gate found the composer busy and the prompt was
-   * accepted-but-deferred rather than dropped (issue #78 B-layer): the daemon
+   * accepted-but-deferred rather than dropped: the daemon
    * stored the text and queued a `prompt_deferred` inbox episode. This is a
    * SUCCESS outcome for the caller — the daemon now owns the message and will
    * hold it for a human to release from the Inbox. Callers MUST NOT retry a

--- a/packages/kobe/src/cli/api/verbs.ts
+++ b/packages/kobe/src/cli/api/verbs.ts
@@ -58,10 +58,10 @@ export const VERB_ALIASES: Readonly<Record<string, string>> = { "spawn-task": "a
  *
  * Deliberately not aliases: `fan-out` folded into `add --count` and
  * `set-vendor` became `set-command`, and both changed their flag contract in
- * the process — an alias would silently accept the old flags and do
- * something subtly different. `archive` (issue #75) had no successor hiding
- * state — its replacement is the destructive-but-recoverable `delete`. A
- * retired verb instead fails loud with
+ * the process — an alias would silently accept the superseded flags and do
+ * something subtly different. `archive` has no successor hiding state — its
+ * replacement is the destructive-but-recoverable `delete`. A removed verb
+ * instead fails loud with
  * `UNKNOWN_VERB` plus the `nextCommandArgs` an agent can run verbatim, which
  * is the same self-healing contract every other high-traffic rejection uses.
  */
@@ -74,9 +74,9 @@ export const RETIRED_VERBS: Readonly<Record<string, { hint: string; nextCommandA
     hint: "set-vendor was replaced by `set-command`, which takes the engine's raw launch command (an engine id from `engine-list`, or a full command line)",
     nextCommandArgs: ["api", "set-command", "--help"],
   },
-  // `archive` went away with the archived-task dimension itself (issue #75) —
-  // there is no "hide but keep" left; `delete` is the cleanup, and its branch
-  // always survives unless the caller explicitly passes --delete-branch.
+  // `archive` went away with the archived-task dimension itself: there is no
+  // "hide but keep"; `delete` is the cleanup, and its branch always survives
+  // unless the caller explicitly passes --delete-branch.
   archive: {
     hint: "archive was removed: there is no hide-without-delete anymore — use `delete` to remove a finished task and its worktree; the git branch survives (pass --delete-branch explicitly only when the history may go)",
     nextCommandArgs: ["api", "delete", "--help"],
@@ -127,10 +127,10 @@ export const API_VERBS = VERBS.map((v) => v.name)
  * (groups + verb summaries), then drills into one verb or one group — instead
  * of slurping every flag of every verb and polluting its context.
  *
- * DERIVED from `VerbSpec.group`, not hand-written: a verb used to state its
- * group twice (once by which `verbs-*.ts` declares it, once in a table here),
- * and forgetting the table half silently produced a group `--group` then
- * rejected as unknown (issue #95). One declaration, one source of truth —
+ * DERIVED from `VerbSpec.group`, not hand-written. Stating a verb's group
+ * twice (once by which `verbs-*.ts` declares it, once in a table here) lets
+ * the table half be forgotten, silently producing a group that `--group` then
+ * rejects as unknown. One declaration, one source of truth —
  * `VerbGroup` is a closed union, so an ungrouped verb is a type error.
  *
  * Group order follows {@link VERB_GROUP_IDS}; verbs within a group follow the

--- a/packages/kobe/src/cli/bun-runtime.ts
+++ b/packages/kobe/src/cli/bun-runtime.ts
@@ -11,8 +11,8 @@
  * Everything in this file must run under plain node: no Bun globals, no
  * imports that pull the Bun bundle in.
  *
- * Deliberately NOT solved by declaring `bun` an optionalDependency (owner,
- * reaffirmed 2026-08-19): that downloads a ~90MB platform binary on EVERY
+ * Deliberately NOT solved by declaring `bun` an optionalDependency: that
+ * downloads a ~90MB platform binary on EVERY
  * install, including `bun install -g`, where a Bun is already present. The
  * install offer below costs nothing and covers the same gap; the npm-package
  * path stays a lookup candidate for anyone who installs `bun` themselves.
@@ -68,7 +68,7 @@ export interface BunLookup {
   env?: NodeJS.ProcessEnv
   platform?: NodeJS.Platform
   home?: string
-  /** Directory of the launcher, used to find a Bun installed beside the package. */
+  /** Directory of the launcher, for finding a Bun installed beside the package. */
   launcherDir?: string
   isExecutable?: (path: string) => boolean
   /** Reads a candidate's `bun --version`; injected so tests never spawn. */
@@ -184,9 +184,8 @@ export function resolveBunBinary(lookup: BunLookup = {}): string | null {
  * Skipping rather than stopping matters: a system Bun on PATH shadowing a
  * current `~/.bun` one is the common shape of this, and Rove works fine if it
  * just uses the newer one. The same holds for a candidate that will not run —
- * a `bun` that is a stray text file, crashes, or hangs, all of which were
- * observed to be relaunched-into before this probe existed, producing garbage
- * output or a wedged process instead of an error.
+ * a `bun` that is a stray text file, crashes, or hangs. Relaunching into one
+ * of those produces garbage output or a wedged process instead of an error.
  *
  * Costs one `bun --version` per candidate until the first hit (~4ms, measured,
  * against a ~300ms node→Bun re-exec), and only on the node launcher path;

--- a/packages/kobe/src/cli/doctor-cmd.ts
+++ b/packages/kobe/src/cli/doctor-cmd.ts
@@ -181,7 +181,7 @@ async function collectDoctor(): Promise<{ lines: string[]; fixes: DoctorFix[] }>
   // Can this process still re-exec itself? A `bun`/`node` process holds its
   // entry open by inode, so uninstalling Rove out from under a running one
   // leaves it alive on a path that is gone — it keeps working until it needs
-  // to spawn a daemon, then fails identically forever (issue #96). The check
+  // to spawn a daemon, then fails identically forever. The check
   // is exactly the resolution the spawn path performs, so the two can never
   // disagree about whether this install is intact.
   const install = describeInstall()
@@ -293,9 +293,9 @@ async function collectDoctor(): Promise<{ lines: string[]; fixes: DoctorFix[] }>
     )
     if (!node) fixes.push(humanOnlyFix("windowsNode"))
   }
-  // macOS: node-pty@1.1.0 ships spawn-helper at 0644 (issue #85). The root
-  // postinstall restores +x on install; a tree from before that fix keeps
-  // failing every node-pty spawn with nothing on screen, so name it here.
+  // macOS: node-pty@1.1.0 ships spawn-helper at 0644. The root postinstall
+  // restores +x on install; a tree where it did not run fails every node-pty
+  // spawn with nothing on screen, so name it here.
   if (process.platform === "darwin") {
     const helpers = spawnHelperDoctorLines(installedSpawnHelpers())
     out.push(...helpers.lines)

--- a/packages/kobe/src/cli/doctor-fix.ts
+++ b/packages/kobe/src/cli/doctor-fix.ts
@@ -92,7 +92,7 @@ export function engineTabsManualFix(): DoctorFix {
 }
 
 /**
- * The install this process runs from was deleted (issue #96). Print-only,
+ * The install this process runs from was deleted. Print-only,
  * and not because it is dangerous: doctor cannot reinstall Rove over the
  * running process, and the running process is the one asking.
  */
@@ -106,7 +106,7 @@ export function reinstallManualFix(): DoctorFix {
   }
 }
 
-/** node-pty's spawn-helper lost its exec bit (issue #85): chmod is idempotent and undoable. */
+/** node-pty's spawn-helper lost its exec bit: chmod is idempotent and undoable. */
 export function spawnHelperFix(paths: readonly string[]): DoctorFix {
   return {
     kind: "run",

--- a/packages/kobe/src/cli/doctor-hook-channel.ts
+++ b/packages/kobe/src/cli/doctor-hook-channel.ts
@@ -5,10 +5,9 @@
  * arriving nothing breaks loudly: `kobe hook` is best-effort by contract
  * (never spawns a daemon, always exits 0, swallows every failure), and the
  * daemon's activity observer keeps painting the badges off a ~10s poll. The
- * UI therefore looks *slow*, not broken — the shape of the 2026-08-26 field
- * report, where every badge lagged 2-3s because an engine's inherited
- * `*_DAEMON_SOCKET_PATH` still pointed at the pre-rename `.kobe` socket and
- * every hook silently dropped its event.
+ * UI therefore looks *slow*, not broken: every badge lags 2-3s, and the
+ * usual cause is an engine whose inherited `*_DAEMON_SOCKET_PATH` points at
+ * a socket nothing is listening on, so every hook drops its event.
  *
  * The tell is already in `debug.inspect`: each tab entry records whether its
  * activity came from a `hook` or from `observed` polling. Live engine tabs
@@ -85,9 +84,9 @@ export function hookChannelDoctorLines(
     "         badges fall back to a ~10s poll, so activity looks seconds late",
     `         daemon socket: ${input.socketPath}`,
   ]
-  // The failure that produced this check: an engine (and every hook it
-  // forks) inherited a `*_DAEMON_SOCKET_PATH` that no longer exists, so
-  // every hook connected to nothing and dropped its event without a word.
+  // The failure this names: an engine (and every hook it forks) inherits a
+  // `*_DAEMON_SOCKET_PATH` pointing at a socket that is gone, so every hook
+  // connects to nothing and drops its event without a word.
   // That env belongs to the engine process, not to doctor, so the hint
   // points at how to read it rather than pretending to check it here.
   out.push(

--- a/packages/kobe/src/cli/doctor-node-pty.ts
+++ b/packages/kobe/src/cli/doctor-node-pty.ts
@@ -2,9 +2,9 @@
  * `rove doctor` row for node-pty's macOS `spawn-helper`. node-pty@1.1.0 is
  * published with `prebuilds/darwin-*\/spawn-helper` at 0644 and no installer
  * adds the exec bit back, so every PTY spawn through node-pty fails until
- * something runs chmod (issue #85). The root `postinstall` does that for
- * installs made after the fix; this row is for the tree that predates it,
- * so the symptom has a name instead of a silent dead terminal.
+ * something runs chmod. The root `postinstall` does that on install; this row
+ * covers a tree where it did not run, so the symptom has a name instead of a
+ * silent dead terminal.
  */
 
 import { readdirSync, statSync } from "node:fs"

--- a/packages/kobe/src/cli/env-checks.ts
+++ b/packages/kobe/src/cli/env-checks.ts
@@ -49,10 +49,10 @@ function binaryLabel(binary: BinaryStatus): string {
 /**
  * One "engines:" block: per-engine CLI binary + account state (read-only).
  *
- * Loops over the REGISTERED engines rather than a fixed set of rows — kimi
- * shipped with a real `detectKimiAccount` and never appeared here, and a
- * contrib/custom engine never could, because adding one meant editing a
- * neutral CLI file. `detectEngineStatuses` is the same probe Settings →
+ * Loops over the REGISTERED engines rather than a fixed set of rows: a fixed
+ * set hides an engine that ships a real account detector, and a contrib or
+ * custom engine can never reach it at all without editing a neutral CLI file.
+ * `detectEngineStatuses` is the same probe Settings →
  * Accounts uses, so the two surfaces can't disagree.
  *
  * Order is `listPresetIds()`: the built-ins in their stable cycle order

--- a/packages/kobe/src/cli/hook-cmd.ts
+++ b/packages/kobe/src/cli/hook-cmd.ts
@@ -88,7 +88,7 @@ export async function runHookSubcommand(argv: readonly string[]): Promise<void> 
     await runHookSetup(rest)
     return
   }
-  // `cleanup` — the sanctioned migration path (issue #37): remove the
+  // `cleanup` — the sanctioned migration path: remove the
   // settings-managed Rove hooks after the Claude Code plugin takes over.
   // User-invoked and loud; the launch-time gate only ever PROMPTS for this.
   if (verb === "cleanup") {
@@ -150,10 +150,10 @@ export async function runHookSubcommand(argv: readonly string[]): Promise<void> 
       client.close()
     }
   } catch (err) {
-    // Still swallowed — a hook must never fail the engine — but no longer
-    // INVISIBLE. A silently-dropped Stop leaves the sidebar spinning with
-    // zero evidence anywhere; debugging that cost a session precisely
-    // because this catch left no trace. Opt-in so normal runs stay quiet.
+    // Swallowed — a hook must never fail the engine — but not INVISIBLE. A
+    // silently-dropped Stop leaves the sidebar spinning with zero evidence
+    // anywhere, and a catch that leaves no trace is undebuggable. Opt-in so
+    // normal runs stay quiet.
     if (process.env.KOBE_HOOK_DEBUG) {
       console.error(`[rove hook] ${verb} failed:`, err instanceof Error ? err.message : String(err))
     }
@@ -179,7 +179,7 @@ function globalSettingsPath(): string {
   return join(homedir(), ".claude", "settings.json")
 }
 
-/** Resolve a persisted sync setting to the settings-file path the old
+/** Resolve a persisted sync setting to the settings-file path the
  *  WorktreeCreate hook was written into (so cleanup finds it), or undefined when
  *  off/unset. Accepts the current form (an absolute path) AND the older
  *  `global` / `repo:<path>` forms for back-compat. */
@@ -199,19 +199,17 @@ function persistedSyncPath(stored: string | undefined): string | undefined {
  *     user's global `~/.claude/settings.json`, so EVERY Claude session reports
  *     normalized events; the daemon maps each hook's cwd to a task. Always
  *     global (a task's badge must light up wherever its engine runs).
- *  2. **Worktree-watch removal** — earlier Rove installed a global `PostToolUse`
- *     (Bash) observer firing `kobe hook worktree-created` after every Bash call,
- *     to archive the task pinned to a removed worktree. Archive was removed
- *     (issue #75), so the hook became a pure tax: a ~170ms process spawn on
- *     EVERY Bash call of every session machine-wide, for nothing. It is no
- *     longer installed, and the removal runs on each launch so users who already
- *     have the entry get it dropped.
- *  3. **WorktreeCreate cleanup** — earlier kobe (0.7.4–0.7.9) installed a global
- *     `WorktreeCreate` hook for external-worktree sync. That was WRONG:
- *     `WorktreeCreate` is a VCS *provider* hook — its mere presence makes Claude
- *     Code delegate worktree creation to it and skip the native git path, so
- *     kobe's observer hook (which returns no path) BROKE `claude --worktree` /
- *     `EnterWorktree` in every repo. We now remove any such hook we ever wrote.
+ *  2. **Worktree-watch removal** — a global `PostToolUse` (Bash) observer
+ *     firing `kobe hook worktree-created` after every Bash call is a pure tax:
+ *     a ~170ms process spawn on EVERY Bash call of every session machine-wide,
+ *     for nothing. Rove never installs it, and the removal runs on each launch
+ *     so a settings file that already carries the entry gets it dropped.
+ *  3. **WorktreeCreate cleanup** — a global `WorktreeCreate` hook for
+ *     external-worktree sync must never be installed: `WorktreeCreate` is a VCS
+ *     *provider* hook, so its mere presence makes Claude Code delegate worktree
+ *     creation to it and skip the native git path, and an observer hook (which
+ *     returns no path) BREAKS `claude --worktree` / `EnterWorktree` in every
+ *     repo. Any such hook already on disk is removed here.
  *     Nothing replaces it: worktree adoption is intent-driven — the daemon's
  *     `session-start` auto-adopt (`daemon/cwd-task.ts` `findAdoptableWorktree`)
  *     catches worktrees first entered by an engine session, and `rove add .`
@@ -222,7 +220,7 @@ function persistedSyncPath(stored: string | undefined): string | undefined {
  */
 export async function ensureGlobalKobeHooks(): Promise<void> {
   try {
-    // 0. Plugin takeover (issue #37): when the Rove Claude Code PLUGIN is
+    // 0. Plugin takeover: when the Rove Claude Code PLUGIN is
     //    enabled, its own hooks.json already carries the Claude activity +
     //    worktree-watch hooks, so the settings-managed install for CLAUDE is
     //    skipped — installing both would double-fire every event. Detection
@@ -252,13 +250,12 @@ export async function ensureGlobalKobeHooks(): Promise<void> {
       const enginePath = a.globalSettingsPath()
       if (!enginePath) continue
       await a.installActivityHooks(enginePath, { toolEvents })
-      // Uninstall the RETIRED PostToolUse(Bash) watch hook. It spawned `kobe
-      // hook worktree-created` after EVERY Bash call to archive the task
-      // pinned to a removed worktree; archive was removed (issue #75), so the
-      // hook had nothing left to do but cost a ~170ms process spawn per Bash
-      // call, machine-wide. Running the removal on every launch is how
-      // already-registered users get it dropped — idempotent, merge-safe, and
-      // it touches only Rove's own group.
+      // Uninstall the PostToolUse(Bash) watch hook. It spawns `kobe hook
+      // worktree-created` after EVERY Bash call for a ~170ms process spawn
+      // per Bash call, machine-wide, and nothing in return. Running the
+      // removal on every launch is how an already-registered settings file
+      // gets it dropped — idempotent, merge-safe, and it touches only Rove's
+      // own group.
       await a.removeWorktreeWatchHook(enginePath)
     }
     // 3. Remove the legacy WorktreeCreate hook wherever it was ever written.
@@ -337,10 +334,10 @@ async function runHookCleanup(): Promise<void> {
 }
 
 /**
- * `kobe hook setup` — DEPRECATED. The external-worktree-sync it configured used
- * a global `WorktreeCreate` hook that broke `claude --worktree` / `EnterWorktree`
- * in every repo (see {@link ensureGlobalKobeHooks}). The command now only cleans
- * up any previously-installed hook; sync is automatic on the daemon side.
+ * `kobe hook setup` — DEPRECATED. External-worktree-sync was configured with a
+ * global `WorktreeCreate` hook, which breaks `claude --worktree` /
+ * `EnterWorktree` in every repo (see {@link ensureGlobalKobeHooks}). The command
+ * only cleans up an installed hook; sync is automatic on the daemon side.
  */
 async function runHookSetup(_argv: readonly string[]): Promise<void> {
   await cleanupWorktreeSyncHook()

--- a/packages/kobe/src/cli/onboarding.ts
+++ b/packages/kobe/src/cli/onboarding.ts
@@ -182,11 +182,11 @@ export function applyOnboardingChoices(
  * That launch re-runs in "primer" mode: no questions (a killed wizard must
  * never re-ask), just the environment page and the keyboard page.
  *
- * The primer flag is NEW, so an absent one cannot mean "killed wizard" — every
- * user who onboarded before this build, and every fixture that seeds
- * `onboarded: true` to skip the wizard, would otherwise be handed a surprise
- * primer on upgrade (and no TUI that launch, since a true return means the
- * caller exits). {@link backfillPrimerForExistingUsers} settles them as done.
+ * An ABSENT primer flag cannot mean "killed wizard": an already-onboarded user
+ * predating the flag, and every fixture that seeds `onboarded: true` to skip
+ * the wizard, would otherwise be handed a surprise primer on upgrade (and no
+ * TUI that launch, since a true return means the caller exits).
+ * {@link backfillPrimerForExistingUsers} settles them as done.
  */
 export async function maybeRunOnboarding(): Promise<boolean> {
   if (!process.stdout.isTTY || !process.stdin.isTTY) return false

--- a/packages/kobe/src/cli/open-dir-cmd.ts
+++ b/packages/kobe/src/cli/open-dir-cmd.ts
@@ -2,11 +2,10 @@
  * `kobe <path>` — the `code .` gesture: open a directory and land in the TUI
  * focused on it. What it opens depends on WHAT the directory is:
  *
- *   - **The root of an eligible git repo** → the project itself (owner call
- *     2026-08-31), i.e. the same outcome as `rove add . && rove`. Opening a
- *     checkout you work in used to mint a throwaway `dir` row beside the main
- *     row it would later be promoted into, so the sidebar listed the same
- *     checkout twice under one header.
+ *   - **The root of an eligible git repo** → the project itself, i.e. the
+ *     same outcome as `rove add . && rove`. Minting a throwaway `dir` row for
+ *     a checkout you work in would put it beside the main row it is later
+ *     promoted into, listing the same checkout twice under one header.
  *   - **Anything else** — a subdirectory, a plain folder, a `/tmp` scratch —
  *     → a standalone `kind:"dir"` task with NO project association: no saved
  *     repo, no main task, no worktree/branch. The task pins the directory
@@ -44,11 +43,11 @@ export function isPathLikeArg(arg: string): boolean {
 }
 
 /**
- * Whether `dir` is the ROOT of a repo eligible to be a project (owner call
- * 2026-08-31). Only the toplevel qualifies: running `rove .` inside
- * `my-monorepo/packages/app` should open a session there, not silently
- * re-target the whole monorepo — and a subdirectory that minted its own
- * project row was the "ghost project named after a subdirectory" bug.
+ * Whether `dir` is the ROOT of a repo eligible to be a project. Only the
+ * toplevel qualifies: running `rove .` inside `my-monorepo/packages/app`
+ * should open a session there, not silently re-target the whole monorepo —
+ * and a subdirectory that mints its own project row is a ghost project named
+ * after a subdirectory.
  */
 async function projectRootFor(dir: string): Promise<string | null> {
   const { isGitRepo, resolveRepoRoot } = await import("../state/repos.ts")
@@ -73,10 +72,10 @@ export async function runOpenDirectory(arg: string): Promise<void> {
     process.stderr.write(`${activeCliName()}: "${arg}" is not a directory (resolved to ${dir}).\n`)
     process.exit(1)
   }
-  // A repo root opens AS THE PROJECT (owner call 2026-08-31): `rove .` in a
-  // checkout you work in is the same gesture as `rove add . && rove`, and
-  // minting a throwaway `dir` row beside the main row it would later be
-  // promoted into just made the sidebar say the same checkout twice.
+  // A repo root opens AS THE PROJECT: `rove .` in a checkout you work in is
+  // the same gesture as `rove add . && rove`, and a throwaway `dir` row would
+  // sit beside the main row it is later promoted into, saying the same
+  // checkout twice.
   // Anything else — a subdirectory, a non-repo folder, a `/tmp` scratch —
   // keeps the dir-task behaviour: pinned to that directory, no project row.
   const projectRoot = await projectRootFor(dir)

--- a/packages/kobe/src/cli/plugin-update.ts
+++ b/packages/kobe/src/cli/plugin-update.ts
@@ -95,10 +95,10 @@ export function printOutdated(): void {
 
 /**
  * An update whose manifest declares a NEW id (the author renamed the
- * plugin) installs under that id, which would leave the old registry entry
- * enabled and pointing at the old checkout — two copies of the same plugin
- * firing every hook. Carry the user's data across and unregister the old
- * one. Nothing is deleted: the stale checkout directory is left in place
+ * plugin) installs under that id, leaving the previous registry entry
+ * enabled and pointing at its own checkout — two copies of the same plugin
+ * firing every hook. Carry the user's data across and unregister the
+ * previous id. Nothing is deleted: the stale checkout directory is left in place
  * and reported, so a rename can never lose configuration.
  */
 function migrateRenamedPlugin(oldId: string, newId: string): void {
@@ -108,7 +108,7 @@ function migrateRenamedPlugin(oldId: string, newId: string): void {
     if (!existsSync(from)) continue
     mkdirSync(to, { recursive: true })
     // Only carry entries the fresh install didn't already create, so a
-    // re-run can't clobber newer values with the old ones.
+    // re-run can't clobber a newer value with a stale one.
     for (const entry of readdirSync(from)) {
       if (existsSync(join(to, entry))) continue
       renameSync(join(from, entry), join(to, entry))

--- a/packages/kobe/src/cli/theme.ts
+++ b/packages/kobe/src/cli/theme.ts
@@ -39,13 +39,10 @@ const THEME_VERB_ALIASES: Readonly<Record<string, string>> = { ls: "list", rm: "
 /**
  * The bundled theme names, read from the map that owns the JSON imports.
  *
- * This list used to be hand-mirrored here, because importing the theme module
- * dragged in opentui + Solid (it built a Solid store at module load). That
- * stopped being true when Solid was removed: `bundled.ts` is now nothing but
- * three `with { type: "json" }` imports and a type-only import, so the CLI can
- * read the real map and the two "keep these in sync" comments can go. Still no
- * disk read — in a published binary those JSONs live inside the compiled JS,
- * not next to it.
+ * Read from the real map rather than hand-mirrored: `bundled.ts` is nothing
+ * but three `with { type: "json" }` imports and a type-only import, so this
+ * pulls in no opentui and no UI runtime. Still no disk read — in a published
+ * binary those JSONs live inside the compiled JS, not next to it.
  */
 const BUNDLED_NAMES: readonly string[] = Object.keys(BUNDLED_THEME_JSONS)
 

--- a/packages/kobe/src/client/remote-orchestrator-connect.ts
+++ b/packages/kobe/src/client/remote-orchestrator-connect.ts
@@ -7,8 +7,7 @@
  * Taking the client + subscribe options + an explicit
  * {@link OrchestratorSignals} deps bag instead of closing over `this` is what
  * makes that testable: drive a handshake or a retry policy with fakes, no
- * socket and no real backoff. Same behavior, moved verbatim — `performInit` is
- * the exact body of the old `RemoteOrchestrator.init`.
+ * socket and no real backoff.
  */
 
 import type { KobeDaemonClient } from "@sma1lboy/kobe-daemon/client"
@@ -48,9 +47,8 @@ export interface PerformInitOptions {
  * that has been deleted, so `ensureReachable` cannot resolve an entry point
  * to re-exec and fails identically forever. The loop gives up there and
  * reports it once, via `onFatal`. Giving up is the SAFE direction — a client
- * that cannot spawn is not a reason to keep pressure on a healthy daemon
- * (PR #733), and the remedy is reinstalling, which no amount of waiting
- * performs.
+ * that cannot spawn is not a reason to keep pressure on a healthy daemon,
+ * and the remedy is reinstalling, which no amount of waiting performs.
  */
 export async function runReconnectLoop(deps: {
   readonly isDisposed: () => boolean
@@ -61,9 +59,9 @@ export async function runReconnectLoop(deps: {
   /** Called once, then the loop stops, when retrying cannot ever succeed. */
   readonly onFatal?: (err: unknown) => void
 }): Promise<void> {
-  // A GUI used to retry with ZERO delay, which made every GUI in the process
-  // wake at the same instant after a shared daemon drop and probe a daemon
-  // that is still cold-starting. Jitter the first GUI attempt so they arrive
+  // Retrying with ZERO delay wakes every GUI in the process at the same
+  // instant after a shared daemon drop, all probing a daemon that is still
+  // cold-starting. Jitter the first GUI attempt so they arrive
   // staggered: the first one through does the work, the rest find a live
   // daemon and never enter the spawn path at all. Small enough to stay
   // imperceptible, wide enough to separate same-tick wakeups.
@@ -80,8 +78,8 @@ export async function runReconnectLoop(deps: {
       return
     } catch (err) {
       // The one non-transient failure: our own install is gone. Retrying is
-      // not recovery here, it is two days of identical throws (the owner's
-      // pid 59121). Say it once and stop.
+      // not recovery here, it is days of identical throws. Say it once and
+      // stop.
       if (isStaleInstallError(err)) {
         logClientError("orch-reconnect-fatal", err)
         deps.onFatal?.(err)
@@ -144,8 +142,8 @@ export async function performInit(
   // Reject a daemon serving a DIFFERENT home BEFORE any of its state is
   // believed. A sandbox daemon that inherited the production socket path
   // answers hello perfectly and hands back its own empty task list; without
-  // this the TUI adopted it as the truth and blanked the sidebar while every
-  // task sat intact on disk (prod 2026-08-13). Throwing keeps the caller's
+  // this the TUI adopts it as the truth and blanks the sidebar while every
+  // task sits intact on disk. Throwing keeps the caller's
   // reconnect loop running, so the moment the real daemon reclaims the socket
   // the client re-syncs on its own.
   const clientHome = homeDir()
@@ -173,11 +171,11 @@ export async function performInit(
   // role so the daemon's lazy-shutdown refcount counts only real
   // front-end attaches (`gui`), not in-tmux helper panes (`pane`).
   await client.subscribe({ role: opts.role, channels: opts.channels })
-  // Daemon-collected worktree changes (issue #6): gate on the hello
+  // Daemon-collected worktree changes: gate on the hello
   // capability list — the honest "does this daemon run the collector?"
   // signal during a rolling upgrade. A capable daemon replays the
-  // channel's last value during subscribe (handled above by handleEvent
-  // before this response resolves); when no value was published yet, an
+  // channel's last value during subscribe (handled by handleEvent before
+  // this response resolves); when no value has been published yet, an
   // EMPTY map (not null) says "daemon collects — trust pushes, spawn no
   // local git". An old daemon without the capability resets the signal
   // to null so the sidebar's local poller engages cleanly — including

--- a/packages/kobe/src/client/remote-orchestrator-events.ts
+++ b/packages/kobe/src/client/remote-orchestrator-events.ts
@@ -7,9 +7,7 @@
  *
  * Taking an explicit {@link OrchestratorSignals} deps bag instead of closing
  * over `this` is what makes that testable: hand it plain closures and drive
- * event payloads through with no daemon and no class. Same behavior, moved
- * verbatim — `handleOrchestratorEvent` is the exact body of the old
- * `RemoteOrchestrator.handleEvent`.
+ * event payloads through with no daemon and no class.
  */
 
 import { logClientError } from "@sma1lboy/kobe-daemon/client/client-log"
@@ -41,12 +39,12 @@ import {
 } from "./remote-orchestrator-payloads.ts"
 
 /**
- * Drop engine-state entries for tasks that no longer exist (leak guard).
+ * Drop engine-state entries for tasks that are gone (leak guard).
  * The `engine-state` channel only removes an entry on an explicit `idle`
  * event for that taskId — a task deleted/pruned while non-idle (running /
  * permission-needed / error, the common delete case) never gets one, so
- * in a long-lived pane process the map grew one stale entry per deleted
- * task, forever. Reconcile against each `task.snapshot` instead: any key
+ * in a long-lived pane process the map grows one stale entry per deleted
+ * task, forever. Reconcile against each `task.snapshot`: any key
  * absent from the authoritative task list is dead. Benign race: an
  * `engine-state` event arriving before the snapshot that introduces its
  * task would be dropped here — the next engine-state event re-adds it
@@ -65,9 +63,9 @@ function pruneEngineState(tasks: readonly SerializedTask[], signals: Orchestrato
     }
     if (next) signals.setEngineStateSig(next)
   }
-  // Same leak guard for the per-tab map — a task deleted while a tab was
-  // non-idle never gets its per-tab idle events on this client if it was
-  // disconnected at the time.
+  // Same leak guard for the per-tab map — a task deleted while a tab is
+  // non-idle never delivers its per-tab idle events to a client that was
+  // disconnected for them.
   const tabs = signals.engineTabStateAcc()
   if (tabs.size > 0) {
     let nextTabs: Map<string, ReadonlyMap<string, TaskEngineState>> | null = null
@@ -92,7 +90,7 @@ function pruneEngineState(tasks: readonly SerializedTask[], signals: Orchestrato
 }
 
 /**
- * Drop task-job entries for tasks that no longer exist — the same leak
+ * Drop task-job entries for tasks that are gone — the same leak
  * guard as {@link pruneEngineState}. A `done`/`error` publish normally
  * clears the entry, but a task DELETED while its job runs (or a dropped
  * terminal frame across a reconnect) would otherwise pin a phantom
@@ -112,7 +110,6 @@ function pruneTaskJobs(tasks: readonly SerializedTask[], signals: OrchestratorSi
   if (next) signals.setTaskJobsSig(next)
 }
 
-/** The exact body of the old `RemoteOrchestrator.handleEvent`. */
 export function handleOrchestratorEvent(name: string, payload: unknown, signals: OrchestratorSignals): void {
   if (name === "task.snapshot") {
     const value = (payload as { tasks?: SerializedTask[] } | undefined)?.tasks
@@ -166,10 +163,10 @@ export function handleOrchestratorEvent(name: string, payload: unknown, signals:
     // Accumulate per-task into a fresh Map (new ref → re-render). A tabId-
     // carrying event updates BOTH levels: the daemon publishes one event per
     // report, and the task entry is its last-event-wins rollup — EXCEPT that
-    // a tab-scoped idle only clears a rollup the SAME tab wrote (issue #11:
-    // the activity observer publishes per-tab idles for quiet sessions, and
-    // letting any tab's idle delete the rollup blanked a task whose live
-    // work — another tab, or an untagged external session — was still going).
+    // a tab-scoped idle only clears a rollup the SAME tab wrote: the activity
+    // observer publishes per-tab idles for quiet sessions, and letting any
+    // tab's idle delete the rollup blanks a task whose live work — another
+    // tab, or an untagged external session — is still going.
     const prevTask = signals.engineStateAcc().get(p.taskId)
     const prevTaskState = prevTask?.state
     const next = new Map(signals.engineStateAcc())
@@ -195,7 +192,7 @@ export function handleOrchestratorEvent(name: string, payload: unknown, signals:
       signals.setEngineLifecycleSig(lifecycle)
     }
     if (tabId) {
-      // An idle entry is KEPT as a tombstone, not deleted (issue #11): the
+      // An idle entry is KEPT as a tombstone, not deleted: the
       // sidebar renders absence as UNKNOWN (no signal — a dotted ◌), so
       // "the daemon said this tab is idle" must stay distinguishable from
       // "the daemon never said anything". Bounded by tabs-per-task; the

--- a/packages/kobe/src/client/remote-orchestrator-payloads.ts
+++ b/packages/kobe/src/client/remote-orchestrator-payloads.ts
@@ -50,7 +50,7 @@ export interface TaskEngineState {
   readonly transcriptPath?: string
   /** The tab that produced this entry, when the event carried one — on the
    *  TASK rollup it records which tab last wrote it, so a tab-scoped idle
-   *  only clears a rollup its own tab owns (issue #11). */
+   *  only clears a rollup its own tab owns. */
   readonly tabId?: string
   readonly at: number
 }
@@ -77,7 +77,7 @@ export interface TaskJobState {
 
 /**
  * Daemon-collected `+N −M` counts keyed by worktree path, from the
- * `worktree.changes` channel (issue #6 — one collector in the daemon
+ * `worktree.changes` channel (one collector in the daemon
  * instead of per-pane git polling). `null` means "no daemon-collected
  * data": either the daemon predates the channel (absent from
  * `hello.capabilities`) or `init()` hasn't completed — the sidebar then
@@ -312,8 +312,8 @@ export interface RemoteOrchestratorOptions {
    * receive EVERY channel (the default — what a primary orchestrator
    * driving the task list needs). Pass a narrow set for a single-purpose
    * consumer: host-boot's UiPrefsSync passes `["ui-prefs", "keybindings"]`
-   * so it no longer receives — nor deserializes — the full `task.snapshot`
-   * fan-out it never reads. When the filter excludes `task.snapshot`, the
+   * so it never receives — nor deserializes — the full `task.snapshot`
+   * fan-out it does not read. When the filter excludes `task.snapshot`, the
    * `hello` task hydration is also skipped (the task list would be dead
    * weight), and `worktreeChangesSignal()` is left null (its consumer isn't
    * subscribed). An older daemon ignores the filter and sends everything;

--- a/packages/kobe/src/client/remote-orchestrator-reads.ts
+++ b/packages/kobe/src/client/remote-orchestrator-reads.ts
@@ -135,7 +135,7 @@ export function taskJobsSignalOp(s: ReadSignals): ReadableState<ReadonlyMap<stri
 
 /**
  * Daemon-collected `+N −M` uncommitted-change counts keyed by worktree
- * path, pushed live on the `worktree.changes` channel (issue #6 — ONE
+ * path, pushed live on the `worktree.changes` channel (ONE
  * collector in the daemon instead of per-pane git polling). `null` =
  * no daemon-collected data (old daemon without the channel, or before
  * `init()`): the sidebar then falls back to its local poller; non-null

--- a/packages/kobe/src/client/remote-orchestrator-writes.ts
+++ b/packages/kobe/src/client/remote-orchestrator-writes.ts
@@ -52,7 +52,7 @@ export async function ensureMainTaskOp(client: KobeDaemonClient, repo: string): 
 }
 
 /** Open a directory as a `kind:"dir"` task; `scratch` marks a temp shell
- *  task for the sidebar's Scratch section (issue #33). */
+ *  task for the sidebar's Scratch section. */
 export async function openDirectoryTaskOp(
   client: KobeDaemonClient,
   input: { dir: string; scratch?: boolean },
@@ -61,7 +61,7 @@ export async function openDirectoryTaskOp(
   return deserializeTask(res.task)
 }
 
-/** Scratch → project migration (issue #33): repoint + clear the flag. */
+/** Scratch → project migration: repoint + clear the flag. */
 export async function adoptScratchRepoOp(client: KobeDaemonClient, id: TaskId | string, repo: string): Promise<void> {
   await client.request("task.adoptScratchRepo", { taskId: String(id), repo })
 }
@@ -77,7 +77,7 @@ export async function forgetProjectOp(client: KobeDaemonClient, repo: string): P
 
 /**
  * Fire-and-forget `turn-interrupted` report for a tab whose engine ended
- * its turn with NO hook of its own — an ESC interrupt (issue #15; the TUI's
+ * its turn with NO hook of its own — an ESC interrupt (the TUI's
  * `InterruptObserver` confirmed the engine's resting title against a
  * hook-claimed `running`). Same `engine.reportEvent` verb the `kobe hook`
  * processes use, so the daemon reduces + broadcasts it like any hook event.
@@ -172,7 +172,7 @@ export async function markAttentionReadOp(
   return res.updated
 }
 
-/** Read one deferred prompt back by id (issue #78 B-layer exit path). */
+/** Read one deferred prompt back by id — the deferral exit path. */
 export async function getDeferredPromptOp(client: KobeDaemonClient, id: string): Promise<DeferredPromptRecord | null> {
   const res = await client.request<{ record: DeferredPromptRecord | null }>("deferredPrompt.get", { id })
   return res.record

--- a/packages/kobe/src/client/remote-orchestrator.ts
+++ b/packages/kobe/src/client/remote-orchestrator.ts
@@ -386,7 +386,7 @@ export class RemoteOrchestrator {
       .request("ui.reportEvent", { kind, ...(taskId ? { taskId } : {}), ...(detail ? { detail } : {}) })
       .catch(() => {})
 
-  /** Confirmed ESC interrupt on a hook-running tab (issue #15) — see
+  /** Confirmed ESC interrupt on a hook-running tab — see
    *  {@link reportEngineInterruptOp}. */
   readonly reportEngineInterrupt = (taskId: TaskId | string, tabId: string): void =>
     reportEngineInterruptOp(this.client, String(taskId), tabId)

--- a/packages/kobe/src/engine/account-detect.ts
+++ b/packages/kobe/src/engine/account-detect.ts
@@ -71,7 +71,7 @@ export type CopilotAccount =
 /**
  * Kimi Code stores an OAuth token bundle at
  * `~/.kimi-code/credentials/kimi-code.json` (`access_token` +
- * `refresh_token` + `expires_at`; verified on a live install 2026-07-18).
+ * `refresh_token` + `expires_at`).
  * The JWT payload has no email claim — only opaque ids — so a logged-in
  * account is reported without one.
  */

--- a/packages/kobe/src/engine/agent-turn.ts
+++ b/packages/kobe/src/engine/agent-turn.ts
@@ -1,5 +1,5 @@
 /**
- * `AgentTurn` — the engine-owned per-turn attribution record (issue #32).
+ * `AgentTurn` — the engine-owned per-turn attribution record.
  *
  * One record per completed agent turn: which model ran, how long it took,
  * what it cost in tokens. The engine adapter is the ONLY thing that knows
@@ -20,8 +20,8 @@ import type { EngineUsageSnapshot } from "@/types/engine"
 
 export interface AgentTurn {
   /**
-   * Vendor-stable identity for this turn, used to dedupe repeated reads of
-   * the same transcript (the hook fires on every Stop, and a transcript is
+   * Vendor-stable identity for this turn: the dedupe key for repeated reads
+   * of the same transcript (the hook fires on every Stop, and a transcript is
    * re-read from the top each time). Claude uses the turn's last assistant
    * `message.id`; another vendor may use whatever it persists — the only
    * contract is that the SAME turn yields the SAME id across reads.

--- a/packages/kobe/src/engine/builtin-engines.ts
+++ b/packages/kobe/src/engine/builtin-engines.ts
@@ -81,15 +81,15 @@ export const BUILTIN_ENGINES: Record<"claude" | "codex" | "copilot" | "kimi", En
     // Rove pins a fresh uuid at launch and the tab is trackable from its
     // first frame. `--session-id <uuid>` is documented; the control flags
     // are every documented way a command can already own its session —
-    // appending a second one makes claude refuse to launch (issue #58).
+    // appending a second one makes claude refuse to launch.
     sessionIdentity: {
       pinFlag: "--session-id",
       sessionControlFlags: ["--session-id", "--resume", "-r", "--continue", "-c", "--from-pr"],
       resumeArgv: (base, id) => [...base, "--resume", id],
       // Fork = resume + branch, and claude lets the caller name the branch,
       // so the forked tab is trackable from its first frame like any other
-      // claude tab. The three flags combine (probed against claude 2.x: the
-      // fork lands in the id we pass).
+      // claude tab. The three flags combine, and the fork lands in the id
+      // we pass.
       forkArgv: (base, sourceId, newId) => {
         const forked = [...base, "--resume", sourceId, "--fork-session"]
         return newId ? [...forked, "--session-id", newId] : forked
@@ -104,8 +104,8 @@ export const BUILTIN_ENGINES: Record<"claude" | "codex" | "copilot" | "kimi", En
     builtin: true,
     displayName: codexIdentity.shortName,
     defaultCommand: ["codex"],
-    // Effort levels real `codex exec` accepts (the broken `minimal` is
-    // deliberately excluded — CHANGELOG 0.5.17).
+    // Effort levels real `codex exec` accepts; `minimal` is broken there and
+    // deliberately excluded.
     effortLevels: ["none", "low", "medium", "high", "xhigh"],
     effortArgv: (base, level) => [...base, "-c", `model_reasoning_effort=${level}`],
     history: codexHistoryReader,
@@ -139,14 +139,14 @@ export const BUILTIN_ENGINES: Record<"claude" | "codex" | "copilot" | "kimi", En
     // No pin flag — codex mints its own thread id and reports it in the OSC
     // title (see `terminalTitle.sessionIdFromTitle`), which is origin (2) in
     // `session-identity.ts`. Resume is a SUBCOMMAND with the id positional
-    // (`codex resume [OPTIONS] [SESSION_ID]`, probed 2026-08-29), so the
+    // (`codex resume [OPTIONS] [SESSION_ID]`), so the
     // launch flags stay between the verb and the id.
     sessionIdentity: {
       resumeArgv: (base, id) => {
         const [bin, ...rest] = base
         return bin ? [bin, "resume", ...rest, id] : base
       },
-      // `codex fork [OPTIONS] [SESSION_ID]` (probed 2026-08-30) — same
+      // `codex fork [OPTIONS] [SESSION_ID]` — same
       // subcommand shape as resume, so the launch flags stay between the
       // verb and the positional id. Codex mints the forked thread's own id,
       // so a caller-set one has nowhere to go.
@@ -175,7 +175,7 @@ export const BUILTIN_ENGINES: Record<"claude" | "codex" | "copilot" | "kimi", En
     displayName: "Kimi",
     defaultCommand: ["kimi"],
     // kimi's positional CLI slot is a subcommand (export/provider/acp/…),
-    // not an initial prompt — argv delivery kills it (issue #25).
+    // not an initial prompt — argv delivery kills it.
     firstMessageDelivery: "paste",
     // The installed Mach-O binary rewrites its process title to `kimi-co`
     // after launch, so a live kimi session's argv[0] never reads `kimi`.
@@ -186,8 +186,8 @@ export const BUILTIN_ENGINES: Record<"claude" | "codex" | "copilot" | "kimi", En
     createHookAdapter: () => new KimiHookAdapter(),
     createTurnDetector: () => new UnknownTurnDetector("kimi"),
     // Kimi cannot be TOLD what to call a new session — `-S [id]` only
-    // resumes an existing one (probed 2026-08-29: "Resume a session. With
-    // ID: resume that session. Without ID: interactively pick."). So its id
+    // resumes an existing one ("Resume a session. With ID: resume that
+    // session. Without ID: interactively pick."). So its id
     // is origin (3): discovered after the fact from the session store this
     // entry's `history` reader already indexes by worktree. `-c/--continue`
     // and `-S` both mean the user's command owns the session already.

--- a/packages/kobe/src/engine/claude-code-local/history.ts
+++ b/packages/kobe/src/engine/claude-code-local/history.ts
@@ -22,7 +22,7 @@
  * Each JSONL line is a record like:
  *
  *     { "type": "user", "message": { "role": "user", "content": "..." },
- *       "timestamp": "2026-05-09T03:59:51.343Z",
+ *       "timestamp": "<iso-8601>",
  *       "sessionId": "<uuid>", "cwd": "/Users/...", ... }
  *
  * The shapes vary — Claude Code persists not just messages but also
@@ -99,16 +99,15 @@ const defaultDeps: HistoryDeps = {
  * Claude Code replaces **every** non-alphanumeric character with `-` —
  * its own encoder is `cwd.replace(/[^a-zA-Z0-9]/g, "-")` (verified in the
  * shipped CLI bundle), so `/`, `.`, `_`, spaces, and non-ASCII letters
- * all fold. Matching only `/` and `.` (the old behavior) pointed every
- * encoding-dependent consumer at a directory Claude never created
- * whenever the worktree path contained e.g. an underscore — silently
- * disabling session-file discovery, activity mtime detection, and
- * interrupted-prompt rescue for that task.
+ * all fold. Matching only `/` and `.` points every encoding-dependent
+ * consumer at a directory Claude never created whenever the worktree path
+ * contains e.g. an underscore, which silently disables session-file
+ * discovery, activity mtime detection, and interrupted-prompt rescue for
+ * that task.
  *
  * No legacy fallback on purpose: the dirs under `~/.claude/projects` are
- * created by Claude with this encoding, so the fix *restores* access to
- * them. The only dirs the old encoding could name were rescue-created by
- * kobe itself, holding orphaned prompts Claude's `--resume` never read.
+ * created by Claude with this encoding, so this is the only encoding that
+ * names a real one.
  *
  * The encoding is lossy (see file-level docstring) and reversal is
  * unreliable — we never decode, only iterate/derive.

--- a/packages/kobe/src/engine/claude-code-local/hook-adapter.ts
+++ b/packages/kobe/src/engine/claude-code-local/hook-adapter.ts
@@ -66,7 +66,7 @@ export const CLAUDE_HOOK_EVENT_MAP: readonly HookEventSpec[] = [
   { event: "PostToolUseFailure", verb: "tool-failed" },
 ]
 
-/** The events kobe owns — used to replace only these in a merge. Deduped:
+/** The events kobe owns — a merge replaces only these. Deduped:
  *  one event can carry several matcher-scoped specs. */
 export const KOBE_HOOK_EVENTS: readonly string[] = [...new Set(CLAUDE_HOOK_EVENT_MAP.map((e) => e.event))]
 

--- a/packages/kobe/src/engine/claude-code-local/normalize.ts
+++ b/packages/kobe/src/engine/claude-code-local/normalize.ts
@@ -9,9 +9,6 @@
  *   - `image` blocks (kobe doesn't render images yet)
  *   - `redacted_thinking` (no usable text)
  *   - any unknown block type
- *
- * These match the historical pre-v0.6 chat renderer drop list, so transcript
- * preview output stays conservative even though kobe no longer owns chat UI.
  */
 
 import type { ContentBlock } from "@/types/content"

--- a/packages/kobe/src/engine/claude-code-local/plugin-migration.ts
+++ b/packages/kobe/src/engine/claude-code-local/plugin-migration.ts
@@ -1,5 +1,5 @@
 /**
- * Claude Code plugin takeover detection (issue #37, migration hard-gate).
+ * Claude Code plugin takeover detection — the migration hard-gate.
  *
  * Once the user installs the Rove Claude Code plugin (`claude-plugin/` in this
  * repo, enabled as `rove@<marketplace>` in `~/.claude/settings.json`), the

--- a/packages/kobe/src/engine/claude-code-local/quota.ts
+++ b/packages/kobe/src/engine/claude-code-local/quota.ts
@@ -138,9 +138,9 @@ async function readKeychainCredentials(): Promise<OAuthCredentials | null> {
     // `-a` is load-bearing, not decoration: a machine can carry SEVERAL
     // items under this one service name (a stale `acct=unknown` row from an
     // older CLI alongside today's login). Querying by service alone returns
-    // whichever `security` scans first — for the owner that was a token
-    // expired two weeks earlier, so the usage dashboard stayed empty through
-    // repeated re-logins. The CLI itself always pairs `-a $USER` with `-s`
+    // whichever `security` scans first, which can be a long-expired token —
+    // the usage dashboard then stays empty through repeated re-logins. The
+    // CLI itself always pairs `-a $USER` with `-s`
     // (refs/claude-code `macOsKeychainStorage.ts`); mirror it exactly.
     const result = await spawnCapture(
       "security",

--- a/packages/kobe/src/engine/claude-code-local/screen.ts
+++ b/packages/kobe/src/engine/claude-code-local/screen.ts
@@ -2,7 +2,7 @@
  * Claude Code screen-state manifest.
  *
  * Claude reports turn state through hooks and its OSC title, so this manifest
- * only covers the delivery gate's composer-empty detection (issue #78).
+ * only covers the delivery gate's composer-empty detection.
  *
  * The composer is NOT the last thing on screen. Claude draws it inside a box
  * and hangs its own status furniture below:

--- a/packages/kobe/src/engine/claude-code-local/trust.ts
+++ b/packages/kobe/src/engine/claude-code-local/trust.ts
@@ -1,5 +1,5 @@
 /**
- * Claude Code workspace trust (issue #28). Claude gates a first launch in a
+ * Claude Code workspace trust. Claude gates a first launch in a
  * never-seen directory behind a "Do you trust the files in this folder?"
  * dialog; a Rove task worktree is always such a directory, so a hosted
  * session would sit at the dialog forever. Rove created the worktree from a

--- a/packages/kobe/src/engine/claude-code-local/turns.ts
+++ b/packages/kobe/src/engine/claude-code-local/turns.ts
@@ -1,6 +1,6 @@
 /**
  * Claude Code's {@link EngineTurnReader} — per-turn telemetry lifted out of
- * its own JSONL transcript (issue #32).
+ * its own JSONL transcript.
  *
  * The turn boundary Claude persists: a `user` record with real prompt content
  * opens a turn, every `assistant` record after it belongs to that turn, and

--- a/packages/kobe/src/engine/codex-local/history-parse.ts
+++ b/packages/kobe/src/engine/codex-local/history-parse.ts
@@ -5,7 +5,7 @@
  *
  * One fold pass extracts BOTH the conversation messages (`response_item`
  * records) and the latest usage snapshot (real rollout `event_msg token_count`,
- * or legacy `codex exec --json` `turn.completed`) — previously two separate
+ * or legacy `codex exec --json` `turn.completed`) instead of two separate
  * full scans of the raw text per poll. The fold is line-local
  * apart from the usage carry-over (latest snapshot + its timestamp), which
  * threads through the cached state, so folding the appended slice onto the
@@ -110,10 +110,10 @@ function foldRolloutChunk(chunk: string, prev: CodexParseState, sessionId: strin
       latestUsage = snapshot
     } else if (latestUsageTimestampMs === null) {
       // No timestamped record has won yet — keep advancing to the latest in
-      // FILE order. Gating on `latestUsage === undefined` (the old check) froze
-      // on the FIRST snapshot when turn.completed lines carry no timestamp, so
-      // every later turn's usage was silently discarded and the session
-      // reported stale first-turn tokens.
+      // FILE order. Gating on `latestUsage === undefined` instead freezes on
+      // the FIRST snapshot when turn.completed lines carry no timestamp, so
+      // every later turn's usage is silently discarded and the session
+      // reports stale first-turn tokens.
       latestUsage = snapshot
     }
   }
@@ -137,9 +137,9 @@ interface CodexUsageFields {
  *   - REAL rollout: `{ type: "event_msg", payload: { type: "token_count",
  *     info: { total_token_usage: {…}, last_token_usage: {…},
  *     model_context_window } } }`. This is what codex-cli actually writes to
- *     `~/.codex/sessions/**.jsonl`; the old parser matched none of it, so
- *     History showed 0 tok and context% was always 0 even though
- *     `model_context_window` was sitting in the file. `total_token_usage` is
+ *     `~/.codex/sessions/**.jsonl`. A parser that misses it shows 0 tok and
+ *     0 context% with `model_context_window` sitting right there in the
+ *     file. `total_token_usage` is
  *     the session aggregate; `last_token_usage` is this turn's delta.
  *   - LEGACY stream: top-level `{ type: "turn.completed", usage: {…} }`, the
  *     `codex exec --json` event shape (no context window, no per-turn split).

--- a/packages/kobe/src/engine/codex-local/history.ts
+++ b/packages/kobe/src/engine/codex-local/history.ts
@@ -168,7 +168,7 @@ export function rolloutCwd(raw: string): string {
  * rollout filenames embed a UUID + ISO timestamp so a path is never
  * reused — a successfully parsed, non-empty cwd is immutable and can be
  * cached forever. The polling callers (the Ops pane's 2.5s activity poll
- * and 1.5s turn poll, the daemon's 4s auto-title tick) previously
+ * and 1.5s turn poll, the daemon's 4s auto-title tick) would otherwise
  * re-READ up to 12–200 whole rollout JSONLs per tick just to re-derive
  * the same first-line cwd.
  *

--- a/packages/kobe/src/engine/codex-local/hook-adapter.ts
+++ b/packages/kobe/src/engine/codex-local/hook-adapter.ts
@@ -52,7 +52,7 @@ const EVENT_MAP: readonly HookEventSpec[] = [
   { event: "PostToolUse", verb: "tool-post" },
 ]
 
-/** The Codex events kobe owns — used to replace only these in a merge. */
+/** The Codex events kobe owns — a merge replaces only these. */
 export const KOBE_CODEX_HOOK_EVENTS: readonly string[] = EVENT_MAP.map((e) => e.event)
 
 /** Where Codex reads user hook definitions. */

--- a/packages/kobe/src/engine/codex-local/quota.ts
+++ b/packages/kobe/src/engine/codex-local/quota.ts
@@ -40,7 +40,7 @@ function toWindow(kind: string, raw: CodexRateWindow | null | undefined, nowMs: 
   if (!raw || typeof raw.used_percent !== "number" || typeof raw.window_minutes !== "number") return null
   // resets_at is epoch SECONDS. A window that already reset is a stale
   // reading, not a live one — the percent it carries belongs to a window
-  // that no longer exists.
+  // that has already closed.
   const resetsAt = typeof raw.resets_at === "number" && raw.resets_at > 0 ? raw.resets_at * 1000 : null
   if (resetsAt == null || resetsAt <= nowMs) return null
   return {

--- a/packages/kobe/src/engine/codex-local/screen.ts
+++ b/packages/kobe/src/engine/codex-local/screen.ts
@@ -2,7 +2,7 @@
  * Codex CLI screen-state manifest.
  *
  * Codex reports turn state through hooks and its OSC title, so this manifest
- * only covers the delivery gate's composer-empty detection (issue #78).
+ * only covers the delivery gate's composer-empty detection.
  * Codex 0.152 renders an empty composer as either a bare `›` or the prompt
  * followed by a dim `Ask Codex to do anything` placeholder. Requiring the dim
  * attribute keeps an identical user draft from being submitted by Rove.

--- a/packages/kobe/src/engine/codex-local/trust.ts
+++ b/packages/kobe/src/engine/codex-local/trust.ts
@@ -1,5 +1,5 @@
 /**
- * Codex workspace trust (issue #28). Codex gates a never-seen directory
+ * Codex workspace trust. Codex gates a never-seen directory
  * behind its own trust prompt; the store is `~/.codex/config.toml` —
  * `[projects."<abspath>"] trust_level = "trusted"`. Pre-trusting a
  * Rove-created worktree is the same trust domain as the repo the user
@@ -8,9 +8,9 @@
  * Append-only: a `[projects.*]` table at EOF attaches to nothing, so the
  * rest of the user's config is never parsed or rewritten.
  *
- * Concurrency: the read-check-append sequence used to be unguarded, so
- * two spawns for the SAME worktree (a retried launch, TUI and daemon at
- * once) could both append the table. Duplicate TOML keys make codex
+ * Concurrency: an unguarded read-check-append lets two spawns for the SAME
+ * worktree (a retried launch, TUI and daemon at once) both append the
+ * table. Duplicate TOML keys make codex
  * reject the ENTIRE config — every codex task on the machine fails, not
  * just the raced one. Two layers prevent that:
  *

--- a/packages/kobe/src/engine/composer-state.ts
+++ b/packages/kobe/src/engine/composer-state.ts
@@ -1,7 +1,7 @@
 /**
  * Composer-empty detection for hosted engine sessions.
  *
- * The delivery gate (issue #78) needs to know whether the engine's composer
+ * The delivery gate needs to know whether the engine's composer
  * already contains user text before auto-pasting a peer/API message. This is
  * a pure function: raw ring bytes + an engine-owned manifest → empty / not
  * empty / unknown. No real PTY is started; rendering happens in a throwaway
@@ -12,18 +12,17 @@ import { Unicode11Addon } from "@xterm/addon-unicode11"
 import { Terminal as XtermHeadless } from "@xterm/headless"
 import type { ComposerEmptyRule, EngineScreenManifest } from "./screen-state.ts"
 
-/** Fixed width for composer rendering — see issue #78. Claude's composer
+/** Fixed width for composer rendering. Claude's composer
  *  line is stable across 150–236 cols; 150 is enough and cheap. */
 export const COMPOSER_RENDER_COLS = 150
 /**
  * Rows the throwaway terminal renders into.
  *
- * Must exceed a real engine screen, not just the footer we want to read. At
- * 12 the ring's own line count overran the buffer and lines CONCATENATED
- * (`──⏵⏵ bypass permissions on …` — a rule and the hint row fused into one),
- * so the composer line was not merely off-window, it no longer existed as a
- * line to match. Every Claude delivery then read as "composer has text" and
- * deferred, whatever the composer actually held.
+ * Must exceed a real engine screen, not just the footer we want to read. Too
+ * few rows and the ring's own line count overruns the buffer, fusing lines
+ * together (`──⏵⏵ bypass permissions on …` — a rule and the hint row in one),
+ * so the composer line does not exist as a line to match at all and every
+ * delivery reads as "composer has text", whatever the composer holds.
  *
  * 60 covers a full-screen engine with headroom. The cost is one throwaway
  * xterm per delivery gate, which is already the price of the render.
@@ -86,11 +85,11 @@ function bottomRegion(capture: readonly RenderedComposerLine[], lines: number): 
  *   `absent` — its ANCHOR is not on screen at all, so this rule saw no
  *              composer and has nothing to say about one.
  *
- * The third outcome is the one that matters. Collapsing it into `text` is
- * what turned a Claude layout change into a total delivery outage: the prompt
- * glyph moved out of the inspected window, no rule matched, and every message
- * to every Claude task deferred as "composer busy" — including the ones whose
- * composers were plainly empty. "I could not see it" is not evidence of text.
+ * The third outcome is the one that matters. Collapsing it into `text` turns
+ * any engine layout change into a total delivery outage: the prompt glyph
+ * moves out of the inspected window, no rule matches, and every message to
+ * that engine defers as "composer busy" — including the ones whose composers
+ * are plainly empty. "I could not see it" is not evidence of text.
  */
 type RuleOutcome = "empty" | "text" | "absent"
 

--- a/packages/kobe/src/engine/engine-presets.ts
+++ b/packages/kobe/src/engine/engine-presets.ts
@@ -22,8 +22,8 @@
  * command in `engineCommand.<id>`, its display name in `engineName.<id>`,
  * and — new here — the protocol it speaks in `engineProtocol.<id>`,
  * declared once at registration so every later dispatch is deterministic
- * instead of re-sniffed. A preset registered before this key existed reads
- * as generic until its protocol is set.
+ * instead of re-sniffed. A preset with no `engineProtocol.<id>` recorded
+ * reads as generic until its protocol is set.
  *
  * State-reading by construction, which is why it is NOT in `registry.ts`
  * (that module stays state-free so vitest and the daemon can import it).
@@ -176,7 +176,7 @@ export interface EngineLaunchSpec {
  *     silently drop every flag, so a declared protocol would buy nothing at
  *     launch time.
  *
- * A built-in id resolves to itself, so this is the same argv it always was.
+ * A built-in id resolves to itself, so the two rules agree for a built-in.
  */
 export function engineLaunchArgv(spec: EngineLaunchSpec): readonly string[] {
   const command = spec.command?.trim()
@@ -210,9 +210,8 @@ function presetBaseArgv(id: string): readonly string[] | null {
  * terminal-title flags, applied to session identity: a preset `claudecpa`
  * declaring the claude protocol IS a claude launch, so it takes claude's
  * `--session-id` / `--resume`. Keying off the id instead would find the
- * empty custom entry and silently drop both — which is exactly what the old
- * `withClaudeSessionId` did with its literal `vendor === "claude"` check,
- * and why every wrapper engine lost its conversation on restart.
+ * empty custom entry and silently drop both, so a wrapper engine would lose
+ * its conversation on restart.
  */
 export function sessionProtocol(vendor: VendorId | undefined): VendorId {
   const id = vendor?.trim()
@@ -228,10 +227,10 @@ export function sessionProtocol(vendor: VendorId | undefined): VendorId {
  * command) and must stay keyed on the raw id. This answers "how do we TALK to
  * it": the transcript reader, the workspace-trust store and first-message
  * delivery are all the wrapped engine's, exactly as `docs/ENGINES.md`
- * promises. Keying those off the raw id found the empty custom entry, so a
- * `claudecpa` preset read no history, got the trust dialog Rove is supposed
- * to pre-answer, and — for a kimi-protocol preset — took the first message on
- * argv, which kills the launch.
+ * promises. Keying those off the raw id finds the empty custom entry, so a
+ * `claudecpa` preset would read no history, meet the trust dialog Rove is
+ * supposed to pre-answer, and — for a kimi-protocol preset — take the first
+ * message on argv, which kills the launch.
  */
 export function protocolEntry(vendor: VendorId | undefined): EngineRegistryEntry {
   return engineEntry(sessionProtocol(vendor))
@@ -277,8 +276,7 @@ export function engineResumeArgv(
  *
  * Protocol-resolved like {@link withPinnedSessionId}: a preset `claudecpa`
  * declaring the claude protocol IS a claude launch, so it forks. Keying off
- * the raw id instead found the empty custom entry and refused — the same
- * silent gap `withClaudeSessionId` had.
+ * the raw id instead finds the empty custom entry and refuses.
  */
 export function engineCanFork(vendor: VendorId | undefined): boolean {
   return acceptsSessionFork(engineEntry(sessionProtocol(vendor)).sessionIdentity)

--- a/packages/kobe/src/engine/foreground.ts
+++ b/packages/kobe/src/engine/foreground.ts
@@ -3,11 +3,11 @@
  * actually running in this shell right now", answered from the process
  * tree instead of the OSC window title.
  *
- * The title was the old signal (`vendorFromTerminalTitle`) and it is
- * structurally wrong: an engine's title is free-form activity text it
- * writes for HUMANS ("✳ Claude Code" at launch, then a summary of what
- * it's doing), so a claude session whose summary happened to mention
- * "codex" identified as codex — a substring collision, not an identity.
+ * The OSC title is structurally wrong for this: an engine's title is
+ * free-form activity text it writes for HUMANS ("✳ Claude Code" at launch,
+ * then a summary of what it's doing), so a claude session whose summary
+ * mentions "codex" identifies as codex — a substring collision, not an
+ * identity.
  *
  * A process tree can't collide like that: we walk the PTY shell's
  * descendants and ask each one's ARGV[0] (the executable, never its
@@ -96,7 +96,7 @@ function childrenIndex(rows: readonly ProcRow[]): Map<number, ProcRow[]> {
 /**
  * Is `ancestorPid` anywhere on `pid`'s parent chain (or `pid` itself)?
  *
- * The lineage half of "am I really running inside this tab" (issue #24):
+ * The lineage half of "am I really running inside this tab":
  * `$KOBE_TASK_ID` is an ordinary env var and inherits down the whole
  * process tree, so a background daemon forked out of an engine tab keeps
  * that identity for as long as it lives. A pid chain can't be inherited —
@@ -139,8 +139,8 @@ export function foregroundEngineIn(rows: readonly ProcRow[], rootPid: number): F
 
 /**
  * Is ANY engine process running under `rootPid`? The delivery gate's
- * question (herdr's "agent is no longer the pane foreground process"):
- * kobe's keepAlive wrapper keeps a tab's PTY alive after its engine exits,
+ * question — is an agent still the pane's foreground process? kobe's
+ * keepAlive wrapper keeps a tab's PTY alive after its engine exits,
  * so "session alive" never proves an engine is there — and pasting a prompt
  * into the fallback SHELL executes it as commands. Vendor-agnostic on
  * purpose: any engine may receive text (cross-vendor send is legitimate);

--- a/packages/kobe/src/engine/history-readers.ts
+++ b/packages/kobe/src/engine/history-readers.ts
@@ -24,8 +24,8 @@ import type { EngineHistoryReader } from "./registry.ts"
 /**
  * The documented empty history reader for engines with no on-disk
  * transcript store (custom engines). Auto-title then keeps the placeholder
- * title rather than mis-reading claude's transcripts (the old
- * `else → claude` default would do exactly that for any unknown id).
+ * title rather than mis-reading claude's transcripts (defaulting an unknown
+ * id to claude would do exactly that).
  */
 export const EMPTY_HISTORY: EngineHistoryReader = {
   async listSessionIdsForWorktree() {

--- a/packages/kobe/src/engine/hook-adapter.ts
+++ b/packages/kobe/src/engine/hook-adapter.ts
@@ -78,25 +78,24 @@ export interface EngineHookAdapter {
   removeActivityHooks(settingsFilePath: string): Promise<void>
 
   /**
-   * Whether this engine ever installed a worktree-sync (`WorktreeCreate`) hook —
-   * used now only to know whose hook needs CLEANUP. The hook itself is removed:
-   * `WorktreeCreate` is a VCS *provider* hook, so installing kobe's observer
-   * broke `claude --worktree` / `EnterWorktree` everywhere. Sync moved to the
-   * daemon (auto-adopt a worktree under a tracked repo on session-start).
+   * Whether this engine's settings file may carry a worktree-sync
+   * (`WorktreeCreate`) hook — the only use is knowing whose file needs
+   * CLEANUP. Rove never installs one: `WorktreeCreate` is a VCS *provider*
+   * hook, so kobe's observer there breaks `claude --worktree` /
+   * `EnterWorktree` everywhere. Sync lives in the daemon instead (auto-adopt
+   * a worktree under a tracked repo on session-start).
    */
   supportsWorktreeSync(): boolean
-  /** Remove the old kobe `WorktreeCreate` hook from a settings file. Idempotent +
+  /** Remove kobe's `WorktreeCreate` hook from a settings file. Idempotent +
    *  merge-safe (preserves the user's own WorktreeCreate hooks). No-op when
    *  unsupported. */
   removeWorktreeSyncHook(settingsFilePath: string): Promise<void>
 
   /**
-   * Remove the retired worktree-WATCH hook — a global `PostToolUse` (Bash)
-   * observer Rove used to install, which spawned `kobe hook worktree-created`
-   * after EVERY Bash call to archive the task pinned to a removed worktree.
-   * Archive was removed (issue #75), leaving the hook a pure ~170ms-per-Bash-call
-   * tax, so it is no longer installed — only uninstalled, on every launch,
-   * until every user's settings file is clean. Idempotent + merge-safe
+   * Remove the worktree-WATCH hook — a global `PostToolUse` (Bash) observer
+   * that spawns `kobe hook worktree-created` after EVERY Bash call, a pure
+   * ~170ms-per-Bash-call tax. Rove never installs it; it uninstalls on every
+   * launch, until every user's settings file is clean. Idempotent + merge-safe
    * (touches only Rove's own group). No-op when {@link supportsHooks} is false.
    */
   removeWorktreeWatchHook(settingsFilePath: string): Promise<void>

--- a/packages/kobe/src/engine/hook-events.ts
+++ b/packages/kobe/src/engine/hook-events.ts
@@ -104,8 +104,8 @@ void _everyStateListed
 /**
  * The activity state machine. Defined ONCE, in the daemon package — the
  * daemon is the only production caller (`DaemonActivityRegistry`), and kobe
- * depends on kobe-daemon (never the reverse), so this side re-exports.
- * A second copy lived here and drifted; a fix now lands in one place.
+ * depends on kobe-daemon (never the reverse), so this side re-exports
+ * rather than keeping a second copy that can drift.
  * @see {@link import("@sma1lboy/kobe-daemon/daemon/activity-reduce").reduceActivity}
  */
 export { reduceActivity } from "@sma1lboy/kobe-daemon/daemon/activity-reduce"

--- a/packages/kobe/src/engine/hosted-session.ts
+++ b/packages/kobe/src/engine/hosted-session.ts
@@ -76,7 +76,7 @@ export async function killHostedSessions(rpc: HostedSessionRpc, keys: readonly s
  * word. Hosted engine tabs launch via `<shell> -ilc '…<engineBin> …'`
  * (`buildEngineSessionLaunch`), so `command[0]` is ALWAYS the shell — an
  * argv[0] comparison against the engine binary never matches in production
- * (issue #19: that dead fallback made delivery silently spawn a duplicate
+ * (a dead fallback there makes delivery silently spawn a duplicate
  * engine). Bare shell tabs (`[shell, "-il"]`) carry no engine word.
  */
 export function commandHasEngineWord(command: readonly string[], engineBin: string): boolean {
@@ -112,12 +112,12 @@ function tabOrder(key: string): number {
  * lowest-numbered alive tab running ANY registered engine. Bare shell tabs
  * never match — they must never receive a prompt.
  *
- * That last rung is vendor-AGNOSTIC on purpose (issue #36): `engineBin`
- * comes from the task's recorded vendor, which drifts from what its tabs
- * actually run — a task pinned to the custom preset `claudecpa` (a zsh
- * wrapper) whose live tabs launch plain `claude` resolved to null, and a
- * bare `send` refused with NO_ENGINE_TAB while its engine sat right there.
- * The delivery gate (`engineProcessIn`) has always accepted any live engine
+ * That last rung is vendor-AGNOSTIC on purpose: `engineBin` comes from the
+ * task's recorded vendor, which drifts from what its tabs actually run — a
+ * task pinned to the custom preset `claudecpa` (a zsh wrapper) whose live
+ * tabs launch plain `claude` would resolve to null, and a bare `send` would
+ * refuse with NO_ENGINE_TAB while its engine sat right there.
+ * The delivery gate (`engineProcessIn`) accepts any live engine
  * and `--tab tab-N` has always allowed cross-vendor send; this makes the
  * resolver agree with both. Safety is unchanged: the caller still re-checks
  * the pick against a live `ps` walk before writing a single byte.
@@ -143,7 +143,7 @@ export function findHostedEngineKey(
 /** Delay between bracketed paste and submit CR so the engine reads two tty events. */
 const SUBMIT_DELAY_MS = 150
 
-/** Typed rejection from the delivery gate (issue #78). Neutral code catches
+/** Typed rejection from the delivery gate. Neutral code catches
  *  this and surfaces a `COMPOSER_BUSY` ApiError to the user/agent. */
 export class ComposerBusyError extends Error {
   constructor(
@@ -348,9 +348,9 @@ export async function writeHostedPrompt(
  *
  * `pty.peek`, NOT `pty.open`: an open from this headless client would
  * last-attach-wins resize a live session out from under the attached TUI
- * (the engine repaints at the delivery client's size and the pane garbles
- * — issue #18), and an open for a key that just died would spawn a bare
- * shell and paste the prompt into it. Peek never attaches, spawns, or
+ * (the engine repaints at the delivery client's size and the pane garbles),
+ * and an open for a key that just died would spawn a bare shell and paste
+ * the prompt into it. Peek never attaches, spawns, or
  * resizes — delivery is pure `pty.write`, exactly like keyboard input.
  */
 export async function deliverToHostedKey(
@@ -415,7 +415,7 @@ export interface PasteFirstMessageOptions extends HostedPromptDeliveryOpts {
 }
 
 /**
- * Deliver a paste-delivery vendor's FIRST message (issue #25): the launch
+ * Deliver a paste-delivery vendor's FIRST message: the launch
  * spawned the bare engine (its positional argv slot is a subcommand, not a
  * prompt), so the prompt is bracketed-pasted once the engine process is
  * actually up — the same reason `send` into a cold engine embeds nowhere
@@ -437,7 +437,7 @@ export async function pastePromptWhenEngineUp(
   // If the session was launched with a repo-init script, the engine child does
   // not appear until init finishes. Wait for the init marker before starting
   // the engine-startup budget so a slow `bun install` does not eat the whole
-  // paste-delivery window (issue #73).
+  // paste-delivery window.
   if (opts.initMarkerPath) {
     const initDeadline = Date.now() + (opts.initTimeoutMs ?? REPO_INIT_TIMEOUT_SECONDS * 1000)
     while (Date.now() < initDeadline) {
@@ -464,7 +464,7 @@ export async function pastePromptWhenEngineUp(
       if (up) {
         // The engine process exists; now wait for it to actually be READING
         // (see `awaitPasteReady`). Only when it never announces bracketed
-        // paste do we fall back to the old blind settle.
+        // paste do we fall back to a blind settle.
         if (!(await awaitPasteReady(rpc, key, { timeoutMs: opts.pasteReadyTimeoutMs, sleep }))) {
           await sleep(opts.settleMs ?? FIRST_MESSAGE_SETTLE_MS)
         }

--- a/packages/kobe/src/engine/interactive-command.ts
+++ b/packages/kobe/src/engine/interactive-command.ts
@@ -154,12 +154,11 @@ export function withEngineTerminalTitle(argv: readonly string[], vendor: VendorI
  * dropped rather than passed through — a bogus value makes the engine refuse
  * to launch.
  *
- * The argv used to be a `v === "codex"` branch under a data-driven level
- * gate, so an engine that declared `effortLevels` had its level accepted by
- * the gate, shown in the TUI and web pickers, threaded through
- * `/api/engines`, and then silently dropped at launch — the user picked
- * "high" and got the default with no error. Same shape as the
- * `withClaudeSessionId` tombstone below.
+ * Keying the argv off a literal vendor id instead would let an engine that
+ * declares `effortLevels` have its level accepted by the gate, shown in the
+ * TUI and web pickers, threaded through `/api/engines`, and then silently
+ * dropped at launch — the user picks "high" and gets the default, with no
+ * error.
  *
  * `vendor` must already be PROTOCOL-RESOLVED by the caller (both call sites
  * do): a preset `mycodex` declaring the codex protocol is a codex launch and
@@ -177,31 +176,9 @@ export function withEngineEffort(
   return entry.effortArgv?.(argv, trimmed) ?? argv
 }
 
-// `argvHasFlag` moved to `../cli/argv.ts` (neutral, no engine import) so the
+// `argvHasFlag` lives in `../cli/argv.ts` (neutral, no engine import) so the
 // CLI value-flag parsers share it; re-exported here for the engine callers.
 export { argvHasFlag } from "../cli/argv.ts"
-
-/**
- * `withClaudeSessionId` lived here (removed 2026-08-29). Its first line was
- * `coerceVendorId(vendor) !== "claude"`, so only an engine literally NAMED
- * claude ever got a session id — kimi tabs and custom wrappers (`claudecpa`)
- * silently got none and lost their conversation on every restart. The pin
- * flag, the "already controls its own session" flags, and the resume verb
- * are now DECLARED by each engine (`engine/session-identity.ts`) and read
- * through `withPinnedSessionId` / `engineResumeArgv` in `registry.ts`.
- */
-
-/**
- * `canForkSession` / `forkSessionArgv` lived here (removed 2026-08-30).
- * Both were vendor ladders — a hardcoded `v === "claude" || v === "codex"`
- * and an inline if-chain of argv shapes — so an engine that ships a fork
- * verb silently could not fork until someone edited this file, and a custom
- * preset declaring a built-in protocol was refused despite launching that
- * exact binary. The verb is now DECLARED by each engine
- * (`EngineSessionIdentity.forkArgv`) and read through `engineCanFork` /
- * `engineForkArgv` in `engine-presets.ts`, which resolve the preset's
- * protocol first — the same fix `withClaudeSessionId` got.
- */
 
 /**
  * Shell-ready `… api` command prefix for protocol prompts. Packaged builds
@@ -209,8 +186,7 @@ export { argvHasFlag } from "../cli/argv.ts"
  * (`bun --preload … src/cli/kobe.ts api`) — the same {@link
  * kobeCliInvocation} every kobe-owned pane uses. Without this, a protocol
  * agent in a dev sandbox resolves `kobe` to whatever STALE global install
- * is on PATH, and any verb newer than that install dies with BAD_VERB
- * (field bug: the dispatcher's `dispatch` verb on kobe@0.7.24).
+ * is on PATH, and any verb newer than that install dies with BAD_VERB.
  */
 export function kobeApiInvocation(): string {
   const quote = (a: string): string => (/^[A-Za-z0-9_/.:=-]+$/.test(a) ? a : `'${a.replace(/'/g, "'\\''")}'`)
@@ -226,16 +202,11 @@ export function kobeApiInvocation(): string {
 /**
  * The system-prompt PROTOCOLS (`statusReportProtocol` / `noteFilingProtocol` /
  * `noteRecallProtocol` / `worktreeProtocol` / `dispatcherProtocol` and their
- * `with*` injectors) moved to `./worktree-protocol.ts` (2026-08-30).
- *
- * Two reasons, one move. Both injectors opened with
- * `coerceVendorId(vendor) !== "claude"` — the third and fourth copies of the
- * ladder the `withClaudeSessionId` tombstone above describes, so a wrapper
- * preset (`claudecpa`) got no status protocol and no field notes, silently.
- * The fix is `sessionProtocol()`, which lives in `engine-presets.ts` — and
+ * `with*` injectors) live in `./worktree-protocol.ts`, not here. They resolve
+ * a launch's protocol through `sessionProtocol()` in `engine-presets.ts`, and
  * that module imports THIS one, so resolving a protocol here would close an
- * import cycle. Moving the block one file over breaks the cycle and keeps
- * both files under the size cap.
+ * import cycle. Keeping the block one file over also keeps both files under
+ * the size cap.
  *
  * Anything that gates on "is this launch a claude launch" belongs behind
  * `sessionProtocol()`, never a literal id compare.

--- a/packages/kobe/src/engine/json-hooks.ts
+++ b/packages/kobe/src/engine/json-hooks.ts
@@ -38,10 +38,10 @@ export function isObject(v: unknown): v is Record<string, unknown> {
 
 /** The `hook <verb>` fragments a kobe activity command may have been written
  *  with, independent of the CLI invocation prefix: the current shell-quoted
- *  `'hook' '<verb>'` form AND the legacy unquoted `hook <verb>` form. Early
- *  kobe wrote the unquoted form; recognizing only the quoted one left those
- *  stale entries behind on every re-install, so upgraded users had every
- *  event firing twice (double `kobe hook` spawns + duplicate daemon reports). */
+ *  `'hook' '<verb>'` form AND the legacy unquoted `hook <verb>` form.
+ *  Recognizing only the quoted one leaves the unquoted entries in place on
+ *  every re-install, which makes every event fire twice (double `kobe hook`
+ *  spawns + duplicate daemon reports). */
 function activityMarkers(eventMap: readonly HookEventSpec[]): string[] {
   return eventMap.flatMap((e) => [quoteShellArgv(["hook", e.verb]), `hook ${e.verb}`])
 }
@@ -129,18 +129,16 @@ export function mergeActivityHooks(
 }
 
 /**
- * The `PostToolUse` (Bash) hook Rove used to install: an observer that fired
- * `kobe hook worktree-created` after EVERY Bash call, machine-wide, to archive
- * the task pinned to a removed worktree. Archive was removed (issue #75), so
- * the hook had nothing left to do — it just paid a ~170ms process spawn on
- * every Bash call of every session. Retired 2026-08-30; these two constants
- * survive only so {@link removeWorktreeWatchHook} can find and delete the
- * entries already written into users' settings files.
+ * A `PostToolUse` (Bash) hook Rove only ever REMOVES: an observer that fires
+ * `kobe hook worktree-created` after every Bash call, machine-wide, for a
+ * ~170ms process spawn each time and nothing in return. These two constants
+ * exist so {@link removeWorktreeWatchHook} can find and delete the entries
+ * already written into users' settings files.
  */
 const RETIRED_WATCH_EVENT = "PostToolUse"
 export const WORKTREE_WATCH_MARKER = "worktree-created"
 
-/** True if a PostToolUse group is the retired Rove worktree-watch hook.
+/** True if a PostToolUse group is Rove's worktree-watch hook.
  *  Keys on the command substring, so both the quoted (`'hook'
  *  'worktree-created'`) and legacy unquoted install forms are matched — and
  *  nothing else in the file is (a user's own PostToolUse hooks, and the hooks
@@ -153,8 +151,8 @@ function isRetiredWatchGroup(group: unknown): boolean {
 }
 
 /**
- * Pure merge: drop the retired worktree-watch hook from a SHARED settings
- * object. Removal-only (there is no install counterpart any more) and
+ * Pure merge: drop the worktree-watch hook from a SHARED settings
+ * object. Removal-only (there is no install counterpart) and
  * merge-safe: it filters ONLY the groups whose command names Rove's verb, so a
  * hand-edited settings file keeps the user's own PostToolUse hooks and every
  * other key untouched. Idempotent — a second pass finds nothing and returns an

--- a/packages/kobe/src/engine/kimi-local/binary.ts
+++ b/packages/kobe/src/engine/kimi-local/binary.ts
@@ -1,6 +1,6 @@
 /**
  * Kimi Code CLI binary discovery. The installer puts the launcher at
- * `~/.kimi-code/bin/kimi` (verified on a live install, 2026-07-18) and
+ * `~/.kimi-code/bin/kimi` and
  * users may also symlink it onto PATH — so probe `which` first, then the
  * install dir, then the usual bin directories.
  */

--- a/packages/kobe/src/engine/kimi-local/history.ts
+++ b/packages/kobe/src/engine/kimi-local/history.ts
@@ -4,8 +4,8 @@
  * The wire format (`agents/<agent>/wire.jsonl`, a protocol stream rather
  * than a message log) is still unverified against a real conversation, so
  * Rove does not parse it: `readHistory` stays empty and auto-title keeps
- * the placeholder rather than guessing. What IS verified (live install,
- * 2026-08-13) is the layout, and that is all a cross-engine handoff needs
+ * the placeholder rather than guessing. What IS verified is the layout, and
+ * that is all a cross-engine handoff needs
  * — it hands the next agent the transcript's PATH and lets it read the
  * file in whatever format it finds (see `session-handoff.ts`).
  *

--- a/packages/kobe/src/engine/kimi-local/hook-adapter.ts
+++ b/packages/kobe/src/engine/kimi-local/hook-adapter.ts
@@ -149,9 +149,8 @@ export function mergeKimiHooks(
  *     included, which is why the class name alone is not enough).
  *   - `error_message` carries a `[provider.*]` code prefix from Kimi's own
  *     ErrorCodes — `provider.rate_limit` for a limit, and
- *     `provider.auth_error` for the 403 in the 2026-08-30 incident
- *     ("You've reached your 5-hour usage limit"), which Kimi files under
- *     AUTH but is a quota wall.
+ *     `provider.auth_error` for the 403 that carries "You've reached your
+ *     5-hour usage limit", which Kimi files under AUTH but is a quota wall.
  *
  * `billing`, not `rate_limit`, for the auth/quota-wall case: it needs a human
  * (re-auth, or a plan change), and the daemon deliberately does NOT arm a
@@ -186,9 +185,8 @@ export class KimiHookAdapter implements EngineHookAdapter {
   /** Kimi's stdin payload spells tool fields `tool_name`; the permission
    *  event is always a permission (Kimi has no elicitation notification).
    *  `turn-failed` classifies the StopFailure — without it every Kimi
-   *  failure reduced to `error` and Kimi could never reach `rate_limited`
-   *  (so it never armed auto-resume), which is exactly what happened when
-   *  Kimi hit its 5-hour limit on 2026-08-30. */
+   *  failure reduces to `error`, Kimi can never reach `rate_limited`, and
+   *  auto-resume is never armed when Kimi hits its 5-hour limit. */
   activityDetailFromPayload(
     kind: EngineActivityKind,
     payload: Record<string, unknown>,
@@ -228,7 +226,7 @@ export class KimiHookAdapter implements EngineHookAdapter {
   }
 
   async removeWorktreeWatchHook(): Promise<void> {
-    /* Never installed the retired PostToolUse watch hook. */
+    /* Kimi never installed the PostToolUse watch hook. */
   }
 }
 

--- a/packages/kobe/src/engine/kimi-local/trust.ts
+++ b/packages/kobe/src/engine/kimi-local/trust.ts
@@ -1,11 +1,11 @@
 /**
- * Kimi Code workspace trust (issue #28 / #25 follow-up). Kimi shows a
+ * Kimi Code workspace trust. Kimi shows a
  * "Trust this folder?" dialog on first launch in a directory — and its
  * default cursor sits on "Don't trust", so a pasted first message's submit
  * Enter EXITS the engine ("Bye!"). The store is one file per workspace:
  * `~/.kimi-code/workspace-trust/wd_<dirname>_<sha256(abspath)[:12]>`
- * containing {"root": <abspath>, "trustedAt": <ms epoch>} (naming verified
- * against live installs 2026-08-15). Pre-trusting a Rove-created worktree
+ * containing {"root": <abspath>, "trustedAt": <ms epoch>}. Pre-trusting a
+ * Rove-created worktree
  * is the same trust domain as the repo the user already runs sessions in.
  */
 

--- a/packages/kobe/src/engine/paste-readiness.ts
+++ b/packages/kobe/src/engine/paste-readiness.ts
@@ -1,8 +1,7 @@
 /**
  * When a hosted engine is actually safe to paste a large prompt into.
  *
- * The bug this exists for (9 tasks dispatched with an empty prompt): a cold
- * engine's pty starts in CANONICAL mode with nothing draining it. The tty's
+ * A cold engine's pty starts in CANONICAL mode with nothing draining it. The tty's
  * canonical input buffer is `MAX_INPUT` (1024 bytes on macOS), and a write
  * past it is DISCARDED, not blocked — so an 8.6KB prompt written into that
  * window arrives as a 1024-byte prefix and the rest is gone. Measured, not
@@ -11,10 +10,9 @@
  *
  * Two things follow, and the second is the one that matters:
  *
- *  - Chunking does NOT fix it. 512-byte chunks with a gap between them lost
+ *  - Chunking does NOT fix it. 512-byte chunks with a gap between them lose
  *    exactly the same 1024 bytes — the buffer is never drained, so slower
- *    writing just refills a full buffer. The old plan of "write in chunks"
- *    would have shipped a no-op.
+ *    writing just refills a full buffer.
  *  - Once the engine is in RAW mode and reading, a single write is safe at
  *    any size we care about — 8.6KB, 64KB, 256KB and 1MB all arrived whole.
  *
@@ -23,8 +21,7 @@
  * terminal into raw mode and started reading stdin, which makes it a direct
  * observation of "this process is draining its tty" rather than a guess.
  * Measured against the three real engines: claude 258ms, codex 321ms, kimi
- * 1953ms — kimi lands AFTER the old hardcoded 1500ms settle, which is
- * exactly why kimi was the vendor that lost prompts.
+ * 1953ms. A fixed settle shorter than that drops kimi's prompt on the floor.
  *
  * It doubles as the bracketed-paste contract the interactive path already
  * honours (`pty-xterm-base.paste`): wrapping in `\x1b[200~ … \x1b[201~` is

--- a/packages/kobe/src/engine/process-cwd.ts
+++ b/packages/kobe/src/engine/process-cwd.ts
@@ -1,5 +1,5 @@
 /**
- * Live cwd of a process — the scratch-task adoption read (issue #33): a
+ * Live cwd of a process — the scratch-task adoption read: a
  * scratch shell "settles" wherever the user cd'd, and that directory (plus
  * a detected harness) decides which project group the row migrates into.
  *

--- a/packages/kobe/src/engine/protocol-sniff.ts
+++ b/packages/kobe/src/engine/protocol-sniff.ts
@@ -27,15 +27,15 @@
  * ten braille frames), so that rule costs nothing now and is what keeps a
  * future engine borrowing a glyph from silently stealing its identity.
  *
- * The consumer (issue #31) is {@link protocolUpgradeFromLiveSession}: the
+ * The consumer is {@link protocolUpgradeFromLiveSession}: the
  * daemon's activity observer relays each walked live session's evidence
  * (foreground-walk vendor + OSC title) and, when a task that recorded the
  * generic protocol is identified, upgrades the record's `vendor` via
  * `setCommand` — metadata only, so the history reader / trust store /
  * delivery mode start applying while WHAT LAUNCHES never changes. The
  * session-store read stays unconsumed there on purpose: a transcript can
- * outlive the engine that wrote it (a worktree previously run with claude,
- * later re-pinned to a genuinely different CLI, would mis-identify), so the
+ * outlive the engine that wrote it (a worktree whose transcripts came from
+ * claude and was later re-pinned to a different CLI would mis-identify), so the
  * record upgrade only trusts evidence that describes the session running
  * right now. Both sniff reads stay pure.
  */

--- a/packages/kobe/src/engine/registry.ts
+++ b/packages/kobe/src/engine/registry.ts
@@ -193,7 +193,7 @@ export interface EngineRegistryEntry {
    *   - "argv" (default): appended to the launch argv as a positional arg —
    *     claude/codex accept an initial prompt there.
    *   - "paste": the CLI's positional slot is a SUBCOMMAND, not a prompt
-   *     (kimi exits `Unknown command` on one — issue #25), so the launch
+   *     (kimi exits `Unknown command` on one), so the launch
    *     spawns bare and the spawner pastes the message once the engine
    *     process is up (`pastePromptWhenEngineUp` in `hosted-session.ts`).
    * Custom engines keep "argv" — their launch-command contract is the
@@ -204,7 +204,7 @@ export interface EngineRegistryEntry {
    * Extra executable basenames this engine's LIVE process may show as in
    * `ps`, beyond `defaultCommand[0]` — for binaries that rewrite their
    * process title post-launch (kimi's Mach-O launcher rewrites argv[0] to
-   * `kimi-co`, verified on two live sessions 2026-08-15). The foreground
+   * `kimi-co`). The foreground
    * walk (`engine/foreground.ts`) matches these the same way it matches
    * the launch binary; without them a running engine reads as a plain
    * shell and prompt delivery refuses with ENGINE_NOT_RUNNING.
@@ -212,7 +212,7 @@ export interface EngineRegistryEntry {
   readonly processNames?: readonly string[]
   /**
    * Pre-trust a Rove-created worktree in the vendor's first-run trust
-   * store (issue #28). Every vendor gates a never-seen directory behind a
+   * store. Every vendor gates a never-seen directory behind a
    * modal trust dialog; hosted sessions can't answer one (kimi's even
    * EXITS when the pasted first message's Enter lands on "Don't trust").
    * Called before a hosted spawn; must be idempotent and merge-preserving.
@@ -220,7 +220,7 @@ export interface EngineRegistryEntry {
    */
   readonly trustWorktree?: (worktreePath: string) => void
   /**
-   * Per-turn telemetry reader (issue #32): completed {@link AgentTurn}s
+   * Per-turn telemetry reader: completed {@link AgentTurn}s
    * lifted from ONE of this engine's session transcripts. Engine-owned by
    * construction — only the adapter knows where its vendor records the
    * model, timings, and token usage of a turn. Absent = this engine has no
@@ -288,15 +288,6 @@ export function supportsStructuredHistory(vendor: VendorId): boolean {
   return engineEntry(vendor).history.readHistory !== EMPTY_HISTORY.readHistory
 }
 
-/*
- * `vendorFromTerminalTitle` lived here (removed 2026-07-27). It matched a
- * live OSC title against each engine's product name / binary by substring,
- * which is how a shell tab where the user typed `claude` joined turn-status
- * management — and also how a claude session whose activity summary said
- * "codex" became a codex tab. Identity now comes from the process tree:
- * `engine/foreground.ts` + `tui/workspace/live-engine.ts`.
- */
-
 /**
  * Every status glyph any built-in engine declares. The fallback vocabulary
  * for a vendor that declares none of its own — see
@@ -326,9 +317,9 @@ export function engineStatusPrefixes(vendor: VendorId): readonly string[] {
  * running the real claude), or simply a process-tree probe that has not
  * answered yet — falls back to the union of every built-in's glyphs. This is
  * the common case, not an edge: the probe is a ~2s `ps` walk, so gating on it
- * let a raw `✳ …` through on every tick it could not answer, and that title
- * is what gets RECORDED (owner report 2026-08-10: the prefix kept coming
- * back). The union is safe precisely because these glyphs are decoration in
+ * lets a raw `✳ …` through on every tick it cannot answer, and that title
+ * is what gets RECORDED. The union is safe precisely because these glyphs
+ * are decoration in
  * any vendor's title — nothing writes a leading `⠹` it wants kept.
  */
 export function stripEngineStatusPrefix(title: string, vendor: VendorId | null | undefined): string {

--- a/packages/kobe/src/engine/session-discovery.ts
+++ b/packages/kobe/src/engine/session-discovery.ts
@@ -7,12 +7,12 @@
  * method EVERY built-in implements, including the readers that ship no
  * message parser.
  *
- * That last point is the whole reason this module exists. The existence
- * check used to be `readHistory(id).length > 0`, which silently means "this
- * engine has a message parser": kimi's reader is paths-only, so every kimi
- * tab answered "your session does not exist", never set `spawned`, and
- * respawned blank on restart even once its id was known. Listing ids is the
- * question actually being asked, and every engine can answer it.
+ * That last point is the whole reason this module exists. Testing existence
+ * with `readHistory(id).length > 0` silently means "this engine has a message
+ * parser": kimi's reader is paths-only, so every kimi tab would answer "your
+ * session does not exist", never set `spawned`, and respawn blank on restart
+ * even once its id was known. Listing ids is the question actually being
+ * asked, and every engine can answer it.
  */
 
 import type { VendorId } from "../types/vendor.ts"

--- a/packages/kobe/src/engine/session-launch.ts
+++ b/packages/kobe/src/engine/session-launch.ts
@@ -140,7 +140,7 @@ export interface EngineSessionLaunch {
   /**
    * When the launch includes a repo-init script, this is the marker file the
    * script creates on success. Paste-delivery spawners wait for it before
-   * starting the engine-startup timer (issue #73).
+   * starting the engine-startup timer.
    */
   readonly initMarkerPath?: string
   /**
@@ -187,7 +187,7 @@ export function buildEngineSessionLaunch(input: EngineSessionLaunchInput): Engin
     dispatcherTaskId,
     gates?.dispatcher,
   )
-  // Paste-delivery vendors (kimi — issue #25) must NOT see the first message
+  // Paste-delivery vendors (kimi) must NOT see the first message
   // in their argv: their positional slot is a subcommand, so the text would
   // kill the launch as an unknown command. The spawner pastes it instead
   // (see EngineSessionLaunch.firstMessage).

--- a/packages/kobe/src/engine/shared-config-write.ts
+++ b/packages/kobe/src/engine/shared-config-write.ts
@@ -50,8 +50,8 @@ import { acquireWithRetry } from "../orchestrator/index/store-codec.ts"
  * Staging path, unique per CALL rather than per process. A shared `<file>.tmp`
  * — or a pid-only one, the moment a caller gains an `await` — lets a second
  * writer clobber the first's staging file and fail the survivor's rename with
- * ENOENT. That is issue #53, already paid for once in the task index
- * (`orchestrator/index/store.ts`).
+ * ENOENT. The task index (`orchestrator/index/store.ts`) stages the same way
+ * for the same reason.
  */
 function stagingPath(file: string): string {
   return `${file}.rove-${process.pid}-${randomBytes(6).toString("hex")}.tmp`

--- a/packages/kobe/src/engine/spinner-frames.ts
+++ b/packages/kobe/src/engine/spinner-frames.ts
@@ -1,19 +1,17 @@
 /**
  * The ONE spinner frame set for running rows.
  *
- * Per-engine brand frames were a registry field (`spinnerFrames`) with
- * exactly one implementation: Claude Code's `·→✢→✱→✶→✻→✽` oscillation,
- * lifted from refs/claude-code. Both were removed 2026-08-15 — on a font
- * without the dingbat block (FiraCode Nerd Font, one of the owner's daily
- * faces) macOS falls each frame back to ZapfDingbats at a DIFFERENT advance
- * per glyph (1.11 / 1.13 / 1.15 / 1.21 / 1.28 cells), so a running row
- * jittered at 10Hz. Braille falls back as ONE face (AppleBraille, 1.11
- * cells for every frame): uniform even when it isn't the base font, which
- * is the property a frame set actually needs.
+ * There is no per-engine brand frame set, and adding one means adding a
+ * registry field for it. On a font without the dingbat block (FiraCode Nerd
+ * Font) macOS falls Claude Code's `·→✢→✱→✶→✻→✽` oscillation back to
+ * ZapfDingbats at a DIFFERENT advance per glyph (1.11 / 1.13 / 1.15 / 1.21 /
+ * 1.28 cells), so a running row jitters at 10Hz. Braille falls back as ONE
+ * face (AppleBraille, 1.11 cells for every frame): uniform even when it isn't
+ * the base font, which is the property a frame set actually needs.
  *
- * Re-introducing a brand set means re-introducing that field. Measure the
- * candidate's per-frame advance in the fonts people run first — equal
- * advance across frames is the bar, not "the vendor uses it".
+ * Measure a candidate's per-frame advance in the fonts people run before
+ * introducing one — equal advance across frames is the bar, not "the vendor
+ * uses it".
  *
  * Must stay importable from vitest and MUST NOT import from `src/tui/`.
  */

--- a/packages/kobe/src/engine/terminal-title.ts
+++ b/packages/kobe/src/engine/terminal-title.ts
@@ -19,7 +19,7 @@
  *
  * Question 3 exists because an engine's title is only as good as what the
  * engine has to put in it. Codex writes its thread UUID until the thread is
- * named, so a fresh codex tab reported `01a00ee9-f0e9-…` where claude and
+ * named, so a fresh codex tab reports `01a00ee9-f0e9-…` where claude and
  * kimi report a sentence. {@link EngineTerminalTitle.sessionIdFromTitle} is
  * how an engine says so — and, because that placeholder happens to be an id,
  * how it says what to name the tab instead. An engine whose bad title carries
@@ -55,7 +55,7 @@ export interface EngineTerminalTitle {
    * turn is running (its animated frames). A title that stops starting
    * with one of these is the engine's own "I stopped working" signal —
    * the one observable event an ESC interrupt leaves behind (claude-code
-   * runs no Stop hook on its abort path; issue #15). Consumed by
+   * runs no Stop hook on its abort path). Consumed by
    * {@link titleTurnHint}. Omit when the engine's resting title is
    * indistinguishable from its working one.
    */
@@ -112,7 +112,7 @@ export function stripStatusPrefix(title: string, prefixes: readonly string[]): s
  * A status-owning engine writes its animated frames (`workingPrefixes`) into
  * the title exactly while a turn runs and rewrites the title the moment it
  * stops — including on an ESC interrupt, which fires no Stop hook at all
- * (claude-code's abort path returns before its stop hooks; issue #15). That
+ * (claude-code's abort path returns before its stop hooks). That
  * rewrite is therefore the one event-grade "the turn ended" signal an
  * interrupt produces.
  *

--- a/packages/kobe/src/engine/trust-worktree.ts
+++ b/packages/kobe/src/engine/trust-worktree.ts
@@ -1,12 +1,12 @@
 /**
- * Worktree pre-trust at spawn time (issue #28). A Rove-created worktree is
+ * Worktree pre-trust at spawn time. A Rove-created worktree is
  * a directory the engine has never seen, and every vendor gates that behind
  * a first-run trust dialog a hosted session cannot answer — kimi's dialog
  * even EXITS the process when the pasted first message's Enter lands on
  * "Don't trust"; claude/codex sit at the prompt forever. The vendor-specific
  * store writes live behind the registry's `trustWorktree` hook; THIS wrapper
  * owns the call policy every spawn path shares: best-effort, never blocks a
- * launch (a failed write leaves the pre-#28 status quo — the dialog).
+ * launch (a failed write just leaves the dialog in the user's way).
  */
 
 import type { VendorId } from "../types/vendor.ts"

--- a/packages/kobe/src/engine/turn-detector.ts
+++ b/packages/kobe/src/engine/turn-detector.ts
@@ -143,8 +143,8 @@ export class ClaudeTurnDetector extends EngineTurnDetector {
   /**
    * Marker memo keyed by transcript path, valid while the file's mtime is
    * unchanged. The Ops pane calls `latestCompletion` from a 1.5s poll, and
-   * before this gate every call re-read + re-parsed up to 4 WHOLE session
-   * JSONLs (multi-MB for a day-long session) even though nothing had been
+   * without this gate every call re-reads + re-parses up to 4 WHOLE session
+   * JSONLs (multi-MB for a day-long session) even when nothing has been
    * appended — the mtime the lister already stat()s is enough to prove the
    * parse would produce the identical marker (it's a pure function of the
    * file content + path + mtime). Pruned to the files of the latest scan,

--- a/packages/kobe/src/engine/worktree-protocol.ts
+++ b/packages/kobe/src/engine/worktree-protocol.ts
@@ -35,12 +35,11 @@ const SYSTEM_PROMPT_PROTOCOL = "claude"
  * True when a launch of `vendor` accepts Rove's system-prompt injection —
  * i.e. it speaks the claude protocol, natively or by declaration.
  *
- * PROTOCOL-resolved, not id-compared. The raw
- * `coerceVendorId(vendor) !== "claude"` this replaced is the same shape as
- * the `withClaudeSessionId` tombstone in `interactive-command.ts`: only an
- * engine literally NAMED claude passed, so a wrapper preset silently got no
- * status protocol (its card never left `in_progress` under
- * `experimental.autoStatus`) and no field notes — with no error anywhere.
+ * PROTOCOL-resolved, not id-compared. A raw
+ * `coerceVendorId(vendor) !== "claude"` would pass only an engine literally
+ * NAMED claude, so a wrapper preset would silently get no status protocol
+ * (its card never leaving `in_progress` under `experimental.autoStatus`) and
+ * no field notes — with no error anywhere.
  */
 function acceptsSystemPrompt(vendor: string | undefined): boolean {
   return sessionProtocol(vendor) === SYSTEM_PROMPT_PROTOCOL

--- a/packages/kobe/src/exec/exec-host.ts
+++ b/packages/kobe/src/exec/exec-host.ts
@@ -170,11 +170,11 @@ export function sshConnectArgs(spec: RemoteSpec, opts: { tty?: boolean; batch?: 
 }
 
 /**
- * Async spawn that collects stdout/stderr and resolves with the same result
- * contract `spawnSync` produced (`status ?? -1`, `stdout/stderr ?? ""`):
+ * Async spawn that collects stdout/stderr and resolves with `spawnSync`'s
+ * result contract (`status ?? -1`, `stdout/stderr ?? ""`):
  *   - non-zero exit → resolved result with that exitCode (never rejects);
  *   - spawn failure (ENOENT, bad cwd, …) → `{ stdout: "", stderr: "", exitCode: -1 }`,
- *     matching the old `SpawnSyncReturns`-derived shape exactly.
+ *     the same shape `SpawnSyncReturns` yields.
  */
 function spawnCollect(
   argv: readonly string[],

--- a/packages/kobe/src/orchestrator/branch-style.ts
+++ b/packages/kobe/src/orchestrator/branch-style.ts
@@ -1,8 +1,8 @@
 /**
- * Repo-convention branch naming (issue #39).
+ * Repo-convention branch naming.
  *
- * A managed task's auto branch used to be `rove/<slug>-<id6>`, which baked
- * the tool's brand into the user's git history. Instead we scan the target
+ * A managed task's auto branch must not bake the tool's brand into the user's
+ * git history (`rove/<slug>-<id6>` and the like). Instead we scan the target
  * repo's existing branch names (local + origin) and infer its dominant
  * naming style — conventional type prefixes (`feat/`, `fix/`, `chore/`, …)
  * or bare kebab slugs — then apply that style to a slug derived from the

--- a/packages/kobe/src/orchestrator/core.ts
+++ b/packages/kobe/src/orchestrator/core.ts
@@ -127,12 +127,11 @@ export class Orchestrator {
    * Pre-flight hook for the TUI to await before the first render.
    *
    * One job: absorb `dir` rows that are sitting on a repository root into
-   * that repo's `main` row. `rove .` has routed a repo root to
-   * `ensureMainTask` since 2026-08-31, so nothing new lands mis-shaped — but
-   * the rows created before that rule keep rendering as a bare path, outside
-   * every behaviour written for a project row (ordering, pin, the fold on a
-   * closed last tab). `ensure` only runs when somebody names the repo, so
-   * without a sweep those rows stay wrong forever.
+   * that repo's `main` row. `rove .` routes a repo root to `ensureMainTask`,
+   * so nothing new lands mis-shaped — but a `dir` row already on disk renders
+   * as a bare path, outside every behaviour written for a project row
+   * (ordering, pin, the fold on a closed last tab). `ensure` only runs when
+   * somebody names the repo, so without a sweep those rows stay wrong forever.
    *
    * Best-effort by construction: it runs before the first frame, and a repo
    * that has moved or a git that will not answer must not stop the TUI from
@@ -231,8 +230,8 @@ export class Orchestrator {
     // Bring the project row into existence alongside the task — but only if
     // the repo may BE a project (state/project-eligibility.ts). A `/tmp`
     // fixture or a checkout inside `.dev-sandbox` still gets its task; it
-    // just stops leaving a permanent sidebar row behind, which is how the
-    // owner's project list reached 12 rows on 2 saved repos. `buildTreeRows`
+    // just stops leaving a permanent sidebar row behind — which is how a
+    // project list reaches a dozen rows on two saved repos. `buildTreeRows`
     // groups a main-less task under a header derived from its own repo, so
     // the task still renders — the header just dies with it.
     //
@@ -242,9 +241,9 @@ export class Orchestrator {
     // succeeds in a subdir) otherwise splits into two sidebar projects: the
     // main row keyed on `/my-monorepo`, this task keyed on
     // `/my-monorepo/packages/app` — a ghost project named after a
-    // subdirectory, with its own worktree root. That normalization used to
-    // ride on the returned main row, so taking it from `normalizeMainRepo`
-    // directly keeps it working when no row is created.
+    // subdirectory, with its own worktree root. Taking the normalization from
+    // `normalizeMainRepo` directly, rather than off the returned main row,
+    // keeps it working when no row is created.
     // Dir/scratch tasks do NOT come through here (see openDirectoryTask),
     // so pinning a user-owned directory is unaffected.
     const mainTask = await this.mainTasks.ensureIfEligible(input.repo, input.projectIntent ?? "explicit")
@@ -284,21 +283,21 @@ export class Orchestrator {
    * (`kobe .`). Deliberately NO project association: no main task is
    * ensured, no worktree or branch is created — the task pins the
    * directory itself and deletion later only drops the index entry.
-   * Every call creates a NEW task (owner 2026-07-20): opening the same
+   * Every call creates a NEW task: opening the same
    * directory twice is two parallel sessions in it, so the title gets a
    * random suffix (`kobe-af3x`) to tell the rows apart.
    */
   async openDirectoryTask(input: {
     readonly dir: string
     readonly vendor?: VendorId
-    /** Temp shell task for the sidebar's Scratch section (issue #33): same
+    /** Temp shell task for the sidebar's Scratch section: same
      *  dir-task shape, `scratch: true`, shell-exit deletes the row. */
     readonly scratch?: boolean
   }): Promise<Task> {
     if (!input.dir) throw new Error("openDirectoryTask: dir is required")
     const dir = canonPath(input.dir)
     // A scratch shell's home is unsettled by definition, so it mints NO
-    // auto-name (issue #42): title stays empty until the user names it or
+    // auto-name: title stays empty until the user names it or
     // adoption derives one; every display surface falls back to path/branch.
     return this.store.create({
       repo: dir,
@@ -313,7 +312,7 @@ export class Orchestrator {
   }
 
   /**
-   * Migrate a scratch task into a repo (issue #33 adoption): the shell's
+   * Migrate a scratch task into a repo (adoption): the shell's
    * live cwd landed in `repo` and a coding harness was detected there, so
    * the row earns a project home. Repoints `repo`/`worktreePath` at the
    * repo root and clears the scratch flag — the task becomes an ordinary

--- a/packages/kobe/src/orchestrator/create-task-input.ts
+++ b/packages/kobe/src/orchestrator/create-task-input.ts
@@ -31,7 +31,7 @@ export interface CreateTaskInput {
   readonly groupId?: string
   /** The kobe session (task + tab) dispatching this create, when one is. */
   readonly dispatcher?: TaskDispatcher
-  /** Marks this the standing session task of a routine (issue #91): the
+  /** Marks this the standing session task of a routine: the
    *  sidebar folds it behind a count row instead of a loose task row. */
   readonly routine?: TaskRoutineLink
   /**

--- a/packages/kobe/src/orchestrator/errors.ts
+++ b/packages/kobe/src/orchestrator/errors.ts
@@ -194,8 +194,8 @@ export const LAND_CONFLICT_CODE = "LAND_CONFLICT"
 
 /**
  * Thrown by `landTask` when the merge hit conflicts. The merge is aborted
- * before this throws, so the base checkout is left exactly as it was; the
- * conflicted paths are carried so the caller can show the human what to resolve.
+ * before the throw, so the base checkout is left untouched; the conflicted
+ * paths are carried so the caller can show the human what to resolve.
  */
 export class LandConflictError extends Error {
   constructor(

--- a/packages/kobe/src/orchestrator/index/lockfile.ts
+++ b/packages/kobe/src/orchestrator/index/lockfile.ts
@@ -4,11 +4,11 @@
  * Goal: prevent two Rove instances from racing to write `~/.rove/tasks.json`
  * and corrupting it. The lockfile holds `pid:token` — the holder's PID plus a
  * per-acquire random token, so two stores in the SAME process are still
- * distinguishable holders (issue #53).
+ * distinguishable holders.
  *
  * Creation is atomic-or-fail: contents are written to a private sidecar file
  * first, then `link(2)`ed into place. The lockfile is therefore never
- * observable in a half-written (empty) state — an empty read used to classify
+ * observable in a half-written (empty) state — an empty read would classify
  * a live holder as stale and break mutual exclusion outright.
  *
  * Failure modes:

--- a/packages/kobe/src/orchestrator/index/store-codec.ts
+++ b/packages/kobe/src/orchestrator/index/store-codec.ts
@@ -79,7 +79,7 @@ const CURRENT_VERSION = 3 as const
  * Copy a corrupt manifest's ORIGINAL bytes aside before the store recovers
  * to an empty index. Without this, the next save read-merge-writes from the
  * empty recovery base and REPLACES the corrupt file — permanently
- * destroying whatever tasks its bytes still held (ported from PR #276).
+ * destroying whatever tasks its bytes still held.
  * Best-effort: a backup failure must never block startup/save; returns the
  * backup path for the caller's warn line, or null when the copy failed.
  */
@@ -242,8 +242,8 @@ function coerceTombstones(parsed: unknown): TaskTombstone[] {
  *   - OUR changes win for ids we touched (`dirty`) — last-write-wins per task.
  *   - A DELETION beats a concurrent edit, from either side: our pending
  *     removals (`removed`) and the on-disk tombstones a peer persisted both
- *     suppress the task, even if we hold it dirty (issue #47 — task ids are
- *     ULIDs and never reused, so a tombstone can't shadow a legit new task).
+ *     suppress the task, even if we hold it dirty (task ids are ULIDs and
+ *     never reused, so a tombstone can't shadow a legit new task).
  *   - A task a peer removed pre-tombstones (gone from disk, untouched by us)
  *     is still NOT resurrected from our stale cache.
  *   - A task a peer created/updated (on disk, untouched by us) is preserved —
@@ -374,7 +374,7 @@ function coerceTask(value: unknown): Task | null {
     // lost the tracker item it was started from.
     ...(quotaResume ? { quotaResume } : {}),
     ...(linkedWorkItem ? { linkedWorkItem } : {}),
-    // Reply address for the collaboration loop (issue #21) — must survive the
+    // Reply address for the collaboration loop — must survive the
     // load coercion or a daemon restart severs every sub-task's route home.
     // Records that predate the field normalize to undefined.
     ...(dispatcher ? { dispatcher } : {}),
@@ -400,7 +400,7 @@ function coerceDispatcher(value: unknown): TaskDispatcher | undefined {
   return { taskId: v.taskId, tabId: v.tabId }
 }
 
-/** Routine back-pointer (issue #91). A link with no automation id is junk —
+/** Routine back-pointer. A link with no automation id is junk —
  *  dropped, so the task reads as an ordinary one rather than folding itself
  *  behind a routine section that can never be resolved back to a schedule. */
 function coerceRoutine(value: unknown): TaskRoutineLink | undefined {

--- a/packages/kobe/src/orchestrator/index/store.ts
+++ b/packages/kobe/src/orchestrator/index/store.ts
@@ -129,7 +129,7 @@ export class TaskIndexStore {
     } catch (err) {
       // Back the original bytes up FIRST: the next save read-merge-writes
       // from this empty recovery base and replaces the corrupt file, so
-      // without a copy the user's tasks are gone for good (PR #276).
+      // without a copy the user's tasks are gone for good.
       const backup = await backupCorruptManifest(sourcePath)
       warnManifestRecovery(
         `[rove] tasks.json at ${sourcePath} is corrupted (${(err as Error).message}); recovering with empty index.${
@@ -192,9 +192,9 @@ export class TaskIndexStore {
       // file is read only by machines, and pretty-printing tripled the bytes.
       const json = `${JSON.stringify(payload)}\n`
 
-      // Unique per save: a shared `<path>.tmp` let a second writer clobber the
-      // first's staging file whenever mutual exclusion broke, failing the
-      // survivor's rename with ENOENT (issue #53).
+      // Unique per save: a shared `<path>.tmp` lets a second writer clobber
+      // the first's staging file whenever mutual exclusion breaks, failing
+      // the survivor's rename with ENOENT.
       const tmpPath = `${this.path}.${process.pid}.${ulid()}.tmp`
       try {
         // 0600: task titles are free-form user prose and every record names a
@@ -292,10 +292,10 @@ export class TaskIndexStore {
    * Bump `updatedAt` to now for recency ONLY — the focus-switch hot path.
    *
    * `setActiveTask` is the most frequent action in the TUI (every task/focus
-   * switch). It used to call {@link update} with an empty patch purely to move
-   * `updatedAt` so the sidebar's `recent` sort tracks focus order — but that
-   * paid a full fsync'd read-merge-write ({@link doSave}) on EVERY switch, all
-   * to move one field the default sort never reads.
+   * switch), and it only needs `updatedAt` moved so the sidebar's `recent`
+   * sort tracks focus order. Routing that through {@link update} with an empty
+   * patch would pay a full fsync'd read-merge-write ({@link doSave}) on EVERY
+   * switch, all to move one field the default sort never reads.
    *
    * This bumps `updatedAt` in the in-memory cache and notifies listeners (so
    * `recent` reorders LIVE, this session, from the pushed snapshot), then marks
@@ -305,7 +305,7 @@ export class TaskIndexStore {
    * orchestrator restores focus from there), so the only thing riding the lazy
    * flush is the finer-grained `recent` ORDERING across a hard restart, which
    * is best-effort and re-established as tasks get real writes. No-op on an
-   * unknown id (mirrors the old empty-patch guard in `setActiveTask`).
+   * unknown id.
    */
   touchRecency(id: TaskId | string): void {
     this.assertLoaded()
@@ -404,7 +404,7 @@ export class TaskIndexStore {
     // Record the deletion so the read-merge-write doesn't resurrect this task
     // from a stale on-disk copy, and stop treating it as a pending edit. The
     // save persists it as a tombstone so PEER writers that still hold the
-    // task dirty in memory don't write it back either (issue #47).
+    // task dirty in memory don't write it back either.
     this.dirtyIds.delete(String(id))
     this.removedIds.set(String(id), new Date().toISOString())
     await this.save()

--- a/packages/kobe/src/orchestrator/land.ts
+++ b/packages/kobe/src/orchestrator/land.ts
@@ -119,8 +119,9 @@ export async function landTaskWithCleanup(task: Task, opts: LandTaskOpts, deps: 
   // Gate it on the worktree ACTUALLY being gone. git refuses to delete a
   // branch a live worktree has checked out, and `deleteBranch` is best-effort
   // (`allowFail`, exit code discarded) — so every path that keeps the worktree
-  // (`removeWorktree: false`, a dirty tree, the caller's own cwd) used to run
-  // the delete, have git refuse it, and report success anyway, anchor and all.
+  // (`removeWorktree: false`, a dirty tree, the caller's own cwd) would
+  // otherwise run the delete, have git refuse it, and report success anyway,
+  // anchor and all.
   // A task that never materialised a worktree has nothing holding the branch,
   // so it deletes normally.
   let branchAnchor: SalvageRecord | null = null
@@ -163,8 +164,8 @@ async function removeLandedWorktree(
   // Same canonicalizer that matched this worktree to its task (`canonPath` /
   // `canonicalize`, plain `fs.realpathSync`) — the refusals below are string
   // compares, so the guard must normalise exactly the way the assignment did.
-  // This used to be the repo's only `realpathSync.native` caller; the two
-  // agree everywhere we run, and one implementation beats a second syscall.
+  // `realpathSync.native` agrees with it everywhere we run, and one
+  // implementation beats a second syscall.
   const wt = canonicalize(worktreePath)
   if (wt === canonicalize(task.repo)) return { removed: false, reason: "refusing to remove the base checkout" }
   if (callerCwd) {
@@ -200,7 +201,7 @@ async function removeLandedWorktree(
   // A removal git half-completed (metadata deregistered, directory undeletable)
   // resolves rather than throws — the worktree IS deregistered, so the land's
   // cleanup is done and reporting `removed: false` would send the user to
-  // retry something git can no longer act on.
+  // retry something git cannot act on at all.
   let residue: WorktreeResidue | undefined
   try {
     await deps.worktrees.remove(worktreePath, {
@@ -214,7 +215,7 @@ async function removeLandedWorktree(
   // Past this point the directory IS gone, so the outcome is `removed: true`
   // whatever the store write does. Folding the two calls into one try/catch
   // would report `removed: false` when only the bookkeeping failed — telling
-  // the user to go look for a worktree that no longer exists. The failure is
+  // the user to go look for a worktree that is already gone. The failure is
   // still reported, in `reason`, because a dangling `worktreePath` is real.
   try {
     await deps.clearWorktreePath(task.id)

--- a/packages/kobe/src/orchestrator/main-task.ts
+++ b/packages/kobe/src/orchestrator/main-task.ts
@@ -33,13 +33,12 @@ export class MainTaskCoordinator {
    * Ensure a `kind: "main"` task exists for the given repo. Idempotent.
    *
    * A directory task already sitting on that exact root is PROMOTED rather
-   * than joined by a second row (owner call 2026-08-25). Both rows pin the
-   * same checkout, so minting a main beside one produced two rows with the
-   * same diff under one project header — one labelled by branch, one by path
-   * — reading as a duplicate of itself. Promotion keeps the session's id, so
-   * its terminal tabs move under the main row instead of being stranded.
-   * Scratch rows are never promoted: their cwd is unsettled by definition and
-   * they belong to the Scratch bench (issue #33).
+   * than joined by a second row. Both rows pin the same checkout, so minting
+   * a main beside one gives two rows with the same diff under one project
+   * header — one labelled by branch, one by path — reading as a duplicate of
+   * itself. Promotion keeps the session's id, so its terminal tabs move under
+   * the main row instead of being stranded. Scratch rows are never promoted:
+   * their cwd is unsettled by definition and they belong to the Scratch bench.
    *
    * Ineligible repos throw — see {@link ensureIfEligible} for the variant
    * every internal caller uses. Direct callers are the ones acting on an
@@ -58,8 +57,8 @@ export class MainTaskCoordinator {
    * {@link ensure}, but returning null instead of creating a row the path
    * does not deserve.
    *
-   * This is the gate on the leak that put four fixture paths permanently in
-   * the owner's sidebar (12 project rows behind 2 saved repos). `createTask`
+   * This is the gate on the leak that puts fixture paths permanently in the
+   * sidebar (a dozen project rows behind two saved repos). `createTask`
    * and `adopt` call this while doing their real work: a task whose repo is a
    * `/tmp` fixture still gets created, it just does not also mint a permanent
    * project row. Nothing breaks downstream — `buildTreeRows` derives a
@@ -81,12 +80,11 @@ export class MainTaskCoordinator {
     if (inflight) return inflight
     const promise = (async () => {
       // A project row and a saved-repos entry are the same fact: the sidebar
-      // shows what the new-task picker offers. They used to be written by
-      // separate paths, so a row minted here (`createTask` on a fresh repo)
-      // was a project you could SEE but could not pick — and closing its last
-      // tab, which now hides it, would have lost it with no way back.
-      // Writing both here keeps them from diverging again. `explicit`: this
-      // path already passed the admission gate above.
+      // shows what the new-task picker offers. Written by separate paths they
+      // diverge: a row minted here (`createTask` on a fresh repo) would be a
+      // project you can SEE but cannot pick, and closing its last tab (which
+      // hides it) would lose it with no way back. `explicit`: this path
+      // already passed the admission gate above.
       addSavedRepo(normalizedRepo, { intent: "explicit" })
       const adoptable = this.store
         .list()

--- a/packages/kobe/src/orchestrator/promote-dir-tasks.ts
+++ b/packages/kobe/src/orchestrator/promote-dir-tasks.ts
@@ -3,8 +3,8 @@
  * `main` row.
  *
  * `rove .` already routes a repo root to `ensureMainTask` (open-dir-cmd.ts),
- * so nothing NEW lands as a mis-shaped row. What has no owner is the rows
- * created before that rule: a `dir` task pinned to a git toplevel, rendering
+ * so nothing NEW lands as a mis-shaped row. What has no owner is a row
+ * already on disk: a `dir` task pinned to a git toplevel, rendering
  * under its own path as though the directory were not a project, and outside
  * every rule written for `main` — the sidebar's project ordering, the pin, the
  * fold. `MainTaskCoordinator.ensure` already knows how to absorb such a row
@@ -33,7 +33,7 @@ export interface PromotableDeps {
  * The repo roots that a `dir` task occupies and no `main` row claims yet.
  *
  * Excludes:
- *   - **scratch** rows — their cwd is unsettled by definition (issue #33), and
+ *   - **scratch** rows — their cwd is unsettled by definition, and
  *     a scratch shell that happens to start inside a repo is still a scratch
  *     shell, not that repo's project row;
  *   - roots that ALREADY have a main row — promoting there would mint a

--- a/packages/kobe/src/orchestrator/task-deletion.ts
+++ b/packages/kobe/src/orchestrator/task-deletion.ts
@@ -107,9 +107,9 @@ export class TaskDeletionCoordinator {
           },
           // A removal git half-completed (metadata deregistered, directory
           // undeletable) is NOT an error here. Parking the task in `error`
-          // would be a lie the user cannot act on: git no longer knows this
+          // would be a lie the user cannot act on: git has forgotten this
           // worktree, so every retry is `fatal: is not a working tree` and the
-          // task is stuck forever (issue #89). The deletion finishes; the
+          // task is stuck forever. The deletion finishes; the
           // leftover directory is reported instead of being made the task's
           // problem — and never deleted from under the user, since whatever
           // made it undeletable may be something they want.

--- a/packages/kobe/src/orchestrator/task-editor.ts
+++ b/packages/kobe/src/orchestrator/task-editor.ts
@@ -46,7 +46,7 @@ export class TaskEditor {
   }
 
   /** Rename a task. Empty / whitespace-only titles are rejected. Naming a
-   *  SCRATCH task is the "keep this" gesture (issue #33) — it clears the
+   *  SCRATCH task is the "keep this" gesture — it clears the
    *  flag, so the row survives its shell exiting. */
   async setTitle(id: TaskId | string, title: string): Promise<void> {
     const trimmed = title.trim()
@@ -62,7 +62,7 @@ export class TaskEditor {
    * branch is still the placeholder-derived default (`new-task`, or a legacy
    * `rove/`/`kobe/` spelling). This is what lets a task auto-named from its
    * first prompt also pick up a meaningful branch. It fires at most
-   * once: after the first rename the branch no longer matches the placeholder
+   * once: after the first rename the branch stops matching the placeholder
    * derivation, so a later title change (or a manual `setBranch`) is never
    * clobbered. Skipped for `main` (no branch) and for not-yet-materialised
    * tasks (their branch is derived fresh from the title in `ensureWorktree`,
@@ -73,7 +73,7 @@ export class TaskEditor {
    * stand, and the placeholder branch simply stays):
    *   - never rename a branch that has an upstream (`branch -m` would orphan
    *     the remote branch / any open PR); an unreadable probe counts as
-   *     ambiguity and also keeps the old name;
+   *     ambiguity and also keeps the existing name;
    *   - a collision with an existing local branch resolves to a `-2`, `-3`…
    *     suffixed unique name instead of failing.
    */
@@ -188,10 +188,10 @@ export class TaskEditor {
   /**
    * Move a task up/down within its visible ordering partition. Main
    * (project) rows move among each other — the sidebar renders projects in
-   * the mains' stored order (owner 2026-07-16), so reordering the store IS
-   * reordering the project list. Regular tasks move within their REPO's
-   * partition (issue #43: the sidebar tree groups tasks under their repo, so
-   * a cross-repo swap would be invisible or jump groups), still split by the
+   * the mains' stored order, so reordering the store IS reordering the
+   * project list. Regular tasks move within their REPO's partition (the
+   * sidebar tree groups tasks under their repo, so a cross-repo swap would be
+   * invisible or jump groups), still split by the
    * pinned flag. Edge-stop: `store.move` past the partition's first/last is
    * a no-op, never a wrap.
    */
@@ -278,8 +278,9 @@ export class TaskEditor {
   /**
    * Record the task brief: the full text of the prompt `add --prompt`
    * delivered into this task's engine. Written on the delivery path so the
-   * brief survives the engine's own transcript — a dead engine used to take
-   * the only copy down with it. Stored verbatim (never truncated); a
+   * brief survives the engine's own transcript — a dead engine would
+   * otherwise take the only copy down with it. Stored verbatim (never
+   * truncated); a
    * whitespace-only prompt is rejected. No-op when the stored text already
    * matches, so a redundant call never churns a write + broadcast.
    */

--- a/packages/kobe/src/orchestrator/title.ts
+++ b/packages/kobe/src/orchestrator/title.ts
@@ -1,8 +1,8 @@
 /**
  * Title derivation + placeholder-branch recognition.
  *
- * Branch NAMES are no longer derived here — `branch-style.ts` owns the
- * repo-convention naming (issue #39). This module keeps the title helpers
+ * Branch NAMES are not derived here — `branch-style.ts` owns the
+ * repo-convention naming. This module keeps the title helpers
  * and the placeholder-branch discriminator that the first-rename
  * branch-follow flow depends on. `deriveTitleFromPrompt` is kept for the
  * rare case where we still accept a free-form prompt as a title source

--- a/packages/kobe/src/orchestrator/worktree-coordinator.ts
+++ b/packages/kobe/src/orchestrator/worktree-coordinator.ts
@@ -182,7 +182,7 @@ export class WorktreeCoordinator {
    * the repo's naming convention from its existing branch names (local +
    * origin), apply it to the title's slug, and de-collide with a short
    * `-2` / `-3` suffix against both existing branches and names other
-   * in-flight materialisations just reserved (issue #39). Never contains
+   * in-flight materialisations just reserved. Never contains
    * a rove/kobe brand token; an unreadable/empty repo falls back to a bare
    * kebab slug.
    */

--- a/packages/kobe/src/orchestrator/worktree/manager-branch.ts
+++ b/packages/kobe/src/orchestrator/worktree/manager-branch.ts
@@ -122,7 +122,7 @@ export async function hasLocalBranch(deps: BranchDeps, worktreePath: string, bra
  * noticing. Idempotent: returns silently when `from === to`, and also when
  * `from` is already gone while `to` exists — the recorded `from` can be
  * stale (a retried call whose first attempt renamed but whose response was
- * lost, a concurrent rename, an out-of-band `git branch -m`; issue #44), and
+ * lost, a concurrent rename, an out-of-band `git branch -m`), and
  * branch refs are shared across worktrees, so old-gone + new-present IS the
  * requested end state. If `to` already exists alongside `from`, throws.
  */

--- a/packages/kobe/src/orchestrator/worktree/manager-remove.ts
+++ b/packages/kobe/src/orchestrator/worktree/manager-remove.ts
@@ -21,8 +21,8 @@
  *
  * Reading the exit code as the whole truth reports that as a total failure and
  * leaves the caller with no forward move: git's own view is that this worktree
- * no longer exists, so no retry, remove, or prune can ever advance it (issue
- * #89 — a task parked in `deletion.phase = "error"` forever). So a non-zero
+ * is already gone, so no retry, remove, or prune can ever advance it, and the
+ * task parks in `deletion.phase = "error"` forever. So a non-zero
  * exit is CLASSIFIED, not trusted, and the leftover directory is reported
  * through `onResidue` rather than deleted: an undeletable tree is exactly the
  * kind of thing that holds something the user still wants.
@@ -159,9 +159,9 @@ export async function removeWorktree(deps: RemoveDeps, worktreePath: string, opt
     // the previous removal already refused to delete.
     //
     // Retrying a removal that already deregistered its worktree must land on
-    // the same answer it gave the first time — git can no longer act on this
-    // path at all, so a second `worktree remove` only ever says `fatal: is not
-    // a working tree` and the caller is stuck (issue #89). Where the pointer
+    // the same answer it gave the first time — git cannot act on this path at
+    // all, so a second `worktree remove` only ever says `fatal: is not a
+    // working tree` and the caller is stuck. Where the pointer
     // survives (macOS) that is answered here; where it does not (Linux) the
     // post-`rm -rf` check below answers it.
     if (await deregisteredWorktreeResidue(exec, worktreePath)) {
@@ -249,7 +249,7 @@ export async function removeWorktree(deps: RemoveDeps, worktreePath: string, opt
 
   // Anchored like `deleteBranch`: `-D` takes the reflog too, and this
   // worktree's own reflog died with the directory a few lines up. Runs on the
-  // residue path too — the branch is no longer checked out anywhere, which is
-  // the only thing that made it undeletable before.
+  // residue path too: by then the branch is checked out nowhere, which is the
+  // only thing that makes it undeletable.
   if (branch) await deleteBranchAnchored(deps.branchDeps(), exec, repo, branch, { force })
 }

--- a/packages/kobe/src/orchestrator/worktree/paths.ts
+++ b/packages/kobe/src/orchestrator/worktree/paths.ts
@@ -102,8 +102,8 @@ export function worktreeRootFor(repo: string): string {
  * the worktrees under A fall out of managed listing + slug allocation.
  * Those tasks are NOT lost — each task record pins its own absolute
  * `worktreePath`, so opening/removing them keeps working; they just stop
- * appearing in "list kobe-managed worktrees" and their slugs no longer
- * block reuse. Recording every base ever used would close the gap but is
+ * appearing in "list kobe-managed worktrees" and their slugs stop blocking
+ * reuse. Recording every base ever used would close the gap but is
  * deliberately out of scope here.
  */
 export function managedWorktreeRootsFor(repo: string): readonly string[] {
@@ -218,7 +218,7 @@ export function isKobeManagedPath(repo: string, candidate: string): boolean {
  * needing to know which repo owns it.
  *
  * `isKobeManagedPath` answers the same question but takes a repo, and the one
- * caller that needs this is the case where the repo can no longer be resolved:
+ * caller that needs this is the case where the repo cannot be resolved at all:
  * a worktree whose upstream `.git` was destroyed (macOS pruning `/tmp`, a
  * deleted checkout) has no discoverable owner, so `remove()` cannot use the
  * repo-keyed form to decide whether the directory is its own to delete.

--- a/packages/kobe/src/orchestrator/worktree/slug-allocator.ts
+++ b/packages/kobe/src/orchestrator/worktree/slug-allocator.ts
@@ -1,8 +1,8 @@
 /**
  * Allocate animal-name slugs for worktree directories.
  *
- * Replaces the old "directory = task ULID" scheme (which produced 26-
- * char dir names that overflowed the terminal pane). The new shape is:
+ * A directory is named for a slug, not the task's ULID — a 26-char dir name
+ * overflows the terminal pane. The shape is:
  *
  *   ~/.rove/worktrees/<repo-key>/panda/
  *   ~/.rove/worktrees/<repo-key>/panda-v2/   # if `panda` was recycled

--- a/packages/kobe/test/cli/api-add-parallel.test.ts
+++ b/packages/kobe/test/cli/api-add-parallel.test.ts
@@ -1,10 +1,9 @@
 /**
  * Request-traffic tests for a PARALLEL `add` round (`--count` / `--agents`).
  *
- * Split out of `api-handlers.test.ts` for the file-size cap: this was the
- * `fan-out` verb's suite, and folding it into `add` (issue #30) kept every
- * rule it pinned — shared groupId, `#i/N` titles, per-sibling failure rows
- * that never orphan a created task — plus the new flag conflicts.
+ * Split out of `api-handlers.test.ts` for the file-size cap. Pins the
+ * parallel contract — shared groupId, `#i/N` titles, per-sibling failure rows
+ * that never orphan a created task — plus the flag conflicts.
  */
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest"
@@ -236,7 +235,7 @@ describe("add --count (parallel round)", () => {
 
   it("counts a deferred sibling as a success, not a delivery failure", async () => {
     // A sibling whose composer is briefly busy resolves accepted-but-deferred
-    // (issue #78 B-layer): `delivered:false` but `deferred` present. The daemon
+    // — `delivered:false` but `deferred` present. The daemon
     // owns the message and queued an inbox episode — the caller must NOT retry.
     // It must land in `tasks` (with the marker), never in `failures`, so the
     // round does not throw PARTIAL_FANOUT and a script does not double-deliver.

--- a/packages/kobe/test/cli/api-cmd-runtime.test.ts
+++ b/packages/kobe/test/cli/api-cmd-runtime.test.ts
@@ -288,10 +288,10 @@ describe("realPromptDeliveryOps (deliverPrompt with the default ops)", () => {
     // rides the "new-task" intent, which is what gates the per-worktree
     // codas (today: the missing-dependency warning) in repo-init.ts.
     //
-    // The spawner id used to ride here too, to address a send-back coda. That
-    // instruction now lives in the Rove agent skill, and the reply address
-    // comes from the task's recorded `dispatcher` — proven identity, covered
-    // by `api-dispatcher.test.ts` (issue #24), not from this payload.
+    // The spawner id deliberately does NOT ride here. The send-back
+    // instruction lives in the Rove agent skill, and the reply address comes
+    // from the task's recorded `dispatcher` — proven identity, covered by
+    // `api-dispatcher.test.ts`, not by this payload.
     vi.stubEnv("KOBE_TASK_ID", "")
     await deliverPrompt(
       client,

--- a/packages/kobe/test/cli/api-custom-vendor.test.ts
+++ b/packages/kobe/test/cli/api-custom-vendor.test.ts
@@ -15,9 +15,9 @@
  *   - `--vendor` survives on the surfaces the dispatch face does NOT own
  *     (routines, work-items), where an engine is still picked by id.
  *
- * `--vendor` on `add`/`send`/`set-vendor` is gone (issue #30); the closed-
- * enum-vs-open-registry gate those verbs used to need went with it, because
- * `--command` is a plain string with no enum to disagree about.
+ * `--vendor` on `add`/`send`/`set-vendor` is gone, and so is the closed-
+ * enum-vs-open-registry gate those verbs needed: `--command` is a plain
+ * string with no enum to disagree about.
  */
 
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
@@ -167,7 +167,7 @@ describe("the dispatch face takes a command, not an engine enum", () => {
     const command = flags.flags.find((f) => f.name === "command")
     expect(command?.type).toBe("string")
     expect(command?.values).toBeUndefined()
-    // ... and the retired flag is gone from the dispatch verbs entirely.
+    // ... and the dropped flag is gone from the dispatch verbs entirely.
     expect(flags.flags.some((f) => f.name === "vendor")).toBe(false)
   })
 })

--- a/packages/kobe/test/cli/api-dispatcher.test.ts
+++ b/packages/kobe/test/cli/api-dispatcher.test.ts
@@ -1,5 +1,5 @@
 /**
- * Dispatcher provenance — the collaboration loop's reply address (issue #21).
+ * Dispatcher provenance — the collaboration loop's reply address.
  *
  * The contract under test is RECEIVER-side routing, not sender-side success:
  * a create records who dispatched it, a worker's bare `send` must land on
@@ -80,9 +80,9 @@ describe("verifiedSelfSession (issue #24: env identity is inheritable, so it mus
   })
 
   it("REFUSES an inherited env: a detached background process no longer descends from the tab", async () => {
-    // The incident shape: a Claude Code background daemon forked out of
-    // boccha's tab-1, reparented to init, and kept exporting boccha's ids.
-    // The session is still perfectly alive — only the lineage is broken.
+    // The shape: a Claude Code background daemon forked out of boccha's
+    // tab-1, reparented to init, and still exporting boccha's ids. The
+    // session is perfectly alive — only the lineage is broken.
     expect(
       await verifiedSelfSession(
         { KOBE_TASK_ID: "boccha", KOBE_TAB_ID: "tab-1" },
@@ -311,7 +311,7 @@ describe("bare send replies to the dispatcher", () => {
       "DISPATCHER_UNREACHABLE",
     )
     // The delivery layer is never entered: a dead reply target must not
-    // boot a fresh engine that swallows the outcome (issue #19's mode).
+    // boot a fresh engine that swallows the outcome.
     expect(calls).toHaveLength(0)
   })
 

--- a/packages/kobe/test/cli/api-handlers-delete.test.ts
+++ b/packages/kobe/test/cli/api-handlers-delete.test.ts
@@ -4,8 +4,8 @@
  * Split out of `api-handlers-lifecycle.test.ts` (file-size cap). These cover
  * one question the rest of the lifecycle suite does not: a delete has THREE
  * outcomes — queued, refused, and queued-then-failed — and each must reach
- * the caller as a different reply. They used to be one indistinguishable
- * empty object, with a failed worktree removal recorded only in `daemon.log`.
+ * the caller as a different reply, not one indistinguishable empty object
+ * with the failed worktree removal recorded only in `daemon.log`.
  */
 
 import { describe, expect, it } from "vitest"
@@ -48,10 +48,10 @@ describe("task delete handler", () => {
     expect(client.requests[1].payload).toEqual({ taskId: "t1", force: false, deleteBranch: true })
   })
 
-  // Requirement of this change: the three outcomes of a delete must be three
-  // different replies. Queued-then-FAILED is the one that used to be
-  // unreachable — `finish()` wrote the git error to the task record and
-  // `daemon.log`, and the caller got the same `{}` a success returned.
+  // The three outcomes of a delete must be three
+  // different replies. Queued-then-FAILED is the easiest one to lose:
+  // `finish()` writes the git error to the task record and `daemon.log`, so
+  // without this the caller gets the same `{}` a success returns.
   it("--wait reports a background removal that failed, with the git error", async () => {
     const client = new FakeClient({
       "task.delete": () => ({ taskId: "t1", queued: true }),

--- a/packages/kobe/test/cli/api-handlers-lifecycle.test.ts
+++ b/packages/kobe/test/cli/api-handlers-lifecycle.test.ts
@@ -233,11 +233,11 @@ describe("task lifecycle handlers", () => {
   })
 
   it("plain land leaves removeWorktree undefined (daemon default: remove) and always sends callerCwd", async () => {
-    // Removal is the default path now, so the "refusing to remove the caller's
+    // Removal is the default path, so the "refusing to remove the caller's
     // own worktree" guard must be armed on EVERY land — sending callerCwd only
     // for the explicit flag would leave an agent free to delete its own cwd.
     // `removeWorktree` stays undefined so the orchestrator default applies;
-    // coercing it to false here would silently pin the old opt-in behaviour.
+    // coercing it to false here would silently pin an opt-in it does not have.
     const client = new FakeClient({
       "task.land": () => ({ result: { branch: "b", strategy: "merge", landedOn: "main", commit: "abc" } }),
     })

--- a/packages/kobe/test/cli/api-handlers-more.test.ts
+++ b/packages/kobe/test/cli/api-handlers-more.test.ts
@@ -94,12 +94,12 @@ describe("schema drill-ins", () => {
     await expectApiError(() => invokeVerb("schema", ["--verb", "frobnicate"], offline), "BAD_VERB")
   })
 
-  // Issue #30 removed `fan-out` and `set-vendor` with NO aliases, because both
-  // changed their flag contract in the process — an alias would accept the old
-  // flags and do something subtly different. What replaces the alias is a
-  // distinct code (`UNKNOWN_VERB`, not the typo code) plus argv an agent that
-  // learned the old name from a stale skill can run verbatim.
-  describe("retired verbs point at their replacement", () => {
+  // `fan-out` and `set-vendor` were removed with NO aliases, because both
+  // changed their flag contract in the process — an alias would accept the
+  // superseded flags and do something subtly different. What replaces the
+  // alias is a distinct code (`UNKNOWN_VERB`, not the typo code) plus argv an
+  // agent that learned the name from a stale skill can run verbatim.
+  describe("removed verbs point at their replacement", () => {
     /** The thrown ApiError itself — this suite asserts on its `data`. */
     async function rejectionOf(verb: string): Promise<ApiError> {
       try {
@@ -114,7 +114,8 @@ describe("schema drill-ins", () => {
     it.each([
       ["fan-out", ["api", "add", "--help"], /--count/],
       ["set-vendor", ["api", "set-command", "--help"], /set-command/],
-      // archive died with issue #75; the rejection must point at delete AND
+      // `archive` died with the archived-task dimension; the rejection must
+      // point at delete AND
       // say the branch survives — a coordinator closing a round should not
       // have to guess between delete and --delete-branch.
       ["archive", ["api", "delete", "--help"], /branch.*survives/s],
@@ -142,8 +143,7 @@ describe("schema drill-ins", () => {
   // compares the listing against `VERB_GROUPS`, and both now derive from
   // `VerbSpec.group`, so they move together. This one is the independent pin —
   // and it is in canonical VERBS order, which is the order the index, `--all`
-  // and `--help` already used, so a group listing can no longer disagree with
-  // them.
+  // and `--help` already use, so a group listing cannot disagree with them.
   it("--group lists that group's verbs compactly (name + summary only)", async () => {
     const result = (await invokeVerb("schema", ["--group", "read"], offline)) as {
       group: string
@@ -173,12 +173,11 @@ describe("schema drill-ins", () => {
     expect(result.verbs.length).toBeGreaterThan(10)
   })
 
-  // Regression for issue #95: `prompt` was declared in `verbs-drive.ts` but
-  // never added to the hand-written group table, so it reported group "other"
-  // — a name `--group` then rejected as unknown, leaving it in NO browsable
-  // group. Groups are now derived from `VerbSpec.group`, so this holds for
-  // every verb by construction; the assertion is what fails if someone
-  // reintroduces a fallback.
+  // A verb declared in `verbs-drive.ts` but missing from a hand-written group
+  // table would report group "other" — a name `--group` then rejects as
+  // unknown, leaving it in NO browsable group. Groups derive from
+  // `VerbSpec.group`, so this holds by construction; the assertion is what
+  // fails if someone reintroduces a fallback.
   it("every verb is reachable through the group it reports", async () => {
     for (const v of VERBS) {
       const listing = (await invokeVerb("schema", ["--group", v.group], offline)) as {

--- a/packages/kobe/test/cli/api-handlers.test.ts
+++ b/packages/kobe/test/cli/api-handlers.test.ts
@@ -130,7 +130,7 @@ describe("add handler", () => {
       runtime: stubRuntime({ deliverPrompt: deliver }),
     })) as Record<string, unknown>
     // newTask marks this as a fresh worktree task's FIRST prompt — the
-    // delivery layer appends the branch-rename coda for it (issue #8).
+    // delivery layer appends the branch-rename coda for it.
     expect(calls[0]).toMatchObject({
       target: { id: "t1", vendor: "codex", modelEffort: "high", newTask: true },
       prompt: "do it",
@@ -183,7 +183,7 @@ describe("send handler", () => {
     expect(client.subscribeCount).toBe(0)
     expect(calls[0].prompt).toBe("hi")
     // send targets an EXISTING task — never flagged as a new-task first
-    // prompt, so the branch-rename coda can't reach it (issue #8).
+    // prompt, so the branch-rename coda can't reach it.
     expect(calls[0].target.newTask).toBeUndefined()
     expect(result).toMatchObject({ ok: true, taskId: "abc", started: true })
   })
@@ -313,7 +313,7 @@ describe("send handler", () => {
     const saved = process.env.KOBE_TASK_ID
     beforeEach(async () => {
       process.env.KOBE_TASK_ID = "sender-1"
-      // Identity is the VERIFIED env pair (issue #24) — prime the memo with a
+      // Identity is the VERIFIED env pair — prime the memo with a
       // process tree where this process really does descend from the tab's
       // shell, so no real pty-host/ps read happens here.
       await verifiedSelfSession(
@@ -377,10 +377,9 @@ describe("send handler", () => {
     it("gives a dispatched task the same reply address in its opening brief", async () => {
       // `add --prompt` from inside a kobe session is agent-to-agent too, and
       // its brief is where the reply address matters most: every report that
-      // task ever sends flows back through it. Before this, `add` recorded the
-      // sender only as `dispatcher` on the task ROW — data a receiver has to
-      // think to go read — so a dispatched survey finished and sat waiting
-      // (2026-09-01, issue #92).
+      // task ever sends flows back through it. Recording the sender only as
+      // `dispatcher` on the task ROW — data a receiver has to think to go
+      // read — leaves a dispatched worker finished and sitting waiting.
       const { calls, deliver } = recordingDelivery()
       await invokeVerb("add", ["--repo", "/repo/x", "--prompt", "研究一下 X"], {
         client: new FakeClient({

--- a/packages/kobe/test/cli/api-inspect.test.ts
+++ b/packages/kobe/test/cli/api-inspect.test.ts
@@ -2,7 +2,7 @@
  * `kobe api inspect` — hermetic offline run. No daemon, no PTY host: the
  * daemon/sessions sections must degrade to null (an honest "couldn't look",
  * never an error), while the offline sections still answer — the persisted
- * tab snapshots from state.json and, since issue #9, the durable session
+ * tab snapshots from state.json and the durable session
  * death records from pty-exits.json (the one place a crashed engine's exit
  * code + output tail survives the host's idle-exit).
  */

--- a/packages/kobe/test/cli/api-routine-clear.test.ts
+++ b/packages/kobe/test/cli/api-routine-clear.test.ts
@@ -1,9 +1,9 @@
 /**
  * `routine-update`'s clear-by-empty convention: `--precheck ''` and
  * `--base-branch ''` must reach the daemon as an explicit `null`, which its
- * `automation.update` handler reads as "clear this field". The CLI used to
- * fold the empty value into "absent" (VerbArgs.str drops `""`), so the clear
- * was silently dropped on the wire and the existing value stayed put.
+ * `automation.update` handler reads as "clear this field". Folding the empty
+ * value into "absent" (VerbArgs.str drops `""`) drops the clear silently on
+ * the wire and leaves the existing value in place.
  */
 
 import { describe, expect, it } from "vitest"

--- a/packages/kobe/test/cli/api-tab-snapshot.test.ts
+++ b/packages/kobe/test/cli/api-tab-snapshot.test.ts
@@ -304,7 +304,7 @@ describe("joinTaskTabs", () => {
   })
 
   it("a task with no snapshot still lists its live sessions as unregistered rows", () => {
-    // Before issue #20 this returned [] — an alive engine invisible to the
+    // Returning [] here would make an alive engine invisible to the
     // discovery read.
     expect(joinTaskTabs(undefined, "t1", [{ key: "t1::tab-1", alive: true }])).toEqual([
       {
@@ -322,9 +322,9 @@ describe("joinTaskTabs", () => {
     ])
   })
 
-  it("surfaces an alive session the snapshot does not list — the issue-#20 invisible engine", () => {
-    // The incident replay: snapshot holds only tab-2, yet the pty host has
-    // tab-1 + tab-2 alive. tab-1 ran for 1h44m with zero UI presence.
+  it("surfaces an alive session the snapshot does not list — the invisible engine", () => {
+    // The shape: snapshot holds only tab-2, yet the pty host has tab-1 +
+    // tab-2 alive, so tab-1 runs for hours with zero UI presence.
     const snap = {
       tabs: [{ kind: "engine", id: "tab-2", title: null, ordinal: 2 }],
       activeId: "tab-2",

--- a/packages/kobe/test/cli/api-version-skew.test.ts
+++ b/packages/kobe/test/cli/api-version-skew.test.ts
@@ -1,10 +1,10 @@
 /**
  * A verb whose daemon RPC does not exist is a VERSION SKEW, not a failed call.
  *
- * The incident: `rove api schema --verb archive` printed a full spec and
- * exited 0, then `rove api archive --task-id …` came back
+ * The failure shape: `rove api schema --verb archive` prints a full spec and
+ * exits 0, then `rove api archive --task-id …` comes back
  * `{"error":{"message":"unknown daemon request: task.archive","code":"RPC_ERROR"}}`
- * 200ms later — the CLI was an older build than the daemon that had dropped
+ * 200ms later, because the CLI is an older build than the daemon that dropped
  * the verb. Schema is how an agent DISCOVERS a capability, so the rejection
  * has to say "these two builds disagree", not "the call failed".
  */
@@ -38,7 +38,7 @@ describe("unknown daemon request", () => {
   })
 
   it("covers both skew directions — old CLI × new daemon is the same rejection", () => {
-    // The removed-verb case from the incident: this CLI still ships `archive`,
+    // The removed-verb direction: this CLI still ships `archive`,
     // the newer daemon does not serve `task.archive`. Identical wire error, so
     // one branch has to answer both directions.
     const err = toApiError(new Error("unknown daemon request: task.archive"))

--- a/packages/kobe/test/cli/dev-sandbox-args.test.ts
+++ b/packages/kobe/test/cli/dev-sandbox-args.test.ts
@@ -56,12 +56,12 @@ describe("sandboxChildEnv", () => {
     expect(env.KOBE_DEV).toBe("1")
   })
 
-  // The prod 2026-08-13 socket hijack: a TUI stamps the production socket onto
-  // every task terminal it spawns, and an explicit socket path outranks
-  // HOME_DIR — so an inherited one made the sandbox daemon bind the REAL
-  // socket and serve its empty task index to attached TUIs. Pinning the paths
-  // under the sandbox home fixes it; deleting them only deferred to HOME_DIR,
-  // which a stray override could still poison.
+  // The socket-hijack shape: a TUI stamps the production socket onto every
+  // task terminal it spawns, and an explicit socket path outranks HOME_DIR —
+  // so an inherited one makes the sandbox daemon bind the REAL socket and
+  // serve its empty task index to attached TUIs. Pinning the paths under the
+  // sandbox home fixes it; deleting them only defers to HOME_DIR, which a
+  // stray override can still poison.
   it("pins socket and pid paths under the sandbox home so inherited overrides cannot outrank it", () => {
     const env = sandboxChildEnv("/tmp/isolated", {
       KOBE_DAEMON_SOCKET_PATH: "/run/user/1000/kobe.sock",

--- a/packages/kobe/test/cli/doctor-cmd.test.ts
+++ b/packages/kobe/test/cli/doctor-cmd.test.ts
@@ -134,12 +134,12 @@ describe("runDoctorSubcommand", () => {
   })
 
   it("prints the whole terminal section, multiplexer and kitty probe included", async () => {
-    // Regression guard: the section shrank to a single env line when the tmux
-    // RUNTIME was removed (b5e3bfd2a) — collateral damage, since multiplexer
-    // NESTING and the kitty probe were never about Rove hosting tmux. The
-    // consequence is real: docs/KEYBINDINGS.md says both split chords need
-    // the kitty protocol, so with the probe gone doctor could not answer a
-    // "split doesn't work" report at all.
+    // Regression guard: this section collapses to a single env line if it is
+    // treated as tmux-runtime output. Multiplexer NESTING and the kitty probe
+    // are not about Rove hosting tmux, and the consequence of losing them is
+    // real: docs/KEYBINDINGS.md says both split chords need the kitty
+    // protocol, so without the probe doctor cannot answer a "split doesn't
+    // work" report at all.
     mocks.request.mockResolvedValue(null)
     await runDoctorSubcommand([])
     const text = output()
@@ -218,9 +218,9 @@ describe("runDoctorSubcommand", () => {
   })
 })
 
-// Why: doctor used to hardcode three rows (claude/codex/copilot) with three
-// hand-written label functions, so kimi was INVISIBLE despite shipping a real
-// `detectKimiAccount`, and no contrib/custom engine could ever appear. The
+// Why: hardcoding three rows (claude/codex/copilot) with three hand-written
+// label functions makes kimi INVISIBLE despite its real `detectKimiAccount`,
+// and no contrib/custom engine can ever appear. The
 // test that catches a regression is "every registered id gets a row", not
 // "these four names are present".
 describe("runDoctorSubcommand engines block", () => {
@@ -279,9 +279,9 @@ describe("runDoctorSubcommand engines block", () => {
     expect(output()).toContain("⚠ parse /home/u/.kimi-code/credentials/kimi-code.json: bad json")
   })
 
-  it("counts ANY usable engine, not just the three that used to be listed", async () => {
-    // Only kimi is installed and logged in. `anyUsable` used to OR three
-    // hardcoded vendors, so this user was told they had NO engine at all.
+  it("counts ANY usable engine, not a hardcoded few", async () => {
+    // Only kimi is installed and logged in. An `anyUsable` that ORs three
+    // hardcoded vendors tells this user they have NO engine at all.
     // The verdict is only visible as a proposed fix, so count them: the
     // no-engine finding is present in one case and absent in the other.
     mocks.listPresetIds.mockReturnValue(["claude", "codex", "copilot", "kimi"])

--- a/packages/kobe/test/cli/doctor-hook-channel.test.ts
+++ b/packages/kobe/test/cli/doctor-hook-channel.test.ts
@@ -5,7 +5,7 @@ const socketPath = "/home/u/.rove/daemon.sock"
 
 describe("classifyHookChannel", () => {
   it("reports down when live tabs exist but none is hook-sourced", () => {
-    // The 2026-08-26 field shape: every badge painted by the ~10s observer
+    // The field shape: every badge painted by the ~10s observer
     // poll because each hook silently dropped its event.
     const verdict = classifyHookChannel({
       socketPath,

--- a/packages/kobe/test/cli/doctor-node-pty.test.ts
+++ b/packages/kobe/test/cli/doctor-node-pty.test.ts
@@ -1,5 +1,5 @@
 /**
- * `rove doctor` node-pty row (issue #85): the pure formatter over injected
+ * `rove doctor` node-pty row: the pure formatter over injected
  * helper states, plus the real resolver against this checkout — which the
  * root postinstall has already fixed, so on macOS it must report healthy.
  */

--- a/packages/kobe/test/cli/export-cmd.test.ts
+++ b/packages/kobe/test/cli/export-cmd.test.ts
@@ -67,7 +67,7 @@ describe("renderExport", () => {
     // display width (4 cells) exceeds its code-unit length (2). With true
     // display-width padding both rows pad the title column to the same cell
     // width, so every later column lines up and the two rows share one total
-    // display width. Measuring by String.length (the old bug) would under-pad
+    // display width. Measuring by String.length would under-pad
     // the CJK row by 2 cells and shove its trailing columns left.
     const asciiTitle = "ab"
     const cjkTitle = String.fromCodePoint(0x4e2d, 0x6587) // 中文

--- a/packages/kobe/test/cli/hook-cmd-dispatch.test.ts
+++ b/packages/kobe/test/cli/hook-cmd-dispatch.test.ts
@@ -17,7 +17,7 @@ const mocks = vi.hoisted(() => ({
   connectIfRunning: vi.fn(),
   request: vi.fn(),
   close: vi.fn(),
-  // Plugin takeover flag (issue #37) — mocked so the gate never reads the
+  // Plugin takeover flag — mocked so the gate never reads the
   // developer's real ~/.claude/settings.json (which may genuinely have the
   // Rove plugin enabled).
   rovePluginEnabled: vi.fn(() => false),
@@ -249,9 +249,9 @@ describe("ensureGlobalKobeHooks (default-ON global install)", () => {
     expect(mocks.adapter.installActivityHooks).toHaveBeenCalledWith("/fake/.claude/settings.json", {
       toolEvents: false,
     })
-    // The retired PostToolUse(Bash) watch hook is UNINSTALLED on every launch —
-    // that is how an already-registered user stops paying its per-Bash-call
-    // spawn. Nothing installs it any more.
+    // The PostToolUse(Bash) watch hook is UNINSTALLED on every launch — that
+    // is how an already-registered user stops paying its per-Bash-call spawn.
+    // Nothing installs it.
     expect(mocks.adapter.removeWorktreeWatchHook).toHaveBeenCalledWith("/fake/.claude/settings.json")
     // The WorktreeCreate provider-hook cleanup runs on every launch.
     expect(mocks.adapter.removeWorktreeSyncHook).toHaveBeenCalledWith(join(homedir(), ".claude", "settings.json"))

--- a/packages/kobe/test/cli/index-add-remove-adopt.test.ts
+++ b/packages/kobe/test/cli/index-add-remove-adopt.test.ts
@@ -17,9 +17,9 @@ const fake = vi.hoisted(() => ({
   repoRootOf: {} as Record<string, string>,
   adoptable: [] as Array<{ path: string; branch: string; dirty?: boolean; kobeManaged?: boolean }>,
   discoverError: null as Error | null,
-  // Mirrors the real `addSavedRepo`, which owns the admission gate as of
-  // 2026-08-31: an ineligible path comes back `rejected` instead of being
-  // written. `rove add` turns that into its exit-1 error.
+  // Mirrors the real `addSavedRepo`, which owns the admission gate: an
+  // ineligible path comes back `rejected` instead of being written.
+  // `rove add` turns that into its exit-1 error.
   addSavedRepo: vi.fn((p: string) =>
     fake.isGitRepo ? { added: true, path: p, total: 1 } : { added: false, path: p, total: 0, rejected: "notGitRepo" },
   ),

--- a/packages/kobe/test/cli/index-dispatch.test.ts
+++ b/packages/kobe/test/cli/index-dispatch.test.ts
@@ -1,4 +1,4 @@
-/** CLI entry routing: public commands, sole TUI launch, and retired surfaces. */
+/** CLI entry routing: public commands, sole TUI launch, and removed surfaces. */
 
 import { type MockInstance, afterEach, beforeEach, describe, expect, test, vi } from "vitest"
 

--- a/packages/kobe/test/cli/onboarding.test.ts
+++ b/packages/kobe/test/cli/onboarding.test.ts
@@ -238,11 +238,11 @@ describe("applyOnboardingChoices", () => {
     expect(lines.some((l) => l.includes("rove skill install"))).toBe(true)
   })
 
-  // The package ships BOTH bins. The final "Run `…` to launch the TUI" line
-  // used to be the ONE line in the wizard that didn't interpolate the invoked
-  // name — a `kobe` user was sent to run a command they'd never installed
-  // under that name. Asserting the kobe direction is the point: the previous
-  // test only checked rove, where the hardcoded literal happened to be right.
+  // The package ships BOTH bins, and the final "Run `…` to launch the TUI"
+  // line is the easiest one to leave un-interpolated — which sends a `kobe`
+  // user to a command they never installed under that name. Asserting the
+  // kobe direction is the point: a rove-only check passes on a hardcoded
+  // literal.
   it("tells a kobe user to run kobe, not rove", async () => {
     setProduct("kobe")
     const { applyOnboardingChoices } = await import("../../src/cli/onboarding.ts")
@@ -350,8 +350,8 @@ describe("maybeRunOnboarding", () => {
     expect(lines.some((l) => l.includes("completions hooked into"))).toBe(true)
   })
 
-  // `onboardedPrimer` is new, so its absence cannot mean "killed wizard":
-  // every user who onboarded before this build looks identical to one. They
+  // An ABSENT `onboardedPrimer` cannot mean "killed wizard": an
+  // already-onboarded user predating the flag looks identical to one. They
   // must not be handed a surprise wizard on upgrade — and since a `true`
   // return means the caller exits instead of starting the TUI, that upgrade
   // would also cost them the launch they asked for.

--- a/packages/kobe/test/cli/pty-delivery-gates.test.ts
+++ b/packages/kobe/test/cli/pty-delivery-gates.test.ts
@@ -1,5 +1,5 @@
 /**
- * `pty-delivery.ts` delivery gates (issue #78): A-layer recent-human-write
+ * `pty-delivery.ts` delivery gates: A-layer recent-human-write
  * and C-layer composer-empty rejections surface as typed `COMPOSER_BUSY`
  * errors instead of silently concatenating peer text with user input.
  *

--- a/packages/kobe/test/cli/pty-delivery.test.ts
+++ b/packages/kobe/test/cli/pty-delivery.test.ts
@@ -62,11 +62,11 @@ describe("deliverToKey", () => {
   it("peeks (never attaches/resizes) then writes bracketed prompt + deferred CR", async () => {
     const { rpc, calls } = recorder()
     const ok = await deliverToKey(rpc, "t1::tab-1", "do the thing")
-    // The outcome is OBSERVED now, not assumed: it carries the byte count,
+    // The outcome is OBSERVED, not assumed: it carries the byte count,
     // the readiness verdict, and whether the tail was echoed back.
     expect(ok).toMatchObject({ ready: true, confirmed: true })
     // pty.peek, NOT pty.open: an open would last-attach-wins resize the
-    // live session away from its attached TUI (issue #18) — delivery must
+    // live session away from its attached TUI — delivery must
     // be indistinguishable from keyboard input (pure pty.write).
     // Peeks (gate, readiness, confirm) then two writes — still no open/resize.
     expect(calls.map((c) => c.name)).toEqual(["pty.peek", "pty.peek", "pty.write", "pty.write", "pty.peek"])
@@ -178,10 +178,10 @@ describe("deliverHostedPrompt", () => {
     expect(calls).toContain("pty.write")
   })
 
-  it("delivers into a surviving shell-wrapped engine tab instead of spawning (issue #19 incident)", async () => {
-    // The incident shape: tab-1 dead, tab-2 a live shell-wrapped engine.
-    // Pre-fix this spawned a fresh unsandboxed engine at launch.key and
-    // returned ok while tab-2 never saw the prompt.
+  it("delivers into a surviving shell-wrapped engine tab instead of spawning", async () => {
+    // The shape that breaks: tab-1 dead, tab-2 a live shell-wrapped engine.
+    // Spawning here mints a fresh unsandboxed engine at launch.key and
+    // returns ok while tab-2 never sees the prompt.
     const calls: string[] = []
     const engine = echoingPeek()
     const rpc = {

--- a/packages/kobe/test/cli/pty-host-cmd.test.ts
+++ b/packages/kobe/test/cli/pty-host-cmd.test.ts
@@ -3,14 +3,14 @@
  *
  * The one thing pinned here is log rotation. `pty.log` is stdout/stderr
  * inherited as an append fd from the parent's `spawnDetachedDaemon`, so boot
- * is the only point at which it can safely be rotated — and it was the one
- * log of the three that never got that call (issue #26 capped client.log and
- * daemon.log only). The PTY host is also the longest-lived process in the
+ * is the only point at which it can safely be rotated — and it is the
+ * easiest of the three logs to leave uncapped. The PTY host is also the
+ * longest-lived process in the
  * system by design, so it is the least likely to ever restart and clean up
  * after itself.
  *
  * Real filesystem against a ROVE_HOME_DIR tempdir; only the server itself is
- * mocked, so the path resolution the fix depends on stays real.
+ * mocked, so the path resolution the rotation depends on stays real.
  */
 
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"

--- a/packages/kobe/test/cli/theme.test.ts
+++ b/packages/kobe/test/cli/theme.test.ts
@@ -99,11 +99,10 @@ describe("runThemeSubcommand list", () => {
   })
 
   // `theme list` must name every bundled theme, not a copy of the list that
-  // happened to be true when it was written. The CLI used to hand-mirror these
-  // names because importing the theme map pulled in opentui + Solid; once Solid
-  // went away the workaround outlived its reason, leaving two files and two
-  // "keep in sync" comments as the only thing holding them together. This
-  // asserts against the map that owns the JSON imports, so adding a bundled
+  // happened to be true when it was written. Hand-mirroring the names leaves
+  // two files and a "keep in sync" comment as the only thing holding them
+  // together. This asserts against the map that owns the JSON imports, so
+  // adding a bundled
   // theme without the CLI picking it up fails here.
   it("lists every bundled theme in the canonical map", async () => {
     await runThemeSubcommand(["list"])

--- a/packages/kobe/test/cli/web-cmd.test.ts
+++ b/packages/kobe/test/cli/web-cmd.test.ts
@@ -85,8 +85,8 @@ describe("runWebSubcommand", () => {
     expect(err()).toContain("--port needs a number")
   })
 
-  // The attached form used to fall through to the default port with no
-  // error (#58): `indexOf("--port")` never saw the `--port=…` token.
+  // An `indexOf("--port")` scan never sees the `--port=…` token, so the
+  // attached form falls through to the default port with no error.
   it("--port=foo exits 2 exactly like the separated form", async () => {
     await expect(runWebSubcommand(["--port=foo"])).rejects.toThrow("exit 2")
     expect(err()).toContain("--port needs a number")

--- a/packages/kobe/test/client/client-log.test.ts
+++ b/packages/kobe/test/client/client-log.test.ts
@@ -84,7 +84,7 @@ describe("client-log", () => {
   })
 
   /**
-   * The pane crash net: each `kobe <pane>` process used to terminate on a
+   * The pane crash net: without it a `kobe <pane>` process terminates on a
    * single stray rejected fire-and-forget. These lock that the handlers are
    * installed exactly once (idempotent) and remove cleanly, mirroring the
    * daemon's `crash-log` contract.

--- a/packages/kobe/test/client/daemon-process.test.ts
+++ b/packages/kobe/test/client/daemon-process.test.ts
@@ -37,10 +37,10 @@ describe("resolveKobeSpawn", () => {
     ])
   })
 
-  // Issue #96. `bun`/`node` hold an entry open by inode, so uninstalling
-  // Rove out from under a running process leaves it alive on a path that no
-  // longer exists — `/opt/homebrew/lib/node_modules/@sma1lboy/` was gone
-  // while a GUI kept running from it (owner's machine, 2026-09-01). The
+  // `bun`/`node` hold an entry open by inode, so uninstalling Rove out from
+  // under a running process leaves it alive on a path that is gone — a GUI
+  // keeps running from a deleted
+  // `/opt/homebrew/lib/node_modules/@sma1lboy/`. The
   // failure has to be DISTINGUISHABLE from an ordinary spawn failure,
   // because the two want opposite handling: retry a transient one, stop on
   // this one.
@@ -118,19 +118,14 @@ describe("testDaemonResponds", () => {
     expect(await testDaemonResponds(path, 300)).toBe(false)
   })
 
-  // CONTRACT CHANGE, 2026-08-30 (issue #83). This was a characterization
-  // test asserting "alive" — pinned as the behavior that shipped, with a
-  // note saying it was not the DESIRED behavior. It is now the assertion it
-  // always wanted to be.
-  //
-  // Before: the hello was `.catch(() => true)`, so a peer that dropped the
-  // connection counted as having ANSWERED. A daemon in its shutdown path
+  // A hello of the form `.catch(() => true)` counts a peer that dropped the
+  // connection as having ANSWERED. A daemon in its shutdown path
   // does exactly that (`server.ts` close() destroys every client socket
-  // after broadcasting `daemon.stopping`), so a probe landing in that
-  // window reported a healthy daemon and handed its caller a socket that
-  // disappeared milliseconds later.
+  // after broadcasting `daemon.stopping`), so a probe landing in that window
+  // would report a healthy daemon and hand its caller a socket that
+  // disappears milliseconds later.
   //
-  // After: a connection the peer drops before answering is `absent`. Not
+  // So a connection the peer drops before answering is `absent`. Not
   // `wedged` — a closing daemon is LEAVING, so the caller should stop+spawn
   // (what absent means), whereas wedged makes `ensureDaemonReachable` throw
   // instead of recover when called from inside an engine session.
@@ -259,8 +254,8 @@ function overrideRoveEnv(vars: Record<string, string | undefined>): () => void {
 
 describe("ensureDaemonReachable under a held spawn lock", () => {
   it("waits for the winner's daemon instead of stacking a second stop+spawn", async () => {
-    // Two clients race after the same daemon drop (the 2026-08-11 twin
-    // autospawn). The loser must NOT kill/spawn — it polls until the
+    // Two clients race after the same daemon drop (twin autospawn). The
+    // loser must NOT kill/spawn — it polls until the
     // winner's daemon answers, and never releases the winner's lock.
     const dir = mkdtempSync(join(tmpdir(), "kobe-spawn-wait-"))
     const socketPath = join(SOCK_DIR, `kobe-dpr-wait-${process.pid}.sock`)
@@ -320,11 +315,10 @@ function busyThenHealthy(silentConnections: number, seen: string[]) {
 
 describe("ensureDaemonReachable when the daemon is busy, not dead", () => {
   it("waits out a live-but-slow daemon instead of stopping it", async () => {
-    // The 2026-08-29 succession storm: a busy daemon misses the hello
-    // deadline, the client concludes it is dead and kills it, the
-    // replacement's arrival makes the old one self-stop, every client
-    // reconnects at once onto a cold-starting daemon, repeat — eleven
-    // successions in fifty minutes.
+    // The succession storm: a busy daemon misses the hello deadline, the
+    // client concludes it is dead and kills it, the replacement's arrival
+    // makes the predecessor self-stop, every client reconnects at once onto a
+    // cold-starting daemon, repeat — eleven successions in fifty minutes.
     //
     // What must hold is an ACTION, not a duration: a daemon whose PROCESS is
     // alive must not be stopped merely for being slow. So the stand-in is a
@@ -332,8 +326,8 @@ describe("ensureDaemonReachable when the daemon is busy, not dead", () => {
     // both halves of "we did not kill it" are asserted directly —
     // `daemon.stop` was never sent, and the process is still running after.
     //
-    // Two earlier versions asserted proxies and stayed green with the fix
-    // deleted, so both traps are pinned here: a pidfile naming THIS process
+    // Two tempting proxies stay green with the guard deleted, so both traps
+    // are pinned here: a pidfile naming THIS process
     // is skipped by the guard (`livePid !== process.pid`) AND by
     // `stopDaemonProcess`, leaving nothing at risk; and destroying the
     // probe's own connection makes `probeDaemonSocket` read the close as a
@@ -401,16 +395,15 @@ describe("ensureDaemonReachable when the daemon is busy, not dead", () => {
 })
 
 /**
- * Issue #96, the destructive half — and the one nobody reported, because its
- * symptom is indistinguishable from the reported one.
+ * The destructive half of a stale install — and the one nobody reports,
+ * because its symptom is indistinguishable from the reported one.
  *
- * `ensureDaemonReachable` used to call `stopDaemonProcess` FIRST and
- * `resolveKobeSpawn` second. On a stale install that ordering does damage:
- * the client kills the daemon and unlinks its socket + pidfile, and only
- * then discovers it has no entry point to re-exec — so it has removed a
- * daemon it cannot replace. PR #733 established that a client which cannot
- * spawn must not be a reason to take down a daemon; this is that rule
- * applied to the one client that can NEVER spawn.
+ * Calling `stopDaemonProcess` FIRST and `resolveKobeSpawn` second does damage
+ * on a stale install: the client kills the daemon and unlinks its socket +
+ * pidfile, and only then discovers it has no entry point to re-exec — so it
+ * has removed a daemon it cannot replace. A client which cannot spawn must
+ * not be a reason to take down a daemon, and this is that rule applied to the
+ * one client that can NEVER spawn.
  *
  * The assertion is about EFFECTS, not the message: a stale install must
  * leave the pidfile and the daemon process exactly as it found them.

--- a/packages/kobe/test/client/deserialize-task-fields.test.ts
+++ b/packages/kobe/test/client/deserialize-task-fields.test.ts
@@ -3,7 +3,7 @@
  * allowlist a Task field has to survive, and the last one before the TUI.
  *
  * The other two: `test/orchestrator/store-codec-roundtrip.test.ts` closes the
- * disk side (`coerceTask`, issue #57), `test/daemon/serialize-task-fields.test.ts`
+ * disk side (`coerceTask`), `test/daemon/serialize-task-fields.test.ts`
  * closes the wire side (`serializeTask`). This closes the decode side, which
  * had no coverage — and it is the single funnel every task the TUI renders
  * passes through, so a field dropped here is invisible in the product even

--- a/packages/kobe/test/client/remote-orchestrator-foreign-home.test.ts
+++ b/packages/kobe/test/client/remote-orchestrator-foreign-home.test.ts
@@ -6,15 +6,15 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest"
 import { RemoteOrchestrator } from "../../src/client/remote-orchestrator.ts"
 
 /**
- * Home-ownership guard (prod 2026-08-13).
+ * Home-ownership guard.
  *
- * A `dev:sandbox` daemon inherited `KOBE_DAEMON_SOCKET_PATH` from the task
+ * A `dev:sandbox` daemon inherits `KOBE_DAEMON_SOCKET_PATH` from the task
  * terminal it was launched in. Because an explicit socket override outranks
- * `*_HOME_DIR`, it bound the PRODUCTION socket while serving its own — empty —
- * task index. Attached TUIs reconnected onto it, `hello` succeeded, and the
- * sidebar went blank ("No active tasks") with all 27 tasks intact on disk.
+ * `*_HOME_DIR`, it binds the PRODUCTION socket while serving its own — empty —
+ * task index. Attached TUIs reconnect onto it, `hello` succeeds, and the
+ * sidebar goes blank ("No active tasks") with every task intact on disk.
  *
- * Every other handshake check passed, because nothing was wrong with the
+ * Every other handshake check passes, because nothing is wrong with the
  * wire. What these lock is that a client refuses a daemon belonging to a
  * DIFFERENT home before adopting a single task from it.
  */

--- a/packages/kobe/test/client/remote-orchestrator-lifecycle.test.ts
+++ b/packages/kobe/test/client/remote-orchestrator-lifecycle.test.ts
@@ -3,8 +3,8 @@ import { handleOrchestratorEvent } from "../../src/client/remote-orchestrator-ev
 import type { OrchestratorSignals } from "../../src/client/remote-orchestrator-payloads.ts"
 
 /**
- * Transient lifecycle marks must never outlive their evidence (the
- * 2026-07-29 stale-mark class): a cancelled compaction sends no
+ * Transient lifecycle marks must never outlive their evidence: a cancelled
+ * compaction sends no
  * post-compact and an esc-interrupted turn may send no idle/stop, so the
  * fold clears marks on every turn edge — and keeps NO compaction state at
  * all, since that one has no reliable clearing event.

--- a/packages/kobe/test/client/remote-orchestrator-reconnect.test.ts
+++ b/packages/kobe/test/client/remote-orchestrator-reconnect.test.ts
@@ -43,8 +43,8 @@ describe("shouldLogReconnectAttempt", () => {
 
 /**
  * Auto-reconnect is the permanent fix for the Tasks-pane create/delete sync
- * drift: a pane that subscribed at boot used to FREEZE its task list when the
- * daemon later idle-stopped / restarted (socket close, no reconnect, no
+ * drift. Without it a pane that subscribed at boot FREEZES its task list when
+ * the daemon later idle-stops / restarts (socket close, no reconnect, no
  * fallback). The contract these lock:
  *   - role "pane"  → on socket close, RETRY a plain reconnect (re-`init`) so
  *     the bus replays the current snapshot and the pane re-syncs.
@@ -183,15 +183,14 @@ describe("RemoteOrchestrator auto-reconnect", () => {
 })
 
 /**
- * Issue #96. A GUI whose own install has been deleted cannot ever bring a
- * daemon up: `ensureReachable` fails identically on every attempt. The loop
- * used to retry it forever — the owner had a GUI two days into that, logging
- * the same resolution failure and looking, from the UI, exactly like a client
- * that was about to reconnect.
+ * A GUI whose own install has been deleted cannot ever bring a daemon up:
+ * `ensureReachable` fails identically on every attempt. Retrying forever logs
+ * the same resolution failure for days and looks, from the UI, exactly like a
+ * client that is about to reconnect.
  *
- * Stopping is also the SAFE direction. PR #733 established that a client
- * which cannot spawn must not keep pressure on a healthy daemon; a client
- * that can NEVER spawn is the extreme of that case.
+ * Stopping is also the SAFE direction: a client which cannot spawn must not
+ * keep pressure on a healthy daemon, and a client that can NEVER spawn is the
+ * extreme of that case.
  */
 describe("RemoteOrchestrator on a stale install", () => {
   // Same isolation as the suite above: the loop's error logging writes to

--- a/packages/kobe/test/client/remote-orchestrator.test.ts
+++ b/packages/kobe/test/client/remote-orchestrator.test.ts
@@ -260,7 +260,7 @@ describe("RemoteOrchestrator channel handling", () => {
     })
   })
 
-  // `worktree.changes` — the daemon-collected `+N −M` map (issue #6). Each
+  // `worktree.changes` — the daemon-collected `+N −M` map. Each
   // push REPLACES the whole map (the daemon publishes the full picture and
   // prunes deleted tasks' entries itself), so unlike engine-state
   // there's no snapshot reconciliation — but unchanged pushes must still be

--- a/packages/kobe/test/engine/activity-observer.test.ts
+++ b/packages/kobe/test/engine/activity-observer.test.ts
@@ -213,7 +213,7 @@ describe("activity observer", () => {
     const w = world()
     w.registry.report(TASK, "awaiting-input", { waiting: "permission" }, "tab-1", { id: "s1" }, "claude")
     // The blocked engine writes nothing and its title rests — exactly the
-    // state the old watchdog wrongly idled. The observer must not.
+    // state a byte/title watchdog reads as idle. The observer must not.
     w.state.sessions = [{ key: KEY, alive: true, pid: 42, title: "✳ waiting", totalBytes: 100 }]
     w.state.engines.set(42, "claude")
     await wait(100)

--- a/packages/kobe/test/engine/claude-history-append-race.test.ts
+++ b/packages/kobe/test/engine/claude-history-append-race.test.ts
@@ -10,9 +10,9 @@ import * as fileBounds from "../../src/engine/file-bounds.ts"
  *
  * `appendInterruptedUserPrompt` runs from `engine.stop`, while the claude
  * subprocess we just SIGTERM'd may still be flushing buffered records to
- * the same JSONL. The old implementation read the whole file into memory,
- * spliced, and `writeFile`-rewrote it — clobbering anything flushed after
- * the read snapshot. These tests prove the writer now only ever appends:
+ * the same JSONL. Reading the whole file into memory, splicing, and
+ * `writeFile`-rewriting it clobbers anything flushed after the read snapshot.
+ * These tests prove the writer only ever appends:
  * a record a "concurrent writer" lands between the read and the write is
  * preserved, and existing bytes are never truncated.
  */
@@ -102,8 +102,8 @@ describe("appendInterruptedUserPrompt — append-only", () => {
   it("does NOT lose a record a concurrent writer appends between the read and the write", async () => {
     const { deps, filePath } = await makeDeps()
     // Merge case: last conversational record is a user turn (a prior rescue
-    // with no assistant reply yet) — the exact path that used to rewrite the
-    // whole file.
+    // with no assistant reply yet) — the path a naive writer rewrites the
+    // whole file on.
     const seed = `${userRecord("first rescued", "u1", "p0")}\n`
     await writeFile(filePath("s"), seed)
 

--- a/packages/kobe/test/engine/claude-hook-adapter.test.ts
+++ b/packages/kobe/test/engine/claude-hook-adapter.test.ts
@@ -217,15 +217,14 @@ describe("mergeWorktreeSyncHook (external worktree sync)", () => {
 })
 
 /**
- * The retired PostToolUse(Bash) observer. Rove installed it into every user's
- * `~/.claude/settings.json` to archive the task pinned to a removed worktree;
- * archive was removed (issue #75) and the hook has done nothing since — while
- * still spawning a ~170ms `kobe hook` process on EVERY Bash call of every
- * session machine-wide. Nothing installs it now, so these tests cover the only
- * remaining direction: getting it back OUT of files that already have it,
- * without disturbing anything the user or another tool put there.
+ * The PostToolUse(Bash) watch observer, which a registered
+ * `~/.claude/settings.json` can still carry: it does nothing but spawn a
+ * ~170ms `kobe hook` process on EVERY Bash call of every session
+ * machine-wide. Nothing installs it, so these tests cover the only direction
+ * that matters: getting it back OUT of files that have it, without disturbing
+ * anything the user or another tool put there.
  */
-describe("removeWorktreeWatchHook (retired PostToolUse observer)", () => {
+describe("removeWorktreeWatchHook (PostToolUse observer)", () => {
   /** What a registered user's settings.json actually holds, verbatim. */
   const REGISTERED = {
     matcher: "Bash",

--- a/packages/kobe/test/engine/claude-quota.test.ts
+++ b/packages/kobe/test/engine/claude-quota.test.ts
@@ -77,13 +77,13 @@ describe("usageFromClaudePayload", () => {
 })
 
 describe("fetchClaudeQuotaUsage keychain lookup", () => {
-  // The owner's machine carried TWO items under this service name: a stale
-  // `acct=unknown` row and today's login. Looking the item up by service
-  // alone returned the stale one, so the dashboard stayed empty through
-  // repeated re-logins. Pin the account flag the CLI itself passes.
+  // A machine can carry TWO items under this service name: a stale
+  // `acct=unknown` row and the current login. Looking the item up by service
+  // alone returns the stale one, leaving the dashboard empty through repeated
+  // re-logins. Pin the account flag the CLI itself passes.
   // darwin-only: the lookup bails before spawning `security` elsewhere,
   // so on Linux CI the spy records no call and the assertions have no
-  // subject (v0.8.66 publish gate failure).
+  // subject.
   it.runIf(process.platform === "darwin")("queries the keychain by account as well as service", async () => {
     spawnCapture.mockResolvedValue({ status: 1, stdout: "", stderr: "" })
     const { fetchClaudeQuotaUsage } = await import("../../src/engine/claude-code-local/quota.ts")

--- a/packages/kobe/test/engine/claude-turns.test.ts
+++ b/packages/kobe/test/engine/claude-turns.test.ts
@@ -1,4 +1,4 @@
-/** Per-turn telemetry extraction from Claude's JSONL (issue #32). */
+/** Per-turn telemetry extraction from Claude's JSONL. */
 
 import { parseClaudeTurns } from "@/engine/claude-code-local/turns"
 import { describe, expect, test } from "vitest"

--- a/packages/kobe/test/engine/codex-copilot-history-incremental.test.ts
+++ b/packages/kobe/test/engine/codex-copilot-history-incremental.test.ts
@@ -13,8 +13,8 @@ import {
 /**
  * Why these tests matter: the history pane polls `readHistory` every ~2.5s
  * and Solid's `<For>` keys rows by object reference — all-new identities per
- * poll destroy + recreate every rendered row. PR #233 gave the claude reader
- * an append-aware parse cache; these tests pin the same contract for the
+ * poll destroy + recreate every rendered row. The claude reader has an
+ * append-aware parse cache; these tests pin the same contract for the
  * codex and copilot readers: (a) already-seen messages keep object identity
  * when the file only appended, (b) output stays identical to a full re-parse,
  * falling back on rewrite/truncation, and (c) copilot's cross-line fold state

--- a/packages/kobe/test/engine/codex-hook-adapter.test.ts
+++ b/packages/kobe/test/engine/codex-hook-adapter.test.ts
@@ -101,7 +101,7 @@ describe("CodexHookAdapter install/remove roundtrip (real file)", () => {
     // kobe's Stop coexists with the user's Stop hook.
     expect(JSON.stringify(hooks.Stop)).toContain("turn-complete")
     expect(JSON.stringify(hooks.Stop)).toContain("user-stop")
-    // The retired PostToolUse(Bash) watch observer is never installed again.
+    // The PostToolUse(Bash) watch observer is never installed.
     expect(hooks.PostToolUse).toBeUndefined()
   })
 
@@ -118,7 +118,7 @@ describe("CodexHookAdapter install/remove roundtrip (real file)", () => {
   })
 
   // End-to-end uninstall through real file I/O: this is what an upgrading user
-  // gets on their next launch. The retired hook goes; a co-resident hook from
+  // gets on their next launch. The watch hook goes; a co-resident hook from
   // another tool must survive, and a second launch must not churn the file.
   it("uninstalls an already-registered watch hook, sparing another tool's entry", async () => {
     await writeFile(

--- a/packages/kobe/test/engine/codex-local.test.ts
+++ b/packages/kobe/test/engine/codex-local.test.ts
@@ -213,8 +213,8 @@ describe("deriveCodexUsageMetrics", () => {
     JSON.stringify({ type: "turn.completed", ...(timestamp ? { timestamp } : {}), usage: { output_tokens: output } })
 
   it("takes the latest (file-order) turn when records carry no timestamp", () => {
-    // Regression: the old `else if (latestUsage === undefined)` froze on the
-    // FIRST timestamp-less turn, reporting stale first-turn usage.
+    // An `else if (latestUsage === undefined)` gate freezes on the FIRST
+    // timestamp-less turn and reports stale first-turn usage.
     const raw = [turn(10), turn(20), turn(30)].join("\n")
     expect(deriveCodexUsageMetrics(raw)).toEqual({ input_tokens: 0, output_tokens: 30 })
   })

--- a/packages/kobe/test/engine/composer-state.test.ts
+++ b/packages/kobe/test/engine/composer-state.test.ts
@@ -81,8 +81,8 @@ describe("isComposerEmpty", async () => {
     // and in a 12-row buffer those wrapped around and fused rows together
     // (`──⏵⏵ bypass permissions on …` — a rule and the hint row in one line).
     // A \r\n-joined fixture cannot reproduce it: it renders identically at 12
-    // and 60 rows, which is why the first version of this test passed against
-    // the very constant it was meant to pin.
+    // and 60 rows, so it would pass against the very constant it is meant to
+    // pin.
     const E = String.fromCharCode(27)
     const parts: string[] = []
     for (let i = 0; i < 40; i++) parts.push(`\r${E}[2C${E}[1Boutput line ${i}`)

--- a/packages/kobe/test/engine/engine-declared-vendor-flags.test.ts
+++ b/packages/kobe/test/engine/engine-declared-vendor-flags.test.ts
@@ -98,8 +98,8 @@ afterEach(() => {
 describe("declared effort reaches the launch argv", () => {
   it("applies a NON-CODEX engine's own effortArgv", () => {
     // The whole bug: this engine declares levels, so "high" passes the gate,
-    // shows in the picker and rides /api/engines — and under the old
-    // `if (v === "codex")` it was then dropped with no error.
+    // shows in the picker and rides /api/engines — and an `if (v === "codex")`
+    // argv branch would then drop it with no error.
     expect(withEngineEffort(["fake-cli"], "fakeengine", "high")).toEqual(["fake-cli", "--reasoning", "high"])
   })
 

--- a/packages/kobe/test/engine/engine-presets.test.ts
+++ b/packages/kobe/test/engine/engine-presets.test.ts
@@ -1,5 +1,5 @@
 /**
- * `engineLaunchArgv` — what a task or tab actually spawns (issue #30).
+ * `engineLaunchArgv` — what a task or tab actually spawns.
  *
  * The subtle rule is the preset-id indirection: `--command claude` must mean
  * "my claude" (the `engineCommand.claude` override I configured in Settings),
@@ -111,9 +111,9 @@ describe("engineLaunchArgv", () => {
 })
 
 // Why: `engine-presets.ts:22-26` promises a declared protocol makes the
-// built-in adapter's knowledge apply — but fork used to read the RAW vendor
-// id, find the empty custom entry, and refuse. A `claudecpa` wrapper launches
-// the claude binary and forks exactly like claude; resolving the protocol
+// built-in adapter's knowledge apply. Reading the RAW vendor id for fork
+// finds the empty custom entry and refuses; a `claudecpa` wrapper launches
+// the claude binary and forks exactly like claude, so resolving the protocol
 // first is what makes the promise true. Needs state, so it lives here rather
 // than beside the other fork tests.
 describe("fork through a declared protocol", () => {

--- a/packages/kobe/test/engine/foreground.test.ts
+++ b/packages/kobe/test/engine/foreground.test.ts
@@ -9,9 +9,9 @@ import {
 } from "../../src/engine/foreground.ts"
 
 /**
- * Verbatim `ps -A -o pid=,ppid=,args=` lines captured while the owner's
- * `claudecpa` zsh function ran in a real PTY (2026-07-27): the shell
- * spawns cc-switch's `/bin/sh -c` wrapper, which spawns the actual
+ * Verbatim `ps -A -o pid=,ppid=,args=` lines captured while a `claudecpa`
+ * zsh function ran in a real PTY: the shell spawns cc-switch's
+ * `/bin/sh -c` wrapper, which spawns the actual
  * claude binary two levels down.
  */
 const REAL_TREE = `
@@ -42,7 +42,7 @@ describe("vendorFromArgv", () => {
   })
 
   it("identifies kimi by its rewritten process title (registry processNames)", () => {
-    // Verbatim `ps -o args=` lines from two live kimi sessions (2026-08-15):
+    // Verbatim `ps -o args=` lines from two live kimi sessions:
     // the Mach-O launcher rewrites argv[0] to `kimi-co`, and what follows is
     // environ memory, not arguments.
     expect(vendorFromArgv("kimi-co NVM_RC_VERSION=")).toBe("kimi")

--- a/packages/kobe/test/engine/hook-events.test.ts
+++ b/packages/kobe/test/engine/hook-events.test.ts
@@ -16,8 +16,8 @@ describe("reduceActivity", () => {
 
   it("a Stop on a KNOWN untracked state is an automated wake, not a completion", () => {
     // Engines fire Stop on hook-driven wakes (a monitor stream ending) with
-    // no user turn in flight — that must not light the ● lamp (owner
-    // 2026-08-02). The wake signature is an explicit idle/sticky previous
+    // no user turn in flight — that must not light the ● lamp. The wake
+    // signature is an explicit idle/sticky previous
     // state; running / permission_needed (a mid-turn approval resumes
     // without a new turn-start) complete.
     expect(reduceActivity("idle", "turn-complete")).toBe("idle")
@@ -28,8 +28,8 @@ describe("reduceActivity", () => {
   it("a Stop on a COLD registry (undefined) completes — the turn outlived a daemon restart", () => {
     // A restart wipes the in-memory registry; a turn that started before the
     // wipe ends with a Stop that is the task's FIRST event since boot.
-    // Swallowing it cost the ● lamp for every turn that outlived a restart
-    // (prod 2026-08-10). Only a known untracked state means "automated wake".
+    // Swallowing it costs the ● lamp for every turn that outlives a restart.
+    // Only a known untracked state means "automated wake".
     expect(reduceActivity(undefined, "turn-complete")).toBe("turn_complete")
   })
 
@@ -41,7 +41,7 @@ describe("reduceActivity", () => {
   })
 
   it("treats awaiting-input as permission_needed — permission prompt AND question dialog", () => {
-    // Owner call 2026-07-12: a question dialog blocks the engine on the user
+    // A question dialog blocks the engine on the user
     // exactly like a permission prompt, and F7 must reach it. `detail.waiting`
     // keeps which one it was.
     expect(reduceActivity("running", "awaiting-input", { waiting: "permission" })).toBe("permission_needed")

--- a/packages/kobe/test/engine/hosted-session.test.ts
+++ b/packages/kobe/test/engine/hosted-session.test.ts
@@ -69,7 +69,7 @@ describe("hosted session helpers", () => {
           key: "task-a::tab-1",
           cwd: "/worktree",
           // No cols/rows: a size-less open must never resize a live
-          // session away from its attached TUI (issue #18).
+          // session away from its attached TUI.
           command: ["engine", "--resume", "session-1"],
           defaultColors,
         },

--- a/packages/kobe/test/engine/kimi-failure-classify.test.ts
+++ b/packages/kobe/test/engine/kimi-failure-classify.test.ts
@@ -1,11 +1,11 @@
 /**
  * Kimi StopFailure → the neutral failure class.
  *
- * Kimi was firing StopFailure all along, but its adapter returned no detail
- * for `turn-failed`, so `reduceActivity` saw `failure: undefined` and every
- * Kimi failure — including the 5-hour quota wall on 2026-08-30 — reduced to a
- * generic `error`. That meant Kimi could never reach `rate_limited`, and so
- * never armed the auto-resume that state triggers.
+ * Kimi fires StopFailure, but an adapter returning no detail for
+ * `turn-failed` leaves `reduceActivity` with `failure: undefined`, so every
+ * Kimi failure — the 5-hour quota wall included — reduces to a generic
+ * `error`. Kimi could then never reach `rate_limited`, and so never arm the
+ * auto-resume that state triggers.
  *
  * The payload shapes below are Kimi's own (verified against the installed
  * 0.37.2 binary): `error_type` is a JS CLASS name, not a category, and the
@@ -39,7 +39,7 @@ describe("kimi turn-failed classification", () => {
   })
 
   it("treats the 5-hour usage wall (a 403 auth error) as needing a human, not a timer", () => {
-    // The literal 2026-08-30 message. Kimi files it under auth; it is a quota
+    // The literal wall message. Kimi files it under auth; it is a quota
     // wall, so it is `billing` — attention, but deliberately NOT auto-resumed.
     const detail = adapter.activityDetailFromPayload("turn-failed", {
       error_type: "APIStatusError",

--- a/packages/kobe/test/engine/kimi-history.test.ts
+++ b/packages/kobe/test/engine/kimi-history.test.ts
@@ -1,6 +1,6 @@
 /**
- * Kimi's path-only history reader: the store layout is verified (live
- * install, 2026-08-13) even though the wire format isn't, which is exactly
+ * Kimi's path-only history reader: the store layout is verified against a
+ * live install even though the wire format isn't, which is exactly
  * enough for a cross-engine handoff — it hands over a PATH, not messages.
  */
 

--- a/packages/kobe/test/engine/plugin-engines-load.test.ts
+++ b/packages/kobe/test/engine/plugin-engines-load.test.ts
@@ -75,8 +75,8 @@ describe("loadPluginEngines", () => {
     expect(loadPluginEngines()).toEqual(["aider"])
     const entry = engineEntry("aider")
     expect(entry.displayName).toBe("Aider")
-    // The manifest still sets `input_placeholder` (a retired key): it must
-    // register without throwing and the field is simply absent.
+    // The manifest sets `input_placeholder`, a key the loader does not know:
+    // it must register without throwing, and the field is simply absent.
     expect(entry.identity).toEqual({ vendorId: "aider", shortName: "Aid" })
   })
 

--- a/packages/kobe/test/engine/plugin-migration.test.ts
+++ b/packages/kobe/test/engine/plugin-migration.test.ts
@@ -1,6 +1,6 @@
 /**
  * Claude Code plugin takeover detection (`engine/claude-code-local/
- * plugin-migration.ts`) — the read-only side of the issue #37 migration
+ * plugin-migration.ts`) — the read-only side of the migration
  * hard-gate. Everything here operates on temp files passed in explicitly;
  * nothing may touch the real ~/.claude (the gate's whole contract is that
  * detection never writes).

--- a/packages/kobe/test/engine/protocol-sniff.test.ts
+++ b/packages/kobe/test/engine/protocol-sniff.test.ts
@@ -1,6 +1,6 @@
 /**
  * Tier (b) of protocol resolution — naming the engine behind a session whose
- * launch command tier (a) could not name (issue #30).
+ * launch command tier (a) could not name.
  *
  * The rule under test is conservatism: evidence identifies, absence of
  * evidence answers null, and AMBIGUOUS evidence also answers null. A wrong

--- a/packages/kobe/test/engine/protocol-upgrade-reporter.test.ts
+++ b/packages/kobe/test/engine/protocol-upgrade-reporter.test.ts
@@ -1,5 +1,5 @@
 /**
- * Tier-(b) protocol sniff CONSUMER (issue #31) — the observer→record chain
+ * Tier-(b) protocol sniff CONSUMER — the observer→record chain
  * that upgrades a `generic` task from its live session. Two layers under
  * test with the real naming rule (`protocolUpgradeFromLiveSession`) plugged
  * in end-to-end:
@@ -75,7 +75,7 @@ describe("createProtocolUpgradeReporter", () => {
     report("task-1", "tab-1", { walkVendor: "claude", title: "⠂ working" })
     await Promise.resolve()
     expect(orch.setCommandCalls).toEqual([{ id: "task-1", command: "my-wrapper.sh", vendor: "claude" }])
-    // Idempotent: the upgraded record is no longer generic, so the next
+    // Idempotent: the upgraded record is not generic any more, so the next
     // tick's identical evidence resolves to no write at all.
     report("task-1", "tab-1", { walkVendor: "claude", title: "⠂ working" })
     await Promise.resolve()

--- a/packages/kobe/test/engine/registry.test.ts
+++ b/packages/kobe/test/engine/registry.test.ts
@@ -1,8 +1,8 @@
 /**
  * Engine registry (engine/registry.ts) — the consolidation point for the
- * per-vendor conditionals that used to be scattered through
- * monitor/auto-title.ts, engine/hook-adapter.ts and the
- * three account detectors. These tests pin the registry's contract:
+ * per-vendor conditionals that would otherwise scatter through
+ * monitor/auto-title.ts, engine/hook-adapter.ts and the three account
+ * detectors. These tests pin the registry's contract:
  *
  *  - known vendors resolve to REAL entries (the right detector, the right
  *    history reader, claude's hook adapter);
@@ -55,7 +55,7 @@ describe("engineEntry — built-in vendors", () => {
     expect(supportsStructuredHistory("claude")).toBe(true)
     expect(supportsStructuredHistory("kimi")).toBe(false)
     expect(supportsStructuredHistory("my-custom-engine")).toBe(false)
-    // First-message delivery (issue #25): kimi's positional CLI slot is a
+    // First-message delivery: kimi's positional CLI slot is a
     // subcommand, so its first message pastes post-spawn; claude/codex and
     // custom engines keep the argv contract.
     expect(engineEntry("kimi").firstMessageDelivery).toBe("paste")

--- a/packages/kobe/test/engine/session-identity.test.ts
+++ b/packages/kobe/test/engine/session-identity.test.ts
@@ -6,9 +6,9 @@
  *   - claude's pin + resume shapes must not drift (they were the only ones
  *     that ever worked, and the whole feature is worthless if it breaks them);
  *   - `withPinnedSessionId` must answer for a CUSTOM engine by the protocol
- *     it declares, not by whether its id spells "claude" — the literal-name
- *     check in the old `withClaudeSessionId` is exactly why `claudecpa` and
- *     every kimi tab lost their conversation on restart.
+ *     it declares, not by whether its id spells "claude" — a literal-name
+ *     check is exactly how `claudecpa` and every kimi tab lose their
+ *     conversation on restart.
  */
 
 import { engineResumeArgv, withPinnedSessionId } from "@/engine/engine-presets"

--- a/packages/kobe/test/engine/shared-config-write.test.ts
+++ b/packages/kobe/test/engine/shared-config-write.test.ts
@@ -141,8 +141,8 @@ describe("staging path", () => {
   // writers from overlapping, so this is unreachable in a healthy run — but the
   // lock has takeover paths (stale steal, forceTakeover) where mutual exclusion
   // breaks, and that is exactly when a shared `<file>.tmp` lets writer B clobber
-  // writer A's staging file and fail A's rename with ENOENT (issue #53, already
-  // paid for once in orchestrator/index/store.ts). Asserted directly because a
+  // writer A's staging file and fail A's rename with ENOENT (the same reason
+  // orchestrator/index/store.ts stages per call). Asserted directly because a
   // race test would pass on a pid-only path.
   it("differs between two calls in the same process", () => {
     const home = tempHome()

--- a/packages/kobe/test/engine/status-prefix.test.ts
+++ b/packages/kobe/test/engine/status-prefix.test.ts
@@ -2,7 +2,7 @@
  * `stripEngineStatusPrefix` — an engine that owns its OSC title writes its
  * turn state into it, and kobe draws that same state in its own glyph
  * column. Rendering both says the fact twice, and the ANIMATED variants make
- * a resting tab look busy (owner 2026-08-10). The glyph vocabulary is
+ * a resting tab look busy. The glyph vocabulary is
  * declared per engine, so no neutral layer hard-codes a vendor's characters.
  */
 
@@ -36,9 +36,9 @@ describe("stripEngineStatusPrefix", () => {
   })
 
   // `vendor` narrows the vocabulary; it never gates the strip. The probe is a
-  // ~2s ps walk, so gating on it let a raw `✳ …` through on every tick it
-  // could not answer — and that title is what gets RECORDED, which is why the
-  // prefix kept coming back (owner report 2026-08-10).
+  // ~2s ps walk, so gating on it lets a raw `✳ …` through on every tick it
+  // cannot answer — and that title is what gets RECORDED, so the prefix keeps
+  // coming back.
   it("strips without a vendor too — an unanswered probe must not leak the prefix", () => {
     expect(stripEngineStatusPrefix("✳ 运行本地Codex处理图片", null)).toBe("运行本地Codex处理图片")
     expect(stripEngineStatusPrefix("✳ whatever", undefined)).toBe("whatever")

--- a/packages/kobe/test/engine/status-protocol.test.ts
+++ b/packages/kobe/test/engine/status-protocol.test.ts
@@ -81,7 +81,7 @@ describe("statusReportProtocol", () => {
   it("the api prefix is injectable — packaged builds bake plain `kobe api`", () => {
     // The default resolves the environment's CLI invocation (the dev bun
     // line from a source checkout), so a protocol agent never drives a
-    // stale global `kobe` that predates a new verb (BAD_VERB field bug).
+    // stale global `kobe` that predates a new verb and answers BAD_VERB.
     expect(statusReportProtocol("t9", "kobe api")).toContain("kobe api set-status --task-id t9")
     expect(noteFilingProtocol("t9", "kobe api")).toContain('kobe api note --task-id t9 --text "<one line')
     expect(dispatcherProtocol("m9", "kobe api")).toContain("kobe api dispatch --task-id <id>")
@@ -193,7 +193,7 @@ describe("dispatcherProtocol", () => {
     const text = dispatcherProtocol("01HMAIN")
     expect(text).toContain("task 01HMAIN")
     expect(text).not.toContain("set-status")
-    // The radar is display-only by explicit decision (2026-06-13): the
+    // The radar is display-only by explicit decision: the
     // dispatcher must never instruct merges/rebases over conflicts.
     expect(text).toContain("Take no action on merge conflicts")
     expect(text).not.toContain("merge-tree")

--- a/packages/kobe/test/engine/trust-worktree.test.ts
+++ b/packages/kobe/test/engine/trust-worktree.test.ts
@@ -1,5 +1,5 @@
 /**
- * Vendor worktree pre-trust (issue #28): each adapter writes its vendor's
+ * Vendor worktree pre-trust: each adapter writes its vendor's
  * first-run trust record for a Rove-created worktree — merge-preserving and
  * idempotent, because these stores belong to the user's real CLI installs.
  * Runs against temp HOME dirs; the real stores are never touched.

--- a/packages/kobe/test/exec/exec-host.test.ts
+++ b/packages/kobe/test/exec/exec-host.test.ts
@@ -279,8 +279,8 @@ describe("LocalExecHost.run (async, non-blocking)", () => {
   })
 
   it("does not block the event loop while the subprocess runs", async () => {
-    // The daemon-freeze regression pin: with the old spawnSync impl a timer
-    // could never fire while a command ran. Start a 300ms subprocess, then
+    // The daemon-freeze pin: under a spawnSync implementation no timer can
+    // fire while a command runs. Start a 300ms subprocess, then
     // prove a 50ms timer resolves FIRST — i.e. the event loop kept turning.
     const host = new LocalExecHost()
     const order: string[] = []

--- a/packages/kobe/test/orchestrator/active-task.test.ts
+++ b/packages/kobe/test/orchestrator/active-task.test.ts
@@ -44,12 +44,13 @@ describe("Orchestrator active task recency", () => {
     expect(orch.getTask(task.id)?.updatedAt).toBe("2026-01-02T00:00:00.000Z")
   })
 
-  // CORRECTNESS PIN for the perf fix (store.touchRecency): dropping the
-  // fsync'd `store.update(id, {})` from the focus path must NOT drop the
-  // `recent` ordering it fed. After a sequence of setActive calls the sidebar's
-  // `recent` sort must still order tasks most-recently-focused first — the bump
-  // now lives in-cache, but it must still change `updatedAt` that `buildRows`
-  // reads. `active-task`/`lastActive` track ONE id; this pins the full ORDER.
+  // CORRECTNESS PIN for `store.touchRecency`: keeping the fsync'd
+  // `store.update(id, {})` off the focus path must NOT cost the `recent`
+  // ordering it would have fed. After a sequence of setActive calls the
+  // sidebar's `recent` sort must still order tasks most-recently-focused
+  // first — the bump lives in-cache, but it must still change the `updatedAt`
+  // that `buildRows` reads. `active-task`/`lastActive` track ONE id; this
+  // pins the full ORDER.
   it("`recent` sort still orders by focus recency after a sequence of setActive calls", async () => {
     vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"))
     const a = await orch.createTask({ repo: "/repo", title: "a", branch: "a", vendor: "claude" })

--- a/packages/kobe/test/orchestrator/branch-anchor.test.ts
+++ b/packages/kobe/test/orchestrator/branch-anchor.test.ts
@@ -1,8 +1,9 @@
 /**
  * Deleting a branch must not make its commits unreachable.
  *
- * `land --strategy squash --delete-branch` is the sequence that used to lose
- * work: the squash writes ONE new commit onto the base with no link back, the
+ * `land --strategy squash --delete-branch` is the sequence that loses work
+ * without an anchor: the squash writes ONE new commit onto the base with no
+ * link back, the
  * worktree removal takes `.git/worktrees/<slug>/logs/HEAD` (the only reflog
  * that ever recorded this branch's tip, because the base checkout never had
  * the branch checked out), and `git branch -D` then takes the branch ref AND

--- a/packages/kobe/test/orchestrator/branch-follow.test.ts
+++ b/packages/kobe/test/orchestrator/branch-follow.test.ts
@@ -95,7 +95,7 @@ describe("branch follows title", () => {
 
     await orch.setTitle(task.id, "Some new title")
 
-    // Branch was no longer the placeholder default, so it stays put.
+    // Branch is not the placeholder default any more, so it stays put.
     expect(orch.getTask(task.id)?.branch).toBe("feature/custom")
     expect(gitBranches()).toContain("feature/custom")
   })
@@ -109,7 +109,7 @@ describe("branch follows title", () => {
     expect(orch.getTask(task.id)?.branch).toBe(afterFirst)
 
     await orch.setTitle(task.id, "Second name")
-    // Branch is no longer the placeholder default, so the second rename
+    // Branch is not the placeholder default any more, so the second rename
     // does not move it — it tracks the first non-placeholder title.
     expect(orch.getTask(task.id)?.branch).toBe(afterFirst)
     expect(gitBranches()).toContain(afterFirst)

--- a/packages/kobe/test/orchestrator/core-mutations.test.ts
+++ b/packages/kobe/test/orchestrator/core-mutations.test.ts
@@ -105,8 +105,8 @@ describe("setVendor", () => {
   })
 
   it("persists an effort-only change even though the vendor is unchanged", async () => {
-    // The same-vendor early return used to swallow this: a user moving codex
-    // from medium to high changes nothing the store ever sees.
+    // A same-vendor early return swallows this: a user moving codex from
+    // medium to high changes nothing the store ever sees.
     const t = await makeTask()
     await orch.setVendor(t.id, "codex", "medium")
     await orch.setVendor(t.id, "codex", "high")
@@ -245,7 +245,7 @@ describe("moveTask", () => {
     expect(orch.listTasks().map((t) => t.id)).toEqual(before)
   })
 
-  // Projects render stored order (owner 2026-07-16), so main rows are
+  // Projects render stored order, so main rows are
   // movable — among each other only, never mixing into the task partition.
   it("moves a main row among other main rows, leaving tasks in place", async () => {
     const regular = await makeTask({ title: "reg" })

--- a/packages/kobe/test/orchestrator/ensure-worktree.test.ts
+++ b/packages/kobe/test/orchestrator/ensure-worktree.test.ts
@@ -8,7 +8,7 @@
  * The store is the one seam we fake: a thin subclass whose `update` can be made
  * to throw once (the write that records `worktreePath`) or to drop the task the
  * instant after a successful write (a concurrent delete). Both are the real
- * failure modes that used to strand an orphan worktree or surface a spurious
+ * failure modes that strand an orphan worktree or surface a spurious
  * `TaskNotFoundError`.
  */
 
@@ -156,10 +156,10 @@ describe("ensureWorktree — partial-failure cleanup (no orphans)", () => {
 describe("ensureWorktree — concurrent delete after a successful write", () => {
   test("returns the created path instead of throwing TaskNotFound", async () => {
     const task = await orch.createTask({ repo })
-    // The write lands, then the task is dropped (a delete racing in the window
-    // where the lock used to be released before the re-fetch). The old code
-    // re-fetched after the lock and threw TaskNotFoundError; we return the path
-    // computed before releasing the lock.
+    // The write lands, then the task is dropped (a delete racing the window
+    // between releasing the lock and a re-fetch). Re-fetching after the lock
+    // would throw TaskNotFoundError; we return the path computed before
+    // releasing the lock.
     store.deleteAfterNextUpdate = true
 
     const p = await orch.ensureWorktree(task.id)
@@ -189,7 +189,7 @@ describe("ensureWorktree — recorded baseRef (durable fork point)", () => {
     expect(orch.getTask(task.id)?.baseRef).toBe("side-base")
 
     // Simulated daemon restart: a brand-new Orchestrator over the SAME store
-    // (the old side-map died with the "process"). The worktree must still
+    // (an in-memory side-map would die with the "process"). The worktree must still
     // cut from side-base, not silently from the repo's current HEAD.
     const restarted = new Orchestrator({ store, worktrees: new GitWorktreeManager() })
     const p = await restarted.ensureWorktree(task.id)

--- a/packages/kobe/test/orchestrator/land.test.ts
+++ b/packages/kobe/test/orchestrator/land.test.ts
@@ -274,8 +274,8 @@ describe("landTaskWithCleanup worktree cleanup", () => {
 
   test("a half-removed worktree still counts as landed, and names the leftover directory", async () => {
     // git deregisters the worktree, then fails to unlink it (an unwritable
-    // directory inside). Before issue #89 this reported `removed: false` and
-    // sent the user to retry a removal git can no longer act on at all.
+    // directory inside). Reporting `removed: false` here would send the user
+    // to retry a removal git cannot act on at all.
     makeWorktree()
     // Committed, not untracked: an untracked file would trip the dirty
     // refusal, which is a different (already-covered) branch. The tree is
@@ -345,7 +345,7 @@ describe("landTaskWithCleanup worktree cleanup", () => {
   /**
    * Same ordering bug as the worktrees page, reached through land: the dirty
    * check that let this land through ran seconds earlier in `landTask`, and
-   * an engine still running has kept writing since. Removing its directory
+   * an engine still running has kept writing since then. Removing its directory
    * first means every write after that goes to an unlinked inode.
    *
    * The assertion is the ORDER — recorded at the moment teardown runs, when
@@ -432,11 +432,11 @@ describe("landTaskWithCleanup worktree cleanup", () => {
       { removeWorktree: false, deleteBranch: true, strategy: "squash" },
       d,
     )
-    // git kept the branch either way — the fix is that the RESULT now says so.
+    // git keeps the branch either way; the point is that the RESULT says so.
     expect(branchExists("feat")).toBe(true)
     expect(res.branchKept?.reason).toMatch(/still has the branch checked out/)
-    // No anchor: it used to be written before the delete was even attempted,
-    // naming a salvage ref for a branch nothing deleted.
+    // No anchor: writing one before the delete is attempted would name a
+    // salvage ref for a branch nothing deleted.
     expect(res.branchAnchor).toBeUndefined()
   })
 

--- a/packages/kobe/test/orchestrator/lockfile.test.ts
+++ b/packages/kobe/test/orchestrator/lockfile.test.ts
@@ -49,7 +49,7 @@ describe("acquire / release", () => {
   })
 
   it("rejects when a SIBLING holder in this same process holds the lock", async () => {
-    // Same pid, different token — the issue #53 topology (two stores, one
+    // Same pid, different token — two stores in one
     // process). The holder is alive, so the second acquirer must wait, not
     // steal.
     await writeFile(lock, `${process.pid}:some-other-instance`)
@@ -77,7 +77,7 @@ describe("acquire / release", () => {
   it("release only removes a lock we still own", async () => {
     // Victim acquires, thief takes over. The victim's release must NOT unlink
     // the thief's lock — that would let a third writer into the critical
-    // section while the thief is still inside it (issue #53's cascade).
+    // section while the thief is still inside it.
     const victim = await acquire(lock)
     const thief = await acquire(lock, { forceTakeover: true })
     await release(lock, victim)

--- a/packages/kobe/test/orchestrator/main-task.test.ts
+++ b/packages/kobe/test/orchestrator/main-task.test.ts
@@ -75,7 +75,7 @@ describe("ensureMainTask", () => {
     expect(task.repo).not.toBe(sub)
     expect(task.repo.endsWith(path.join("packages", "app"))).toBe(false)
     // One project row, not two: the sidebar groups by string comparison on
-    // this exact field, so task and main agreeing IS the fix.
+    // this exact field, so task and main must agree on it exactly.
     const mains = orch.listTasks().filter((t) => t.kind === "main")
     expect(mains).toHaveLength(1)
     expect(task.repo).toBe(mains[0]?.repo)
@@ -84,8 +84,8 @@ describe("ensureMainTask", () => {
 
   test("promotes an existing directory task on the same root instead of adding a second row", async () => {
     // Both rows pin the SAME checkout, so minting a main beside a dir task
-    // put two rows with the same diff under one project header — one labelled
-    // by branch, one by path (owner report 2026-08-25, `~/i/quill-all`).
+    // puts two rows with the same diff under one project header — one
+    // labelled by branch, one by path.
     const dir = await orch.openDirectoryTask({ dir: repo })
     await orch.createTask({ repo, title: "t" })
     const mains = orch.listTasks().filter((t) => t.kind === "main")
@@ -222,9 +222,9 @@ describe("project admission (state/project-eligibility.ts)", () => {
 
 describe("a project row and a saved-repos entry are the same fact", () => {
   test("ensureMainTask saves the repo, so the sidebar and the picker agree", async () => {
-    // They used to be written by separate paths: a row minted by createTask
-    // was a project you could SEE but not pick. Once closing the last tab
-    // hides such a project, that gap loses it with no way back.
+    // Written by separate paths they diverge: a row minted by createTask is a
+    // project you can SEE but not pick. Once closing the last tab hides such
+    // a project, that gap loses it with no way back.
     expect(getSavedRepos()).not.toContain(repo)
     await orch.ensureMainTask(repo)
     expect(getSavedRepos()).toContain(repo)

--- a/packages/kobe/test/orchestrator/promote-dir-tasks.test.ts
+++ b/packages/kobe/test/orchestrator/promote-dir-tasks.test.ts
@@ -1,11 +1,11 @@
 /**
  * Which `dir` rows deserve to become a project's `main` row.
  *
- * `rove .` has routed a repo root to `ensureMainTask` since 2026-08-31, so
- * nothing new lands mis-shaped. The rows created BEFORE that have no owner:
- * they sit on a git toplevel rendering as a bare path, outside every rule
- * written for `main` — the project ordering, the pin, the fold on a closed
- * last tab. This is the sweep that finds them.
+ * `rove .` routes a repo root to `ensureMainTask`, so nothing new lands
+ * mis-shaped. A `dir` row already on disk has no owner: it sits on a git
+ * toplevel rendering as a bare path, outside every rule written for `main` —
+ * the project ordering, the pin, the fold on a closed last tab. This is the
+ * sweep that finds them.
  *
  * The exclusions are the whole reason this is a function and not a filter
  * inline: each one is a row that LOOKS promotable and must not be.
@@ -63,7 +63,7 @@ describe("promotableDirTasks", () => {
 
   it("promotes only the first of two dir rows on the SAME root", () => {
     // Both would resolve to one main row; the second would be absorbed into a
-    // row that no longer needs it, so it stays a dir row and the user decides.
+    // row that does not need it, so it stays a dir row and the user decides.
     const a = task("a", { repo: "/i/site" })
     const b = task("b", { repo: "/i/site" })
     expect(ids(promotableDirTasks({ tasks: [a, b], isRepoRoot: anyRepo }))).toEqual(["a"])

--- a/packages/kobe/test/orchestrator/set-active-perf.test.ts
+++ b/packages/kobe/test/orchestrator/set-active-perf.test.ts
@@ -3,12 +3,12 @@
  * COUNTS, never wall-clock (docs/HARNESS.md §Performance contracts).
  *
  * `setActiveTask` is the single most frequent user action in this multi-
- * session TUI (every task/focus switch). It used to call
- * `store.update(id, {})` with an EMPTY patch purely to bump `updatedAt` so
- * the sidebar's `recent` sort tracks focus order. That empty patch still
- * ran a full fsync'd read-merge-write (`doSave`: flock + read + merge +
- * `handle.sync()` + rename) on EVERY switch — one fsync'd disk rewrite +
- * one full-list broadcast, all to move a field the DEFAULT sort never reads.
+ * session TUI (every task/focus switch), and all it needs is `updatedAt`
+ * bumped so the sidebar's `recent` sort tracks focus order. Routing that
+ * through `store.update(id, {})` with an EMPTY patch runs a full fsync'd
+ * read-merge-write (`doSave`: flock + read + merge + `handle.sync()` +
+ * rename) on EVERY switch — one fsync'd disk rewrite + one full-list
+ * broadcast, all to move a field the DEFAULT sort never reads.
  *
  * The fix (`store.touchRecency`) bumps `updatedAt` in-cache + notifies
  * listeners (so `recent` still reorders LIVE) but flushes lazily on the next
@@ -103,10 +103,10 @@ describe("setActiveTask focus-switch op budget", () => {
       await orch.setActiveTask(ids[i % 5] ?? null)
     }
 
-    // THE win: the focus path no longer fsyncs a disk rewrite per switch.
+    // THE win: the focus path fsyncs no disk rewrite per switch.
     expect(diskWritesToManifest()).toBe(0)
     // Listeners STILL notified per switch so live `recent` reorders — the
-    // broadcast is not the cost we removed (the fsync'd disk rewrite is).
+    // broadcast is not the cost being avoided (the fsync'd disk rewrite is).
     expect(snapshotPublishes).toBe(10)
 
     // Lazy flush: the accumulated recency bumps ride the NEXT real mutation's

--- a/packages/kobe/test/orchestrator/store-codec-roundtrip.test.ts
+++ b/packages/kobe/test/orchestrator/store-codec-roundtrip.test.ts
@@ -1,5 +1,5 @@
 /**
- * Schema round-trip guard for the tasks.json codec (issue #57).
+ * Schema round-trip guard for the tasks.json codec.
  *
  * `coerceTask` is a hand-written coercer: the WRITE path picks up a new Task
  * field automatically (object spread), but the READ path needs a hand-written

--- a/packages/kobe/test/orchestrator/store-concurrency.test.ts
+++ b/packages/kobe/test/orchestrator/store-concurrency.test.ts
@@ -5,11 +5,11 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest"
 import { type TaskCreateInput, TaskIndexStore } from "../../src/orchestrator/index/store.ts"
 
 /**
- * Multi-process consistency for the task index (fix B). Two kobe instances
- * (TUI + daemon + CLI) write the SAME `~/.rove/tasks.json`. Before the lock +
- * read-merge-write, a save serialized the writer's WHOLE in-memory snapshot,
- * so process B silently clobbered the task process A had just created (lost
- * update). These tests pin the two guarantees the fix adds: interleaved writes
+ * Multi-process consistency for the task index. Two kobe instances (TUI +
+ * daemon + CLI) write the SAME `~/.rove/tasks.json`. Without the lock +
+ * read-merge-write, a save serializes the writer's WHOLE in-memory snapshot,
+ * so process B silently clobbers the task process A just created (lost
+ * update). These tests pin the two guarantees: interleaved writes
  * keep BOTH tasks, and the lock is actually taken on the write path so two
  * processes can't physically race.
  */
@@ -54,7 +54,7 @@ describe("TaskIndexStore multi-process consistency", () => {
 
     // Interleave the two creates. Without the lock + merge, whichever wrote
     // last would persist only its own task (it based the write on its empty
-    // load snapshot). With the fix the loser re-reads, finds the peer's task,
+    // load snapshot). With the merge the loser re-reads, finds the peer's task,
     // and merges its own on top.
     const [taskA, taskB] = await Promise.all([procA.create(input("alpha")), procB.create(input("beta"))])
 
@@ -74,7 +74,7 @@ describe("TaskIndexStore multi-process consistency", () => {
     await procB.load()
     expect(procB.get(task.id)).toBeDefined()
 
-    // A removes it (disk no longer has it). B then writes an UNRELATED create.
+    // A removes it (gone from disk). B then writes an UNRELATED create.
     // B's stale cache still holds the doomed task, but the merge must take the
     // peer's deletion as truth and not write it back.
     await procA.remove(task.id)
@@ -96,8 +96,8 @@ describe("TaskIndexStore multi-process consistency", () => {
 
     // A deletes; B then touches the SAME task without flushing (touchRecency
     // marks dirty but defers the save). At B's next save the task is dirty in
-    // B's memory while gone from disk — the exact issue #47 resurrection
-    // recipe: the merge's dirty branch used to write it back unconditionally.
+    // B's memory while gone from disk — the resurrection recipe: a merge
+    // whose dirty branch writes it back unconditionally.
     // A's on-disk tombstone must beat B's pending edit.
     await procA.remove(task.id)
     procB.touchRecency(task.id)

--- a/packages/kobe/test/orchestrator/store-heal.test.ts
+++ b/packages/kobe/test/orchestrator/store-heal.test.ts
@@ -65,10 +65,10 @@ describe("TaskIndexStore self-heal on load", () => {
 })
 
 /**
- * Vendor coercion on load. The bug it guards: `coerceTask` used to validate
- * the persisted `vendor` against a narrow `claude | codex` literal check, so a
- * `copilot` task — or any user-registered custom engine — silently downgraded
- * to `claude` on every daemon restart. Engines are an OPEN set, so load must
+ * Vendor coercion on load. The bug it guards: validating the persisted
+ * `vendor` against a narrow `claude | codex` literal check silently downgrades
+ * a `copilot` task — or any user-registered custom engine — to `claude` on
+ * every daemon restart. Engines are an OPEN set, so load must
  * preserve any non-empty recorded vendor (built-in OR custom) and only fall
  * back to the default for a truly absent/empty value.
  */

--- a/packages/kobe/test/orchestrator/store-load-edge.test.ts
+++ b/packages/kobe/test/orchestrator/store-load-edge.test.ts
@@ -91,7 +91,7 @@ describe("load() recovery", () => {
   it("corrupt JSON recovers empty with a warning, backing the original bytes up first", async () => {
     // Why the backup matters: the next save read-merge-writes from the empty
     // recovery base and REPLACES the corrupt file — without the copy, the
-    // tasks its bytes still held are gone for good (ported from PR #276).
+    // tasks its bytes still held are gone for good.
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {})
     await primeDir()
     await writeManifest("{ not json !!!")

--- a/packages/kobe/test/orchestrator/store-tmp-collision.test.ts
+++ b/packages/kobe/test/orchestrator/store-tmp-collision.test.ts
@@ -1,14 +1,14 @@
 /**
- * Deterministic reconstruction of the CI flake behind issue #53:
+ * Deterministic reconstruction of the CI flake
  * `ENOENT: rename '.../tasks.json.tmp' -> '.../tasks.json'`.
  *
- * The flake needed two writers inside the critical section at once (the old
- * lockfile could be stolen through its empty-content window) PLUS a shared
- * staging file: writer B renamed `<path>.tmp` away, so writer A's rename hit
- * ENOENT. Stress runs only reproduced it under a full 8-worker suite; this
- * test builds the interleaving by construction instead — it pauses writer A
- * between its tmp write and its rename, force-breaks the lock the way the
- * old steal did, lets writer B complete a save, then resumes A.
+ * The flake needs two writers inside the critical section at once (a lockfile
+ * stealable through an empty-content window) PLUS a shared staging file:
+ * writer B renames `<path>.tmp` away, so writer A's rename hits ENOENT.
+ * Stress runs only reproduce it under a full 8-worker suite; this test builds
+ * the interleaving by construction instead — it pauses writer A between its
+ * tmp write and its rename, force-breaks the lock the way a steal would, lets
+ * writer B complete a save, then resumes A.
  *
  * Own file because it module-mocks `node:fs/promises` to add the pause hook.
  */
@@ -88,15 +88,15 @@ describe("TaskIndexStore staging-file isolation (issue #53)", () => {
     const saveA = storeA.create(input("alpha"))
     await paused // A holds the lock; tmp written; rename pending
 
-    // Force-break the lock exactly the way the old empty-window steal did:
+    // Force-break the lock exactly the way an empty-window steal does:
     // the lockfile vanishes under A, so B's save enters the critical section
     // while A is still inside it.
     await unlink(join(home, ".rove", "tasks.json.lock"))
     await storeB.create(input("beta"))
 
-    // Resume A. With the old SHARED `<path>.tmp`, B's completed save had
-    // renamed the staging file away and this rename threw ENOENT — the CI
-    // flake. With per-save staging names it completes. (B's task is
+    // Resume A. With a SHARED `<path>.tmp`, B's completed save has renamed
+    // the staging file away and this rename throws ENOENT — the CI flake.
+    // With per-save staging names it completes. (B's task is
     // legitimately clobbered here: we broke the mutex on purpose, so
     // last-write-wins on the whole file is the expected data outcome — the
     // invariant under test is only that A's save cannot CRASH.)

--- a/packages/kobe/test/orchestrator/task-deletion.test.ts
+++ b/packages/kobe/test/orchestrator/task-deletion.test.ts
@@ -49,7 +49,7 @@ describe("durable background task deletion", () => {
     expect(orch.getTask(task.id)?.deletion?.phase).toBe("running")
 
     await orch.finishTaskDeletion(task.id)
-    // Design guarantee (issue #29): delete keeps the branch by default —
+    // Design guarantee: delete keeps the branch by default —
     // git is the durable record, the task row is not.
     expect(worktrees.remove).toHaveBeenCalledWith(
       "/wt/task",
@@ -122,9 +122,9 @@ describe("durable background task deletion", () => {
   })
 
   it("a half-completed removal COMPLETES the deletion and reports the leftover directory", async () => {
-    // git deregistered the worktree but could not delete its directory (issue
-    // #89). Parking the task in `error` would be unfixable: git no longer
-    // knows this worktree, so every retry is `fatal: is not a working tree`.
+    // git deregistered the worktree but could not delete its directory.
+    // Parking the task in `error` would be unfixable: git has forgotten this
+    // worktree, so every retry is `fatal: is not a working tree`.
     // The task must go, and the leftover path must reach the sink — it is the
     // only place that directory is ever named again.
     const residues: { taskId: string; path: string; reason: string }[] = []
@@ -173,10 +173,10 @@ describe("durable background task deletion", () => {
   })
 
   it("deleting a dir task never touches its directory, forced or not", async () => {
-    // The scratch-shell teardown used to pass `force: true` on the reasoning
-    // that a scratch row owns no worktree. That is true only while the row is
-    // `kind: "dir"` — and the flag was unconditional, so it stood ready to
-    // authorise a real destructive removal if the row's kind ever changed.
+    // A scratch-shell teardown passing `force: true` reasons that a scratch
+    // row owns no worktree. That is true only while the row is `kind: "dir"`,
+    // and an unconditional flag stands ready to authorise a real destructive
+    // removal if the row's kind ever changes.
     // Both gates already special-case `dir`, which is what makes the flag
     // redundant; this pins that, so dropping it stays safe.
     for (const force of [false, true]) {

--- a/packages/kobe/test/orchestrator/worktree-remove-partial.test.ts
+++ b/packages/kobe/test/orchestrator/worktree-remove-partial.test.ts
@@ -4,9 +4,9 @@
  *
  * Real git, real `chmod -w`: an unwritable directory inside a worktree makes
  * `git worktree remove --force` exit 255 AFTER it has already deregistered the
- * worktree. Reading the exit code as the whole truth reported that as a total
- * failure and left every retry fatal (`is not a working tree`), so a task
- * parked in `deletion.phase = "error"` forever (issue #89).
+ * worktree. Reading the exit code as the whole truth reports that as a total
+ * failure and leaves every retry fatal (`is not a working tree`), parking the
+ * task in `deletion.phase = "error"` forever.
  *
  * These are the only tests that ask GIT what actually happened rather than
  * asserting on a mock's arguments — a stub cannot produce the split.
@@ -97,8 +97,8 @@ describe("remove() when git deregisters but cannot delete", () => {
     const wt = undeletableWorktree("wt-locked", "kobe/locked")
     const seen: WorktreeResidue[] = []
 
-    // Red before the fix: `runGit` threw on exit 255 and the caller saw a
-    // GitCommandError for a removal git had already half-applied.
+    // Treating exit 255 as a plain `runGit` failure hands the caller a
+    // GitCommandError for a removal git has already half-applied.
     await expect(manager.remove(wt, { force: true, onResidue: (r) => seen.push(r) })).resolves.toBeUndefined()
 
     expect(seen).toHaveLength(1)
@@ -124,9 +124,9 @@ describe("remove() when git deregisters but cannot delete", () => {
     await manager.remove(wt, { force: true, onResidue: () => {} })
 
     const second: WorktreeResidue[] = []
-    // Red before the fix AND red if the retry only stops throwing: git can no
-    // longer resolve this path, so without the deregistered-dir probe the call
-    // threw `is not a git worktree` and the caller had no forward move.
+    // Also red if the retry merely stops throwing: git cannot resolve this
+    // path at all, so without the deregistered-dir probe the call answers
+    // `is not a git worktree` and the caller has no forward move.
     await expect(manager.remove(wt, { force: true, onResidue: (r) => second.push(r) })).resolves.toBeUndefined()
     expect(second).toHaveLength(1)
     expect(second[0].path).toBe(wt)

--- a/packages/kobe/test/orchestrator/worktree.test.ts
+++ b/packages/kobe/test/orchestrator/worktree.test.ts
@@ -220,7 +220,7 @@ describe("GitWorktreeManager.remove", () => {
     const metadataDir = path.join(repo, ".git", "worktrees", "task-rt")
     expect(fs.existsSync(metadataDir)).toBe(false)
 
-    // Worktree no longer in `git worktree list`.
+    // Worktree gone from `git worktree list`.
     const list = spawnSync("git", ["worktree", "list", "--porcelain"], { cwd: repo, encoding: "utf8" })
     expect(list.stdout).not.toContain(target)
 

--- a/packages/kobe/test/web/diff.test.ts
+++ b/packages/kobe/test/web/diff.test.ts
@@ -18,9 +18,9 @@ describe("mapPool", () => {
 
   it("runs exactly `limit` workers concurrently, never more (deterministic gate)", async () => {
     // Gate every worker on a manually-released promise instead of a
-    // wall-clock sleep: the old `peak > 1` assertion raced the scheduler
-    // (under load all microtasks could settle serially → peak===1 → flaky
-    // red), exactly the "timing never gates CI" rule in docs/HARNESS.md.
+    // wall-clock sleep. A `peak > 1` assertion races the scheduler (under
+    // load all microtasks can settle serially → peak===1 → flaky red),
+    // exactly the "timing never gates CI" rule in docs/HARNESS.md.
     // Here the concurrency is OBSERVED precisely: after one macrotask the
     // pool has spawned its initial cohort and parked it, so inFlight is
     // exactly `limit` — no race, we only wait for already-queued work.


### PR DESCRIPTION
Comments that explain how the code got here rather than what it does now, removed from `src/engine`, `src/cli`, `src/web`, `src/orchestrator`, `src/client`, `src/worktree`, `src/exec`, `src/*.ts` and `packages/kobe-web/**`, plus the matching tests. Invariants, non-obvious mechanisms and deliberate refusals are kept, rewritten into the present tense. Executable code is untouched.

## Numbers

- **391** worklist lines from the "Done means" grep at the start of this slice → **0** now.
- A second, manual pass over every remaining comment in the touched files caught **~45** more the regex misses ("originally", "the incident", "the fix", "prod 2026-08-13", "the owner's machine", commit SHA `b5e3bfd2a`, …).
- **193** files touched (192 source/test + 1 changeset).

## esbuild proof

`esbuild <file> --format=esm` does **not** strip comments — it preserves them, so the command as written in RULES.md compares comments against comments and can never fail. `--minify-whitespace` does strip them without renaming identifiers, so the proof uses that. The BEFORE copy is written as a *sibling* of the real file, because esbuild resolves `tsconfig.json` from the file's directory and a `/tmp` copy silently gets a different JSX mode (that alone produced 5 phantom diffs on `.tsx`).

**188 / 193 byte-identical.** The other 5 differ by exactly one `describe`/`it` string literal each — the test-name carve-out in RULES.md ("rename only if the string itself is history"). Character-level diff of the comment-stripped output, confirming nothing else moved:

```
api-handlers-more.test.ts    re[-tir-]{+mov+}ed verbs point at their replacement
api-tab-snapshot.test.ts     … does not list — the i[-ssue-#20 i-]nvisible engine
doctor-cmd.test.ts           counts ANY usable engine, not [-just the three that used to be listed-]{+a hardcoded few+}
pty-delivery.test.ts         … instead of spawning[-(issue #19 incident)-]
claude-hook-adapter.test.ts  removeWorktreeWatchHook ([-retired-]PostToolUse observer)
```

No executable code changed in any file.

## Gates

- `bun run lint` (repo root) — clean.
- `bun run typecheck` — clean (plugin-sdk, kobe-daemon, kobe).
- `env -u ROVE_INVOKED_AS bun run test:fast` — 4176 passed, 4 failed. All 4 are the known `~/.rove/worktrees` path-shape artifact (`project-eligibility` classifies the checkout as `roveInternal`), in `test/state/project-eligibility.test.ts` and `test/cli/open-dir-cmd.test.ts` — neither file is in this diff, and a comment-only change with byte-identical compiled output cannot reach them. They pass in CI, which does not run from `~/.rove/worktrees`.
- Coverage measured with `vitest run --coverage --coverage.reportOnFailure` (vitest skips the report on failure by default, which is why a plain `bun run coverage` writes no summary here). Three touched files sit under the 50% floor and were already there.

coverage-exemption: packages/kobe/src/cli/plugin-update.ts — comment-only change, esbuild output identical
coverage-exemption: packages/kobe/src/client/remote-orchestrator-writes.ts — comment-only change, esbuild output identical
coverage-exemption: packages/kobe/src/engine/kimi-local/binary.ts — comment-only change, esbuild output identical

### file-size-cap

Two touched files are over the cap and were **already over on `main`, at exactly the same line count** (comment removal only shrinks). Per RULES.md I name the seam rather than splitting here:

- `src/client/remote-orchestrator.ts` (503, unchanged) — the seam is *reads vs writes*: the class is already a thin facade over `-reads.ts` / `-writes.ts` / `-events.ts` / `-connect.ts`, and what is left is two groups of delegating members. Splitting the facade along that same line is mechanical.
- `test/client/remote-orchestrator.test.ts` (523, unchanged) — the seam is *per-channel*: the file is a sequence of `describe` blocks each owning one push channel (`task.snapshot`, `engine-state`, `task.jobs`, `worktree.changes`, store twins). One file per channel needs no shared fixture beyond `fakeSignals()`.

file-size-exemption: packages/kobe/src/client/remote-orchestrator.ts — comment-only change, line count unchanged from main (503)
file-size-exemption: packages/kobe/test/client/remote-orchestrator.test.ts — comment-only change, line count unchanged from main (523)

## Three hardest judgment calls

**1. Tombstones for deleted functions — deleted, except where they carried a live rule.**
`interactive-command.ts` held three blocks of the form "`withClaudeSessionId` lived here (removed 2026-08-29)…", and `registry.ts` one for `vendorFromTerminalTitle`. These are pure history and went. But the third tombstone ended on a rule that is still binding, so the pointer and the rule survived and the story did not:

> `…moved to ./worktree-protocol.ts (2026-08-30).` / `Two reasons, one move. Both injectors opened with coerceVendorId(vendor) !== "claude" — the third and fourth copies of the ladder the withClaudeSessionId tombstone above describes, so a wrapper preset (claudecpa) got no status protocol…`

→ `…live in ./worktree-protocol.ts, not here. They resolve a launch's protocol through sessionProtocol() in engine-presets.ts, and that module imports THIS one, so resolving a protocol here would close an import cycle.` (the closing "Anything that gates on 'is this launch a claude launch' belongs behind `sessionProtocol()`, never a literal id compare" kept verbatim).

**2. Past-bug narratives that are actually invariants — rewritten conditional, not deleted.**
The temptation is to cut "X broke, so now Y" wholesale, but a lot of it is the only statement of *why the current shape is load-bearing*. `composer-state.ts`:

> `Collapsing it into text is what turned a Claude layout change into a total delivery outage: the prompt glyph moved out of the inspected window, no rule matched, and every message to every Claude task deferred as "composer busy"`

→ `Collapsing it into text turns any engine layout change into a total delivery outage: the prompt glyph moves out of the inspected window, no rule matches, and every message to that engine defers as "composer busy"` — same warning, now true of the code as it stands instead of of one week in August.

**3. `spinner-frames.ts`: history wrapped around a deliberate refusal.**
The module doc was mostly "per-engine brand frames were a registry field… both were removed 2026-08-15", which reads as pure archaeology — but deleting it removes the only reason nobody re-adds the field. The measured font fact is the rule:

> `Per-engine brand frames were a registry field (spinnerFrames) with exactly one implementation… Both were removed 2026-08-15 — on a font without the dingbat block (FiraCode Nerd Font, one of the owner's daily faces) macOS falls each frame back to ZapfDingbats at a DIFFERENT advance per glyph… Re-introducing a brand set means re-introducing that field.`

→ `There is no per-engine brand frame set, and adding one means adding a registry field for it. On a font without the dingbat block (FiraCode Nerd Font) macOS falls Claude Code's ·→✢→✱→✶→✻→✽ oscillation back to ZapfDingbats at a DIFFERENT advance per glyph (1.11 / 1.13 / 1.15 / 1.21 / 1.28 cells), so a running row jitters at 10Hz… Measure a candidate's per-frame advance in the fonts people run before introducing one — equal advance across frames is the bar, not "the vendor uses it".`

## One thing I deliberately did not do

~30 `it(...)` / `describe(...)` strings in this slice still carry bare issue tags — `"(issue #25)"`, `"(issue #58)"`, `"the issue-#5 bug"`, and one `describe("a git repo ROOT opens as the project (owner call 2026-08-31)")` in `test/cli/open-dir-cmd.test.ts`. RULES.md says to rename a test string "only if the string itself is history; otherwise leave", and every rename costs the byte-identity proof, so I renamed only the five where the string states a *past behaviour* and left the tracker tags alone. The `(owner call 2026-08-31)` one is the clearest candidate for a follow-up sweep if you want the tags gone too — it is a date, not a tag.
