### PR TITLE
SECURITY: stop serving the web token to unauthenticated callers

### DIFF
--- a/.changeset/web-token-not-served-to-anonymous-callers.md
+++ b/.changeset/web-token-not-served-to-anonymous-callers.md
@@ -1,0 +1,22 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Stop serving the web-transport bearer token to unauthenticated callers.
+
+The daemon injected `<meta name="rove-web-token">` into every `GET /`, and
+that route is deliberately ungated (a browser cannot attach a bearer header to
+the subresources it fetches itself). So any caller that could open the
+loopback port — `curl` sends no `Origin`, which the CSRF check permits — read
+the credential out of the page body and then drove the whole `/api/*` surface,
+including `task.setCommand`, which sets an engine's launch argv. On a shared
+machine that reached any other local user, which is exactly the boundary the
+token file's 0600 mode exists to hold. Exposure was limited to callers who
+could reach the daemon's web port; it was not reachable from a remote network
+unless the port had been bound off loopback.
+
+The shell is still served to anyone — it is public build output — but the
+token is now echoed back only to a request that already presented it. `rove
+web` prints a URL carrying `?token=…` so the first navigation bootstraps, and
+the dashboard remembers it for the rest of the browser session, so in-app
+navigation and reloads keep working.

--- a/packages/kobe-daemon/package.json
+++ b/packages/kobe-daemon/package.json
@@ -70,6 +70,7 @@
     "./daemon/transcript-activity-collector": "./src/daemon/transcript-activity-collector.ts",
     "./daemon/ui-prefs-watcher": "./src/daemon/ui-prefs-watcher.ts",
     "./daemon/web-server": "./src/daemon/web-server.ts",
+    "./daemon/web-token": "./src/daemon/web-token.ts",
     "./daemon/web-session": "./src/daemon/web-session.ts",
     "./daemon/worktree-changes-collector": "./src/daemon/worktree-changes-collector.ts",
     "./plugins/env": "./src/plugins/env.ts",

--- a/packages/kobe-daemon/src/daemon/web-server.ts
+++ b/packages/kobe-daemon/src/daemon/web-server.ts
@@ -249,21 +249,29 @@ async function quickPromptsPut(runtime: DaemonRuntimeAdapter, req: Request): Pro
 }
 
 /**
- * Hand the SPA its token by rewriting the served HTML.
+ * Echo the token back into the served HTML, for a caller that already proved
+ * it holds one.
  *
- * The alternative — a `/api/token` endpoint the SPA calls on boot — cannot
- * work: to be reachable before the SPA holds a token it would have to be
- * unauthenticated, which makes it a back door that hands the credential to
- * precisely the caller this whole mechanism exists to turn away. Shipping the
- * token WITH the page is safe for the same reason the page itself is: both
- * are already behind the Origin check and the loopback bind, and anything
- * able to fetch the page could equally read the token file.
+ * This is a CONVENIENCE, never a bootstrap: the SPA arrives at `/?token=…`
+ * (the URL `rove web` prints), and the meta tag is how the token crosses from
+ * the address bar into a place `fetch` can read on every later navigation.
+ *
+ * It must stay bound to an authenticated requester. `/` is deliberately
+ * outside {@link requiresWebToken} — a browser cannot attach a bearer header
+ * or the query token to the subresources it fetches on its own, so gating the
+ * shell 401s every script and stylesheet. Injecting unconditionally into that
+ * open page turned it into a credential dispenser: `curl` with no Origin and
+ * no token read the value out of the body and drove the whole `/api/*`
+ * surface, including `task.setCommand` (arbitrary command execution). The
+ * 0600 mode on the token file exists to stop exactly that caller.
  */
 function injectWebToken(html: string, token: string): string {
   const tag = `<meta name="rove-web-token" content="${token}">`
   return html.includes("</head>") ? html.replace("</head>", `  ${tag}\n  </head>`) : `${tag}${html}`
 }
 
