### PR TITLE
One batch of eight small owner-decided items (seven landed)

### DIFF
--- a/.changeset/eight-small-owner-approved.md
+++ b/.changeset/eight-small-owner-approved.md
@@ -1,0 +1,12 @@
+---
+"@sma1lboy/rove": patch
+---
+
+A batch of small owner-decided changes.
+
+- **The Files pane watches the worktree again.** The watcher had been behind `KOBE_FILETREE_WATCH=1` since the freeze it guarded against was fixed by moving git scans and preview reads off the event loop, and nothing had set that variable since the tmux Ops pane was removed — so the pane only ever repopulated on `r`. It now watches by default; `KOBE_FILETREE_WATCH=0` turns it off on a repo where a recursive watcher costs more than the staleness.
+- **`ctrl+a` `p` follows the sidebar cursor.** With the sidebar focused, Create PR now acts on the highlighted row instead of always on the active task, entering that row to deliver the prompt — the rule `ctrl+a` `o` already followed.
+- **Land is reachable from a task row.** The sidebar row menu gains "Land into base branch", running the same merge, confirm and cleanup toasts as the Worktrees page's `l`. Withheld from project-main, directory and never-entered rows, where landing has no branch to act on.
+- **A wrapper preset learns its protocol once.** When the process walk finds a built-in engine behind one of your registered custom engines, Rove records `engineProtocol.<id>` for the preset rather than re-sniffing on every task, so history, workspace-trust pre-answer and conversation forking start working for the next task too. A protocol you declared yourself is never overwritten.
+
+Internal: one repo-key derivation behind the issues and notes stores, the web Issue types read from the daemon instead of two hand-copies, a round-trip guard for the Issue field allowlist, and test names that say what they assert.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -89,6 +89,11 @@ Rove tries the `code`, `cursor`, `windsurf`, and `zed` CLIs in that order,
 then the platform opener. These variables do not change the file tree's
 per-file TTY editor.
 
+The Files pane watches the worktree so edits appear without a keypress. Set
+`KOBE_FILETREE_WATCH=0` to turn that watcher off — worth doing on a repo large
+enough that a recursive watcher costs more than the staleness it removes. With
+it off, `r` is the only thing that repopulates the list.
+
 ### Engines
 
 | Key | Type | Default | What it does |

--- a/docs/ENGINES.md
+++ b/docs/ENGINES.md
@@ -240,6 +240,13 @@ The protocol is **derived** from the command, never declared beside it:
    deliberately conservative: ambiguous or absent evidence leaves the task
    generic, and a task whose protocol is already known is never flipped.
 
+   When that engine tab was launched from one of *your* registered presets
+   and the walk found a built-in's process in it, Rove also writes
+   `engineProtocol.<id>` for the preset itself, so the next task on it starts
+   named instead of sniffing again. Only the process walk mints that key — a
+   title glyph names one session, and this outlives every session on the
+   preset — and a protocol you declared is never overwritten.
+
 `rove api engine-list` prints every entry with its raw command and resolved
 protocol; copy one into `rove api add --command` verbatim, or edit a flag
 first. See [API.md](./API.md) for the dispatch verbs.

--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -55,7 +55,7 @@ shows only actions that can run right now.
 | `ctrl+a` `1` / `2` / `3` | Kanban / Routines / Issues |
 | `ctrl+a` `z` | Toggle zen mode |
 | `ctrl+a` `,` | Open Settings |
-| `ctrl+a` `p` / `P` | Create a PR from the active task |
+| `ctrl+a` `p` / `P` | Create a PR from the active task, or from the sidebar row under the cursor |
 
 `ctrl+a` `c` picks an engine first. Claude and Codex can fork their own
 conversations natively. Copilot and Kimi use a transcript handoff even for a

--- a/docs/TUI.md
+++ b/docs/TUI.md
@@ -199,8 +199,10 @@ engine without submitting it, and `o` sends audio, video, or PDF files to the
 system application. Remote files cannot use a local system viewer.
 
 The pane watches local worktrees for changes and also supports `r` for an
