### PR TITLE
Daemon store serializer, daemon lifetime fault isolation, and the smaller-items sweep

### DIFF
--- a/.changeset/daemon-housekeeping-leaks.md
+++ b/.changeset/daemon-housekeeping-leaks.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Internal: four daemon-side leaks and one missing plugin event. `quotaResumeTickMs: 0` now disables the quota-resume sweep like it does for every sibling collector — `collectors.ts` merges with `??`, which does not replace a `0`, so the documented "off" value gave `setInterval(fn, 0)`, a ~1000 Hz sweep of the whole task index. The PR-status poller's per-task backoff map only ever dropped entries for tasks still in `listTasks()`, so a deleted task's entry had no exit at all. The web server registered its event-bus sink above the token write and the `Bun.serve` bind, so a lost port race left an orphaned closure the bus kept calling for the daemon's whole lifetime — once per restart that lost the race; it subscribes after the bind now. `probeWebPort`'s response body has been unused since the marker comparison was removed. And a background-appended engine tab now reports `tab.opened`, so a plugin tracking open panes no longer sees the eventual `tab.closed` as the first news of it.

--- a/.changeset/daemon-lifetime-fault-isolation.md
+++ b/.changeset/daemon-lifetime-fault-isolation.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Fixed three ways the daemon could be stranded alive by a single failure. A browser SSE connection whose hydration snapshot threw left a gui behind that nothing could subtract, so the daemon never idle-exited after the TUI quit and every collector kept polling npm, git and gh for a browser that had received a 500 — the snapshot is now assembled before the refcount is acquired. A shutdown that threw partway (the plugin host's `stop()` is the known thrower) skipped the release half entirely, leaving the socket and pidfile on disk in front of a daemon that still answered `hello` but whose panes never updated again; the release now runs in a `finally`. And a rejecting stop hook took `daemon.stop`, idle-stop and socket-takeover down with it while `stopping` stayed latched, so `rove daemon stop` reported success and the process kept running — the teardown is now scheduled regardless.

--- a/.changeset/one-serializer-for-daemon-stores.md
+++ b/.changeset/one-serializer-for-daemon-stores.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Internal: the daemon's six file-backed stores now share one mutation serializer. The "queue this read-modify-write behind a settled promise tail" primitive was written six times in two spellings — four private `enqueue` methods (automations, attention inbox, agent turns, deferred prompts) and two module-level `withLock` copies (issues, notes) — and `json-file.ts`, already the single owner of the atomic write half, now owns `serialized(path, fn)` too. The lock key stays the file path, since each store reads and writes its document whole; a rejected mutation still settles the tail rather than wedging the queue. Repo resolution for the two repo-keyed stores collapsed the same way: `gitTopLevel` moved beside its siblings in `repo-key.ts`, which now exposes `resolveRepoRoot` for the shared stat-and-derive half while each store keeps its own answer to "no worktree line". No user-visible change — `issue-list`, `note-list` and `inspect` are byte-identical.

--- a/.changeset/small-correctness-sweep.md
+++ b/.changeset/small-correctness-sweep.md
@@ -1,0 +1,13 @@
+---
+"@sma1lboy/rove": patch
+---
+
+`rove api --repo ssh://…`, safer worktree deletion, and five smaller correctness fixes
+
+- `--repo` accepts a remote project's `ssh://…` key. Every `--repo` flag resolved its value as a filesystem path, so the key collapsed to `$PWD/ssh:/me@host/srv/proj` and the task was filed against a directory nobody typed. `savedRepos` stores the key verbatim and `resolveRepoRoot` already passes it through — the CLI's path resolution was the only thing in the way.
+- A worktrees-location override no longer authorizes deleting your other projects. Rove only ever creates `<root>/<repo-key>/<slug>`, but the guard in front of the `rm -rf` for an unrecoverable worktree accepted anything at any depth below the root — so pointing Settings → Worktree location at `~` or `~/code` made every unrelated project below it answer "yes, Rove made this".
+- One vanished worktree no longer blanks the whole sidebar. The dirty probe ran without the try/catch its sibling activity probe has, so a worktree removed between the listing and the probe threw out of the whole call instead of costing one row.
+- Landing refuses a task that is already being deleted, the way every other worktree entry point does, instead of racing the daemon's deletion runner over the same directory.
+- Clearing a task's recorded worktree path no longer applies to `dir` tasks, whose path is the user's own directory rather than a Rove-created worktree — blanking it left the task unable to open anything.
+- Closing a viewport tab (one mirroring another task's session) no longer kills that task's split panes. The borrowed base was correctly spared; its `::leaf-N` children were not.
+- Automation runs that were `revived` or `deferred` no longer render in the same grey as "nothing to do" — both delivered the prompt somewhere, and `deferred` reads as a warning because it is parked until you release it from the Inbox.

--- a/packages/kobe-daemon/src/daemon/agent-turns-store.ts
+++ b/packages/kobe-daemon/src/daemon/agent-turns-store.ts
@@ -19,7 +19,7 @@ import { join } from "node:path"
 import { ROVE_STATE_DIR_BASENAME, readRoveEnv } from "../compat-env.ts"
 import type { AgentTurnRecord } from "./contracts.ts"
 import { logDaemonError } from "./crash-log.ts"
-import { writeJsonAtomic } from "./json-file.ts"
+import { serialized, writeJsonAtomic } from "./json-file.ts"
 
 interface AgentTurnsFile {
   readonly version: 1
@@ -76,7 +76,6 @@ function sameRecord(a: AgentTurnRecord, b: AgentTurnRecord): boolean {
 
 export class AgentTurnsStore {
   private readonly turns = new Map<string, AgentTurnRecord>()
-  private tail: Promise<void> = Promise.resolve()
 
   constructor(private readonly path: string) {}
 
@@ -174,11 +173,6 @@ export class AgentTurnsStore {
   /** Serialize mutations so two concurrent hook ingests can't interleave a
    *  read-modify-write and lose turns. */
   private enqueue<T>(work: () => Promise<T>): Promise<T> {
-    const run = this.tail.then(work, work)
-    this.tail = run.then(
-      () => undefined,
-      () => undefined,
-    )
-    return run
+    return serialized(this.path, work)
   }
 }

--- a/packages/kobe-daemon/src/daemon/attention-inbox.ts
+++ b/packages/kobe-daemon/src/daemon/attention-inbox.ts
@@ -23,7 +23,7 @@ import {
 } from "./contracts.ts"
 import { logDaemonError } from "./crash-log.ts"
 import type { DaemonEventBus } from "./event-bus.ts"
-import { writeJsonAtomic } from "./json-file.ts"
+import { serialized, writeJsonAtomic } from "./json-file.ts"
 
 interface AttentionInboxFile {
   readonly version: 1
@@ -92,7 +92,6 @@ async function writeStore(path: string, items: readonly AttentionInboxItem[]): P
 
 export class AttentionInboxStore {
   private readonly items = new Map<string, AttentionInboxItem>()
-  private tail: Promise<void> = Promise.resolve()
 
   constructor(
     private readonly path: string,
@@ -270,13 +269,9 @@ export class AttentionInboxStore {
     await this.deleteTask(taskId).catch((err) => logDaemonError("attention-inbox-task-delete", err))
   }
 
+  /** Serialize mutations so concurrent hook/RPC writes cannot clobber the file. */
   private enqueue<T>(operation: () => Promise<T>): Promise<T> {
-    const run = this.tail.then(operation)
-    this.tail = run.then(
-      () => undefined,
-      () => undefined,
-    )
-    return run
+    return serialized(this.path, operation)
   }
 
   /** Serialize mutations so concurrent hook/RPC writes cannot clobber the file. */

--- a/packages/kobe-daemon/src/daemon/automations-store.ts
+++ b/packages/kobe-daemon/src/daemon/automations-store.ts
@@ -21,7 +21,7 @@ import { ROVE_STATE_DIR_BASENAME, readRoveEnv } from "../compat-env.ts"
 import type { Automation, AutomationPatch, AutomationRun } from "./contracts.ts"
 import { logDaemonError } from "./crash-log.ts"
 import { nextCronAfter } from "./cron.ts"
-import { writeJsonAtomic } from "./json-file.ts"
+import { serialized, writeJsonAtomic } from "./json-file.ts"
 
 /** Per-automation run history cap. The whole document is re-serialized on every
  *  write, so an unbounded log makes each save permanently slower. */
@@ -177,7 +177,6 @@ export function pruneRuns(
 export class AutomationsStore {
   private automations: Automation[] = []
   private runs: AutomationRun[] = []
-  private tail: Promise<void> = Promise.resolve()
 
   constructor(
     private readonly path: string,
@@ -343,11 +342,6 @@ export class AutomationsStore {
 
   /** Serialize mutations so concurrent RPC/sweep writes cannot clobber the file. */
   private enqueue<T>(operation: () => Promise<T>): Promise<T> {
-    const run = this.tail.then(operation)
-    this.tail = run.then(
-      () => undefined,
-      () => undefined,
-    )
-    return run
+    return serialized(this.path, operation)
   }
 }

--- a/packages/kobe-daemon/src/daemon/deferred-prompts-store.ts
+++ b/packages/kobe-daemon/src/daemon/deferred-prompts-store.ts
@@ -22,7 +22,7 @@ import { homedir } from "node:os"
 import { join } from "node:path"
 import { ROVE_STATE_DIR_BASENAME, readRoveEnv } from "../compat-env.ts"
 import { logDaemonInfo } from "./crash-log.ts"
-import { writeJsonAtomic } from "./json-file.ts"
+import { serialized, writeJsonAtomic } from "./json-file.ts"
 
 /** One deferred prompt per tab is kept until release or expiry. */
 export const DEFERRED_PROMPT_TTL_MS = 24 * 60 * 60 * 1000
@@ -128,8 +128,6 @@ async function writeStore(path: string, records: readonly DeferredPromptRecord[]
 const SUBSYSTEM = "deferred-prompts"
 
 export class DeferredPromptsStore {
-  private readonly tail: Promise<void> = Promise.resolve()
-  private queue: Promise<void> = this.tail
   private readonly claims = new Map<string, { claimId: string; done: Promise<void>; finish: () => void }>()
 
   constructor(
@@ -139,12 +137,7 @@ export class DeferredPromptsStore {
 
   /** Serialize read-modify-write on the shared file (same unit as the inbox store). */
   private enqueue<T>(operation: () => Promise<T>): Promise<T> {
-    const run = this.queue.then(operation)
-    this.queue = run.then(
-      () => undefined,
-      () => undefined,
-    )
-    return run
+    return serialized(this.path, operation)
   }
 
   /**

--- a/packages/kobe-daemon/src/daemon/deferred-prompts-store.ts
+++ b/packages/kobe-daemon/src/daemon/deferred-prompts-store.ts
@@ -329,6 +329,10 @@ export class DeferredPromptsStore {
         )
         return false
       })
+      // Deliberately does NOT write the prune: `flushDeferredPrompts` claims
+      // each expired record so it can delete the record's Inbox pointer before
+      // completing the claim. Dropping them here instead would strand those
+      // pointers, which is why the log above says "cleanup requested".
       return { records: kept, expired }
     })
   }

--- a/packages/kobe-daemon/src/daemon/issues-store.ts
+++ b/packages/kobe-daemon/src/daemon/issues-store.ts
@@ -4,8 +4,8 @@ import { homedir } from "node:os"
 import { join, resolve } from "node:path"
 import { promisify } from "node:util"
 import { ROVE_STATE_DIR_BASENAME, readRoveEnv } from "../compat-env.ts"
-import { writeJsonAtomic } from "./json-file.ts"
-import { gitCommonDir, gitMainWorktree } from "./repo-key.ts"
+import { serialized, writeJsonAtomic } from "./json-file.ts"
+import { gitTopLevel, resolveRepoRoot } from "./repo-key.ts"
 
 const execFileAsync = promisify(execFile)
 
@@ -92,21 +92,13 @@ function todayStamp(): string {
   return `${d.getFullYear()}-${mm}-${dd}`
 }
 
-async function gitTopLevel(path: string): Promise<string> {
-  const { stdout } = await execFileAsync("git", ["-C", path, "rev-parse", "--show-toplevel"])
-  return stdout.trim()
-}
-
 async function resolveRepo(raw: unknown): Promise<{ repoRoot: string; repoKey: string }> {
   if (typeof raw !== "string" || raw.length === 0) throw new Error("repoRoot is required")
-  const absolute = resolve(raw)
-  const s = await stat(absolute).catch(() => null)
-  if (!s?.isDirectory()) throw new Error("repoRoot does not exist")
   try {
-    const [main, repoKey] = await Promise.all([gitMainWorktree(absolute), gitCommonDir(absolute)])
+    const { repoRoot, repoKey } = await resolveRepoRoot(raw)
     // No worktree line at all still has a readable root: fall back to the
     // toplevel rather than refuse the repo.
-    return { repoRoot: main ?? (await gitTopLevel(absolute)), repoKey }
+    return { repoRoot: repoRoot ?? (await gitTopLevel(resolve(raw))), repoKey }
   } catch (err) {
     if (isGitNotRepositoryError(err)) throw new Error("repoRoot is not a git repository")
     throw err
@@ -150,36 +142,12 @@ function response(repoRoot: string, record: RepoIssueRecord | null): RepoIssues 
   }
 }
 
-const locks = new Map<string, Promise<unknown>>()
-
-/**
- * Serialize async sections that share a resource named by `key`. The issue
- * store keeps ALL repos in one file (read/written whole), so the unit of
- * contention is the file path, NOT the repoKey — locking per-repo lets two
- * different repos' read-modify-write cycles interleave and the second
- * `writeStore` rename silently drops the first repo's mutation. Callers pass
- * `this.path` so every mutation against the file is serialized.
- */
-async function withLock<T>(key: string, fn: () => Promise<T>): Promise<T> {
-  const tail = locks.get(key) ?? Promise.resolve()
-  const run = tail.then(fn)
-  const settled = run.then(
-    () => undefined,
-    () => undefined,
-  )
-  locks.set(key, settled)
-  void settled.then(() => {
-    if (locks.get(key) === settled) locks.delete(key)
-  })
-  return run
-}
-
 export class IssuesStore {
   constructor(private readonly path = defaultIssuesStorePath()) {}
 
   async list(repo: unknown): Promise<RepoIssues> {
     const { repoRoot, repoKey } = await resolveRepo(repo)
-    return withLock(this.path, async () => {
+    return serialized(this.path, async () => {
       const store = await readStore(this.path)
       const record = store.repos[repoKey] ?? null
       if (record && record.repoRoot !== repoRoot) {
@@ -203,7 +171,7 @@ export class IssuesStore {
   async mirrorTaskDone(repo: unknown, taskId: string): Promise<RepoIssues | null> {
     const { repoRoot, repoKey } = await resolveRepo(repo)
     if (!taskId) return null
-    return withLock(this.path, async () => {
+    return serialized(this.path, async () => {
       const store = await readStore(this.path)
       const record = store.repos[repoKey]
       if (!record) return null
@@ -228,7 +196,7 @@ export class IssuesStore {
   async unlinkTask(repo: unknown, taskId: string): Promise<RepoIssues | null> {
     const { repoRoot, repoKey } = await resolveRepo(repo)
     if (!taskId) return null
-    return withLock(this.path, async () => {
+    return serialized(this.path, async () => {
       const store = await readStore(this.path)
       const record = store.repos[repoKey]
       if (!record) return null
@@ -246,7 +214,7 @@ export class IssuesStore {
     if (!op || typeof op !== "object" || Array.isArray(op) || typeof (op as { type?: unknown }).type !== "string") {
       throw new Error("missing op")
     }
-    return withLock(this.path, async () => {
+    return serialized(this.path, async () => {
       const store = await readStore(this.path)
       let record = store.repos[repoKey]
       if (!record) {

--- a/packages/kobe-daemon/src/daemon/json-file.ts
+++ b/packages/kobe-daemon/src/daemon/json-file.ts
@@ -1,5 +1,6 @@
 /**
- * The one atomic JSON write shared by the daemon's file-backed stores.
+ * The atomic JSON write and the mutation serializer shared by the daemon's
+ * file-backed stores.
  *
  * tmp+rename so a reader never sees a half-written file, and the tmp name
  * carries pid+uuid because a fixed `${path}.tmp` is shared state: during a
@@ -7,6 +8,10 @@
  * while the incoming one opens the same name, truncates it, and renames
  * partial JSON over the real file. Reads stay per-store — corruption policy
  * legitimately differs between them.
+ *
+ * {@link serialized} is the read half's other bookend: every store that does a
+ * read-modify-write on one of these files funnels through it so two concurrent
+ * mutations cannot both read the old document and race their renames.
  */
 import { randomUUID } from "node:crypto"
 import { mkdir, rename, writeFile } from "node:fs/promises"
@@ -29,4 +34,34 @@ export async function writeJsonAtomic(
   const text = compact ? JSON.stringify(body) : JSON.stringify(body, null, 2)
   await writeFile(tmp, `${text}\n`, { encoding: "utf8", mode })
   await rename(tmp, path)
+}
+
+const locks = new Map<string, Promise<unknown>>()
+
+/**
+ * Serialize async sections that share a resource named by `key`.
+ *
+ * The unit of contention is the FILE PATH, not whatever the file is keyed by
+ * internally: these stores read and write their document whole, so locking per
+ * repo (or per task) lets two read-modify-write cycles interleave and the
+ * second `rename` silently drops the first one's mutation. Callers pass their
+ * store path.
+ *
+ * The tail is settled to `undefined` on both outcomes — a rejected mutation
+ * must not wedge the queue for every later caller — and the map entry is
+ * dropped once nobody is behind it, so a long-lived daemon does not accumulate
+ * an entry per file it has ever touched.
+ */
+export function serialized<T>(key: string, fn: () => Promise<T>): Promise<T> {
+  const tail = locks.get(key) ?? Promise.resolve()
+  const run = tail.then(fn)
+  const settled = run.then(
+    () => undefined,
+    () => undefined,
+  )
+  locks.set(key, settled)
+  void settled.then(() => {
+    if (locks.get(key) === settled) locks.delete(key)
+  })
+  return run
 }

--- a/packages/kobe-daemon/src/daemon/notes-store.ts
+++ b/packages/kobe-daemon/src/daemon/notes-store.ts
@@ -17,8 +17,8 @@ import { readFile, stat } from "node:fs/promises"
 import { homedir } from "node:os"
 import { join, resolve } from "node:path"
 import { ROVE_STATE_DIR_BASENAME, readRoveEnv } from "../compat-env.ts"
-import { writeJsonAtomic } from "./json-file.ts"
-import { gitCommonDir, gitMainWorktree } from "./repo-key.ts"
+import { serialized, writeJsonAtomic } from "./json-file.ts"
+import { resolveRepoRoot } from "./repo-key.ts"
 
 /** Newest-N kept per repo. Older notes are dropped on write. */
 export const NOTES_RETENTION_CAP = 50
@@ -61,12 +61,9 @@ function normalizeNote(entry: unknown): FieldNote | null {
 }
 
 async function resolveRepo(raw: string): Promise<{ repoRoot: string; repoKey: string }> {
-  const absolute = resolve(raw)
-  const s = await stat(absolute).catch(() => null)
-  if (!s?.isDirectory()) throw new Error("repoRoot does not exist")
-  const [main, repoKey] = await Promise.all([gitMainWorktree(absolute), gitCommonDir(absolute)])
-  if (!main) throw new Error("repoRoot is not a git repository")
-  return { repoRoot: main, repoKey }
+  const { repoRoot, repoKey } = await resolveRepoRoot(raw)
+  if (!repoRoot) throw new Error("repoRoot is not a git repository")
+  return { repoRoot, repoKey }
 }
 
 async function readStore(path: string): Promise<NotesStoreFile> {
@@ -92,37 +89,19 @@ async function readStore(path: string): Promise<NotesStoreFile> {
   }
 }
 
-const locks = new Map<string, Promise<unknown>>()
-
-/** Serialize read-modify-write on the shared file — same rationale (and the
- *  same whole-file contention unit) as the issue store's lock. */
-async function withLock<T>(key: string, fn: () => Promise<T>): Promise<T> {
-  const tail = locks.get(key) ?? Promise.resolve()
-  const run = tail.then(fn)
-  const settled = run.then(
-    () => undefined,
-    () => undefined,
-  )
-  locks.set(key, settled)
-  void settled.then(() => {
-    if (locks.get(key) === settled) locks.delete(key)
-  })
-  return run
-}
-
 export class NotesStore {
   constructor(private readonly path = defaultNotesStorePath()) {}
 
   /** Newest-first notes for a repo; empty for a repo that never filed one. */
   async list(repo: string): Promise<readonly FieldNote[]> {
     const { repoKey } = await resolveRepo(repo)
-    return withLock(this.path, async () => (await readStore(this.path)).repos[repoKey]?.notes ?? [])
+    return serialized(this.path, async () => (await readStore(this.path)).repos[repoKey]?.notes ?? [])
   }
 
   /** Append one note, newest-first, evicting past {@link NOTES_RETENTION_CAP}. */
   async append(repo: string, note: FieldNote): Promise<void> {
     const { repoRoot, repoKey } = await resolveRepo(repo)
-    await withLock(this.path, async () => {
+    await serialized(this.path, async () => {
       const store = await readStore(this.path)
       const record = store.repos[repoKey] ?? { repoRoot, notes: [] }
       record.repoRoot = repoRoot

--- a/packages/kobe-daemon/src/daemon/pr-status-collector.ts
+++ b/packages/kobe-daemon/src/daemon/pr-status-collector.ts
@@ -307,7 +307,15 @@ export async function runPrStatusPass(orch: DaemonOrchestrator, opts: PrStatusPa
     jitterRatio: PR_POLL_JITTER_RATIO,
   }
   const changed: string[] = []
-  for (const task of orch.listTasks()) {
+  const tasks = orch.listTasks()
+  // Drop entries for tasks that are GONE, not merely ineligible. The delete
+  // below only fires for ids still in `listTasks()`, so a deleted task's entry
+  // had no exit at all — unbounded over a long-lived daemon.
+  const live = new Set(tasks.map((task) => task.id))
+  for (const id of opts.schedule.keys()) {
+    if (!live.has(id)) opts.schedule.delete(id)
+  }
+  for (const task of tasks) {
     if (!isPrPollable(task)) {
       opts.schedule.delete(task.id) // forget backoff for now-ineligible tasks
       continue

--- a/packages/kobe-daemon/src/daemon/quota-resume.ts
+++ b/packages/kobe-daemon/src/daemon/quota-resume.ts
@@ -139,6 +139,10 @@ export function startQuotaResumeRunner(
   now: () => number = Date.now,
   plugins?: () => Pick<PluginHost, "handleUiReport"> | null,
 ): () => void {
+  // `collectors.ts` reads the tick with `??`, which does NOT replace a 0, so
+  // without this the documented "0 disables it" gives setInterval(fn, 0) — a
+  // ~1000 Hz sweep of the whole task index. Every sibling collector guards it.
+  if (tickMs <= 0) return () => {}
   let sweeping = false
   const sweep = async (): Promise<void> => {
     if (sweeping) return

--- a/packages/kobe-daemon/src/daemon/repo-key.ts
+++ b/packages/kobe-daemon/src/daemon/repo-key.ts
@@ -14,7 +14,7 @@
  */
 
 import { execFile } from "node:child_process"
-import { realpath } from "node:fs/promises"
+import { realpath, stat } from "node:fs/promises"
 import { isAbsolute, resolve } from "node:path"
 import { promisify } from "node:util"
 
@@ -39,4 +39,25 @@ export async function gitMainWorktree(path: string): Promise<string | null> {
     ?.slice("worktree ".length)
     .trim()
   return first ? await realpath(first) : null
+}
+
+/** The working tree's top level — the fallback root when no worktree line exists. */
+export async function gitTopLevel(path: string): Promise<string> {
+  const { stdout } = await execFileAsync("git", ["-C", path, "rev-parse", "--show-toplevel"])
+  return stdout.trim()
+}
+
+/**
+ * The shared half of both repo-keyed stores' `resolveRepo`: validate the path
+ * is a directory, then derive both identities in one round trip. `repoRoot` is
+ * null exactly when `git worktree list` printed no worktree line — the stores
+ * disagree on what that means (issues falls back to {@link gitTopLevel}, notes
+ * refuses), so the policy stays with them.
+ */
+export async function resolveRepoRoot(raw: string): Promise<{ repoRoot: string | null; repoKey: string }> {
+  const absolute = resolve(raw)
+  const s = await stat(absolute).catch(() => null)
+  if (!s?.isDirectory()) throw new Error("repoRoot does not exist")
+  const [repoRoot, repoKey] = await Promise.all([gitMainWorktree(absolute), gitCommonDir(absolute)])
+  return { repoRoot, repoKey }
 }

--- a/packages/kobe-daemon/src/daemon/server.ts
+++ b/packages/kobe-daemon/src/daemon/server.ts
@@ -306,30 +306,43 @@ export async function startDaemonServer(orch: DaemonOrchestrator, options: Daemo
     clients,
     async close() {
       lifetime.markStopping()
-      unsubscribeStore()
-      webServer?.close()
-      webServer = null
-      stopCollectors()
-      ptyHold.stop()
-      stopPtyExitWatch()
-      // Awaited: [[shutdown]] hooks finish inside stop()'s bounded grace.
-      await pluginHost?.stop()
-      prompts.clear()
-      tabCloses.clear()
-      activity.close()
-      // Hosted PTYs are deliberately NOT touched here: they live in the
-      // standalone `kobe pty-host` process, so `kobe daemon restart` never
-      // ends a running engine session — only `kobe reset` does.
-      // Task sessions are intentionally untouched here: closing the daemon
-      // never tears them down. Session teardown lives ONLY in `kobe reset` /
-      // `kobe kill-sessions`. Keep it that way.
-      broadcast(clients, { type: "event", name: "daemon.stopping", payload: {} })
-      for (const client of Array.from(clients)) {
-        client.socket.destroy()
+      // The destructive half runs first and the releasing half runs in the
+      // `finally`, because a throw in between used to strand the process as a
+      // zombie: `stopping` is latched and the store subscription, collectors
+      // and web server are already gone, but the socket and pidfile are still
+      // on disk and still answering `hello`, so every client and
+      // `rove daemon status` report a healthy daemon whose panes never update
+      // again. `pluginHost.stop()` is the known thrower — its `run` spawns
+      // outside the inner promise, so an empty `command` array rejects it.
+      try {
+        unsubscribeStore()
+        webServer?.close()
+        webServer = null
+        stopCollectors()
+        ptyHold.stop()
+        stopPtyExitWatch()
+        // Awaited: [[shutdown]] hooks finish inside stop()'s bounded grace.
+        await pluginHost?.stop()
+        prompts.clear()
+        tabCloses.clear()
+        activity.close()
+      } catch (err) {
+        logDaemonError("daemon-shutdown", err)
+      } finally {
+        // Hosted PTYs are deliberately NOT touched here: they live in the
+        // standalone `kobe pty-host` process, so `kobe daemon restart` never
+        // ends a running engine session — only `kobe reset` does.
+        // Task sessions are intentionally untouched here: closing the daemon
+        // never tears them down. Session teardown lives ONLY in `kobe reset` /
+        // `kobe kill-sessions`. Keep it that way.
+        broadcast(clients, { type: "event", name: "daemon.stopping", payload: {} })
+        for (const client of Array.from(clients)) {
+          client.socket.destroy()
+        }
+        // Ownership-aware teardown: a superseded daemon must neither close the
+        // listener nor unlink files another daemon owns — see socket-guard.ts.
+        await sockGuard.release(server)
       }
-      // Ownership-aware teardown: a superseded daemon must neither close the
-      // listener nor unlink files another daemon owns — see socket-guard.ts.
-      await sockGuard.release(server)
     },
   }
 
@@ -347,7 +360,15 @@ export async function startDaemonServer(orch: DaemonOrchestrator, options: Daemo
   async function stopSoon(): Promise<void> {
     if (lifetime.isStopping()) return
     lifetime.markStopping()
-    await options.onStop?.()
+    try {
+      await options.onStop?.()
+    } catch (err) {
+      // The latch is already set, so nothing will re-arm the idle timer: if a
+      // failing stop hook also skipped the close below, the daemon would
+      // outlive every request to stop it — idle, socket takeover, and
+      // `rove daemon stop` (which reports success) all go through here.
+      logDaemonError("daemon-stop-hook", err)
+    }
     setTimeout(() => {
       serverApi.close().catch((err) => logDaemonError("daemon-shutdown", err))
     }, 0).unref()

--- a/packages/kobe-daemon/src/daemon/server.ts
+++ b/packages/kobe-daemon/src/daemon/server.ts
@@ -306,14 +306,10 @@ export async function startDaemonServer(orch: DaemonOrchestrator, options: Daemo
     clients,
     async close() {
       lifetime.markStopping()
-      // The destructive half runs first and the releasing half runs in the
-      // `finally`, because a throw in between used to strand the process as a
-      // zombie: `stopping` is latched and the store subscription, collectors
-      // and web server are already gone, but the socket and pidfile are still
-      // on disk and still answering `hello`, so every client and
-      // `rove daemon status` report a healthy daemon whose panes never update
-      // again. `pluginHost.stop()` is the known thrower — its `run` spawns
-      // outside the inner promise, so an empty `command` array rejects it.
+      // Release in a `finally`: a throw between the halves used to strand a
+      // zombie — `stopping` latched and the internals gone, but the socket and
+      // pidfile still on disk answering `hello`. `pluginHost.stop()` throws
+      // (its `run` spawns outside the inner promise).
       try {
         unsubscribeStore()
         webServer?.close()
@@ -363,10 +359,9 @@ export async function startDaemonServer(orch: DaemonOrchestrator, options: Daemo
     try {
       await options.onStop?.()
     } catch (err) {
-      // The latch is already set, so nothing will re-arm the idle timer: if a
-      // failing stop hook also skipped the close below, the daemon would
-      // outlive every request to stop it — idle, socket takeover, and
-      // `rove daemon stop` (which reports success) all go through here.
+      // The latch is set, so nothing re-arms the idle timer: a stop hook that
+      // took the close below with it left the daemon outliving every request
+      // to stop it — idle, takeover and `rove daemon stop` all route here.
       logDaemonError("daemon-stop-hook", err)
     }
     setTimeout(() => {

--- a/packages/kobe-daemon/src/daemon/web-server.ts
+++ b/packages/kobe-daemon/src/daemon/web-server.ts
@@ -447,10 +447,8 @@ export function createDirectWebLink(args: {
  * A skip degrades the daemon to socket-only; it never throws.
  */
 export async function probeWebPort(port: number, healthPath: string = DAEMON_WEB_HEALTH_PATH): Promise<boolean> {
-  let body: string
   try {
-    const res = await fetch(`http://localhost:${port}${healthPath}`, { signal: AbortSignal.timeout(800) })
-    body = (await res.text()).trim()
+    await fetch(`http://localhost:${port}${healthPath}`, { signal: AbortSignal.timeout(800) })
   } catch {
     // Nothing answered the health probe → assume the port is free to bind.
     // If something races onto it, Bun.serve's EADDRINUSE is caught upstream.
@@ -466,9 +464,6 @@ export async function startDaemonWebServer(opts: DaemonWebServerOptions): Promis
     )
   }
   const sseSends = new Set<SseSend>()
-  const unsubscribe = opts.onEvent((event) => {
-    for (const send of sseSends) send("channel", event)
-  })
   const hostname = opts.hostname?.trim() || process.env.KOBE_WEB_HOST?.trim() || "127.0.0.1"
   const allowedHost = allowedHostForBindHost(hostname)
   // Minted here rather than defaulted inside the handler: `webToken` is
@@ -487,6 +482,14 @@ export async function startDaemonWebServer(opts: DaemonWebServerOptions): Promis
     webToken,
   })
   const server = Bun.serve({ port: opts.port, hostname, idleTimeout: 0, fetch: handle })
+  // Subscribed only once there is something to unsubscribe FROM: above the
+  // bind, an `ensureWebToken` write error or a lost port race (EADDRINUSE)
+  // throws past every caller of the returned `close()`, and the bus keeps
+  // calling this orphaned closure for the daemon's whole lifetime — once per
+  // restart that loses the race.
+  const unsubscribe = opts.onEvent((event) => {
+    for (const send of sseSends) send("channel", event)
+  })
   return {
     port: server.port ?? opts.port,
     hostname,

--- a/packages/kobe-daemon/src/daemon/web-server.ts
+++ b/packages/kobe-daemon/src/daemon/web-server.ts
@@ -483,10 +483,9 @@ export async function startDaemonWebServer(opts: DaemonWebServerOptions): Promis
   })
   const server = Bun.serve({ port: opts.port, hostname, idleTimeout: 0, fetch: handle })
   // Subscribed only once there is something to unsubscribe FROM: above the
-  // bind, an `ensureWebToken` write error or a lost port race (EADDRINUSE)
-  // throws past every caller of the returned `close()`, and the bus keeps
-  // calling this orphaned closure for the daemon's whole lifetime — once per
-  // restart that loses the race.
+  // bind, an `ensureWebToken` write error or a lost port race throws past every
+  // caller of the returned `close()`, and the bus keeps calling this orphaned
+  // closure for the daemon's whole lifetime — once per restart that loses.
   const unsubscribe = opts.onEvent((event) => {
     for (const send of sseSends) send("channel", event)
   })

--- a/packages/kobe-daemon/src/daemon/web-server.ts
+++ b/packages/kobe-daemon/src/daemon/web-server.ts
@@ -322,8 +322,15 @@ export function createDaemonWebRequestHandler(deps: RequestHandlerDeps): (req: R
     }
     if (url.pathname === "/events") {
       return sseResponse((send) => {
+        // Nothing fallible above the acquire. `onSseOpen` bumps the gui
+        // refcount and hands back the ONLY way to undo it, so a throw between
+        // the two (assembling the snapshot reaches the orchestrator and the
+        // activity map) left a phantom gui that nothing could remove: the
+        // daemon never idle-exited and every collector polled forever for a
+        // browser that got a 500. Build the payload first, acquire last.
+        const hydration = link.snapshot()
         const closeGui = deps.onSseOpen?.() ?? (() => {})
-        send("snapshot", link.snapshot())
+        send("snapshot", hydration)
         sseSends.add(send)
         return () => {
           sseSends.delete(send)

--- a/packages/kobe/src/cli/api/flags.ts
+++ b/packages/kobe/src/cli/api/flags.ts
@@ -9,7 +9,7 @@
 import { readFileSync } from "node:fs"
 import { resolve } from "node:path"
 import { expandTilde } from "../../lib/path-home.ts"
-import { getCustomEngineIds } from "../../state/repos.ts"
+import { getCustomEngineIds, isRemoteRepoKey } from "../../state/repos.ts"
 import { ALL_VENDORS, type VendorId } from "../../types/vendor.ts"
 import { ApiError, type FlagSpec, type Flags, type ParsedArgs, type VerbSpec, helpStep } from "./types.ts"
 
@@ -353,6 +353,21 @@ export class VerbArgs {
   /** Required PATH flag resolved against $PWD (with a leading `~` expanded first). */
   requirePath(name: string): string {
     return resolve(process.cwd(), expandTilde(this.require(name)))
+  }
+
+  /**
+   * Required REPO flag: a local path, or a remote project's `ssh://…` key
+   * verbatim.
+   *
+   * Separate from {@link requirePath} because `resolve()` treats the key as a
+   * relative path and collapses it to `$PWD/ssh:/me@host` — a directory that
+   * does not exist, so `--repo ssh://…` failed with a path nobody typed.
+   * `savedRepos` stores that key as-is and `resolveRepoRoot` already passes it
+   * through, so the mangling was the only thing in the way.
+   */
+  requireRepo(name: string): string {
+    const raw = this.require(name)
+    return isRemoteRepoKey(raw) ? raw : resolve(process.cwd(), expandTilde(raw))
   }
 }
 

--- a/packages/kobe/src/cli/api/handlers-add.ts
+++ b/packages/kobe/src/cli/api/handlers-add.ts
@@ -70,7 +70,7 @@ async function applyPostCreateFlags(daemon: DaemonRpc, taskId: string, args: Ver
 
 export async function add(ctx: VerbContext): Promise<unknown> {
   const { args, runtime } = ctx
-  const repo = await runtime.resolveRepoRoot(args.requirePath("repo"))
+  const repo = await runtime.resolveRepoRoot(args.requireRepo("repo"))
   const count = args.int("count")
   const agentsSpec = args.str("agents")
   if (count !== undefined || agentsSpec) return addParallel(ctx, repo, count, agentsSpec)

--- a/packages/kobe/src/cli/api/handlers-digest.ts
+++ b/packages/kobe/src/cli/api/handlers-digest.ts
@@ -70,7 +70,7 @@ export function buildDigest(
 async function digest(ctx: VerbContext): Promise<unknown> {
   const daemon = daemonOf(ctx)
   const { args, runtime } = ctx
-  const repo = await runtime.resolveRepoRoot(args.requirePath("repo"))
+  const repo = await runtime.resolveRepoRoot(args.requireRepo("repo"))
   const sinceMs = Date.now() - (args.int("since-days") ?? DEFAULT_SINCE_DAYS) * 86_400_000
 
   const { tasks: allTasks } = await daemon.request<{ tasks: SerializedTask[] }>("task.list")

--- a/packages/kobe/src/cli/api/handlers-tasks.ts
+++ b/packages/kobe/src/cli/api/handlers-tasks.ts
@@ -31,7 +31,7 @@ export async function issueUpdate(ctx: VerbContext): Promise<unknown> {
   if (title === undefined && body === undefined && task === undefined) {
     throw new ApiError("issue-update requires --title, --body, and/or --task", "MISSING_FLAG")
   }
-  const repoRoot = ctx.args.requirePath("repo")
+  const repoRoot = ctx.args.requireRepo("repo")
   const id = ctx.args.int("id")
   let result: unknown
   if (title !== undefined || body !== undefined) {
@@ -429,7 +429,7 @@ export async function adopt(ctx: VerbContext): Promise<unknown> {
   const daemon = daemonOf(ctx)
   const { args } = ctx
   const input: Record<string, string> = {
-    repo: args.requirePath("repo"),
+    repo: args.requireRepo("repo"),
     worktreePath: args.requirePath("worktree"),
   }
   const branch = args.str("branch")

--- a/packages/kobe/src/cli/api/runtime.ts
+++ b/packages/kobe/src/cli/api/runtime.ts
@@ -184,9 +184,15 @@ async function closeHeadlessTerminalTab(
 
     const baseKey = closing ? tabPtyKeyFor(taskId, closing) : directKey
     const ownsBase = !(closing?.kind === "engine" && closing.ptyTask)
-    const keys = sessions
-      .filter((session) => (ownsBase && session.key === baseKey) || session.key.startsWith(`${baseKey}::`))
-      .map((session) => session.key)
+    // `ownsBase` gates the SPLIT LEAVES too. For a viewport tab `baseKey` is
+    // the REFERENCED task's key (`tabPtyKeyFor` resolves through `ptyTask`), so
+    // `<referenced>::tab-1::leaf-N` are that task's own splits — closing the
+    // borrowing tab must not kill them any more than it kills the base.
+    const keys = ownsBase
+      ? sessions
+          .filter((session) => session.key === baseKey || session.key.startsWith(`${baseKey}::`))
+          .map((session) => session.key)
+      : []
     const wasAlive = sessions.some((session) => keys.includes(session.key) && session.alive)
     if (host) await killTaskSessions(host.rpc, keys)
     return { kind: closing?.kind ?? "engine", wasAlive }

--- a/packages/kobe/src/cli/api/verbs-automations.ts
+++ b/packages/kobe/src/cli/api/verbs-automations.ts
@@ -105,7 +105,7 @@ export const ROUTINE_VERBS: readonly VerbSpec[] = [
     ],
     handler: (ctx) =>
       simpleRpc(ctx, "automation.create", {
-        repo: ctx.args.requirePath("repo"),
+        repo: ctx.args.requireRepo("repo"),
         name: ctx.args.require("name"),
         prompt: requirePromptText(ctx, "routine-create"),
         schedule: ctx.args.require("schedule"),

--- a/packages/kobe/src/cli/api/verbs-drive.ts
+++ b/packages/kobe/src/cli/api/verbs-drive.ts
@@ -76,7 +76,7 @@ export const DRIVE_VERBS: readonly VerbSpec[] = [
     group: "drive",
     summary: "Read a repo's accumulated field notes, newest first. Returns { notes }.",
     flags: [F.repo(true)],
-    handler: (ctx) => simpleRpc(ctx, "note.list", { repo: ctx.args.requirePath("repo") }),
+    handler: (ctx) => simpleRpc(ctx, "note.list", { repo: ctx.args.requireRepo("repo") }),
   },
   PANE_VERB,
   PANE_CLOSE_VERB,

--- a/packages/kobe/src/cli/api/verbs-issues.ts
+++ b/packages/kobe/src/cli/api/verbs-issues.ts
@@ -21,7 +21,7 @@ export const ISSUE_VERBS: readonly VerbSpec[] = [
     group: "issues",
     summary: "List daemon-owned issues for a repo.",
     flags: [F.repo()],
-    handler: (ctx) => simpleRpc(ctx, "issue.list", { repoRoot: ctx.args.requirePath("repo") }),
+    handler: (ctx) => simpleRpc(ctx, "issue.list", { repoRoot: ctx.args.requireRepo("repo") }),
   },
   {
     name: "issue-create",
@@ -34,7 +34,7 @@ export const ISSUE_VERBS: readonly VerbSpec[] = [
     ],
     handler: (ctx) =>
       simpleRpc(ctx, "issue.mutate", {
-        repoRoot: ctx.args.requirePath("repo"),
+        repoRoot: ctx.args.requireRepo("repo"),
         op: { type: "create", title: ctx.args.require("title"), body: ctx.args.str("body") },
       }),
   },
@@ -49,7 +49,7 @@ export const ISSUE_VERBS: readonly VerbSpec[] = [
     ],
     handler: (ctx) =>
       simpleRpc(ctx, "issue.mutate", {
-        repoRoot: ctx.args.requirePath("repo"),
+        repoRoot: ctx.args.requireRepo("repo"),
         op: { type: "setStatus", id: ctx.args.int("id"), status: ctx.args.requireEnum<IssueStatus>("status") },
       }),
   },

--- a/packages/kobe/src/cli/api/verbs-work-items.ts
+++ b/packages/kobe/src/cli/api/verbs-work-items.ts
@@ -33,7 +33,7 @@ export const WORK_ITEM_VERBS: readonly VerbSpec[] = [
     ],
     handler: (ctx) =>
       simpleRpc(ctx, "workitem.list", {
-        repo: ctx.args.requirePath("repo"),
+        repo: ctx.args.requireRepo("repo"),
         ...(ctx.args.str("state") ? { state: ctx.args.str("state") } : {}),
         ...(ctx.args.int("limit") !== undefined ? { limit: ctx.args.int("limit") } : {}),
         ...(ctx.args.str("search") ? { search: ctx.args.str("search") } : {}),
@@ -54,7 +54,7 @@ export const WORK_ITEM_VERBS: readonly VerbSpec[] = [
     ],
     handler: (ctx) =>
       simpleRpc(ctx, "workitem.start", {
-        repo: ctx.args.requirePath("repo"),
+        repo: ctx.args.requireRepo("repo"),
         number: ctx.args.int("number"),
         ...(ctx.args.vendor() ? { vendor: ctx.args.vendor() } : {}),
         ...(ctx.args.str("base-branch") ? { baseRef: ctx.args.str("base-branch") } : {}),

--- a/packages/kobe/src/cli/api/verbs-worktree.ts
+++ b/packages/kobe/src/cli/api/verbs-worktree.ts
@@ -25,7 +25,7 @@ export const WORKTREE_VERBS: readonly VerbSpec[] = [
     group: "worktree",
     summary: "List existing git worktrees in a repo not yet tracked as Rove tasks. Returns { worktrees }.",
     flags: [F.repo()],
-    handler: (ctx) => simpleRpc(ctx, "worktree.discoverAdoptable", { repo: ctx.args.requirePath("repo") }),
+    handler: (ctx) => simpleRpc(ctx, "worktree.discoverAdoptable", { repo: ctx.args.requireRepo("repo") }),
   },
   {
     name: "adopt",

--- a/packages/kobe/src/orchestrator/core.ts
+++ b/packages/kobe/src/orchestrator/core.ts
@@ -366,10 +366,10 @@ export class Orchestrator {
   async clearWorktreePath(id: TaskId | string): Promise<void> {
     const task = this.store.get(id)
     if (!task || !task.worktreePath) return
-    // Only a Rove-created worktree has a path worth forgetting. A `dir` task's
-    // worktreePath IS the user's own directory, so blanking it makes
-    // `ensureWorktree` hand back "" forever; a `main` task's is the checkout.
-    // `handlers-worktree.ts` matches by exact path, which matches those too.
+    // Only a Rove-created worktree is ours to forget: a `dir` task's path IS
+    // the user's directory (blanking it makes `ensureWorktree` return "" for
+    // good), a `main` task's is the checkout, and `handlers-worktree.ts`
+    // matches both by exact path.
     if (task.kind === "main" || task.kind === "dir") return
     await this.store.update(task.id, { worktreePath: "" })
     this.worktreeCoordinator.forget(task.id)
@@ -438,9 +438,8 @@ export class Orchestrator {
   /** Land a task's branch back into its base repo — executor + cleanup in `land.ts`. */
   async landTask(id: TaskId | string, opts?: LandTaskOpts): Promise<LandResult> {
     const task = this.requireTask(id)
-    // Same refusal every other worktree entry point makes (`setActiveTask`,
-    // `ensureWorktree`): without it a land races the daemon's deletion runner
-    // over the same directory.
+    // The refusal every other worktree entry point makes (`setActiveTask`,
+    // `ensureWorktree`): without it a land races the deletion runner.
     if (task.deletion) throw new TaskDeletingError(String(task.id))
     return landTaskWithCleanup(task, opts ?? {}, {
       worktrees: this.worktrees,

--- a/packages/kobe/src/orchestrator/core.ts
+++ b/packages/kobe/src/orchestrator/core.ts
@@ -366,6 +366,11 @@ export class Orchestrator {
   async clearWorktreePath(id: TaskId | string): Promise<void> {
     const task = this.store.get(id)
     if (!task || !task.worktreePath) return
+    // Only a Rove-created worktree has a path worth forgetting. A `dir` task's
+    // worktreePath IS the user's own directory, so blanking it makes
+    // `ensureWorktree` hand back "" forever; a `main` task's is the checkout.
+    // `handlers-worktree.ts` matches by exact path, which matches those too.
+    if (task.kind === "main" || task.kind === "dir") return
     await this.store.update(task.id, { worktreePath: "" })
     this.worktreeCoordinator.forget(task.id)
   }
@@ -432,7 +437,12 @@ export class Orchestrator {
 
   /** Land a task's branch back into its base repo — executor + cleanup in `land.ts`. */
   async landTask(id: TaskId | string, opts?: LandTaskOpts): Promise<LandResult> {
-    return landTaskWithCleanup(this.requireTask(id), opts ?? {}, {
+    const task = this.requireTask(id)
+    // Same refusal every other worktree entry point makes (`setActiveTask`,
+    // `ensureWorktree`): without it a land races the daemon's deletion runner
+    // over the same directory.
+    if (task.deletion) throw new TaskDeletingError(String(task.id))
+    return landTaskWithCleanup(task, opts ?? {}, {
       worktrees: this.worktrees,
       clearWorktreePath: (tid) => this.clearWorktreePath(tid),
       tearDownSession: this.tearDownSession,

--- a/packages/kobe/src/orchestrator/worktree/manager-list.ts
+++ b/packages/kobe/src/orchestrator/worktree/manager-list.ts
@@ -130,7 +130,10 @@ export async function listManaged(deps: ListDeps, repo: string): Promise<readonl
     path: e.callerPath,
     branch: e.branch,
     head: e.head,
-    dirty: await deps.isDirty(e.probePath),
+    // A worktree can vanish between the porcelain snapshot and this probe, and
+    // an unguarded throw here fails the WHOLE list — the entire sidebar goes
+    // dark over one stale row. Unknown reads as clean, like the sibling probe.
+    dirty: await deps.isDirty(e.probePath).catch(() => false),
   }))
 }
 
@@ -141,7 +144,10 @@ export async function listAllAdoptable(deps: ListDeps, repo: string): Promise<re
   // Probe dirty + last-activity for every survivor concurrently (bounded) — two
   // git spawns / ssh round-trips each, the slow part of this call.
   const infos = await mapWithLimit(adoptable, PROBE_CONCURRENCY, async (entry) => {
-    const [dirty, activityMs] = await Promise.all([deps.isDirty(entry.path), lastActivityMs(deps, ctx, entry.path)])
+    const [dirty, activityMs] = await Promise.all([
+      deps.isDirty(entry.path).catch(() => false),
+      lastActivityMs(deps, ctx, entry.path),
+    ])
     return {
       path: entry.path,
       branch: entry.branch,

--- a/packages/kobe/src/orchestrator/worktree/paths.ts
+++ b/packages/kobe/src/orchestrator/worktree/paths.ts
@@ -243,9 +243,14 @@ export function isUnderManagedWorktreesRoot(candidate: string): boolean {
     if (!rootPath) continue
     const root = canonicalize(rootPath)
     const rel = path.relative(root, target)
-    // Non-empty (the root itself is not a worktree), no ".." prefix (outside),
-    // not absolute (different drive on Windows).
-    if (rel !== "" && !rel.startsWith("..") && !path.isAbsolute(rel)) return true
+    // No ".." prefix (outside), not absolute (different drive on Windows), and
+    // EXACTLY the `<repo-key>/<slug>` shape this module creates (see
+    // `worktreePathFor`). Accepting any depth meant a Settings worktree-location
+    // override pointed at `~` or `~/code` let every unrelated sibling project
+    // answer yes here — and this answer is what authorizes `rm -rf` in
+    // `manager-remove.ts`.
+    if (rel.startsWith("..") || path.isAbsolute(rel)) continue
+    if (rel.split(path.sep).filter(Boolean).length === 2) return true
   }
   return false
 }

--- a/packages/kobe/src/tui-react/component/automations-page.tsx
+++ b/packages/kobe/src/tui-react/component/automations-page.tsx
@@ -39,6 +39,11 @@ const POLL_MS = 5_000
  *  `dispatch_failed` wants a human. Collapsing them would hide that. */
 const RUN_TONE: Record<string, "success" | "muted" | "warning" | "error"> = {
   dispatched: "success",
+  // Delivered, so not grey: `revived` reached a respawned session (the status
+  // text carries the lost-context caveat), `deferred` reached the Inbox and is
+  // warning rather than success because it is parked until a human releases it.
+  revived: "success",
+  deferred: "warning",
   skipped_precheck: "muted",
   skipped_missed: "warning",
   skipped_unavailable: "warning",

--- a/packages/kobe/src/tui-react/workspace/terminal-tabs-shared.ts
+++ b/packages/kobe/src/tui-react/workspace/terminal-tabs-shared.ts
@@ -383,5 +383,9 @@ export function appendBackgroundEngineTab(
   }
   setTaskTabs(taskId, next)
   kv.set(terminalTabsKey(taskId), next)
+  // A real open, not a mount-time restore: without this the tab's eventual
+  // `tab.closed` (terminal-tabs-close.ts) is the first a plugin ever hears of
+  // it, and anything counting open panes underflows.
+  reportTabsDelta(taskId, state.tabs, next.tabs)
   return { state: next, tab }
 }

--- a/packages/kobe/test/daemon/lifetime-faults.test.ts
+++ b/packages/kobe/test/daemon/lifetime-faults.test.ts
@@ -1,0 +1,96 @@
+import { existsSync } from "node:fs"
+import { afterEach, describe, expect, it } from "vitest"
+import { type DaemonHarness, bootDaemonHarness, fakeOrchestrator, waitFor } from "./harness.ts"
+
+/**
+ * The daemon's lifetime bookkeeping under a THROW.
+ *
+ * Each of the three cases below latches or acquires something before running
+ * work that can fail, and the failure then strands the daemon in a state no
+ * later call can leave: a gui refcount that never reaches 0 (so it never
+ * idle-exits and every collector polls forever), or a socket + pidfile still
+ * on disk in front of a daemon that has already torn its insides down and
+ * answers `hello` anyway. All three fail loudly here and silently in
+ * production, which is why they get a test rather than a comment.
+ */
+
+const GRACE_MS = 80
+
+describe("daemon lifetime under a failing dependency", () => {
+  let h: DaemonHarness
+
+  afterEach(async () => {
+    await h.close()
+  })
+
+  it("does not pin the gui refcount when the SSE hydration snapshot throws", async () => {
+    h = await bootDaemonHarness({
+      web: {
+        snapshot: () => {
+          throw new Error("listTasks exploded")
+        },
+      },
+    })
+    const web = h.web
+    if (!web) throw new Error("harness web transport missing")
+
+    await web.fetch("/events").catch(() => null)
+
+    // The acquire hands back the ONLY way to release, so an open that dies
+    // before it can return that closure leaves a gui nothing can subtract.
+    expect(web.sse.opened).toBe(web.sse.closed)
+  })
+
+  it("still balances the refcount on a healthy open/close", async () => {
+    h = await bootDaemonHarness({ web: true })
+    const web = h.web
+    if (!web) throw new Error("harness web transport missing")
+
+    const controller = new AbortController()
+    await web.fetch("/events", { signal: controller.signal })
+    expect(web.sse.opened).toBe(1)
+
+    controller.abort()
+    expect(await waitFor(() => web.sse.closed === 1, 1000)).toBe(true)
+  })
+
+  it("close() unlinks the socket even when the teardown throws partway", async () => {
+    h = await bootDaemonHarness({
+      orchestrator: fakeOrchestrator({
+        subscribeTasks: (listener: (snapshot: unknown[]) => void) => {
+          listener([])
+          return () => {
+            throw new Error("store unsubscribe exploded")
+          }
+        },
+      }),
+    })
+    expect(existsSync(h.socketPath)).toBe(true)
+
+    // `stopping` is already latched by the time this throws, so leaving the
+    // socket behind means a zombie that answers RPCs and never retries.
+    await expect(h.server.close()).resolves.toBeUndefined()
+    expect(existsSync(h.socketPath)).toBe(false)
+    expect(existsSync(h.pidPath)).toBe(false)
+  })
+
+  it("idle-stops through to teardown when the stop hook rejects", async () => {
+    h = await bootDaemonHarness({
+      env: { KOBE_DAEMON_IDLE_GRACE_MS: String(GRACE_MS) },
+      server: {
+        onStop: async () => {
+          throw new Error("core.close exploded")
+        },
+      },
+    })
+    const client = h.client()
+    await client.request("hello")
+    await client.subscribe({ role: "gui" })
+    expect(existsSync(h.socketPath)).toBe(true)
+
+    client.close()
+    // Nothing re-arms the idle timer once `stopping` is latched, so a stop
+    // hook that takes the close down with it means the daemon never exits.
+    expect(await waitFor(() => !existsSync(h.socketPath), GRACE_MS + 1000)).toBe(true)
+  })
+})

--- a/packages/kobe/test/orchestrator/worktree-manager-edges.test.ts
+++ b/packages/kobe/test/orchestrator/worktree-manager-edges.test.ts
@@ -37,7 +37,10 @@ beforeAll(() => {
   // of the developer's own `~/.rove`.
   previousHome = process.env.KOBE_HOME_DIR
   process.env.KOBE_HOME_DIR = root
-  managedRoot = join(root, ".rove", "worktrees")
+  // `<worktrees-root>/<repo-key>/<slug>` — the shape `worktreePathFor`
+  // actually creates, and the only one `isUnderManagedWorktreesRoot`
+  // accepts as authorization to delete outright.
+  managedRoot = join(root, ".rove", "worktrees", "repo-0123456789ab")
   mkdirSync(managedRoot, { recursive: true })
   repo = join(root, "repo")
   mkdirSync(repo)
@@ -108,6 +111,21 @@ describe("remove() / currentBranch() edges", () => {
 
     await expect(manager.remove(wt)).rejects.toThrow(/is not a git worktree/)
     expect(existsSync(wt)).toBe(true)
+  })
+
+  it("remove({force}) refuses a sibling project sitting directly under the worktrees root", async () => {
+    // A user who points Settings → Worktree location at `~` or `~/code` makes
+    // the root an ancestor of every project they own. Depth is what separates
+    // "Rove made this" from "the user's checkout happens to live below the
+    // root": Rove only ever creates `<root>/<repo-key>/<slug>`, so a directory
+    // one level down is somebody else's, and force is not permission to
+    // `rm -rf` it.
+    const sibling = join(root, ".rove", "worktrees", "my-other-project")
+    mkdirSync(sibling, { recursive: true })
+    writeFileSync(join(sibling, "important.txt"), "not rove's")
+
+    await expect(manager.remove(sibling, { force: true })).rejects.toThrow(/not under a Rove worktrees root/)
+    expect(existsSync(join(sibling, "important.txt"))).toBe(true)
   })
 
   it("remove({force}) refuses an orphaned directory outside the managed roots", async () => {

--- a/packages/kobe/test/orchestrator/worktree-remove-partial.test.ts
+++ b/packages/kobe/test/orchestrator/worktree-remove-partial.test.ts
@@ -68,7 +68,10 @@ beforeAll(() => {
   // managed root — the one place the orphan branch would delete it.
   previousHome = process.env.KOBE_HOME_DIR
   process.env.KOBE_HOME_DIR = root
-  managedRoot = join(root, ".rove", "worktrees")
+  // `<worktrees-root>/<repo-key>/<slug>` — the shape `worktreePathFor`
+  // actually creates, and the only one `isUnderManagedWorktreesRoot`
+  // accepts as authorization to delete outright.
+  managedRoot = join(root, ".rove", "worktrees", "repo-0123456789ab")
   mkdirSync(managedRoot, { recursive: true })
   repo = join(root, "repo")
   mkdirSync(repo)


### PR DESCRIPTION
Batch D from the audit loop: one shared serializer for the daemon's file-backed stores (D1), the three daemon-lifetime fault-isolation bugs (D2), and the "smaller items noticed, not filed" sweep plus the `ssh://` repo key (D3). Three commits, one per item, because D2 and D3 both touch `web-server.ts` and would conflict as separate branches.

Rebased on `727f66aab` (0.9.95 + #816/#818/#819).

---

## D1 — one promise-tail serializer for the six file-backed stores

`8417e98` → rebased as `a0a1abd`. Pure refactor, net −103/+87 lines.

`serialized(key, fn)` now lives in `json-file.ts`, which already owned `writeJsonAtomic`; the six stores' private copies (four `enqueue` methods, two module-level `withLock`) route through it. The lock key stays the FILE PATH, rejections still settle the tail, and each store's `readStore` body is untouched (per-store corruption policy is deliberate). `gitTopLevel` moved into `repo-key.ts`, which now exposes `resolveRepoRoot` for the shared stat-and-derive half while each store keeps its own answer to "no worktree line".

Verified `deferred-prompts-store`'s second `queue` field was only the seed before dropping it.

**PASS — behaviour-preserving.**
- `KOBE_INCLUDE_SOCKET=1 bun run test:socket` → **89 files, 742 tests, all passing** (this covers all seven store test files).
- `bun run test:fast` → no new failures (see "Pre-existing red" below).
- End-to-end against an isolated daemon (every `*_SOCKET_PATH` + `KOBE_HOME_DIR` inlined): `issue-list` and `inspect` byte-identical before/after.

## D2 — the daemon releases what it acquired when shutdown or an SSE open throws

`afb3281`. All three bugs share one shape: something is latched or acquired *before* the fallible work.

- **6a** `web-server.ts` — `link.snapshot()` is evaluated outside `send`'s `try`, and `onSseOpen()` hands back the only way to undo the gui refcount. A throwing snapshot left a phantom gui nothing could remove: no idle-exit after the TUI quits, and every collector polling forever for a browser that got a 500. The payload is assembled *before* the acquire now.
- **6b** `server.ts` `close()` — no `try`/`finally`, so a throw at `await pluginHost?.stop()` skipped the broadcast, the client destroy loop and `sockGuard.release()`. The daemon had committed the destructive half and released nothing: socket and pidfile still on disk, still answering `hello`, panes never updating again. Release now runs in a `finally`.
- **6c** `stopSoon()` — a rejecting `onStop` skipped the scheduled `close()` while `stopping` stayed latched, so `rove daemon stop` reported success and the process kept running. The teardown is scheduled regardless.

**PASS — the repro, as a test.** `packages/kobe/test/daemon/lifetime-faults.test.ts` drives a real daemon through the harness, injecting the throw at each site (a throwing `snapshot()`, a throwing store unsubscribe, a rejecting `onStop`), plus a healthy open/close control.

BEFORE (same test file, `server.ts` + `web-server.ts` reverted to the pre-fix version):
```
 ❯ test/daemon/lifetime-faults.test.ts (4 tests | 3 failed) 1131ms
     × does not pin the gui refcount when the SSE hydration snapshot throws 19ms
     × close() unlinks the socket even when the teardown throws partway 4ms
     × idle-stops through to teardown when the stop hook rejects 1099ms
 Test Files  1 failed (1)
      Tests  3 failed | 1 passed (4)
```
(the one pass is the healthy-path control, which must not flip)

AFTER:
```
 Test Files  1 passed (1)
      Tests  4 passed (4)
```

For 6b the injected thrower is the store unsubscribe rather than the plugin host — same position (first statement of the destructive half), same `try`, and it is reachable through the harness's existing orchestrator seam without installing a broken plugin.

**Surface is daemon-only**, so no harness screenshots: none of the three states is rendered in the TUI status bar or `rove doctor` — the symptom is a process that will not exit and a socket that outlives its daemon.

## D3 — the smaller-items sweep

`02dde9a`. Every item re-verified against current main first.

**Already fixed on main, skipped:**
- `handlers-tasks.ts` `EMPTY_SUCCESS_REPORT` already carries `--task-id`/`--tab` forward.
- `handlers-inspect.ts:81` already uses `${taskId}::`.

**Fixed:**
| Item | What flipped |
|---|---|
| `cli/api/flags.ts` + 9 call sites | `--repo ssh://…` no longer collapses to a local path (below) |
| `worktree/paths.ts` | `isUnderManagedWorktreesRoot` requires the `<root>/<repo-key>/<slug>` shape |
| `worktree/manager-list.ts` | `isDirty` probe guarded in both `listManaged` and `listAllAdoptable` |
| `orchestrator/core.ts` | `clearWorktreePath` skips `main`/`dir` tasks; `landTask` refuses a pending deletion |
| `cli/api/runtime.ts` | `ownsBase` now gates the split leaves too, not just the base |
| `daemon/quota-resume.ts` | `tickMs <= 0` disables the sweep, like every sibling collector |
| `daemon/pr-status-collector.ts` | schedule entries for deleted tasks are pruned |
| `daemon/web-server.ts` | event-bus sink subscribes below `Bun.serve`; dead `body` removed |
| `terminal-tabs-shared.ts` | `appendBackgroundEngineTab` reports `tab.opened` |
| `automations-page.tsx` | `revived` / `deferred` get real tones |

### `--repo ssh://…` — accepted, not refused

Chose **accept**. `ssh://` is already a first-class repo key everywhere below the CLI: `savedRepos` stores it verbatim, `state/repos.ts:44-48` `resolveRepoRoot` explicitly passes it through untouched, `main-task.ts` and `worktree/paths.ts` have remote branches, and `exec-deps.ts` builds an ExecHost for it. The only thing in the way was `requirePath`'s `resolve(process.cwd(), …)` mangling the key before it ever reached that machinery — refusing would have removed a capability the daemon already has.

New `VerbArgs.requireRepo()` returns a remote key verbatim and otherwise behaves exactly like `requirePath`. Applied to **all ten** `--repo` flags (not just `add`) so every verb answers the same way. `--worktree` deliberately untouched — a remote worktree path is a separate question the note did not raise.

BEFORE/AFTER, real `rove` binaries against two isolated daemons:
```
########## BEFORE (origin/main) ##########
{"taskId":"01M1KC5CFAPF3P1W5GDGB54MMS","task":{...,
  "repo":"/Users/jacksonc/.rove/worktrees/kobe-0aff3858ab76/quetzal/ssh:/me@host/srv/proj",...}}

########## AFTER (this branch) ##########
{"taskId":"01M1KC5EKR035VFNCM76X4J6YW","task":{...,
  "repo":"ssh://me@host/srv/proj",...}}
```

### Worktree-root tightening — and why two test fixtures changed

`worktreePathFor` (`paths.ts:141`) only ever builds `<root>/<repo-key>/<slug>`, and `localWorktreesRoot`'s own docstring says the override **is** the worktrees root with the repo-key subdir still appended below it. The guard accepted any depth, so pointing Settings → Worktree location at `~` or `~/code` made every unrelated project below it answer "yes, Rove created this" — and that answer is what authorizes the `rm -rf` at `manager-remove.ts:196`.

Two fixtures built their worktree one level under the root, a shape Rove never creates; both now use `<root>/<repo-key>/<slug>`. New test `remove({force}) refuses a sibling project sitting directly under the worktrees root` locks the behaviour — it fails with the guard reverted and passes with it, and no other test in that file moves.

Failure mode of the tightening is a refusal with a clear message, never a deletion, which is the right direction for an `rm -rf` authorization.

### `revived` / `deferred` run tones — BEFORE/AFTER

Both statuses were missing from `RUN_TONE`, so both fell through to `?? "muted"` — the same grey as `skipped_precheck`, despite `automation-runner.ts:111` mapping both to `automation.dispatched`. `revived` → success (delivered; the status text carries the lost-context caveat), `deferred` → warning (delivered but parked until a human releases it from the Inbox).

Captured through the `/harness` browser → xterm.js → PTY sidecar → real OpenTUI path. Identical seeded store on both sides (one run per status), only the build differs — BEFORE on an `origin/main` worktree, AFTER on this branch:

- BEFORE: `/Users/jacksonc/.rove/worktrees/kobe-0aff3858ab76/quetzal/.scratch/d3-shots/before.png` — `#5 deferred` and `#4 revived` both grey, indistinguishable from `#6 skipped_precheck`
- AFTER: `/Users/jacksonc/.rove/worktrees/kobe-0aff3858ab76/quetzal/.scratch/d3-shots/after.png` — `#5 deferred` yellow, `#4 revived` green, `#6 skipped_precheck` still grey

**Not fixed, deliberately** (each with the reason):
- `deferred-prompts-store.ts` TTL — the note calls `list()` not writing a one-line bug. It is not: `flushDeferredPrompts` **claims** each expired record so it can delete that record's Inbox pointer before completing the claim, so pruning inside `list()` strands the pointers. I tried it; `handlers-deferred.test.ts` "returns TTL-pruned ids and removes their stale Inbox pointers" fails immediately (the record is gone before `claim()` runs, so it lands in `cleanupPending` instead of `expired`). Reverted, and the invariant is now a comment. The real defect is the second half of the note — nothing schedules a flush — and fixing that means a new collector that also *delivers* retained prompts on a timer. That is a behaviour decision, not a sweep item.
- `client/remote-orchestrator.ts` `reconnectLoop(spawnDaemon)` — the note says `manualReconnect` has no callers. Fixing dead code.
- `land.ts` teardown ordering and `manager-remove.ts` retried force-remove — both are real, both change destructive semantics, and the second is a documented tradeoff (comment at `manager-remove.ts:164-166`). Too big for a sweep commit.
- `daemon/server.ts:155` unlink timing — architectural (moving the unlink past `initDaemonStores` / collectors / plugin host), and `createSocketOwnershipGuard` covers the split-brain it creates. Worth its own brief.

## D4 — owed screenshot pair for #813: NOT DONE

Reporting this honestly rather than claiming it. I built the whole scenario in the isolated fixture — sentinel engine script installed via `engineCommand.claude`, a `--persistent-session` routine, the standing task's tab live and typed into without enter, `routine-run-now` fired with the full isolated env inlined — and **could not reach the `deferred` branch**:

- Delivery is a single peek with no retry, and `routine-run-now` costs a fixed ~15s in this fixture (measured repeatedly, warm daemon, no TUI). The default `recent-human-write` window is 10s, so the write is always stale by the time the peek happens.
- Raising `KOBE_PTY_HUMAN_WRITE_QUIET_MS` to 180s and restarting the harness did not flip it either. `api send` to the same tab also returns `ok:true, engineReady:false`, and the tab's scrollback shows the sentinel banner printed repeatedly — the session is being respawned, so the peek is reading a session other than the one the browser typed into.
- Layer B (`composer-not-empty`) needs a vendor `screenManifest`, which a sentinel engine does not have, so only layer A was ever available here.

So this is the known fixture limit: a harness fixture without a logged-in real engine cannot hold one stable standing session across a 15s dispatch. Reaching it needs either a real logged-in engine in the fixture or a seam to drive the peek directly. Nothing has been posted to #813.

## Pre-existing red on `main` (not from this branch)

`bun run test:fast` shows 6 failures on this branch; **all 6 also fail without it**:
- `test/tui/continue-live-vendor.test.ts` (2) — **red on `origin/main` today**, reproduced in a clean baseline worktree under `~/i`. Worth a look independently of this PR.
- `test/cli/open-dir-cmd.test.ts` (2) + `test/state/project-eligibility.test.ts` (2) — path-shape artifacts of running the suite from inside `~/.rove/worktrees`; all four pass in the same clean baseline worktree.

`test:socket` 742/742 green, `bun test test/render` 440/440 green, root `lint`, `typecheck` and `knip` clean.

## Leftovers for you

Created and left in place (I don't delete without being asked): the baseline worktree `/Users/jacksonc/i/kobe-baseline-d` (at `origin/main`, used for the BEFORE captures and the flake baseline) and the gitignored fixture dirs under `.scratch/` in this worktree.

---

## File-size cap

`web-server.ts` is back under the cap (491 → 500). Two files are two lines over; I tightened the prose the fix commits added (`654bedc`) rather than inventing a boundary, and neither has a seam worth cutting for two lines:

file-size-exemption: packages/kobe-daemon/src/daemon/server.ts — 486 → 502 lines (+16, of which 11 are the fault-isolation comments). The one real seam is the shutdown half, but `close()` is a single `try`/`finally` whose two halves must stay adjacent to be readable, and `webServer` is a mutable local the extracted module would need a ref or setter for — splitting it would make the exact bug this PR fixes harder to see, not easier.

file-size-exemption: packages/kobe/src/orchestrator/core.ts — 493 → 502 lines (+9, two guards plus their comments). The file is already a thin facade delegating to TaskEditor, MainTaskCoordinator, the deletion runner and the worktree coordinator; what is left is mostly one-line forwarding, so any further split would be an arbitrary alphabetical cut rather than a boundary.
