### PR TITLE
Blocking RPCs, the deferred-prompt TTL, and a zero missed-run grace

### DIFF
--- a/.changeset/blocking-rpcs-keep-their-own-deadline.md
+++ b/.changeset/blocking-rpcs-keep-their-own-deadline.md
@@ -1,0 +1,19 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Stop killing long-running daemon calls at 20 seconds.
+
+Every RPC except six worktree verbs got a 20s client deadline, and blowing it
+did more than fail the call: it rejected with "daemon wedged?", force-closed
+the socket and dropped every channel subscription. So `rove api prompt`
+returned an RPC error at 20s no matter what `--timeout` said, and a `task.land`
+on a large repo put the whole workspace into the reconnect path while the
+daemon was healthy.
+
+A verb whose contract is to block now says so on its own registry entry
+(`blocking: true`, beside `web: true`), and the client reads that set instead
+of a hand-kept list far from where verbs are defined. Covers `ui.prompt`,
+`task.land`, `workitem.start`, `automation.runNow`, and both deferred-prompt
+release paths alongside the worktree verbs. The wedge detector still guards
+everything that answers in milliseconds.

--- a/.changeset/deferred-prompt-ttl-is-enforced.md
+++ b/.changeset/deferred-prompt-ttl-is-enforced.md
@@ -1,0 +1,17 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Expire deferred prompts and their Inbox rows after 24 hours, as the policy
+always said.
+
+The store documented a 24h TTL, but nothing ever swept: expiry was only
+computed inside `deferredPrompt.flush`, which a human reaches by opening
+Settings and toggling the composer gate. A prompt the delivery gate parked
+because a composer was busy therefore sat on disk forever, and its
+`prompt_deferred` Inbox row outlived every later turn on that tab — the
+deferred episode has its own lane, so nothing else cleared it.
+
+The daemon now runs the same coordinated record + Inbox cleanup on boot and
+hourly, ungated on attached UIs. It expires only: re-delivering a live record
+stays a deliberate human action, so a parked prompt is never pasted by a timer.

--- a/.changeset/zero-grace-routines-actually-run.md
+++ b/.changeset/zero-grace-routines-actually-run.md
@@ -1,0 +1,19 @@
+---
+"@sma1lboy/rove": patch
+---
+
+A routine with a zero missed-run grace now runs instead of skipping forever.
+
+The sweep is a poller, so it can only ever see an occurrence after it happened
+— `now - scheduledFor` lands somewhere in 0..60s on a perfectly healthy run.
+The grace window was compared strictly against that gap, so
+`missedRunGraceMinutes: 0` made every single firing "missed": the routine
+recorded `skipped_missed`, advanced its schedule, and never dispatched, while
+its run history filled with skips.
+
+The window now has a floor of one tick — a grace of N means "up to N minutes
+late, plus the tick that discovered it" — and a genuinely late occurrence is
+still skipped. Negative values, which used to be accepted and then silently
+rewritten to 60 on the next daemon restart, are refused at the RPC boundary,
+as is a non-positive `precheck.timeoutSeconds`. `--grace 0` is now expressible
+from the CLI, where it previously failed the positive-integer check.

--- a/packages/kobe-daemon/package.json
+++ b/packages/kobe-daemon/package.json
@@ -34,6 +34,7 @@
     "./daemon/crash-log": "./src/daemon/crash-log.ts",
     "./daemon/collectors": "./src/daemon/collectors.ts",
     "./daemon/cwd-task": "./src/daemon/cwd-task.ts",
+    "./daemon/deferred-prompt-sweep": "./src/daemon/deferred-prompt-sweep.ts",
     "./daemon/deferred-prompts-store": "./src/daemon/deferred-prompts-store.ts",
     "./daemon/engine-events-log": "./src/daemon/engine-events-log.ts",
     "./daemon/event-bus": "./src/daemon/event-bus.ts",

--- a/packages/kobe-daemon/src/client/index.ts
+++ b/packages/kobe-daemon/src/client/index.ts
@@ -1,6 +1,7 @@
 import { type Socket, connect } from "node:net"
 import { StringDecoder } from "node:string_decoder"
 import {
+  BLOCKING_RPCS,
   type ChannelName,
   type ChannelPayloads,
   type DaemonEventName,
@@ -44,21 +45,6 @@ function rpcTimeoutMs(): number {
   }
   return 20_000
 }
-
-/**
- * RPCs that do git worktree work and/or forge lookups (ls-remote, gh PR
- * states) — legitimately minute-scale, so the deadline is disabled for them.
- * Everything else (task.create/status/delete/rename/… — the write surface the
- * TUI drives interactively) gets the default deadline.
- */
-const RPC_TIMEOUT_EXEMPT: ReadonlySet<DaemonRequestName> = new Set<DaemonRequestName>([
-  "task.ensureWorktree",
-  "task.ensureMain",
-  "worktree.discoverAdoptable",
-  "worktree.adopt",
-  "worktree.list",
-  "worktree.remove",
-])
 
 /**
  * Single connection-lifecycle hook — fires when the socket transitions from
@@ -245,7 +231,7 @@ export class KobeDaemonClient implements DaemonRpcClient {
       // RpcTimeoutError and force-disconnect, routing the wedge into the same
       // close→disconnected→reconnect recovery path a crashed daemon takes.
       const timeoutMs = rpcTimeoutMs()
-      if (timeoutMs > 0 && !RPC_TIMEOUT_EXEMPT.has(name)) {
+      if (timeoutMs > 0 && !BLOCKING_RPCS.has(name)) {
         entry.timer = setTimeout(() => this.onRequestTimeout(id, name, timeoutMs), timeoutMs)
       }
       this.pending.set(id, entry)

--- a/packages/kobe-daemon/src/daemon/automation-runner.ts
+++ b/packages/kobe-daemon/src/daemon/automation-runner.ts
@@ -54,10 +54,20 @@ export function dueAutomations(automations: readonly Automation[], nowMs: number
  * deserves to be tested without a clock or a filesystem. `notBefore` is the
  * automation's creation time so a brand-new schedule cannot claim occurrences
  * that predate it.
+ *
+ * The grace window has a FLOOR of one tick, because the sweep is a poller:
+ * `scheduledFor` is the occurrence at or before now, and the earliest the
+ * sweep can possibly see it is the tick that follows it, so `now -
+ * scheduledFor` is somewhere in 0..tickMs on a perfectly healthy run. Without
+ * the floor, `missedRunGraceMinutes: 0` made `missed` true on EVERY firing:
+ * the automation recorded `skipped_missed` forever and never dispatched, and
+ * zero looks like a reasonable setting. So a grace of N means "up to and
+ * including N minutes late, plus the tick that discovered it".
  */
 export function resolveDueOccurrence(
   automation: Automation,
   nowMs: number,
+  tickMs: number = DEFAULT_AUTOMATION_TICK_MS,
 ): { scheduledFor: number; missed: boolean } | null {
   const notBefore = Date.parse(automation.createdAt)
   const scheduledFor = latestCronAtOrBefore(automation.schedule, nowMs, Number.isFinite(notBefore) ? notBefore : 0)
@@ -65,7 +75,7 @@ export function resolveDueOccurrence(
   // current expression (a hand-edited file, or an edit that lost a race). The
   // caller just re-anchors the schedule.
   if (scheduledFor === null) return null
-  const graceMs = automation.missedRunGraceMinutes * 60_000
+  const graceMs = automation.missedRunGraceMinutes * 60_000 + Math.max(tickMs, 0)
   return { scheduledFor, missed: nowMs - scheduledFor > graceMs }
 }
 
@@ -220,12 +230,14 @@ export async function runAutomationOnce(
   })
 }
 
