### PR TITLE
One owner for the sidebar callbacks, and for engine display names

### DIFF
--- a/.changeset/one-owner-for-engine-names.md
+++ b/.changeset/one-owner-for-engine-names.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Engine display names now come from one place. `humanizeSlug` was implemented twice (settings model and the daemon settings adapter) and `engineLabel` was a third derivation of the same answer; the registry-backed `engineDisplayName` in `engine/interactive-command.ts` owns it now, and the hard-coded `"claude"` fallbacks in the adapter and `add` handler read a named `DEFAULT_VENDOR`. No user-visible change — the daemon settings snapshot is byte-identical.

--- a/packages/kobe/src/cli/api/handlers-add.ts
+++ b/packages/kobe/src/cli/api/handlers-add.ts
@@ -20,7 +20,7 @@ import type { SerializedTask } from "@sma1lboy/kobe-daemon/daemon/protocol"
 import { resolveCommandProtocol } from "../../engine/engine-presets.ts"
 import { ulid } from "../../orchestrator/index/ulid.ts"
 import type { TaskStatus } from "../../types/task.ts"
-import type { VendorId } from "../../types/vendor.ts"
+import { DEFAULT_VENDOR, type VendorId } from "../../types/vendor.ts"
 import type { DaemonRpc } from "../daemon-session.ts"
 import { dispatcherEnvPayload, withPeerProvenance } from "./dispatcher.ts"
 import { FANOUT_CAP, buildCountPlan, parseAgentsSpec } from "./flags.ts"
