### PR TITLE
A recycled tab keeps its pinned engine, gets a fresh id, and ctrl+a w closes it

### DIFF
--- a/.changeset/tab-recycle-keeps-its-engine.md
+++ b/.changeset/tab-recycle-keeps-its-engine.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+A tab that exits as the task's last one now comes back as the engine it was pinned to. Recycling used to hand back a bare first tab, so a tab you pointed at Codex respawned as the task's engine while still wearing the Codex conversation's title. It also reused `tab-1`, which let a recycled tab inherit a dead tab's Inbox episodes and its in-flight orphan suppression — ids are minted from the task's ordinal counter now, and are never reused. Separately, `ctrl+a` `w` closes the tab when there is no split, instead of being swallowed.

--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -52,7 +52,7 @@ shows only actions that can run right now.
 | `ctrl+a` `o` | Open the Task directory in your editor |
 | `ctrl+a` `m` | Reorder sidebar rows (scope-aware: tab / task / project) |
 | `ctrl+a` `n` | New task |
-| `ctrl+a` `w` | Close the active split |
+| `ctrl+a` `w` | Close the active split, otherwise the tab — the prefix twin of `ctrl+w` |
 | `ctrl+a` `1` / `2` / `3` | Kanban / Routines / Issues |
 | `ctrl+a` `z` | Toggle zen mode |
 | `ctrl+a` `,` | Open Settings |

--- a/docs/design/keybinding-decisions.md
+++ b/docs/design/keybinding-decisions.md
@@ -422,6 +422,27 @@ answer `setStatus` and the two copies got: the capability exists now, and a
 chord can be added later if reaching for the mouse turns out to be the
 friction rather than the safety.
 
+## `<prefix> w` closes the tab when there is no split
+
+No chord was added or moved. `ctrl+w` and `<prefix> w` are one documented
+gesture — "close the active split, otherwise the tab" — split across two
+registry rows that are mutually gated so exactly one is live:
+`workspace.split.close` while the active tab is split, `chat.tab.close`
+otherwise.
+
+Only the split row declared `prefixKeys: ["w"]`. On an unsplit tab the second
+stroke therefore found no enabled prefix binding, and the dispatcher CONSUMES
+a prefix miss on purpose (so a deliberate sequence can never type into a
+terminal). The key was eaten, silently, while `KEYBINDINGS.md`, the row's own
+F1 help text and its i18n twin all promised it closed the tab.
+
+The fix gives `chat.tab.close` the same `prefixKeys: ["w"]` its twin already
+had, so whichever row the gate leaves live owns BOTH strokes. Nothing new is
+reachable that the direct chord did not already reach, and no other binding
+loses a key. Its handler is wrapped in `prefixAction` for the same reason the
+split row's is: the prefix HUD's clickable option resolves through `action`,
+not `cmd`.
+
 ## Adding or moving a chord
 
 Get owner sign-off on direct versus prefix placement, the selected key, and

