### PR TITLE
Show the active session's context-window occupancy in the footer

### DIFF
--- a/.changeset/footer-context-meter.md
+++ b/.changeset/footer-context-meter.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+The workspace footer now shows how full the active session's context window is — `ctx 62%`, in the same ok/warn/crit tones as the quota chips beside it, suffixed `~` when the figure is the engine's own estimate rather than a number it reports. It answers a different question from the quota chips: not how much budget is left this week, but how much room is left in this conversation, which is the thing that quietly compacts your session away. The number was already engine-computed and already rendered in the browser; the TUI was discarding it. Nothing is summed or guessed in a neutral layer — a vendor that does not report its context window renders nothing rather than a percentage of an invented denominator.

--- a/packages/kobe-daemon/package.json
+++ b/packages/kobe-daemon/package.json
@@ -46,6 +46,7 @@
     "./daemon/notes-store": "./src/daemon/notes-store.ts",
     "./daemon/paths": "./src/daemon/paths.ts",
     "./daemon/platform-shell": "./src/daemon/platform-shell.js",
+    "./daemon/context-usage-collector": "./src/daemon/context-usage-collector.ts",
     "./daemon/pr-failing-checks": "./src/daemon/pr-failing-checks.ts",
     "./daemon/pr-status-collector": "./src/daemon/pr-status-collector.ts",
     "./daemon/prompt-broker": "./src/daemon/prompt-broker.ts",

