### PR TITLE
fix: request kitty reportText so IME commits carry their characters

### DIFF
--- a/.changeset/kitty-report-text.md
+++ b/.changeset/kitty-report-text.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Chinese, Japanese and Korean input works again in kitty-protocol terminals (iTerm2 3.5+, kitty, Ghostty, WezTerm). 0.9.8x requested the protocol's "report all keys as escape codes" flag for the ctrl-hold guide, which makes the terminal encode an input-method commit as a text event whose characters travel only under the "report associated text" flag; that flag is now requested too.

--- a/packages/kobe/src/tui/lib/host-render-options.ts
+++ b/packages/kobe/src/tui/lib/host-render-options.ts
@@ -13,13 +13,23 @@
  * spread in only when present so a host without teardown passes the exact
  * same shape as before.
  */
+/**
+ * Kitty keyboard protocol flags. `events` + `allKeysAsEscapes` are what let a
+ * kitty-protocol terminal report bare modifier press/release (the ctrl-hold
+ * shortcut guide). `allKeysAsEscapes` also makes the terminal encode IME
+ * commits as a `CSI 0 u` text event whose characters live ONLY in the third
+ * field, and that field is sent only under `reportText` — without it every
+ * Chinese/Japanese/Korean input arrives as an empty key and is dropped.
+ */
+const KITTY_KEYBOARD = { events: true, allKeysAsEscapes: true, reportText: true } as const
+
 export function hostRenderOptions(onDestroy?: () => void): Record<string, unknown> {
   const base = {
     backgroundColor: "transparent",
     externalOutputMode: "passthrough",
     exitOnCtrlC: false,
     screenMode: "alternate-screen",
-    useKittyKeyboard: { events: true, allKeysAsEscapes: true },
+    useKittyKeyboard: KITTY_KEYBOARD,
   }
   return onDestroy ? { ...base, onDestroy } : base
 }
@@ -41,7 +51,7 @@ export function inlineRenderOptions(heightRows: number, onDestroy?: () => void):
     exitOnCtrlC: false,
     screenMode: "split-footer",
     footerHeight: heightRows,
-    useKittyKeyboard: { events: true, allKeysAsEscapes: true },
+    useKittyKeyboard: KITTY_KEYBOARD,
   }
   return onDestroy ? { ...base, onDestroy } : base
 }

--- a/packages/kobe/test/tui/host-render-options.test.ts
+++ b/packages/kobe/test/tui/host-render-options.test.ts
@@ -38,7 +38,7 @@ describe("hostRenderOptions", () => {
 
   it("requests kitty press, repeat, release, and all-keys-as-escapes reporting", () => {
     expect(hostRenderOptions()).toMatchObject({
-      useKittyKeyboard: { events: true, allKeysAsEscapes: true },
+      useKittyKeyboard: { events: true, allKeysAsEscapes: true, reportText: true },
     })
   })
 })

--- a/packages/kobe/test/tui/terminal-keys-pure.test.ts
+++ b/packages/kobe/test/tui/terminal-keys-pure.test.ts
@@ -89,6 +89,25 @@ describe("keyEventToShellBytes", () => {
     expect(keyEventToShellBytes(evt({ name: "c", ctrl: true, sequence: "\x03", raw: "\x03" } as never))).toBe("\x03")
   })
 
+  it("forwards a kitty IME text event (CSI 0 u with reportText) as the committed characters", () => {
+    // allKeysAsEscapes makes a terminal encode an input-method commit as
+    // codepoint 0 with the text in the third field. Without reportText that
+    // field is absent and the event carries nothing to type.
+    const committed = {
+      name: "中文",
+      sequence: "中文",
+      raw: "\x1b[0;1;20013:25991u",
+      source: "kitty",
+      ctrl: false,
+      meta: false,
+      shift: false,
+      option: false,
+    } as unknown as KeyEvent
+    expect(keyEventToShellBytes(committed)).toBe("中文")
+    const empty = { name: "", sequence: "\x1b[0u", raw: "\x1b[0u", source: "kitty" } as unknown as KeyEvent
+    expect(keyEventToShellBytes(empty)).toBeNull()
+  })
+
   it("re-encodes printable keys when kitty sends every key as CSI-u", () => {
     expect(keyEventToShellBytes(evt({ name: "a", sequence: "a", raw: "\x1b[97u" } as never))).toBe("a")
     expect(keyEventToShellBytes(evt({ name: "1", sequence: "1", raw: "\x1b[49u" } as never))).toBe("1")


### PR DESCRIPTION
Owner report 2026-09-02: Chinese input stopped working on another machine on the latest release.

**Root cause:** #743 changed `useKittyKeyboard` from `{}` to `{ events, allKeysAsEscapes }` (kitty flags 5 → 15) for the ctrl-hold guide. Under `allKeysAsEscapes` a kitty-protocol terminal (iTerm2 3.5+, kitty, Ghostty, WezTerm) encodes an IME commit as a text event: `CSI 0 u` with the characters in the third field. That field is only sent when `reportText` (flag 16) is also requested. Without it opentui parses `\x1b[0u` to `name="" sequence="\x1b[0u"` and `keyEventToShellBytes` returns null, so every CJK commit was dropped. Terminals without the protocol (Terminal.app, tmux) never negotiated it and were unaffected, which is why it only showed on the other machine.

Probe through opentui 0.4.3's real parser:
```
CSI 0 u             (flag 8 only)  → name="" seq="\x1b[0u"  shell=null      ← dropped
CSI 0;1;20013 u     (flag 8+16)    → name="中" seq="中"      shell="中"
CSI 0;1;20013:25991 u              → name="中文"               shell="中文"
CSI 122;;122 u  / CSI 122:90;2;90 u → z / Z                                   (ASCII unchanged)
```

**Change:** request `reportText: true` as well (flags 15 → 31), hoisted into one documented constant used by both render-option builders. Test pins the flag set and the IME text-event pass-through.

Not screenshot-able: the harness runs xterm.js, which does not speak the kitty protocol, so the bug cannot be reproduced there; the evidence is the parser probe above.