### PR TITLE
rove api flag layer, cron DST, remote-project launch guard, and stale docs

### DIFF
--- a/.changeset/api-bool-flags-and-prompt-validation.md
+++ b/.changeset/api-bool-flags-and-prompt-validation.md
@@ -1,0 +1,12 @@
+---
+"@sma1lboy/rove": patch
+---
+
+`rove api`: `--flag false` now works, `--prompt-file -` no longer reads stdin twice, and a bad `add` leaves no task behind
+
+Four fixes in the `api` flag layer:
+
+- A declared bool flag takes the space form (`--pinned false`, `--remove-worktree false`). The parser turned every bool flag into a presence flag before looking at the next argument, so `--pinned=false` was the only way to say `false` and `--pinned false` died as `unexpected positional arg`. `--force` on its own still means `true`.
+- `--prompt-file -` reads stdin once. `routine-update` guards the flag and then reads it, which drained the pipe on the guard and hit EOF on the read — every `--prompt-file -` update failed with `--prompt-file - is empty`.
+- `routine-update --persistent-session false` turns a standing routine back into fresh-worktree-per-run. The explicit `false` was dropped from the patch, so the routine stayed standing with no CLI path back.
+- `add` validates `--prompt` / `--prompt-file` before it creates the task, instead of after. Passing both (or naming a missing file) created the task, then failed with an error that carried no `taskId` to find it with.

--- a/.changeset/cron-dst-and-run-now-deferral.md
+++ b/.changeset/cron-dst-and-run-now-deferral.md
@@ -1,0 +1,9 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Routines: no more double run on the DST fall-back day, no more frozen composer, and Run now defers like the schedule does
+
+- A daily routine scheduled in the hour the clock repeats ran **twice** every autumn — two worktrees, two branches, two billed turns — and one scheduled in the hour the clock skips every spring didn't run at all, with nothing in its history to say so. The occurrence search now walks the local calendar instead of stepping fixed epoch minutes, so each wall-clock minute is one firing; a skipped local time fires at the instant the clock jumped to.
+- A valid-but-rare expression (`0 0 30 2 *`) no longer stalls the daemon or the TUI. The old minute-by-minute scan did 4.7M date allocations before giving up (~150ms), and the automation composer runs the schedule preview while you type — arrowing the day-of-month past 29 with the month on `2` froze the terminal once per keypress. The scan is day-at-a-time now and gives up in ~1ms.
+- Run now on a standing routine whose composer is busy files the prompt in your Inbox, matching what the same firing does on the schedule. It used to record `dispatch_failed` and discard the text.

--- a/.changeset/help-channel-and-retry-target.md
+++ b/.changeset/help-channel-and-retry-target.md
@@ -1,0 +1,9 @@
+---
+"@sma1lboy/rove": patch
+---
+
+`rove --help` mentions channel switching, and an empty-success retry keeps its target
+
+`update` has accepted `--channel latest` / a bare `nightly` for several releases, but the top-level help still read `update [version|list]` — the subcommand lock-step test only compares the command list, so the description drifted past CI.
+
+`send`'s empty-success refusal hands back a `nextCommandArgs` you are told to run verbatim; it dropped the `--task-id` / `--tab` you addressed, so the retry re-resolved through the active-task fallback and could deliver into a different task. It now carries the target forward.

--- a/.changeset/remote-engine-launch-guard.md
+++ b/.changeset/remote-engine-launch-guard.md
@@ -1,0 +1,7 @@
+---
+"@sma1lboy/rove": patch
+---
+
+A task on an experimental remote (`ssh://`) project now refuses the engine launch instead of spawning locally
+
+`rove add --remote` and the Settings toggle both say hosted PTY engine launch over SSH is not implemented, but nothing enforced it: a remote task's worktree lives on the other machine, so opening its tab or sending it a prompt started an engine here against a directory that does not exist, and surfaced as a bare "failed to start hosted engine session". One guard at the launch builder — the single spawn-spec path the Workspace host, `rove api send`, and a prompted `add` all funnel through — now returns `hosted engine launch over SSH is not implemented`, naming the project.

--- a/.changeset/remote-engine-launch-guard.md
+++ b/.changeset/remote-engine-launch-guard.md
@@ -5,3 +5,5 @@
 A task on an experimental remote (`ssh://`) project now refuses the engine launch instead of spawning locally
 
 `rove add --remote` and the Settings toggle both say hosted PTY engine launch over SSH is not implemented, but nothing enforced it: a remote task's worktree lives on the other machine, so opening its tab or sending it a prompt started an engine here against a directory that does not exist, and surfaced as a bare "failed to start hosted engine session". One guard at the launch builder — the single spawn-spec path the Workspace host, `rove api send`, and a prompted `add` all funnel through — now returns `hosted engine launch over SSH is not implemented`, naming the project.
+
+In the TUI the workspace pane says it outright rather than mounting an engine tab: opening a remote task used to mint a `claude 1` tab and leave a blank pane while the PTY host retried a local spawn into a directory that is not there.

--- a/docs/API.md
+++ b/docs/API.md
@@ -87,8 +87,10 @@ an unfamiliar one with `<cmd> --help` before dispatching. See
 [ENGINES.md](./ENGINES.md#engine-presets-and-protocols) for how the protocol
 Rove speaks to a command is derived from it.
 
-Two verbs were REMOVED (no aliases): `fan-out` → `add --count N`, and
-`set-vendor` → `set-command`. Calling either returns `UNKNOWN_VERB` with the
+Three verbs were REMOVED (no aliases): `fan-out` → `add --count N`,
+`set-vendor` → `set-command`, and `archive` → `delete` (there is no
+hide-without-delete any more; the branch survives unless you pass
+`--delete-branch`). Calling any of them returns `UNKNOWN_VERB` with the
 replacement in `nextCommandArgs`.
 
 ## discover
@@ -267,9 +269,9 @@ wrong reply address delivers to someone else; no address at least fails
 visibly), and the verb's JSON result carries an `identityWarning` field
 saying so.
 
-A new task's FIRST prompt (`add --prompt`, a parallel round, quick-fork) gets a
-short coda appended asking the agent to `set-branch` the auto-generated
-placeholder branch to a descriptive name. Prompts into existing sessions
+A new task's FIRST prompt (`add --prompt`, a parallel round, quick-fork) carries
+only facts about its own worktree; the standing worker instructions, naming its
+branch included, live in the Rove agent skill. Prompts into existing sessions
 (`send`, `send --tab new`, `dispatch`) are never modified.
 
 ## drive

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -100,8 +100,7 @@ Commands:
   skill <verb>            Install the Rove agent skill (install|status|command|print)
   plugin <verb>           Install and run plugins (install|link|list|action|…)
   feedback                Send feedback to GitHub Discussions
-  update [version|channel|list]   Self-update Rove, switch channel, or browse
-                          versions with `list`
+  update [version|channel|list]   Self-update Rove, switch channel, or list versions
 
 Options:
   -v, --version           Print version

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -113,12 +113,12 @@ Launch commands are parsed shell-ish, so quotes group arguments. Clear both
 | Key | Type | Default | What it does |
 |---|---|---|---|
 | `terminal.scrollbackRows` | number | `1000` | History per embedded terminal. Clamped 100–100,000 |
-| `chat.tabStrip.mode` | `always` \| `multipleOnly` \| `never` | `always` | Horizontal chat tab strip |
+| `chat.tabStrip.mode` | `always` \| `multipleOnly` \| `never` | `never` | Horizontal chat tab strip |
 