--- a/packages/kobe-daemon/src/daemon/channels.ts
+++ b/packages/kobe-daemon/src/daemon/channels.ts
@@ -10,6 +10,7 @@ import { DAEMON_CHANNELS } from "@sma1lboy/rove-plugin-sdk/contract"
 import type {
   AttentionInboxItem,
   EngineActivityDetail,
+  EngineContextUsage,
   EngineQuotaUsage,
   TaskActivityState,
   UpdateInfo,
@@ -254,6 +255,20 @@ export interface ChannelPayloads {
    */
   "usage.snapshot": {
     usage: Record<string, EngineQuotaUsage>
+  }
+  /**
+   * Per-SESSION context-window occupancy, keyed `taskId::tabId` — the
+   * workspace footer's `ctx 62%` meter. The sibling of `usage.snapshot`, and
+   * deliberately a separate channel rather than a second field on it: the two
+   * have different producers and different cadences, and one last-value slot
+   * per channel means a co-tenant would clobber the other's replay.
+   *
+   * STATE channel, full-map-replace like `worktree.changes`. A session whose
+   * engine reports no usage simply never appears — the footer then renders
+   * nothing, which is the honest answer, not a zero.
+   */
+  "usage.context": {
+    context: Record<string, EngineContextUsage>
   }
   /**
    * One "ask the human for a line of text" request (`kobe api prompt` —

--- a/packages/kobe-daemon/src/daemon/collectors.ts
+++ b/packages/kobe-daemon/src/daemon/collectors.ts
@@ -12,6 +12,7 @@ import type { DaemonActivityRegistry } from "./activity-registry.ts"
 import { DEFAULT_AUTO_TITLE_POLL_MS, startAutoTitlePoller } from "./auto-title-poller.ts"
 import { DEFAULT_AUTOMATION_TICK_MS, startAutomationRunner } from "./automation-runner.ts"
 import type { AutomationsStore } from "./automations-store.ts"
+import { DEFAULT_CONTEXT_USAGE_TICK_MS, startContextUsageCollector } from "./context-usage-collector.ts"
 import type { DaemonOrchestrator, UpdateInfo } from "./contracts.ts"
 import { logDaemonError, logDaemonInfo } from "./crash-log.ts"
 import type { DaemonEventBus } from "./event-bus.ts"
@@ -45,6 +46,7 @@ export interface DaemonCollectorOptions {
   readonly keybindingsDebounceMs?: number
   readonly worktreeChangesTickMs?: number
   readonly transcriptActivityTickMs?: number
+  readonly contextUsageTickMs?: number
   readonly quotaResumeTickMs?: number
   readonly quotaUsageTickMs?: number
   readonly automationTickMs?: number
@@ -207,6 +209,21 @@ export function startDaemonCollectors(
     hasSubscribers,
   )
 
+  // Context-window occupancy per live engine session (the footer's `ctx N%`).
+  // Gated on subscribers like the other display collectors: with no pane
+  // attached there is no footer to draw it in. Needs the activity registry —
+  // it is what knows which tabs have a live session.
+  const stopContextUsageCollector = activity
+    ? startContextUsageCollector(
+        activity,
+        orch,
+        bus,
+        runtime,
+        options.contextUsageTickMs ?? DEFAULT_CONTEXT_USAGE_TICK_MS,
+        hasSubscribers,
+      )
+    : () => {}
+
   // PR status is the only CI truth Rove holds, and an unattended agent is the
   // consumer that needs it most — so this collector's gate also opens on a
   // live engine, not just an attached pane (see startPrStatusPoller). With
@@ -270,5 +287,6 @@ export function startDaemonCollectors(
     stopKeybindingsWatcher()
     stopWorktreeChangesCollector()
     stopTranscriptActivityCollector()
+    stopContextUsageCollector()
   }
 }

--- a/packages/kobe-daemon/src/daemon/context-usage-collector.ts
+++ b/packages/kobe-daemon/src/daemon/context-usage-collector.ts
@@ -1,0 +1,212 @@
+/**
+ * Daemon-side context-window collector.
+ *
+ * The engine already knows how full its context window is — every adapter's
+ * history reader computes it (`readUsageSnapshot`), the browser renders it,
+ * and the TUI threw it away. This is the missing fan-out: one guarded read per
+ * LIVE ENGINE SESSION, published on `usage.context` keyed `taskId::tabId`, so
+ * the workspace footer can say `ctx 62%` without any pane touching a vendor
+ * transcript.
+ *
+ * Scope is the activity registry's live per-tab entries that carry a session
+ * id — a shell tab, a task nobody has opened, and a custom engine with no
+ * transcript store all contribute nothing, and therefore render nothing.
+ *
+ * Cadence is deliberately SLOW ({@link DEFAULT_CONTEXT_USAGE_TICK_MS}): the
+ * number moves once per agent turn, not once per frame, and each read parses a
+ * session transcript. It rides the same guards as the other collectors
+ * (in-flight dedupe, timeout, backoff, adaptive cadence) through
+ * `@/lib/poll-scheduling`'s shared shape.
+ *
+ * Publish contract, same as `worktree.changes`: the FULL map, republished only
+ * when membership or a value actually changed, so the bus's last-value replay
+ * hands a late subscriber the whole picture and quiet ticks cost nothing.
+ * Reads are best-effort — a throw keeps the entry's last value.
+ */
+
+import type { DaemonActivityRegistry } from "./activity-registry.ts"
+import type { DaemonOrchestrator, EngineContextUsage, VendorId } from "./contracts.ts"
+import { logDaemonError } from "./crash-log.ts"
+import type { DaemonEventBus } from "./event-bus.ts"
+import type { DaemonRuntimeAdapter, PollCadenceConfig, PollScheduleState } from "./runtime.ts"
+
+/** Once per ~10s: a context reading changes per TURN, not per frame. */
+export const DEFAULT_CONTEXT_USAGE_TICK_MS = 10_000
+/** Kill a transcript parse that runs longer than this. */
+export const CONTEXT_USAGE_TIMEOUT_MS = 4_000
+/** After a timeout, leave the session alone for this long. */
+export const CONTEXT_USAGE_SLOW_RETRY_MS = 60_000
+/** Floor between successful reads per session. */
+export const CONTEXT_USAGE_MIN_INTERVAL_MS = 5_000
+
+/** One live engine session the collector reads. Pure — unit-tested. */
+export interface ContextUsageTarget {
+  /** `taskId::tabId` — the published map's key. */
+  readonly key: string
+  readonly vendor: VendorId
+  readonly sessionId: string
+}
+
+export function sameContextUsage(a: EngineContextUsage, b: EngineContextUsage): boolean {
+  return (
+    a.contextTokens === b.contextTokens &&
+    a.contextWindowTokens === b.contextWindowTokens &&
+    a.approximate === b.approximate
+  )
+}
+
+/**
+ * The live engine sessions worth reading: registry entries that name BOTH a
+ * tab and a session id, joined to their task's vendor.
+ *
+ * A task-level entry with no `tabId` is skipped on purpose — the footer meter
+ * is about the tab you are looking at, and a task rollup cannot say which of
+ * its tabs the number belongs to. A session whose task is gone is skipped too:
+ * the registry outlives a delete by one tick. Pure — unit-tested.
+ */
+export function contextUsageTargets(
+  states: readonly { taskId: string; tabId?: string; sessionId?: string }[],
+  getVendor: (taskId: string) => VendorId | undefined,
+): ContextUsageTarget[] {
+  const seen = new Set<string>()
+  const targets: ContextUsageTarget[] = []
+  for (const state of states) {
+    if (!state.tabId || !state.sessionId) continue
+    const vendor = getVendor(state.taskId)
+    if (!vendor) continue
+    const key = `${state.taskId}::${state.tabId}`
+    if (seen.has(key)) continue
+    seen.add(key)
+    targets.push({ key, vendor, sessionId: state.sessionId })
+  }
+  return targets
+}
+
+interface Entry extends PollScheduleState {
+  value?: EngineContextUsage
+  /** The session this entry's value belongs to — a tab that started a NEW
+   *  session must not keep showing the old one's occupancy. */
+  sessionId?: string
+}
+
+export interface ContextUsageCollectorOptions {
+  readonly cadence?: PollCadenceConfig
+  /** Injectable reader — tests avoid real transcripts. */
+  readonly read?: (target: ContextUsageTarget, signal: AbortSignal) => Promise<EngineContextUsage | null>
+  /** Consumer gate, same as the other collectors: no subscribers, no work. */
+  readonly hasSubscribers?: () => boolean
+}
+
+export class ContextUsageCollector {
+  private readonly entries = new Map<string, Entry>()
+  private stopped = false
+
+  constructor(
+    private readonly registry: Pick<DaemonActivityRegistry, "currentNonIdle">,
+    private readonly orch: Pick<DaemonOrchestrator, "getTask">,
+    private readonly bus: DaemonEventBus,
+    private readonly runtime: Pick<DaemonRuntimeAdapter, "readEngineContextUsage">,
+    private readonly options: ContextUsageCollectorOptions = {},
+  ) {}
+
+  tick(): void {
+    if (this.stopped) return
+    if (this.options.hasSubscribers && !this.options.hasSubscribers()) return
+    try {
+      const targets = contextUsageTargets(this.registry.currentNonIdle(), (id) => this.orch.getTask(id)?.vendor)
+      const live = new Set(targets.map((t) => t.key))
+      let pruned = false
+      for (const key of [...this.entries.keys()]) {
+        if (live.has(key)) continue
+        if (this.entries.get(key)?.value) pruned = true
+        this.entries.delete(key)
+      }
+      if (pruned) this.publish()
+      for (const target of targets) this.collect(target)
+    } catch (err) {
+      logDaemonError("context-usage", err)
+    }
+  }
+
+  stop(): void {
+    this.stopped = true
+  }
+
+  private collect(target: ContextUsageTarget): void {
+    let entry = this.entries.get(target.key)
+    if (!entry) {
+      entry = { inFlight: false, nextAllowedAt: 0 }
+      this.entries.set(target.key, entry)
+    }
+    // A tab that started a new session drops the old reading immediately
+    // rather than showing it until the next successful read lands — and the
+    // drop is PUBLISHED, or the footer keeps drawing the previous
+    // conversation's occupancy at exactly the moment it is most wrong.
+    if (entry.sessionId !== undefined && entry.sessionId !== target.sessionId) {
+      const had = entry.value !== undefined
+      entry.value = undefined
+      entry.nextAllowedAt = 0
+      entry.sessionId = target.sessionId
+      if (had) this.publish()
+    }
+    entry.sessionId = target.sessionId
+    const cadence = this.options.cadence ?? {
+      timeoutMs: CONTEXT_USAGE_TIMEOUT_MS,
+      slowRetryMs: CONTEXT_USAGE_SLOW_RETRY_MS,
+      minIntervalMs: CONTEXT_USAGE_MIN_INTERVAL_MS,
+    }
+    const read =
+      this.options.read ?? ((t: ContextUsageTarget) => this.runtime.readEngineContextUsage(t.vendor, t.sessionId))
+    const startedAt = Date.now()
+    if (entry.inFlight || startedAt < entry.nextAllowedAt) return
+    entry.inFlight = true
+    const controller = new AbortController()
+    const timer = setTimeout(() => controller.abort(), cadence.timeoutMs)
+    const held = entry
+    void read(target, controller.signal)
+      .then((value) => {
+        if (controller.signal.aborted || this.stopped) return
+        // Pruned (task deleted) mid-read: a completion must not resurrect it.
+        if (this.entries.get(target.key) !== held) return
+        if (!value) return
+        if (held.value && sameContextUsage(held.value, value)) return
+        held.value = value
+        this.publish()
+      })
+      .catch(() => {})
+      .finally(() => {
+        clearTimeout(timer)
+        const finishedAt = Date.now()
+        held.nextAllowedAt = controller.signal.aborted
+          ? startedAt + cadence.slowRetryMs
+          : finishedAt + Math.max(cadence.minIntervalMs, (finishedAt - startedAt) * 5)
+        held.inFlight = false
+      })
+  }
+
+  private publish(): void {
+    const context: Record<string, EngineContextUsage> = {}
+    for (const [key, entry] of this.entries) if (entry.value) context[key] = entry.value
+    this.bus.publish("usage.context", { context })
+  }
+}
+
+/** Start the production collector on an interval; `tickMs <= 0` disables it. */
+export function startContextUsageCollector(
+  registry: Pick<DaemonActivityRegistry, "currentNonIdle">,
+  orch: Pick<DaemonOrchestrator, "getTask">,
+  bus: DaemonEventBus,
+  runtime: Pick<DaemonRuntimeAdapter, "readEngineContextUsage">,
+  tickMs: number = DEFAULT_CONTEXT_USAGE_TICK_MS,
+  hasSubscribers?: () => boolean,
+): () => void {
+  if (tickMs <= 0) return () => {}
+  const collector = new ContextUsageCollector(registry, orch, bus, runtime, { hasSubscribers })
+  collector.tick()
+  const timer = setInterval(() => collector.tick(), tickMs)
+  timer.unref?.()
+  return () => {
+    clearInterval(timer)
+    collector.stop()
+  }
+}

--- a/packages/kobe-daemon/src/daemon/contracts.ts
+++ b/packages/kobe-daemon/src/daemon/contracts.ts
@@ -402,6 +402,24 @@ export interface UpdateInfo {
   readonly hasUpdate: boolean
 }
 
+/**
+ * The CONTEXT half of an engine's usage snapshot, for one live session.
+ *
+ * Structural mirror of the three context fields on kobe's
+ * `EngineUsageSnapshot` (`kobe/src/types/engine.ts`, the contract's source of
+ * truth), narrowed to what the footer meter renders. The daemon never
+ * COMPUTES these — the engine's own history reader does, because what counts
+ * as "context" is vendor arithmetic (CLAUDE.md, "Engine-owned UI data").
+ */
+export interface EngineContextUsage {
+  /** Tokens currently in the session's context window. */
+  readonly contextTokens: number
+  /** The model's context window, when the vendor reports one. */
+  readonly contextWindowTokens?: number
+  /** True when `contextTokens` is estimated rather than engine-reported. */
+  readonly approximate?: boolean
+}
+
 export interface WorktreeChanges {
   readonly added: number
   readonly deleted: number

--- a/packages/kobe-daemon/src/daemon/runtime.ts
+++ b/packages/kobe-daemon/src/daemon/runtime.ts
@@ -4,6 +4,7 @@ import type {
   DaemonOrchestrator,
   DaemonTask,
   EngineActivityKind,
+  EngineContextUsage,
   EngineQuotaUsage,
   UpdateInfo,
   VendorId,
@@ -87,6 +88,14 @@ export interface DaemonRuntimeAdapter {
    *  falls back to its own resolution ladder when it is absent or stale, and
    *  omits `behind` when nothing resolves. */
   runWorktreeStatus(worktreePath: string, signal: AbortSignal, baseRef?: string): Promise<WorktreeChanges>
+  /**
+   * The engine's own context-window reading for one live session. Delegated
+   * straight to the vendor's history reader — the daemon never sums vendor
+   * fields itself. `null` when the engine reports none (custom engines, a
+   * session with no transcript yet, kimi's unverified wire), which is
+   * different from a reported zero.
+   */
+  readEngineContextUsage(vendor: VendorId, sessionId: string): Promise<EngineContextUsage | null>
   maybeAutoStart(orch: DaemonOrchestrator, taskId: string): Promise<string>
   listWorktreeProjects(network: boolean): Promise<unknown[]>
   /** Remove a worktree. Resolves with the leftover directory when git

--- a/packages/kobe-plugin-sdk/src/contract.ts
+++ b/packages/kobe-plugin-sdk/src/contract.ts
@@ -128,6 +128,7 @@ export const DAEMON_CHANNELS = [
   "engine.lifecycle",
   "notice.event",
   "usage.snapshot",
+  "usage.context",
   "ui.prompt",
 ] as const
 

--- a/packages/kobe/src/client/remote-orchestrator-events.ts
+++ b/packages/kobe/src/client/remote-orchestrator-events.ts
@@ -30,9 +30,11 @@ import {
   decodeUiPrefsPayload,
   describePayload,
   deserializeTask,
+  parseContextUsagePayload,
   parseTranscriptActivityPayload,
   parseUsageSnapshotPayload,
   parseWorktreeChangesPayload,
+  sameContextUsageMap,
   sameTranscriptActivityMap,
   sameUsageSnapshotMap,
   sameWorktreeChangesMap,
@@ -270,6 +272,17 @@ export function handleOrchestratorEvent(name: string, payload: unknown, signals:
     const current = signals.usageSnapshotAcc()
     if (current && sameUsageSnapshotMap(current, next)) return
     signals.setUsageSnapshotSig(next)
+    return
+  }
+  if (name === "usage.context") {
+    const next = parseContextUsagePayload(payload)
+    if (!next) {
+      logClientError("orch", `dropped usage.context event: malformed context payload (${describePayload(payload)})`)
+      return
+    }
+    const current = signals.contextUsageAcc()
+    if (current && sameContextUsageMap(current, next)) return
+    signals.setContextUsageSig(next)
     return
   }
   if (name === "worktree.changes") {

--- a/packages/kobe/src/client/remote-orchestrator-payloads.ts
+++ b/packages/kobe/src/client/remote-orchestrator-payloads.ts
@@ -179,6 +179,56 @@ export function sameWorktreeChangesMap(a: WorktreeChangesMap, b: WorktreeChanges
 export type UsageSnapshotMap = ReadonlyMap<string, EngineQuotaUsage>
 
 /**
+ * Context-window occupancy per live engine session, keyed `taskId::tabId`,
+ * from the `usage.context` channel. `null` means "no daemon-collected data
+ * yet" (older daemon, nothing live) — the footer then renders nothing.
+ */
+export interface ContextUsage {
+  readonly contextTokens: number
+  readonly contextWindowTokens?: number
+  readonly approximate?: boolean
+}
+export type ContextUsageMap = ReadonlyMap<string, ContextUsage>
+
+/**
+ * Parse a `usage.context` wire payload. `null` for a malformed one (the event
+ * is ignored rather than clobbering a good map). Each entry is validated
+ * field-by-field: this is a trust boundary, and one bad row drops the payload.
+ */
+export function parseContextUsagePayload(payload: unknown): Map<string, ContextUsage> | null {
+  const context = (payload as { context?: unknown } | undefined)?.context
+  if (!context || typeof context !== "object" || Array.isArray(context)) return null
+  const map = new Map<string, ContextUsage>()
+  for (const [key, value] of Object.entries(context as Record<string, unknown>)) {
+    const v = value as { contextTokens?: unknown; contextWindowTokens?: unknown; approximate?: unknown } | undefined
+    if (typeof v?.contextTokens !== "number") return null
+    if (v.contextWindowTokens !== undefined && typeof v.contextWindowTokens !== "number") return null
+    map.set(key, {
+      contextTokens: v.contextTokens,
+      ...(typeof v.contextWindowTokens === "number" ? { contextWindowTokens: v.contextWindowTokens } : {}),
+      ...(v.approximate === true ? { approximate: true } : {}),
+    })
+  }
+  return map
+}
+
+/** Value equality for two context maps (gate re-renders on real changes). */
+export function sameContextUsageMap(a: ContextUsageMap, b: ContextUsageMap): boolean {
+  if (a.size !== b.size) return false
+  for (const [key, value] of a) {
+    const other = b.get(key)
+    if (
+      !other ||
+      other.contextTokens !== value.contextTokens ||
+      other.contextWindowTokens !== value.contextWindowTokens ||
+      other.approximate !== value.approximate
+    )
+      return false
+  }
+  return true
+}
+
+/**
  * Folded `engine.lifecycle` state per task — the sidebar's subagent mark.
  * Compaction deliberately keeps NO client state: its end event can be
  * cancelled (esc during /compact), so a compacting flag has no reliable
@@ -352,6 +402,8 @@ export interface OrchestratorSignals {
   readonly setWorktreeChangesSig: (next: WorktreeChangesMap | null) => void
   readonly usageSnapshotAcc: ReadableState<UsageSnapshotMap | null>
   readonly setUsageSnapshotSig: (next: UsageSnapshotMap | null) => void
+  readonly contextUsageAcc: ReadableState<ContextUsageMap | null>
+  readonly setContextUsageSig: (next: ContextUsageMap | null) => void
   readonly transcriptActivityAcc: ReadableState<TranscriptActivityMap | null>
   readonly setTranscriptActivitySig: (next: TranscriptActivityMap | null) => void
   readonly setNoticeSig: (next: NoticeEventPayload | null) => void

--- a/packages/kobe/src/client/remote-orchestrator-reads.ts
+++ b/packages/kobe/src/client/remote-orchestrator-reads.ts
@@ -21,6 +21,7 @@ import type { Task, TaskId } from "../types/task.ts"
 import type { UpdateInfo } from "../version.ts"
 import type {
   AttentionInboxItem,
+  ContextUsageMap,
   DaemonConnectionState,
   EngineTabStateMap,
   TaskEngineState,
@@ -43,6 +44,7 @@ export interface ReadSignals {
   readonly taskJobsAcc: ReadableState<ReadonlyMap<string, TaskJobState>>
   readonly worktreeChangesAcc: ReadableState<WorktreeChangesMap | null>
   readonly usageSnapshotAcc: ReadableState<UsageSnapshotMap | null>
+  readonly contextUsageAcc: ReadableState<ContextUsageMap | null>
   readonly transcriptActivityAcc: ReadableState<TranscriptActivityMap | null>
   readonly transcriptActivityStoreInner: ExternalStore<TranscriptActivityMap | null>
   readonly noticeAcc: ReadableState<NoticeEventPayload | null>
@@ -157,6 +159,11 @@ export function worktreeChangesSignalOp(s: ReadSignals): ReadableState<WorktreeC
  */
 export function usageSnapshotSignalOp(s: ReadSignals): ReadableState<UsageSnapshotMap | null> {
   return s.usageSnapshotAcc
+}
+
+/** Per-session context occupancy (`usage.context`) — the footer's ctx meter. */
+export function contextUsageSignalOp(s: ReadSignals): ReadableState<ContextUsageMap | null> {
+  return s.contextUsageAcc
 }
 
 /**

--- a/packages/kobe/src/client/remote-orchestrator.ts
+++ b/packages/kobe/src/client/remote-orchestrator.ts
@@ -36,6 +36,7 @@ import { performInit, runReconnectLoop } from "./remote-orchestrator-connect.ts"
 import { handleOrchestratorEvent } from "./remote-orchestrator-events.ts"
 import {
   type AttentionInboxItem,
+  type ContextUsageMap,
   type DaemonConnectionState,
   type EngineLifecycleMap,
   type EngineTabStateMap,
@@ -94,6 +95,7 @@ export class RemoteOrchestrator {
   private readonly taskJobsAcc = createStateCell<ReadonlyMap<string, TaskJobState>>(new Map())
   private readonly worktreeChangesAcc = createStateCell<WorktreeChangesMap | null>(null)
   private readonly usageSnapshotAcc = createStateCell<UsageSnapshotMap | null>(null)
+  private readonly contextUsageAcc = createStateCell<ContextUsageMap | null>(null)
   private readonly transcriptActivityAcc = createStateCell<TranscriptActivityMap | null>(null)
   private readonly noticeAcc = createStateCell<NoticeEventPayload | null>(null)
   private readonly tabOpenAcc = createStateCell<TabOpenPayload | null>(null)
@@ -144,6 +146,8 @@ export class RemoteOrchestrator {
       setWorktreeChangesSig: this.worktreeChangesAcc.set,
       usageSnapshotAcc: this.usageSnapshotAcc,
       setUsageSnapshotSig: this.usageSnapshotAcc.set,
+      contextUsageAcc: this.contextUsageAcc,
+      setContextUsageSig: this.contextUsageAcc.set,
       transcriptActivityAcc: this.transcriptActivityAcc,
       setTranscriptActivitySig: this.transcriptActivityAcc.set,
       setNoticeSig: this.noticeAcc.set,
@@ -168,6 +172,7 @@ export class RemoteOrchestrator {
       taskJobsAcc: this.taskJobsAcc,
       worktreeChangesAcc: this.worktreeChangesAcc,
       usageSnapshotAcc: this.usageSnapshotAcc,
+      contextUsageAcc: this.contextUsageAcc,
       transcriptActivityAcc: this.transcriptActivityAcc,
       transcriptActivityStoreInner: this.transcriptActivityAcc,
       noticeAcc: this.noticeAcc,
@@ -290,6 +295,8 @@ export class RemoteOrchestrator {
     reads.worktreeChangesSignalOp(this.reads)
 
   readonly usageSnapshotSignal = (): ReadableState<UsageSnapshotMap | null> => reads.usageSnapshotSignalOp(this.reads)
+  /** Per-session context occupancy (`usage.context`) — the footer's ctx meter. */
+  readonly contextUsageSignal = (): ReadableState<ContextUsageMap | null> => reads.contextUsageSignalOp(this.reads)
 
   readonly transcriptActivitySignal = (): ReadableState<TranscriptActivityMap | null> =>
     reads.transcriptActivitySignalOp(this.reads)

--- a/packages/kobe/src/core/daemon-runtime.ts
+++ b/packages/kobe/src/core/daemon-runtime.ts
@@ -143,6 +143,19 @@ export const daemonRuntime: DaemonRuntimeAdapter = {
   ensureTaskSession: ensureTaskSessionAdapter,
   startTaskSessionWithPrompt: startTaskSessionWithPromptAdapter,
   tearDownTaskSession: tearDownTaskSessionAdapter,
+  // Delegated straight to the vendor's own history reader: what counts as
+  // "context" is vendor arithmetic, and the neutral layers only render it.
+  async readEngineContextUsage(vendor, sessionId) {
+    const read = engineEntry(vendor).history.readUsageSnapshot
+    if (!read) return null
+    const snapshot = await read(sessionId)
+    if (snapshot?.context_tokens === undefined) return null
+    return {
+      contextTokens: snapshot.context_tokens,
+      ...(snapshot.context_window_tokens === undefined ? {} : { contextWindowTokens: snapshot.context_window_tokens }),
+      ...(snapshot.context_tokens_approximate ? { approximate: true } : {}),
+    }
+  },
   quotaUsage: (vendor) => engineEntry(vendor).quotaUsage?.() ?? Promise.resolve(null),
   vendorsWithQuotaProbe,
   deliverPromptToLiveEngine: deliverPromptToLiveEngineAdapter,

--- a/packages/kobe/src/tui-react/component/settings-dialog/usage-core.ts
+++ b/packages/kobe/src/tui-react/component/settings-dialog/usage-core.ts
@@ -182,6 +182,43 @@ export function buildFooterChips(opts: {
 }
 
 /**
+ * The context-window chip — `ctx 62%`, or `ctx 62%~` when the figure is the
+ * engine's own estimate rather than a number it reports.
+ *
+ * Answers a different question from the quota chips beside it: those say how
+ * much budget is left this week, this says how much room is left in THIS
+ * conversation. The moment it runs out the session compacts and the agent
+ * quietly loses the context you spent an hour building; the first symptom is
+ * a worse answer.
+ *
+ * `null` — render nothing — in three cases, and all three are the same honest
+ * refusal: no snapshot, no `contextWindowTokens` (only some vendors report the
+ * model's window, and a percentage of an unknown denominator is a made-up
+ * number), or a window of zero. The neutral layer must NOT guess the
+ * denominator from a model name: what a vendor counts toward its context is
+ * the ADAPTER's arithmetic (CLAUDE.md, "Engine-owned UI data").
+ *
+ * Same three tones as the quota chips, so one glance reads both halves of the
+ * footer the same way. Pure — unit-tested.
+ */
+export function contextChip(
+  usage: { contextTokens: number; contextWindowTokens?: number; approximate?: boolean } | null | undefined,
+): UsageChipView | null {
+  if (!usage) return null
+  const window = usage.contextWindowTokens
+  if (window === undefined || window <= 0) return null
+  // Clamp: a vendor that reports a prompt slightly over its own advertised
+  // window (tool definitions, system prompt) must read as full, not 103%.
+  const percent = Math.min(100, Math.max(0, Math.round((usage.contextTokens / window) * 100)))
+  return {
+    label: "ctx",
+    percentText: `${percent}%${usage.approximate ? "~" : ""}`,
+    resetText: "",
+    tone: toneOf(percent),
+  }
+}
+
+/**
  * One aligned meter row per quota window, in the vendor's own order (the
  * usage API lists session before weekly). Label column width tracks the
  * longest label (scoped windows carry model display names) with a hard cap

--- a/packages/kobe/src/tui-react/workspace/host-footer.tsx
+++ b/packages/kobe/src/tui-react/workspace/host-footer.tsx
@@ -28,11 +28,39 @@ import type { RemoteOrchestrator } from "../../client/remote-orchestrator"
 import { engineDisplayName } from "../../engine/interactive-command"
 import { displayWidth } from "../../lib/display-width"
 import { StatusKeyHintBar, useStatusKeyHintItems } from "../component/keyboard-hints"
-import { buildFooterChips, usageChipsBudget } from "../component/settings-dialog/usage-core"
+import { buildFooterChips, contextChip, usageChipsBudget } from "../component/settings-dialog/usage-core"
 import { ShortcutRevealProvider } from "../component/shortcut-reveal"
 import { useTheme } from "../context/theme"
 import { isNarrowWidth } from "../lib/narrow-mode"
 import { useAccessor } from "../lib/use-accessor"
+
+/**
+ * The active session's context-window meter, left of the vendor quota chips.
+ *
+ * The chip is resolved by `WorkspaceFrame`, not here: the frame decides whether
+ * the footer ROW exists at all, and a context reading has to count toward that
+ * — otherwise a session with a meter but no quota data and a muted hint bar
+ * would hide the row it belongs to. This component only paints. A null chip
+ * renders nothing: no reading for this tab (a shell tab, a session that has not
+ * run a turn, a vendor that does not report its context window) is absence,
+ * never `0%`.
+ */
+function ContextChip(props: { chip: ReturnType<typeof contextChip> }) {
+  const { theme } = useTheme()
+  const chip = props.chip
+  if (!chip) return null
+  const toneColor = { ok: theme.success, warn: theme.warning, crit: theme.error } as const
+  return (
+    <box flexDirection="row" gap={1} flexShrink={0}>
+      <text fg={theme.textMuted} wrapMode="none">
+        {chip.label}
+      </text>
+      <text fg={toneColor[chip.tone]} wrapMode="none">
+        {chip.percentText}
+      </text>
+    </box>
+  )
+}
 
 function UsageChips(props: { orchestrator: RemoteOrchestrator; narrow: boolean; budget: number }) {
   const { theme } = useTheme()
@@ -100,6 +128,9 @@ export function WorkspaceFrame(props: {
   orchestrator: RemoteOrchestrator
   /** Wires the footer's clickable [settings] button; absent = no settings segment. */
   onOpenSettings?: () => void
+  /** The tab the context meter reads — the workspace's active engine session. */
+  activeTaskId?: string | null
+  activeTabId?: string | null
   /** Top-of-window strip (the daemon-down banner) — rendered above the pane
    *  row. The host owns it because the surfaces that BYPASS this frame
    *  (settings, worktrees, update) need the same strip. */
@@ -110,15 +141,26 @@ export function WorkspaceFrame(props: {
   const dims = useTerminalDimensions()
   const narrow = isNarrowWidth(dims.width)
   const usage = useAccessor(props.orchestrator.usageSnapshotSignal())
+  const context = useAccessor(props.orchestrator.contextUsageSignal())
+  const ctxChip =
+    props.activeTaskId && props.activeTabId
+      ? contextChip(context?.get(`${props.activeTaskId}::${props.activeTabId}`))
+      : null
   // The same options the bar below renders with — the budget must measure
   // the bar that is actually on screen (compact drops the [settings] chip).
   const hintItems = useStatusKeyHintItems({
     onOpenSettings: narrow ? undefined : props.onOpenSettings,
     compact: narrow,
   })
-  const footerVisible = (usage != null && usage.size > 0) || hintItems.length > 0
+  const footerVisible = (usage != null && usage.size > 0) || ctxChip !== null || hintItems.length > 0
   const hintCells = hintItems.reduce((sum, item, index) => sum + displayWidth(item.text) + (index > 0 ? 3 : 0), 0)
-  const chipsBudget = usageChipsBudget({ terminalWidth: dims.width, hintCells })
+  // The context chip shares the chips' half of the row, so its cells come out
+  // of the quota budget — otherwise the two together overflow onto the hint
+  // bar at exactly the widths the budget exists to protect. `ctx 100%~` + the
+  // inter-box gap is 11; reserving the max keeps the reservation constant
+  // instead of making the quota chips reflow as the percentage changes.
+  const contextCells = 11
+  const chipsBudget = Math.max(0, usageChipsBudget({ terminalWidth: dims.width, hintCells }) - contextCells)
   return (
     <ShortcutRevealProvider>
       <box flexDirection="column" flexGrow={1} backgroundColor={theme.background}>
@@ -130,7 +172,8 @@ export function WorkspaceFrame(props: {
           <box flexDirection="row" flexShrink={0} height={1} paddingLeft={1} paddingRight={1} gap={2}>
             {/* The chips yield first: shrink + clip is the hard guarantee,
                 the budget-truncated view model the graceful one. */}
-            <box flexGrow={1} flexShrink={1} flexDirection="row" overflow="hidden">
+            <box flexGrow={1} flexShrink={1} flexDirection="row" gap={2} overflow="hidden">
+              <ContextChip chip={ctxChip} />
               <UsageChips orchestrator={props.orchestrator} narrow={narrow} budget={chipsBudget} />
             </box>
             {/* Narrow drops the verbs and the [settings] chip: `⌃A · F1`. */}

--- a/packages/kobe/src/tui-react/workspace/host.tsx
+++ b/packages/kobe/src/tui-react/workspace/host.tsx
@@ -309,7 +309,13 @@ export function WorkspaceRoot(props: { orchestrator: RemoteOrchestrator }) {
     )
 
   return (
-    <WorkspaceFrame orchestrator={orch} onOpenSettings={pages.openSettings} banner={banner.element}>
+    <WorkspaceFrame
+      orchestrator={orch}
+      onOpenSettings={pages.openSettings}
+      banner={banner.element}
+      activeTaskId={selectedId}
+      activeTabId={selectedTabId}
+    >
       {/* Tasks sidebar stays visible in zen (tmux parity) — its
           ☯ ZEN chip is also the exit affordance. */}
       {/* Borderless rail (owner call 2026-07-27): no frame, no divider —

--- a/packages/kobe/test/daemon/context-usage-collector.test.ts
+++ b/packages/kobe/test/daemon/context-usage-collector.test.ts
@@ -1,0 +1,143 @@
+/**
+ * The context-usage collector: which live sessions it reads, and the publish
+ * gate. The reader is injected, so no transcripts are involved.
+ */
+
+import {
+  ContextUsageCollector,
+  contextUsageTargets,
+  sameContextUsage,
+} from "@sma1lboy/kobe-daemon/daemon/context-usage-collector"
+import { DaemonEventBus } from "@sma1lboy/kobe-daemon/daemon/event-bus"
+import { describe, expect, test } from "vitest"
+
+const FAST = { timeoutMs: 1_000, slowRetryMs: 1_000, minIntervalMs: 0 }
+const settle = async (): Promise<void> => {
+  for (let i = 0; i < 5; i++) await new Promise((r) => setTimeout(r, 0))
+}
+
+describe("contextUsageTargets", () => {
+  const vendorOf = (id: string) => (id === "gone" ? undefined : ("claude" as const))
+
+  test("keeps only per-TAB entries that name a session", () => {
+    // A task-level entry cannot say which of its tabs the number belongs to,
+    // and the footer meter is about the tab you are looking at.
+    expect(
+      contextUsageTargets(
+        [
+          { taskId: "t1", tabId: "tab-1", sessionId: "s1" },
+          { taskId: "t1", sessionId: "s1" },
+          { taskId: "t1", tabId: "tab-2" },
+        ],
+        vendorOf,
+      ),
+    ).toEqual([{ key: "t1::tab-1", vendor: "claude", sessionId: "s1" }])
+  })
+
+  test("skips a session whose task is gone — the registry outlives a delete", () => {
+    expect(contextUsageTargets([{ taskId: "gone", tabId: "tab-1", sessionId: "s1" }], vendorOf)).toEqual([])
+  })
+
+  test("dedupes repeated entries for the same tab, first one wins", () => {
+    const targets = contextUsageTargets(
+      [
+        { taskId: "t1", tabId: "tab-1", sessionId: "first" },
+        { taskId: "t1", tabId: "tab-1", sessionId: "second" },
+      ],
+      vendorOf,
+    )
+    expect(targets).toHaveLength(1)
+    expect(targets[0]?.sessionId).toBe("first")
+  })
+})
+
+describe("sameContextUsage", () => {
+  test("distinguishes an estimate from an engine-reported figure of the same size", () => {
+    const exact = { contextTokens: 10, contextWindowTokens: 100 }
+    expect(sameContextUsage(exact, { ...exact })).toBe(true)
+    expect(sameContextUsage(exact, { ...exact, approximate: true })).toBe(false)
+    expect(sameContextUsage(exact, { ...exact, contextWindowTokens: 200 })).toBe(false)
+  })
+})
+
+function harness(states: { taskId: string; tabId?: string; sessionId?: string }[]) {
+  const bus = new DaemonEventBus()
+  const published: { context: Record<string, unknown> }[] = []
+  bus.onPublish((event) => {
+    if (event.channel === "usage.context") published.push(event.payload as { context: Record<string, unknown> })
+  })
+  let live = states
+  let value: { contextTokens: number; contextWindowTokens?: number } | null = {
+    contextTokens: 10,
+    contextWindowTokens: 100,
+  }
+  const collector = new ContextUsageCollector(
+    { currentNonIdle: () => live as never },
+    { getTask: () => ({ vendor: "claude" }) as never },
+    bus,
+    { readEngineContextUsage: async () => value },
+    { cadence: FAST, read: async () => value },
+  )
+  return {
+    collector,
+    published,
+    setLive: (next: typeof states) => {
+      live = next
+    },
+    setValue: (next: typeof value) => {
+      value = next
+    },
+  }
+}
+
+describe("ContextUsageCollector", () => {
+  test("publishes once per real change, and not on an unchanged tick", async () => {
+    const h = harness([{ taskId: "t1", tabId: "tab-1", sessionId: "s1" }])
+    h.collector.tick()
+    await settle()
+    expect(h.published.at(-1)?.context).toEqual({ "t1::tab-1": { contextTokens: 10, contextWindowTokens: 100 } })
+
+    h.collector.tick()
+    await settle()
+    expect(h.published).toHaveLength(1)
+
+    h.setValue({ contextTokens: 60, contextWindowTokens: 100 })
+    h.collector.tick()
+    await settle()
+    expect(h.published).toHaveLength(2)
+    expect(h.published.at(-1)?.context).toEqual({ "t1::tab-1": { contextTokens: 60, contextWindowTokens: 100 } })
+  })
+
+  test("a null reading never publishes — 'not reported' is not zero", async () => {
+    const h = harness([{ taskId: "t1", tabId: "tab-1", sessionId: "s1" }])
+    h.setValue(null)
+    h.collector.tick()
+    await settle()
+    expect(h.published).toEqual([])
+  })
+
+  test("a closed tab drops out of the map on the next tick", async () => {
+    const h = harness([{ taskId: "t1", tabId: "tab-1", sessionId: "s1" }])
+    h.collector.tick()
+    await settle()
+    expect(Object.keys(h.published.at(-1)?.context ?? {})).toEqual(["t1::tab-1"])
+
+    h.setLive([])
+    h.collector.tick()
+    await settle()
+    expect(h.published.at(-1)?.context).toEqual({})
+  })
+
+  test("a NEW session in the same tab drops the old reading rather than showing it", async () => {
+    // Otherwise a fresh conversation reports the previous one's occupancy
+    // until the next read lands — the worst moment to be wrong about it.
+    const h = harness([{ taskId: "t1", tabId: "tab-1", sessionId: "s1" }])
+    h.collector.tick()
+    await settle()
+    h.setLive([{ taskId: "t1", tabId: "tab-1", sessionId: "s2" }])
+    h.setValue(null)
+    h.collector.tick()
+    await settle()
+    expect(h.published.at(-1)?.context).toEqual({})
+  })
+})

--- a/packages/kobe/test/render/host-version-skew-banner.test.tsx
+++ b/packages/kobe/test/render/host-version-skew-banner.test.tsx
@@ -82,6 +82,7 @@ function fakeOrchestrator() {
     transcriptActivitySignal: () => NULL_CELL,
     transcriptActivityStore: () => NULL_CELL,
     usageSnapshotSignal: () => NULL_CELL,
+    contextUsageSignal: () => NULL_CELL,
     uiPrefsSignal: () => NULL_CELL,
     keybindingsRevSignal: () => NULL_CELL,
     updateSignal: () => NULL_CELL,

--- a/packages/kobe/test/render/keyboard-hints.test.tsx
+++ b/packages/kobe/test/render/keyboard-hints.test.tsx
@@ -58,7 +58,10 @@ const CLOSED_PAGES: HostPagesState = {
 /** Minimal orchestrator stand-in — the frame only reads the usage signal. */
 function fakeOrchestrator(): RemoteOrchestrator {
   const cell = createStateCell(null)
-  return { usageSnapshotSignal: () => cell } as unknown as RemoteOrchestrator
+  return {
+    usageSnapshotSignal: () => cell,
+    contextUsageSignal: () => createStateCell(null),
+  } as unknown as RemoteOrchestrator
 }
 
 /** Find a substring's cell coordinates in a captured char frame. */

--- a/packages/kobe/test/render/stale-daemon-reads.test.tsx
+++ b/packages/kobe/test/render/stale-daemon-reads.test.tsx
@@ -96,6 +96,7 @@ test("WorkspaceFrame renders a banner above the pane row", async () => {
   const usage = createStateCell(null)
   const orch = {
     usageSnapshotSignal: () => usage,
+    contextUsageSignal: () => createStateCell(null),
   } as unknown as RemoteOrchestrator
   const { frame } = await renderComponent(
     <WorkspaceFrame orchestrator={orch} banner={<text>TOP STRIP</text>}>

--- a/packages/kobe/test/render/workspace-usage-footer.test.tsx
+++ b/packages/kobe/test/render/workspace-usage-footer.test.tsx
@@ -11,10 +11,22 @@ import { WorkspaceFrame } from "../../src/tui-react/workspace/host-footer"
 import type { EngineQuotaUsage } from "../../src/types/engine"
 import { renderComponent } from "./harness"
 
-/** Minimal stand-in: the footer only ever calls `usageSnapshotSignal()`. */
-function orchestratorWith(usage: ReadonlyMap<string, EngineQuotaUsage> | null): RemoteOrchestrator {
-  const cell = createStateCell(usage)
-  return { usageSnapshotSignal: () => cell } as unknown as RemoteOrchestrator
+/** Minimal stand-in: the footer reads the quota map and the per-session
+ *  context map, and nothing else. `context` defaults to empty so the existing
+ *  quota cases keep asserting the quota half alone. */
+function orchestratorWith(
+  usage: ReadonlyMap<string, EngineQuotaUsage> | null,
+  context: ReadonlyMap<
+    string,
+    { contextTokens: number; contextWindowTokens?: number; approximate?: boolean }
+  > | null = null,
+): RemoteOrchestrator {
+  const usageCell = createStateCell(usage)
+  const contextCell = createStateCell(context)
+  return {
+    usageSnapshotSignal: () => usageCell,
+    contextUsageSignal: () => contextCell,
+  } as unknown as RemoteOrchestrator
 }
 
 const IN_AN_HOUR = Date.now() + 60 * 60 * 1000
@@ -92,4 +104,37 @@ test("narrow footer collapses each vendor to its session-window percent", async 
   expect(footer).not.toContain("5h")
   expect(footer).not.toContain("12%")
   expect(footer).not.toContain("→")
+})
+
+test("the context meter renders the active tab's occupancy, and only that tab's", async () => {
+  const orch = orchestratorWith(
+    null,
+    new Map([
+      ["t1::tab-1", { contextTokens: 124_000, contextWindowTokens: 200_000 }],
+      ["t1::tab-2", { contextTokens: 8_000, contextWindowTokens: 200_000 }],
+    ]),
+  )
+  const { frame } = await renderComponent(
+    <WorkspaceFrame orchestrator={orch} activeTaskId="t1" activeTabId="tab-1">
+      <box />
+    </WorkspaceFrame>,
+    { width: 80, height: 6 },
+  )
+  const out = await frame()
+  expect(out).toContain("ctx 62%")
+  // tab-2's 4% belongs to a session the user is not looking at.
+  expect(out).not.toContain("4%")
+})
+
+test("no reading for the active tab renders no meter at all", async () => {
+  // A shell tab, a session that has not run a turn, or a vendor that does not
+  // report its context window — all three read as absence, never as 0%.
+  const orch = orchestratorWith(null, new Map([["t1::tab-1", { contextTokens: 124_000 }]]))
+  const { frame } = await renderComponent(
+    <WorkspaceFrame orchestrator={orch} activeTaskId="t1" activeTabId="tab-1">
+      <text>body</text>
+    </WorkspaceFrame>,
+    { width: 80, height: 6 },
+  )
+  expect(await frame()).not.toContain("ctx")
 })

--- a/packages/kobe/test/tui-react/context-chip.test.ts
+++ b/packages/kobe/test/tui-react/context-chip.test.ts
@@ -1,0 +1,47 @@
+/**
+ * The footer's context-window chip (`contextChip`) — the pure half of the
+ * `ctx 62%` meter. What matters here is the three REFUSALS: the chip must not
+ * invent a denominator it was not given, because a percentage of a guessed
+ * window is a made-up number wearing a tone colour.
+ */
+
+import { describe, expect, test } from "vitest"
+import { contextChip } from "../../src/tui-react/component/settings-dialog/usage-core"
+
+describe("contextChip", () => {
+  test("absent data renders nothing — three ways", () => {
+    expect(contextChip(undefined)).toBeNull()
+    expect(contextChip(null)).toBeNull()
+    // Claude reports context_tokens but no window. A percentage would need a
+    // denominator the neutral layer is not allowed to guess.
+    expect(contextChip({ contextTokens: 120_000 })).toBeNull()
+    expect(contextChip({ contextTokens: 1, contextWindowTokens: 0 })).toBeNull()
+  })
+
+  test("an engine-reported reading is an exact percent, tone by fullness", () => {
+    expect(contextChip({ contextTokens: 124_000, contextWindowTokens: 200_000 })).toEqual({
+      label: "ctx",
+      percentText: "62%",
+      resetText: "",
+      tone: "ok",
+    })
+    expect(contextChip({ contextTokens: 160_000, contextWindowTokens: 200_000 })?.tone).toBe("warn")
+    expect(contextChip({ contextTokens: 195_000, contextWindowTokens: 200_000 })?.tone).toBe("crit")
+  })
+
+  test("an ESTIMATED reading is suffixed, so it never reads as engine-reported", () => {
+    expect(contextChip({ contextTokens: 100_000, contextWindowTokens: 200_000, approximate: true })).toEqual({
+      label: "ctx",
+      percentText: "50%~",
+      resetText: "",
+      tone: "ok",
+    })
+  })
+
+  test("a prompt over the advertised window reads as full, not 103%", () => {
+    // Tool definitions and the system prompt can push the reported figure past
+    // the vendor's own advertised number.
+    expect(contextChip({ contextTokens: 210_000, contextWindowTokens: 200_000 })?.percentText).toBe("100%")
+    expect(contextChip({ contextTokens: -5, contextWindowTokens: 200_000 })?.percentText).toBe("0%")
+  })
+})


### PR DESCRIPTION
> Rebased onto `main` (`686504467`, i.e. after #824 merged). One commit.

## Chords needing owner sign-off

**None.** This PR adds no keybinding. (#817 proposes `ctrl+a k`, #820 proposes
`ctrl+a u`; both are recorded as *proposed* in
`docs/design/keybinding-decisions.md`.)

---

## What changed

You cannot tell that a session is one turn from compacting. The moment it does,
the agent quietly loses the context you spent an hour building, and the first
symptom is a worse answer. The footer showed subscription quota, which answers
a different question: how much budget is left this week, not how much room is
left in this conversation.

The number already existed — `EngineUsageSnapshot.context_tokens` /
`context_window_tokens` are engine-normalized, both built-in adapters populate
them, and `kobe-web` renders them. The TUI discarded them.

- **Daemon** — `context-usage-collector.ts`: one guarded read per LIVE ENGINE
  SESSION (an activity-registry entry that names both a tab and a session id),
  fanned out on a new `usage.context` channel keyed `taskId::tabId`. Slow tick
  (10s — the number moves per TURN, not per frame), same in-flight
  dedupe / timeout / backoff shape as the other collectors, gated on
  subscribers.
- **A separate channel, not a second field on `usage.snapshot`.** The two have
  different producers and cadences, and the bus keeps one last-value slot per
  channel — a co-tenant would clobber the other's replay.
- **Engine contract unchanged.** `runtime.readEngineContextUsage` delegates
  straight to `engineEntry(vendor).history.readUsageSnapshot`. The neutral
  layer never sums vendor fields (CLAUDE.md, "Engine-owned UI data").
- **Footer** — `contextChip()` in `usage-core.ts` beside `buildFooterChips`,
  same ok/warn/crit tones. `~` suffix when `context_tokens_approximate` is set,
  so a Claude estimate never reads as an engine-reported fact.

### Three refusals, on purpose

`contextChip` returns null — renders nothing — for no snapshot, for a zero
window, and for a snapshot with **no `contextWindowTokens`**. Only some vendors
report the model's window (codex does, Claude does not), and a percentage of a
denominator the neutral layer guessed would be a made-up number wearing a tone
colour. Absence is the honest answer.

The chip is resolved in `WorkspaceFrame`, not inside `ContextChip`, because the
frame decides whether the footer ROW exists at all — a session with a meter but
no quota data and a muted hint bar would otherwise hide the row it belongs to.
A render test pins that.

## PASS criteria and proof

**1. Unit test on the chip builder for absent / exact / approximate** —
`test/tui-react/context-chip.test.ts` (4), covering all three refusals, the
tone ladder, the `~` suffix, and the over-100% clamp (tool definitions can push
a reported prompt past the vendor's own advertised window). Plus
`test/daemon/context-usage-collector.test.ts` (8) on target selection and the
publish gate — including that a NEW session in the same tab drops the previous
conversation's reading instead of showing it, which is exactly the moment being
wrong matters most. Plus 2 render cases in
`test/render/workspace-usage-footer.test.tsx` (the active tab's reading only;
absence renders no meter at all).

**2. Harness BEFORE/AFTER at 80 and 120 columns** — `/harness` → xterm.js →
PTY sidecar → real OpenTUI, isolated fixture on `KOBE_VISUAL_PORT_BASE=6273`.
Seeded end to end through the real read path: a codex rollout written into the
fixture's `~/.codex/sessions/2026/09/03/` with
`model_context_window: 200000` and `last_token_usage.input_tokens: 124000`,
the fixture task switched to the codex protocol, and a `turn-complete` carrying
that session id reported through the real `engine.reportEvent` RPC. The daemon
then read it with the vendor's own history reader — 124000/200000 = **62%**, and
no `~` because codex reports the figure rather than estimating it.

| | |
| --- | --- |
| BEFORE 80 cols — footer holds only the hint bar | `/tmp/loop-r2-e/e3/before-80col.png`, cropped `…/before-80col-crop.png` |
| AFTER 80 cols — `ctx 62%` left, hint bar right, no collision | `/tmp/loop-r2-e/e3/after-80col.png`, cropped `…/after-80col-crop.png` |
| BEFORE 120 cols | `/tmp/loop-r2-e/e3/before-120col.png`, cropped `…/before-120col-crop.png` |
| AFTER 120 cols | `/tmp/loop-r2-e/e3/after-120col.png`, cropped `…/after-120col-crop.png` |
| AFTER 46 cols — still fits, still no collision | `/tmp/loop-r2-e/e3/after-46col.png`, cropped `…/after-46col-crop.png` |

## Gates

`bun run lint`, `bun run typecheck`, `bun run test:fast`, `bun run test:socket`
(90 files pass), `bun test test/render` (442 pass / 0 fail).

**Six pre-existing `test:fast` failures are NOT from this PR** — identical on a
pristine `origin/main` worktree in this environment (`project-eligibility` ×2
and `open-dir-cmd` ×2 reject anything under `~/.rove/worktrees` by path shape;
`continue-live-vendor` ×2 resolve a `claudecpa` preset out of the operator's
real config).

## Not proved

- **The chip alongside real quota chips.** The visual fixture's `HOME` is
  redirected, so no vendor has a readable login and the quota half of the
  footer is empty in every capture. The budget arithmetic that keeps the two
  from colliding (`usageChipsBudget` minus a constant 11 cells for
  `ctx 100%~` + the gap) is reasoned, not photographed.
- **The `~` suffix in the harness.** It needs a Claude session, and Claude
  reports no `context_window_tokens`, so the chip correctly draws nothing for
  it — the suffix is covered by unit test only.

`file-size-exemption: none` — `host.tsx` 452, `host-footer.tsx` 186.
