### PR TITLE
fix: New task is prefix+n, and the dialog's mode row is a chip row

### DIFF
--- a/.changeset/prefix-n-new-task.md
+++ b/.changeset/prefix-n-new-task.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+New task moves from `ctrl+n` to the prefix: `ctrl+a` `n` opens it from anywhere, including inside an engine or shell terminal, and a bare `ctrl+n` always reaches the PTY. The sidebar keeps bare `n`. The dialog's Existing / New Repo / Adopt selector is now a `MODE` chip row like the engine picker.

--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -51,6 +51,7 @@ shows only actions that can run right now.
 | `ctrl+a` `h` / `l` | Move focus left / right across panes |
 | `ctrl+a` `o` | Open the Task directory in your editor |
 | `ctrl+a` `m` | Reorder sidebar rows (scope-aware: tab / task / project) |
+| `ctrl+a` `n` | New task |
 | `ctrl+a` `w` | Close the active split |
 | `ctrl+a` `1` / `2` / `3` | Kanban / Routines / Issues |
 | `ctrl+a` `z` | Toggle zen mode |
@@ -93,7 +94,6 @@ for terminal support.
 | Key | Action |
 |---|---|
 | `F1` | The live keymap; works from every pane, including inside the terminal (not while a dialog or a full-page view — Settings / Worktrees / Update — is open) |
-| `ctrl+n` | New task from any non-input UI surface; inside an engine composer or embedded shell terminal it keeps its readline/emacs meaning and passes through |
 | `ctrl+q` | Focus the sidebar; pressed again there, quit immediately (`q` in the sidebar quits with a confirm) |
 | `ctrl+t` | New engine tab |
 | `ctrl+e` | New-conversation dialog with the engine/shell picker; inside it, `←`/`→` (or `h`/`l`) pick the engine and `enter` confirms, `tab` switches the destination (new tab here ⇄ fork a child task) and `ctrl+f` the context (fresh ⇄ continue this chat). The trailing "scratch shell" choice opens a Scratch shell task |
@@ -114,11 +114,9 @@ is split, otherwise the tab. `F2` follows the same rule. `enter` is bound only
 by the "no sessions here" pane, which has no input and no tab of its own —
 everywhere else in the workspace it reaches the terminal as usual.
 