-explicit refresh. See [Keybindings](KEYBINDINGS.md#sidebar-and-files) for the
-complete navigation table.
+explicit refresh. Set `KOBE_FILETREE_WATCH=0` to turn the watcher off and leave
+`r` as the only way to repopulate the list. See
+[Keybindings](KEYBINDINGS.md#sidebar-and-files) for the complete navigation
+table.
 
 ## Create a pull request with the active agent
 

--- a/docs/design/keybinding-decisions.md
+++ b/docs/design/keybinding-decisions.md
@@ -398,6 +398,37 @@ gesture one pane over.
 not a second chord for one action; it is the existing chord staying
 answerable in the one state where its usual owner is unmounted.
 
+## `ctrl+a` `p` follows the sidebar cursor; landing stays menu-only
+
+Owner call, 2026-09-02.
+
+`files.createPR` was global-scope and always acted on the ACTIVE task, so
+the only way to open a PR for a task you were looking at in the sidebar was
+to enter it first. It now reads the highlighted row while the sidebar has
+focus — the same rule `task.openEditor` (`ctrl+a` `o`) already follows, so
+the two row-scoped prefix verbs behave alike rather than each having its own
+answer to "which task did you mean?".
+
+Aiming at another row has to ENTER it. The PR prompt is delivered through
+the send closure the mounted `TerminalTabs` hands up, so there is no engine
+to reach in a task whose workspace is not mounted. The chord therefore parks
+the request (`workspace/use-create-pr.ts`) and activates the row; the target
+task's next mount claims it. A task switch the user did not ask for is the
+cost, and it is the honest one: the alternative is a chord that silently
+does nothing on three quarters of the rows.
+
+`shift+p` still rides along as an alias of `p` — unchanged, and not part of
+this decision.
+
+**Landing got NO chord.** "Land into base branch" is a sidebar row-menu
+entry that calls the same `orch.landTask` and confirm dialog as the
+Worktrees page's `l`. Landing is rare, irreversible from the row's point of
+view (the worktree goes with it), and every letter near `p` is either taken
+or too easy to fat-finger into a merge. Menu-only is the same sequencing
+answer `setStatus` and the two copies got: the capability exists now, and a
+chord can be added later if reaching for the mouse turns out to be the
+friction rather than the safety.
+
 ## Adding or moving a chord
 
 Get owner sign-off on direct versus prefix placement, the selected key, and

--- a/packages/kobe-daemon/src/daemon/issues-store.ts
+++ b/packages/kobe-daemon/src/daemon/issues-store.ts
@@ -1,10 +1,11 @@
 import { execFile } from "node:child_process"
-import { readFile, realpath, stat } from "node:fs/promises"
+import { readFile, stat } from "node:fs/promises"
 import { homedir } from "node:os"
-import { isAbsolute, join, resolve } from "node:path"
+import { join, resolve } from "node:path"
 import { promisify } from "node:util"
 import { ROVE_STATE_DIR_BASENAME, readRoveEnv } from "../compat-env.ts"
 import { writeJsonAtomic } from "./json-file.ts"
+import { gitCommonDir, gitMainWorktree } from "./repo-key.ts"
 
 const execFileAsync = promisify(execFile)
 
@@ -91,25 +92,9 @@ function todayStamp(): string {
   return `${d.getFullYear()}-${mm}-${dd}`
 }
 
-async function gitCommonDir(path: string): Promise<string> {
-  const { stdout } = await execFileAsync("git", ["-C", path, "rev-parse", "--git-common-dir"])
-  const dir = stdout.trim()
-  return realpath(isAbsolute(dir) ? dir : resolve(path, dir))
-}
-
 async function gitTopLevel(path: string): Promise<string> {
   const { stdout } = await execFileAsync("git", ["-C", path, "rev-parse", "--show-toplevel"])
   return stdout.trim()
-}
-
-async function gitMainWorktree(path: string): Promise<string> {
-  const { stdout } = await execFileAsync("git", ["-C", path, "worktree", "list", "--porcelain"])
-  const first = stdout
-    .split(/\r?\n/)
-    .find((line) => line.startsWith("worktree "))
-    ?.slice("worktree ".length)
-    .trim()
-  return first ? realpath(first) : gitTopLevel(path)
 }
 
 async function resolveRepo(raw: unknown): Promise<{ repoRoot: string; repoKey: string }> {
@@ -118,8 +103,10 @@ async function resolveRepo(raw: unknown): Promise<{ repoRoot: string; repoKey: s
   const s = await stat(absolute).catch(() => null)
   if (!s?.isDirectory()) throw new Error("repoRoot does not exist")
   try {
-    const [repoRoot, repoKey] = await Promise.all([gitMainWorktree(absolute), gitCommonDir(absolute)])
-    return { repoRoot, repoKey }
+    const [main, repoKey] = await Promise.all([gitMainWorktree(absolute), gitCommonDir(absolute)])
+    // No worktree line at all still has a readable root: fall back to the
+    // toplevel rather than refuse the repo.
+    return { repoRoot: main ?? (await gitTopLevel(absolute)), repoKey }
   } catch (err) {
     if (isGitNotRepositoryError(err)) throw new Error("repoRoot is not a git repository")
     throw err

--- a/packages/kobe-daemon/src/daemon/notes-store.ts
+++ b/packages/kobe-daemon/src/daemon/notes-store.ts
@@ -13,15 +13,12 @@
  * genuinely outgrow it wants tagging and retrieval, not a bigger number.
  */
 
-import { execFile } from "node:child_process"
-import { readFile, realpath, stat } from "node:fs/promises"
+import { readFile, stat } from "node:fs/promises"
 import { homedir } from "node:os"
-import { isAbsolute, join, resolve } from "node:path"
-import { promisify } from "node:util"
+import { join, resolve } from "node:path"
 import { ROVE_STATE_DIR_BASENAME, readRoveEnv } from "../compat-env.ts"
 import { writeJsonAtomic } from "./json-file.ts"
-
-const execFileAsync = promisify(execFile)
+import { gitCommonDir, gitMainWorktree } from "./repo-key.ts"
 
 /** Newest-N kept per repo. Older notes are dropped on write. */
 export const NOTES_RETENTION_CAP = 50
@@ -63,29 +60,13 @@ function normalizeNote(entry: unknown): FieldNote | null {
   }
 }
 
-async function gitCommonDir(path: string): Promise<string> {
-  const { stdout } = await execFileAsync("git", ["-C", path, "rev-parse", "--git-common-dir"])
-  const dir = stdout.trim()
-  return realpath(isAbsolute(dir) ? dir : resolve(path, dir))
-}
-
-async function gitMainWorktree(path: string): Promise<string> {
-  const { stdout } = await execFileAsync("git", ["-C", path, "worktree", "list", "--porcelain"])
-  const first = stdout
-    .split(/\r?\n/)
-    .find((line) => line.startsWith("worktree "))
-    ?.slice("worktree ".length)
-    .trim()
-  if (!first) throw new Error("repoRoot is not a git repository")
-  return realpath(first)
-}
-
 async function resolveRepo(raw: string): Promise<{ repoRoot: string; repoKey: string }> {
   const absolute = resolve(raw)
   const s = await stat(absolute).catch(() => null)
   if (!s?.isDirectory()) throw new Error("repoRoot does not exist")
-  const [repoRoot, repoKey] = await Promise.all([gitMainWorktree(absolute), gitCommonDir(absolute)])
-  return { repoRoot, repoKey }
+  const [main, repoKey] = await Promise.all([gitMainWorktree(absolute), gitCommonDir(absolute)])
+  if (!main) throw new Error("repoRoot is not a git repository")
+  return { repoRoot: main, repoKey }
 }
 
 async function readStore(path: string): Promise<NotesStoreFile> {

--- a/packages/kobe-daemon/src/daemon/repo-key.ts
+++ b/packages/kobe-daemon/src/daemon/repo-key.ts
@@ -1,0 +1,42 @@
+/**
+ * How a repo path becomes the two identities the per-repo daemon stores need.
+ *
+ * Both stores key their records by the git COMMON dir, so every linked
+ * worktree of one repository reads and writes the same record — that is what
+ * makes an issue filed from a task's worktree visible from the main checkout.
+ * The main worktree's path is the human-readable `repoRoot` shown alongside it.
+ *
+ * Shared because the issues and notes stores each grew a private copy that
+ * then drifted (one fell back to `--show-toplevel` when `worktree list`
+ * answered nothing, the other threw). The derivation is the same question;
+ * the ANSWER to "no worktree line" is a per-store policy, so this returns
+ * null and each store's own `resolveRepo` keeps deciding.
+ */
+
+import { execFile } from "node:child_process"
+import { realpath } from "node:fs/promises"
+import { isAbsolute, resolve } from "node:path"
+import { promisify } from "node:util"
+
+const execFileAsync = promisify(execFile)
+
+/** The repository's shared git dir, resolved absolute — the record key. */
+export async function gitCommonDir(path: string): Promise<string> {
+  const { stdout } = await execFileAsync("git", ["-C", path, "rev-parse", "--git-common-dir"])
+  const dir = stdout.trim()
+  return realpath(isAbsolute(dir) ? dir : resolve(path, dir))
+}
+
+/**
+ * The repository's MAIN worktree path, or null when `git worktree list`
+ * printed no worktree line at all (the caller decides what that means).
+ */
+export async function gitMainWorktree(path: string): Promise<string | null> {
+  const { stdout } = await execFileAsync("git", ["-C", path, "worktree", "list", "--porcelain"])
+  const first = stdout
+    .split(/\r?\n/)
+    .find((line) => line.startsWith("worktree "))
+    ?.slice("worktree ".length)
+    .trim()
+  return first ? await realpath(first) : null
+}

--- a/packages/kobe-web/src/lib/board.ts
+++ b/packages/kobe-web/src/lib/board.ts
@@ -13,8 +13,8 @@
  * affordance) but the task itself is NOT a card here (docs/design/web-kanban.md).
  */
 
+import type { Issue, RepoIssues } from "./issues.ts"
 import { textMatchesQuery } from "./text-match.ts"
-import type { Issue, RepoIssues } from "./types.ts"
 
 /**
  * One card on the board: always an issue, carrying its source `repo` so
@@ -89,7 +89,9 @@ export function issueColumnKey(issue: Issue): string {
   return "backlog"
 }
 
-/** True when an issue is linked to a task — drives the "open task" affordance. */
+/** True when an issue is linked to a task — drives the "open task" affordance,
+ *  and a LIVE task here hides the issue from the unified board (the task card
+ *  represents it). */
 export function isLinkedIssue(issue: Issue): boolean {
   return issue.taskId !== undefined && issue.taskId !== ""
 }

--- a/packages/kobe-web/src/lib/issues.ts
+++ b/packages/kobe-web/src/lib/issues.ts
@@ -6,6 +6,11 @@
  */
 
 import { ROVE_PRODUCT_NAME } from "@sma1lboy/kobe-daemon/compat-env"
+import type {
+  Issue,
+  IssueStatus,
+  RepoIssues,
+} from "@sma1lboy/kobe-daemon/daemon/issues-store"
 // One implementation of the story prompts, shared with the TUI
 // (`kobe/src/state/issue-chat.ts`). The copies these two files kept by hand
 // had already drifted apart.
@@ -37,26 +42,14 @@ async function fetchKobeApiInvocation(): Promise<string> {
     : DEFAULT_CLI_API
 }
 
-export type IssueStatus = "open" | "doing" | "hold" | "done"
-
-export interface Issue {
-  id: number
-  title: string
-  status: IssueStatus
-  created: string
-  body: string
-  /** Task this issue was quick-started into — kept in sync with the web
-   *  Task interface (lib/types.ts). A live task here hides the issue from the
-   *  unified board. */
-  taskId?: string
-}
-
-export interface RepoIssues {
-  repoRoot: string
-  exists: boolean
-  nextId: number
-  issues: Issue[]
-}
+/** The daemon's own issue shape, re-exported so the web keeps importing
+ *  these from `lib/issues.ts`. They used to be hand-copied here and in
+ *  `lib/types.ts`, which is two places for a field the daemon adds. */
+export type {
+  Issue,
+  IssueStatus,
+  RepoIssues,
+} from "@sma1lboy/kobe-daemon/daemon/issues-store"
 
 export async function fetchProjects(): Promise<string[]> {
   const data = await api.get<{ projects?: unknown }>("/api/projects", {
@@ -336,7 +329,11 @@ export async function quickStartIssue(
   setActiveTaskBestEffort(taskId)
   const api = await fetchKobeApiInvocation().catch(() => DEFAULT_CLI_API)
   const tabId = ensureEngineTab(taskId)
-  await sendPtyText(tabId, taskId, issueWorktreePrompt(issue, api, displayProductName()))
+  await sendPtyText(
+    tabId,
+    taskId,
+    issueWorktreePrompt(issue, api, displayProductName()),
+  )
   return { taskId }
 }
 
@@ -412,7 +409,11 @@ export async function startIssueChat(
     )
     setActiveTaskBestEffort(mainId)
     const tabId = addTab(mainId, taskId)
-    await sendPtyText(tabId, taskId, issueWorktreePrompt(issue, api, displayProductName()))
+    await sendPtyText(
+      tabId,
+      taskId,
+      issueWorktreePrompt(issue, api, displayProductName()),
+    )
     return { taskId, workspaceTaskId: mainId }
   }
   // `project` — no worktree, no task link: the engine runs on the checkout.

--- a/packages/kobe-web/src/lib/types.ts
+++ b/packages/kobe-web/src/lib/types.ts
@@ -3,7 +3,20 @@
  * imported from the kobe package) so no server code leaks into the client
  * bundle — these must stay in sync with
  * packages/kobe-daemon/src/daemon/protocol.ts (SerializedTask + ChannelPayloads).
+ *
+ * The issue types are the exception: the daemon publishes them structurally
+ * unchanged over `issue.snapshot`, so this re-exports the store's own
+ * declaration instead of mirroring it (`lib/issues.ts` is the other door to
+ * the same type).
  */
+
+import type { RepoIssues } from "@sma1lboy/kobe-daemon/daemon/issues-store"
+
+export type {
+  Issue,
+  IssueStatus,
+  RepoIssues,
+} from "@sma1lboy/kobe-daemon/daemon/issues-store"
 
 export type TaskKind = "main" | "task" | "dir"
 export type TaskStatus = string
@@ -51,31 +64,6 @@ export interface Task {
   }
   createdAt: string
   updatedAt: string
-}
-
-export type IssueStatus = "open" | "doing" | "hold" | "done"
-
-/** One daemon-owned issue (mirror of the daemon issue store record). The web
- *  Issues page reads/edits these via /api/issues; quick-start spawns a task
- *  and stamps `taskId`. */
-export interface Issue {
-  id: number
-  title: string
-  status: IssueStatus
-  created: string
-  body: string
-  /** Task this issue was quick-started into (link) — a LIVE task here hides
-   *  the issue from the unified board (the task card represents it). */
-  taskId?: string
-}
-
-/** One repo's full issue state — the unit the daemon publishes per
- *  `issue.snapshot` and the bridge returns from /api/issues. */
-export interface RepoIssues {
-  repoRoot: string
-  exists: boolean
-  nextId: number
-  issues: Issue[]
 }
 
 /** Transient engine activity (what the agent is doing right now). */

--- a/packages/kobe-web/test/board.test.ts
+++ b/packages/kobe-web/test/board.test.ts
@@ -22,7 +22,7 @@ import {
   setBoardQuery,
   setBoardRepo,
 } from "../src/lib/board-state.ts"
-import type { Issue, RepoIssues } from "../src/lib/types.ts"
+import type { Issue, RepoIssues } from "../src/lib/issues.ts"
 
 /**
  * Issues-only kanban column math. The load-bearing rules: the board renders

--- a/packages/kobe/src/core/daemon-runtime.ts
+++ b/packages/kobe/src/core/daemon-runtime.ts
@@ -2,10 +2,11 @@
 
 import type { DaemonRuntimeAdapter } from "@sma1lboy/kobe-daemon/daemon/runtime"
 import { availableEngineIds } from "../engine/account-detect.ts"
+import { engineProtocolKey } from "../engine/engine-presets.ts"
 import { foregroundEngineIn, parsePsSnapshot, psSnapshot } from "../engine/foreground.ts"
 import { affectsActivityState, isEngineActivityKind } from "../engine/hook-events.ts"
 import { engineDisplayName, kobeApiInvocation } from "../engine/interactive-command.ts"
-import { protocolUpgradeFromLiveSession } from "../engine/protocol-sniff.ts"
+import { protocolUpgradeFromLiveSession, protocolWriteBackFromLiveSession } from "../engine/protocol-sniff.ts"
 import { engineEntry, engineTitleTurnHint, vendorsWithQuotaProbe } from "../engine/registry.ts"
 import { createEngineTurnDetector } from "../engine/turn-detector.ts"
 import { issueAssetsDir } from "../env.ts"
@@ -17,7 +18,7 @@ import { GH_PR_VIEW_FIELDS, classifyGhFailure, mapGhPrView, nextPrPoll, samePrSt
 import { maybeAutoStart } from "../monitor/status-rules.ts"
 import { type Orchestrator, PLACEHOLDER_TASK_TITLE } from "../orchestrator/core.ts"
 import { composerGateEnabled } from "../state/composer-gate.ts"
-import { getPersistedString, getSavedRepos, setPersistedString } from "../state/repos.ts"
+import { getCustomEngineIds, getPersistedString, getSavedRepos, setPersistedString } from "../state/repos.ts"
 import { parsePorcelain } from "../tui/panes/sidebar/worktree-changes.ts"
 import { DEFAULT_TASK_VENDOR, isTaskStatus } from "../types/task.ts"
 import type { VendorId } from "../types/vendor.ts"
@@ -43,6 +44,27 @@ import {
   removeWorktreeAdapter,
 } from "./daemon-worktree-adapter.ts"
 
+/**
+ * The observer's protocol hook, doing tier (b)'s two jobs in one pass: name
+ * THIS task's record (returned to the daemon, which writes it via
+ * `setCommand`) and — separately — learn the custom PRESET's protocol, so the
+ * next task launched on that preset starts named instead of re-sniffing.
+ *
+ * Both rules live in `protocol-sniff.ts`; the preset write is here because it
+ * is the only half that touches state.json, and it is a write rather than a
+ * return value because the daemon's `resolveProtocolUpgrade` contract is
+ * about one task's record. Idempotent — the key it writes is what makes the
+ * next call refuse — so no dedupe is needed around it.
+ */
+function resolveProtocolUpgradeAndLearnPreset(
+  task: { readonly vendor?: string; readonly command?: string },
+  evidence: { readonly walkVendor: VendorId | null; readonly title: string },
+): { command: string; vendor: VendorId } | null {
+  const preset = protocolWriteBackFromLiveSession(task, evidence, getCustomEngineIds())
+  if (preset) setPersistedString(engineProtocolKey(preset.id), preset.protocol)
+  return protocolUpgradeFromLiveSession(task, evidence)
+}
+
 export const daemonRuntime: DaemonRuntimeAdapter = {
   currentVersion: CURRENT_VERSION,
   defaultTaskVendor: DEFAULT_TASK_VENDOR,
@@ -63,8 +85,9 @@ export const daemonRuntime: DaemonRuntimeAdapter = {
   },
   titleTurnHint: engineTitleTurnHint,
   // Tier-(b) protocol sniff: the record upgrade for a generic
-  // task identified by its live session — rules live with the sniffer.
-  resolveProtocolUpgrade: protocolUpgradeFromLiveSession,
+  // task identified by its live session, plus the preset write-back —
+  // rules live with the sniffer.
+  resolveProtocolUpgrade: resolveProtocolUpgradeAndLearnPreset,
   // Per-turn telemetry — delegated straight to the vendor's own
   // adapter; an engine without a turn reader simply reports none.
   readEngineTurns: async (vendor, transcriptPath) => (await engineEntry(vendor).readTurns?.(transcriptPath)) ?? [],

--- a/packages/kobe/src/engine/protocol-sniff.ts
+++ b/packages/kobe/src/engine/protocol-sniff.ts
@@ -41,7 +41,7 @@
  */
 
 import { BUILTIN_VENDORS, type VendorId, isBuiltinVendor } from "@/types/vendor"
-import { GENERIC_PROTOCOL, resolveCommandProtocol } from "./engine-presets.ts"
+import { GENERIC_PROTOCOL, getEngineProtocol, resolveCommandProtocol } from "./engine-presets.ts"
 import { engineEntry } from "./registry.ts"
 
 /**
@@ -132,4 +132,51 @@ export function protocolUpgradeFromLiveSession(
   const walk = evidence.walkVendor
   const vendor = walk !== null && isBuiltinVendor(walk) ? walk : sniffProtocolFromTitle(evidence.title)
   return vendor ? { command, vendor } : null
+}
+
+/**
+ * Tier (b)'s SECOND product: the protocol to persist for the custom PRESET
+ * the session was launched under, or null.
+ *
+ * The record upgrade above names ONE task. A wrapper preset (`claudecpa`, a
+ * zsh function that passes `"$@"` to claude) is launched by every future task
+ * that picks it, and each one re-learns nothing: the preset itself has no
+ * `engineProtocol.<id>`, so the history reader, the trust store and the fork
+ * verb all keep answering "no transcript" until someone opens Settings and
+ * declares it. Writing the key once, from the process the walk actually
+ * found, is what makes the next task start named.
+ *
+ * The refusals differ from the record upgrade's on purpose:
+ *
+ *   - a declared protocol wins, always. `getEngineProtocol` already answers
+ *     the id itself for a built-in or contrib engine, so those are covered by
+ *     the same check.
+ *   - the id must be a REGISTERED custom engine. That is the durability bar:
+ *     a raw `--command` string is a one-off, and minting a persistent
+ *     `engineProtocol.<one-off>` key from one would leave state.json growing
+ *     a row per ad-hoc command line.
+ *   - only the WALK names it. A title glyph is what the engine last wrote and
+ *     is good enough for a record that a later `setCommand` can correct; this
+ *     key outlives every session on the preset, so it takes the running
+ *     process as its only evidence.
+ *
+ * Deliberately NOT gated on a pinned `command`: a preset id IS the launch
+ * instruction (`engineCommand.<id>` holds the command line), so the reason
+ * the record upgrade refuses a command-less task — that writing there would
+ * change what spawns — does not apply to a key that only says how to TALK.
+ *
+ * Idempotent: the write makes `getEngineProtocol(id)` answer, so the next
+ * tick resolves null.
+ */
+export function protocolWriteBackFromLiveSession(
+  task: { readonly vendor?: string },
+  evidence: LiveSessionEvidence,
+  customEngineIds: readonly string[],
+): { id: string; protocol: VendorId } | null {
+  const id = task.vendor?.trim()
+  if (!id) return null
+  if (getEngineProtocol(id) !== undefined) return null
+  if (!customEngineIds.includes(id)) return null
+  const walk = evidence.walkVendor
+  return walk !== null && isBuiltinVendor(walk) ? { id, protocol: walk } : null
 }

--- a/packages/kobe/src/tui-react/component/worktrees-page.tsx
+++ b/packages/kobe/src/tui-react/component/worktrees-page.tsx
@@ -38,14 +38,13 @@ import { useT } from "../i18n"
 import { pageCloseBindings, useBindings } from "../lib/keymap"
 import { useDialog } from "../ui/dialog"
 import { DialogConfirm } from "../ui/dialog-confirm"
+import { landTaskAction } from "../workspace/land-task-action"
 
 function flattenRows(projects: readonly WorktreeProject[]): readonly WorktreeAuditRow[] {
   return projects.flatMap((p) => p.worktrees)
 }
 
 const DIRTY_REFUSAL_RE = /refusing to remove dirty worktree/
-const LAND_CONFLICT_RE = /LAND_CONFLICT/
-const MAIN_DIRTY_RE = /MAIN_CHECKOUT_DIRTY/
 
 /** Match a worktree row's path to a tracked task id (loose realpath tolerance). */
 function taskIdForPath(orch: RemoteOrchestrator, wtPath: string): string | undefined {
@@ -196,49 +195,32 @@ export function WorktreesPage(props: { orchestrator: RemoteOrchestrator | null; 
       console.error("[rove worktrees] land refused: no tracked task for", row.path)
       return
     }
-    const ok = await DialogConfirm.show(
-      dialog,
-      t("worktrees.land.confirmTitle"),
-      t("worktrees.land.confirmBody", { branch: row.branch || row.path }),
-      t("common.cancel"),
-      t("worktrees.land.button"),
-    )
-    if (ok !== true) return
+    // The land itself is shared with the sidebar row menu
+    // (`workspace/land-task-action.ts`); the page adds only the busy row and
+    // the refetch that clears it, since landing removes the worktree.
     setBusyPath(row.path)
     try {
-      // Land removes the worktree by default — same as the CLI, so the row
-      // clears itself. `callerCwd` lets the daemon refuse the worktree this
-      // TUI is itself running from instead of deleting its own cwd.
-      const res = await orch.landTask(taskId, { callerCwd: process.cwd() })
-      notifyInfo(t("worktrees.land.done", { branch: res.branch, landedOn: res.landedOn, commit: res.commit }))
-      // Two cleanup outcomes carry information, and neither is ever thrown —
-      // surface them as attention toasts (yellow) so the user knows there is
-      // manual follow-up. A refused removal leaves the directory in place; a
-      // removal whose bookkeeping write failed takes the directory but leaves
-      // the task still pointing at it. They need different copy: `worktreeKept`
-      // would be actively wrong for the second.
-      const cleanup = res.worktree
-      if (cleanup && !cleanup.removed) {
-        notifyNeedsInput(t("worktrees.land.worktreeKept", { reason: cleanup.reason ?? "refused" }))
-      } else if (cleanup?.reason) {
-        notifyNeedsInput(t("worktrees.land.worktreePathStale", { reason: cleanup.reason }))
-      }
-      if (cleanup?.residue) {
-        notifyNeedsInput(
-          t("worktrees.land.worktreeResidue", { path: cleanup.residue.path, reason: cleanup.residue.reason }),
-        )
-      }
+      await landTaskAction(
+        {
+          orchestrator: orch,
+          confirm: (branch) =>
+            DialogConfirm.show(
+              dialog,
+              t("worktrees.land.confirmTitle"),
+              t("worktrees.land.confirmBody", { branch }),
+              t("common.cancel"),
+              t("worktrees.land.button"),
+            ).then((ok) => ok === true),
+          notifyInfo,
+          notifyNeedsInput,
+          notifyError,
+          t,
+          callerCwd: process.cwd(),
+        },
+        taskId,
+        row.branch || row.path,
+      )
       refetch()
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err)
-      if (LAND_CONFLICT_RE.test(msg)) {
-        notifyNeedsInput(t("worktrees.land.conflict", { files: msg }))
-      } else if (MAIN_DIRTY_RE.test(msg)) {
-        notifyNeedsInput(t("worktrees.land.dirtyBase"))
-      } else {
-        notifyError(t("worktrees.land.failed", { error: msg }))
-      }
-      console.error("[rove worktrees] land failed:", err)
     } finally {
       setBusyPath(null)
     }

--- a/packages/kobe/src/tui-react/panes/filetree/FileTree.tsx
+++ b/packages/kobe/src/tui-react/panes/filetree/FileTree.tsx
@@ -232,12 +232,13 @@ export function FileTree(props: FileTreeProps) {
     return () => controller.abort()
   }, [scope, base, refetch])
 
-  // Realtime watch is opt-in (see watchWorktree) — the default path is
-  // explicit refresh (`r`) plus tab/worktree changes.
+  // Realtime watch is on by default; `KOBE_FILETREE_WATCH=0` opts out (see
+  // watchWorktree) and leaves explicit refresh (`r`) plus tab/worktree
+  // changes as the only paths that repopulate the pane.
   useEffect(() => {
     const path = props.worktreePath
     if (path == null) return
-    if (process.env.KOBE_FILETREE_WATCH !== "1") return
+    if (process.env.KOBE_FILETREE_WATCH === "0") return
     return watchWorktree(path, () => setRefreshTick((n) => n + 1))
   }, [props.worktreePath])
 

--- a/packages/kobe/src/tui-react/panes/sidebar/types.ts
+++ b/packages/kobe/src/tui-react/panes/sidebar/types.ts
@@ -17,6 +17,9 @@ import type { WorktreeChanges } from "../../../tui/panes/sidebar/worktree-change
  */
 export type SidebarTaskCallbacks = {
   onDeleteRequest?: (taskId: string) => void
+  /** Row menu only — merge this task's branch into its base repo's current
+   *  branch, the same flow as the Worktrees page's `l`. */
+  onLandRequest?: (taskId: string) => void
   /** Shift+M — lowercase `m` is captured but ignored (shift dropped on letters). */
   onLocalMergeRequest?: (taskId: string) => void
   /** Scope-aware reorder mode: j/k move the cursor row's LEVEL

--- a/packages/kobe/src/tui-react/panes/sidebar/use-tree-menu.ts
+++ b/packages/kobe/src/tui-react/panes/sidebar/use-tree-menu.ts
@@ -201,6 +201,11 @@ export function useTreeMenu(deps: TreeMenuDeps): TreeMenu {
         case "changeEngine":
           actions.onChangeEngineRequest?.(taskId)
           break
+        // Menu-only, like `setStatus` above: no chord to mirror, so the
+        // ROW's task is the only thing it could mean.
+        case "land":
+          actions.onLandRequest?.(taskId)
+          break
         case "delete":
           actions.onDeleteRequest?.(taskId)
           break

--- a/packages/kobe/src/tui-react/workspace/host-keybindings.ts
+++ b/packages/kobe/src/tui-react/workspace/host-keybindings.ts
@@ -63,6 +63,8 @@ export type WorkspaceKeybindingDeps = {
   enterMoveMode: () => void
   /** prefix+p / prefix+P — send the Create PR prompt into the engine pane. */
   createPR: () => void
+  /** Same action aimed at a sidebar ROW's task: enter it, then send there. */
+  createPRFor: (id: string) => void
   /** `t` — flip the sidebar task sort between default and recent. */
   toggleSortMode: () => void
 }
@@ -144,7 +146,16 @@ export function useWorkspaceKeybindings(deps: WorkspaceKeybindingDeps): void {
         // row exists in the table (and docs); without a handler here the
         // chord is dead outside the sidebar.
         "settings.open": prefixAction(() => deps.pages.openSettings()),
-        "files.createPR": prefixAction(() => deps.createPR()),
+        // Global scope, so it acts on the active task — except while the
+        // sidebar has focus, where the highlighted row is what the user
+        // means (the same rule `task.openEditor` follows below). Aiming at
+        // another row has to enter it first: the send closure belongs to
+        // the mounted workspace, so there is no other task to send into.
+        "files.createPR": prefixAction(() => {
+          const row = focus.focused === "sidebar" ? deps.cursorTaskId() : null
+          if (row !== null && row !== deps.selectedId) deps.createPRFor(row)
+          else deps.createPR()
+        }),
         // Global scope, so it acts on the active task — except while the
         // sidebar has focus, where the highlighted row is what the user means.
         "task.openEditor": prefixAction(() => {

--- a/packages/kobe/src/tui-react/workspace/host-sidebar.tsx
+++ b/packages/kobe/src/tui-react/workspace/host-sidebar.tsx
@@ -44,6 +44,7 @@ export interface HostSidebarProps {
   readonly transcriptActivity?: ReadonlyMap<string, { readonly mtimeMs: number }> | null
   readonly onAddTask: () => void
   readonly onDeleteRequest: (taskId: string) => void
+  readonly onLandRequest?: (taskId: string) => void
   readonly onRenameRequest: (taskId: string) => void
   readonly onPinRequest: (taskId: string) => void
   /** Menu-only (no chord): open the board-status picker for the row's task. */
@@ -136,6 +137,7 @@ export function HostSidebar(props: HostSidebarProps) {
     transcriptActivity: props.transcriptActivity,
     focused: props.focused,
     onDeleteRequest: props.onDeleteRequest,
+    onLandRequest: props.onLandRequest,
     onRenameRequest: props.onRenameRequest,
     onPinRequest: props.onPinRequest,
     onSetStatusRequest: props.onSetStatusRequest,

--- a/packages/kobe/src/tui-react/workspace/host-task-actions.ts
+++ b/packages/kobe/src/tui-react/workspace/host-task-actions.ts
@@ -35,7 +35,9 @@ import { FieldNotesDialog } from "../component/field-notes-dialog"
 import { RunAgainDialog } from "../component/run-again-dialog"
 import { StatusPickerDialog } from "../component/status-picker-dialog"
 import type { DialogContext } from "../ui/dialog"
+import { DialogConfirm } from "../ui/dialog-confirm"
 import { buildBaseCreateTaskContext, selectNextAfterDelete } from "../ui/task-dialog-adapters"
+import { landTaskAction } from "./land-task-action"
 
 export type WorkspaceTaskActionDeps = {
   orchestrator: RemoteOrchestrator
@@ -43,6 +45,11 @@ export type WorkspaceTaskActionDeps = {
   dialog: DialogContext
   notifyError: (message: string) => void
   notifyInfo: (message: string) => void
+  /** Attention tone (yellow): it worked, but something needs a human next. */
+  notifyNeedsInput: (message: string) => void
+  /** The host's live translator — passed in rather than pulled from `useT()`,
+   *  which would tie this hook to a React render its unit tests do not have. */
+  t: (key: string, params?: Record<string, string | number>) => string
   selectedId: () => string | null
   setSelectedId: (id: string | null) => void
   selectedTask: () => Task | undefined
@@ -78,11 +85,15 @@ export type WorkspaceTaskActions = {
    * the new task's mount; this half is the dialog and the lookup.
    */
   confirmRunAgain: (id: string) => Promise<Task | undefined>
+  /** Row menu "Land into base branch" — the Worktrees page's `l` reachable
+   *  from the row. No busy state: the row goes with its worktree. */
+  landTask: (id: string) => Promise<void>
 }
 
 export function useWorkspaceTaskActions(deps: WorkspaceTaskActionDeps): WorkspaceTaskActions {
   const { orchestrator, tasks, dialog, notifyError } = deps
   const renderer = useRenderer()
+  const t = deps.t
 
   const taskActions: CreateTaskContext = {
     ...buildBaseCreateTaskContext({
@@ -176,6 +187,34 @@ export function useWorkspaceTaskActions(deps: WorkspaceTaskActionDeps): Workspac
     await applyVendorChange(taskActions, id, pick.vendor, { effort: pick.effort })
   }
 
+  // Row menu "Land into base branch". The land itself is shared with the
+  // Worktrees page (`land-task-action.ts`); this is only the host's dialog,
+  // toasts and row lookup — the same division `pickVendor` follows.
+  async function landTask(id: string): Promise<void> {
+    const task = tasks().find((candidate) => String(candidate.id) === id)
+    if (!task) return
+    await landTaskAction(
+      {
+        orchestrator,
+        confirm: (branch) =>
+          DialogConfirm.show(
+            dialog,
+            t("worktrees.land.confirmTitle"),
+            t("worktrees.land.confirmBody", { branch }),
+            t("common.cancel"),
+            t("worktrees.land.button"),
+          ).then((ok: unknown) => ok === true),
+        notifyInfo: deps.notifyInfo,
+        notifyNeedsInput: deps.notifyNeedsInput,
+        notifyError,
+        t,
+        callerCwd: process.cwd(),
+      },
+      id,
+      task.branch || task.title,
+    )
+  }
+
   return {
     createTask: () => createTaskFlow(taskActions),
     deleteTask: (id) => deleteTaskFlow(taskActions, id),
@@ -196,5 +235,6 @@ export function useWorkspaceTaskActions(deps: WorkspaceTaskActionDeps): Workspac
     copyTaskField: (id, field) => copyTaskFieldFlow(taskActions, id, field),
     showFieldNotes: (repo) => FieldNotesDialog.show(dialog, { repo, load: () => orchestrator.listFieldNotes(repo) }),
     confirmRunAgain,
+    landTask,
   }
 }

--- a/packages/kobe/src/tui-react/workspace/host.tsx
+++ b/packages/kobe/src/tui-react/workspace/host.tsx
@@ -25,6 +25,7 @@ import { useDaemonNotices } from "../lib/use-daemon-notices"
 import { useLatest } from "../lib/use-latest"
 import { useSidebarHostState } from "../panes/sidebar/use-sidebar-host-state.tsx"
 import { useDialog } from "../ui/dialog"
+import { DialogConfirm } from "../ui/dialog-confirm"
 import { FullWindowPage, useHostBanner } from "./host-banner"
 import { HostFilesPane } from "./host-files-pane"
 import { WorkspaceFrame } from "./host-footer"
@@ -32,11 +33,13 @@ import { useWorkspaceKeybindings } from "./host-keybindings"
 import { useHostPagesRender, useHostPagesState } from "./host-pages"
 import { HostSidebar } from "./host-sidebar"
 import { useWorkspaceTaskActions } from "./host-task-actions"
+import { landTaskAction } from "./land-task-action"
 import { openTaskWorktreeFor } from "./open-task-worktree"
 import { useQuickFork } from "./quick-fork"
 import { ShowWorkspace } from "./show-workspace"
 import { activeTabIdFor, forgetTaskTabs, requestTabActivation, setUiEventReporter } from "./terminal-tabs-shared"
 import { useAttention } from "./use-attention"
+import { requestCreatePR } from "./use-create-pr"
 import { useDaemonState } from "./use-daemon-state"
 import { useEditorHandles } from "./use-editor-handles"
 import { useInboxHost } from "./use-inbox-host"
@@ -252,6 +255,35 @@ export function WorkspaceRoot(props: { orchestrator: RemoteOrchestrator }) {
   const openTaskWorktree = (id: string): void =>
     openTaskWorktreeFor(id, { tasks, ensureWorktree: orch.ensureWorktree.bind(orch), notifyError })
 
+  // Row menu's "Land into base branch" — the Worktrees page's `l` reachable
+  // from the row itself, sharing the confirm, the cleanup toasts and the two
+  // actionable failures (`workspace/land-task-action.ts`). No busy state to
+  // keep here: the row disappears with its worktree when the land succeeds.
+  const landRowTask = async (id: string): Promise<void> => {
+    const task = tasks.find((candidate) => String(candidate.id) === id)
+    if (!task) return
+    await landTaskAction(
+      {
+        orchestrator: orch,
+        confirm: (branch) =>
+          DialogConfirm.show(
+            dialog,
+            t("worktrees.land.confirmTitle"),
+            t("worktrees.land.confirmBody", { branch }),
+            t("common.cancel"),
+            t("worktrees.land.button"),
+          ).then((ok) => ok === true),
+        notifyInfo,
+        notifyNeedsInput: (message) => notif.notify({ kind: "needs_input", taskId: id, tabId: "", title: message }),
+        notifyError,
+        t,
+        callerCwd: process.cwd(),
+      },
+      id,
+      task.branch || task.title,
+    )
+  }
+
   // Filled by the mounted SidebarTree; null until it mounts (a rail page,
   // zen), which is fine — every reader is gated on sidebar focus.
   const cursorTaskIdRef = useRef<() => string | null>(() => null)
@@ -271,6 +303,12 @@ export function WorkspaceRoot(props: { orchestrator: RemoteOrchestrator }) {
     jumpToNextAttention,
     openInbox: inbox.show,
     createPR: () => void editor.onCreatePR(),
+    // The row under the sidebar cursor, which is not the mounted task: park
+    // the request, then enter the row so its workspace mounts and claims it.
+    createPRFor: (id) => {
+      requestCreatePR(id)
+      activateTask(id)
+    },
     // prefix+m — global entry into the sidebar's move mode: focus the
     // sidebar, highlight the selection (falling back to the first task),
     // then j/k reorders the cursor row's level (tab/task/project) and
@@ -362,6 +400,7 @@ export function WorkspaceRoot(props: { orchestrator: RemoteOrchestrator }) {
           // fire these; the flows are the shared lib/task-actions bodies.
           onAddTask={() => void createTask()}
           onDeleteRequest={(id) => void deleteTask(id)}
+          onLandRequest={(id) => void landRowTask(id)}
           onRenameRequest={(id) => void renameTask(id)}
           onPinRequest={(id) => void togglePin(id)}
           onSetStatusRequest={(id) => void setStatus(id)}

--- a/packages/kobe/src/tui-react/workspace/host.tsx
+++ b/packages/kobe/src/tui-react/workspace/host.tsx
@@ -25,7 +25,6 @@ import { useDaemonNotices } from "../lib/use-daemon-notices"
 import { useLatest } from "../lib/use-latest"
 import { useSidebarHostState } from "../panes/sidebar/use-sidebar-host-state.tsx"
 import { useDialog } from "../ui/dialog"
-import { DialogConfirm } from "../ui/dialog-confirm"
 import { FullWindowPage, useHostBanner } from "./host-banner"
 import { HostFilesPane } from "./host-files-pane"
 import { WorkspaceFrame } from "./host-footer"
@@ -33,7 +32,6 @@ import { useWorkspaceKeybindings } from "./host-keybindings"
 import { useHostPagesRender, useHostPagesState } from "./host-pages"
 import { HostSidebar } from "./host-sidebar"
 import { useWorkspaceTaskActions } from "./host-task-actions"
-import { landTaskAction } from "./land-task-action"
 import { openTaskWorktreeFor } from "./open-task-worktree"
 import { useQuickFork } from "./quick-fork"
 import { ShowWorkspace } from "./show-workspace"
@@ -166,12 +164,15 @@ export function WorkspaceRoot(props: { orchestrator: RemoteOrchestrator }) {
     copyTaskField,
     showFieldNotes,
     confirmRunAgain,
+    landTask,
   } = useWorkspaceTaskActions({
     orchestrator: orch,
     tasks: () => tasks,
     dialog,
     notifyError,
     notifyInfo,
+    notifyNeedsInput: (message) => notif.notify({ kind: "needs_input", taskId: "", tabId: "", title: message }),
+    t,
     selectedId: () => selectedId,
     setSelectedId,
     selectedTask: () => selectedTask,
@@ -254,35 +255,6 @@ export function WorkspaceRoot(props: { orchestrator: RemoteOrchestrator }) {
   // under the cursor (the menu's row IS the cursor row).
   const openTaskWorktree = (id: string): void =>
     openTaskWorktreeFor(id, { tasks, ensureWorktree: orch.ensureWorktree.bind(orch), notifyError })
-
-  // Row menu's "Land into base branch" — the Worktrees page's `l` reachable
-  // from the row itself, sharing the confirm, the cleanup toasts and the two
-  // actionable failures (`workspace/land-task-action.ts`). No busy state to
-  // keep here: the row disappears with its worktree when the land succeeds.
-  const landRowTask = async (id: string): Promise<void> => {
-    const task = tasks.find((candidate) => String(candidate.id) === id)
-    if (!task) return
-    await landTaskAction(
-      {
-        orchestrator: orch,
-        confirm: (branch) =>
-          DialogConfirm.show(
-            dialog,
-            t("worktrees.land.confirmTitle"),
-            t("worktrees.land.confirmBody", { branch }),
-            t("common.cancel"),
-            t("worktrees.land.button"),
-          ).then((ok) => ok === true),
-        notifyInfo,
-        notifyNeedsInput: (message) => notif.notify({ kind: "needs_input", taskId: id, tabId: "", title: message }),
-        notifyError,
-        t,
-        callerCwd: process.cwd(),
-      },
-      id,
-      task.branch || task.title,
-    )
-  }
 
   // Filled by the mounted SidebarTree; null until it mounts (a rail page,
   // zen), which is fine — every reader is gated on sidebar focus.
@@ -400,7 +372,7 @@ export function WorkspaceRoot(props: { orchestrator: RemoteOrchestrator }) {
           // fire these; the flows are the shared lib/task-actions bodies.
           onAddTask={() => void createTask()}
           onDeleteRequest={(id) => void deleteTask(id)}
-          onLandRequest={(id) => void landRowTask(id)}
+          onLandRequest={(id) => void landTask(id)}
           onRenameRequest={(id) => void renameTask(id)}
           onPinRequest={(id) => void togglePin(id)}
           onSetStatusRequest={(id) => void setStatus(id)}

--- a/packages/kobe/src/tui-react/workspace/land-task-action.ts
+++ b/packages/kobe/src/tui-react/workspace/land-task-action.ts
@@ -1,0 +1,73 @@
+/**
+ * Land a task's branch into its base repo — the flow behind BOTH the
+ * Worktrees page's `l` and the sidebar row menu's "Land into base branch".
+ *
+ * Its own module because the two callers differ only in what surrounds it
+ * (the page has a busy row and a list to refetch; the sidebar has neither),
+ * while everything that makes landing correct is the same: the confirm the
+ * user must clear, the two cleanup outcomes that need a follow-up toast
+ * rather than an error, and the two failure messages the daemon returns as
+ * codes because they are the ones a human can act on (a merge conflict, a
+ * dirty base checkout).
+ *
+ * React-free so it can be unit-tested and so neither caller has to be the
+ * one that "owns" landing.
+ */
+
+import type { RemoteOrchestrator } from "../../client/remote-orchestrator"
+
+const LAND_CONFLICT_RE = /LAND_CONFLICT/
+const MAIN_DIRTY_RE = /MAIN_CHECKOUT_DIRTY/
+
+export interface LandTaskDeps {
+  readonly orchestrator: Pick<RemoteOrchestrator, "landTask">
+  /** Resolved confirm: true = go ahead. The caller owns the dialog stack. */
+  readonly confirm: (branchLabel: string) => Promise<boolean>
+  readonly notifyInfo: (message: string) => void
+  /** Attention tone (yellow): landed, but something needs a human next. */
+  readonly notifyNeedsInput: (message: string) => void
+  readonly notifyError: (message: string) => void
+  readonly t: (key: string, params?: Record<string, string | number>) => string
+  /** Where this TUI is running, so the daemon can refuse to delete its own
+   *  cwd instead of pulling the floor out from under it. */
+  readonly callerCwd: string
+}
+
+/**
+ * Run one land. Resolves true when the branch landed (whatever the cleanup
+ * did afterwards), false on a refusal, a declined confirm, or a failure —
+ * every one of which has already been reported through the notifiers.
+ */
+export async function landTaskAction(deps: LandTaskDeps, taskId: string, branchLabel: string): Promise<boolean> {
+  const { t } = deps
+  if (!(await deps.confirm(branchLabel))) return false
+  try {
+    // Land removes the worktree by default — same as the CLI.
+    const res = await deps.orchestrator.landTask(taskId, { callerCwd: deps.callerCwd })
+    deps.notifyInfo(t("worktrees.land.done", { branch: res.branch, landedOn: res.landedOn, commit: res.commit }))
+    // Two cleanup outcomes carry information and neither is ever thrown.
+    // They need different copy: a refused removal leaves the directory in
+    // place, while a removal whose bookkeeping write failed took the
+    // directory but left the task still pointing at it — `worktreeKept`
+    // would be actively wrong for the second.
+    const cleanup = res.worktree
+    if (cleanup && !cleanup.removed) {
+      deps.notifyNeedsInput(t("worktrees.land.worktreeKept", { reason: cleanup.reason ?? "refused" }))
+    } else if (cleanup?.reason) {
+      deps.notifyNeedsInput(t("worktrees.land.worktreePathStale", { reason: cleanup.reason }))
+    }
+    if (cleanup?.residue) {
+      deps.notifyNeedsInput(
+        t("worktrees.land.worktreeResidue", { path: cleanup.residue.path, reason: cleanup.residue.reason }),
+      )
+    }
+    return true
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err)
+    if (LAND_CONFLICT_RE.test(msg)) deps.notifyNeedsInput(t("worktrees.land.conflict", { files: msg }))
+    else if (MAIN_DIRTY_RE.test(msg)) deps.notifyNeedsInput(t("worktrees.land.dirtyBase"))
+    else deps.notifyError(t("worktrees.land.failed", { error: msg }))
+    console.error("[rove land] failed:", err)
+    return false
+  }
+}

--- a/packages/kobe/src/tui-react/workspace/use-create-pr.ts
+++ b/packages/kobe/src/tui-react/workspace/use-create-pr.ts
@@ -44,6 +44,33 @@ export function createPRAction(deps: CreatePRDeps): () => Promise<void> {
   }
 }
 
+/**
+ * "Create a PR for THAT task" — the sidebar-row aim of `prefix+p`, held
+ * across the task switch it needs.
+ *
+ * The action can only run where the engine is: `sendToEngineFn` is handed up
+ * by the mounted TerminalTabs, so a row that is not the active task has no
+ * send closure to reach. The host therefore activates the row and parks the
+ * request here; the next `onEngineSendReady` for that task claims it. Same
+ * shape as the sidebar menu's `requestNewTab`, kept in this module because
+ * the action is what it is about.
+ *
+ * One slot: a second press before the first is claimed retargets it rather
+ * than queueing, which is what a user pressing the chord twice means.
+ */
+let pendingCreatePR: string | null = null
+
+export function requestCreatePR(taskId: string): void {
+  pendingCreatePR = taskId
+}
+
+/** Claim a parked request for this task. */
+export function takeCreatePR(taskId: string | null): boolean {
+  if (taskId === null || pendingCreatePR !== taskId) return false
+  pendingCreatePR = null
+  return true
+}
+
 export function useCreatePR(args: Omit<CreatePRDeps, "t" | "gather" | "build">): () => Promise<void> {
   const t = useT()
   return createPRAction({ ...args, t })

--- a/packages/kobe/src/tui-react/workspace/use-editor-handles.tsx
+++ b/packages/kobe/src/tui-react/workspace/use-editor-handles.tsx
@@ -9,7 +9,7 @@ import { useRef } from "react"
 import type { RemoteOrchestrator } from "../../client/remote-orchestrator"
 import type { FocusContextValue } from "../context/focus"
 import { useLatest } from "../lib/use-latest"
-import { useCreatePR } from "./use-create-pr"
+import { takeCreatePR, useCreatePR } from "./use-create-pr"
 import { useFileOpenActions } from "./use-file-open-actions"
 
 export interface UseEditorHandlesOpts {
@@ -96,6 +96,10 @@ export function useEditorHandles(opts: UseEditorHandlesOpts): UseEditorHandlesRe
     },
     onEngineSendReady: (send) => {
       sendToEngineFn.current = send
+      // A `prefix+p` aimed at a sidebar row that was not the active task
+      // activated it and parked the request; this mount is the first moment
+      // the prompt can actually be sent, so claim it here.
+      if (takeCreatePR(selectedId)) void createPR()
     },
     onEnginePasteReady: (paste) => {
       pasteToEngineFn.current = paste

--- a/packages/kobe/src/tui/i18n/messages/tasks.ts
+++ b/packages/kobe/src/tui/i18n/messages/tasks.ts
@@ -48,6 +48,7 @@ export const en = {
     openEditor: "Open in editor",
     renameBranch: "Rename branch",
     changeEngine: "Change engine",
+    land: "Land into base branch",
     delete: "Delete",
   },
   /** The six `TaskStatus` values, for the set-status picker and its row chip.
@@ -187,6 +188,7 @@ export const zh: typeof en = {
     openEditor: "在编辑器中打开",
     renameBranch: "重命名分支",
     changeEngine: "切换引擎",
+    land: "合入基础分支",
     delete: "删除",
   },
   status: {

--- a/packages/kobe/src/tui/panes/filetree/pane-core.ts
+++ b/packages/kobe/src/tui/panes/filetree/pane-core.ts
@@ -182,16 +182,16 @@ type EventedWatcher = ReturnType<typeof watch> & { on(event: "error", listener: 
  * Recursive fs watch over a worktree with a 500ms trailing debounce.
  * Returns a disposer. Errors are swallowed (the `r` keystroke remains as
  * the escape hatch); an unwatchable path degrades to manual refresh.
- * Opt-in at the call site via `KOBE_FILETREE_WATCH=1` — on large repos a
- * recursive watcher can overwhelm the TUI process before the user does
- * anything.
+ * On by default; `KOBE_FILETREE_WATCH=0` at the call site opts out, for a
+ * repo big enough that a recursive watcher costs more than the staleness it
+ * removes.
  *
  * Known window, deliberately NOT closed: macOS FSEvents arms
  * asynchronously, so a write landing right after this call may be dropped
  * before the stream is live. The daemon's single-file watchers close that
  * with a stat-poll, but stat-polling a whole worktree is disproportionate
  * here — the cost of a miss is only a stale pane until the next fs event
- * or a manual `r`, in a feature that is already opt-in and best-effort.
+ * or a manual `r`, in a feature that is best-effort by contract.
  */
 export function watchWorktree(path: string, onChange: () => void, debounceMs = 500): () => void {
   let debounceTimer: ReturnType<typeof setTimeout> | null = null

--- a/packages/kobe/src/tui/panes/sidebar/tree-menu.ts
+++ b/packages/kobe/src/tui/panes/sidebar/tree-menu.ts
@@ -9,13 +9,14 @@
  * (`withCursorTask` walks up from a tab to its worktree, because rename /
  * delete have no tab-level meaning).
  *
- * `setStatus`, `copyBranch` and `copyPath` are the documented exceptions, and
- * they are SEQUENCING ones rather than a change of rule: a chord is the
- * owner's call (AGENTS.md, "Keybindings"), and until one is agreed the menu is
- * the only place a human can set a status the injected agent protocol already
- * tells every engine to write (`engine/worktree-protocol.ts`), or copy the
- * row's branch / worktree path for another shell. When a chord lands, the
- * entry mirrors it like the rest.
+ * `setStatus`, `copyBranch`, `copyPath` and `land` are the documented
+ * exceptions, and they are SEQUENCING ones rather than a change of rule: a
+ * chord is the owner's call (AGENTS.md, "Keybindings"), and until one is
+ * agreed the menu is the only place a human can set a status the injected
+ * agent protocol already tells every engine to write
+ * (`engine/worktree-protocol.ts`), copy the row's branch / worktree path for
+ * another shell, or land the row's branch without walking to the Worktrees
+ * page. When a chord lands, the entry mirrors it like the rest.
  *
  * The new-conversation pair reads the same rule one pane over:
  * ctrl+e already opens the engine/shell picker for the task the
@@ -50,6 +51,7 @@ export type TreeMenuAction =
   | "openEditor"
   | "renameBranch"
   | "changeEngine"
+  | "land"
   | "delete"
 
 export interface TreeMenuItem {
@@ -112,6 +114,15 @@ function taskVerbs(task: Task): TreeMenuItem[] {
   verbs.push({ action: "openEditor", labelKey: "tasks.menu.openEditor" })
   if (task.branch !== "") verbs.push({ action: "renameBranch", labelKey: "tasks.menu.renameBranch" })
   verbs.push({ action: "changeEngine", labelKey: "tasks.menu.changeEngine" })
+  // Menu-only, like `setStatus`: landing is the Worktrees page's `l`, and a
+  // second chord for it is the owner's call
+  // (docs/design/keybinding-decisions.md). Gated the same way `copyBranch`
+  // is, plus the kind: `landTask` throws outright for a `main` or `dir` task
+  // (neither owns a Rove-managed branch), and a task that never materialised
+  // has no branch to land.
+  if (task.kind === "task" && task.branch !== "") {
+    verbs.push({ action: "land", labelKey: "tasks.menu.land" })
+  }
   verbs.push({ action: "delete", labelKey: "tasks.menu.delete", danger: true })
   return verbs
 }

--- a/packages/kobe/test/cli/api-cmd-run.test.ts
+++ b/packages/kobe/test/cli/api-cmd-run.test.ts
@@ -141,7 +141,7 @@ describe("runApiSubcommand", () => {
     expect(JSON.parse(stdoutText())).toHaveProperty("tasks")
   })
 
-  test("an unverified session identity rides the verb's own JSON result (issue #24)", async () => {
+  test("an unverified session identity rides the verb's own JSON result", async () => {
     // The degrade must be VISIBLE: stderr carries one JSON error envelope by
     // contract, so a plain-text warning there would corrupt it — the notice
     // goes on stdout, attached to the successful result.

--- a/packages/kobe/test/cli/api-cmd-runtime.test.ts
+++ b/packages/kobe/test/cli/api-cmd-runtime.test.ts
@@ -124,7 +124,7 @@ describe("defaultApiRuntime", () => {
     await expect(defaultApiRuntime.isTaskRunning("t1")).resolves.toBe(true)
   })
 
-  it("isTaskRunning is true when only a LATER engine tab is alive (issue #5)", async () => {
+  it("isTaskRunning is true when only a LATER engine tab is alive", async () => {
     mocks.listSessions.mockResolvedValue([
       { key: "t1::tab-1", alive: false },
       { key: "t1::tab-2", alive: true },

--- a/packages/kobe/test/cli/api-dispatcher.test.ts
+++ b/packages/kobe/test/cli/api-dispatcher.test.ts
@@ -64,7 +64,7 @@ afterEach(() => {
   restoreEnv("KOBE_TAB_ID", savedTabId)
 })
 
-describe("verifiedSelfSession (issue #24: env identity is inheritable, so it must be proven)", () => {
+describe("verifiedSelfSession (env identity is inheritable, so it must be proven)", () => {
   it("accepts the env when the named tab is alive AND owns this process", async () => {
     expect(await verifiedSelfSession({ KOBE_TASK_ID: "d1", KOBE_TAB_ID: "tab-4" }, probeFor("d1::tab-4"))).toEqual({
       taskId: "d1",
@@ -173,7 +173,7 @@ describe("create records the dispatcher ($KOBE_TASK_ID/$KOBE_TAB_ID)", () => {
     expect(client.requests[0].payload).toEqual({ repo: "/repo/x" })
   })
 
-  it("add with an INHERITED env records no dispatcher at all (issue #24)", async () => {
+  it("add with an INHERITED env records no dispatcher at all", async () => {
     // Every field is real — boccha's task exists, its tab-1 is alive — but
     // this process was forked out of it days ago and detached. Recording
     // {boccha, tab-1} here is what sent finished workers' reports to a

--- a/packages/kobe/test/cli/api-handlers.test.ts
+++ b/packages/kobe/test/cli/api-handlers.test.ts
@@ -142,7 +142,7 @@ describe("add handler", () => {
     expect(client.requests).toContainEqual({ name: "task.setPrompt", payload: { taskId: "t1", prompt: "do it" } })
   })
 
-  it("reports a created task whose prompt never landed (issue #72/#73)", async () => {
+  it("reports a created task whose prompt never landed", async () => {
     const task = taskFixture({ kind: "task", vendor: "kimi" })
     const client = new FakeClient({
       "task.create": () => ({ taskId: "t1", task }),

--- a/packages/kobe/test/cli/api-inspect.test.ts
+++ b/packages/kobe/test/cli/api-inspect.test.ts
@@ -118,7 +118,7 @@ describe("kobe api inspect (offline)", () => {
  * called out as `unregistered`, never silently dropped — that silence is how
  * a writable engine stayed invisible for 1h44m.
  */
-describe("inspect tabs section reconciliation (issue #20)", () => {
+describe("inspect tabs section reconciliation", () => {
   type TabsOut = Record<string, { activeId: string | null; tabs: { id: string }[]; unregistered?: string[] }>
 
   it("flags an alive session missing from the task's snapshot", () => {

--- a/packages/kobe/test/cli/api-tab-snapshot.test.ts
+++ b/packages/kobe/test/cli/api-tab-snapshot.test.ts
@@ -273,7 +273,7 @@ describe("joinTaskTabs", () => {
   const vendorSnap = (tabs: unknown[]): TabsState =>
     ({ tabs, activeId: "tab-1", nextOrdinal: tabs.length + 1 }) as unknown as TabsState
 
-  it("a live foreground-walk verdict overrides the recorded liveVendor (issue #33)", () => {
+  it("a live foreground-walk verdict overrides the recorded liveVendor", () => {
     const snap = vendorSnap([
       { kind: "command", id: "tab-1", title: null, ordinal: 1 }, // shell, user typed claude
       { kind: "engine", id: "tab-2", title: null, ordinal: 2, liveVendor: "codex" }, // ctrl+C'd
@@ -369,7 +369,7 @@ describe("joinTaskTabs", () => {
     expect(rows[0]).toMatchObject({ alive: false, exit })
   })
 
-  it("keeps clean exits quiet: code 0 reports exit null (issue #9 no-noise rule)", () => {
+  it("keeps clean exits quiet: code 0 reports exit null — the no-noise rule", () => {
     const exit = { code: 0, signal: null, at: "2026-08-11T00:00:00.000Z" }
     const rows = joinTaskTabs(oneTabSnap("tab-1"), "t1", [{ key: "t1::tab-1", alive: false, exit }])
     expect(rows[0]?.exit).toBeNull()

--- a/packages/kobe/test/cli/open-dir-cmd.test.ts
+++ b/packages/kobe/test/cli/open-dir-cmd.test.ts
@@ -146,7 +146,7 @@ describe("runOpenDirectory", () => {
     expect(mocks.startTui).toHaveBeenCalled()
   })
 
-  describe("a git repo ROOT opens as the project (owner call 2026-08-31)", () => {
+  describe("a git repo ROOT opens as the project", () => {
     /** The opened dir is its own git toplevel = a repo root. */
     function asRepoRoot(): void {
       mocks.statSync.mockReturnValue({ isDirectory: () => true })

--- a/packages/kobe/test/cli/pty-delivery.test.ts
+++ b/packages/kobe/test/cli/pty-delivery.test.ts
@@ -211,7 +211,7 @@ describe("deliverHostedPrompt", () => {
     expect(calls).not.toContain("pty.open") // NEVER a new engine while one lives
   })
 
-  it("FAILS LOUD instead of spawning when live tabs exist but none is an engine (issue #19)", async () => {
+  it("FAILS LOUD instead of spawning when live tabs exist but none is an engine", async () => {
     // A live shell tab, no engine anywhere: pre-fix this silently booted a
     // brand-new engine at tab-1 and reported ok — sender and receiver both
     // believed the message arrived. It must be a typed error instead.
@@ -238,7 +238,7 @@ describe("deliverHostedPrompt", () => {
     expect(calls).not.toContain("pty.write") // and nothing was pasted anywhere
   })
 
-  it("bare send reaches a live non-tab-1 engine instead of refusing (issue #36)", async () => {
+  it("bare send reaches a live non-tab-1 engine instead of refusing", async () => {
     // End-to-end shape of the report: the task's only live tab is tab-22
     // running plain `claude` while the task's vendor is the `claudecpa`
     // preset. Pre-fix the resolver returned null and this threw

--- a/packages/kobe/test/cli/pty-engine-key.test.ts
+++ b/packages/kobe/test/cli/pty-engine-key.test.ts
@@ -70,7 +70,7 @@ describe("findEngineKey", () => {
     expect(findEngineKey(sessions, "t1", "codex")).toBe("t1::tab-5")
   })
 
-  it("resolves a SHELL-WRAPPED engine tab when tab-1 is absent (issue #19)", () => {
+  it("resolves a SHELL-WRAPPED engine tab when tab-1 is absent", () => {
     // Every hosted session launches via `<shell> -ilc '…<engine> …'`
     // (buildEngineSessionLaunch), so command[0] is NEVER the engine binary.
     // The old `command[0] === engineBin` fallback was dead code in
@@ -103,7 +103,7 @@ describe("findEngineKey", () => {
     expect(findEngineKey(sessions, "t1")).toBe("t1::tab-1")
   })
 
-  it("resolves a live engine tab whose binary is NOT the task's vendor (issue #36)", () => {
+  it("resolves a live engine tab whose binary is NOT the task's vendor", () => {
     // The reported shape: a long-lived task pinned to the custom preset
     // `claudecpa` (a zsh wrapper) whose tab-1 is long gone and whose only
     // live tabs launch plain `claude`. engineBin is `claudecpa`, so the

--- a/packages/kobe/test/client/remote-orchestrator.test.ts
+++ b/packages/kobe/test/client/remote-orchestrator.test.ts
@@ -493,7 +493,7 @@ describe("worktree.changes pure helpers", () => {
   })
 })
 
-describe("framework-free store twins (React hosts, issue #15 G3)", () => {
+describe("framework-free store twins (React hosts)", () => {
   it("ui-prefs channel lands in uiPrefsStore and notifies subscribers", () => {
     const { client, emit } = fakeClient()
     const orch = new RemoteOrchestrator(client)

--- a/packages/kobe/test/client/task-deletion-protocol.test.ts
+++ b/packages/kobe/test/client/task-deletion-protocol.test.ts
@@ -29,7 +29,7 @@ describe("task deletion wire state", () => {
     expect(deserializeTask(wire).deletion).toEqual(task.deletion)
   })
 
-  it("an empty title serializes with a display fallback — no consumer can render blank (issue #42)", () => {
+  it("an empty title serializes with a display fallback — no consumer can render blank", () => {
     const scratch: Task = {
       id: toTaskId("s1"),
       title: "",

--- a/packages/kobe/test/core/daemon-session-adapter.test.ts
+++ b/packages/kobe/test/core/daemon-session-adapter.test.ts
@@ -111,7 +111,7 @@ describe("daemon session adapter", () => {
     })
   })
 
-  it("surfaces a paste-delivery vendor's first message in the engine spec (issue #25)", async () => {
+  it("surfaces a paste-delivery vendor's first message in the engine spec", async () => {
     // kimi's repo init-prompt rides OUTSIDE the launch argv; the web PTY
     // sidecar pastes it post-spawn, so the spec must carry it — dropping it
     // here would silently lose the message.

--- a/packages/kobe/test/daemon/activity-arbitrate.test.ts
+++ b/packages/kobe/test/daemon/activity-arbitrate.test.ts
@@ -22,7 +22,7 @@ describe("recomputeTabActivity", () => {
     expect(recomputeTabActivity({}, T)).toBeUndefined()
   })
 
-  it("observed running fills the hole when no hook ever reported (#16 restart seeding)", () => {
+  it("observed running fills the hole when no hook ever reported (restart seeding)", () => {
     const eff = recomputeTabActivity({ observed: { state: "running", at: T } }, T)
     expect(eff).toMatchObject({ state: "running", source: "observed" })
   })

--- a/packages/kobe/test/daemon/automation-precheck.test.ts
+++ b/packages/kobe/test/daemon/automation-precheck.test.ts
@@ -90,7 +90,7 @@ describe("runAutomationPrecheck", () => {
     expect(result.exitCode).toBe(0)
   })
 
-  it("spawns the shell with -ilc, the same interactive login form engine tabs use (#26)", async () => {
+  it("spawns the shell with -ilc, the same interactive login form engine tabs use", async () => {
     // A spy shell records the exact argv it was invoked with, so this pins the
     // flag contract rather than just "a shell ran".
     const dir = mkdtempSync(join(tmpdir(), "kobe-precheck-spy-"))

--- a/packages/kobe/test/daemon/issues-roundtrip-fields.test.ts
+++ b/packages/kobe/test/daemon/issues-roundtrip-fields.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Disk-codec field guard for `normalizeIssue` — the hand-written allowlist an
+ * Issue field has to survive.
+ *
+ * `normalizeIssue` rebuilds every field by name, so a new optional on `Issue`
+ * writes to issues.json, reads back as `undefined`, and nothing fails: the
+ * type says the field exists, the store silently drops it, and the first
+ * report is a user wondering why a value they set vanished.
+ *
+ * Same technique as `test/daemon/serialize-task-fields.test.ts`, which closes
+ * the same hole on the wire codec: `DeepRequired` forces the fixture to name
+ * every field at compile time, so a new optional breaks the BUILD here until
+ * it is listed, and the assertion then goes red until `normalizeIssue`
+ * carries it.
+ */
+
+import { execFileSync } from "node:child_process"
+import { mkdir, mkdtemp, realpath, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { type Issue, IssuesStore } from "@sma1lboy/kobe-daemon/daemon/issues-store"
+import { afterEach, expect, it } from "vitest"
+
+type DeepRequired<T> = {
+  [K in keyof T]-?: NonNullable<T[K]> extends string | number | boolean
+    ? NonNullable<T[K]>
+    : DeepRequired<NonNullable<T[K]>>
+}
+
+/** Every field an Issue can carry, each with a distinguishable value. */
+const FULL: DeepRequired<Issue> = {
+  id: 7,
+  title: "disk fixture",
+  status: "hold",
+  created: "2026-07-15",
+  body: "the body text",
+  taskId: "01ARZ3NDEKTSV4RRFFQ69G5FAV",
+}
+
+const cleanups: string[] = []
+
+afterEach(async () => {
+  while (cleanups.length) await rm(cleanups.pop()!, { recursive: true, force: true })
+})
+
+/** A git repo plus an issues.json already holding `issues`, keyed the way the
+ *  store keys it (git common dir), so `list` reads a file it did not write. */
+async function seedStore(issues: unknown[]): Promise<{ repo: string; store: IssuesStore }> {
+  const parent = await mkdtemp(join(tmpdir(), "kobe-issue-fields-"))
+  cleanups.push(parent)
+  const repo = join(parent, "repo")
+  await mkdir(repo)
+  execFileSync("git", ["init", "--quiet"], { cwd: repo })
+
+  const storePath = join(parent, "home", ".kobe", "issues.json")
+  await mkdir(join(parent, "home", ".kobe"), { recursive: true })
+  await writeFile(
+    storePath,
+    JSON.stringify({
+      version: 1,
+      repos: {
+        [await realpath(join(repo, ".git"))]: { repoRoot: await realpath(repo), nextId: 99, issues },
+      },
+    }),
+    "utf8",
+  )
+  return { repo, store: new IssuesStore(storePath) }
+}
+
+it("reads back every field an Issue declares", async () => {
+  const { repo, store } = await seedStore([FULL])
+  const read = await store.list(repo)
+  expect(read.issues).toEqual([FULL])
+})
+
+it("keeps the known fields of a record carrying an unknown key, and defaults the absent ones", async () => {
+  const { repo, store } = await seedStore([{ id: 3, title: "from a newer Rove", futureField: { nested: true } }])
+  const read = await store.list(repo)
+  // Absent `body`/`created` read back as "" and `status` as "open" — the
+  // fallbacks are the contract, not incidental.
+  expect(read.issues).toEqual([{ id: 3, title: "from a newer Rove", status: "open", created: "", body: "" }])
+})

--- a/packages/kobe/test/engine/activity-observer.test.ts
+++ b/packages/kobe/test/engine/activity-observer.test.ts
@@ -108,7 +108,7 @@ const waitFor = async (cond: () => boolean, timeoutMs = 1500): Promise<void> => 
 const wait = (ms: number) => new Promise((r) => setTimeout(r, ms))
 
 describe("activity observer", () => {
-  it("re-seeds a busy session's dot on the first pass after a daemon restart (#16)", async () => {
+  it("re-seeds a busy session's dot on the first pass after a daemon restart", async () => {
     // Fresh registry (the restart wiped it); the engine is mid-turn: alive,
     // foreground claude, working title frame. No hook event will come until
     // the next turn boundary — the walk + title frame must light the row.
@@ -177,7 +177,7 @@ describe("activity observer", () => {
     expect(w.row("tab-2")?.state).toBe("running")
   })
 
-  it("a pty-host outage never resurrects an already-corrected idle as phantom running (#27)", async () => {
+  it("a pty-host outage never resurrects an already-corrected idle as phantom running", async () => {
     // Regression for 073deeaf: after an ESC correction the tab held
     // {hook: running@T0, observed: idle}. The host-unreachable retire path
     // calls observeTab with NO correction gate, so the Infinity default

--- a/packages/kobe/test/engine/foreground.test.ts
+++ b/packages/kobe/test/engine/foreground.test.ts
@@ -150,7 +150,7 @@ describe("foregroundEngine", () => {
   })
 })
 
-describe("hasAncestor (issue #24: env inherits, a pid chain doesn't)", () => {
+describe("hasAncestor (env inherits, a pid chain doesn't)", () => {
   // A tab shell (10) → engine (11) → its tool shell (12) → this CLI (13),
   // plus a sibling (20) that detached out of the same shell days ago and
   // reparented to init — it still carries the tab's exported env.

--- a/packages/kobe/test/engine/hosted-session.test.ts
+++ b/packages/kobe/test/engine/hosted-session.test.ts
@@ -79,7 +79,7 @@ describe("hosted session helpers", () => {
   })
 })
 
-describe("pastePromptWhenEngineUp (issue #25 first-message paste delivery)", () => {
+describe("pastePromptWhenEngineUp (first-message paste delivery)", () => {
   const noSleep = () => Promise.resolve()
   // ps -A -o pid=,ppid=,args= shape: a shell (pid 42) with a kimi child.
   const withEngine = "  42   1 /bin/zsh -ilc kimi\n  43  42 kimi\n"
@@ -148,7 +148,7 @@ describe("pastePromptWhenEngineUp (issue #25 first-message paste delivery)", () 
     expect(request).not.toHaveBeenCalledWith("pty.write", expect.anything())
   })
 
-  it("waits for the init marker before budgeting engine-startup time (issue #73)", async () => {
+  it("waits for the init marker before budgeting engine-startup time", async () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "kobe-hosted-init-marker-"))
     const marker = path.join(tmp, "marker")
     let written = ""
@@ -214,7 +214,7 @@ describe("pastePromptWhenEngineUp (issue #25 first-message paste delivery)", () 
   })
 })
 
-describe("deliverToHostedKey A+C gates (issue #78)", () => {
+describe("deliverToHostedKey A+C gates", () => {
   function rpcWith(
     peek: Partial<{ alive: boolean; data: string; lastHumanWriteMs: number; humanWriteQuietMs: number }>,
   ) {

--- a/packages/kobe/test/engine/protocol-sniff.test.ts
+++ b/packages/kobe/test/engine/protocol-sniff.test.ts
@@ -16,6 +16,7 @@ import { join } from "node:path"
 import { afterEach, beforeEach, describe, expect, it } from "vitest"
 import {
   protocolUpgradeFromLiveSession,
+  protocolWriteBackFromLiveSession,
   sniffProtocolFromSessions,
   sniffProtocolFromTitle,
 } from "../../src/engine/protocol-sniff.ts"
@@ -156,5 +157,76 @@ describe("protocolUpgradeFromLiveSession", () => {
     expect(protocolUpgradeFromLiveSession(generic, { walkVendor: null, title: "" })).toBeNull()
     // A walk verdict that is not a built-in identifies no protocol either.
     expect(protocolUpgradeFromLiveSession(generic, { walkVendor: "mystery-engine", title: "bash" })).toBeNull()
+  })
+})
+
+describe("protocolWriteBackFromLiveSession", () => {
+  // Same sandboxed state home as the record upgrade: the eligibility rule
+  // reads `engineProtocol.<id>` and the custom-engine registry, so the
+  // user's real presets must not decide the answer.
+  let home: string
+  let originalHome: string | undefined
+
+  function writeState(state: Record<string, unknown>): void {
+    const dir = join(home, ".config", "rove")
+    mkdirSync(dir, { recursive: true })
+    writeFileSync(join(dir, "state.json"), JSON.stringify(state), "utf8")
+  }
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), "kobe-protocol-writeback-"))
+    originalHome = process.env.KOBE_HOME_DIR
+    process.env.KOBE_HOME_DIR = home
+    writeState({})
+  })
+
+  afterEach(() => {
+    if (originalHome === undefined) {
+      // biome-ignore lint/performance/noDelete: the var must be truly unset when it started unset.
+      delete process.env.KOBE_HOME_DIR
+    } else process.env.KOBE_HOME_DIR = originalHome
+    rmSync(home, { recursive: true, force: true })
+  })
+
+  const registered = ["wrap"]
+
+  it("names a registered wrapper preset from the built-in the walk found", () => {
+    // No pinned `command` — the shape a preset-launched task actually has,
+    // and the one the record upgrade refuses.
+    expect(protocolWriteBackFromLiveSession({ vendor: "wrap" }, { walkVendor: "claude", title: "zsh" }, registered)) //
+      .toEqual({ id: "wrap", protocol: "claude" })
+  })
+
+  it("refuses a preset that already declares its protocol", () => {
+    writeState({ customEngineIds: registered, "engineProtocol.wrap": "codex" })
+    expect(
+      protocolWriteBackFromLiveSession({ vendor: "wrap" }, { walkVendor: "claude", title: "✳ x" }, registered),
+    ).toBeNull()
+  })
+
+  it("refuses a built-in, which IS its own protocol", () => {
+    expect(
+      protocolWriteBackFromLiveSession({ vendor: "claude" }, { walkVendor: "codex", title: "⠹ x" }, registered),
+    ).toBeNull()
+  })
+
+  it("refuses an id that is not a registered preset — the durability bar", () => {
+    // A one-off `--command` string must never mint a persistent
+    // `engineProtocol.<id>` key.
+    expect(
+      protocolWriteBackFromLiveSession({ vendor: "one-off" }, { walkVendor: "claude", title: "✳ x" }, registered),
+    ).toBeNull()
+  })
+
+  it("refuses a title glyph — this key outlives the session, so only the walk counts", () => {
+    expect(
+      protocolWriteBackFromLiveSession({ vendor: "wrap" }, { walkVendor: null, title: "✳ refactoring" }, registered),
+    ).toBeNull()
+  })
+
+  it("refuses a walk verdict that is not a built-in", () => {
+    expect(
+      protocolWriteBackFromLiveSession({ vendor: "wrap" }, { walkVendor: "mystery-engine", title: "zsh" }, registered),
+    ).toBeNull()
   })
 })

--- a/packages/kobe/test/engine/session-launch.test.ts
+++ b/packages/kobe/test/engine/session-launch.test.ts
@@ -60,7 +60,7 @@ describe("hosted engine session launch", () => {
     expect(launch.command[2]).not.toContain("set-branch")
   })
 
-  test("keeps a paste vendor's first message OUT of the argv and hands it to the spawner (issue #25)", () => {
+  test("keeps a paste vendor's first message OUT of the argv and hands it to the spawner", () => {
     const launch = buildEngineSessionLaunch({
       task: { id: "task-1", kind: "task", vendor: "kimi", repo: "/repo" },
       worktreePath: "/repo/.worktrees/task-1",

--- a/packages/kobe/test/engine/status-protocol.test.ts
+++ b/packages/kobe/test/engine/status-protocol.test.ts
@@ -61,7 +61,7 @@ describe("withWorktreeProtocol", () => {
     expect(withWorktreeProtocol(customFile, "claude", "t1", { status: on, notes: on })).toEqual(customFile)
   })
 
-  it("never double-injects over the attached --flag=value form either (issue #58)", () => {
+  it("never double-injects over the attached --flag=value form either", () => {
     const attached = ["claude", "--append-system-prompt=user's own"]
     expect(withWorktreeProtocol(attached, "claude", "t1", { status: on, notes: on })).toEqual(attached)
     const attachedFile = ["claude", "--append-system-prompt-file=/tmp/p.txt"]
@@ -159,7 +159,7 @@ describe("withDispatcherProtocol", () => {
     expect(withDispatcherProtocol(["claude"], "claude", undefined, on)).toEqual(["claude"])
   })
 
-  it("never double-injects over a custom command that sets the flag — either form (issue #58)", () => {
+  it("never double-injects over a custom command that sets the flag — either form", () => {
     const custom = ["claude", "--append-system-prompt", "user's own"]
     expect(withDispatcherProtocol(custom, "claude", "m1", on)).toEqual(custom)
     const attached = ["claude", "--append-system-prompt=user's own"]

--- a/packages/kobe/test/lib/git-parsers.test.ts
+++ b/packages/kobe/test/lib/git-parsers.test.ts
@@ -189,7 +189,7 @@ describe("parseNumstatRows", () => {
     expect(parseNumstatRows("0\t0\t\0ü.txt\0üv2.txt\0")).toEqual([numstat("üv2.txt", 0, 0, "ü.txt")])
   })
 
-  test("issue #63 regression: literal brace in a rename path", () => {
+  test("a literal brace survives a rename path", () => {
     // Brace-compaction makes this path unparseable without `-z`:
     //   path:       src/{a{b/f.txt  →  src/c/f.txt
     //   non-z:      src/{{a{b => c}/f.txt   (three `{`, ambiguous)

--- a/packages/kobe/test/orchestrator/dir-task.test.ts
+++ b/packages/kobe/test/orchestrator/dir-task.test.ts
@@ -93,7 +93,7 @@ describe("openDirectoryTask", () => {
   })
 })
 
-describe("scratch tasks (issue #33)", () => {
+describe("scratch tasks", () => {
   it("openDirectoryTask({scratch:true}) marks the row; a plain open does not", async () => {
     const scratch = await orch.openDirectoryTask({ dir, scratch: true })
     const plain = await orch.openDirectoryTask({ dir })
@@ -101,7 +101,7 @@ describe("scratch tasks (issue #33)", () => {
     expect(plain.scratch).toBeUndefined()
   })
 
-  it("a scratch task mints NO auto-name — title stays empty until named or adopted (issue #42)", async () => {
+  it("a scratch task mints NO auto-name — title stays empty until named or adopted", async () => {
     const scratch = await orch.openDirectoryTask({ dir, scratch: true })
     expect(scratch.title).toBe("")
     // Adoption derives the title from the repo it lands in (rule ①).

--- a/packages/kobe/test/orchestrator/store-tmp-collision.test.ts
+++ b/packages/kobe/test/orchestrator/store-tmp-collision.test.ts
@@ -44,7 +44,7 @@ import { mkdir, mkdtemp, readFile, rm, unlink } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { type TaskCreateInput, TaskIndexStore } from "../../src/orchestrator/index/store.ts"
 
-describe("TaskIndexStore staging-file isolation (issue #53)", () => {
+describe("TaskIndexStore staging-file isolation", () => {
   let home: string
 
   beforeEach(async () => {

--- a/packages/kobe/test/orchestrator/worktree-manager-edges.test.ts
+++ b/packages/kobe/test/orchestrator/worktree-manager-edges.test.ts
@@ -145,7 +145,7 @@ describe("remove() / currentBranch() edges", () => {
   })
 })
 
-describe("renameBranch() convergence (issue #44)", () => {
+describe("renameBranch() convergence", () => {
   it("resolves when the recorded old name is stale but the branch already carries the new name", async () => {
     const wt = join(root, "wt-stale-rename")
     await manager.create(repo, "rename-old", wt)

--- a/packages/kobe/test/render/keyboard-hints.test.tsx
+++ b/packages/kobe/test/render/keyboard-hints.test.tsx
@@ -92,6 +92,7 @@ function WorkspaceDriver(props: { children?: React.ReactNode; onToggleZen?: () =
     openInbox: NOOP,
     enterMoveMode: NOOP,
     createPR: NOOP,
+    createPRFor: NOOP,
     toggleSortMode: NOOP,
   })
   return <>{props.children}</>

--- a/packages/kobe/test/render/pty-delivery-size.test.ts
+++ b/packages/kobe/test/render/pty-delivery-size.test.ts
@@ -68,7 +68,7 @@ function deliveryRpc(host: PtyHost): HostedSessionRpc {
   }
 }
 
-describe("prompt delivery vs pane size (issue #18)", () => {
+describe("prompt delivery vs pane size", () => {
   test("after a peer delivery, the PTY still has the attached pane's size", async () => {
     const host = makeHost()
     const { frames, sink } = collector()

--- a/packages/kobe/test/render/pty-hosted.test.ts
+++ b/packages/kobe/test/render/pty-hosted.test.ts
@@ -296,7 +296,7 @@ describe("HostedTaskPty over a real pty-host socket", () => {
     c.kill()
   })
 
-  test("park + wake restores the exact screen: serialize at park, only the delta replayed (issue #29)", async () => {
+  test("park + wake restores the exact screen: serialize at park, only the delta replayed", async () => {
     // A sibling handle that never detaches is the oracle: after the parked
     // handle wakes, its screen must be BYTE-IDENTICAL to the sibling's —
     // the contract that made re-enabling the auto-park sweep safe.

--- a/packages/kobe/test/render/sidebar-row-chords-cursor.test.tsx
+++ b/packages/kobe/test/render/sidebar-row-chords-cursor.test.tsx
@@ -87,6 +87,7 @@ function ChordHost({ spies }: { spies: Spies }) {
     openInbox: () => {},
     enterMoveMode: () => {},
     createPR: () => {},
+    createPRFor: () => {},
     toggleSortMode: () => {},
   })
   return (

--- a/packages/kobe/test/render/sidebar-sort-key.test.tsx
+++ b/packages/kobe/test/render/sidebar-sort-key.test.tsx
@@ -92,6 +92,7 @@ function SortHost() {
     openInbox: () => {},
     enterMoveMode: () => {},
     createPR: () => {},
+    createPRFor: () => {},
     toggleSortMode: () => setSortMode((mode) => (mode === "default" ? "recent" : "default")),
   })
   return (

--- a/packages/kobe/test/render/sidebar-tree-menu.test.tsx
+++ b/packages/kobe/test/render/sidebar-tree-menu.test.tsx
@@ -230,7 +230,7 @@ test("a tab row's menu opens a new shell in its worktree", async () => {
   expect(asked).toEqual([["a", "shell"]])
 })
 
-test("a worktree's LAST tab DOES offer a close (owner call 2026-08-31)", async () => {
+test("a worktree's LAST tab DOES offer a close", async () => {
   // Closing it leaves the task with no sessions — the row stays and re-opens
   // on ⏎ / ctrl+e — so there is nothing for the menu to withhold.
   tabsByTask.clear()

--- a/packages/kobe/test/render/task-new-direct-key.test.tsx
+++ b/packages/kobe/test/render/task-new-direct-key.test.tsx
@@ -97,6 +97,7 @@ function Driver(props: {
     openInbox: NOOP,
     enterMoveMode: NOOP,
     createPR: NOOP,
+    createPRFor: NOOP,
     toggleSortMode: NOOP,
   })
   if (props.terminalWrites) return <TerminalInput writes={props.terminalWrites} />
@@ -167,6 +168,7 @@ function SearchUnmountTransition() {
     openInbox: NOOP,
     enterMoveMode: NOOP,
     createPR: NOOP,
+    createPRFor: NOOP,
     toggleSortMode: NOOP,
   })
   if (updateOpen) {

--- a/packages/kobe/test/render/which-key-help.test.tsx
+++ b/packages/kobe/test/render/which-key-help.test.tsx
@@ -91,6 +91,7 @@ function WorkspaceHelpDriver(props: { showDialogTarget?: boolean; showFocusTarge
     openInbox: NOOP,
     enterMoveMode: NOOP,
     createPR: NOOP,
+    createPRFor: NOOP,
     toggleSortMode: NOOP,
   })
   return (

--- a/packages/kobe/test/tui-react/host-task-actions-rename-branch.test.ts
+++ b/packages/kobe/test/tui-react/host-task-actions-rename-branch.test.ts
@@ -62,6 +62,8 @@ function makeActions(tasks: readonly Task[]) {
     dialog: {} as never,
     notifyError: vi.fn(),
     notifyInfo: vi.fn(),
+    notifyNeedsInput: vi.fn(),
+    t: (key: string) => key,
     selectedId: () => null,
     setSelectedId: vi.fn(),
     selectedTask: () => undefined,

--- a/packages/kobe/test/tui-react/host-task-actions-set-status.test.ts
+++ b/packages/kobe/test/tui-react/host-task-actions-set-status.test.ts
@@ -81,6 +81,8 @@ function makeActions(tasks: readonly Task[]) {
     dialog: DIALOG,
     notifyError,
     notifyInfo: vi.fn(),
+    notifyNeedsInput: vi.fn(),
+    t: (key: string) => key,
     selectedId: () => null,
     setSelectedId: vi.fn(),
     selectedTask: () => undefined,

--- a/packages/kobe/test/tui-react/sidebar-orphan-tabs.test.ts
+++ b/packages/kobe/test/tui-react/sidebar-orphan-tabs.test.ts
@@ -30,7 +30,7 @@ describe("orphanTabsByTask", () => {
     expect(map.get("t1")?.[0]?.label).toBe("⚠ claude — building")
   })
 
-  it("surfaces a live session missing from its task's snapshot — the issue-#20 invisible engine", () => {
+  it("surfaces a live session missing from its task's snapshot — the invisible engine", () => {
     // Snapshot answered for tab-2 only; tab-1 is alive on the host.
     const map = orphanTabsByTask([session("t1::tab-1"), session("t1::tab-2")], new Set(["t1::tab-2"]))
     expect(map.get("t1")?.map((t) => t.id)).toEqual(["tab-1"])

--- a/packages/kobe/test/tui-react/workspace-open-worktree-bindings.test.ts
+++ b/packages/kobe/test/tui-react/workspace-open-worktree-bindings.test.ts
@@ -77,6 +77,7 @@ describe("workspace open-worktree bindings", () => {
       openInbox: vi.fn(),
       enterMoveMode: vi.fn(),
       createPR: vi.fn(),
+      createPRFor: vi.fn(),
       toggleSortMode,
     })
 
@@ -155,6 +156,7 @@ describe("workspace open-worktree bindings", () => {
       openInbox: vi.fn(),
       enterMoveMode: vi.fn(),
       createPR: vi.fn(),
+      createPRFor: vi.fn(),
       toggleSortMode: vi.fn(),
     })
 
@@ -208,6 +210,7 @@ describe("workspace open-worktree bindings", () => {
       openInbox: vi.fn(),
       enterMoveMode: vi.fn(),
       createPR: vi.fn(),
+      createPRFor: vi.fn(),
       toggleSortMode: vi.fn(),
       ...over,
     }

--- a/packages/kobe/test/tui/chord-glyphs.test.ts
+++ b/packages/kobe/test/tui/chord-glyphs.test.ts
@@ -21,7 +21,7 @@ describe("formatChord", () => {
     expect(formatChord("shift+tab")).toBe("⇧ tab")
   })
 
-  it("keeps function keys, and keeps BARE keys in their typed case (#14)", () => {
+  it("keeps function keys, and keeps BARE keys in their typed case", () => {
     expect(formatChord("F1")).toBe("F1")
     expect(formatChord("f2")).toBe("F2")
     expect(formatChord("n")).toBe("n") // bare plain-letter — the literal key to press

--- a/packages/kobe/test/tui/new-task-dialog/state.test.ts
+++ b/packages/kobe/test/tui/new-task-dialog/state.test.ts
@@ -137,7 +137,7 @@ describe("splitRepoRow (repo rows lead with the basename)", () => {
   })
 })
 
-describe("offersProjectIntent (issue #90)", () => {
+describe("offersProjectIntent", () => {
   it("offers only for a repo that already has a project checkout", () => {
     const mains = new Set(["/repos/codefox"])
     expect(offersProjectIntent("/repos/codefox", mains)).toBe(true)
@@ -173,7 +173,7 @@ describe("nextField / firstFieldFor (per-tab field cycling)", () => {
     expect(nextField("engine", "existing")).toBe("repo")
   })
 
-  it("inserts the intent stop only when that row renders (issue #90)", () => {
+  it("inserts the intent stop only when that row renders", () => {
     // The row exists only for a repo that already has a project checkout, so
     // the walk is TOLD whether it is on screen. Offering the stop
     // unconditionally parks focus on nothing; omitting it when the row IS

--- a/packages/kobe/test/tui/pty-hosted-first-message.test.ts
+++ b/packages/kobe/test/tui/pty-hosted-first-message.test.ts
@@ -55,7 +55,7 @@ function openWith(result: unknown): void {
   })
 }
 
-describe("HostedTaskPty first-message paste (issue #25)", () => {
+describe("HostedTaskPty first-message paste", () => {
   it("hands firstMessage to pastePromptWhenEngineUp on a fresh spawn", async () => {
     openWith({ alive: true, created: true, replay: "", pid: 42, offset: 0 })
     const pty = new HostedTaskPty({

--- a/packages/kobe/test/tui/sidebar-tree-core.test.ts
+++ b/packages/kobe/test/tui/sidebar-tree-core.test.ts
@@ -119,7 +119,7 @@ describe("buildTreeRows", () => {
     expect(result.filter((r) => r.kind === "tab")).toHaveLength(0)
   })
 
-  test("scratch tasks render in one Scratch section above every project (issue #33)", () => {
+  test("scratch tasks render in one Scratch section above every project", () => {
     const result = rows({
       tasks: [
         task("m", { kind: "main", repo: "/repos/rove", branch: "", worktreePath: "/repos/rove" }),
@@ -136,7 +136,7 @@ describe("buildTreeRows", () => {
     ])
   })
 
-  test("a scratch task with tabs renders NO worktree row — tabs hang under the header (issue #41)", () => {
+  test("a scratch task with tabs renders NO worktree row — tabs hang under the header", () => {
     // The auto-generated scratch name is noise; the shell IS the session.
     // The task stays real in the data layer — only its middle row is skipped.
     const result = rows({
@@ -300,7 +300,7 @@ describe("rowLiveBranchPath", () => {
   })
 })
 
-describe("worktreeRowLabel (issue #42)", () => {
+describe("worktreeRowLabel", () => {
   test("a branch names the row, over everything else", () => {
     expect(worktreeRowLabel(task("a", { branch: "feat/a", title: "some title" }))).toBe("feat/a")
   })
@@ -353,7 +353,7 @@ describe("worktreeRowLabel (issue #42)", () => {
   })
 })
 
-describe("a project closed down to nothing (owner call 2026-08-31)", () => {
+describe("a project closed down to nothing", () => {
   const mainOf = (repo: string, id = "m") => task(id, { kind: "main", repo, title: repo.split("/").pop() ?? repo })
 
   test("hides the project when its only row is main and its tabs are closed", () => {

--- a/packages/kobe/test/tui/sidebar-tree-menu-items.test.ts
+++ b/packages/kobe/test/tui/sidebar-tree-menu-items.test.ts
@@ -158,7 +158,7 @@ describe("treeMenuItems", () => {
     ])
   })
 
-  test("the LAST tab IS offered a close (owner call 2026-08-31)", () => {
+  test("the LAST tab IS offered a close", () => {
     // Closing it leaves the task with no sessions; its sidebar row stays and
     // re-opens on ⏎ / ctrl+e. The entry is NOT withheld — closeTab accepts
     // the last tab.

--- a/packages/kobe/test/tui/sidebar-tree-menu-items.test.ts
+++ b/packages/kobe/test/tui/sidebar-tree-menu-items.test.ts
@@ -56,6 +56,7 @@ describe("treeMenuItems", () => {
       "openEditor",
       "renameBranch",
       "changeEngine",
+      "land",
       "delete",
     ])
   })
@@ -135,6 +136,22 @@ describe("treeMenuItems", () => {
     expect(actions(worktreeRow())).toContain("renameBranch")
   })
 
+  test("Land reaches only a materialised managed task — never main, dir, or a branchless row", () => {
+    // `landTask` throws outright for a main or dir task (neither owns a
+    // Rove-managed branch) and for a task that never materialised, so the
+    // entry could only end in the error toast — the same
+    // entry-that-does-nothing rule Rename branch follows.
+    for (const row of [
+      worktreeRow({ kind: "main", branch: "" }),
+      worktreeRow({ kind: "dir", branch: "" }),
+      worktreeRow({ branch: "" }),
+    ]) {
+      expect(actions(row)).not.toContain("land")
+    }
+    expect(actions(worktreeRow())).toContain("land")
+    expect(actions(projectRow)).not.toContain("land")
+  })
+
   test("the o/b/v trio never reaches a project header", () => {
     for (const verb of ["openEditor", "renameBranch", "changeEngine"]) expect(actions(projectRow)).not.toContain(verb)
   })
@@ -154,6 +171,7 @@ describe("treeMenuItems", () => {
       "openEditor",
       "renameBranch",
       "changeEngine",
+      "land",
       "delete",
     ])
   })
@@ -191,6 +209,7 @@ describe("treeMenuItems", () => {
       "openEditor",
       "renameBranch",
       "changeEngine",
+      "land",
       "delete",
     ])
   })

--- a/packages/kobe/test/tui/tab-close-scratch.test.ts
+++ b/packages/kobe/test/tui/tab-close-scratch.test.ts
@@ -71,7 +71,7 @@ describe("closeActive on the only tab", () => {
   })
 })
 
-describe("closing down to zero tabs (owner call 2026-08-31)", () => {
+describe("closing down to zero tabs", () => {
   it("an emptied task keeps its snapshot empty across a remount", () => {
     // The close only appears to take if rehydration honours it. Without
     // `allowEmpty` the task grows a fresh tab back on the next mount, and

--- a/packages/kobe/test/tui/terminal-pty-park.test.ts
+++ b/packages/kobe/test/tui/terminal-pty-park.test.ts
@@ -120,7 +120,7 @@ describe("PtyRegistry.parkIdle", () => {
     expect(reg.get("t::tab-1")).toBe(woken)
   })
 
-  it("carries the parked screen into the wake acquire exactly once (issue #29)", () => {
+  it("carries the parked screen into the wake acquire exactly once", () => {
     const SCREEN: ParkedScreen = {
       serialized: "\x1b[1mparked\x1b[0m",
       title: "vim",

--- a/packages/kobe/test/tui/terminal-registry.test.ts
+++ b/packages/kobe/test/tui/terminal-registry.test.ts
@@ -115,7 +115,7 @@ describe("TaskPty onExit contract (mock backend)", () => {
   })
 })
 
-describe("releaseWhere (task-scoped teardown, issue #16)", () => {
+describe("releaseWhere (task-scoped teardown)", () => {
   it("kills exactly the matching task's tab PTYs and leaves the rest alive", () => {
     const reg = new PtyRegistry(mockFactory)
     const a1 = reg.acquire("task-a::tab-1", "/a")

--- a/packages/kobe/test/tui/terminal-solid-block.test.ts
+++ b/packages/kobe/test/tui/terminal-solid-block.test.ts
@@ -50,7 +50,7 @@ describe("engine-owned terminal style rewrites", () => {
   })
 })
 
-describe("solid-block minimum-contrast immunity (issue #1 zebra)", () => {
+describe("solid-block minimum-contrast immunity (the zebra artefact)", () => {
   it("fg==bg solid blocks become bg-only spaces", async () => {
     const row = await rowFor("\x1b[38;2;238;238;238m\x1b[48;2;238;238;238m▄▄▄\x1b[0m")
     expect(row).toHaveLength(1)

--- a/packages/kobe/test/tui/terminal-tab-fork-argv.test.ts
+++ b/packages/kobe/test/tui/terminal-tab-fork-argv.test.ts
@@ -55,7 +55,7 @@ describe("engineForkArgv", () => {
     expect(engineForkArgv(["claude"], "claude", "")).toBeNull()
   })
 
-  it("declines a claude base that already controls its own session — either flag form (issue #58)", () => {
+  it("declines a claude base that already controls its own session — either flag form", () => {
     // A second --resume makes claude refuse to launch; the user's override
     // wins and the caller opens an ordinary tab on the base command.
     expect(engineForkArgv(["claude", "--resume", "pinned"], "claude", "src", "new")).toBeNull()
@@ -214,7 +214,7 @@ describe("engineTabSpawnFor with a tab-owned handoff prompt", () => {
 // `firstMessage` for the hosted PTY's post-spawn paste
 // (`pastePromptWhenEngineUp`). This pins the composition half of that
 // contract; the delivery half lives in hosted-session.test.ts.
-describe("engineTabSpawnFor with a paste-delivery vendor (kimi — issue #25)", () => {
+describe("engineTabSpawnFor with a paste-delivery vendor (kimi)", () => {
   const opts = {
     live: false,
     shell: "/bin/zsh",

--- a/packages/kobe/test/tui/workspace-task-selection.test.ts
+++ b/packages/kobe/test/tui/workspace-task-selection.test.ts
@@ -194,7 +194,7 @@ describe("pure-TUI workspace task activation", () => {
     expect(firstSelectableTask([], null)).toBeUndefined()
   })
 
-  test("a routine's standing session never wins the recency fallback (issue #91)", () => {
+  test("a routine's standing session never wins the recency fallback", () => {
     const mine = { ...task("mine", "/worktrees/mine"), updatedAt: "2026-07-01T00:00:00.000Z" }
     // Fired at 03:00, so it is genuinely the most recently updated task in the
     // install — and the least likely thing the user meant to open. Its sidebar


### PR DESCRIPTION
Eight independent items dispatched together, one commit each so a reviewer can bisect. **Seven landed; item 5 is left out** — see the last section.

| # | Item | Commit |
|---|---|---|
| 1 | Test names say what they assert, not where they came from | `test: name tests by what they assert…` |
| 2 | Files pane watches by default (`KOBE_FILETREE_WATCH=0` opts out) | `feat: watch the worktree in the Files pane…` |
| 3 | `ctrl+a` `p` follows the sidebar row; Land lands in the row menu | `feat: aim ctrl+a p at the sidebar row…` |
| 4 | Wrapper-preset protocol write-back | `feat: learn a wrapper preset's protocol…` |
| 5 | Persistent-session routines resume on revive | **not in this PR** |
| 6 | One repo-key derivation for the issues + notes stores | `refactor: one repo-key derivation…` |
| 7 | Delete kobe-web's two Issue type copies | `refactor: web reads the daemon's Issue types…` |
| 8 | Guard the Issue field allowlist | `test: guard the Issue field allowlist…` |

## Proofs

**1.** `git diff -U0` on that commit has no changed line outside an `it` / `describe` / `test` first argument. The grayscale-ramp name keeps its `#080808` — a colour, not an issue ref.

**2.** Harness before/after, same fixture, a file written into the worktree from OUTSIDE the TUI ~20s after the pane mounted, no `r` pressed:
- `.scratch/small-batch/watch-BEFORE.png` — old opt-in guard: `WATCH-BEFORE.md` is on disk but absent from the pane.
- `.scratch/small-batch/watch-AFTER.png` — `WATCH-AFTER.md` appears on its own.

The macOS FSEvents arming window in `pane-core.ts` stays documented and unclosed, as instructed. `docs/TUI.md` and `docs/CONFIGURATION.md` now describe the variable as an opt-OUT.

**3.** `.scratch/small-batch/pr-row-BEFORE.png` — cursor on the non-active `second-task` row, active task `visual-fixture` (its worktree's files in the Files pane). `.scratch/small-batch/pr-row-AFTER.png` — after `ctrl+a` `p`: `second-task` is active with a freshly spawned `claude 1` tab, the PR prompt text is in THAT tab, and the Files pane now shows second-task's worktree. `.scratch/small-batch/land-menu-entry.png` — the row menu with "Land into base branch" between Change engine and Delete.

Decision recorded in `docs/design/keybinding-decisions.md`; `docs/KEYBINDINGS.md` row reworded.

**Note for the owner:** `shift+p` still rides along as an alias of `p`. Not changed here.

**4.** Durability bar chosen: **the walked binary is a built-in AND the preset id is in `customEngineIds`** (single pass, no state to carry across ticks). Against a scratch home with `customEngineIds: ["wrap"]`, `engineCommand.wrap: "claude"` and no `engineProtocol.wrap`, a walk naming `claude` on a task with **no pinned command** (the shape the record upgrade refuses) writes `engineProtocol.wrap: "claude"`; a second tick with a contradicting `codex` walk does NOT flip it; an unregistered id mints nothing. Unit tests cover the rule with a fake walk. The owner's real `~/.config/rove/state.json` was not touched.

**6.** Both stores' unit tests pass unchanged (24 tests). Mutation: `--git-common-dir` → `--git-dir` in the new shared helper turns BOTH stores' worktree-sharing tests red, then green on restore — the helper is load-bearing for each. Each store keeps its own `resolveRepo`, so the toplevel fallback, the error mapping and the throw all survive verbatim.

**7.** kobe-web `tsc --noEmit` error set is **byte-identical before and after — diff size 0** (107 pre-existing `@/lib/*` alias errors both times). `bun run test` 576 pass, `bun run build` clean. `bun run check` has 5 pre-existing failures in files this PR does not touch (markdown/settings/store/web-token/worktrees); the three it does touch were formatted.

Two consumers the brief did not list also read those types from `lib/types.ts` (`lib/store.ts` and `test/board.test.ts`), plus types.ts's own `WebTransportEvent`. The test now imports from `lib/issues.ts` like every other issue consumer; `lib/types.ts` re-exports the daemon declaration for `store.ts`. Still zero hand-written copies.

**8.** Mutation A — drop the `taskId:` line from `normalizeIssue` → red. Mutation B (different site) — `body` fallback `""` → `"(untitled)"` → red on the other case. Restored, both green, the source file byte-identical.

## Item 5 left out

`--persistent-session` resume is bigger than a screen and the brief said to drop such an item rather than half-land it. It needs, at minimum: a new argument on the daemon's `startTaskSessionWithPrompt` runtime contract (`kobe-daemon/src/daemon/runtime.ts`, both call sites), a resume path through `buildEngineSessionLaunch` (which today has no resume verb wired in — `engineResumeArgv` is the TUI's tab-restart path), a way for the daemon to learn the session id (either a new Task field, which is four hand-written allowlists, or a new runtime read that asks the engine's history store for the worktree's newest session), plus `docs/ROUTINES.md` and the `routine-runs` help text. Its proof also needs a real engine PTY killed between two firings. Worth its own task.

## Gates

`bun x tsc --noEmit` clean in kobe and kobe-daemon; root `bun run lint` clean; `bun test test/render` 431 pass; `KOBE_INCLUDE_SOCKET=1 bun run test:socket` 728 pass; `bun run test:fast` 4245 pass / 4 fail.

Those 4 are the known false failures from running inside `~/.rove/worktrees` — `test/state/project-eligibility.test.ts` and `test/cli/open-dir-cmd.test.ts` classify the repo root by path shape and read this worktree as Rove-internal. Neither file nor its source is touched by this branch (`git diff --name-only origin/main` has no match for either); CI runs from an ordinary checkout.

## File-size cap

`host.tsx` went 485 → 524 with the two row-scoped actions this PR adds, so it is split along a real seam: the "Land into base branch" binder (row lookup, confirm copy, toasts) moves to `host-task-actions.ts`, which already owns exactly that job for every other row verb, and `host.tsx` is back to 495. That hook now takes `t` and `notifyNeedsInput` through deps rather than calling `useT()` — its unit tests call it outside a React render.

file-size-exemption: packages/kobe/test/client/remote-orchestrator.test.ts — already 523 lines on `main`; this PR's only edit to it is deleting `, issue #15 G3` from one `describe` name (item 1), which changes no line count and gives no seam to split on.