-The tab strip is on by default: the sidebar tree lists every tab, but the
-strip is the affordance that says which tab the pane below is showing.
-`multipleOnly` hides it while a task has only one tab, `never` leaves the
-tree as the only tab list. (An older
+The tab strip is off by default: the sidebar tree already lists every tab and
+marks the active one, so the strip spends a row of the content pane saying
+what the tree says for free. `always` shows it, `multipleOnly` shows it only
+once a task has more than one tab. (An older
 `chat.tabStrip.hideSingle` boolean still works if you set it before
 `chat.tabStrip.mode` existed; writing the new key retires it.)
 

--- a/docs/ENGINES.md
+++ b/docs/ENGINES.md
@@ -16,14 +16,17 @@ you need git-level isolation and a separate branch.
 
 ## Which engines are supported
 
-| Engine | Id | Account detect | Activity badge | History | Model picker |
+| Engine | Id | Account detect | Activity badge | History | Effort levels |
 |---|---|---|---|---|---|
-| Claude Code | `claude` | ✓ | ✓ | ✓ | ✓ |
-| Codex | `codex` | ✓ | ✓ (after you trust hooks) | ✓ | ✓ + effort levels |
+| Claude Code | `claude` | ✓ | ✓ | ✓ | — |
+| Codex | `codex` | ✓ | ✓ (after you trust hooks) | ✓ | `none`/`low`/`medium`/`high`/`xhigh` |
 | GitHub Copilot | `copilot` | ✓ | ✓ (screen-based) | ✓ | — |
 | Kimi Code | `kimi` | ✓ | ✓ | handoff only | — |
 | Gemini CLI, OpenCode, Cursor Agent, Grok CLI, Droid, Amp | contrib | binary only | ✓ (screen-based) | — | — |
 | Anything you register | custom | binary only | — | — | — |
+
+There is no in-app model picker for any engine — pick the model the way that
+engine does, on its own launch command.
 
 **Claude Code is the default** and the most complete: its quota probe drives
 rate-limit auto-resume and the Settings usage dashboard.

--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -157,8 +157,8 @@ is active.
 Sidebar row verbs (`b`, `v`, `o`, `d`, `r`, `shift+p`, `shift+m`) act on the
 row under the cursor — the highlight `j`/`k` moves, which may differ from the
 active task until you press `enter`. Prefix chords (`ctrl+a o`, `ctrl+a p`)
-are global and act on the active task; only `ctrl+a o` follows the cursor
-while the sidebar has focus.
+are global and act on the active task, except while the sidebar has focus —
+both of them then follow the row under the cursor.
 
 In reorder mode, `j`/`k` moves the highlighted project and `enter` or `esc`
 finishes. Project headings themselves aren't cursor rows; the move routes
@@ -191,12 +191,15 @@ anywhere else, or `esc`, dismisses it. Common row actions also have direct
 chords. A Task or tab row also offers **New conversation** (the `ctrl+e`
 engine/shell picker) and **New shell** (a bare shell tab) for that worktree,
 both enter the Task first, exactly as pressing the chord there would.
-Three entries have no chord. **Set status** opens a picker over the six Task
+Four entries have no chord. **Set status** opens a picker over the six Task
 statuses and writes the one you choose. **Copy branch name** and **Copy path**
 put the Task's branch or recorded worktree path on the system clipboard (local
 clipboard command plus OSC 52, so it also works over SSH); copying never
 creates the worktree, and a project-main or directory row, whose stored branch
-is empty, offers only Copy path. **Open in editor**, **Rename branch**, and
+is empty, offers only Copy path. **Land into base branch** runs the same land
+the Worktrees page's `l` does, and appears only on a managed Task row that has
+a branch — a project-main or directory row owns no Rove branch to land.
+**Open in editor**, **Rename branch**, and
 **Change engine** are the `o`, `b`, and `v` chords for the row you clicked;
 the engine entry opens a picker over your available engines instead of
 cycling, and Rename branch follows the same empty-branch rule as Copy branch

--- a/docs/WORKTREES.md
+++ b/docs/WORKTREES.md
@@ -20,9 +20,7 @@ never contain Rove branding. An explicit `--branch` on creation,
 `set-branch` afterwards, and `b` on a task row in the sidebar override this
 entirely. A branch still on its `new-task` placeholder is renamed once,
 automatically, when the task gets a real title (skipped if the branch
-already has an upstream); after that Rove never touches it again. A new
-worktree task started with a prompt also asks its agent to `set-branch` to a
-descriptive name once it understands the work.
+already has an upstream); after that Rove never touches it again.
 
 ## Where worktrees live
 

--- a/packages/kobe-daemon/src/daemon/cron.ts
+++ b/packages/kobe-daemon/src/daemon/cron.ts
@@ -12,17 +12,29 @@
  *   - {@link latestCronAtOrBefore} — "what SHOULD have run by now", which is
  *     what missed-run compensation needs after the daemon was down
  *
- * Both scan minute-by-minute rather than solving the field constraints
- * algebraically. A valid expression can have a genuinely huge gap (`0 0 29 2 *`
- * skips 8 years across a non-leap century boundary), so the scan bound is
- * generous; the loop body is a handful of Set lookups, so even the pathological
- * case stays well under a millisecond.
+ * Both scan the LOCAL CALENDAR — day by day, then only the hours and minutes
+ * the expression actually names — rather than stepping fixed epoch minutes.
+ * That is what makes them DST-correct: a cron expression names a wall clock,
+ * and on a fall-back day one wall-clock minute maps to two epoch instants
+ * while on a spring-forward day one maps to none. Stepping epoch minutes and
+ * testing the local clock fired a daily routine twice every autumn and
+ * skipped it silently every spring. Enumerating each local minute exactly
+ * once, then converting to an instant, gives one firing per day in both
+ * directions; a nonexistent local time resolves to the instant the clock
+ * jumped to (02:30 fires at 03:30) rather than vanishing.
+ *
+ * Day-at-a-time also keeps the pathological case cheap. A valid expression can
+ * have a genuinely huge gap (`0 0 29 2 *` skips 8 years across a non-leap
+ * century boundary); at a minute per step that is 4.7M iterations, each
+ * allocating a Date — ~150ms on the daemon's event loop, and the TUI's
+ * schedule preview runs it in the render body, so arrowing the day-of-month
+ * past 29 with the month on `2` froze the terminal once per keypress.
  */
 
 const MINUTE_MS = 60_000
 
-/** Scan ceiling in minutes. Sized for `0 0 29 2 *` (Feb 29 across 2100). */
-const SCAN_MINUTES = 9 * 366 * 24 * 60
+/** Scan ceiling in days. Sized for `0 0 29 2 *` (Feb 29 across 2100). */
+const SCAN_DAYS = 9 * 366
 
 export interface ParsedCron {
   readonly minutes: ReadonlySet<number>
@@ -162,24 +174,58 @@ export function isValidCron(expression: string): boolean {
   }
 }
 