-`ctrl+n` has the same input boundary as an ordinary typed key. It opens New
-task from the sidebar, Files, read-only content tabs, Worktrees, Update, and
-the Kanban, Routines, and Issues pages. Sidebar search, Settings, dialogs, and
-engine or shell terminals keep input ownership; a focused PTY receives its
-`ctrl+n` byte unchanged.
+New task is `ctrl+a` `n` from anywhere (the sidebar also answers to bare
+`n`). It is a prefix sequence, not a direct `ctrl+n`, so the embedded engine
+and shell terminals keep `ctrl+n` for readline/emacs next-history.
 
 Both split chords need a terminal speaking the kitty keyboard protocol
 (legacy terminals can't encode `ctrl+=`, and `ctrl+\` would be SIGQUIT);

--- a/docs/design/dialogs.md
+++ b/docs/design/dialogs.md
@@ -39,10 +39,11 @@ story drawer commits with Enter from any selector field — it has no such stop,
 and a button nothing can focus would be a fourth thing to explain. It states
 the verb in its legend instead.
 
-**Tabs are not fields.** The new-task dialog's Existing / New Repo / Adopt
-strip navigates between three bodies. It stays a `▸ `-marked tab strip rather
-than becoming a chip row, because chips are how this grammar says "pick one
-value for this field".
+**The mode row is a chip row too.** The new-task dialog's Existing / New
+Repo / Adopt selector navigates between three bodies, but it reads and
+operates like every other choose-one in the card: `MODE` label, `ChipButton`
+per choice, ←/→ while focused. One selector shape per dialog (owner call,
+2026-09-03).
 
 ## The frames give way before the button does
 

--- a/docs/design/keybinding-decisions.md
+++ b/docs/design/keybinding-decisions.md
@@ -8,23 +8,16 @@ reasoning is recorded so the next agent has the context.
 The user-facing vocabulary lives in [`../KEYBINDINGS.md`](../KEYBINDINGS.md).
 `F1` renders the live keymap and is authoritative over both.
 
-## New task from non-input panes
+## New task from anywhere
 
-**2026-09-02 — `ctrl+n` opens New task from non-input UI surfaces; the
-sidebar keeps bare `n`, and engine composers and embedded terminals keep
-`ctrl+n` as input.** The owner wanted task creation directly reachable from
-the content side without first returning to the sidebar. Restoring the old
-unconditional global binding would also restore the reason it was removed:
-readline and emacs-style inputs use `ctrl+n` for next-history, including inside
-the embedded engine and shell terminals.
-
-The binding is therefore global across non-input Rove UI surfaces. It is
-reachable from the sidebar, Files, read-only content tabs, Worktrees, Update,
-Kanban, Routines, and Issues. Sidebar search, Settings, and dialogs retain
-input or modal ownership. When the focused surface forwards input to a PTY,
-dispatch and shortcut discovery both exclude the Rove action, so the engine
-receives the byte and F1 or the direct-shortcut guide does not advertise a
-command that cannot run there.
+**2026-09-03 — `prefix+n` opens New task from anywhere; the sidebar keeps
+bare `n`; there is no direct `ctrl+n`.** The 2026-09-02 direct `ctrl+n` was
+gated to non-input surfaces so the embedded terminals kept readline/emacs
+next-history, which made it unreachable from exactly the place the owner is
+usually looking — the engine pane. The owner's call: move it behind the
+prefix. The prefix's first stroke never passes through, so `ctrl+a` `n` works
+inside the terminal too, and `ctrl+n` reaches the PTY unconditionally. The
+`yieldToPassthrough` mechanism stays for future direct chords.
 
 ## Prefix tap presentation
 

--- a/packages/kobe/src/tui-react/component/new-task-dialog/dialog.tsx
+++ b/packages/kobe/src/tui-react/component/new-task-dialog/dialog.tsx
@@ -1,14 +1,13 @@
 /** @jsxImportSource @opentui/react */
 /**
  * The new-task dialog's JSX shell. Three sibling sub-tabs share one frame
- * (Existing / New Repo / Adopt), switched with Ctrl+[ / Ctrl+] or ←/→ on the
- * mode selector; the engine selector cycles with ctrl+e. All state, effects,
+ * (Existing / New Repo / Adopt), a chip row switched with Ctrl+[ / Ctrl+] or
+ * ←/→ while focused; the engine selector cycles with ctrl+e. All state, effects,
  * commit paths and key bindings live in `./view-model.ts` (pure helpers in
  * `state.ts`/`clone.ts`); the tab bodies live in `./tab-*.tsx`. Every
  * user-visible string resolves through `useT()`.
  */
 
-import { TextAttributes } from "@opentui/core"
 import type { DialogTab } from "../../../tui/component/new-task-dialog/state"
 import { useTheme } from "../../context/theme"
 import { useT } from "../../i18n"
@@ -34,35 +33,31 @@ export function NewTaskDialogView(props: NewTaskDialogProps) {
     clone: t("newTask.tabs.clone"),
     adopt: t("newTask.tabs.adopt"),
   }
-  const tabsFocused = vm.field === "tabs"
-  // Active selections keep ▸ + bold + primary; an underline marks them only
-  // while that selector holds keyboard focus.
-  const selectedAttrs = (selected: boolean, focused: boolean) =>
-    selected ? (focused ? TextAttributes.BOLD | TextAttributes.UNDERLINE : TextAttributes.BOLD) : undefined
 
   return (
     <box paddingLeft={padX} paddingRight={padX} gap={0}>
       <DialogHeader title={t("newTask.title")} onClose={() => props.onCancel()} />
       <box gap={1} paddingTop={1}>
-        {/* Mode-tab selector — reachable by Tab; ←/→ switches while focused,
-            ctrl+[/] from anywhere, mouse click selects. Stays a tab strip
-            rather than a chip row: it navigates between three bodies, it is
-            not one of the card's fields (docs/design/dialogs.md). */}
-        <box flexDirection="row" gap={2}>
-          {TAB_ORDER.map((tabId) => {
-            const active = vm.tab === tabId
-            return (
-              <text
+        {/* Mode selector — Tab reaches it; ←/→ switches while focused,
+            ctrl+[/] from anywhere, click picks. Same chip row as every
+            other choose-one in this dialog. */}
+        <DialogSection
+          label={t("newTask.field.mode")}
+          focused={vm.field === "tabs"}
+          hint={t("newTask.hint.modeCycle")}
+          onPress={() => vm.setField("tabs")}
+        >
+          <box flexDirection="row" flexWrap="wrap" gap={1}>
+            {TAB_ORDER.map((tabId) => (
+              <ChipButton
                 key={tabId}
-                fg={active ? theme.primary : theme.textMuted}
-                attributes={selectedAttrs(active, tabsFocused)}
-                onMouseUp={() => vm.switchToTab(tabId)}
-              >
-                {active ? `▸ ${tabLabel[tabId]}` : `  ${tabLabel[tabId]}`}
-              </text>
-            )
-          })}
-        </box>
+                label={tabLabel[tabId]}
+                selected={vm.tab === tabId}
+                onPress={() => vm.switchToTab(tabId)}
+              />
+            ))}
+          </box>
+        </DialogSection>
         {/* Engine selector — Tab reaches it; ←/→ cycles while focused,
             ctrl+e from anywhere, click picks. Detected vendors only. */}
         <DialogSection

--- a/packages/kobe/src/tui-react/workspace/host-keybindings.ts
+++ b/packages/kobe/src/tui-react/workspace/host-keybindings.ts
@@ -165,9 +165,9 @@ export function useWorkspaceKeybindings(deps: WorkspaceKeybindingDeps): void {
       }),
     ],
   }))