@@ -222,7 +222,7 @@ async function addParallel(
   const choice = await engineChoice(ctx, repo)
   const plan: VendorId[] = agentsSpec
     ? parseAgentsSpec(agentsSpec)
-    : buildCountPlan(count ?? 1, choice.vendor ?? "claude")
+    : buildCountPlan(count ?? 1, choice.vendor ?? DEFAULT_VENDOR)
   if (plan.length > FANOUT_CAP) {
     throw new ApiError(
       `a parallel round of ${plan.length} exceeds the cap of ${FANOUT_CAP} — spawn in batches`,

--- a/packages/kobe/src/core/daemon-settings-adapter.ts
+++ b/packages/kobe/src/core/daemon-settings-adapter.ts
@@ -3,6 +3,7 @@ import {
   engineCommandKey,
   engineDisplayName,
   engineNameKey,
+  humanizeSlug,
 } from "../engine/interactive-command.ts"
 import { AUTO_STATUS_KEY } from "../state/auto-status.ts"
 import { DISPATCHER_KEY } from "../state/dispatcher.ts"
@@ -15,7 +16,7 @@ import {
   normalizeEditorKind,
 } from "../tui/lib/editor-prefs.ts"
 import type { VendorId } from "../types/task.ts"
-import { BUILTIN_VENDORS, isBuiltinVendor } from "../types/vendor.ts"
+import { BUILTIN_VENDORS, DEFAULT_VENDOR, isBuiltinVendor } from "../types/vendor.ts"
 
 const FOCUS_ACCENTS = ["primary", "success", "info"] as const
 const ENGINE_ID_RE = /^[a-z][a-z0-9_-]{0,47}$/
@@ -28,18 +29,6 @@ function customEngineIdsFrom(state: Record<string, unknown>): string[] {
   return raw.filter((id): id is string => typeof id === "string" && ENGINE_ID_RE.test(id) && !isBuiltinVendor(id))
 }
 
-function humanizeSlug(id: string): string {
-  return id
-    .split(/[-_]+/)
-    .filter(Boolean)
-    .map((part) => `${part.slice(0, 1).toUpperCase()}${part.slice(1)}`)
-    .join(" ")
-}
-
-function engineLabel(state: Record<string, unknown>, id: VendorId): string {
-  return stringValue(state[engineNameKey(id)]).trim() || engineDisplayName(id)
-}
-
 function engineCommand(state: Record<string, unknown>, id: VendorId): string {
   return stringValue(state[engineCommandKey(id)]).trim() || defaultEngineCommand(id).join(" ")
 }
@@ -48,7 +37,7 @@ export function daemonSettingsSnapshot(): Response {
   const state = loadStateFile()
   const custom = customEngineIdsFrom(state)
   const engineIds = [...BUILTIN_VENDORS, ...custom] as VendorId[]
-  const defaultEngine = stringValue(state.defaultVendor, stringValue(state.lastSelectedVendor, "claude"))
+  const defaultEngine = stringValue(state.defaultVendor, stringValue(state.lastSelectedVendor, DEFAULT_VENDOR))
   const focusAccent = stringValue(state.focusAccent, "primary")
   return Response.json({
     activeTheme: stringValue(state.activeTheme, "claude"),
@@ -64,7 +53,7 @@ export function daemonSettingsSnapshot(): Response {
     defaultEngine,
     engines: engineIds.map((id) => ({
       id,
-      label: engineLabel(state, id),
+      label: engineDisplayName(id),
       command: engineCommand(state, id),
       isBuiltin: isBuiltinVendor(id),
       isCustom: !isBuiltinVendor(id),
@@ -122,8 +111,8 @@ export async function daemonSettingsPatch(request: Request): Promise<Response> {
       patch.customEngineIds = custom.filter((engine) => engine !== id)
       patch[engineCommandKey(id)] = undefined
       patch[engineNameKey(id)] = undefined
-      if (state.defaultVendor === id) patch.defaultVendor = "claude"
-      if (state.lastSelectedVendor === id) patch.lastSelectedVendor = "claude"
+      if (state.defaultVendor === id) patch.defaultVendor = DEFAULT_VENDOR
+      if (state.lastSelectedVendor === id) patch.lastSelectedVendor = DEFAULT_VENDOR
     }
     if (Object.keys(patch).length > 0) patchStateFile(patch)
     return daemonSettingsSnapshot()

--- a/packages/kobe/src/engine/interactive-command.ts
+++ b/packages/kobe/src/engine/interactive-command.ts
@@ -69,6 +69,25 @@ export function engineDisplayName(vendor: VendorId): string {
 }
 
 /**
+ * Turn a custom-engine slug into a presentable display name: split on
+ * `-`/`_` and title-case each word. `my-local-agent` → `My Local Agent`.
+ * Used so a custom engine added with no name still reads like the
+ * title-cased built-ins instead of its raw lowercase-hyphenated id.
+ *
+ * Deliberately a PURE string transform, unlike {@link engineDisplayName}: this
+ * is the fallback written INTO `engineName.<id>` when the user typed no name,
+ * so consulting the override here would overwrite a user-typed name with the
+ * title-cased slug on the next write.
+ */
+export function humanizeSlug(id: string): string {
+  return id
+    .split(/[-_]+/)
+    .filter((word) => word.length > 0)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ")
+}
+
+/**
  * Built-in default launch argv for a vendor (undefined → claude), read
  * from the engine registry. A custom engine id has no built-in default —
  * its command lives in the `engineCommand.<id>` override the user set when

--- a/packages/kobe/src/tui-react/component/settings-dialog/use-engine-settings.ts
+++ b/packages/kobe/src/tui-react/component/settings-dialog/use-engine-settings.ts
@@ -13,10 +13,14 @@
 import { useEffect, useState } from "react"
 import { installedEngineIds } from "../../../engine/account-detect"
 import { ENGINE_PROTOCOLS, engineProtocolKey } from "../../../engine/engine-presets"
-import { defaultEngineCommand, engineCommandKey, engineNameKey } from "../../../engine/interactive-command"
+import {
+  defaultEngineCommand,
+  engineCommandKey,
+  engineNameKey,
+  humanizeSlug,
+} from "../../../engine/interactive-command"
 import { engineEntry } from "../../../engine/registry"
 import { getGlobalDefaultVendor, setGlobalDefaultVendor } from "../../../state/vendor-prefs"
-import { humanizeSlug } from "../../../tui/component/settings-dialog/model"
 import { DEFAULT_TASK_VENDOR, type VendorId } from "../../../types/task"
 import { ALL_VENDORS, isBuiltinVendor } from "../../../types/vendor"
 import type { KVContext } from "../../context/kv"

--- a/packages/kobe/src/tui-react/panes/sidebar/use-tree-bindings.ts
+++ b/packages/kobe/src/tui-react/panes/sidebar/use-tree-bindings.ts
@@ -24,10 +24,14 @@ import type { createSidebarController } from "../../../tui/panes/sidebar/control
 import { RECENT_ROW_ID, parseRowId } from "../../../tui/panes/sidebar/tree-core"
 import { bindByIds } from "../../context/keybindings"
 import { useBindings } from "../../lib/keymap"
+import type { SidebarTaskCallbacks } from "./types"
 import type { TreeMenu } from "./use-tree-menu"
 import type { TreeSearch } from "./use-tree-search"
 
-export interface TreeBindingsOpts {
+export interface TreeBindingsOpts
+  extends Readonly<
+    Pick<SidebarTaskCallbacks, "onDeleteRequest" | "onRenameRequest" | "onPinRequest" | "onLocalMergeRequest">
+  > {
   readonly focused: boolean
   readonly search: TreeSearch
   readonly menu: Pick<TreeMenu, "open" | "moveCursor" | "pickCurrent" | "close">
@@ -37,10 +41,6 @@ export interface TreeBindingsOpts {
   readonly flatIdsRef: React.MutableRefObject<readonly string[]>
   readonly cursorRef: React.MutableRefObject<number>
   readonly moveCursorRow: (delta: -1 | 1) => void
-  readonly onDeleteRequest?: (id: string) => void
-  readonly onRenameRequest?: (id: string) => void
-  readonly onPinRequest?: (id: string) => void
-  readonly onLocalMergeRequest?: (id: string) => void
   readonly markKeysUsed: () => void
 }
 

--- a/packages/kobe/src/tui-react/workspace/host-sidebar.tsx
+++ b/packages/kobe/src/tui-react/workspace/host-sidebar.tsx
@@ -3,9 +3,14 @@
  * The workspace host's left rail — which sidebar renders, and its wiring.
  *
  * Its own component because `host.tsx` should compose the workspace, not know
- * how one rail is wired. The ~30 props below are that wiring made explicit —
+ * how one rail is wired. The props below are that wiring made explicit —
  * having to pass them is the honest cost of the boundary, and it is why a new
  * sidebar concern lands here instead of accreting on the host.
+ *
+ * The fourteen task-lifecycle callbacks are NOT re-declared here: they come
+ * from {@link SidebarTaskCallbacks}, whose whole point is that the surfaces
+ * can't drift. They arrive here REQUIRED (the host supplies every one) except
+ * `onLandRequest`, which stays optional exactly as the shared type has it.
  */
 
 import type { TaskEngineState, TaskJobState } from "@/client/remote-orchestrator"
@@ -20,11 +25,14 @@ import { useNotifications } from "../context/notifications"
 import { useTheme } from "../context/theme"
 import { useT } from "../i18n"
 import { SidebarTree } from "../panes/sidebar/SidebarTree"
+import type { SidebarTaskCallbacks } from "../panes/sidebar/types"
 import { closeTaskTab } from "./terminal-tabs-close"
 import { moveTaskTab } from "./terminal-tabs-move"
 import { requestNewTab } from "./terminal-tabs-shared"
 
-export interface HostSidebarProps {
+export interface HostSidebarProps
+  extends Readonly<Required<Omit<SidebarTaskCallbacks, "onLandRequest">>>,
+    Readonly<Pick<SidebarTaskCallbacks, "onLandRequest">> {
   readonly width: number
   readonly nav: SidebarNav
   readonly onNavChange: (nav: SidebarNav) => void
@@ -43,26 +51,6 @@ export interface HostSidebarProps {
   readonly worktreeChanges?: ReadonlyMap<string, WorktreeChanges> | null
   readonly transcriptActivity?: ReadonlyMap<string, { readonly mtimeMs: number }> | null
   readonly onAddTask: () => void
-  readonly onDeleteRequest: (taskId: string) => void
-  readonly onLandRequest?: (taskId: string) => void
-  readonly onRenameRequest: (taskId: string) => void
-  readonly onPinRequest: (taskId: string) => void
-  /** Menu-only (no chord): open the board-status picker for the row's task. */
-  readonly onSetStatusRequest: (taskId: string) => void
-  /** Menu-only (no chord): copy the row's branch name or worktree path. */
-  readonly onCopyRequest: (taskId: string, field: "branch" | "path") => void
-  /** Menu-only (no chord): re-fire the row's stored brief as a new task. */
-  readonly onRunAgainRequest: (taskId: string) => void
-  /** Menu routes of the `o` / `b` / `v` chords, landing on the ROW's task. */
-  readonly onOpenEditorRequest: (taskId: string) => void
-  readonly onRenameBranchRequest: (taskId: string) => void
-  readonly onChangeEngineRequest: (taskId: string) => void
-  /** Menu-only (no chord): open the repo's field-notes reader. */
-  readonly onFieldNotesRequest: (repo: string) => void
-  readonly moveMode: boolean
-  readonly onMoveRequest: (taskId: string, delta: -1 | 1) => void
-  readonly onMoveModeExit: () => void
-  readonly onLocalMergeRequest: (taskId: string) => void
   readonly onSearchActiveChange: (active: boolean) => void
   readonly headerStatus: { label: string; emphasize: boolean }
   readonly onHeaderStatusClick: () => void
@@ -81,6 +69,7 @@ export interface HostSidebarProps {
 }
 
 export function HostSidebar(props: HostSidebarProps) {
+  const { onFocusRequest: _rail, recentTask: _recent, ...treeProps } = props
   const { theme } = useTheme()
   const kv = useKV()
   const notif = useNotifications()
@@ -121,46 +110,6 @@ export function HostSidebar(props: HostSidebarProps) {
     },
     [props.onActivate],
   )
-  const common = {
-    width: props.width,
-    nav: props.nav,
-    onNavChange: props.onNavChange,
-    tasks: props.tasks,
-    selectedId: props.selectedId,
-    onSelect: props.onSelect,
-    onActivate: props.onActivate,
-    engineState: props.engineState,
-    engineTabState: props.engineTabState,
-    engineLifecycle: props.engineLifecycle,
-    taskJobs: props.taskJobs,
-    worktreeChanges: props.worktreeChanges,
-    transcriptActivity: props.transcriptActivity,
-    focused: props.focused,
-    onDeleteRequest: props.onDeleteRequest,
-    onLandRequest: props.onLandRequest,
-    onRenameRequest: props.onRenameRequest,
-    onPinRequest: props.onPinRequest,
-    onSetStatusRequest: props.onSetStatusRequest,
-    onCopyRequest: props.onCopyRequest,
-    onRunAgainRequest: props.onRunAgainRequest,
-    onOpenEditorRequest: props.onOpenEditorRequest,
-    onRenameBranchRequest: props.onRenameBranchRequest,
-    onChangeEngineRequest: props.onChangeEngineRequest,
-    onFieldNotesRequest: props.onFieldNotesRequest,
-    onLocalMergeRequest: props.onLocalMergeRequest,
-    moveMode: props.moveMode,
-    onMoveRequest: props.onMoveRequest,
-    onMoveModeExit: props.onMoveModeExit,
-    onSearchActiveChange: props.onSearchActiveChange,
-    onAddTask: props.onAddTask,
-    headerStatus: props.headerStatus,
-    onHeaderStatusClick: props.onHeaderStatusClick,
-    updateChip: props.updateChip,
-    onUpdateChipClick: props.onUpdateChipClick,
-    zenActive: props.zenActive,
-    onZenClick: props.onZenClick,
-    sortMode: props.sortMode,
-  }
   return (
     <box
       width={props.width}
@@ -169,15 +118,15 @@ export function HostSidebar(props: HostSidebarProps) {
       backgroundColor={theme.backgroundPanel}
       onMouseUp={props.onFocusRequest}
     >
+      {/* HostSidebarProps is SidebarTreeProps plus the rail's own two props,
+          so the tree takes the rest wholesale rather than a re-listing of
+          thirty names that can silently fall out of date. */}
       <SidebarTree
-        {...common}
-        selectedTabId={props.selectedTabId}
-        onSelectTab={props.onSelectTab}
+        {...treeProps}
         onCloseTab={closeTab}
         onNewTab={newTab}
         onMoveTabRequest={moveTab}
         recentTask={props.recentTask ?? null}
-        cursorTaskIdRef={props.cursorTaskIdRef}
       />
       {/* First-use key hint (component/keyboard-hints.tsx): renders until
           the sidebar's own keys have been used, then never again. */}

--- a/packages/kobe/src/tui/component/settings-dialog/model.ts
+++ b/packages/kobe/src/tui/component/settings-dialog/model.ts
@@ -257,21 +257,6 @@ export function rowAt(rows: readonly SettingsRow[], index: number): SettingsRow 
   return rows[index]
 }
 
-/**
- * Turn a custom-engine slug into a presentable display name: split on
- * `-`/`_` and title-case each word. `my-local-agent` → `My Local Agent`.
- * Used so a custom engine added with no name still reads like the
- * title-cased built-ins instead of its raw lowercase-hyphenated id.
- * (Shared by the Solid and React settings dialogs.)
- */
-export function humanizeSlug(id: string): string {
-  return id
-    .split(/[-_]+/)
-    .filter((word) => word.length > 0)
-    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-    .join(" ")
-}
-
 /** Cells the section sidebar reserves, and the gap between it and the body. */
 export const SECTIONS_SIDEBAR_WIDTH = 14
 const SECTIONS_COLUMN_GAP = 2

--- a/packages/kobe/src/types/vendor.ts
+++ b/packages/kobe/src/types/vendor.ts
@@ -25,6 +25,11 @@ export type VendorId = "claude" | "codex" | "copilot" | "kimi" | (string & {})
 export const BUILTIN_VENDORS = ["claude", "codex", "copilot", "kimi"] as const
 export type BuiltinVendorId = (typeof BUILTIN_VENDORS)[number]
 
+/** The engine everything falls back to: a fresh install's default, and where
+ *  `defaultVendor`/`lastSelectedVendor` land when the custom engine they named
+ *  is deleted. Named so those call sites stop spelling the literal. */
+export const DEFAULT_VENDOR: BuiltinVendorId = BUILTIN_VENDORS[0]
+
 /**
  * Built-in vendors, in cycle order. NB: this is the BUILT-IN set only;
  * surfaces that should also offer user-added engines (the new-task selector,

--- a/packages/kobe/test/tui/settings-rows.test.ts
+++ b/packages/kobe/test/tui/settings-rows.test.ts
@@ -15,6 +15,7 @@
  */
 
 import { describe, expect, it } from "vitest"
+import { humanizeSlug } from "../../src/engine/interactive-command.ts"
 import {
   SECTIONS,
   type SettingsRowsInput,
@@ -25,7 +26,6 @@ import {
   feedbackRows,
   focusAccentRowId,
   generalRows,
-  humanizeSlug,
   pluginRowId,
   pluginRows,
   pluginSettingRowId,


### PR DESCRIPTION
Batch C items **C3** and **C4** — two "one owner" refactors, no behaviour change. Detailed proof in the first comment.

**C3 — `SidebarTaskCallbacks` was re-declared at four more layers.** The type's own docblock says it exists so "the two surfaces can't drift", and then `HostSidebarProps` spelled all fourteen callbacks out inline, `host-sidebar.tsx` re-listed the same fourteen into a `common` object, and `use-tree-bindings.ts` declared four of them a fourth time with the parameter renamed `id` instead of `taskId`.

`HostSidebarProps` now extends the shared type. Required-ness is preserved exactly, not weakened: `Readonly<Required<Omit<SidebarTaskCallbacks, "onLandRequest">>>` plus `Readonly<Pick<…, "onLandRequest">>`, because the host supplied every callback except that one. The `common` object is gone — `HostSidebarProps` is `SidebarTreeProps` plus the rail's own two props, so the tree takes the rest by spread instead of a re-listing of thirty names that can silently fall out of date. `TreeBindingsOpts` takes a `Pick` of the four it uses, which also settles the `id`/`taskId` split. No callback changed from menu-only to chord-bound or back.

**C4 — engine display names had three owners.** `humanizeSlug` was duplicated verbatim (settings model + daemon settings adapter, differing only in equivalent spellings), and the adapter's `engineLabel` was a third derivation of the same answer that `engineDisplayName` already gives from the registry. Both copies are deleted; `humanizeSlug` now lives in `engine/interactive-command.ts` beside `engineDisplayName`, which sits below both `src/core/` and `src/tui/` so neither import inverts. It stays a **pure string transform** — it is the fallback written *into* `engineName.<id>`, so giving it the override lookup would overwrite a user-typed name with the title-cased slug on the next write. `engineLabel` folds into `engineDisplayName(id)`. The bare `"claude"` fallbacks in the adapter (default engine, and the two resets when the active custom engine is deleted) and in `handlers-add.ts` now read a named `DEFAULT_VENDOR` from `types/vendor.ts`. `kobe-web/src/lib/vendor.ts` deliberately untouched — that package is frozen for new work.

### Gates
- `bun run typecheck` clean, **no new `any` or non-null assertion** at any of the five C3 sites; `bun run lint` clean; `bash scripts/file-size-check.sh` clean.
- `bun test test/render` — 431 pass, 0 fail (`sidebar-tree-menu.test.tsx`, `sidebar-tree.test.tsx`, `sidebar-row-chords-cursor.test.tsx` included).
- Render coverage gate clean on both touched React files: `host-sidebar.tsx` 90.20%, `use-engine-settings.ts` 81.41%.
- Named unit tests green: `sidebar-tree-menu-items`, `sidebar-controller`, `daemon-settings-adapter`, `settings-rows`, `interactive-command-overrides`, and the `engine-owned-copy` architecture guard.
- **C4 byte-identity:** the daemon settings snapshot for a state holding a custom engine id with **no** `engineName` override — the exact path both deleted copies served — is byte-for-byte identical before and after (953 bytes, `cmp` clean), including `"label":"my-local-agent"`.
- **C3 harness:** sidebar row menu open, BEFORE on `origin/main` and AFTER on this branch through `/harness` → xterm.js → PTY sidecar → real OpenTUI. Pixel diff of the menu region `(28,158)-(204,400)`: **0 differing rows of 242**.
- `bun run test:fast` — 4259 pass, 6 fail, all pre-existing and environmental; the identical failure set appears on my other, disjoint branch (#812). `continue-live-vendor` reads the owner's locally-registered `claudecpa` engine out of the real `state.json`; `project-eligibility` / `open-dir-cmd` are the known `~/.rove/worktrees` path-shape false failures. CI runs from an ordinary Linux checkout.

Net: −108 lines across ten files.