-/** One sweep pass. Exported so tests can drive it without a timer. */
-export async function sweepAutomations(deps: RunnerDeps): Promise<void> {
+/** One sweep pass. Exported so tests can drive it without a timer.
+ *  `tickMs` is the runner's own cadence, which sets the grace floor — see
+ *  {@link resolveDueOccurrence}. */
+export async function sweepAutomations(deps: RunnerDeps, tickMs: number = DEFAULT_AUTOMATION_TICK_MS): Promise<void> {
   const now = deps.now ?? Date.now
   for (const automation of dueAutomations(deps.store.list(), now())) {
     const nowMs = now()
-    const occurrence = resolveDueOccurrence(automation, nowMs)
+    const occurrence = resolveDueOccurrence(automation, nowMs, tickMs)
     if (!occurrence) {
       await deps.store.advanceNextRun(automation.id, nowMs)
       continue
@@ -273,7 +285,7 @@ export function startAutomationRunner(deps: RunnerDeps, tickMs: number = DEFAULT
     if (sweeping) return
     sweeping = true
     try {
-      await sweepAutomations(deps)
+      await sweepAutomations(deps, tickMs)
     } finally {
       sweeping = false
     }

--- a/packages/kobe-daemon/src/daemon/collectors.ts
+++ b/packages/kobe-daemon/src/daemon/collectors.ts
@@ -14,6 +14,11 @@ import { DEFAULT_AUTOMATION_TICK_MS, startAutomationRunner } from "./automation-
 import type { AutomationsStore } from "./automations-store.ts"
 import type { DaemonOrchestrator, UpdateInfo } from "./contracts.ts"
 import { logDaemonError, logDaemonInfo } from "./crash-log.ts"
+import {
+  DEFAULT_DEFERRED_SWEEP_TICK_MS,
+  type DeferredSweepDeps,
+  startDeferredPromptSweep,
+} from "./deferred-prompt-sweep.ts"
 import type { DaemonEventBus } from "./event-bus.ts"
 import {
   DEFAULT_KEYBINDINGS_DEBOUNCE_MS,
@@ -48,6 +53,7 @@ export interface DaemonCollectorOptions {
   readonly quotaResumeTickMs?: number
   readonly quotaUsageTickMs?: number
   readonly automationTickMs?: number
+  readonly deferredSweepTickMs?: number
 }
 
 /** What the automation sweep needs; omitted in tests that don't exercise it. */
@@ -146,6 +152,10 @@ export function startDaemonCollectors(
    *  Optional so handler-level tests that build collectors without one keep
    *  working; the real server always passes it. */
   activity?: DaemonActivityRegistry,
+  /** Deferred-prompt expiry sweep. Separate from `automations` on purpose:
+   *  the TTL must be enforced on every daemon, including one with no
+   *  routines configured. */
+  deferredSweep?: DeferredSweepDeps,
 ): () => void {
   // Activity observer: first tick immediately (restart seeding), then the
   // slow poll; gated per-tick on subscribers like every collector here. Its
@@ -247,6 +257,14 @@ export function startDaemonCollectors(
       )
     : () => {}
 
+  // Deferred-prompt TTL: ungated for the same reason as the two above —
+  // expiring a record nobody is watching is the point — and with an
+  // immediate first pass, so a restart clears what went stale while the
+  // daemon was down.
+  const stopDeferredPromptSweep = deferredSweep
+    ? startDeferredPromptSweep(deferredSweep, options.deferredSweepTickMs ?? DEFAULT_DEFERRED_SWEEP_TICK_MS)
+    : () => {}
+
   // Usage poller (Settings dashboard + workspace footer): gated on
   // subscribers — the resume scheduler does its own on-demand cache reads.
   // Every vendor WITH A PROBE is polled, not just the ones some task
@@ -265,6 +283,7 @@ export function startDaemonCollectors(
     stopPrStatusPoller()
     stopQuotaResumeRunner()
     stopAutomationRunner()
+    stopDeferredPromptSweep()
     stopQuotaUsagePoller()
     stopUiPrefsWatcher()
     stopKeybindingsWatcher()

--- a/packages/kobe-daemon/src/daemon/deferred-prompt-sweep.ts
+++ b/packages/kobe-daemon/src/daemon/deferred-prompt-sweep.ts
@@ -1,0 +1,111 @@
+/**
+ * Expiry sweep for the deferred-prompt store.
+ *
+ * `DEFERRED_PROMPT_TTL_MS` is the store's stated retention policy, but nothing
+ * enforced it: `list()` is the only method that computes `expired`, and its
+ * only caller was `deferredPrompt.flush`, which fires when a human opens
+ * Settings and toggles the composer gate. A prompt the delivery gate parked
+ * because a composer was busy therefore sat on disk indefinitely, with a
+ * permanent `prompt_deferred` Inbox row that no later turn on that tab could
+ * clear (`attentionInboxItemKey` gives the deferred episode its own lane, so
+ * the `turn-start` branch never deletes it).
+ *
+ * This module supplies the missing drainer: the same coordinated record +
+ * Inbox cleanup, driven by a boot pass and a timer instead of a human.
+ *
+ * It expires ONLY. Do not fold the live-record delivery retry in here —
+ * `flushDeferredPrompts` re-attempts delivery for every non-expired record,
+ * and that is a deliberate human-triggered action (the gate just turned off).
+ */
+
+import type { AttentionInboxStore } from "./attention-inbox.ts"
+import { logDaemonError } from "./crash-log.ts"
+import type { DeferredPromptRecord, DeferredPromptsStore } from "./deferred-prompts-store.ts"
+
+/** Once an hour is plenty for a 24h boundary, and a tick is one file read. */
+export const DEFAULT_DEFERRED_SWEEP_TICK_MS = 60 * 60 * 1000
+
+export interface DeferredSweepDeps {
+  readonly store: DeferredPromptsStore
+  readonly inbox: Pick<AttentionInboxStore, "deleteEpisode">
+}
+
+export interface DeferredSweepFailure {
+  readonly id: string
+  readonly taskId: string
+  readonly tabId: string
+  readonly error: string
+}
+
+export interface DeferredSweepReport {
+  readonly expired: string[]
+  readonly cleanupPending: DeferredSweepFailure[]
+}
+
+function errorText(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+/**
+ * Drop every past-TTL record together with its Inbox pointer.
+ *
+ * Order matters: the Inbox row goes first, then the claim completes. A record
+ * whose pointer deletion throws keeps its claim released and is reported as
+ * `cleanupPending`, so the next pass retries it rather than orphaning a row
+ * that points at a record that is gone.
+ */
+export async function sweepExpiredDeferredPrompts(deps: DeferredSweepDeps): Promise<DeferredSweepReport> {
+  const report: DeferredSweepReport = { expired: [], cleanupPending: [] }
+  const listed = await deps.store.list()
+  for (const expired of listed.expired) {
+    const claimed = await deps.store.claim(expired.id)
+    if (claimed.kind !== "claimed") {
+      report.cleanupPending.push(failure(expired, claimed.kind))
+      continue
+    }
+    try {
+      await deps.inbox.deleteEpisode(expired.taskId, expired.tabId, undefined, "prompt_deferred", expired.id)
+      await deps.store.completeClaim(claimed.claim)
+      report.expired.push(expired.id)
+    } catch (error) {
+      await deps.store.releaseClaim(claimed.claim).catch(() => {})
+      report.cleanupPending.push(failure(expired, errorText(error)))
+    }
+  }
+  return report
+}
+
+function failure(record: DeferredPromptRecord, error: string): DeferredSweepFailure {
+  return { id: record.id, taskId: record.taskId, tabId: record.tabId, error }
+}
+
+/**
+ * Start the expiry sweep, with an immediate first pass.
+ *
+ * Deliberately NOT gated on `hasSubscribers`, for the same reason
+ * `startQuotaResumeRunner` is not: expiring a record nobody is watching is the
+ * entire point. The immediate pass is what makes a daemon restart clear
+ * records that went stale while it was down.
+ */
+export function startDeferredPromptSweep(
+  deps: DeferredSweepDeps,
+  tickMs: number = DEFAULT_DEFERRED_SWEEP_TICK_MS,
+): () => void {
+  let sweeping = false
+  const sweep = async (): Promise<void> => {
+    if (sweeping) return
+    sweeping = true
+    try {
+      await sweepExpiredDeferredPrompts(deps)
+    } catch (err) {
+      logDaemonError("deferred-prompt-sweep", err)
+    } finally {
+      sweeping = false
+    }
+  }
+  void sweep()
+  if (tickMs <= 0) return () => {}
+  const timer = setInterval(() => void sweep(), tickMs)
+  timer.unref?.()
+  return () => clearInterval(timer)
+}

--- a/packages/kobe-daemon/src/daemon/handlers-automations.ts
+++ b/packages/kobe-daemon/src/daemon/handlers-automations.ts
@@ -21,8 +21,29 @@ function readPrecheck(payload: Record<string, unknown>): AutomationPrecheck | nu
   if (raw === null) return null
   if (!raw || typeof raw !== "object") throw new Error("precheck must be an object or null")
   const command = requireString(raw as Record<string, unknown>, "command")
+  // Same silent-rewrite trap as the grace window: `automations-store.ts` only
+  // keeps a timeout `> 0`, so a 0 or negative one survives in memory and turns
+  // into 120 on the next boot.
   const timeoutSeconds = optionalNumber(raw as Record<string, unknown>, "timeoutSeconds") ?? 120
+  if (timeoutSeconds <= 0) throw new Error("precheck.timeoutSeconds must be greater than zero")
   return { command, timeoutSeconds }
+}
+
+/**
+ * Read a grace window, refusing a negative one at the boundary.
+ *
+ * `optionalNumber` only rejects non-finite values, so `-1` used to pass and
+ * make every firing `missed`, until `normalizeAutomation` silently rewrote it
+ * to 60 on the next daemon boot — "it started working after I restarted the
+ * daemon" is the resulting bug report. Zero is legal and means "no slack
+ * beyond the tick that discovers the occurrence" (see `resolveDueOccurrence`).
+ */
+function readGraceMinutes(payload: Record<string, unknown>): number | undefined {
+  const value = optionalNumber(payload, "missedRunGraceMinutes")
+  if (value !== undefined && value < 0) {
+    throw new Error("missedRunGraceMinutes must be zero or more minutes")
+  }
+  return value
 }
 
 export const AUTOMATION_HANDLERS: readonly DaemonRequestHandler[] = [
@@ -47,7 +68,7 @@ export const AUTOMATION_HANDLERS: readonly DaemonRequestHandler[] = [
         repo: requireString(payload, "repo"),
         prompt: requireString(payload, "prompt"),
         schedule: requireSchedule(payload, "schedule"),
-        missedRunGraceMinutes: optionalNumber(payload, "missedRunGraceMinutes") ?? 60,
+        missedRunGraceMinutes: readGraceMinutes(payload) ?? 60,
         ...(optionalVendor(payload, "vendor") ? { vendor: optionalVendor(payload, "vendor") } : {}),
         ...(precheck ? { precheck } : {}),
         ...(optionalString(payload, "baseRef") ? { baseRef: optionalString(payload, "baseRef") } : {}),
@@ -71,9 +92,7 @@ export const AUTOMATION_HANDLERS: readonly DaemonRequestHandler[] = [
         ...(readPrecheck(payload) !== undefined ? { precheck: readPrecheck(payload) } : {}),
         ...("baseRef" in payload ? { baseRef: optionalString(payload, "baseRef") ?? null } : {}),
         ...(optionalBoolean(payload, "enabled") !== undefined ? { enabled: optionalBoolean(payload, "enabled") } : {}),
-        ...(optionalNumber(payload, "missedRunGraceMinutes") !== undefined
-          ? { missedRunGraceMinutes: optionalNumber(payload, "missedRunGraceMinutes") }
-          : {}),
+        ...(readGraceMinutes(payload) !== undefined ? { missedRunGraceMinutes: readGraceMinutes(payload) } : {}),
         ...(optionalBoolean(payload, "persistentSession") !== undefined
           ? { persistentSession: optionalBoolean(payload, "persistentSession") }
           : {}),
@@ -103,6 +122,7 @@ export const AUTOMATION_HANDLERS: readonly DaemonRequestHandler[] = [
   },
   {
     name: "automation.runNow",
+    blocking: true,
     async handle(payload, ctx) {
       const id = requireString(payload, "id")
       const automation = ctx.automations.get(id)

--- a/packages/kobe-daemon/src/daemon/handlers-deferred.ts
+++ b/packages/kobe-daemon/src/daemon/handlers-deferred.ts
@@ -7,6 +7,7 @@
  * delivery and clean up the Inbox pointer.
  */
 
+import { sweepExpiredDeferredPrompts } from "./deferred-prompt-sweep.ts"
 import {
   type DeferredPromptClaim,
   DeferredPromptPendingError,
@@ -238,32 +239,14 @@ async function flushDeferredPrompts(ctx: DaemonHandlerContext): Promise<{
     retained: [],
     cleanupPending: [],
   }
+  // Expiry is the timer's job too (deferred-prompt-sweep.ts), so it lives
+  // there and both callers share one implementation. `list()` reports the
+  // expired set and drops it from `records`, so the loop below sees only the
+  // live half either way.
+  const swept = await sweepExpiredDeferredPrompts({ store: ctx.deferredPrompts, inbox: ctx.inbox })
+  report.expired.push(...swept.expired)
+  report.cleanupPending.push(...swept.cleanupPending)
   const listed = await ctx.deferredPrompts.list()
-  for (const expired of listed.expired) {
-    const claimed = await ctx.deferredPrompts.claim(expired.id)
-    if (claimed.kind !== "claimed") {
-      report.cleanupPending.push({
-        id: expired.id,
-        taskId: expired.taskId,
-        tabId: expired.tabId,
-        error: claimed.kind,
-      })
-      continue
-    }
-    try {
-      await deleteDeferredInboxPointer(expired, ctx)
-      await ctx.deferredPrompts.completeClaim(claimed.claim)
-      report.expired.push(expired.id)
-    } catch (error) {
-      await ctx.deferredPrompts.releaseClaim(claimed.claim).catch(() => {})
-      report.cleanupPending.push({
-        id: expired.id,
-        taskId: expired.taskId,
-        tabId: expired.tabId,
-        error: errorText(error),
-      })
-    }
-  }
   for (const record of listed.records) {
     if (record.deliveredAt || record.deliveryStartedAt) {
       const claimed = await ctx.deferredPrompts.claim(record.id)
@@ -347,6 +330,7 @@ export const DEFERRED_PROMPT_HANDLERS: readonly DaemonRequestHandler[] = [
   },
   {
     name: "deferredPrompt.release",
+    blocking: true,
     async handle(payload, ctx) {
       const id = requireString(payload, "id")
       if (!ctx.deferredPrompts) throw new Error("deferred prompt store unavailable")
@@ -375,6 +359,7 @@ export const DEFERRED_PROMPT_HANDLERS: readonly DaemonRequestHandler[] = [
   },
   {
     name: "deferredPrompt.flush",
+    blocking: true,
     async handle(_payload, ctx) {
       return await flushDeferredPrompts(ctx)
     },

--- a/packages/kobe-daemon/src/daemon/handlers-task.ts
+++ b/packages/kobe-daemon/src/daemon/handlers-task.ts
@@ -189,6 +189,7 @@ export const TASK_HANDLERS: readonly DaemonRequestHandler[] = [
   },
   {
     name: "task.land",
+    blocking: true,
     web: true,
     async handle(payload, ctx) {
       const taskId = requireString(payload, "taskId")
@@ -303,6 +304,7 @@ export const TASK_HANDLERS: readonly DaemonRequestHandler[] = [
   },
   {
     name: "task.ensureMain",
+    blocking: true,
     web: true,
     async handle(payload, ctx) {
       const repo = requireString(payload, "repo")
@@ -320,6 +322,7 @@ export const TASK_HANDLERS: readonly DaemonRequestHandler[] = [
   },
   {
     name: "task.ensureWorktree",
+    blocking: true,
     web: true,
     async handle(payload, ctx) {
       const taskId = requireString(payload, "taskId")

--- a/packages/kobe-daemon/src/daemon/handlers-ui.ts
+++ b/packages/kobe-daemon/src/daemon/handlers-ui.ts
@@ -100,6 +100,7 @@ export const UI_HANDLERS: readonly DaemonRequestHandler[] = [
   },
   {
     name: "ui.prompt",
+    blocking: true,
     async handle(payload, ctx) {
       // Host-provided input dialog (plugins → `kobe api prompt`): publish
       // the request to every attached TUI and block until one answers via

--- a/packages/kobe-daemon/src/daemon/handlers-work-items.ts
+++ b/packages/kobe-daemon/src/daemon/handlers-work-items.ts
@@ -60,6 +60,7 @@ export const WORK_ITEM_HANDLERS: readonly DaemonRequestHandler[] = [
   },
   {
     name: "workitem.start",
+    blocking: true,
     async handle(payload, ctx) {
       const repo = requireString(payload, "repo")
       const number = requireNumberField(payload, "number")

--- a/packages/kobe-daemon/src/daemon/handlers-worktree.ts
+++ b/packages/kobe-daemon/src/daemon/handlers-worktree.ts
@@ -27,6 +27,7 @@ import { serializeTask } from "./protocol.ts"
 export const WORKTREE_HANDLERS: readonly DaemonRequestHandler[] = [
   {
     name: "worktree.discoverAdoptable",
+    blocking: true,
     web: true,
     async handle(payload, ctx) {
       const repo = requireString(payload, "repo")
@@ -36,6 +37,7 @@ export const WORKTREE_HANDLERS: readonly DaemonRequestHandler[] = [
   },
   {
     name: "worktree.adopt",
+    blocking: true,
     web: true,
     async handle(payload, ctx) {
       const task = await ctx.orch.adoptWorktree({
@@ -51,12 +53,14 @@ export const WORKTREE_HANDLERS: readonly DaemonRequestHandler[] = [
   },
   {
     name: "worktree.list",
+    blocking: true,
     async handle(payload, ctx) {
       return { projects: await ctx.runtime.listWorktreeProjects(payload.network !== false) }
     },
   },
   {
     name: "worktree.remove",
+    blocking: true,
     async handle(payload, ctx) {
       const path = requireString(payload, "path")
       const force = payload.force === true

--- a/packages/kobe-daemon/src/daemon/handlers.ts
+++ b/packages/kobe-daemon/src/daemon/handlers.ts
@@ -174,6 +174,15 @@ export interface DaemonRequestHandler {
    * kill switch (`daemon.stop`), and hook-ingest paths must stay unexposed.
    */
   readonly web?: boolean
+  /**
+   * Can this verb legitimately outlive the client's 20s wedge deadline?
+   * Declared HERE, beside `web`, so the question is in front of whoever
+   * writes the handler — the socket client cannot import this registry
+   * (that would pull every daemon module into the CLI), so it reads the
+   * mirror in `protocol.ts`. `test/daemon/rpc-deadline.test.ts` fails when
+   * the two drift.
+   */
+  readonly blocking?: boolean
   handle(payload: Record<string, unknown>, ctx: DaemonHandlerContext): Promise<unknown> | unknown
 }
 
@@ -183,6 +192,15 @@ export function webExposedRpcNames(
 ): ReadonlySet<DaemonRequestName> {
   const names = new Set<DaemonRequestName>()
   for (const entry of registry.values()) if (entry.web === true) names.add(entry.name)
+  return names
+}
+
+/** The registry-derived blocking set: every entry marked `blocking: true`. */
+export function blockingRpcNames(
+  registry: ReadonlyMap<DaemonRequestName, DaemonRequestHandler>,
+): ReadonlySet<DaemonRequestName> {
+  const names = new Set<DaemonRequestName>()
+  for (const entry of registry.values()) if (entry.blocking === true) names.add(entry.name)
   return names
 }
 

--- a/packages/kobe-daemon/src/daemon/protocol.ts
+++ b/packages/kobe-daemon/src/daemon/protocol.ts
@@ -319,6 +319,49 @@ export type DaemonRequestName =
   | "deferredPrompt.flush"
 
 /**
+ * Verbs whose CONTRACT is to block, so the client must not put a wedge
+ * deadline on them.
+ *
+ * The socket client gives every request a 20s deadline, and blowing it is not
+ * a plain failure: it rejects with `RpcTimeoutError("… daemon wedged?")`, then
+ * force-disconnects and emits a lifecycle `close`, dropping every channel
+ * subscription on the TUI's long-lived connection. That is the right move for
+ * a genuinely wedged daemon and the wrong one for a verb that is simply still
+ * working — a `task.land` on a large repo would put the whole workspace into
+ * the reconnect path while the daemon is perfectly healthy.
+ *
+ * Each name here either waits on a human (`ui.prompt`), shells out on a
+ * user-sized repo or through `gh`, or delivers serially into PTYs. For all of
+ * them the DAEMON owns settlement, so the client's timer buys nothing.
+ *
+ * This set lives in the wire contract, next to {@link DaemonRequestName},
+ * because both the client (which must not import the handler registry — that
+ * would drag every daemon module into the CLI) and the registry need it. The
+ * registry entry is where a verb DECLARES it (`blocking: true` beside
+ * `web: true`), and `test/daemon/rpc-deadline.test.ts` fails if the two drift.
+ */
+export const BLOCKING_RPCS: ReadonlySet<DaemonRequestName> = new Set<DaemonRequestName>([
+  // Blocks on a human answering the TUI dialog (default 120s, max 600s).
+  "ui.prompt",
+  // Merge/squash plus optional worktree removal, on a repo of any size.
+  "task.land",
+  // `gh` lookup (its own 20s subprocess budget) then task/worktree/engine setup.
+  "workitem.start",
+  // Precheck subprocess, then a full session start.
+  "automation.runNow",
+  // One PTY delivery per queued record, serially.
+  "deferredPrompt.flush",
+  "deferredPrompt.release",
+  // Worktree work and forge lookups (ls-remote, gh PR states) — minute-scale.
+  "task.ensureWorktree",
+  "task.ensureMain",
+  "worktree.discoverAdoptable",
+  "worktree.adopt",
+  "worktree.list",
+  "worktree.remove",
+])
+
+/**
  * Subscribe role (KOB) — distinguishes WHO is subscribing, so the daemon's
  * refcounted lazy-shutdown counts only real front-end attaches.
  *

--- a/packages/kobe-daemon/src/daemon/server.ts
+++ b/packages/kobe-daemon/src/daemon/server.ts
@@ -50,6 +50,7 @@ import { WorkItemCache } from "./work-items.ts"
 // RPC handler registry + per-request dispatch seam — re-exported so consumers
 // (tests, kobe-web bridge) keep the existing `daemon/server` import path.
 export {
+  blockingRpcNames,
   createDaemonHandlerRegistry,
   dispatchDaemonRequest,
   shapeDaemonError,
@@ -254,6 +255,7 @@ export async function startDaemonServer(orch: DaemonOrchestrator, options: Daemo
       inbox,
     },
     activity,
+    deferredPrompts ? { store: deferredPrompts, inbox } : undefined,
   )
 
   // Plugin runtime: startup hooks + channel-derived event hooks (plugins/runtime.ts).

--- a/packages/kobe/src/cli/api/flags.ts
+++ b/packages/kobe/src/cli/api/flags.ts
@@ -33,6 +33,14 @@ export function parsePositiveInt(raw: string): number | undefined {
   return Number.isSafeInteger(n) && n > 0 ? n : undefined
 }
 
+/** Same shape as {@link parsePositiveInt}, admitting zero. The regex already
+ *  excludes a leading `-`, so this rejects negatives the same way. */
+function parseNonNegativeInt(raw: string): number | undefined {
+  if (!/^\d+$/.test(raw.trim())) return undefined
+  const n = Number.parseInt(raw, 10)
+  return Number.isSafeInteger(n) && n >= 0 ? n : undefined
+}
+
 /**
  * A boolean flag's value, or `undefined` when the string isn't one. Shared by
  * the parser (deciding whether `--pinned false` is a value or a presence flag)
@@ -202,6 +210,11 @@ export function validateAgainstSpec(verb: VerbSpec, flags: Flags): void {
       if (raw !== undefined && parsePositiveInt(raw) === undefined)
         throw new ApiError(`--${f.name} must be a positive integer`, "BAD_FLAG")
     }
+    if (f.type === "uint") {
+      const raw = flags.get(f.name)
+      if (raw !== undefined && parseNonNegativeInt(raw) === undefined)
+        throw new ApiError(`--${f.name} must be a non-negative integer`, "BAD_FLAG")
+    }
   }
 }
 
@@ -341,6 +354,20 @@ export class VerbArgs {
     if (raw === undefined) return undefined
     const n = parsePositiveInt(raw)
     if (n === undefined) throw new ApiError(`--${name} must be a positive integer`, "BAD_FLAG")
+    return n
+  }
+
+  /** A `uint` flag: like {@link int}, but zero is a legal value rather than a
+   *  floor error. For a flag whose zero MEANS something — `--grace 0` is "no
+   *  slack beyond the tick that discovers the occurrence", not "unset".
+   *  Rejecting it would leave a setting the daemon honours but the CLI cannot
+   *  express. */
+  nonNegativeInt(name: string): number | undefined {
+    this.spec(name)
+    const raw = this.str(name)
+    if (raw === undefined) return undefined
+    const n = parseNonNegativeInt(raw)
+    if (n === undefined) throw new ApiError(`--${name} must be a non-negative integer`, "BAD_FLAG")
     return n
   }
 

--- a/packages/kobe/src/cli/api/types.ts
+++ b/packages/kobe/src/cli/api/types.ts
@@ -48,7 +48,10 @@ export function helpStep(verbName: string): Record<string, unknown> {
 
 // ── Declarative verb + flag specs (single source of truth) ───────────────────
 
-type FlagType = "string" | "int" | "bool" | "enum" | "csv"
+/** `int` is a POSITIVE integer (the common case: counts, limits, ids).
+ *  `uint` also admits zero, for a flag whose zero means something rather
+ *  than "unset" — see `--grace` on the routine verbs. */
+type FlagType = "string" | "int" | "uint" | "bool" | "enum" | "csv"
 
 export interface FlagSpec {
   readonly name: string

--- a/packages/kobe/src/cli/api/verbs-automations.ts
+++ b/packages/kobe/src/cli/api/verbs-automations.ts
@@ -44,7 +44,7 @@ const PRECHECK_FLAGS = [
 
 const GRACE_FLAG = {
   name: "grace",
-  type: "int",
+  type: "uint",
   placeholder: "MIN",
   default: "60",
   description:
@@ -112,7 +112,9 @@ export const ROUTINE_VERBS: readonly VerbSpec[] = [
         ...(ctx.args.vendor() ? { vendor: ctx.args.vendor() } : {}),
         ...(ctx.args.str("base-branch") ? { baseRef: ctx.args.str("base-branch") } : {}),
         ...precheckPayload(ctx),
-        ...(ctx.args.int("grace") !== undefined ? { missedRunGraceMinutes: ctx.args.int("grace") } : {}),
+        ...(ctx.args.nonNegativeInt("grace") !== undefined
+          ? { missedRunGraceMinutes: ctx.args.nonNegativeInt("grace") }
+          : {}),
         ...(ctx.args.bool("persistent-session") ? { persistentSession: true } : {}),
         ...(ctx.args.bool("disabled") ? { enabled: false } : {}),
       }),
@@ -144,7 +146,9 @@ export const ROUTINE_VERBS: readonly VerbSpec[] = [
         // that empty value visible where `str` would fold it into "absent".
         ...(ctx.args.present("base-branch") ? { baseRef: ctx.args.str("base-branch") ?? null } : {}),
         ...precheckPayload(ctx),
-        ...(ctx.args.int("grace") !== undefined ? { missedRunGraceMinutes: ctx.args.int("grace") } : {}),
+        ...(ctx.args.nonNegativeInt("grace") !== undefined
+          ? { missedRunGraceMinutes: ctx.args.nonNegativeInt("grace") }
+          : {}),
         // `present` + `bool`, not a bare `bool` ternary: an explicit
         // `--persistent-session false` is falsy, so the ternary dropped the key
         // and left the routine standing — there was no CLI path back to

--- a/packages/kobe/test/daemon/automation-runner.test.ts
+++ b/packages/kobe/test/daemon/automation-runner.test.ts
@@ -125,6 +125,49 @@ describe("resolveDueOccurrence", () => {
     expect(resolveDueOccurrence(fresh, NOW)).toBeNull()
   })
 
+  it("a zero grace still runs an occurrence discovered on the next tick", () => {
+    // The sweep is a poller: it can only ever see an occurrence AFTER it
+    // happened, so `now - scheduledFor` lands somewhere in 0..tickMs on a
+    // perfectly healthy run. Without a one-tick floor, grace 0 made `missed`
+    // true on every single firing — the automation recorded `skipped_missed`
+    // forever and never dispatched, while zero looks like a sane setting.
+    const zero = automation({
+      schedule: "*/5 * * * *",
+      missedRunGraceMinutes: 0,
+      createdAt: new Date(0).toISOString(),
+    })
+    const scheduled = new Date(2026, 6, 31, 10, 5, 0).getTime()
+    const out = resolveDueOccurrence(zero, scheduled + 30_000)
+    expect(out?.scheduledFor).toBe(scheduled)
+    expect(out?.missed).toBe(false)
+  })
+
+  it("still calls a genuinely late occurrence missed with a zero grace", () => {
+    // The floor is ONE tick, not an amnesty: 10 minutes after the fact is a
+    // real outage and must still be skipped rather than fired stale. A daily
+    // schedule, so 10 minutes late really is late — under `*/5` the resolver
+    // would just hand back the newer occurrence.
+    const zero = automation({ missedRunGraceMinutes: 0 })
+    const scheduled = new Date(2026, 6, 31, 9, 0, 0).getTime()
+    expect(resolveDueOccurrence(zero, scheduled + 10 * 60_000)?.missed).toBe(true)
+    // …while the tick that discovers it is still on time.
+    expect(resolveDueOccurrence(zero, scheduled + 30_000)?.missed).toBe(false)
+  })
+
+  it("scales the floor with the runner's own tick period", () => {
+    // A harness (or a future slower cadence) passes its real tickMs, so the
+    // floor tracks the poll it actually runs at rather than the default 60s.
+    const zero = automation({
+      schedule: "*/5 * * * *",
+      missedRunGraceMinutes: 0,
+      createdAt: new Date(0).toISOString(),
+    })
+    const scheduled = new Date(2026, 6, 31, 10, 5, 0).getTime()
+    const seenAt = scheduled + 90_000
+    expect(resolveDueOccurrence(zero, seenAt)?.missed).toBe(true)
+    expect(resolveDueOccurrence(zero, seenAt, 120_000)?.missed).toBe(false)
+  })
+
   it("returns the single most recent occurrence after a long outage", () => {
     // Daemon down for three days: the answer is yesterday's 09:00 (one run),
     // never a stampede of every missed day.

--- a/packages/kobe/test/daemon/deferred-prompt-sweep.test.ts
+++ b/packages/kobe/test/daemon/deferred-prompt-sweep.test.ts
@@ -1,0 +1,131 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import type { AttentionInboxStore } from "@sma1lboy/kobe-daemon/daemon/attention-inbox"
+import {
+  DEFAULT_DEFERRED_SWEEP_TICK_MS,
+  startDeferredPromptSweep,
+  sweepExpiredDeferredPrompts,
+} from "@sma1lboy/kobe-daemon/daemon/deferred-prompt-sweep"
+import { DEFERRED_PROMPT_TTL_MS, DeferredPromptsStore } from "@sma1lboy/kobe-daemon/daemon/deferred-prompts-store"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+/**
+ * The deferred-prompt TTL drainer.
+ *
+ * `DEFERRED_PROMPT_TTL_MS` was dead policy: `list()` is the only method that
+ * computes `expired`, and its only caller was `deferredPrompt.flush`, which a
+ * human reaches by opening Settings and toggling the composer gate. So a
+ * parked prompt sat on disk forever with a permanent `prompt_deferred` Inbox
+ * row — `attentionInboxItemKey` gives that episode its own lane, so no later
+ * turn on the tab cleared it either.
+ */
+
+type DeleteEpisode = AttentionInboxStore["deleteEpisode"]
+type DeletedEpisode = Parameters<DeleteEpisode>
+
+function fakeInbox(): { deleteEpisode: DeleteEpisode; deleted: DeletedEpisode[] } {
+  const deleted: DeletedEpisode[] = []
+  return {
+    deleted,
+    async deleteEpisode(...args: DeletedEpisode) {
+      deleted.push(args)
+      return true
+    },
+  }
+}
+
+describe("deferred-prompt expiry sweep", () => {
+  let dir: string | null = null
+  let now = 1_000_000
+
+  afterEach(async () => {
+    if (dir) await rm(dir, { recursive: true, force: true })
+    dir = null
+    now = 1_000_000
+  })
+
+  async function create(): Promise<{ store: DeferredPromptsStore; path: string }> {
+    dir = await mkdtemp(join(tmpdir(), "kobe-deferred-sweep-"))
+    const path = join(dir, "deferred-prompts.json")
+    return { store: new DeferredPromptsStore(path, () => now), path }
+  }
+
+  const base = { taskId: "task-1", tabId: "tab-1", prompt: "held text", layer: "composer-not-empty" as const }
+
+  it("drops a past-TTL record and its Inbox pointer", async () => {
+    const { store, path } = await create()
+    const record = await store.file({ ...base, at: now })
+    now += DEFERRED_PROMPT_TTL_MS + 1
+
+    const inbox = fakeInbox()
+    const report = await sweepExpiredDeferredPrompts({ store, inbox })
+
+    expect(report.expired).toEqual([record.id])
+    expect(report.cleanupPending).toEqual([])
+    // The Inbox pointer goes with it: the row is keyed by the deferred id in
+    // its own `prompt_deferred` lane, so nothing else would ever clear it.
+    expect(inbox.deleted).toEqual([["task-1", "tab-1", undefined, "prompt_deferred", record.id]])
+    // …and the record is gone from disk, not just from the in-memory list.
+    expect(JSON.parse(await readFile(path, "utf8")).records).toEqual([])
+  })
+
+  it("leaves a live record alone — the timer expires, it never delivers", async () => {
+    // The load-bearing half of the split: `flushDeferredPrompts` re-attempts
+    // DELIVERY for every non-expired record, and that is a deliberate
+    // human-triggered action (the composer gate just turned off). A timer
+    // that also redelivered would paste into a composer nobody asked it to.
+    const { store, path } = await create()
+    const record = await store.file({ ...base, at: now })
+    now += DEFERRED_PROMPT_TTL_MS - 1
+
+    const inbox = fakeInbox()
+    const report = await sweepExpiredDeferredPrompts({ store, inbox })
+
+    expect(report.expired).toEqual([])
+    expect(inbox.deleted).toEqual([])
+    expect(JSON.parse(await readFile(path, "utf8")).records).toHaveLength(1)
+    expect(await store.get(record.id)).not.toBeNull()
+  })
+
+  it("reports a record whose Inbox deletion failed instead of orphaning the row", async () => {
+    const { store } = await create()
+    const record = await store.file({ ...base, at: now })
+    now += DEFERRED_PROMPT_TTL_MS + 1
+
+    const report = await sweepExpiredDeferredPrompts({
+      store,
+      inbox: {
+        deleteEpisode: async () => {
+          throw new Error("inbox write failed")
+        },
+      },
+    })
+
+    expect(report.expired).toEqual([])
+    expect(report.cleanupPending).toEqual([
+      { id: record.id, taskId: "task-1", tabId: "tab-1", error: "inbox write failed" },
+    ])
+    // Still on disk, so the next pass retries rather than leaving an Inbox row
+    // pointing at a record that no longer exists.
+    expect(await store.get(record.id)).not.toBeNull()
+  })
+
+  it("runs a pass immediately, before the first interval — this is the boot sweep", async () => {
+    const { store } = await create()
+    const record = await store.file({ ...base, at: now })
+    now += DEFERRED_PROMPT_TTL_MS + 1
+
+    const inbox = fakeInbox()
+    // A tick period far longer than the test: anything cleaned here came from
+    // the immediate pass, which is what makes a daemon restart clear records
+    // that went stale while it was down.
+    const stop = startDeferredPromptSweep({ store, inbox }, DEFAULT_DEFERRED_SWEEP_TICK_MS)
+    try {
+      await vi.waitFor(() => expect(inbox.deleted).toHaveLength(1))
+      expect(await store.get(record.id)).toBeNull()
+    } finally {
+      stop()
+    }
+  })
+})

--- a/packages/kobe/test/daemon/rpc-deadline.test.ts
+++ b/packages/kobe/test/daemon/rpc-deadline.test.ts
@@ -1,0 +1,64 @@
+import { BLOCKING_RPCS, type DaemonRequestName } from "@sma1lboy/kobe-daemon/daemon/protocol"
+import { blockingRpcNames, createDaemonHandlerRegistry } from "@sma1lboy/kobe-daemon/daemon/server"
+import { describe, expect, it } from "vitest"
+
+/**
+ * The client's per-request deadline table.
+ *
+ * WHY this matters: the socket client rejects an over-deadline request with
+ * `RpcTimeoutError("… daemon wedged?")`, then force-disconnects AND emits a
+ * lifecycle "close" — on the TUI's long-lived connection that drops every
+ * channel subscription. Applying that to a verb whose contract is to block
+ * (a `task.land` on a large repo, a `ui.prompt` waiting on a human) puts the
+ * whole workspace into the reconnect path while the daemon is healthy, and
+ * reports it as a wedge.
+ *
+ * The set is declared twice on purpose: `protocol.ts` is the copy the client
+ * reads (it cannot import this registry — that would pull every daemon module
+ * into the CLI), the registry entry is where a verb declares itself. This file
+ * is the join that keeps them from drifting.
+ */
+
+/** Every verb that may outlive the 20s default, pinned EXACTLY. */
+const BLOCKING: readonly DaemonRequestName[] = [
+  "ui.prompt",
+  "task.land",
+  "workitem.start",
+  "automation.runNow",
+  "deferredPrompt.flush",
+  "deferredPrompt.release",
+  "task.ensureWorktree",
+  "task.ensureMain",
+  "worktree.discoverAdoptable",
+  "worktree.adopt",
+  "worktree.list",
+  "worktree.remove",
+]
+
+describe("rpc deadline policy", () => {
+  it("exempts exactly the pinned blocking surface", () => {
+    expect([...BLOCKING_RPCS].sort()).toEqual([...BLOCKING].sort())
+  })
+
+  it("matches what the handler registry declares", () => {
+    // The drift guard. Marking a handler `blocking: true` without adding it to
+    // protocol.ts leaves it dying at 20s; the reverse silently disables the
+    // wedge detector for a verb that should have it.
+    expect([...blockingRpcNames(createDaemonHandlerRegistry())].sort()).toEqual([...BLOCKING_RPCS].sort())
+  })
+
+  it("keeps the interactive write surface on the deadline", () => {
+    // These answer in milliseconds. Losing the wedge detector on them is how a
+    // hung daemon turns into a silently frozen UI on stale state.
+    for (const name of [
+      "task.create",
+      "task.rename",
+      "task.delete",
+      "task.status",
+      "task.list",
+      "daemon.status",
+    ] as const) {
+      expect(BLOCKING_RPCS.has(name), name).toBe(false)
+    }
+  })
+})


### PR DESCRIPTION
Three daemon fixes with the same shape: a policy the code stated and never enforced.

Each item's PASS criterion, and the run that proves it, is below. All three end-to-end
comparisons run the SAME command against an `origin/main` build and this branch, in isolated
`ROVE_HOME_DIR`s.

---

## G2 — every blocking RPC died at 20s and force-disconnected the client

`RPC_TIMEOUT_EXEMPT` in the socket client covered only six worktree verbs. Everything else got
`rpcTimeoutMs()` = 20s, and blowing it is not a plain failure: `onRequestTimeout` rejects with
`RpcTimeoutError("… daemon wedged?")`, then calls `forceDisconnect()` **and** emits a lifecycle
`close`. On the TUI's long-lived orchestrator client that tears down the socket and drops every
channel subscription — so a slow `task.land` put the whole workspace into the reconnect path while
the daemon was perfectly healthy, and reported it as a wedge.

**Shape chosen.** Not a longer number, and not a bigger hand-kept exempt list — that list is
maintained in the client, far from where verbs are defined, so a new blocking verb is silently
broken until someone hits it. Instead a verb declares itself on its own registry entry:

```ts
{ name: "task.land", blocking: true, web: true, async handle(…) {…} }
```

`BLOCKING_RPCS` in `protocol.ts` is the copy the client reads. The client **cannot** import the
handler registry — `handlers.ts` pulls in every handler module, which would drag the whole daemon
into every CLI invocation — so the set lives in the shared wire contract, and
`test/daemon/rpc-deadline.test.ts` fails if the two ever drift. Newly covered: `ui.prompt`,
`task.land`, `workitem.start`, `automation.runNow`, `deferredPrompt.flush`,
`deferredPrompt.release`.

**PASS: `rove api prompt --timeout 30000` returns `{cancelled, reason:"timeout"}` after 30s
instead of failing at 20s.** At the shipped default (`KOBE_RPC_TIMEOUT_MS` unset):

```
### BEFORE (origin/main 0.9.96)
{"error":{"message":"daemon rpc \"ui.prompt\" timed out after 20000ms (daemon wedged?)","code":"RPC_ERROR"}}
real	0m20.517s

### AFTER (this branch)
{"cancelled":true,"reason":"timeout"}
real	0m30.391s
```

**PASS: a unit test pinning the deadline table** — `test/daemon/rpc-deadline.test.ts`, 3 tests:
the pinned membership, the registry↔protocol drift guard, and that the interactive write surface
(`task.create`/`rename`/`delete`/`status`/`list`, `daemon.status`) keeps its wedge detector.

**Not done, deliberately:** Brief 1's second half — the daemon releasing a `ui.prompt` whose
requester ctrl-C'd, so the dialog stops sitting on every attached TUI for the full 120s. It is a
separate bug (the daemon holding a dialog for a dead client, not the client's deadline), it is not
in this item's stated PASS, and settling the RPC alone would not remove the rendered dialog — that
needs a dismiss broadcast plus its own harness screenshots. Flagging rather than half-doing it.

---

## G3 — the deferred-prompt 24h TTL was never enforced

`DEFERRED_PROMPT_TTL_MS` was dead policy. `list()` is the only method that computes `expired`, and
its whole call graph ended at `deferredPrompt.flush` → the Settings composer-gate toggle. No timer,
no boot pass. A prompt the delivery gate parked because a composer was busy sat on disk forever,
and its `prompt_deferred` Inbox row outlived every later turn on that tab (`attentionInboxItemKey`
gives the deferred episode its own lane, so `record`'s `turn-start` branch never cleared it).

New `deferred-prompt-sweep.ts` owns the expiry half, and `flushDeferredPrompts` now calls the same
function — one implementation, two callers. Wired in `collectors.ts` beside `startQuotaResumeRunner`
and `startAutomationRunner`, **ungated on `hasSubscribers`** (expiring a record nobody is watching is
the point) with an immediate first pass, so a restart clears what went stale while the daemon was
down. It expires **only**: re-delivering a live record stays the deliberate human action it is.

**PASS: seed a record 48h old, restart the daemon.**

```
### BEFORE (origin/main 0.9.96) — both survive
--- deferred-prompts.json ---
{"version":1,"records":[{"id":"stale-1","taskId":"T1","tabId":"tab-1","prompt":"held text","layer":"composer-not-empty","at":1788259890000}]}
--- attention-inbox.json ---
{"version":1,"items":[{"taskId":"T1","tabId":"tab-1","state":"prompt_deferred",…,"unread":true,…}]}

### AFTER (this branch) — both cleared
--- deferred-prompts.json ---   { "version": 1, "records": [] }
--- attention-inbox.json ---    { "version": 1, "items": [] }
```

**PASS: the store's own expiry line, which never printed before:**

```
[2026-09-03T10:51:54.888Z] daemon [deferred-prompts]: expired deferred prompt stale-1 for T1::tab-1 (age 172801s) — cleanup requested
```

**PASS: harness screenshots of the Inbox pane.** Identical seed (a 2-day-old record + its Inbox
row), identical `ctrl+a i`, two fixtures — `origin/main` on port base 5983, this branch on 5893:

- BEFORE `.scratch/g2-g4-evidence/g3-before-inbox.png` — **`INBOX 1`**, `ATTENTION / fixture-repo /
  Visual Fixture / ≡ message queued / 2d`. Two days old, past the TTL, still there after a restart.
- AFTER `.scratch/g2-g4-evidence/g3-after-inbox.png` — **`INBOX 0` / "No pending attention"**, and
  both JSON files empty.

Absolute paths: `/Users/jacksonc/.rove/worktrees/kobe-0aff3858ab76/urial/.scratch/g2-g4-evidence/g3-{before,after}-inbox.png`

**PASS: a test that a live record is NOT delivered by the timer** —
`test/daemon/deferred-prompt-sweep.test.ts`, 4 tests: expired record + Inbox pointer dropped, a
live record left completely alone, a failed Inbox delete reported as `cleanupPending` (rather than
orphaning a row pointing at a deleted record), and the immediate boot pass.

---

## G4 — `missedRunGraceMinutes: 0` recorded `skipped_missed` forever

`scheduledFor` is the cron occurrence at or **before** now and the sweep ticks once a minute, so
`now - scheduledFor` is always somewhere in 0..60000ms on a healthy run — strictly greater than 0.
With a grace of 0, `missed` was true on every firing: the sweep advanced `nextRunAt`, recorded
`skipped_missed`, and never dispatched.

**Semantics chosen: 0 stays legal and means "no slack beyond the tick that discovered it".** The
grace window gets a floor of one tick, because the sweep is a poller and can only ever see an
occurrence after it happened. Rejecting 0 instead would have thrown away a useful setting to work
around an off-by-a-poll-interval. The runner passes its own `tickMs`, so the floor tracks the
cadence actually in use rather than a hardcoded 60s.

**PASS: the brief's failing test passes** — plus two more, in
`test/daemon/automation-runner.test.ts`: a genuinely late occurrence (grace 0, discovered 10
minutes after the fact) is still `missed: true`, and the floor scales with the runner's tick.
`automations-store.test.ts` stays green — default-60 behaviour is unchanged.

**PASS: `routine-runs` shows no `skipped_missed`.** Same hand-seeded grace-0 `* * * * *` routine in
two isolated homes, two firings each:

```
### BEFORE (origin/main)
  2026-09-03T10:59:00.000Z -> skipped_missed missed by more than the 0m grace window
  2026-09-03T10:58:00.000Z -> skipped_missed missed by more than the 0m grace window

### AFTER (this branch)
  2026-09-03T10:59:00.000Z -> dispatched
  2026-09-03T10:58:00.000Z -> dispatched
```

**PASS: `--grace -1` errors clearly.** Two layers, because the value is reachable from both:

```
### AFTER: --grace -1 refused
{"error":{"message":"--grace must be a non-negative integer","code":"BAD_FLAG"}}

### AFTER: --grace 0 accepted and stored
{'id': '8b421375-…', 'name': 'zero', 'schedule': '*/5 * * * *', 'missedRunGraceMinutes': 0, 'enabled': True}

### AFTER: the RPC boundary refuses it on update too
{"error":{"message":"--grace must be a non-negative integer","code":"BAD_FLAG"}}
```

`readGraceMinutes` in `handlers-automations.ts` rejects a negative value at `automation.create`
and `automation.update`, and `readPrecheck` now rejects a non-positive `timeoutSeconds` for the
same reason (`automations-store.ts` keeps it only when `> 0`, so 0 survived in memory and became
120 on the next boot — "it started working after I restarted the daemon").

**One extra thing this exposed:** the CLI was *stricter* than the daemon — `--grace` used the
shared `type: "int"` spec, whose gate is `parsePositiveInt`, so **`--grace 0` was rejected outright
on `origin/main`**. A setting the daemon honours that the CLI cannot express is the same class of
bug, so `FlagType` gains `"uint"` (non-negative) and `--grace` uses it. `int` is untouched
everywhere else — counts and ids should stay positive.

---

## Mutation checks

| item | mutation | result |
|---|---|---|
| G2 | — (proven end-to-end above, both directions) | |
| G4 | drop `+ Math.max(tickMs, 0)` from `graceMs` | 3 of the new tests go red |

```
× resolveDueOccurrence > a zero grace still runs an occurrence discovered on the next tick
× resolveDueOccurrence > still calls a genuinely late occurrence missed with a zero grace
× resolveDueOccurrence > scales the floor with the runner's own tick period
 Tests  3 failed | 19 passed (22)
```

## Gates

- repo-root `bun run lint` — clean
- repo-root `bun run typecheck` — clean (4 packages)
- `bun run test:socket` — **90 files / 748 tests passed**
- `bun run test:fast` — 4264 passed, **6 pre-existing environmental failures**
  (`project-eligibility`, `open-dir-cmd`, `continue-live-vendor`). Verified against a detached
  `origin/main` worktree at the same `~/.rove/worktrees/...` path shape: **identical 6**
  (`expected 'roveInternal' to be null`, `expected 'claudecpa' to be 'claude'`). None of the three
  files import anything in this diff.

## Notes

- One line added to `kobe-daemon`'s `exports` (`./daemon/deferred-prompt-sweep`), and
  `blockingRpcNames` re-exported from `daemon/server` next to `createDaemonHandlerRegistry`.
- `startDaemonCollectors` gains a trailing optional `deferredSweep` parameter rather than riding on
  the `automations` block: `automations` is optional, and the TTL must be enforced on every daemon,
  including one with no routines configured.
- No new keybindings.

---

file-size-exemption: packages/kobe-daemon/src/daemon/server.ts — it arrives from `main` at 502 lines, already over the cap before this branch (#821 grew it); this PR adds 2 — `blockingRpcNames` beside the existing registry re-exports, and one collector argument. Splitting it is a real refactor of a file under concurrent change, so it is flagged here rather than bundled into a daemon bug-fix PR.
