### PR TITLE
fix: stop requesting kitty allKeysAsEscapes; it crashes iTerm2 on IME input

### DIFF
--- a/.changeset/revert-kitty-all-keys.md
+++ b/.changeset/revert-kitty-all-keys.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Rove no longer asks the terminal for the kitty keyboard protocol's "report all keys as escape codes" mode. 0.9.87 and 0.9.88 requested it for the ctrl-hold shortcut guide, and on iTerm2 3.5 typing with a Chinese input method then crashed the whole terminal app. Keyboard handling is back to what it was before 0.9.87; the ctrl-hold guide does not appear until a terminal can report bare modifier keys without that mode.

--- a/packages/kobe/src/tui/lib/host-render-options.ts
+++ b/packages/kobe/src/tui/lib/host-render-options.ts
@@ -14,14 +14,15 @@
  * same shape as before.
  */
 /**
- * Kitty keyboard protocol flags. `events` + `allKeysAsEscapes` are what let a
- * kitty-protocol terminal report bare modifier press/release (the ctrl-hold
- * shortcut guide). `allKeysAsEscapes` also makes the terminal encode IME
- * commits as a `CSI 0 u` text event whose characters live ONLY in the third
- * field, and that field is sent only under `reportText` — without it every
- * Chinese/Japanese/Korean input arrives as an empty key and is dropped.
+ * Kitty keyboard protocol flags: opentui's defaults only (disambiguate +
+ * alternate keys). `allKeysAsEscapes` is deliberately NOT requested: under it
+ * a terminal encodes input-method commits as `CSI 0 u` text events, and
+ * iTerm2 3.5.x crashes on that path (owner report: typing Chinese quit the
+ * whole app). The ctrl-hold shortcut guide, which wanted bare modifier
+ * press/release, degrades to "never shows" on every terminal, the same way
+ * it already did on Terminal.app and inside tmux.
  */
-const KITTY_KEYBOARD = { events: true, allKeysAsEscapes: true, reportText: true } as const
+const KITTY_KEYBOARD = {} as const
 
 export function hostRenderOptions(onDestroy?: () => void): Record<string, unknown> {
   const base = {

--- a/packages/kobe/test/tui/host-render-options.test.ts
+++ b/packages/kobe/test/tui/host-render-options.test.ts
@@ -38,7 +38,7 @@ describe("hostRenderOptions", () => {
 
   it("requests kitty press, repeat, release, and all-keys-as-escapes reporting", () => {
     expect(hostRenderOptions()).toMatchObject({
-      useKittyKeyboard: { events: true, allKeysAsEscapes: true, reportText: true },
+      useKittyKeyboard: {},
     })
   })
 })


### PR DESCRIPTION
Owner report 2026-09-02: on another machine running the latest release, typing Chinese in iTerm2 crashes iTerm2 itself. It did not before 0.9.87.

#743 changed `useKittyKeyboard` from `{}` to `{ events, allKeysAsEscapes }` so the ctrl-hold guide could see bare modifier press/release. Under `allKeysAsEscapes` a kitty-protocol terminal must encode an IME commit as a `CSI 0 u` text event; iTerm2 3.5's implementation of that path (already known to mis-encode associated text, gitlab #12177) takes the whole app down. #807 added `reportText` on top, which fixes the *dropped characters* symptom on correct implementations but does nothing for a terminal that crashes before sending anything.

**Change:** back to `useKittyKeyboard: {}` (opentui defaults: disambiguate + alternate keys), the flag set every release through 0.9.86 ran with. The constant and its comment stay so the next person who wants flag 8 reads why it is off.

**What degrades:** the ctrl-hold guide never appears (it needs bare modifier events). That was already its behaviour on Terminal.app and inside tmux. Everything else in #743 (ctrl-hold state machine, kitty CSI-u re-encoding, modifier-key filtering) is untouched and still tested.

Tests: `host-render-options` pins `{}`; keys-pure / ctrl-hold / keymap-dispatch / render kitty-input-paths all green. No screenshot: the harness is xterm.js and cannot negotiate the protocol.