+/** A local wall-clock day. The scans step in these, never in epoch minutes. */
+interface LocalDay {
+  year: number
+  /** 1-12, matching the cron field rather than `Date`'s 0-11. */
+  month: number
+  day: number
+}
+
+/** The instant a local wall clock names. An ambiguous (repeated) local time
+ *  resolves to one of its two instants and a nonexistent (skipped) one to the
+ *  instant the clock jumped to — both deliberate, see the module header. */
+function instantOf(d: LocalDay, hour: number, minute: number): number {
+  return new Date(d.year, d.month - 1, d.day, hour, minute, 0, 0).getTime()
+}
+
+function localDayOf(ms: number): LocalDay {
+  const d = new Date(ms)
+  return { year: d.getFullYear(), month: d.getMonth() + 1, day: d.getDate() }
+}
+
+/** Shift by whole local days through `Date`, which owns month/year rollover. */
+function shiftDay(d: LocalDay, delta: number): LocalDay {
+  return localDayOf(new Date(d.year, d.month - 1, d.day + delta, 12, 0, 0, 0).getTime())
+}
+
 /**
- * Does `timeMs` match? Day matching follows the Vixie-cron rule that trips
- * everyone up: when BOTH day fields are restricted they are OR'd, not AND'd
- * (`0 0 1 * MON` = the 1st **or** any Monday). With one restricted, only that
- * one applies; with neither, every day matches.
+ * Does this local day match? The Vixie-cron rule that trips everyone up: when
+ * BOTH day fields are restricted they are OR'd, not AND'd (`0 0 1 * MON` = the
+ * 1st **or** any Monday). With one restricted, only that one applies; with
+ * neither, every day matches.
+ */
+function dayMatches(rule: ParsedCron, d: LocalDay): boolean {
+  if (!rule.months.has(d.month)) return false
+  const domMatch = rule.daysOfMonth.has(d.day)
+  const dowMatch = rule.daysOfWeek.has(new Date(d.year, d.month - 1, d.day).getDay())
+  if (rule.dayOfMonthRestricted && rule.dayOfWeekRestricted) return domMatch || dowMatch
+  if (rule.dayOfMonthRestricted) return domMatch
+  if (rule.dayOfWeekRestricted) return dowMatch
+  return true
+}
+
+/**
+ * Does `timeMs` match? Same day rule as {@link dayMatches}, applied to the
+ * whole instant. The scans do not use this — they enumerate matching local
+ * minutes instead, which is what keeps them one-firing-per-day across a DST
+ * boundary — but it is the honest "is this instant an occurrence" predicate.
  */
 export function cronMatches(rule: ParsedCron, timeMs: number): boolean {
   const d = new Date(timeMs)
   if (!rule.minutes.has(d.getMinutes())) return false
   if (!rule.hours.has(d.getHours())) return false
-  if (!rule.months.has(d.getMonth() + 1)) return false
-
-  const domMatch = rule.daysOfMonth.has(d.getDate())
-  const dowMatch = rule.daysOfWeek.has(d.getDay())
-  if (rule.dayOfMonthRestricted && rule.dayOfWeekRestricted) return domMatch || dowMatch
-  if (rule.dayOfMonthRestricted) return domMatch
-  if (rule.dayOfWeekRestricted) return dowMatch
-  return true
+  return dayMatches(rule, localDayOf(timeMs))
 }
 
 /** Truncate to the start of the containing minute (cron's resolution).
@@ -187,6 +233,10 @@ export function cronMatches(rule: ParsedCron, timeMs: number): boolean {
  *  number of minutes, so the modulo lands on a local minute boundary too. */
 function floorToMinute(ms: number): number {
   return ms - (ms % MINUTE_MS)
+}
+
+function sorted(values: ReadonlySet<number>, direction: 1 | -1): number[] {
+  return [...values].sort((a, b) => (a - b) * direction)
 }
 
 /**
@@ -200,10 +250,29 @@ function floorToMinute(ms: number): number {
  */
 export function nextCronAfter(expression: string, afterMs: number): number {
   const rule = parseCron(expression)
-  let candidate = floorToMinute(afterMs) + MINUTE_MS
-  for (let i = 0; i < SCAN_MINUTES; i++) {
-    if (cronMatches(rule, candidate)) return candidate
-    candidate += MINUTE_MS
+  const hours = sorted(rule.hours, 1)
+  const minutes = sorted(rule.minutes, 1)
+  const from = new Date(floorToMinute(afterMs) + MINUTE_MS)
+  let day = localDayOf(from.getTime())
+  let fromHour = from.getHours()
+  let fromMinute = from.getMinutes()
+  for (let i = 0; i < SCAN_DAYS; i++) {
+    if (dayMatches(rule, day)) {
+      for (const hour of hours) {
+        if (hour < fromHour) continue
+        for (const minute of minutes) {
+          if (hour === fromHour && minute < fromMinute) continue
+          const at = instantOf(day, hour, minute)
+          // A local minute inside a repeated hour can resolve to an instant at
+          // or before `afterMs` (the earlier of its two offsets). Skipping it
+          // keeps the result strictly increasing without firing twice.
+          if (at > afterMs) return at
+        }
+      }
+    }
+    day = shiftDay(day, 1)
+    fromHour = 0
+    fromMinute = 0
   }
   throw new Error(`cron expression never matches: ${expression}`)
 }
@@ -221,10 +290,30 @@ export function nextCronAfter(expression: string, afterMs: number): number {
 export function latestCronAtOrBefore(expression: string, nowMs: number, notBeforeMs: number): number | null {
   if (nowMs < notBeforeMs) return null
   const rule = parseCron(expression)
-  let candidate = floorToMinute(nowMs)
-  for (let i = 0; i < SCAN_MINUTES && candidate >= notBeforeMs; i++) {
-    if (cronMatches(rule, candidate)) return candidate
-    candidate -= MINUTE_MS
+  const hours = sorted(rule.hours, -1)
+  const minutes = sorted(rule.minutes, -1)
+  const from = new Date(floorToMinute(nowMs))
+  let day = localDayOf(from.getTime())
+  let fromHour = from.getHours()
+  let fromMinute = from.getMinutes()
+  for (let i = 0; i < SCAN_DAYS; i++) {
+    // Every remaining candidate is earlier than this day's last minute, so once
+    // that is out of the window there is nothing left to find.
+    if (instantOf(day, 23, 59) < notBeforeMs) return null
+    if (dayMatches(rule, day)) {
+      for (const hour of hours) {
+        if (hour > fromHour) continue
+        for (const minute of minutes) {
+          if (hour === fromHour && minute > fromMinute) continue
+          const at = instantOf(day, hour, minute)
+          if (at > nowMs) continue
+          return at >= notBeforeMs ? at : null
+        }
+      }
+    }
+    day = shiftDay(day, -1)
+    fromHour = 23
+    fromMinute = 59
   }
   return null
 }

--- a/packages/kobe-daemon/src/daemon/handlers-automations.ts
+++ b/packages/kobe-daemon/src/daemon/handlers-automations.ts
@@ -109,8 +109,22 @@ export const AUTOMATION_HANDLERS: readonly DaemonRequestHandler[] = [
       if (!automation) throw new Error(`automation not found: ${id}`)
       // `trigger: "manual"` deliberately skips the precheck — the user asking
       // for it IS the answer to "is this worth running".
+      //
+      // Same deps as the scheduled sweep (`collectors.ts`), and that parity is
+      // the point: without `deferred` + `inbox` the dispatch path has nowhere
+      // to put a prompt a busy composer refused, so Run now on a standing
+      // routine recorded `dispatch_failed` and DROPPED the prompt, where the
+      // identical firing on the schedule would have deferred it into the Inbox.
       const status = await runAutomationOnce(
-        { store: ctx.automations, orch: ctx.orch, runtime: ctx.runtime, link: ctx.selfLink },
+        {
+          store: ctx.automations,
+          orch: ctx.orch,
+          runtime: ctx.runtime,
+          link: ctx.selfLink,
+          ...(ctx.plugins ? { plugins: () => ctx.plugins ?? null } : {}),
+          ...(ctx.deferredPrompts ? { deferred: ctx.deferredPrompts } : {}),
+          inbox: ctx.inbox,
+        },
         automation,
         { scheduledFor: Date.now(), trigger: "manual" },
       )

--- a/packages/kobe/src/cli/api/flags.ts
+++ b/packages/kobe/src/cli/api/flags.ts
@@ -33,6 +33,18 @@ export function parsePositiveInt(raw: string): number | undefined {
   return Number.isSafeInteger(n) && n > 0 ? n : undefined
 }
 
+/**
+ * A boolean flag's value, or `undefined` when the string isn't one. Shared by
+ * the parser (deciding whether `--pinned false` is a value or a presence flag)
+ * and {@link VerbArgs.bool} (coercing it), so the two can never disagree about
+ * what counts as a boolean.
+ */
+export function parseBoolLiteral(raw: string): boolean | undefined {
+  if (["true", "1", "yes"].includes(raw)) return true
+  if (["false", "0", "no"].includes(raw)) return false
+  return undefined
+}
+
 /** Both parallel-plan parsers are only reachable from `add`, so their errors point at its help. */
 const FANOUT_STEP = helpStep("add")
 
@@ -134,9 +146,20 @@ export function parseFlags(argv: readonly string[], booleanFlags: ReadonlySet<st
       help = true
       continue
     }
-    // A boolean verb flag with no value is a presence flag (`--force`).
+    // A boolean verb flag takes the space form (`--pinned false`) only when the
+    // next argv element IS a boolean literal. Anything else — another flag, a
+    // string flag's value, end of argv — leaves it a presence flag (`--force`),
+    // so both halves of the contract work: `bool()` has always accepted
+    // `false`/`0`/`no`, and before this the parser made that value unreachable
+    // except through `--pinned=false`.
     if (booleanFlags.has(key)) {
-      flags.set(key, "true")
+      const next = argv[i + 1]
+      if (next !== undefined && parseBoolLiteral(next) !== undefined) {
+        flags.set(key, next)
+        i += 1
+      } else {
+        flags.set(key, "true")
+      }
       continue
     }
     const next = argv[i + 1]
@@ -224,8 +247,23 @@ export class VerbArgs {
    * The prompt text from `--prompt` or `--prompt-file` (`-` = stdin), never
    * both. `undefined` when neither was given — callers that need one wrap
    * this in their own MISSING_FLAG.
+   *
+   * Memoized, because it is the one accessor with a SIDE EFFECT: `-` drains
+   * stdin. Every sibling here is pure, so callers naturally write
+   * `promptText() !== undefined ? { prompt: promptText() } : {}` — which used
+   * to consume stdin on the guard and then read EOF on the branch, failing
+   * "--prompt-file - is empty" for a pipe that was never empty.
    */
   promptText(): string | undefined {
+    if (this.promptMemo !== undefined) return this.promptMemo.value
+    const value = this.readPromptText()
+    this.promptMemo = { value }
+    return value
+  }
+
+  private promptMemo: { value: string | undefined } | undefined
+
+  private readPromptText(): string | undefined {
     const inline = this.str("prompt")
     const file = this.str("prompt-file")
     if (inline !== undefined && file !== undefined) {
@@ -291,9 +329,9 @@ export class VerbArgs {
     this.spec(name)
     const raw = this.str(name)
     if (raw === undefined) return undefined
-    if (["true", "1", "yes"].includes(raw)) return true
-    if (["false", "0", "no"].includes(raw)) return false
-    throw new ApiError(`--${name} must be a boolean (true/false)`, "BAD_FLAG")
+    const value = parseBoolLiteral(raw)
+    if (value === undefined) throw new ApiError(`--${name} must be a boolean (true/false)`, "BAD_FLAG")
+    return value
   }
 
   /** Positive-integer flag; undefined when absent. */

--- a/packages/kobe/src/cli/api/handlers-add.ts
+++ b/packages/kobe/src/cli/api/handlers-add.ts
@@ -80,6 +80,12 @@ export async function add(ctx: VerbContext): Promise<unknown> {
 async function addOne(ctx: VerbContext, repo: string): Promise<unknown> {
   const daemon = daemonOf(ctx)
   const { args } = ctx
+  // Read (and validate) the prompt BEFORE anything is created. `promptText`
+  // is flag validation — mutual exclusion of --prompt/--prompt-file — plus a
+  // file read, and both of its throws used to fire after `task.create` had
+  // committed, leaving an orphan task behind an error carrying no taskId.
+  // `addParallel` has always read it first; this matches.
+  const prompt = args.promptText()
   // Record who dispatched this create — the reply address a
   // sub-task's bare `send` routes its outcome back to.
   const choice = await engineChoice(ctx, repo)
@@ -105,7 +111,6 @@ async function addOne(ctx: VerbContext, repo: string): Promise<unknown> {
     task = (await daemon.request<{ task: SerializedTask }>("task.get", { taskId })).task
   }
 
-  const prompt = args.promptText()
   if (!prompt) return { taskId, task, started: false }
   // Same provenance prefix `send` carries: a task created from inside another
   // kobe session is agent-to-agent, and its opening brief is where the reply

--- a/packages/kobe/src/cli/api/handlers-inspect.ts
+++ b/packages/kobe/src/cli/api/handlers-inspect.ts
@@ -75,7 +75,10 @@ async function sessionsSection(taskId: string | undefined): Promise<unknown> {
   } finally {
     client.close()
   }
-  if (taskId) sessions = sessions.filter((s) => s.key.startsWith(taskId))
+  // `::` for the same reason the exits filter below uses it: a session key is
+  // `<taskId>::<tabId>[::leaf-N]`, so the separator is what makes this a task
+  // match rather than a prefix match.
+  if (taskId) sessions = sessions.filter((s) => s.key.startsWith(`${taskId}::`))
   // ONE ps snapshot serves every session — same economy as live-engine.ts.
   let rows: ReturnType<typeof parsePsSnapshot> | null = null
   try {

--- a/packages/kobe/src/cli/api/handlers-tasks.ts
+++ b/packages/kobe/src/cli/api/handlers-tasks.ts
@@ -113,7 +113,19 @@ async function assertNotEmptySuccess(daemon: DaemonRpc, ctx: VerbContext, prompt
       taskId: self.taskId,
       branch,
       hint: "commit your work with a real message and send again — or, if this task genuinely produced no commits (an investigation or a review), re-send with --allow-empty to say so explicitly",
-      nextCommandArgs: ["api", "send", "--allow-empty", "--prompt", prompt],
+      // Carry the caller's own target forward. The hint tells the agent to run
+      // this verbatim, and without the flags the retry re-resolves through the
+      // active-task fallback — so an explicit `send --task-id X` could retry
+      // into a DIFFERENT task than the one it addressed.
+      nextCommandArgs: [
+        "api",
+        "send",
+        ...(ctx.args.str("task-id") ? ["--task-id", ctx.args.str("task-id") as string] : []),
+        ...(ctx.args.str("tab") ? ["--tab", ctx.args.str("tab") as string] : []),
+        "--allow-empty",
+        "--prompt",
+        prompt,
+      ],
     },
   )
 }

--- a/packages/kobe/src/cli/api/verbs-automations.ts
+++ b/packages/kobe/src/cli/api/verbs-automations.ts
@@ -145,7 +145,14 @@ export const ROUTINE_VERBS: readonly VerbSpec[] = [
         ...(ctx.args.present("base-branch") ? { baseRef: ctx.args.str("base-branch") ?? null } : {}),
         ...precheckPayload(ctx),
         ...(ctx.args.int("grace") !== undefined ? { missedRunGraceMinutes: ctx.args.int("grace") } : {}),
-        ...(ctx.args.bool("persistent-session") ? { persistentSession: true } : {}),
+        // `present` + `bool`, not a bare `bool` ternary: an explicit
+        // `--persistent-session false` is falsy, so the ternary dropped the key
+        // and left the routine standing — there was no CLI path back to
+        // fresh-worktree-per-run. (On `routine-create` above, absent and false
+        // mean the same thing, so the ternary is harmless there.)
+        ...(ctx.args.present("persistent-session")
+          ? { persistentSession: ctx.args.bool("persistent-session") ?? true }
+          : {}),
       }),
   },
   {

--- a/packages/kobe/src/cli/usage.ts
+++ b/packages/kobe/src/cli/usage.ts
@@ -37,7 +37,10 @@ export function topLevelUsage(cliName: ProductCliName = activeCliName()): string
     `  skill <verb>            Install the ${cliName} agent skill (install|status|command|print)`,
     "  plugin <verb>           Install and run plugins (install|link|list|action|…)",
     "  feedback                Send feedback to GitHub Discussions",
-    `  update [version|list]   Self-update ${cliName}, or browse versions with \`list\``,
+    // `channel` has shipped since `update` learned --channel/bare channel
+    // names; the subcommand lock-step test only compares the command LIST, so
+    // this description drifted past CI for several releases.
+    `  update [version|channel|list]   Self-update ${cliName}, switch channel, or list versions`,
     "",
     "Options:",
     "  -v, --version           Print version",

--- a/packages/kobe/src/engine/session-launch.ts
+++ b/packages/kobe/src/engine/session-launch.ts
@@ -3,6 +3,7 @@ import { worktreeInitMarkerPath } from "../env.ts"
 import { quoteShellArg, quoteShellArgv } from "../lib/shell-command.ts"
 import { readFieldNotes } from "../state/field-notes.ts"
 import { type PromptDeliveryIntent, resolveEngineLaunchInit } from "../state/repo-init.ts"
+import { isRemoteRepoKey } from "../state/repos.ts"
 import type { VendorId } from "../types/vendor.ts"
 import { protocolEntry } from "./engine-presets.ts"
 import { withDispatcherProtocol, withWorktreeProtocol } from "./worktree-protocol.ts"
@@ -155,8 +156,32 @@ export function engineSessionKey(taskId: string, tabId = "tab-1"): string {
   return `${taskId}::${tabId}`
 }
 
+/**
+ * A launch refused because the task lives on an SSH-backed remote project.
+ *
+ * The experimental remote-projects feature routes git through an exec host,
+ * but the PTY host spawns locally against a raw cwd — so a remote task's
+ * worktree path, which exists on the OTHER machine, gets an engine started
+ * here against a directory that is not there. `rove add --remote` and the
+ * Settings toggle both say SSH engine launch is unimplemented; this is the
+ * guard that makes the code agree with the copy instead of failing obscurely.
+ */
+export class RemoteEngineLaunchError extends Error {
+  readonly code = "REMOTE_ENGINE_LAUNCH_UNSUPPORTED"
+  constructor(readonly repo: string) {
+    super(`hosted engine launch over SSH is not implemented (remote project ${repo})`)
+    this.name = "RemoteEngineLaunchError"
+  }
+}
+
 /** Build one PTY Host spawn spec shared by interactive and headless entry. */
 export function buildEngineSessionLaunch(input: EngineSessionLaunchInput): EngineSessionLaunch {
+  // ONE guard, here, because this is the single spawn-spec builder every entry
+  // point funnels through — the Workspace host's tab open, `rove api send`,
+  // and a prompted `add` alike (docs/ARCHITECTURE.md names it the canonical
+  // launch builder). A per-caller check would leave whichever caller came next.
+  const remoteKey = [input.task.repo, input.worktreePath].find((key) => key && isRemoteRepoKey(key))
+  if (remoteKey) throw new RemoteEngineLaunchError(remoteKey)
   const protocolTaskId = input.task.kind === "main" ? undefined : input.task.id
   const dispatcherTaskId = input.task.kind === "main" ? input.task.id : undefined
   const gates = input.protocolGates

--- a/packages/kobe/src/tui-react/workspace/show-workspace.tsx
+++ b/packages/kobe/src/tui-react/workspace/show-workspace.tsx
@@ -10,6 +10,7 @@
 import type { ReactNode } from "react"
 import type { RemoteOrchestrator } from "../../client/remote-orchestrator.ts"
 import { engineLaunchArgv } from "../../engine/engine-presets.ts"
+import { isRemoteRepoKey } from "../../state/repos.ts"
 import { DEFAULT_TASK_VENDOR, type Task, type VendorId } from "../../types/task.ts"
 import type { QuickTaskResult } from "../component/quick-task-composer"
 import { useOptionalKV } from "../context/kv"
@@ -71,6 +72,19 @@ export function ShowWorkspace(props: {
     )
   }
   const path = props.worktree
+  // An experimental remote (`ssh://`) project: the worktree lives on the other
+  // machine and the PTY host only spawns locally, so `buildEngineSessionLaunch`
+  // refuses. Say so here instead of mounting TerminalTabs and letting that
+  // refusal throw through the render path — a thrown launch reaches the user as
+  // "This pane crashed", which tells them nothing about what is unimplemented.
+  const remoteKey = [props.task?.repo, path].find((key) => key && isRemoteRepoKey(key))
+  if (remoteKey) {
+    return (
+      <box flexGrow={1} alignItems="center" justifyContent="center">
+        <text fg={theme.textMuted}>{t("workspace.empty.remoteUnsupported", { host: remoteKey })}</text>
+      </box>
+    )
+  }
   // A task whose last tab you closed has KNOWN, empty tabs. Mounting
   // TerminalTabs over that list would immediately mint a replacement — its
   // `active` tab is non-null by construction and 17 call sites downstream rely

--- a/packages/kobe/src/tui/i18n/messages/workspace.ts
+++ b/packages/kobe/src/tui/i18n/messages/workspace.ts
@@ -15,6 +15,10 @@ export const en = {
     /** Every tab of this task was closed — the task and its worktree remain.
      *  Both chords are bound by `EmptyWorkspacePane`, which renders this. */
     noSessions: "No sessions here — press ⏎ or ctrl+e to start one",
+    /** Experimental remote (`ssh://`) project: the worktree is on the other
+     *  machine, and the PTY host only spawns locally. Said here rather than
+     *  letting the launch guard throw through the render path. */
+    remoteUnsupported: "Hosted engine launch over SSH is not implemented — this task's worktree is on {host}",
   },
   /** Zero-tasks welcome panel (first launch) */
   welcome: {
@@ -84,6 +88,7 @@ export const zh: typeof en = {
   empty: {
     selectTask: "请选择一个带 worktree 的任务",
     noSessions: "这里没有会话——按 ⏎ 或 ctrl+e 开一个",
+    remoteUnsupported: "尚未实现通过 SSH 启动托管引擎——该任务的 worktree 在 {host} 上",
   },
   welcome: {
     title: "欢迎使用 Rove",

--- a/packages/kobe/test/cli/api-bool-flags.test.ts
+++ b/packages/kobe/test/cli/api-bool-flags.test.ts
@@ -1,0 +1,82 @@
+/**
+ * The `--flag false` space form, and the two things that used to make an
+ * explicit `false` unreachable: the parser short-circuiting every declared
+ * bool flag into a presence flag, and a payload builder folding `false` into
+ * "absent" with a bare ternary.
+ *
+ * Also pins that `add` validates its prompt flags BEFORE it creates anything
+ * — the failure mode there was a task left behind an error that carried no
+ * taskId to find it with.
+ */
+
+import { describe, expect, it } from "vitest"
+import { invokeVerb } from "../../src/cli/api-cmd.ts"
+import { parseFlags } from "../../src/cli/api/flags.ts"
+import { FakeClient, expectApiError, stubRuntime } from "./api-handler-fixtures.ts"
+
+describe("a bool flag takes the space form", () => {
+  const bools = new Set(["force"])
+
+  it("consumes the next argv element when it is a boolean literal", () => {
+    for (const [raw, expected] of [
+      ["false", "false"],
+      ["true", "true"],
+      ["0", "0"],
+      ["no", "no"],
+      ["1", "1"],
+      ["yes", "yes"],
+    ]) {
+      expect([...parseFlags(["--force", raw], bools).flags]).toEqual([["force", expected]])
+    }
+  })
+
+  // The presence form is what `--force` means on its own; a bool flag must not
+  // swallow an unrelated following flag or run off the end of argv.
+  it("stays a presence flag when the next element is not a boolean literal", () => {
+    expect([...parseFlags(["--force"], bools).flags]).toEqual([["force", "true"]])
+    expect([...parseFlags(["--force", "--task-id", "T"], bools).flags]).toEqual([
+      ["force", "true"],
+      ["task-id", "T"],
+    ])
+  })
+
+  it("still accepts the = form", () => {
+    expect([...parseFlags(["--force=false"], bools).flags]).toEqual([["force", "false"]])
+  })
+})
+
+describe("routine-update --persistent-session", () => {
+  // `bool()` returns `true | false | undefined`, so the old
+  // `bool(...) ? { persistentSession: true } : {}` dropped an explicit false
+  // and left the routine standing — no CLI path back to a fresh worktree per
+  // run. `present()` is what tells "set it false" from "leave it alone".
+  it("sends false when explicitly disabled, and omits the key when absent", async () => {
+    const client = new FakeClient({ "automation.update": () => ({ ok: true }) })
+    await invokeVerb("routine-update", ["--id", "r1", "--persistent-session", "false"], {
+      client,
+      runtime: stubRuntime(),
+    })
+    await invokeVerb("routine-update", ["--id", "r1", "--persistent-session"], { client, runtime: stubRuntime() })
+    await invokeVerb("routine-update", ["--id", "r1", "--name", "n"], { client, runtime: stubRuntime() })
+    expect(client.requests.map((r) => r.payload)).toEqual([
+      { id: "r1", persistentSession: false },
+      { id: "r1", persistentSession: true },
+      { id: "r1", name: "n" },
+    ])
+  })
+})
+
+describe("add validates prompt flags before it creates anything", () => {
+  it("rejects --prompt with --prompt-file without issuing task.create", async () => {
+    const client = new FakeClient({ "task.create": () => ({ taskId: "t1", task: {} }) })
+    await expectApiError(
+      () =>
+        invokeVerb("add", ["--repo", process.cwd(), "--prompt", "hi", "--prompt-file", "/etc/hosts"], {
+          client,
+          runtime: stubRuntime(),
+        }),
+      "BAD_FLAG",
+    )
+    expect(client.requestNames).not.toContain("task.create")
+  })
+})

--- a/packages/kobe/test/cli/api-send-empty-success.test.ts
+++ b/packages/kobe/test/cli/api-send-empty-success.test.ts
@@ -99,8 +99,18 @@ describe("send refuses an empty-branch success report", () => {
       const data = (error as { data?: Record<string, unknown> }).data ?? {}
       expect(data.branch).toBe("fix/thing")
       expect(String(data.hint)).toMatch(/commit your work/)
-      // The retry argv must be runnable verbatim, carrying the original text.
-      expect(data.nextCommandArgs).toEqual(["api", "send", "--allow-empty", "--prompt", "succeeded: done"])
+      // The retry argv must be runnable verbatim, carrying the original text
+      // AND the target it was addressed to: run without `--task-id`, the retry
+      // re-resolves through the active-task fallback and can land somewhere else.
+      expect(data.nextCommandArgs).toEqual([
+        "api",
+        "send",
+        "--task-id",
+        "coord-1",
+        "--allow-empty",
+        "--prompt",
+        "succeeded: done",
+      ])
     }
   })
 

--- a/packages/kobe/test/daemon/cron-dst.test.ts
+++ b/packages/kobe/test/daemon/cron-dst.test.ts
@@ -1,0 +1,80 @@
+/**
+ * DST behaviour and scan cost. Separate from `cron.test.ts` because these pin
+ * `TZ` for the whole process — a cron expression names a wall clock, so a
+ * DST test that inherits the machine's timezone tests nothing on most boxes.
+ *
+ * `TZ` is set before the module under test is imported so the first `Date`
+ * construction already sees it.
+ */
+
+process.env.TZ = "America/New_York"
+
+import { describe, expect, it } from "vitest"
+import { latestCronAtOrBefore, nextCronAfter } from "../../../kobe-daemon/src/daemon/cron.ts"
+
+function day(ms: number): string {
+  const d = new Date(ms)
+  const p = (n: number) => String(n).padStart(2, "0")
+  return `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())} ${p(d.getHours())}:${p(d.getMinutes())}`
+}
+
+function fireTimes(expression: string, fromIso: string, count: number): string[] {
+  let t = new Date(fromIso).getTime()
+  const out: string[] = []
+  for (let i = 0; i < count; i++) {
+    t = nextCronAfter(expression, t)
+    out.push(day(t))
+  }
+  return out
+}
+
+describe("DST fall-back", () => {
+  // 2025-11-02 01:00 America/New_York happens twice — once at UTC-4, once at
+  // UTC-5. Scanning epoch minutes and testing the local clock matched both, so
+  // a daily routine ran twice: two worktrees, two branches, two billed turns.
+  it("fires a daily routine once on the day the clock repeats an hour", () => {
+    expect(fireTimes("0 1 * * *", "2025-11-01T12:00:00Z", 3)).toEqual([
+      "2025-11-02 01:00",
+      "2025-11-03 01:00",
+      "2025-11-04 01:00",
+    ])
+  })
+
+  it("holds for an hour that repeats only under a different rule (02:00, EU-style time)", () => {
+    expect(fireTimes("0 1 * * *", "2025-11-02T05:30:00Z", 2)).toEqual(["2025-11-03 01:00", "2025-11-04 01:00"])
+  })
+})
+
+describe("DST spring-forward", () => {
+  // 2025-03-09 02:30 America/New_York does not exist. The old scan found no
+  // matching instant that day and the routine vanished — no run, and no
+  // `skipped_missed` either, because the backwards search missed it too.
+  it("still fires on the day the local time is skipped", () => {
+    expect(fireTimes("30 2 * * *", "2025-03-08T12:00:00Z", 3)).toEqual([
+      "2025-03-09 03:30",
+      "2025-03-10 02:30",
+      "2025-03-11 02:30",
+    ])
+  })
+
+  it("missed-run compensation sees that day too", () => {
+    const found = latestCronAtOrBefore(
+      "30 2 * * *",
+      new Date(2025, 2, 9, 18, 0).getTime(),
+      new Date(2025, 2, 1).getTime(),
+    )
+    expect(found === null ? null : day(found)).toBe("2025-03-09 03:30")
+  })
+})
+
+describe("scan cost", () => {
+  // `0 0 30 2 *` parses and never matches, so it walks the whole scan bound.
+  // At a minute per step that was ~4.7M Date allocations (150ms+ measured),
+  // run synchronously on the daemon's event loop AND in the TUI composer's
+  // render body — one freeze per arrow keypress.
+  it("a valid-but-never-matching expression fails fast", () => {
+    const started = Date.now()
+    expect(() => nextCronAfter("0 0 30 2 *", Date.now())).toThrow(/never matches/)
+    expect(Date.now() - started).toBeLessThan(50)
+  })
+})

--- a/packages/kobe/test/daemon/handlers-automation-run-now.test.ts
+++ b/packages/kobe/test/daemon/handlers-automation-run-now.test.ts
@@ -1,0 +1,109 @@
+/**
+ * `automation.runNow` (the Automations page's Run now, and
+ * `rove api routine-run-now`) has to reach the SAME dispatch outcome the
+ * scheduled sweep would for the same firing.
+ *
+ * The one that mattered: a standing routine fired into a busy composer.
+ * Without the deferred-prompt store and the Inbox on its deps, the dispatch
+ * path has nowhere to put the text and gives up with `dispatch_failed` — so a
+ * manual run DROPPED the report while the identical scheduled firing filed it
+ * in the Inbox. Two indistinguishable-looking outcomes, one of them lossy.
+ *
+ * Driven through the real RPC handler on a real daemon (temp home, temp
+ * socket) because the bug was in the handler's dep object, not in the runner
+ * the runner-level tests already cover.
+ */
+
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+import { describe, expect, it } from "vitest"
+import type { DaemonTask } from "../../../kobe-daemon/src/daemon/contracts.ts"
+import type { Orchestrator } from "../../src/orchestrator/core.ts"
+import { type DaemonHarness, bootDaemonHarness, fakeOrchestrator } from "./harness.ts"
+
+const REPO = process.cwd()
+
+function standingTask(): DaemonTask {
+  return {
+    id: "task-standing",
+    title: "daily audit",
+    repo: REPO,
+    branch: "routine/daily-audit",
+    worktreePath: join(REPO, ".worktree-double"),
+    kind: "task",
+    status: "in_progress",
+    pinned: false,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  } as unknown as DaemonTask
+}
+
+/** An orchestrator that always hands back the same standing task. */
+function orchestratorWithStandingTask(): Orchestrator {
+  const task = standingTask()
+  return fakeOrchestrator({
+    listTasks: () => [task],
+    getTask: (id: string) => (id === task.id ? task : undefined),
+    createTask: async () => task,
+  })
+}
+
+/** A runtime whose live engine always refuses: the composer has text in it. */
+const busyRuntime = {
+  startTaskSessionWithPrompt: async () => true,
+  deliverPromptToLiveEngineDetailed: async () => ({
+    outcome: "busy" as const,
+    tabId: "tab-1",
+    layer: "composer-not-empty" as const,
+  }),
+}
+
+function inboxItems(harness: DaemonHarness): unknown[] {
+  const path = join(harness.dir, ".rove", "attention-inbox.json")
+  try {
+    const parsed = JSON.parse(readFileSync(path, "utf8")) as { items?: unknown[]; episodes?: unknown[] }
+    return parsed.items ?? parsed.episodes ?? []
+  } catch {
+    return []
+  }
+}
+
+describe("automation.runNow on a standing routine with a busy composer", () => {
+  it("defers the prompt into the Inbox instead of dropping it", async () => {
+    const harness = await bootDaemonHarness({
+      orchestrator: orchestratorWithStandingTask(),
+      server: {
+        automationTickMs: 0,
+        runtime: { ...(await import("../../src/core/daemon-runtime.ts")).daemonRuntime, ...busyRuntime },
+      },
+    })
+    try {
+      const client = harness.client()
+      const created = await client.request<{ automation: { id: string } }>("automation.create", {
+        repo: REPO,
+        name: "daily audit",
+        prompt: "what changed since yesterday?",
+        schedule: "0 9 * * *",
+        persistentSession: true,
+      })
+      const id = created.automation.id
+
+      // First run adopts the standing task (its engine "starts"); the second
+      // one is the firing that meets the busy composer.
+      const first = await client.request<{ status: string }>("automation.runNow", { id })
+      expect(first.status).toBe("dispatched")
+      expect(inboxItems(harness)).toHaveLength(0)
+
+      const second = await client.request<{ status: string }>("automation.runNow", { id })
+      expect(second.status).toBe("deferred")
+      expect(inboxItems(harness).length).toBeGreaterThan(0)
+
+      // The run history is what the user reads, so it has to say the same.
+      const { runs } = await client.request<{ runs: Array<{ status: string }> }>("automation.runs", { id })
+      expect(runs.map((r) => r.status)).toContain("deferred")
+      expect(runs.map((r) => r.status)).not.toContain("dispatch_failed")
+    } finally {
+      await harness.close()
+    }
+  })
+})

--- a/packages/kobe/test/daemon/handlers-automation-run-now.test.ts
+++ b/packages/kobe/test/daemon/handlers-automation-run-now.test.ts
@@ -72,10 +72,9 @@ describe("automation.runNow on a standing routine with a busy composer", () => {
   it("defers the prompt into the Inbox instead of dropping it", async () => {
     const harness = await bootDaemonHarness({
       orchestrator: orchestratorWithStandingTask(),
-      server: {
-        automationTickMs: 0,
-        runtime: { ...(await import("../../src/core/daemon-runtime.ts")).daemonRuntime, ...busyRuntime },
-      },
+      // The scheduled sweep can't interfere: the routine's next run is 09:00
+      // tomorrow, so every firing in this test is a manual one.
+      server: { runtime: { ...(await import("../../src/core/daemon-runtime.ts")).daemonRuntime, ...busyRuntime } },
     })
     try {
       const client = harness.client()

--- a/packages/kobe/test/engine/session-launch.test.ts
+++ b/packages/kobe/test/engine/session-launch.test.ts
@@ -206,3 +206,50 @@ describe("hosted engine session launch", () => {
     expect(seen).toEqual(["/repo"])
   })
 })
+
+describe("remote projects", () => {
+  // The experimental SSH-backed projects feature routes git through an exec
+  // host, but the PTY host spawns locally against a raw cwd — so a remote
+  // task used to start an engine on THIS machine in a worktree that lives on
+  // the other one. `rove add --remote` and the Settings toggle both say SSH
+  // engine launch is unimplemented; the guard makes the code say it too.
+  //
+  // Asserted here rather than per caller: every launch path — Workspace host
+  // tab open, `rove api send`, prompted `add` — funnels through this builder.
+  const remote = {
+    shell: "/bin/zsh",
+    argv: ["claude"],
+    promptIntent: { kind: "explicit" as const, prompt: "go" },
+    protocolGates: { status: () => false, notes: () => false, dispatcher: () => false },
+  }
+
+  test("refuses a launch whose project is an ssh:// key", () => {
+    expect(() =>
+      buildEngineSessionLaunch({
+        task: { id: "task-r", kind: "task", vendor: "claude", repo: "ssh://me@box/srv/app" },
+        worktreePath: "/srv/rove/task-r",
+        ...remote,
+      }),
+    ).toThrow(/hosted engine launch over SSH is not implemented/)
+  })
+
+  test("refuses one whose worktree is remote even when the repo key reads local", () => {
+    expect(() =>
+      buildEngineSessionLaunch({
+        task: { id: "task-r", kind: "task", vendor: "claude", repo: "/repo" },
+        worktreePath: "ssh://me@box/srv/rove/task-r",
+        ...remote,
+      }),
+    ).toThrow(/hosted engine launch over SSH is not implemented/)
+  })
+
+  test("a local project is untouched", () => {
+    expect(() =>
+      buildEngineSessionLaunch({
+        task: { id: "task-l", kind: "task", vendor: "claude", repo: "/repo" },
+        worktreePath: "/repo/.worktrees/task-l",
+        ...remote,
+      }),
+    ).not.toThrow()
+  })
+})

--- a/packages/kobe/test/render/show-workspace-empty.test.tsx
+++ b/packages/kobe/test/render/show-workspace-empty.test.tsx
@@ -101,3 +101,34 @@ describe("a task whose last tab was closed", () => {
     expect(await frameForTask(SELECTED)).not.toContain("No sessions here")
   })
 })
+
+/**
+ * An experimental remote (`ssh://`) project. The worktree is on the other
+ * machine and the PTY host only spawns locally, so the launch builder refuses
+ * — and a refusal thrown from inside TerminalTabs reaches the user as
+ * "This pane crashed", which names nothing. Not mounting is the whole fix.
+ */
+describe("a task on a remote ssh:// project", () => {
+  const REMOTE = { id: "t1", repo: "ssh://me@buildbox", kind: "task" } as unknown as Task
+
+  const frameForRemote = async (task: Task, worktree: string): Promise<string> => {
+    tabsByTask.clear()
+    const { frame } = await renderComponent(<ShowWorkspace {...props(ONE_TASK)} task={task} worktree={worktree} />)
+    await act(async () => {})
+    return await frame()
+  }
+
+  it("says what is unimplemented instead of mounting an engine tab", async () => {
+    const frame = await frameForRemote(REMOTE, "/srv/rove/me-buildbox/t1")
+    expect(frame).toContain("SSH is not implemented")
+    expect(frame).toContain("ssh://me@buildbox")
+  })
+
+  it("catches a remote WORKTREE under a repo key that reads local", async () => {
+    expect(await frameForRemote(SELECTED, "ssh://me@buildbox/srv/rove/t1")).toContain("SSH is not implemented")
+  })
+
+  it("leaves a local task mounting as before", async () => {
+    expect(await frameForRemote(SELECTED, "/wt/t1")).not.toContain("SSH is not implemented")
+  })
+})


### PR DESCRIPTION
Batch A from `loop-r1`: the `rove api` flag layer, two cron bugs plus `runNow`'s missing deps, a remote-projects launch guard, and seven stale doc/help claims.

Evidence files are committed under `.scratch/loop-r1-a-evidence/` (absolute path: `/Users/jacksonc/.rove/worktrees/kobe-0aff3858ab76/bullfrog/.scratch/loop-r1-a-evidence/`). Every BEFORE was captured against a `.scratch/before` worktree checked out at `9007b5933` (origin/main at branch time), built separately — never a stash.

---

## A1 — four `rove api` flag-layer defects

**PASS:** `--pinned false` unpins and `--pinned=false` still works; `echo p | routine-update --prompt-file -` succeeds; `--persistent-session false` sticks; a bad `add` leaves no task behind.

Run against an isolated daemon (`KOBE_HOME_DIR` + every `*_SOCKET_PATH`/web-port var inlined, never `~/.rove`).

**BEFORE** (`a1-before-e2e.txt`, unfixed CLI):
```
$ rove api pin --task-id $T --pinned false
{"error":{"message":"unexpected positional arg: false","code":"BAD_FLAG"}}
$ echo 'piped prompt' | rove api routine-update --id $R1 --prompt-file -
{"error":{"message":"--prompt-file - is empty","code":"BAD_FLAG"}}
$ rove api routine-update --id $R1 --persistent-session false
{"error":{"message":"unexpected positional arg: false","code":"BAD_FLAG"}}
   persistentSession now: [["probe",true,"orig"]]
$ rove api add --repo . --title orphan --prompt hi --prompt-file /etc/hosts
{"error":{"message":"pass --prompt or --prompt-file, not both","code":"BAD_FLAG",...}}
   tasks titled 'orphan' left behind: 1
```

**AFTER** (`a1-after-e2e.txt`):
```
$ rove api pin --task-id $T --pinned true   → pinned now: true
$ rove api pin --task-id $T --pinned false  → pinned now: false
$ rove api pin --task-id $T --pinned=true   → pinned now: true      (= form intact)
$ echo 'piped prompt' | rove api routine-update --id $R1 --prompt-file -   → OK
$ rove api routine-update --id $R1 --persistent-session false
   [name, persistentSession, prompt]: [["probe",false,"piped prompt\n"]]
$ rove api add --repo . --title orphan --prompt hi --prompt-file /etc/hosts
   tasks titled 'orphan' left behind: 0
$ rove api delete --task-id $T --force      → {"taskId":…,"queued":true}   (presence form intact)
```

`1a` is fixed in the parser, not per verb: a declared bool flag consumes the next argv element only when `parseBoolLiteral` accepts it, so `--force --task-id X` stays a presence flag. `bool()` now reads the same literal table, so the parser and the accessor cannot disagree again.

Regression test `test/cli/api-bool-flags.test.ts` — 3 of its 5 cases fail on `9007b5933`, the 2 guard cases (presence form, `=` form) pass on both.

## A2 — cron DST, scan cost, and `runNow`'s deps

**PASS (3a/3b):** three distinct calendar days for `0 1 * * *` across Nov 1–3 2025 under `TZ=America/New_York`; `30 2 * * *` fires on Mar 9 2025 or records a miss; `0 0 30 2 *` scans in under 5 ms.

**BEFORE** (`a2-before.txt`):
```
fire: Sun Nov 02 2025 01:00:00 GMT-0400 (EDT)
fire: Sun Nov 02 2025 01:00:00 GMT-0500 (EST)      ← same wall clock, second firing
fire: Mon Nov 03 2025 01:00:00 GMT-0500 (EST)
30 2 * * * → Mon Mar 10 …    ← Mar 9 skipped entirely
   latestCronAtOrBefore on Mar 9 18:00: Sat Mar 08 02:30   ← no miss recorded either
scan ms: 156
```

**AFTER** (`a2-after.txt`):
```
fire: Sun Nov 02 2025 01:00:00 GMT-0400 (EDT)
fire: Mon Nov 03 2025 01:00:00 GMT-0500 (EST)
fire: Tue Nov 04 2025 01:00:00 GMT-0500 (EST)
30 2 * * * → Sun Mar 09 2025 03:30 (the instant the clock jumped to), then Mar 10, Mar 11
   latestCronAtOrBefore on Mar 9 18:00: Sun Mar 09 2025 03:30
scan ms: 2
```
Also checked under `TZ=Europe/Berlin` for the EU fall-back (2025-10-26): one firing.

Root cause was one mismatch: `cronMatches` tested a **local wall clock** while the scan stepped **epoch minutes**. Both scans now enumerate local calendar minutes and convert each to an instant once. Day-at-a-time is also what drops the never-matching scan from ~150 ms to ~1 ms — which is the TUI freeze, since `automation-composer-dialog.tsx` calls `previewSchedule` in the render body.

Tests: `test/daemon/cron-dst.test.ts` (TZ pinned before import) — **all 5 fail on `9007b5933`**, including `expected 454 to be less than 50` for the scan bound. The 25 existing `cron.test.ts` cases still pass.

**PASS (3c):** `runNow` on a standing routine with a busy composer returns `deferred` and files an Inbox item, matching the scheduled path.

`test/daemon/handlers-automation-run-now.test.ts` drives the **real `automation.runNow` RPC handler** on a real daemon (temp home, temp socket) — the bug was the handler's dep object, so the existing runner-level tests could not see it. On `9007b5933` it fails with `expected 'dispatch_failed' to be 'deferred'`; on this branch the run records `deferred`, `attention-inbox.json` gains an entry, and `automation.runs` shows `deferred` with no `dispatch_failed`.

> **Not proven by screenshot.** I did not produce harness screenshots of the Inbox for 3c. Reaching the busy-composer branch through `/harness` needs a persistent-session routine with a live engine and text sitting in its standing tab's composer; I judged the daemon-level end-to-end above (real handler, real RPC, real Inbox file) the tighter proof and stopped there rather than claim a screenshot I did not take.

## A3 — remote (`ssh://`) projects refuse the engine launch

**PASS:** a task on a registered `ssh://` project returns the named error; before, it spawned locally against a path that does not exist here.

One guard in `buildEngineSessionLaunch` — the single spawn-spec builder the Workspace host, `rove api send`, and a prompted `add` all funnel through (`docs/ARCHITECTURE.md` §107-110). No per-caller checks.

**CLI end-to-end** (`a3-send-e2e.txt`), same isolated-daemon discipline:
```
BEFORE  {"error":{"message":"failed to start hosted engine session for 01M…","code":"SESSION_FAILED"}}
        pty.log: spawn failed for 01M…::tab-1: ENOENT: no such file or directory, posix_spawn '/bin/zsh'
AFTER   {"error":{"message":"hosted engine session failed for 01M…: hosted engine launch over SSH is
                   not implemented (remote project ssh://me@buildbox)","code":"SESSION_FAILED"}}
        pty.log: (nothing — refused at the launch boundary)
```

**Harness screenshots** — `/harness` browser → xterm.js → PTY sidecar → real OpenTUI, two isolated fixtures (port bases 5893 for AFTER on this branch, 5903 for BEFORE in the `.scratch/before` worktree):

- BEFORE `.scratch/loop-r1-a-evidence/a3-before.png` — the sidebar mints a `claude 1` tab under `remote-probe` and the pane sits blank with a bare cursor, while the fixture's `pty.log` shows the local spawn retrying into `/srv/rove/…`:
  `spawn failed for 01M0000000000000000000000A::tab-1: ENOENT … posix_spawn '/bin/zsh'` (×5)
- AFTER `.scratch/loop-r1-a-evidence/a3-after.png` — no tab is minted and the pane reads *"Hosted engine launch over SSH is not implemented — this task's worktree is on ssh://me@buildbox"*. The fixture `pty.log` has no session for that task at all.

**The screenshot changed the fix.** My first AFTER shot rendered **"This pane crashed"**: `terminal-tab-argv.ts` builds the launch inside the render path, so the thrown guard killed the pane and named nothing. `showWorkspace` — which already owns the "don't mount TerminalTabs, render a placeholder" decision for a closed-last-tab task — now takes the same branch for a remote task. The guard itself stayed in one place.

Tests: 3 cases appended to `test/render/show-workspace-empty.test.tsx`; the 2 new-behavior ones fail on `9007b5933` (with the pane-crash stack), the local-task guard passes on both. Plus 3 cases in `test/engine/session-launch.test.ts` covering the remote repo key, a remote worktree path under a local-looking key, and a local task untouched.

> **Limit, stated plainly.** I could not run the fully organic path — `rove add --remote` against a *reachable* SSH host — because none is available here (`ssh localhost` wants a key I am not going to install). Both proofs above therefore seed the state a reachable host would have left (a registered `remoteRepos` entry plus a task whose worktree is on the far side) and drive the real launch path from there. Separately: `rove api add --repo ssh://…` cannot create a remote task at all today — `requirePath` resolves the flag to an absolute local path and collapses `ssh://` to `ssh:/`. That is a different gap and I have not touched it.

`workspace.empty.remoteUnsupported` added to both locales; `bun run check-i18n` → `750 keys × 2 locales in sync`.

## A4 — six stale doc lines and one stale help string

**PASS:** `rove --help | grep update` shows the channel form; each cited grep returns the corrected state; `sync-docs.mjs` runs clean. Full output in `a4-greps.txt` / `a4-help.txt` / `a4-sync.txt`.

| # | Fixed |
|---|---|
| 1 | `CONFIGURATION.md` — `chat.tabStrip.mode` defaults to `never`, and the paragraph now argues the same way `tab-strip.ts:25-32` does |
| 2 | `API.md` — three retired verbs, not two (`archive` was missing) |
| 3 | `WORKTREES.md` + `API.md` — dropped the first-prompt `set-branch` coda both promised; there is no prompt-construction site left, and `repo-init.test.ts:166-174` pins its removal |
| 4 | `ENGINES.md` — the Model picker column is gone (zero hits for `setModel\|selectModel\|modelList\|availableModels\|pickModel`); replaced with Effort levels, which only codex declares |
| 5 | `KEYBINDINGS.md:160` — `ctrl+a p` follows the sidebar cursor too (`host-keybindings.ts:154-158`), matching what the table at `:59` already said |
| 6 | `KEYBINDINGS.md:194` — four chordless menu entries, not three; `land` described |
| 7 | **code:** `cli/usage.ts` — top-level help now reads `update [version|channel|list]`, matching `docs/CLI.md` and the `--channel` support that shipped in `update.ts:105` |

Item 7 needed a second pass: my first version wrapped the description onto a continuation line, and `usage.test.ts`'s lock-step guard parses the first token of every line in the `Commands:` block — it read `versions` as a subcommand and went red. Kept to one line and matched `docs/CLI.md` to it.

## A5 — small items in `cli/api/**`

- `handlers-tasks.ts` — `EMPTY_SUCCESS_REPORT`'s `nextCommandArgs` now carries the caller's `--task-id`/`--tab`. The hint tells the agent to run it verbatim; without the flags the retry re-resolved through the active-task fallback and could deliver into a different task. `api-send-empty-success.test.ts` had pinned the buggy argv while its own comment stated the intent ("runnable verbatim") — updated to the intent.
- `handlers-inspect.ts:78` — added the `::` that line 114 and `isHostedTaskKey` both use.

Skipped `runtime.ts:185-192` (the viewport-tab teardown killing the referenced task's split leaves). It is real, but the brief itself notes it needs a TUI-minted viewport tab plus a detached CLI to reproduce — I had no way to prove a fix, and an unproven change to session teardown is worse than the bug.

---

## Gates

| Gate | Result |
|---|---|
| `bun run lint` (repo root) | clean, 1360 files |
| `bun run typecheck` | clean, all 4 packages |
| `bun run test:fast` | 4267 passed, **6 failed** |
| `bun test test/render` | 434 passed, 0 failed |
| `KOBE_INCLUDE_SOCKET=1 bun run test:socket` | 734 passed, 88 files |
| `bun run check-i18n` | 750 keys × 2 locales in sync |

The 6 `test:fast` failures are **pre-existing** — `open-dir-cmd` (2), `project-eligibility` (2), `continue-live-vendor` (2). All six fail identically in the `.scratch/before` worktree at `9007b5933`: they are the known path-shape false failures from running inside `~/.rove/worktrees`. Nothing my changes touch.