+/** `token` is supplied ONLY when the request presented it — see
+ *  {@link injectWebToken}. An anonymous caller gets the shell verbatim. */
 async function staticResponse(pathname: string, staticDir: string, token?: string): Promise<Response> {
   const rel = pathname === "/" ? "/index.html" : pathname
   const resolved = normalize(join(staticDir, rel))
@@ -313,11 +321,11 @@ export function createDaemonWebRequestHandler(deps: RequestHandlerDeps): (req: R
     // A `curl` sends no Origin and so sails past the check above; it is this
     // gate that stops it. Everything that reads or mutates daemon state goes
     // through here, so a route added later is authenticated by default.
-    if (
-      requiresWebToken(url, DAEMON_WEB_HEALTH_PATH) &&
-      deps.webToken &&
-      !tokensMatch(presentedToken(req, url), deps.webToken)
-    ) {
+    // Computed for EVERY path, not just the gated ones, because the static
+    // shell needs the same answer to decide whether it may echo the token
+    // back (see injectWebToken).
+    const authenticated = deps.webToken !== undefined && tokensMatch(presentedToken(req, url), deps.webToken)
+    if (requiresWebToken(url, DAEMON_WEB_HEALTH_PATH) && deps.webToken && !authenticated) {
       return unauthorizedResponse()
     }
     if (url.pathname === "/events") {
@@ -360,7 +368,7 @@ export function createDaemonWebRequestHandler(deps: RequestHandlerDeps): (req: R
     if (worktrees) return worktrees
     const themes = runtime.handleThemesRequest(req, url)
     if (themes) return themes
-    if (staticDir) return staticResponse(url.pathname, staticDir, deps.webToken)
+    if (staticDir) return staticResponse(url.pathname, staticDir, authenticated ? deps.webToken : undefined)
     return new Response("not found", { status: 404 })
   }
 }

--- a/packages/kobe-web/src/lib/web-token.ts
+++ b/packages/kobe-web/src/lib/web-token.ts
@@ -1,11 +1,17 @@
 /**
  * The web transport's bearer token, as the browser sees it.
  *
- * The daemon serves index.html and rewrites a `<meta name="rove-web-token">`
- * into the head on the way out, so the token arrives with the page rather
- * than over a separate fetch. There is no endpoint to ask for it: an endpoint
- * reachable before the SPA holds a token would have to be unauthenticated,
- * which is the exact hole the token exists to close.
+ * The daemon rewrites a `<meta name="rove-web-token">` into index.html for a
+ * request that ALREADY presented the token — the `?token=` on the URL `rove
+ * web` prints. It will not mint one for an anonymous caller, because `/` is
+ * ungated (a browser cannot attach a header to the subresources it fetches
+ * itself) and injecting there handed the credential to any `curl`.
+ *
+ * So the meta tag only appears on the entry navigation. `sessionStorage`
+ * carries it from there: an in-app route change drops the query, and a reload
+ * of `/board` would otherwise arrive with neither channel. Per-tab and
+ * per-origin, so it is scoped to this browser profile — the local user who
+ * cannot read the 0600 token file cannot read this either.
  *
  * Read once, but LAZILY on first use rather than at import: this module is
  * pulled in by `api-client.ts`, which unit tests import under node with no
@@ -18,12 +24,37 @@
  * nothing injects the tag. `VITE_ROVE_WEB_TOKEN` covers that case; without
  * either, requests go out bare and the daemon answers 401 with a hint.
  */
+const STORAGE_KEY = "rove-web-token"
+
+/** Storage throws outright in a few configurations (Safari private mode,
+ *  third-party-cookie blocking), and a dead dashboard is a worse outcome than
+ *  re-opening the printed URL — so every access is best-effort. */
+function remembered(): string {
+  try {
+    return sessionStorage.getItem(STORAGE_KEY)?.trim() ?? ""
+  } catch {
+    return ""
+  }
+}
+
+function remember(token: string): void {
+  try {
+    sessionStorage.setItem(STORAGE_KEY, token)
+  } catch {
+    /* storage unavailable — the token still works for this page load */
+  }
+}
+
 function readToken(): string {
-  const injected =
-    typeof document === "undefined"
-      ? undefined
-      : document.querySelector('meta[name="rove-web-token"]')?.getAttribute("content")?.trim()
-  if (injected) return injected
+  if (typeof document !== "undefined") {
+    const injected = document.querySelector('meta[name="rove-web-token"]')?.getAttribute("content")?.trim()
+    if (injected) {
+      remember(injected)
+      return injected
+    }
+    const saved = remembered()
+    if (saved) return saved
+  }
   return (import.meta.env?.VITE_ROVE_WEB_TOKEN as string | undefined)?.trim() ?? ""
 }
 

--- a/packages/kobe-web/test/web-token.test.ts
+++ b/packages/kobe-web/test/web-token.test.ts
@@ -23,10 +23,12 @@ async function freshModule(html: string | null) {
 describe("web token", () => {
   beforeEach(() => {
     document.head.innerHTML = ""
+    sessionStorage.clear()
   })
   afterEach(() => {
     vi.unstubAllGlobals()
     document.head.innerHTML = ""
+    sessionStorage.clear()
   })
 
   it("reads the token the daemon injected into the served HTML", async () => {
@@ -47,6 +49,31 @@ describe("web token", () => {
     const { withWebTokenQuery } = await freshModule('<meta name="rove-web-token" content="tok 123">')
     expect(withWebTokenQuery("/events")).toBe("/events?token=tok%20123")
     expect(withWebTokenQuery("/events?x=1")).toBe("/events?x=1&token=tok%20123")
+  })
+
+  it("remembers the entry token for later loads that carry no meta tag", async () => {
+    // The daemon injects the tag only for a request that already presented the
+    // token — the `?token=` on the URL `rove web` prints. An in-app route
+    // change drops that query, so a reload of /board arrives with neither
+    // channel and would otherwise go out unauthenticated.
+    const first = await freshModule('<meta name="rove-web-token" content="tok-entry">')
+    expect(first.webToken()).toBe("tok-entry")
+
+    const reload = await freshModule("")
+    expect(reload.webToken()).toBe("tok-entry")
+  })
+
+  it("survives storage that throws (Safari private mode)", async () => {
+    vi.stubGlobal("sessionStorage", {
+      getItem: () => {
+        throw new Error("denied")
+      },
+      setItem: () => {
+        throw new Error("denied")
+      },
+    })
+    const { webToken } = await freshModule('<meta name="rove-web-token" content="tok-nostore">')
+    expect(webToken()).toBe("tok-nostore")
   })
 
   it("leaves requests untouched when no token was injected (vite dev)", async () => {

--- a/packages/kobe/src/cli/web-cmd.ts
+++ b/packages/kobe/src/cli/web-cmd.ts
@@ -19,7 +19,8 @@ import { fileURLToPath } from "node:url"
 import { errorMessage } from "@/lib/error-message"
 import { ensureDaemonReachable } from "@sma1lboy/kobe-daemon/client/daemon-process"
 import { readRoveEnv, setRoveEnv } from "@sma1lboy/kobe-daemon/compat-env"
-import { DEFAULT_DAEMON_WEB_PORT } from "@sma1lboy/kobe-daemon/daemon/paths"
+import { DEFAULT_DAEMON_WEB_PORT, defaultWebTokenPath } from "@sma1lboy/kobe-daemon/daemon/paths"
+import { ensureWebToken } from "@sma1lboy/kobe-daemon/daemon/web-token"
 import { parsePositiveInt } from "./api/flags.ts"
 import { argvHasFlag, flagValue } from "./argv.ts"
 import { activeCliName } from "./rename-compat.ts"
@@ -142,6 +143,22 @@ async function startPtyServer(opts: {
   })
 }
 
+/**
+ * The URL to open, carrying the bearer token as a query param.
+ *
+ * A top-level navigation cannot set an `Authorization` header, so the query
+ * is the only channel a first page load has — and the daemon refuses to hand
+ * the token to a caller that did not present one, precisely so `curl` cannot
+ * read it out of the served HTML. Whoever runs this command already owns the
+ * 0600 token file, so putting it in the URL grants nothing they did not have.
+ * The SPA remembers it for the rest of the browser session, so in-app
+ * navigations and reloads no longer need the query.
+ */
+function dashboardUrl(port: number): string {
+  const token = ensureWebToken(defaultWebTokenPath())
+  return `http://localhost:${port}/?token=${encodeURIComponent(token)}`
+}
+
 async function ensureDaemonWeb(port: number, staticDir?: string): Promise<void> {
   setRoveEnv("DAEMON_WEB_PORT", String(port))
   if (staticDir) setRoveEnv("DAEMON_WEB_STATIC_DIR", staticDir)
@@ -219,7 +236,7 @@ export async function runWebSubcommand(args: readonly string[]): Promise<void> {
       process.stdout.write(`  home: ${homeLabel()}\n`)
     } else {
       pty = await startPtyServer({ webPort: port, takeover })
-      process.stdout.write(`${CLI_NAME} web → http://localhost:${port}\n`)
+      process.stdout.write(`${CLI_NAME} web → ${dashboardUrl(port)}\n`)
       process.stdout.write(`  home: ${homeLabel()}\n`)
       if (!pty) {
         process.stderr.write(`${CLI_NAME} web: PTY server not found; terminal tabs will be unavailable\n`)

--- a/packages/kobe/test/daemon/harness.ts
+++ b/packages/kobe/test/daemon/harness.ts
@@ -108,7 +108,9 @@ export interface DaemonHarnessOptions {
   /** Env vars to set for the daemon's lifetime; restored on `close()`. */
   env?: Record<string, string>
   /** Also build the web request handler (see module doc). */
-  web?: boolean | { allowedHost?: string; webToken?: string; snapshot?: () => DaemonWebSnapshotState }
+  web?:
+    | boolean
+    | { allowedHost?: string; webToken?: string; staticDir?: string; snapshot?: () => DaemonWebSnapshotState }
 }
 
 export interface DaemonHarness {
@@ -195,6 +197,7 @@ export async function bootDaemonHarness(opts: DaemonHarnessOptions = {}): Promis
       sseSends,
       allowedHost: webOpts.allowedHost,
       webToken: webOpts.webToken,
+      staticDir: webOpts.staticDir,
       // Injected recorder instead of the real tearDownTaskSession: the real
       // one reaches for PTY-sidecar state this fixture never creates.
       tearDownSession: (taskId) => tornDownSessions.push(taskId),

--- a/packages/kobe/test/daemon/web-auth.test.ts
+++ b/packages/kobe/test/daemon/web-auth.test.ts
@@ -1,7 +1,7 @@
-import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs"
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
-import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { DAEMON_WEB_HEALTH_PATH, requiresWebToken } from "../../../kobe-daemon/src/daemon/web-server.ts"
 import { ensureWebToken, presentedToken, tokensMatch } from "../../../kobe-daemon/src/daemon/web-token.ts"
 import { type DaemonHarness, bootDaemonHarness } from "./harness.ts"
@@ -100,6 +100,78 @@ describe("web transport auth — disabled", () => {
     } finally {
       await harness.close()
     }
+  })
+})
+
+describe("the served shell never mints a token", () => {
+  // The regression this pins: `/` is outside `requiresWebToken` (a browser
+  // cannot attach a bearer header to the subresources it fetches itself), and
+  // the daemon used to inject the token into that ungated page. A `curl` with
+  // no Origin and no credential read the value out of the body and then drove
+  // the whole /api/* surface — including task.setCommand, i.e. arbitrary
+  // command execution — defeating the 0600 mode on the token file.
+  const SHELL = "<html><head></head><body>ok</body></html>"
+  let dir: string
+  let harness: DaemonHarness
+
+  beforeEach(async () => {
+    dir = mkdtempSync(join(tmpdir(), "kobe-web-static-"))
+    writeFileSync(join(dir, "index.html"), SHELL, "utf8")
+    // `staticResponse` reads through `Bun.file`, and this suite runs under
+    // vitest/node where that global does not exist. A Blob is the closest
+    // faithful stand-in: `new Response(blob)` and `.text()` behave the same,
+    // so the real handler, the real route table and the real injection
+    // decision all still run — only the file primitive is substituted.
+    vi.stubGlobal("Bun", {
+      file: (path: string) => {
+        const blob = new Blob([readFileSync(path, "utf8")], { type: "text/html" })
+        return Object.assign(blob, { exists: async () => existsSync(path) })
+      },
+    })
+    harness = await bootDaemonHarness({ web: { webToken: TOKEN, staticDir: dir } })
+  })
+  afterEach(async () => {
+    vi.unstubAllGlobals()
+    await harness.close()
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  const body = async (path: string, init?: RequestInit): Promise<string> => {
+    const res = await harness.web!.fetch(path, init)
+    expect(res.status).toBe(200)
+    return await res.text()
+  }
+
+  it("serves the shell to an anonymous caller WITHOUT the token", async () => {
+    const html = await body("/")
+    expect(html).not.toContain("rove-web-token")
+    expect(html).not.toContain(TOKEN)
+    expect(html).toContain("<body>ok</body>")
+  })
+
+  it("does not leak it through a wrong token either", async () => {
+    const html = await body("/", { headers: { authorization: "Bearer not-the-token" } })
+    expect(html).not.toContain(TOKEN)
+  })
+
+  it("echoes it back to a caller that already presented it", async () => {
+    // The bootstrap `rove web` prints: a top-level navigation cannot set a
+    // header, so the query is the only channel the first page load has.
+    expect(await body(`/?token=${TOKEN}`)).toContain(`content="${TOKEN}"`)
+    expect(await body("/", { headers: { authorization: `Bearer ${TOKEN}` } })).toContain(`content="${TOKEN}"`)
+  })
+
+  it("leaves the stolen-token RPC path shut", async () => {
+    // The half that made the leak load-bearing rather than cosmetic.
+    const html = await body("/")
+    const scraped = /rove-web-token" content="([^"]*)"/.exec(html)?.[1]
+    expect(scraped).toBeUndefined()
+    const res = await harness.web!.fetch("/api/rpc", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ name: "daemon.status" }),
+    })
+    expect(res.status).toBe(401)
   })
 })
 


### PR DESCRIPTION
## G1 — SECURITY: the 0600 web token was served to any unauthenticated caller through `GET /`

`requiresWebToken` deliberately exempts the static shell (a browser cannot attach a bearer header
or the `?token=` query to the subresources it fetches itself, so gating them 401s every script and
the dashboard renders blank). But `injectWebToken` wrote the token into that same open page, and
`originAllowed(null)` lets a header-less request through — so `curl` with no Origin and no
credential read the value out of the body and then drove the whole `/api/*` surface, including
`task.setCommand` (arbitrary command execution). The 0600 mode on the token file exists to stop
exactly that caller.

### What changed

- **`web-server.ts`** — `authenticated` is now computed for every request, not only the gated
  paths, and the static shell is handed the token **only when the requester already presented it**
  (`authenticated ? deps.webToken : undefined`). An anonymous `GET /` gets the shell verbatim.
- **`web-cmd.ts`** — `rove web` now prints `http://localhost:<port>/?token=…`. A top-level
  navigation cannot set a header, so the query is the only channel the first page load has; whoever
  runs the command already owns the 0600 file, so the URL grants them nothing new.
- **`kobe-web/src/lib/web-token.ts`** — the SPA remembers the entry token in `sessionStorage`. An
  in-app route change drops the query, so a reload of `/board` would otherwise arrive with neither
  channel. Per-tab and per-origin, so it is scoped to the browser profile — the local user who
  cannot read the token file cannot read this either. Every access is wrapped (storage throws
  outright in Safari private mode).
- The `injectWebToken` doc comment's false premise ("anything able to fetch the page could equally
  read the token file") is gone, replaced with what actually makes the echo safe.

**Why option 2 (bind injection to the requester) over option 1 (gate `/` itself):** serving the
shell to anyone costs nothing once the meta tag is gone — it is public build output with no secrets
in it — and a 401 on `/` turns a stale bookmark into an error page instead of a dashboard. What had
to stop was *minting a credential for an anonymous caller*, and this stops exactly that.

### PASS criteria and proof

| criterion | result |
|---|---|
| `curl -s http://127.0.0.1:PORT/` carries no token | ✅ body is the bare shell |
| `curl -X POST /api/rpc` with no token still 401s | ✅ unchanged |
| a real browser still loads the dashboard and reaches `/events` | ✅ screenshots below |
| `test/daemon/` test pins a token-less `/` yielding HTML without the meta tag | ✅ 4 new tests in `web-auth.test.ts` |

**BEFORE** (`.scratch/g1-web-token/BEFORE-curl.txt`) — run against this branch's parent:

```
### curl -s http://127.0.0.1:7391/    (no Origin, no token)
<html><head>  <meta name="rove-web-token" content="Bz7Kj15uY13Ir7LgEWvBUoUhlflC_GKqp4CA3-kiHW4">
  </head><body>ok</body></html>

### steal the token out of the page, then drive the RPC surface
stolen token: Bz7Kj15uY13Ir7LgEWvBUoUhlflC_GKqp4CA3-kiHW4
{"result":{"daemonPid":53948,"kobeVersion":"0.9.95","uptimeMs":7767,...,"webPort":7391,"webError":null}}
```

**AFTER** (`.scratch/g1-web-token/AFTER-curl.txt`):

```
### curl -s http://127.0.0.1:7391/    (no Origin, no token)
<html><head></head><body>ok</body></html>

### try to steal the token out of the page, then drive the RPC surface
stolen token: ''  (empty = nothing to steal)
{"error":"unauthorized: this request carried no valid web token","name":"WEB_TOKEN_REQUIRED",...}

### control: RPC with no token (unchanged 401)
{"error":"unauthorized: this request carried no valid web token","name":"WEB_TOKEN_REQUIRED",...}

### the legitimate holder still gets it (the bootstrap `rove web` prints)
<html><head>  <meta name="rove-web-token" content="wHm7irvBhe2j88p-NlVtPjxem9LnXpbGZ_IWaJdCgnI">
  </head><body>ok</body></html>
```

**Screenshots** (real Chrome against an isolated daemon on `/tmp/g1-home`, port 7392, real built
web assets, three tasks seeded):

- BEFORE: `/Users/jacksonc/.rove/worktrees/kobe-0aff3858ab76/urial/.scratch/g1-web-token/before-dashboard.png`
- AFTER: `/Users/jacksonc/.rove/worktrees/kobe-0aff3858ab76/urial/.scratch/g1-web-token/after-dashboard.png`
  — identical: "daemon connected", the same 3 tasks in the sidebar, loaded through `/?token=…`.
- AFTER, deep-route reload: `/Users/jacksonc/.rove/worktrees/kobe-0aff3858ab76/urial/.scratch/g1-web-token/after-deep-route-reload.png`
  — navigated to Board (which drops the query), then hard-reloaded `http://127.0.0.1:7392/board`
  with **no** `?token=`. Still authenticated: the project header renders
  `g1-repo · 0 · /private/tmp/g1-repo`, which only comes from an authorized `/api/*` call. This is
  the `sessionStorage` carry-over doing its job.

### Mutation check

Reverting only the wiring line (`authenticated ? deps.webToken : undefined` → `deps.webToken`)
turns 3 of the 4 new tests red:

```
× the served shell never mints a token > serves the shell to an anonymous caller WITHOUT the token
× the served shell never mints a token > does not leak it through a wrong token either
× the served shell never mints a token > leaves the stolen-token RPC path shut
 Tests  3 failed | 21 passed (24)
```

### Gates

- repo-root `bun run lint` — clean
- repo-root `bun run typecheck` — clean (4 packages)
- `bun run test:socket` — **88 files / 742 tests passed**
- `bun run test:fast` — 4264 passed, **6 pre-existing environmental failures**
  (`project-eligibility`, `open-dir-cmd`, `continue-live-vendor`). Verified against a detached
  `origin/main` worktree at the same `~/.rove/worktrees/...` path shape: **identical 6 failures**
  (`expected 'roveInternal' to be null`, and `expected 'claudecpa' to be 'claude'` — a local engine
  preset on this machine). None of the three files import anything in this diff.
- `packages/kobe-web` `vitest run test/web-token.test.ts` — 9 passed (2 new)

### Notes

- One line added to `kobe-daemon`'s `exports` (`./daemon/web-token`) so the CLI can read the token
  for the printed URL.
- `test/daemon/harness.ts` gains a `staticDir` option so the shell route is reachable from the
  daemon suite at all. `staticResponse` reads through `Bun.file`, which does not exist under
  vitest/node, so the new describe block stubs `Bun.file` with a `Blob` — the real handler, route
  table and injection decision all still run; only the file primitive is substituted.