--- a/packages/kobe/src/tui-react/workspace/TerminalTabs.tsx
+++ b/packages/kobe/src/tui-react/workspace/TerminalTabs.tsx
@@ -59,7 +59,6 @@ import {
   initialShellTabs,
   initialTabs,
   isTabSplit,
-  recycleTabs,
   rehydrateTabs,
   renameActiveTab,
   selectTab,
@@ -425,7 +424,9 @@ export function TerminalTabs(props: TerminalTabsProps): ReactNode {
   useBindings(() => ({
     enabled: props.focused && !activeIsSplit,
     bindings: bindByIds({
-      "chat.tab.close": () => tabClose.closeActive(),
+      // prefixAction so the prefix HUD's clickable option resolves too —
+      // the mouse path needs `action`, not just `cmd`.
+      "chat.tab.close": prefixAction(() => tabClose.closeActive()),
       "chat.tab.rename": requestRename,
     }),
   }))

--- a/packages/kobe/src/tui-react/workspace/terminal-tabs-shared.ts
+++ b/packages/kobe/src/tui-react/workspace/terminal-tabs-shared.ts
@@ -130,42 +130,71 @@ export function knownTaskTabs(
 }
 
 /**
- * Cross-component "activate this tab" request (the F7 attention jump). The
- * mounted TerminalTabs for `taskId` consumes it via the listener; a task
- * that isn't mounted yet consumes it on mount (the host selects the task
- * first, TerminalTabs mounts, then reads the pending request). Unknown tab
- * ids are dropped on consume — the tab may have closed meanwhile.
+ * One cross-component request slot: a caller (the sidebar, a plugin, the F7
+ * jump) names a task, and whoever owns that task's tab state claims it.
+ *
+ * Every box shares ONE listener set — a request of any kind wakes every
+ * mounted consumer, which is what lets `use-tab-requests.ts` drain them all in
+ * a fixed order on a single pass. `take` hands the payload only to the task it
+ * was addressed to. `takeUnclaimed` returns it whoever it was for, and is
+ * re-exported ONLY by the three boxes whose callers have a background
+ * fallback; the other four must wait for a mount (see {@link requestNewTab}).
  */
-let pendingTabActivation: { taskId: string; tabId: string } | null = null
 export const tabActivationListeners = new Set<() => void>()
 
-export function requestTabActivation(taskId: string, tabId: string): void {
-  pendingTabActivation = { taskId, tabId }
-  for (const listener of tabActivationListeners) listener()
+function requestBox<T>(): {
+  request(taskId: string, payload: T): void
+  take(taskId: string): T | null
+  takeUnclaimed(): { taskId: string; payload: T } | null
+} {
+  let pending: { taskId: string; payload: T } | null = null
+  return {
+    request(taskId, payload) {
+      pending = { taskId, payload }
+      for (const listener of tabActivationListeners) listener()
+    },
+    take(taskId) {
+      if (pending?.taskId !== taskId) return null
+      const { payload } = pending
+      pending = null
+      return payload
+    },
+    takeUnclaimed() {
+      const claimed = pending
+      pending = null
+      return claimed
+    },
+  }
 }
 
-/** Consume a pending activation for this task, or null. */
-export function takeTabActivation(taskId: string): string | null {
-  if (pendingTabActivation?.taskId !== taskId) return null
-  const tabId = pendingTabActivation.tabId
-  pendingTabActivation = null
-  return tabId
-}
-
-/**
- * Cross-component "open a command tab" request (`tab.open` — plugin panes).
- * pendingTabActivation's twin: consumed by the mounted TerminalTabs via the
- * same listener set, or on mount for a task selected later.
- */
-let pendingTabOpen: {
-  taskId: string
+const activationBox = requestBox<string>()
+const openBox = requestBox<{
   argv: readonly string[]
   title: string
   tabId?: string
   placement?: "split" | "tab"
   direction?: "right" | "down"
-} | null = null
+}>()
+const newTabBox = requestBox<"chat" | "shell">()
+const paneCloseBox = requestBox<{ title: string; tabId?: string }>()
+const tabCloseBox = requestBox<string>()
+const adoptBox = requestBox<readonly string[]>()
+const moveBox = requestBox<{ tabId: string; delta: -1 | 1 }>()
 
+/**
+ * "Activate this tab" (the F7 attention jump). The mounted TerminalTabs for
+ * `taskId` consumes it via the listener; a task that isn't mounted yet
+ * consumes it on mount (the host selects the task first, TerminalTabs mounts,
+ * then reads the pending request). Unknown tab ids are dropped on consume —
+ * the tab may have closed meanwhile.
+ */
+export const requestTabActivation = activationBox.request
+export const takeTabActivation = activationBox.take
+
+/** "Open a command tab" (`tab.open` — plugin panes). Activation's twin:
+ *  consumed by the mounted TerminalTabs, or on mount for a task selected
+ *  later. Positional args rather than the box's payload object because every
+ *  caller is a plugin bridge passing them one at a time. */
 export function requestTabOpen(
   taskId: string,
   argv: readonly string[],
@@ -174,157 +203,74 @@ export function requestTabOpen(
   direction?: "right" | "down",
   tabId?: string,
 ): void {
-  pendingTabOpen = { taskId, argv, title, placement, direction, tabId }
-  for (const listener of tabActivationListeners) listener()
+  openBox.request(taskId, { argv, title, placement, direction, tabId })
 }
+export const takeTabOpen = openBox.take
 
 /**
- * Cross-component "add a session to this task" request — the sidebar tree's
- * right-click "New conversation" / "New shell".
+ * "Add a session to this task" — the sidebar tree's right-click
+ * "New conversation" / "New shell".
  *
  * Twin of {@link requestTabActivation}, not of {@link requestTabClose}: both
- * kinds need the task's OWN workspace (the picker is a dialog; a shell tab
- * has to spawn its PTY where the tabs render), so the caller selects the task
+ * kinds need the task's OWN workspace (the picker is a dialog; a shell tab has
+ * to spawn its PTY where the tabs render), so the caller selects the task
  * first and an unclaimed request simply waits for that mount instead of
- * falling back to a background write.
+ * falling back to a background write. That is why this box — and activation,
+ * open and pane-close — exposes no unclaimed reader.
  */
-let pendingNewTab: { taskId: string; kind: "chat" | "shell" } | null = null
+export const requestNewTab = newTabBox.request
+export const takeNewTab = newTabBox.take
 
-export function requestNewTab(taskId: string, kind: "chat" | "shell"): void {
-  pendingNewTab = { taskId, kind }
-  for (const listener of tabActivationListeners) listener()
-}
-
-/** Consume a pending new-tab request for this task, or null. */
-export function takeNewTab(taskId: string): "chat" | "shell" | null {
-  if (pendingNewTab?.taskId !== taskId) return null
-  const kind = pendingNewTab.kind
-  pendingNewTab = null
-  return kind
-}
-
-/**
- * Cross-component "close panes opened under a title" request (`tab.close` —
- * pane-close, the inverse of {@link requestTabOpen}). Consumed by the
- * mounted TerminalTabs; matching is by pane label, so only titled
- * split-leaves / command tabs (the ones tab.open creates) are affected.
- */
-let pendingPaneClose: { taskId: string; title: string; tabId?: string } | null = null
-
+/** "Close panes opened under a title" (`tab.close` — the inverse of
+ *  {@link requestTabOpen}). Consumed by the mounted TerminalTabs; matching is
+ *  by pane label, so only titled split-leaves / command tabs (the ones
+ *  tab.open creates) are affected. */
 export function requestPaneClose(taskId: string, title: string, tabId?: string): void {
-  pendingPaneClose = { taskId, title, tabId }
-  for (const listener of tabActivationListeners) listener()
+  paneCloseBox.request(taskId, { title, tabId })
 }
-
-/** Consume a pending pane-close for this task, or null. */
-export function takePaneClose(taskId: string): { title: string; tabId?: string } | null {
-  if (pendingPaneClose?.taskId !== taskId) return null
-  const { title, tabId } = pendingPaneClose
-  pendingPaneClose = null
-  return { title, tabId }
-}
+export const takePaneClose = paneCloseBox.take
 
 /**
- * Cross-component "close this tab" request — the third of the same family.
- *
- * Unlike its twins, this one has a caller that can name a tab of a task whose
- * TerminalTabs is NOT mounted (the sidebar tree lists every worktree's tabs),
- * so an unconsumed request is not "wait for mount" — it means nobody owns that
- * task's state right now and the write has to happen in the background.
- * `closeTaskTab` (terminal-tabs-close.ts) is what decides between the two by
- * checking whether the request survived the listener sweep.
+ * "Close this tab". Unlike its twins above, this one has a caller that can
+ * name a tab of a task whose TerminalTabs is NOT mounted (the sidebar tree
+ * lists every worktree's tabs), so an unconsumed request is not "wait for
+ * mount" — it means nobody owns that task's state right now and the write has
+ * to happen in the background. `closeTaskTab` (terminal-tabs-close.ts) is what
+ * decides between the two by checking whether the request survived the
+ * listener sweep. Adopt and move below share that protocol.
  */
-let pendingTabClose: { taskId: string; tabId: string } | null = null
-
-export function requestTabClose(taskId: string, tabId: string): void {
-  pendingTabClose = { taskId, tabId }
-  for (const listener of tabActivationListeners) listener()
-}
-
-/** Consume a pending close for this task, or null. */
-export function takeTabClose(taskId: string): string | null {
-  if (pendingTabClose?.taskId !== taskId) return null
-  const tabId = pendingTabClose.tabId
-  pendingTabClose = null
-  return tabId
-}
+export const requestTabClose = tabCloseBox.request
+export const takeTabClose = tabCloseBox.take
 
 /** Whether the last {@link requestTabClose} went unclaimed — i.e. no mounted
  *  TerminalTabs owns that task. Clears the request either way. */
 export function takeUnclaimedTabClose(): { taskId: string; tabId: string } | null {
-  const pending = pendingTabClose
-  pendingTabClose = null
-  return pending
+  const claimed = tabCloseBox.takeUnclaimed()
+  return claimed && { taskId: claimed.taskId, tabId: claimed.payload }
 }
 
-/**
- * Cross-component "adopt these live tab ids" request — same claim protocol as
- * {@link requestTabClose}: a mounted TerminalTabs owns its task's state and
- * must do the write itself, and only an UNCLAIMED request may be written in
- * the background. See `terminal-tabs-adopt.ts` for what adoption is for.
- */
-let pendingTabAdopt: { taskId: string; tabIds: readonly string[] } | null = null
-
-export function requestTabAdopt(taskId: string, tabIds: readonly string[]): void {
-  pendingTabAdopt = { taskId, tabIds }
-  for (const listener of tabActivationListeners) listener()
-}
-
-/** Consume a pending adoption for this task, or null. */
-export function takeTabAdopt(taskId: string): readonly string[] | null {
-  if (pendingTabAdopt?.taskId !== taskId) return null
-  const tabIds = pendingTabAdopt.tabIds
-  pendingTabAdopt = null
-  return tabIds
-}
+/** "Adopt these live tab ids" — see `terminal-tabs-adopt.ts` for what
+ *  adoption is for. */
+export const requestTabAdopt = adoptBox.request
+export const takeTabAdopt = adoptBox.take
 
 /** The twin of {@link takeUnclaimedTabClose} for adoption. */
 export function takeUnclaimedTabAdopt(): { taskId: string; tabIds: readonly string[] } | null {
-  const pending = pendingTabAdopt
-  pendingTabAdopt = null
-  return pending
+  const claimed = adoptBox.takeUnclaimed()
+  return claimed && { taskId: claimed.taskId, tabIds: claimed.payload }
 }
 
-/**
- * Cross-component "move this tab up/down" request (sidebar move mode) —
- * same claim protocol as {@link requestTabClose}: the sidebar can name
- * a tab of a task whose TerminalTabs is not mounted, so an unclaimed request
- * is written in the background (`moveTaskTabRow`).
- */
-let pendingTabMove: { taskId: string; tabId: string; delta: -1 | 1 } | null = null
-
+/** "Move this tab up/down" (sidebar move mode); the background write is
+ *  `moveTaskTabRow`. */
 export function requestTabMove(taskId: string, tabId: string, delta: -1 | 1): void {
-  pendingTabMove = { taskId, tabId, delta }
-  for (const listener of tabActivationListeners) listener()
+  moveBox.request(taskId, { tabId, delta })
 }
-
-/** Consume a pending tab-move for this task, or null. */
-export function takeTabMove(taskId: string): { tabId: string; delta: -1 | 1 } | null {
-  if (pendingTabMove?.taskId !== taskId) return null
-  const { tabId, delta } = pendingTabMove
-  pendingTabMove = null
-  return { tabId, delta }
-}
+export const takeTabMove = moveBox.take
 
 /** The twin of {@link takeUnclaimedTabClose} for tab moves. */
 export function takeUnclaimedTabMove(): { taskId: string; tabId: string; delta: -1 | 1 } | null {
-  const pending = pendingTabMove
-  pendingTabMove = null
-  return pending
-}
-
-/** Consume a pending tab-open for this task, or null. */
-export function takeTabOpen(taskId: string): {
-  argv: readonly string[]
-  title: string
-  tabId?: string
-  placement?: "split" | "tab"
-  direction?: "right" | "down"
-} | null {
-  if (pendingTabOpen?.taskId !== taskId) return null
-  const request = pendingTabOpen
-  pendingTabOpen = null
-  return request
+  const claimed = moveBox.takeUnclaimed()
+  return claimed && { taskId: claimed.taskId, ...claimed.payload }
 }
 
 /**

--- a/packages/kobe/src/tui-react/workspace/use-tab-close.ts
+++ b/packages/kobe/src/tui-react/workspace/use-tab-close.ts
@@ -163,9 +163,9 @@ export function useTabClose(deps: TabCloseDeps): TabClose {
     // not visibly rename the tab.
     getDefaultPtyRegistry().release(tabPtyKeyFor(taskId(), active))
     deps.resumeTriedRef.current.clear()
-    const fresh = deps.pinSession(recycleTabs(active), undefined)
-    deps.updateRef.current(fresh)
-    if (fresh.activeId === active.id) deps.bumpResetToken()
+    // The recycled tab gets a NEW id, so its `${taskId}::${tabId}` pty key
+    // differs and Terminal re-acquires on its own — no resetToken nudge.
+    deps.updateRef.current(deps.pinSession(recycleTabs(deps.stateRef.current, active), undefined))
   }
 
   return { closeActive, closeById, closeExited, handleActiveExit }

--- a/packages/kobe/src/tui/context/keybindings-chat.ts
+++ b/packages/kobe/src/tui/context/keybindings-chat.ts
@@ -116,8 +116,14 @@ export const CHAT_BINDINGS: readonly KobeBinding[] = [
   {
     id: "chat.tab.close",
     scope: "workspace",
-    // Direct-only, same as chat.tab.new.
+    // ctrl+w AND prefix-w, mirroring workspace.split.close exactly. The two
+    // rows are mutually gated (see that row's comment), so whichever is live
+    // owns BOTH strokes: without the prefix half here, `<prefix> w` on an
+    // unsplit tab found no enabled prefix binding and was swallowed, while
+    // docs/KEYBINDINGS.md and the split row's own help text
+    // ("Close active split (tab when unsplit)") both promise it closes the tab.
     keys: ["ctrl+w"],
+    prefixKeys: ["w"],
     category: "Workspace",
     description: "Close chat tab",
     hint: { keys: "ctrl+w" },
@@ -224,12 +230,13 @@ export const CHAT_BINDINGS: readonly KobeBinding[] = [
     presentation: "onePress",
   },
   {
-    // Same chord as chat.tab.close, contextual scope: while the tab is
-    // SPLIT, ctrl+w closes the active leaf (the innermost thing — VS
-    // Code/iTerm/Warp convention). Resolution is mutual
+    // Same chords as chat.tab.close (ctrl+w and prefix-w), contextual scope:
+    // while the tab is SPLIT they close the active leaf (the innermost thing
+    // — VS Code/iTerm/Warp convention). Resolution is mutual
     // gating (React stacks ancestors on top — see tui-react/lib/keymap.ts):
     // TerminalSplit enables this entry only when split, and TerminalTabs
-    // disables its close-tab entry while split, so exactly one is live.
+    // disables its close-tab entry while split, so exactly one is live — and
+    // whichever it is owns BOTH strokes.
     id: "workspace.split.close",
     scope: "workspace",
     keys: ["ctrl+w"],

--- a/packages/kobe/src/tui/workspace/terminal-tab-shapes.ts
+++ b/packages/kobe/src/tui/workspace/terminal-tab-shapes.ts
@@ -169,3 +169,27 @@ export interface ContentTab extends TabBase {
  * tab, close-on-exit without a command) cannot be represented.
  */
 export type TerminalTab = EngineTab | CommandTab | ContentTab
+
+/**
+ * A task's whole tab list, as persisted. The SHAPE of the list lives beside
+ * the shape of a tab; who is allowed to produce one from what is
+ * `terminal-tabs-lifecycle.ts` (start / restart / revive / recycle) and
+ * `terminal-tabs-core.ts` (a user action on an existing list).
+ */
+export interface TabsState {
+  readonly tabs: readonly TerminalTab[]
+  readonly activeId: string
+  /** Next ordinal to hand out (monotonic — close does not recycle). */
+  readonly nextOrdinal: number
+  /**
+   * What the LAST tab was, recorded as it closed, so re-entering an emptied
+   * task reopens the same kind of session instead of always an engine
+   * ({@link reopenTabs}). Only set when `tabs` is empty — a task with tabs
+   * doesn't need it, and a stale value would outlive its meaning.
+   *
+   * An older snapshot simply lacks the field, so {@link reopenTabs} treats
+   * absence as "use the default" rather than as an error: upgrading in place
+   * has to stay silent.
+   */
+  readonly reopenAs?: { readonly kind: "engine"; readonly vendor?: VendorId } | { readonly kind: "command" }
+}

--- a/packages/kobe/src/tui/workspace/terminal-tabs-core.ts
+++ b/packages/kobe/src/tui/workspace/terminal-tabs-core.ts
@@ -35,82 +35,15 @@ export {
 // argv composition and the component can depend on the shapes without
 // depending on these transitions. Re-exported here so importers keep one
 // entry point.
-export type { CommandTab, ContentTab, EngineTab, TerminalTab } from "./terminal-tab-shapes"
-import type { CommandTab, ContentTab, TerminalTab } from "./terminal-tab-shapes"
+export type { CommandTab, ContentTab, EngineTab, TabsState, TerminalTab } from "./terminal-tab-shapes"
+import type { CommandTab, ContentTab, TabsState, TerminalTab } from "./terminal-tab-shapes"
 
-export interface TabsState {
-  readonly tabs: readonly TerminalTab[]
-  readonly activeId: string
-  /** Next ordinal to hand out (monotonic — close does not recycle). */
-  readonly nextOrdinal: number
-  /**
-   * What the LAST tab was, recorded as it closed, so re-entering an emptied
-   * task reopens the same kind of session instead of always an engine
-   * ({@link reopenTabs}). Only set when `tabs` is empty — a task with tabs
-   * doesn't need it, and a stale value would outlive its meaning.
-   *
-   * An older snapshot simply lacks the field, so {@link reopenTabs} treats
-   * absence as "use the default" rather than as an error: upgrading in place
-   * has to stay silent.
-   */
-  readonly reopenAs?: { readonly kind: "engine"; readonly vendor?: VendorId } | { readonly kind: "command" }
-}
-
-/** A task's initial state: one untitled engine tab, active. */
-export function initialTabs(): TabsState {
-  return { tabs: [{ kind: "engine", id: "tab-1", title: null, ordinal: 1 }], activeId: "tab-1", nextOrdinal: 2 }
-}
-
-/**
- * What to reopen an emptied task as, derived from the tab that just closed.
- *
- * Only the SHAPE is carried, never the session: the PTY died with the tab, so
- * an engine comes back as a fresh engine (its `sessionId` deliberately absent)
- * and a shell as a fresh shell. A content/preview tab has no session to speak
- * of and reopens as an engine — reviving a file preview as the whole workspace
- * would be a strange thing to land in.
- */
-function reopenHintFor(closed: TerminalTab | undefined): TabsState["reopenAs"] {
-  if (closed?.kind === "command") return { kind: "command" }
-  if (closed?.kind === "engine" && closed.vendor) return { kind: "engine", vendor: closed.vendor }
-  return { kind: "engine" }
-}
-
-/**
- * Revive a task whose last tab was closed: one fresh tab of the kind that was
- * there before, active. `shell` is the argv a `command` tab respawns with.
- *
- * `reopenAs` is absent for a snapshot written before it existed (an install
- * upgrading in place), and absence means the default engine tab — the same
- * thing {@link initialTabs} gives a brand-new task. That is the fallback, not
- * an error path: a user who upgrades mid-session should not be able to reach a
- * task that refuses to reopen.
- */
-export function reopenTabs(state: TabsState, shell: string): TabsState {
-  const ordinal = state.nextOrdinal
-  const id = `tab-${ordinal}`
-  const next = state.nextOrdinal + 1
-  if (state.reopenAs?.kind === "command") {
-    return { tabs: [{ kind: "command", id, title: null, ordinal, command: [shell] }], activeId: id, nextOrdinal: next }
-  }
-  const vendor = state.reopenAs?.kind === "engine" ? state.reopenAs.vendor : undefined
-  return {
-    tabs: [{ kind: "engine", id, title: null, ordinal, ...(vendor ? { vendor } : {}) }],
-    activeId: id,
-    nextOrdinal: next,
-  }
-}
-
-/** A SCRATCH task's initial state: one bare shell tab, active —
- *  the task is the shell, an engine only appears when the user types one.
- *  Same shape the ctrl+e "shell" pick mints ({@link openCommandTab}). */
-export function initialShellTabs(shell: string): TabsState {
-  return {
-    tabs: [{ kind: "command", id: "tab-1", title: null, ordinal: 1, command: [shell] }],
-    activeId: "tab-1",
-    nextOrdinal: 2,
-  }
-}
+// Whole-list lifecycle (first mount, restart, revive, recycle) lives in
+// `./terminal-tabs-lifecycle` — where a list COMES FROM, versus this file's
+// what a user action does to one that exists. Re-exported here so importers
+// keep one entry point.
+export { initialShellTabs, initialTabs, recycleTabs, rehydrateTabs, reopenTabs } from "./terminal-tabs-lifecycle"
+import { initialTabs, reopenHintFor } from "./terminal-tabs-lifecycle"
 
 /** Shared insert: append `tab` after the active tab and focus it. */
 function insertAfterActive(state: TabsState, tab: TerminalTab): TabsState {
@@ -360,76 +293,6 @@ export function markTabSpawned(state: TabsState, id: string): TabsState {
 // entry point.
 export { type TabExitAction, engineTabArgv, engineTabSpawnFor, tabExitAction } from "./terminal-tab-argv"
 export { type TabSpawn, shellCommandLine, shellIdentityInput, shellSpawn } from "./terminal-tab-spawn"
-
-/**
- * Rehydrate a persisted tab snapshot. A tab is a TERMINAL: claude/an editor
- * are just processes that ran in it, so EVERY tab survives restart. Engine
- * tabs keep their identity
- * + sessionId so the host can `--resume` the conversation; command tabs
- * (a shell pick, a dead editor) come back running `shell` — their
- * process is gone, and spawning a fresh engine
- * in its place would reopen a closed shell as claude. Same
- * freeze-the-layout rule splitTree restore follows. Guards against a
- * corrupt/empty snapshot by falling back to `initialTabs()`; re-anchors
- * `activeId` if it pointed at a tab that is absent.
- */
-export function rehydrateTabs(
-  persisted: TabsState,
-  shell: readonly string[],
-  /** Keep an intentionally-empty snapshot empty.
-   *  Without this a task whose last tab you closed grows one back on the next
-   *  mount, so the close never appears to take. Off by default so a CORRUPT
-   *  snapshot still recovers. */
-  opts: { readonly allowEmpty?: boolean } = {},
-): TabsState {
-  const tabs = persisted.tabs.map(
-    (t): TerminalTab => (t.kind === "command" ? { ...t, command: shell, purpose: undefined } : t),
-  )
-  if (tabs.length === 0) return opts.allowEmpty ? persisted : initialTabs()
-  const activeId = tabs.some((t) => t.id === persisted.activeId) ? persisted.activeId : tabs[0].id
-  const maxOrdinal = tabs.reduce((max, t) => Math.max(max, t.ordinal), 0)
-  return { tabs, activeId, nextOrdinal: Math.max(persisted.nextOrdinal, maxOrdinal + 1) }
-}
-
-/**
- * Recycle-in-place state for the last tab's exit: a fresh engine tab (new
- * session) that KEEPS the exited tab's name — user `title` and `autoTitle`
- * carry over, so the strip doesn't visibly rename itself on every recycle.
- * The carried autoTitle also blocks the naming pass from deriving a new one
- * (its `!title && !autoTitle` self-limit), which was the "title changes
- * every recycle" bug.
- *
- * The tab's PINNED engine carries over too (`vendor`/`engineCommand`), the
- * same way {@link reopenHintFor} carries it for the revive path: a tab the
- * user pointed at Codex must not come back as the task's engine while still
- * wearing the Codex conversation's title.
- *
- * The id is minted from `state.nextOrdinal` rather than reset to `tab-1`,
- * because `TabBase.id` is never reused within a task: inbox episodes and the
- * orphan-adoption suppression in `terminal-tabs-close.ts` are both keyed
- * `(taskId, tabId)`, so a recycled `tab-1` would inherit a dead tab's
- * episodes and its in-flight suppression.
- */
-export function recycleTabs(state: TabsState, prev: TerminalTab): TabsState {
-  const ordinal = state.nextOrdinal
-  const id = `tab-${ordinal}`
-  const pinned = prev.kind === "engine" ? prev : undefined
-  return {
-    tabs: [
-      {
-        kind: "engine",
-        id,
-        ordinal,
-        title: prev.title,
-        autoTitle: prev.autoTitle,
-        ...(pinned?.vendor ? { vendor: pinned.vendor } : {}),
-        ...(pinned?.engineCommand ? { engineCommand: pinned.engineCommand } : {}),
-      },
-    ],
-    activeId: id,
-    nextOrdinal: ordinal + 1,
-  }
-}
 
 /** Cycle the active tab by ±1, wrapping at the ends. */
 export function cycleTab(state: TabsState, delta: 1 | -1): TabsState {

--- a/packages/kobe/src/tui/workspace/terminal-tabs-core.ts
+++ b/packages/kobe/src/tui/workspace/terminal-tabs-core.ts
@@ -392,17 +392,43 @@ export function rehydrateTabs(
 }
 
 /**
- * Recycle-in-place state for the last tab's exit: a fresh engine tab
- * (new session, ordinal 1) that KEEPS the exited tab's name — user
- * `title` and `autoTitle` carry over, so the strip doesn't visibly
- * rename itself on every recycle. The carried autoTitle also blocks the
- * naming pass from deriving a new one (its `!title && !autoTitle`
- * self-limit), which was the "title changes every recycle" bug.
+ * Recycle-in-place state for the last tab's exit: a fresh engine tab (new
+ * session) that KEEPS the exited tab's name — user `title` and `autoTitle`
+ * carry over, so the strip doesn't visibly rename itself on every recycle.
+ * The carried autoTitle also blocks the naming pass from deriving a new one
+ * (its `!title && !autoTitle` self-limit), which was the "title changes
+ * every recycle" bug.
+ *
+ * The tab's PINNED engine carries over too (`vendor`/`engineCommand`), the
+ * same way {@link reopenHintFor} carries it for the revive path: a tab the
+ * user pointed at Codex must not come back as the task's engine while still
+ * wearing the Codex conversation's title.
+ *
+ * The id is minted from `state.nextOrdinal` rather than reset to `tab-1`,
+ * because `TabBase.id` is never reused within a task: inbox episodes and the
+ * orphan-adoption suppression in `terminal-tabs-close.ts` are both keyed
+ * `(taskId, tabId)`, so a recycled `tab-1` would inherit a dead tab's
+ * episodes and its in-flight suppression.
  */
-export function recycleTabs(prev: TerminalTab): TabsState {
-  const fresh = initialTabs()
-  const tabs = [{ ...fresh.tabs[0], title: prev.title, autoTitle: prev.autoTitle }]
-  return { ...fresh, tabs }
+export function recycleTabs(state: TabsState, prev: TerminalTab): TabsState {
+  const ordinal = state.nextOrdinal
+  const id = `tab-${ordinal}`
+  const pinned = prev.kind === "engine" ? prev : undefined
+  return {
+    tabs: [
+      {
+        kind: "engine",
+        id,
+        ordinal,
+        title: prev.title,
+        autoTitle: prev.autoTitle,
+        ...(pinned?.vendor ? { vendor: pinned.vendor } : {}),
+        ...(pinned?.engineCommand ? { engineCommand: pinned.engineCommand } : {}),
+      },
+    ],
+    activeId: id,
+    nextOrdinal: ordinal + 1,
+  }
 }
 
 /** Cycle the active tab by ±1, wrapping at the ends. */

--- a/packages/kobe/src/tui/workspace/terminal-tabs-lifecycle.ts
+++ b/packages/kobe/src/tui/workspace/terminal-tabs-lifecycle.ts
@@ -1,0 +1,145 @@
+/**
+ * How a task's tab list BEGINS, comes BACK, and starts OVER — every
+ * transition that mints a whole {@link TabsState} from something other than a
+ * user action: first mount, a restart snapshot, re-entering an emptied task,
+ * and the last tab exiting.
+ *
+ * That is the seam. `terminal-tabs-core.ts` answers "what does this user
+ * action do to the list that exists"; these four answer "where does a list
+ * come from when there is none, or none that can be used". They are separated
+ * because they must AGREE with each other, and silently did not: reopen
+ * carried the closed tab's pinned engine and consumed `nextOrdinal` while
+ * recycle dropped the engine and rewound to `tab-1`. Keeping them in one file
+ * makes the next divergence visible.
+ *
+ * Depends only on `./terminal-tab-shapes` (types), so core can re-export these
+ * for a single import entry point without an import cycle.
+ */
+
+import type { TabsState, TerminalTab } from "./terminal-tab-shapes"
+
+/** A task's initial state: one untitled engine tab, active. */
+export function initialTabs(): TabsState {
+  return { tabs: [{ kind: "engine", id: "tab-1", title: null, ordinal: 1 }], activeId: "tab-1", nextOrdinal: 2 }
+}
+
+/**
+ * What to reopen an emptied task as, derived from the tab that just closed.
+ *
+ * Only the SHAPE is carried, never the session: the PTY died with the tab, so
+ * an engine comes back as a fresh engine (its `sessionId` deliberately absent)
+ * and a shell as a fresh shell. A content/preview tab has no session to speak
+ * of and reopens as an engine — reviving a file preview as the whole workspace
+ * would be a strange thing to land in.
+ */
+export function reopenHintFor(closed: TerminalTab | undefined): TabsState["reopenAs"] {
+  if (closed?.kind === "command") return { kind: "command" }
+  if (closed?.kind === "engine" && closed.vendor) return { kind: "engine", vendor: closed.vendor }
+  return { kind: "engine" }
+}
+
+/**
+ * Revive a task whose last tab was closed: one fresh tab of the kind that was
+ * there before, active. `shell` is the argv a `command` tab respawns with.
+ *
+ * `reopenAs` is absent for a snapshot written before it existed (an install
+ * upgrading in place), and absence means the default engine tab — the same
+ * thing {@link initialTabs} gives a brand-new task. That is the fallback, not
+ * an error path: a user who upgrades mid-session should not be able to reach a
+ * task that refuses to reopen.
+ */
+export function reopenTabs(state: TabsState, shell: string): TabsState {
+  const ordinal = state.nextOrdinal
+  const id = `tab-${ordinal}`
+  const next = state.nextOrdinal + 1
+  if (state.reopenAs?.kind === "command") {
+    return { tabs: [{ kind: "command", id, title: null, ordinal, command: [shell] }], activeId: id, nextOrdinal: next }
+  }
+  const vendor = state.reopenAs?.kind === "engine" ? state.reopenAs.vendor : undefined
+  return {
+    tabs: [{ kind: "engine", id, title: null, ordinal, ...(vendor ? { vendor } : {}) }],
+    activeId: id,
+    nextOrdinal: next,
+  }
+}
+
+/** A SCRATCH task's initial state: one bare shell tab, active —
+ *  the task is the shell, an engine only appears when the user types one.
+ *  Same shape the ctrl+e "shell" pick mints ({@link openCommandTab}). */
+export function initialShellTabs(shell: string): TabsState {
+  return {
+    tabs: [{ kind: "command", id: "tab-1", title: null, ordinal: 1, command: [shell] }],
+    activeId: "tab-1",
+    nextOrdinal: 2,
+  }
+}
+
+/**
+ * Rehydrate a persisted tab snapshot. A tab is a TERMINAL: claude/an editor
+ * are just processes that ran in it, so EVERY tab survives restart. Engine
+ * tabs keep their identity
+ * + sessionId so the host can `--resume` the conversation; command tabs
+ * (a shell pick, a dead editor) come back running `shell` — their
+ * process is gone, and spawning a fresh engine
+ * in its place would reopen a closed shell as claude. Same
+ * freeze-the-layout rule splitTree restore follows. Guards against a
+ * corrupt/empty snapshot by falling back to `initialTabs()`; re-anchors
+ * `activeId` if it pointed at a tab that is absent.
+ */
+export function rehydrateTabs(
+  persisted: TabsState,
+  shell: readonly string[],
+  /** Keep an intentionally-empty snapshot empty.
+   *  Without this a task whose last tab you closed grows one back on the next
+   *  mount, so the close never appears to take. Off by default so a CORRUPT
+   *  snapshot still recovers. */
+  opts: { readonly allowEmpty?: boolean } = {},
+): TabsState {
+  const tabs = persisted.tabs.map(
+    (t): TerminalTab => (t.kind === "command" ? { ...t, command: shell, purpose: undefined } : t),
+  )
+  if (tabs.length === 0) return opts.allowEmpty ? persisted : initialTabs()
+  const activeId = tabs.some((t) => t.id === persisted.activeId) ? persisted.activeId : tabs[0].id
+  const maxOrdinal = tabs.reduce((max, t) => Math.max(max, t.ordinal), 0)
+  return { tabs, activeId, nextOrdinal: Math.max(persisted.nextOrdinal, maxOrdinal + 1) }
+}
+
+/**
+ * Recycle-in-place state for the last tab's exit: a fresh engine tab (new
+ * session) that KEEPS the exited tab's name — user `title` and `autoTitle`
+ * carry over, so the strip doesn't visibly rename itself on every recycle.
+ * The carried autoTitle also blocks the naming pass from deriving a new one
+ * (its `!title && !autoTitle` self-limit), which was the "title changes
+ * every recycle" bug.
+ *
+ * The tab's PINNED engine carries over too (`vendor`/`engineCommand`), the
+ * same way {@link reopenHintFor} carries it for the revive path: a tab the
+ * user pointed at Codex must not come back as the task's engine while still
+ * wearing the Codex conversation's title.
+ *
+ * The id is minted from `state.nextOrdinal` rather than reset to `tab-1`,
+ * because `TabBase.id` is never reused within a task: inbox episodes and the
+ * orphan-adoption suppression in `terminal-tabs-close.ts` are both keyed
+ * `(taskId, tabId)`, so a recycled `tab-1` would inherit a dead tab's
+ * episodes and its in-flight suppression.
+ */
+export function recycleTabs(state: TabsState, prev: TerminalTab): TabsState {
+  const ordinal = state.nextOrdinal
+  const id = `tab-${ordinal}`
+  const pinned = prev.kind === "engine" ? prev : undefined
+  return {
+    tabs: [
+      {
+        kind: "engine",
+        id,
+        ordinal,
+        title: prev.title,
+        autoTitle: prev.autoTitle,
+        ...(pinned?.vendor ? { vendor: pinned.vendor } : {}),
+        ...(pinned?.engineCommand ? { engineCommand: pinned.engineCommand } : {}),
+      },
+    ],
+    activeId: id,
+    nextOrdinal: ordinal + 1,
+  }
+}

--- a/packages/kobe/test/tui/terminal-tabs-core.test.ts
+++ b/packages/kobe/test/tui/terminal-tabs-core.test.ts
@@ -34,13 +34,6 @@ import {
 } from "../../src/tui/workspace/terminal-tabs-core"
 
 describe("terminal tabs state", () => {
-  it("starts with one untitled active tab", () => {
-    const s = initialTabs()
-    expect(s.tabs).toHaveLength(1)
-    expect(s.activeId).toBe("tab-1")
-    expect(s.tabs[0].title).toBeNull()
-  })
-
   it("addTab inserts after the active tab, focuses it, never reuses ids", () => {
     let s = addTab(initialTabs()) // [1, 2*]
     s = cycleTab(s, -1) // [1*, 2]
@@ -174,40 +167,6 @@ describe("terminal tabs state", () => {
     expect(after.tabs[1]).not.toHaveProperty("sessionId", "uuid-2")
   })
 
-  // Why: rehydrateTabs is the restart contract — a tab is a TERMINAL, so
-  // every tab survives: engine tabs
-  // come back resumable, command tabs (a degraded shell, a dead editor)
-  // come back as plain shells. Dropping command tabs reopens a closed
-  // shell as claude: a lone degraded tab falls through to
-  // initialTabs(), resurrecting a fresh engine in the terminal's place.
-  it("rehydrateTabs keeps every tab; command tabs respawn as shells", () => {
-    let s = addTab(initialTabs(), "codex") // [1, 2*(codex)]
-    s = setTabSessionId(s, "tab-1", "uuid-1")
-    s = openEditorTab(s, ["sh", "-c", "nvim x"], "x") // [1, 2, 3*(editor)]
-    const back = rehydrateTabs(s, ["/bin/zsh"])
-    expect(back.tabs.map((t) => t.id)).toEqual(["tab-1", "tab-2", "tab-3"])
-    expect(back.activeId).toBe("tab-3")
-    expect(back.tabs[0]).toMatchObject({ kind: "engine", sessionId: "uuid-1" })
-    // The editor's process is gone — its terminal comes back as a shell.
-    expect(back.tabs[2]).toMatchObject({ kind: "command", command: ["/bin/zsh"] })
-    expect(back.tabs[2]).toHaveProperty("purpose", undefined)
-    expect(back.nextOrdinal).toBe(s.nextOrdinal)
-    // THE reported bug: a single persisted COMMAND tab (a shell pick from
-    // an older snapshot) must reopen as that shell, NOT as a fresh engine.
-    const shellOnly = rehydrateTabs(
-      {
-        tabs: [{ kind: "command", id: "tab-1", title: null, ordinal: 1, command: ["/bin/zsh"] }],
-        activeId: "tab-1",
-        nextOrdinal: 2,
-      },
-      ["/bin/zsh"],
-    )
-    expect(shellOnly.tabs).toHaveLength(1)
-    expect(shellOnly.tabs[0]).toMatchObject({ kind: "command", id: "tab-1", command: ["/bin/zsh"] })
-    // Corrupt/empty snapshot still falls back to a fresh initial state.
-    expect(rehydrateTabs({ tabs: [], activeId: "tab-1", nextOrdinal: 1 }, ["/bin/zsh"])).toEqual(initialTabs())
-  })
-
   // Why: the frozen split layout must survive the
   // persist → rehydrate round-trip so a `claude | shell` group reopens
   // after restart. setTabSplit stores/clears the tree; rehydrateTabs keeps
@@ -265,61 +224,6 @@ describe("terminal tabs state", () => {
     expect(meaningfulAutoTitle("?!")).toBeNull()
     expect(meaningfulAutoTitle("123")).toBeNull()
     expect(meaningfulAutoTitle(" fix the race ")).toBe("fix the race")
-  })
-
-  // Why: a last-tab in-place recycle that reset to bare initialTabs() would
-  // drop title/autoTitle — the naming pass would then derive a NEW name from
-  // the fresh session's first prompt, so the tab would visibly rename itself
-  // on every recycle. Carrying both fields keeps the name stable AND blocks
-  // re-derivation (the pass only names tabs with neither field set).
-  it("recycleTabs keeps the exited tab's title/autoTitle on the fresh tab", () => {
-    let s = setTabAutoTitle(initialTabs(), "tab-1", "fix the resize race")
-    s = renameActiveTab(s, "my name")
-    const fresh = recycleTabs(s, s.tabs[0])
-    expect(fresh.tabs).toHaveLength(1)
-    expect(fresh.tabs[0]).toMatchObject({
-      kind: "engine",
-      title: "my name",
-      autoTitle: "fix the resize race",
-    })
-    // Fresh session: no carried sessionId/spawned from the dead tab.
-    expect((fresh.tabs[0] as EngineTab).sessionId).toBeUndefined()
-    expect((fresh.tabs[0] as EngineTab).spawned).toBeUndefined()
-    // An untitled tab recycles untitled — nothing invented.
-    const bare = initialTabs()
-    expect(recycleTabs(bare, bare.tabs[0]).tabs[0]).toMatchObject({ title: null })
-  })
-
-  // Why: the recycle used to hand back `initialTabs()` wholesale, which
-  // dropped the tab's PINNED engine — a tab the user pointed at Codex came
-  // back running the TASK's engine while still wearing the Codex
-  // conversation's title, so the swap was invisible. `reopenHintFor` already
-  // carries `vendor` for the sibling revive path; recycle must too.
-  it("recycleTabs carries the exited tab's pinned vendor and engineCommand", () => {
-    const s: TabsState = {
-      tabs: [{ kind: "engine", id: "tab-3", title: null, ordinal: 3, vendor: "codex", engineCommand: "codex --yolo" }],
-      activeId: "tab-3",
-      nextOrdinal: 4,
-    }
-    expect(recycleTabs(s, s.tabs[0]).tabs[0]).toMatchObject({ vendor: "codex", engineCommand: "codex --yolo" })
-  })
-
-  // Why: `TabBase.id` is "never reused within a task" — inbox episodes and
-  // the orphan-adoption suppression in terminal-tabs-close.ts are both keyed
-  // `(taskId, tabId)`. Resetting to `tab-1` handed the recycled tab a dead
-  // tab's episodes and its in-flight suppression. `reopenTabs` already
-  // consumes `nextOrdinal`; recycle must too.
-  it("recycleTabs mints a fresh id from nextOrdinal instead of reusing tab-1", () => {
-    let s = initialTabs()
-    s = addTab(s) // tab-2
-    s = addTab(s) // tab-3
-    const recycled = recycleTabs(s, s.tabs[2])
-    expect(recycled.tabs[0]?.id).toBe("tab-4")
-    expect(recycled.tabs[0]?.ordinal).toBe(4)
-    expect(recycled.activeId).toBe("tab-4")
-    expect(recycled.nextOrdinal).toBe(5)
-    // Never rewinds onto an id this task already handed out.
-    for (const used of s.tabs) expect(recycled.tabs[0]?.id).not.toBe(used.id)
   })
 
   // Why: closing the engine leaf (`leaf-1`) inside a split keeps `kind:

--- a/packages/kobe/test/tui/terminal-tabs-core.test.ts
+++ b/packages/kobe/test/tui/terminal-tabs-core.test.ts
@@ -275,11 +275,10 @@ describe("terminal tabs state", () => {
   it("recycleTabs keeps the exited tab's title/autoTitle on the fresh tab", () => {
     let s = setTabAutoTitle(initialTabs(), "tab-1", "fix the resize race")
     s = renameActiveTab(s, "my name")
-    const fresh = recycleTabs(s.tabs[0])
+    const fresh = recycleTabs(s, s.tabs[0])
     expect(fresh.tabs).toHaveLength(1)
     expect(fresh.tabs[0]).toMatchObject({
       kind: "engine",
-      id: "tab-1",
       title: "my name",
       autoTitle: "fix the resize race",
     })
@@ -287,7 +286,40 @@ describe("terminal tabs state", () => {
     expect((fresh.tabs[0] as EngineTab).sessionId).toBeUndefined()
     expect((fresh.tabs[0] as EngineTab).spawned).toBeUndefined()
     // An untitled tab recycles untitled — nothing invented.
-    expect(recycleTabs(initialTabs().tabs[0]).tabs[0]).toMatchObject({ title: null })
+    const bare = initialTabs()
+    expect(recycleTabs(bare, bare.tabs[0]).tabs[0]).toMatchObject({ title: null })
+  })
+
+  // Why: the recycle used to hand back `initialTabs()` wholesale, which
+  // dropped the tab's PINNED engine — a tab the user pointed at Codex came
+  // back running the TASK's engine while still wearing the Codex
+  // conversation's title, so the swap was invisible. `reopenHintFor` already
+  // carries `vendor` for the sibling revive path; recycle must too.
+  it("recycleTabs carries the exited tab's pinned vendor and engineCommand", () => {
+    const s: TabsState = {
+      tabs: [{ kind: "engine", id: "tab-3", title: null, ordinal: 3, vendor: "codex", engineCommand: "codex --yolo" }],
+      activeId: "tab-3",
+      nextOrdinal: 4,
+    }
+    expect(recycleTabs(s, s.tabs[0]).tabs[0]).toMatchObject({ vendor: "codex", engineCommand: "codex --yolo" })
+  })
+
+  // Why: `TabBase.id` is "never reused within a task" — inbox episodes and
+  // the orphan-adoption suppression in terminal-tabs-close.ts are both keyed
+  // `(taskId, tabId)`. Resetting to `tab-1` handed the recycled tab a dead
+  // tab's episodes and its in-flight suppression. `reopenTabs` already
+  // consumes `nextOrdinal`; recycle must too.
+  it("recycleTabs mints a fresh id from nextOrdinal instead of reusing tab-1", () => {
+    let s = initialTabs()
+    s = addTab(s) // tab-2
+    s = addTab(s) // tab-3
+    const recycled = recycleTabs(s, s.tabs[2])
+    expect(recycled.tabs[0]?.id).toBe("tab-4")
+    expect(recycled.tabs[0]?.ordinal).toBe(4)
+    expect(recycled.activeId).toBe("tab-4")
+    expect(recycled.nextOrdinal).toBe(5)
+    // Never rewinds onto an id this task already handed out.
+    for (const used of s.tabs) expect(recycled.tabs[0]?.id).not.toBe(used.id)
   })
 
   // Why: closing the engine leaf (`leaf-1`) inside a split keeps `kind:

--- a/packages/kobe/test/tui/terminal-tabs-lifecycle.test.ts
+++ b/packages/kobe/test/tui/terminal-tabs-lifecycle.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Whole-list lifecycle transitions (`terminal-tabs-lifecycle.ts`): where a
+ * task's tab list comes from when there is none, or none that can be used —
+ * first mount, a restart snapshot, and the last tab exiting.
+ *
+ * Kept apart from `terminal-tabs-core.test.ts` (what a user action does to an
+ * existing list) for the same reason the source is: these four must AGREE
+ * about ordinal minting and carried identity, and reading them together is
+ * what makes a divergence obvious.
+ */
+
+import { describe, expect, it } from "vitest"
+import {
+  type EngineTab,
+  type TabsState,
+  addTab,
+  initialTabs,
+  openCommandTab,
+  openEditorTab,
+  recycleTabs,
+  rehydrateTabs,
+  renameActiveTab,
+  setTabAutoTitle,
+  setTabSessionId,
+  setTabSpawned,
+} from "../../src/tui/workspace/terminal-tabs-core"
+
+describe("terminal tabs lifecycle", () => {
+  it("starts with one untitled active tab", () => {
+    const s = initialTabs()
+    expect(s.tabs).toHaveLength(1)
+    expect(s.activeId).toBe("tab-1")
+    expect(s.tabs[0].title).toBeNull()
+  })
+  // Why: rehydrateTabs is the restart contract — a tab is a TERMINAL, so
+  // every tab survives: engine tabs
+  // come back resumable, command tabs (a degraded shell, a dead editor)
+  // come back as plain shells. Dropping command tabs reopens a closed
+  // shell as claude: a lone degraded tab falls through to
+  // initialTabs(), resurrecting a fresh engine in the terminal's place.
+  it("rehydrateTabs keeps every tab; command tabs respawn as shells", () => {
+    let s = addTab(initialTabs(), "codex") // [1, 2*(codex)]
+    s = setTabSessionId(s, "tab-1", "uuid-1")
+    s = openEditorTab(s, ["sh", "-c", "nvim x"], "x") // [1, 2, 3*(editor)]
+    const back = rehydrateTabs(s, ["/bin/zsh"])
+    expect(back.tabs.map((t) => t.id)).toEqual(["tab-1", "tab-2", "tab-3"])
+    expect(back.activeId).toBe("tab-3")
+    expect(back.tabs[0]).toMatchObject({ kind: "engine", sessionId: "uuid-1" })
+    // The editor's process is gone — its terminal comes back as a shell.
+    expect(back.tabs[2]).toMatchObject({ kind: "command", command: ["/bin/zsh"] })
+    expect(back.tabs[2]).toHaveProperty("purpose", undefined)
+    expect(back.nextOrdinal).toBe(s.nextOrdinal)
+    // THE reported bug: a single persisted COMMAND tab (a shell pick from
+    // an older snapshot) must reopen as that shell, NOT as a fresh engine.
+    const shellOnly = rehydrateTabs(
+      {
+        tabs: [{ kind: "command", id: "tab-1", title: null, ordinal: 1, command: ["/bin/zsh"] }],
+        activeId: "tab-1",
+        nextOrdinal: 2,
+      },
+      ["/bin/zsh"],
+    )
+    expect(shellOnly.tabs).toHaveLength(1)
+    expect(shellOnly.tabs[0]).toMatchObject({ kind: "command", id: "tab-1", command: ["/bin/zsh"] })
+    // Corrupt/empty snapshot still falls back to a fresh initial state.
+    expect(rehydrateTabs({ tabs: [], activeId: "tab-1", nextOrdinal: 1 }, ["/bin/zsh"])).toEqual(initialTabs())
+  })
+  // Why: a last-tab in-place recycle that reset to bare initialTabs() would
+  // drop title/autoTitle — the naming pass would then derive a NEW name from
+  // the fresh session's first prompt, so the tab would visibly rename itself
+  // on every recycle. Carrying both fields keeps the name stable AND blocks
+  // re-derivation (the pass only names tabs with neither field set).
+  it("recycleTabs keeps the exited tab's title/autoTitle on the fresh tab", () => {
+    let s = setTabAutoTitle(initialTabs(), "tab-1", "fix the resize race")
+    s = renameActiveTab(s, "my name")
+    const fresh = recycleTabs(s, s.tabs[0])
+    expect(fresh.tabs).toHaveLength(1)
+    expect(fresh.tabs[0]).toMatchObject({
+      kind: "engine",
+      title: "my name",
+      autoTitle: "fix the resize race",
+    })
+    // Fresh session: no carried sessionId/spawned from the dead tab.
+    expect((fresh.tabs[0] as EngineTab).sessionId).toBeUndefined()
+    expect((fresh.tabs[0] as EngineTab).spawned).toBeUndefined()
+    // An untitled tab recycles untitled — nothing invented.
+    const bare = initialTabs()
+    expect(recycleTabs(bare, bare.tabs[0]).tabs[0]).toMatchObject({ title: null })
+  })
+  // Why: the recycle used to hand back `initialTabs()` wholesale, which
+  // dropped the tab's PINNED engine — a tab the user pointed at Codex came
+  // back running the TASK's engine while still wearing the Codex
+  // conversation's title, so the swap was invisible. `reopenHintFor` already
+  // carries `vendor` for the sibling revive path; recycle must too.
+  it("recycleTabs carries the exited tab's pinned vendor and engineCommand", () => {
+    const s: TabsState = {
+      tabs: [{ kind: "engine", id: "tab-3", title: null, ordinal: 3, vendor: "codex", engineCommand: "codex --yolo" }],
+      activeId: "tab-3",
+      nextOrdinal: 4,
+    }
+    expect(recycleTabs(s, s.tabs[0]).tabs[0]).toMatchObject({ vendor: "codex", engineCommand: "codex --yolo" })
+  })
+  // Why: `TabBase.id` is "never reused within a task" — inbox episodes and
+  // the orphan-adoption suppression in terminal-tabs-close.ts are both keyed
+  // `(taskId, tabId)`. Resetting to `tab-1` handed the recycled tab a dead
+  // tab's episodes and its in-flight suppression. `reopenTabs` already
+  // consumes `nextOrdinal`; recycle must too.
+  it("recycleTabs mints a fresh id from nextOrdinal instead of reusing tab-1", () => {
+    let s = initialTabs()
+    s = addTab(s) // tab-2
+    s = addTab(s) // tab-3
+    const recycled = recycleTabs(s, s.tabs[2])
+    expect(recycled.tabs[0]?.id).toBe("tab-4")
+    expect(recycled.tabs[0]?.ordinal).toBe(4)
+    expect(recycled.activeId).toBe("tab-4")
+    expect(recycled.nextOrdinal).toBe(5)
+    // Never rewinds onto an id this task already handed out.
+    for (const used of s.tabs) expect(recycled.tabs[0]?.id).not.toBe(used.id)
+  })
+})


### PR DESCRIPTION
Batch C items **C1** and **C2** — they share the tab core, so one PR. Full proof (screenshots, mutation runs, pixel diffs, gate numbers) is in the first PR comment.

**C1 — `recycleTabs` dropped the tab's pinned engine and reused `tab-1`.**
It returned `initialTabs()` wholesale with only `title`/`autoTitle` copied, so a tab you pointed at another engine respawned on the *task's* engine while still wearing the old conversation's title — and the new tab was `tab-1` again, breaking the `TabBase.id` "never reused within a task" invariant that Inbox episodes and orphan suppression both key on. It now carries `vendor`/`engineCommand` the way its sibling `reopenHintFor`/`reopenTabs` already does and mints the id from `state.nextOrdinal`.

**C1 — `ctrl+a` `w` was a dead key on an unsplit tab.**
`workspace.split.close` was the sole owner of `prefixKeys: ["w"]` and only registers while split; `chat.tab.close` — the row that is live when it is not — declared none, so the second stroke hit no enabled prefix binding and was consumed. `chat.tab.close` now carries the same `prefixKeys: ["w"]` its mutually-gated twin already had. **No chord added or moved** — it is the existing chord's existing documented meaning, and nothing becomes reachable that `ctrl+w` did not already reach. Flagging it for owner sign-off anyway; recorded in `docs/design/keybinding-decisions.md`, and `docs/KEYBINDINGS.md:55` now matches.

**C2 — one request-box factory.**
Seven copies of the pending-slot/take/take-unclaimed reducer in `terminal-tabs-shared.ts` collapse into one `requestBox<T>()`. Exported names, argument shapes, the shared listener set, the consumption order in `use-tab-requests.ts` and the deliberate absence of `takeUnclaimed` for four of the seven are all unchanged, so no call site moves. 441 → 387 lines.

**CI follow-up (this push).** `terminal-tabs-core.ts` had crossed the size cap, so the seam it was hiding is now named: everything that mints a *whole* `TabsState` from something other than a user action — first mount, restart snapshot, reviving an emptied task, recycling on exit — moves to `terminal-tabs-lifecycle.ts`. Those four have to agree about ordinal minting and carried identity, and this bug is what a silent disagreement between two of them looks like. `TabsState` joins the other shapes in `terminal-tab-shapes.ts` so the new module needs no runtime import back into core; core re-exports, so no importer changes. The test file splits the same way. 502 → 365 and 523 → 427.

### Gates
`bun run typecheck`, `bun run lint`, `bash scripts/file-size-check.sh` — clean. `bun test test/render` — 431 pass, 0 fail. `bun run test:fast` — 4261 pass, 6 fail, all pre-existing and environmental (identical failure set on my other, disjoint branch): `continue-live-vendor` reads the owner's locally-registered `claudecpa` engine out of the real `state.json`, and `project-eligibility` / `open-dir-cmd` are the known `~/.rove/worktrees` path-shape false failures. CI runs from an ordinary Linux checkout.

coverage-exemption: packages/kobe/src/tui-react/workspace/TerminalTabs.tsx — measured baseline on origin/main is LF 263 / LH 90 = 34.22%, already 16pp under the floor; this PR's two touched lines (one deleted import, one `prefixAction` wrapper) leave it at LF 265 / LH 90 = 33.96%. Nothing in test/render mounts TerminalTabs at all — `show-workspace-close-last.test.tsx` documents why ("opens a daemon socket and needs four more providers"), so the whole `useBindings` block containing the touched line is uncovered on both sides. The changed behaviour is proven instead through the repo's own ground truth for it: a `/harness` BEFORE/AFTER pair driving the real mounted component with real keys (see the comment).