-  // New task belongs to every non-input UI surface, including the Worktrees
-  // and Update full-window pages. Keep the explicit input gates here instead
-  // of inheriting the broader page gate used by ordinary workspace chords.
+  // New task belongs everywhere but a dialog, Settings, or the sidebar
+  // search box — including the Worktrees and Update full-window pages and
+  // the terminal (the prefix's first stroke does not pass through).
   useBindings(() => ({
     enabled: !pages.dialogOpen && !pages.settingsOpen && !deps.searchActive,
     bindings: bindByIds({ "task.new.global": () => deps.createTask() }),

--- a/packages/kobe/src/tui/context/keybindings-table.ts
+++ b/packages/kobe/src/tui/context/keybindings-table.ts
@@ -142,16 +142,15 @@ export const KobeKeymap: readonly KobeBinding[] = [
     hint: { keys: "n" },
   },
   {
-    // Direct from every non-input UI surface. Unlike the old global
-    // ctrl+n, this yields when an engine composer or shell terminal owns
-    // input, preserving readline/emacs next-history inside the PTY.
+    // From anywhere via the prefix. Not a direct ctrl+n: readline/emacs
+    // next-history inside the embedded engine and shell terminals owns
+    // that chord, and the prefix's first stroke never passes through.
     id: "task.new.global",
     scope: "global",
-    keys: ["ctrl+n"],
+    keys: [],
+    prefixKeys: ["n"],
     category: "Global",
     description: "New task",
-    presentation: "onePress",
-    yieldToPassthrough: true,
   },
   {
     id: "task.openEditor",

--- a/packages/kobe/src/tui/i18n/messages/newTask.ts
+++ b/packages/kobe/src/tui/i18n/messages/newTask.ts
@@ -14,6 +14,7 @@ export const en = {
   },
 
   field: {
+    mode: "MODE",
     engine: "ENGINE",
     repo: "REPO",
     fromBranch: "FROM BRANCH",
@@ -38,6 +39,7 @@ export const en = {
   },
 
   hint: {
+    modeCycle: "ctrl+[ ]",
     engineCycle: "ctrl+e",
     remembered: "(remembered — next clone defaults to this dir)",
     currentDir: "(current dir)",
@@ -105,6 +107,7 @@ export const zh: typeof en = {
   },
 
   field: {
+    mode: "模式",
     engine: "引擎",
     repo: "仓库",
     fromBranch: "基准分支",
@@ -129,6 +132,7 @@ export const zh: typeof en = {
   },
 
   hint: {
+    modeCycle: "ctrl+[ ]",
     engineCycle: "ctrl+e",
     remembered: "（已记住 — 下次克隆默认使用此目录）",
     currentDir: "（当前目录）",

--- a/packages/kobe/test/render/task-new-prefix-key.test.tsx
+++ b/packages/kobe/test/render/task-new-prefix-key.test.tsx
@@ -1,10 +1,8 @@
 /** @jsxImportSource @opentui/react */
-/** Real-render coverage for ctrl+n's UI-only New task scope. */
+/** Real-render coverage for the prefix+n New task chord and the ctrl+n terminal boundary. */
 
 import { describe, expect, it } from "bun:test"
-import type { KeyEvent } from "@opentui/core"
-import { useRenderer } from "@opentui/react"
-import { useEffect, useState } from "react"
+import { useState } from "react"
 import { FocusProvider, type PaneId, useFocus } from "../../src/tui-react/context/focus"
 import { useBindings } from "../../src/tui-react/lib/keymap"
 import { SidebarBrandHeader, SidebarSearchInput } from "../../src/tui-react/panes/sidebar/chrome"
@@ -13,6 +11,7 @@ import { useTerminalBindings } from "../../src/tui-react/panes/terminal/keys"
 import { useDialog } from "../../src/tui-react/ui/dialog"
 import { useWorkspaceKeybindings } from "../../src/tui-react/workspace/host-keybindings"
 import type { HostPagesState } from "../../src/tui-react/workspace/host-pages"
+import { resetPrefixState } from "../../src/tui/lib/keymap-dispatch"
 import { act, renderComponent, settle } from "./harness"
 
 const NOOP = (): void => {}
@@ -57,17 +56,7 @@ function TerminalInput(props: { writes: string[] }) {
   return <text>engine composer</text>
 }
 
-function SearchInput(props: { defaultPrevented: boolean[] }) {
-  const renderer = useRenderer()
-  useEffect(() => {
-    const listener = (event: KeyEvent): void => {
-      if (event.name === "n" && event.ctrl) props.defaultPrevented.push(event.defaultPrevented)
-    }
-    renderer.keyInput.on("keypress", listener)
-    return () => {
-      renderer.keyInput.off("keypress", listener)
-    }
-  }, [renderer, props.defaultPrevented])
+function SearchInput() {
   return <SidebarSearchInput query="" matchCount={0} totalCount={0} />
 }
 
@@ -75,7 +64,6 @@ function Driver(props: {
   initialFocus: PaneId
   openPage?: OpenPage
   searchActive?: boolean
-  searchEvents?: boolean[]
   terminalWrites?: string[]
 }) {
   const focus = useFocus()
@@ -101,11 +89,11 @@ function Driver(props: {
     toggleSortMode: NOOP,
   })
   if (props.terminalWrites) return <TerminalInput writes={props.terminalWrites} />
-  if (props.searchEvents) return <SearchInput defaultPrevented={props.searchEvents} />
+  if (props.searchActive) return <SearchInput />
   return <text>content pane</text>
 }
 
-async function pressCtrlN(props: Parameters<typeof Driver>[0]): Promise<string> {
+async function pressNewTask(props: Parameters<typeof Driver>[0] & { bareCtrlN?: boolean }): Promise<string> {
   const { frame, mockInput, destroy } = await renderComponent(
     <FocusProvider initial={props.initialFocus}>
       <Driver {...props} />
@@ -118,11 +106,17 @@ async function pressCtrlN(props: Parameters<typeof Driver>[0]): Promise<string> 
   )
   await settle()
   await act(async () => {
-    mockInput.pressKey("n", { ctrl: true })
+    if (props.bareCtrlN) {
+      mockInput.pressKey("n", { ctrl: true })
+    } else {
+      mockInput.pressKey("a", { ctrl: true })
+      mockInput.pressKey("n")
+    }
     await settle()
   })
   const text = await frame()
   act(() => destroy())
+  resetPrefixState()
   return text
 }
 
@@ -184,33 +178,31 @@ function SearchUnmountTransition() {
   return <SearchSurface onActiveChange={setSearchActive} onOpenUpdate={() => setUpdateOpen(true)} />
 }
 
-describe("ctrl+n New task", () => {
+describe("prefix+n New task", () => {
   it("opens the dialog from sidebar, files, and a non-input content pane", async () => {
     for (const initialFocus of ["sidebar", "files", "workspace"] as const) {
-      expect(await pressCtrlN({ initialFocus })).toContain("New task dialog opened")
+      expect(await pressNewTask({ initialFocus })).toContain("New task dialog opened")
     }
   })
 
   it("opens the dialog from kanban, routines, and issues pages", async () => {
     for (const openPage of ["kanbanOpen", "automationsOpen", "workItemsOpen"] as const) {
-      expect(await pressCtrlN({ initialFocus: "workspace", openPage })).toContain("New task dialog opened")
+      expect(await pressNewTask({ initialFocus: "workspace", openPage })).toContain("New task dialog opened")
     }
   })
 
   it("opens the dialog from the Worktrees and Update full-window pages", async () => {
     for (const openPage of ["worktreesOpen", "updateOpen"] as const) {
-      expect(await pressCtrlN({ initialFocus: "workspace", openPage })).toContain("New task dialog opened")
+      expect(await pressNewTask({ initialFocus: "workspace", openPage })).toContain("New task dialog opened")
     }
   })
 
-  it("leaves ctrl+n unclaimed while the real sidebar search input is active", async () => {
-    const searchEvents: boolean[] = []
-    const text = await pressCtrlN({ initialFocus: "sidebar", searchActive: true, searchEvents })
+  it("leaves prefix+n unclaimed while the real sidebar search input is active", async () => {
+    const text = await pressNewTask({ initialFocus: "sidebar", searchActive: true })
     expect(text).not.toContain("New task dialog opened")
-    expect(searchEvents).toEqual([false])
   })
 
-  it("restores ctrl+n after search unmounts behind the Update page", async () => {
+  it("restores prefix+n after search unmounts behind the Update page", async () => {
     const { frame, mockInput, mockMouse } = await renderComponent(
       <FocusProvider initial="sidebar">
         <SearchUnmountTransition />
@@ -238,16 +230,24 @@ describe("ctrl+n New task", () => {
       await mockMouse.click(text.split("\n")[closeRow]!.indexOf("Close Update") + 1, closeRow)
     })
     await settle()
-    act(() => mockInput.pressKey("n", { ctrl: true }))
+    act(() => {
+      mockInput.pressKey("a", { ctrl: true })
+      mockInput.pressKey("n")
+    })
     await settle()
     expect(await frame()).toContain("New task dialog opened")
+    resetPrefixState()
   })
 
-  it("does not open over an engine composer or terminal and forwards ctrl+n", async () => {
+  it("opens over an engine composer via the prefix, while a bare ctrl+n reaches the PTY", async () => {
     const writes: string[] = []
-    const text = await pressCtrlN({ initialFocus: "workspace", terminalWrites: writes })
-    expect(text).not.toContain("New task dialog opened")
-    expect(text).toContain("engine composer")
+    const opened = await pressNewTask({ initialFocus: "workspace", terminalWrites: writes })
+    expect(opened).toContain("New task dialog opened")
+    expect(writes).toEqual([])
+
+    const forwarded = await pressNewTask({ initialFocus: "workspace", terminalWrites: writes, bareCtrlN: true })
+    expect(forwarded).not.toContain("New task dialog opened")
+    expect(forwarded).toContain("engine composer")
     expect(writes).toEqual(["\x0e"])
   })
 })

--- a/packages/kobe/test/tui/keymap-dispatch-passthrough.test.ts
+++ b/packages/kobe/test/tui/keymap-dispatch-passthrough.test.ts
@@ -196,28 +196,48 @@ describe("prefix passthrough boundary", () => {
   })
 })
 
-describe("content-only direct chords", () => {
-  test("ctrl+n opens New task on a UI surface", () => {
-    let opened = false
-    const ui: RegisteredBinding = {
-      id: 1,
-      config: () => ({
-        bindings: bindByIds({
-          "task.new.global": () => {
-            opened = true
-          },
+describe("prefix+n New task", () => {
+  test("opens New task on a UI surface and inside terminal passthrough", () => {
+    for (const passthrough of [false, true]) {
+      resetPrefixState()
+      let opened = false
+      let forwarded = false
+      const terminal: RegisteredBinding = {
+        id: 1,
+        config: () => ({
+          bindings: [
+            {
+              key: "ctrl+n",
+              passthrough: true,
+              cmd: () => {
+                forwarded = true
+              },
+            },
+          ],
         }),
-      }),
-    }
+      }
+      const host: RegisteredBinding = {
+        id: 2,
+        config: () => ({
+          bindings: bindByIds({
+            "task.new.global": () => {
+              opened = true
+            },
+          }),
+        }),
+      }
+      const stack = passthrough ? [terminal, host] : [host]
+      expect(bindingReachability(stack).prefix).toContain("task.new.global")
+      expect(bindingReachability(stack).direct).not.toContain("task.new.global")
 
-    const evt = makeEvt("n", { ctrl: true })
-    expect(dispatchKeyEvent([ui], evt, 100)).toBe(true)
-    expect(opened).toBe(true)
-    expect(evt.defaultPrevented).toBe(true)
-    expect(bindingReachability([ui]).direct).toContain("task.new.global")
+      expect(dispatchKeyEvent(stack, makeEvt("a", { ctrl: true }), 100)).toBe(true)
+      expect(dispatchKeyEvent(stack, makeEvt("n"), 200)).toBe(true)
+      expect(opened).toBe(true)
+      expect(forwarded).toBe(false)
+    }
   })
 
-  test("ctrl+n yields to engine and shell input even when the host binding is above it", () => {
+  test("a bare ctrl+n reaches the terminal, never New task", () => {
     let opened = false
     let forwarded = false
     const terminal: RegisteredBinding = {
@@ -234,9 +254,6 @@ describe("content-only direct chords", () => {
         ],
       }),
     }
-    // React registers ancestor effects after child effects, so the host is
-    // above the terminal in production. The content-only policy, not stack
-    // order, must still leave readline/emacs ctrl+n with the PTY.
     const host: RegisteredBinding = {
       id: 2,
       config: () => ({
@@ -247,13 +264,8 @@ describe("content-only direct chords", () => {
         }),
       }),
     }
-
-    const evt = makeEvt("n", { ctrl: true })
-    expect(dispatchKeyEvent([terminal, host], evt, 100)).toBe(true)
+    expect(dispatchKeyEvent([terminal, host], makeEvt("n", { ctrl: true }), 100)).toBe(true)
     expect(opened).toBe(false)
     expect(forwarded).toBe(true)
-    expect(evt.defaultPrevented).toBe(true)
-    expect(bindingReachability([terminal, host]).direct).not.toContain("task.new.global")
-    expect(bindingReachability([terminal, host]).inputPassthrough).toBe(true)
   })
 })


### PR DESCRIPTION
## What

- \`task.new.global\` moves from a direct \`ctrl+n\` (which yielded to terminal passthrough) to \`ctrl+a\` \`n\`. Works from anywhere including inside an engine/shell terminal; a bare \`ctrl+n\` always reaches the PTY. Sidebar keeps bare \`n\`.
- New task dialog: the Existing / New Repo / Adopt tab strip becomes a \`MODE\` \`ChipButton\` row, same shape as the ENGINE and OPENS pickers. Keys unchanged (\`ctrl+[ ]\`, ←/→ while focused, click).
- Docs: KEYBINDINGS.md prefix table, keybinding-decisions.md (owner call 2026-09-03), design/dialogs.md.

## Evidence

Harness (xterm → PTY → real OpenTUI):

- BEFORE \`.scratch/prefix-n/before-dialog.png\` — \`▸ For Existing\` text strip.
- AFTER \`.scratch/prefix-n/after-dialog.png\` — MODE chip row above ENGINE.
- AFTER \`.scratch/prefix-n/after-from-terminal.png\` — focus on the engine pane (orange border), \`ctrl+a n\` opens the dialog.

Tests: \`test/tui/keymap-dispatch-passthrough.test.ts\` (prefix+n opens with and without passthrough; bare ctrl+n forwards), \`test/render/task-new-prefix-key.test.tsx\` (renamed; every surface + terminal + search gate). \`bun test test/render\` 431/0, vitest 4247 pass; the 2 \`continue-live-vendor\` failures reproduce on clean main and come from that test reading the real \`~/.rove\` state.