### PR TITLE
One scheduling core and one ticker for the daemon collectors

### DIFF
--- a/.changeset/one-scheduler-and-one-ticker-for-collectors.md
+++ b/.changeset/one-scheduler-and-one-ticker-for-collectors.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Daemon collectors share one poll scheduler and one ticker. `maybeStartScheduledRun` lived three times (once in the CLI package, twice byte-identical in the daemon) because the daemon cannot import the CLI; it now lives in the daemon and the CLI re-exports it. Eight daemon loops that each hand-rolled the same `setInterval` skeleton (tick guard, reentrancy flag, subscriber gate, unref, clear) share `startTicker`, with the three real per-collector variations kept as explicit options. Behavior add: the quota-usage cache gains the `tickMs <= 0` disable guard every sibling already had.

--- a/packages/kobe-daemon/package.json
+++ b/packages/kobe-daemon/package.json
@@ -48,6 +48,7 @@
     "./daemon/paths": "./src/daemon/paths.ts",
     "./daemon/platform-shell": "./src/daemon/platform-shell.js",
     "./daemon/context-usage-collector": "./src/daemon/context-usage-collector.ts",
+    "./daemon/poll-scheduling": "./src/daemon/poll-scheduling.ts",
     "./daemon/pr-failing-checks": "./src/daemon/pr-failing-checks.ts",
     "./daemon/pr-status-collector": "./src/daemon/pr-status-collector.ts",
     "./daemon/prompt-broker": "./src/daemon/prompt-broker.ts",
@@ -90,7 +91,8 @@
     "./daemon/quota-resume": "./src/daemon/quota-resume.ts",
     "./prompts/issue-prompts": "./src/prompts/issue-prompts.ts",
     "./prompts/observed-language": "./src/prompts/observed-language.ts",
-    "./daemon/terminal-rows": "./src/daemon/terminal-rows.ts"
+    "./daemon/terminal-rows": "./src/daemon/terminal-rows.ts",
+    "./daemon/ticker": "./src/daemon/ticker.ts"
   },
   "scripts": {
     "typecheck": "tsc --noEmit"

--- a/packages/kobe-daemon/src/daemon/auto-title-poller.ts
+++ b/packages/kobe-daemon/src/daemon/auto-title-poller.ts
@@ -26,6 +26,7 @@
 import type { DaemonOrchestrator, VendorId } from "./contracts.ts"
 import { logDaemonError } from "./crash-log"
 import type { DaemonRuntimeAdapter } from "./runtime.ts"
+import { startTicker } from "./ticker.ts"
 
 /** Default re-scan cadence; responsive without hammering disk. */
 export const DEFAULT_AUTO_TITLE_POLL_MS = 4000
@@ -116,23 +117,13 @@ export function startAutoTitlePoller(
   intervalMs: number = DEFAULT_AUTO_TITLE_POLL_MS,
   hasSubscribers?: () => boolean,
 ): () => void {
-  if (intervalMs <= 0) return () => {}
-  let running = false
-  const tick = (): void => {
+  return startTicker({
+    name: "auto-title-poller",
+    tickMs: intervalMs,
     // Consumer gate: no subscribed pane means no Tasks pane is rendering a
     // live rename, so skip the disk work entirely.
-    if (hasSubscribers && !hasSubscribers()) return
-    // Skip if a previous pass is still in flight so a slow disk read can't
-    // pile up overlapping scans.
-    if (running) return
-    running = true
-    void runAutoTitlePass(orch, runtime.deriveTitleFromSession, runtime.placeholderTaskTitle, runtime.defaultTaskVendor)
-      .catch((err) => logDaemonError("auto-title-poller", err))
-      .finally(() => {
-        running = false
-      })
-  }
-  const timer = setInterval(tick, intervalMs)
-  timer.unref?.()
-  return () => clearInterval(timer)
+    ...(hasSubscribers ? { gate: hasSubscribers } : {}),
+    run: () =>
+      runAutoTitlePass(orch, runtime.deriveTitleFromSession, runtime.placeholderTaskTitle, runtime.defaultTaskVendor),
+  })
 }

--- a/packages/kobe-daemon/src/daemon/automation-runner.ts
+++ b/packages/kobe-daemon/src/daemon/automation-runner.ts
@@ -33,6 +33,7 @@ import { logDaemonError, logDaemonInfo } from "./crash-log.ts"
 import { latestCronAtOrBefore } from "./cron.ts"
 import type { DeferredPromptsStore } from "./deferred-prompts-store.ts"
 import type { DaemonRuntimeAdapter } from "./runtime.ts"
+import { startTicker } from "./ticker.ts"
 
 /** How often the sweep looks for due schedules. Cron's own resolution is one
  *  minute, so a faster tick would only re-ask the same question. */
@@ -279,18 +280,7 @@ export async function sweepAutomations(deps: RunnerDeps, tickMs: number = DEFAUL
  * daemon with every collector zeroed, and this must honour that too.
  */
 export function startAutomationRunner(deps: RunnerDeps, tickMs: number = DEFAULT_AUTOMATION_TICK_MS): () => void {
-  if (tickMs <= 0) return () => {}
-  let sweeping = false
-  const tick = async (): Promise<void> => {
-    if (sweeping) return
-    sweeping = true
-    try {
-      await sweepAutomations(deps, tickMs)
-    } finally {
-      sweeping = false
-    }
-  }
-  const timer = setInterval(() => void tick().catch((err) => logDaemonError("automation-sweep", err)), tickMs)
-  timer.unref?.()
-  return () => clearInterval(timer)
+  // Ungated for the same reason as quota-resume, only more so: a schedule
+  // that requires an audience is not a schedule.
+  return startTicker({ name: "automation-sweep", tickMs, run: () => sweepAutomations(deps, tickMs) })
 }

--- a/packages/kobe-daemon/src/daemon/deferred-prompt-sweep.ts
+++ b/packages/kobe-daemon/src/daemon/deferred-prompt-sweep.ts
@@ -21,6 +21,7 @@
 import type { AttentionInboxStore } from "./attention-inbox.ts"
 import { logDaemonError } from "./crash-log.ts"
 import type { DeferredPromptRecord, DeferredPromptsStore } from "./deferred-prompts-store.ts"
+import { startTicker } from "./ticker.ts"
 
 /** Once an hour is plenty for a 24h boundary, and a tick is one file read. */
 export const DEFAULT_DEFERRED_SWEEP_TICK_MS = 60 * 60 * 1000
@@ -91,21 +92,10 @@ export function startDeferredPromptSweep(
   deps: DeferredSweepDeps,
   tickMs: number = DEFAULT_DEFERRED_SWEEP_TICK_MS,
 ): () => void {
-  let sweeping = false
-  const sweep = async (): Promise<void> => {
-    if (sweeping) return
-    sweeping = true
-    try {
-      await sweepExpiredDeferredPrompts(deps)
-    } catch (err) {
-      logDaemonError("deferred-prompt-sweep", err)
-    } finally {
-      sweeping = false
-    }
-  }
-  void sweep()
-  if (tickMs <= 0) return () => {}
-  const timer = setInterval(() => void sweep(), tickMs)
-  timer.unref?.()
-  return () => clearInterval(timer)
+  return startTicker({
+    name: "deferred-prompt-sweep",
+    tickMs,
+    immediate: true,
+    run: () => sweepExpiredDeferredPrompts(deps),
+  })
 }

--- a/packages/kobe-daemon/src/daemon/poll-scheduling.ts
+++ b/packages/kobe-daemon/src/daemon/poll-scheduling.ts
@@ -1,0 +1,186 @@
+/**
+ * Pure scheduling core for subprocess-backed background polling.
+ *
+ * It lives in `kobe-daemon` because BOTH sides need it and the dependency
+ * arrow only runs one way: `kobe` depends on `kobe-daemon`, never the
+ * reverse. When this module sat in `kobe/src/lib`, the daemon's two
+ * collectors physically could not import it, so each carried its own
+ * byte-identical copy of {@link maybeStartScheduledRun} — and the module doc
+ * here still claimed they "reuse the EXACT guards", which had quietly stopped
+ * being true. `kobe/src/lib/poll-scheduling.ts` is now a re-export, so every
+ * TUI-side import path is unchanged.
+ *
+ * The three guards live here; the bindings differ only in where a finished
+ * value goes:
+ *
+ *   - **in-flight dedupe** — one run per key at a time
+ *     ({@link shouldPoll}); ticks landing mid-run are dropped.
+ *   - **adaptive cadence** — the next run is allowed only after
+ *     `max(minIntervalMs, 5 × last duration)` ({@link computeNextAllowedAt}):
+ *     fast repos keep the tick cadence, slow-but-finishing repos self-thin.
+ *   - **timeout + hard backoff** — a run exceeding `timeoutMs` is aborted
+ *     (children spawned via {@link spawnCapture} get SIGKILLed) and the key
+ *     backs off for `slowRetryMs`.
+ *
+ * Dependency-free apart from `node:child_process` — safe for the daemon,
+ * vitest, and any render process.
+ */
+
+import { spawn } from "node:child_process"
+
+/** The cadence knobs every scheduled-poll consumer must pin down. */
+export interface PollCadenceConfig {
+  /** Abort a run (and back off hard) after this long. */
+  readonly timeoutMs: number
+  /** After a timeout, leave the key alone for this long before retrying. */
+  readonly slowRetryMs: number
+  /** Floor between successful runs — typically the caller's tick cadence. */
+  readonly minIntervalMs: number
+}
+
+/** Per-key scheduling state the guards read/write. */
+export interface PollScheduleState {
+  inFlight: boolean
+  nextAllowedAt: number
+}
+
+/**
+ * When the next run may start. Pure — exported for unit tests.
+ * Timed-out runs back off hard; completed runs scale with their own
+ * duration so slow repos self-thin without a special case.
+ */
+export function computeNextAllowedAt(
+  startedAt: number,
+  finishedAt: number,
+  timedOut: boolean,
+  cfg: { readonly slowRetryMs: number; readonly minIntervalMs: number },
+): number {
+  if (timedOut) return startedAt + cfg.slowRetryMs
+  return finishedAt + Math.max(cfg.minIntervalMs, (finishedAt - startedAt) * 5)
+}
+
+/** Whether a run may start now. Pure — exported for unit tests. */
+export function shouldPoll(state: { inFlight: boolean; nextAllowedAt: number }, now: number): boolean {
+  return !state.inFlight && now >= state.nextAllowedAt
+}
+
+/**
+ * Spread a delay by ± `ratio` so many keys coming due together (e.g. after a
+ * network reconnect re-arms every poller at once) don't fire in lockstep.
+ * `ratio` is clamped to `[0, 1]`; the result lands in
+ * `[delayMs·(1−ratio), delayMs·(1+ratio))` and is never negative. `rand`
+ * defaults to `Math.random` and is injectable so tests are deterministic
+ * (`() => 0.5` yields exactly `delayMs`, the no-jitter midpoint). Pure.
+ */
+export function applyJitter(delayMs: number, ratio: number, rand: () => number = Math.random): number {
+  const r = Math.max(0, Math.min(1, ratio))
+  const offset = (rand() * 2 - 1) * delayMs * r
+  return Math.max(0, delayMs + offset)
+}
+
+/**
+ * Exponential backoff capped at `capMs`: `baseMs · 2^attempt`, with `attempt`
+ * the zero-based retry index (0 → `baseMs`, 1 → `2·baseMs`, …). Negative
+ * attempts clamp to `baseMs`; the result never exceeds `capMs`. Pure —
+ * exported for unit tests.
+ */
+export function exponentialBackoff(baseMs: number, attempt: number, capMs: number): number {
+  if (attempt <= 0) return Math.min(baseMs, capMs)
+  return Math.min(baseMs * 2 ** attempt, capMs)
+}
+
+/**
+ * Maybe start one guarded background run for a key's schedule state.
+ * Returns `false` (no run) when the guards say no — in flight, or inside
+ * the cadence/backoff window. Otherwise marks the state in-flight, runs
+ * `run` with an AbortSignal that fires at `timeoutMs` (pass it to
+ * {@link spawnCapture} so a runaway child is SIGKILLed), and on settle
+ * updates `nextAllowedAt` + clears the in-flight flag.
+ *
+ * Failure contract (same as the TUI poller it was extracted from): a run
+ * that throws, is aborted, or resolves after the timeout never calls
+ * `onValue` — the consumer keeps its last good value, so UIs go stale or
+ * stay hidden rather than erroring.
+ */
+export function maybeStartScheduledRun<T>(
+  state: PollScheduleState,
+  cfg: PollCadenceConfig,
+  run: (signal: AbortSignal) => Promise<T>,
+  onValue: (value: T) => void,
+): boolean {
+  const startedAt = Date.now()
+  if (!shouldPoll(state, startedAt)) return false
+  state.inFlight = true
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), cfg.timeoutMs)
+  void (async () => {
+    let value: T | undefined
+    let ok = false
+    try {
+      value = await run(controller.signal)
+      ok = true
+    } catch {
+      // Keep the last value — the consumer goes stale, never errors.
+    }
+    clearTimeout(timer)
+    const timedOut = controller.signal.aborted
+    state.nextAllowedAt = computeNextAllowedAt(startedAt, Date.now(), timedOut, cfg)
+    state.inFlight = false
+    if (ok && !timedOut) onValue(value as T)
+  })()
+  return true
+}
+
+export interface SpawnCaptureResult {
+  /** Exit code, or null when the child errored / was killed (timeout). */
+  readonly status: number | null
+  readonly stdout: string
+}
+
+/**
+ * Decode captured stdout chunks to one UTF-8 string. Chunks MUST be joined as
+ * bytes before decoding: a stdout pipe splits on an arbitrary byte boundary
+ * (~64 KB), so a multi-byte UTF-8 sequence (a non-ASCII path with
+ * `core.quotepath=false`, or any commit message / diff body git never quotes)
+ * can straddle two chunks. Decoding each chunk on its own — `String(chunk)` —
+ * turns the split character into replacement bytes (`�`); concatenating
+ * the raw bytes first decodes it intact. Pure — exported for unit tests.
+ */
+export function decodeCapturedChunks(chunks: readonly (Buffer | string)[]): string {
+  return Buffer.concat(chunks.map((c) => (typeof c === "string" ? Buffer.from(c) : c))).toString("utf8")
+}
+
+/**
+ * Async spawn that collects stdout and resolves on close. Never rejects —
+ * a spawn error (missing cwd, binary not on PATH) or an abort resolves
+ * with `status: null` so callers branch on status, mirroring the
+ * never-throw contract of the pane-side sync git helpers it replaces.
+ * The AbortSignal kills the child with SIGKILL.
+ */
+export function spawnCapture(
+  cmd: string,
+  args: readonly string[],
+  opts: { readonly cwd: string; readonly env?: NodeJS.ProcessEnv; readonly signal: AbortSignal },
+): Promise<SpawnCaptureResult> {
+  return new Promise((resolve) => {
+    const chunks: (Buffer | string)[] = []
+    let settled = false
+    const finish = (status: number | null): void => {
+      if (settled) return
+      settled = true
+      resolve({ status, stdout: decodeCapturedChunks(chunks) })
+    }
+    const child = spawn(cmd, args.slice(), {
+      cwd: opts.cwd,
+      stdio: ["ignore", "pipe", "ignore"],
+      env: opts.env,
+      signal: opts.signal,
+      killSignal: "SIGKILL",
+    })
+    child.stdout?.on("data", (chunk: Buffer | string) => {
+      chunks.push(chunk)
+    })
+    child.on("error", () => finish(null))
+    child.on("close", (code) => finish(code))
+  })
+}

--- a/packages/kobe-daemon/src/daemon/pr-status-collector.ts
+++ b/packages/kobe-daemon/src/daemon/pr-status-collector.ts
@@ -61,6 +61,7 @@ import { spawn } from "node:child_process"
 import type { DaemonOrchestrator, DaemonTask as Task } from "./contracts.ts"
 import { logDaemonError, logDaemonInfo } from "./crash-log.ts"
 import type { DaemonRuntimeAdapter } from "./runtime.ts"
+import { startTicker } from "./ticker.ts"
 
 export interface GhPrView {
   readonly number?: number
@@ -412,27 +413,21 @@ export function startPrStatusPoller(
   run: PrViewRunner = makeGhPrViewRunner(runtime.prStatus.classify, runtime.prStatus.viewFields),
   hasWorkingAgent?: () => boolean,
 ): () => void {
-  if (intervalMs <= 0) return () => {}
   const schedule: PrPollSchedule = new Map()
-  let running = false
-  const tick = (): void => {
-    if (hasSubscribers && !hasSubscribers() && !hasWorkingAgent?.()) return
-    if (running) return
-    running = true
-    void runPrStatusPass(orch, {
-      runtime,
-      run,
-      now: Date.now(),
-      at: new Date().toISOString(),
-      schedule,
-      tickMs: intervalMs,
-    })
-      .catch((err) => logDaemonError("pr-status-poller", err))
-      .finally(() => {
-        running = false
-      })
-  }
-  const timer = setInterval(tick, intervalMs)
-  timer.unref?.()
-  return () => clearInterval(timer)
+  return startTicker({
+    name: "pr-status-poller",
+    tickMs: intervalMs,
+    // Two-term gate: an unattended agent is the consumer that needs CI truth
+    // most, so a live engine opens it even with no pane attached.
+    ...(hasSubscribers ? { gate: () => hasSubscribers() || (hasWorkingAgent?.() ?? false) } : {}),
+    run: () =>
+      runPrStatusPass(orch, {
+        runtime,
+        run,
+        now: Date.now(),
+        at: new Date().toISOString(),
+        schedule,
+        tickMs: intervalMs,
+      }),
+  })
 }

--- a/packages/kobe-daemon/src/daemon/quota-resume.ts
+++ b/packages/kobe-daemon/src/daemon/quota-resume.ts
@@ -20,6 +20,7 @@ import type { DaemonOrchestrator, DaemonTask, EngineQuotaUsage } from "./contrac
 import { logDaemonError, logDaemonInfo } from "./crash-log.ts"
 import type { QuotaUsageCache } from "./quota-usage-cache.ts"
 import type { DaemonRuntimeAdapter } from "./runtime.ts"
+import { startTicker } from "./ticker.ts"
 
 /**
  * Engine-neutral continuation instruction typed into the resumed session,
@@ -139,23 +140,18 @@ export function startQuotaResumeRunner(
   now: () => number = Date.now,
   plugins?: () => Pick<PluginHost, "handleUiReport"> | null,
 ): () => void {
-  // `collectors.ts` reads the tick with `??`, which does NOT replace a 0, so
-  // without this the documented "0 disables it" gives setInterval(fn, 0) — a
-  // ~1000 Hz sweep of the whole task index. Every sibling collector guards it.
-  if (tickMs <= 0) return () => {}
-  let sweeping = false
-  const sweep = async (): Promise<void> => {
-    if (sweeping) return
-    sweeping = true
-    try {
+  // Ungated on purpose: resuming a rate-limited engine while nobody is
+  // attached is the entire job. `tickMs <= 0` disabling the sweep is
+  // `startTicker`'s job now — `collectors.ts` reads the tick with `??`, which
+  // does NOT replace a 0, so without that guard the documented "0 disables it"
+  // gives setInterval(fn, 0): a ~1000 Hz sweep of the whole task index.
+  return startTicker({
+    name: "quota-resume",
+    tickMs,
+    run: async () => {
       for (const task of dueQuotaResumes(orch.listTasks(), now())) {
         await resumeDueTask(orch, runtime, task, plugins).catch((err) => logDaemonError("quota-resume", err))
       }
-    } finally {
-      sweeping = false
-    }
-  }
-  const timer = setInterval(() => void sweep(), tickMs)
-  timer.unref?.()
-  return () => clearInterval(timer)
+    },
+  })
 }

--- a/packages/kobe-daemon/src/daemon/quota-usage-cache.ts
+++ b/packages/kobe-daemon/src/daemon/quota-usage-cache.ts
@@ -21,6 +21,7 @@
 import type { EngineQuotaUsage, VendorId } from "./contracts.ts"
 import type { DaemonEventBus } from "./event-bus.ts"
 import type { DaemonRuntimeAdapter } from "./runtime.ts"
+import { startTicker } from "./ticker.ts"
 
 /** Refresh interval while a snapshot exists (usage moves slowly for display). */
 export const FRESH_POLL_MS = 15 * 60 * 1000
@@ -133,12 +134,13 @@ export function startQuotaUsagePoller(
   hasSubscribers: () => boolean,
   tickMs: number = MIN_FETCH_INTERVAL_MS,
 ): () => void {
-  const tick = (): void => {
-    if (!hasSubscribers()) return
-    for (const vendor of new Set(listVendors())) void cache.refreshIfDue(vendor)
-  }
-  tick()
-  const timer = setInterval(tick, tickMs)
-  timer.unref?.()
-  return () => clearInterval(timer)
+  return startTicker({
+    name: "quota-usage-poller",
+    tickMs,
+    gate: hasSubscribers,
+    immediate: true,
+    run: () => {
+      for (const vendor of new Set(listVendors())) void cache.refreshIfDue(vendor)
+    },
+  })
 }

--- a/packages/kobe-daemon/src/daemon/runtime.ts
+++ b/packages/kobe-daemon/src/daemon/runtime.ts
@@ -25,16 +25,10 @@ export interface EngineTurnDetectorAdapter {
   supportsCompletionMarkers(): boolean
 }
 
-export interface PollCadenceConfig {
-  readonly timeoutMs: number
-  readonly slowRetryMs: number
-  readonly minIntervalMs: number
-}
-
-export interface PollScheduleState {
-  inFlight: boolean
-  nextAllowedAt: number
-}
+/** The cadence knobs + per-key state the scheduling core reads and writes.
+ *  Re-exported, not restated: this file used to carry its own copies of both
+ *  shapes alongside the ones in `poll-scheduling.ts`. */
+export type { PollCadenceConfig, PollScheduleState } from "./poll-scheduling.ts"
 
 export interface DaemonRuntimeAdapter {
   readonly currentVersion: string

--- a/packages/kobe-daemon/src/daemon/ticker.ts
+++ b/packages/kobe-daemon/src/daemon/ticker.ts
@@ -1,0 +1,74 @@
+/**
+ * The shared skeleton behind every daemon background loop.
+ *
+ * Each `start*` collector re-implemented the same parts by hand: a
+ * `tickMs <= 0` no-op guard, a reentrancy flag, an optional subscriber gate, a
+ * `setInterval`, `timer.unref?.()`, a `logDaemonError(<scope>, err)` catch, and
+ * a `clearInterval` teardown. The guard line alone appeared verbatim in five
+ * files — and its ABSENCE from `quota-resume` and `quota-usage-cache` meant a
+ * zero there armed a hot loop instead of disabling the poll.
+ *
+ * The seam: this module owns WHEN a pass may run; each collector owns what a
+ * pass does. The per-key adaptive backoff in `poll-scheduling.ts` is the inner
+ * loop and stays there. `activity-observer.ts` stays hand-rolled — it counts
+ * ticks and walks every Nth, which needs options nobody else uses.
+ */
+
+import { logDaemonError } from "./crash-log.ts"
+
+function isThenable(value: unknown): value is Promise<unknown> {
+  return typeof (value as { then?: unknown } | null | undefined)?.then === "function"
+}
+
+export interface TickerOptions {
+  /** `logDaemonError` scope, grepped in `daemon.log` during triage — verbatim. */
+  readonly name: string
+  /** `<= 0` disables the ticker entirely: no interval, and no immediate pass. */
+  readonly tickMs: number
+  /** Checked before EVERY pass, the immediate one included. Omitted means
+   *  ungated — the deliberate setting for the sweeps whose whole job is
+   *  running while nobody is attached. Never default one on. */
+  readonly gate?: () => boolean
+  /** Run one pass before arming the interval (restart seeding). */
+  readonly immediate?: boolean
+  /** One pass. A returned promise is awaited and its value discarded. */
+  readonly run: () => unknown
+  /** Extra teardown beside `clearInterval` — the collectors' `stop()`. */
+  readonly onStop?: () => void
+}
+
+export function startTicker(opts: TickerOptions): () => void {
+  if (opts.tickMs <= 0) return () => {}
+  let running = false
+  const tick = (): void => {
+    if (opts.gate && !opts.gate()) return
+    if (running) return
+    let result: unknown
+    try {
+      result = opts.run()
+    } catch (err) {
+      logDaemonError(opts.name, err)
+      return
+    }
+    // A SYNCHRONOUS pass is already finished here, so it must not arm the
+    // reentrancy flag — `quota-usage-cache` and the two collectors never had
+    // one, and giving them one would drop a tick whenever the flag outlived
+    // the pass. Only a pass that returns a promise gets guarded, which is
+    // exactly the shape the other five hand-rolled.
+    if (!isThenable(result)) return
+    running = true
+    void result
+      .catch((err: unknown) => logDaemonError(opts.name, err))
+      .finally(() => {
+        running = false
+      })
+  }
+  if (opts.immediate) tick()
+  const timer = setInterval(tick, opts.tickMs)
+  // Without unref a gui-less daemon never exits and `rove daemon restart` hangs.
+  timer.unref?.()
+  return () => {
+    clearInterval(timer)
+    opts.onStop?.()
+  }
+}

--- a/packages/kobe-daemon/src/daemon/transcript-activity-collector.ts
+++ b/packages/kobe-daemon/src/daemon/transcript-activity-collector.ts
@@ -53,43 +53,13 @@
 import type { DaemonTask as Task, VendorId } from "./contracts.ts"
 import { logDaemonError } from "./crash-log.ts"
 import type { DaemonEventBus } from "./event-bus.ts"
+import { type PollCadenceConfig, type PollScheduleState, maybeStartScheduledRun } from "./poll-scheduling.ts"
 import type { TranscriptActivityPayload } from "./protocol.ts"
-import type {
-  DaemonRuntimeAdapter,
-  EngineTurnDetectorAdapter as EngineTurnDetector,
-  PollCadenceConfig,
-  PollScheduleState,
-} from "./runtime.ts"
+import type { DaemonRuntimeAdapter, EngineTurnDetectorAdapter as EngineTurnDetector } from "./runtime.ts"
+import { startTicker } from "./ticker.ts"
 
 function isRemoteRepoKey(value: string): boolean {
   return value.startsWith("ssh://")
-}
-
-function maybeStartScheduledRun<T>(
-  state: PollScheduleState,
-  cfg: PollCadenceConfig,
-  run: (signal: AbortSignal) => Promise<T>,
-  onValue: (value: T) => void,
-): boolean {
-  const startedAt = Date.now()
-  if (state.inFlight || startedAt < state.nextAllowedAt) return false
-  state.inFlight = true
-  const controller = new AbortController()
-  const timer = setTimeout(() => controller.abort(), cfg.timeoutMs)
-  void run(controller.signal)
-    .then((value) => {
-      if (!controller.signal.aborted) onValue(value)
-    })
-    .catch(() => {})
-    .finally(() => {
-      clearTimeout(timer)
-      const finishedAt = Date.now()
-      state.nextAllowedAt = controller.signal.aborted
-        ? startedAt + cfg.slowRetryMs
-        : finishedAt + Math.max(cfg.minIntervalMs, (finishedAt - startedAt) * 5)
-      state.inFlight = false
-    })
-  return true
 }
 
 /** Tick cadence — matches the Ops pane's 1.5s turn-detector poll (the most responsive consumer). */
@@ -332,7 +302,6 @@ export function startTranscriptActivityCollector(
   tickMs: number = DEFAULT_TRANSCRIPT_ACTIVITY_TICK_MS,
   hasSubscribers?: () => boolean,
 ): () => void {
-  if (tickMs <= 0) return () => {}
   const collector = new TranscriptActivityCollector(orch, bus, {
     hasSubscribers,
     createDetector: runtime.createEngineTurnDetector,
@@ -346,11 +315,12 @@ export function startTranscriptActivityCollector(
       return { mtimeMs: resolvedMtime, completionId: marker?.id ?? null, completionAt: marker?.timestampMs ?? 0 }
     },
   })
-  collector.tick()
-  const timer = setInterval(() => collector.tick(), tickMs)
-  timer.unref?.()
-  return () => {
-    clearInterval(timer)
-    collector.stop()
-  }
+  // Gate lives inside `collector.tick()`, as in the worktree collector.
+  return startTicker({
+    name: "transcript-activity-collector",
+    tickMs,
+    immediate: true,
+    run: () => collector.tick(),
+    onStop: () => collector.stop(),
+  })
 }

--- a/packages/kobe-daemon/src/daemon/worktree-changes-collector.ts
+++ b/packages/kobe-daemon/src/daemon/worktree-changes-collector.ts
@@ -45,8 +45,10 @@ import { spawn } from "node:child_process"
 import type { DaemonTask as Task, WorktreeChanges } from "./contracts.ts"
 import { logDaemonError } from "./crash-log.ts"
 import type { DaemonEventBus } from "./event-bus.ts"
+import { type PollCadenceConfig, type PollScheduleState, maybeStartScheduledRun } from "./poll-scheduling.ts"
 import type { WorktreeChangesPayload } from "./protocol.ts"
-import type { DaemonRuntimeAdapter, PollCadenceConfig, PollScheduleState } from "./runtime.ts"
+import type { DaemonRuntimeAdapter } from "./runtime.ts"
+import { startTicker } from "./ticker.ts"
 
 function isRemoteRepoKey(value: string): boolean {
   return value.startsWith("ssh://")
@@ -54,33 +56,6 @@ function isRemoteRepoKey(value: string): boolean {
 
 function sameWorktreeChanges(a: WorktreeChanges, b: WorktreeChanges): boolean {
   return a.added === b.added && a.deleted === b.deleted && a.behind === b.behind
-}
-
-function maybeStartScheduledRun<T>(
-  state: PollScheduleState,
-  cfg: PollCadenceConfig,
-  run: (signal: AbortSignal) => Promise<T>,
-  onValue: (value: T) => void,
-): boolean {
-  const startedAt = Date.now()
-  if (state.inFlight || startedAt < state.nextAllowedAt) return false
-  state.inFlight = true
-  const controller = new AbortController()
-  const timer = setTimeout(() => controller.abort(), cfg.timeoutMs)
-  void run(controller.signal)
-    .then((value) => {
-      if (!controller.signal.aborted) onValue(value)
-    })
-    .catch(() => {})
-    .finally(() => {
-      clearTimeout(timer)
-      const finishedAt = Date.now()
-      state.nextAllowedAt = controller.signal.aborted
-        ? startedAt + cfg.slowRetryMs
-        : finishedAt + Math.max(cfg.minIntervalMs, (finishedAt - startedAt) * 5)
-      state.inFlight = false
-    })
-  return true
 }
 
 /** Tick cadence — matches the sidebar's ~2s `branchTick` the pane pollers rode. */
@@ -337,13 +312,14 @@ export function startWorktreeChangesCollector(
   tickMs: number = DEFAULT_WORKTREE_CHANGES_TICK_MS,
   hasSubscribers?: () => boolean,
 ): () => void {
-  if (tickMs <= 0) return () => {}
   const collector = new WorktreeChangesCollector(orch, bus, { hasSubscribers, run: runtime.runWorktreeStatus })
-  collector.tick()
-  const timer = setInterval(() => collector.tick(), tickMs)
-  timer.unref?.()
-  return () => {
-    clearInterval(timer)
-    collector.stop()
-  }
+  // No `gate` here: the subscriber check lives inside `collector.tick()`,
+  // which also owns its own per-key in-flight state.
+  return startTicker({
+    name: "worktree-changes-collector",
+    tickMs,
+    immediate: true,
+    run: () => collector.tick(),
+    onStop: () => collector.stop(),
+  })
 }

--- a/packages/kobe/src/lib/poll-scheduling.ts
+++ b/packages/kobe/src/lib/poll-scheduling.ts
@@ -1,183 +1,21 @@
 /**
- * Pure scheduling core for subprocess-backed background polling, kept out
- * of `src/tui/lib/background-poll.ts` so the
- * daemon's worktree-changes collector can reuse the EXACT guards that
- * keep huge-repo `git status` off the event loop, without importing
- * UI state primitives into daemon code.
- *
- * The three guards live here; the two bindings differ only in where a
- * finished value goes:
- *
- *   - **in-flight dedupe** — one run per key at a time
- *     ({@link shouldPoll}); ticks landing mid-run are dropped.
- *   - **adaptive cadence** — the next run is allowed only after
- *     `max(minIntervalMs, 5 × last duration)` ({@link computeNextAllowedAt}):
- *     fast repos keep the tick cadence, slow-but-finishing repos self-thin.
- *   - **timeout + hard backoff** — a run exceeding `timeoutMs` is aborted
- *     (children spawned via {@link spawnCapture} get SIGKILLed) and the key
- *     backs off for `slowRetryMs`.
- *
- * `src/tui/lib/background-poll.ts` re-exports everything here, so its
- * public API is unchanged; TUI code keeps importing from there.
- * Dependency-free apart from `node:child_process` — safe for the daemon,
- * vitest, and any render process.
+ * Re-export of the scheduling core, which now lives in `kobe-daemon` so the
+ * daemon's collectors can import the same module instead of copying it (the
+ * dependency arrow runs kobe → kobe-daemon, never back). Kept as a shim
+ * because `src/tui/lib/background-poll.ts`, `src/monitor/pr-status.ts`,
+ * `src/core/daemon-runtime.ts` and `src/engine/claude-code-local/quota.ts`
+ * all import from here.
  */
 
-import { spawn } from "node:child_process"
-
-/** The cadence knobs every scheduled-poll consumer must pin down. */
-export interface PollCadenceConfig {
-  /** Abort a run (and back off hard) after this long. */
-  readonly timeoutMs: number
-  /** After a timeout, leave the key alone for this long before retrying. */
-  readonly slowRetryMs: number
-  /** Floor between successful runs — typically the caller's tick cadence. */
-  readonly minIntervalMs: number
-}
-
-/** Per-key scheduling state the guards read/write. */
-export interface PollScheduleState {
-  inFlight: boolean
-  nextAllowedAt: number
-}
-
-/**
- * When the next run may start. Pure — exported for unit tests.
- * Timed-out runs back off hard; completed runs scale with their own
- * duration so slow repos self-thin without a special case.
- */
-export function computeNextAllowedAt(
-  startedAt: number,
-  finishedAt: number,
-  timedOut: boolean,
-  cfg: { readonly slowRetryMs: number; readonly minIntervalMs: number },
-): number {
-  if (timedOut) return startedAt + cfg.slowRetryMs
-  return finishedAt + Math.max(cfg.minIntervalMs, (finishedAt - startedAt) * 5)
-}
-
-/** Whether a run may start now. Pure — exported for unit tests. */
-export function shouldPoll(state: { inFlight: boolean; nextAllowedAt: number }, now: number): boolean {
-  return !state.inFlight && now >= state.nextAllowedAt
-}
-
-/**
- * Spread a delay by ± `ratio` so many keys coming due together (e.g. after a
- * network reconnect re-arms every poller at once) don't fire in lockstep.
- * `ratio` is clamped to `[0, 1]`; the result lands in
- * `[delayMs·(1−ratio), delayMs·(1+ratio))` and is never negative. `rand`
- * defaults to `Math.random` and is injectable so tests are deterministic
- * (`() => 0.5` yields exactly `delayMs`, the no-jitter midpoint). Pure.
- */
-export function applyJitter(delayMs: number, ratio: number, rand: () => number = Math.random): number {
-  const r = Math.max(0, Math.min(1, ratio))
-  const offset = (rand() * 2 - 1) * delayMs * r
-  return Math.max(0, delayMs + offset)
-}
-
-/**
- * Exponential backoff capped at `capMs`: `baseMs · 2^attempt`, with `attempt`
- * the zero-based retry index (0 → `baseMs`, 1 → `2·baseMs`, …). Negative
- * attempts clamp to `baseMs`; the result never exceeds `capMs`. Pure —
- * exported for unit tests.
- */
-export function exponentialBackoff(baseMs: number, attempt: number, capMs: number): number {
-  if (attempt <= 0) return Math.min(baseMs, capMs)
-  return Math.min(baseMs * 2 ** attempt, capMs)
-}
-
-/**
- * Maybe start one guarded background run for a key's schedule state.
- * Returns `false` (no run) when the guards say no — in flight, or inside
- * the cadence/backoff window. Otherwise marks the state in-flight, runs
- * `run` with an AbortSignal that fires at `timeoutMs` (pass it to
- * {@link spawnCapture} so a runaway child is SIGKILLed), and on settle
- * updates `nextAllowedAt` + clears the in-flight flag.
- *
- * Failure contract (same as the TUI poller it was extracted from): a run
- * that throws, is aborted, or resolves after the timeout never calls
- * `onValue` — the consumer keeps its last good value, so UIs go stale or
- * stay hidden rather than erroring.
- */
-export function maybeStartScheduledRun<T>(
-  state: PollScheduleState,
-  cfg: PollCadenceConfig,
-  run: (signal: AbortSignal) => Promise<T>,
-  onValue: (value: T) => void,
-): boolean {
-  const startedAt = Date.now()
-  if (!shouldPoll(state, startedAt)) return false
-  state.inFlight = true
-  const controller = new AbortController()
-  const timer = setTimeout(() => controller.abort(), cfg.timeoutMs)
-  void (async () => {
-    let value: T | undefined
-    let ok = false
-    try {
-      value = await run(controller.signal)
-      ok = true
-    } catch {
-      // Keep the last value — the consumer goes stale, never errors.
-    }
-    clearTimeout(timer)
-    const timedOut = controller.signal.aborted
-    state.nextAllowedAt = computeNextAllowedAt(startedAt, Date.now(), timedOut, cfg)
-    state.inFlight = false
-    if (ok && !timedOut) onValue(value as T)
-  })()
-  return true
-}
-
-export interface SpawnCaptureResult {
-  /** Exit code, or null when the child errored / was killed (timeout). */
-  readonly status: number | null
-  readonly stdout: string
-}
-
-/**
- * Decode captured stdout chunks to one UTF-8 string. Chunks MUST be joined as
- * bytes before decoding: a stdout pipe splits on an arbitrary byte boundary
- * (~64 KB), so a multi-byte UTF-8 sequence (a non-ASCII path with
- * `core.quotepath=false`, or any commit message / diff body git never quotes)
- * can straddle two chunks. Decoding each chunk on its own — `String(chunk)` —
- * turns the split character into replacement bytes (`�`); concatenating
- * the raw bytes first decodes it intact. Pure — exported for unit tests.
- */
-export function decodeCapturedChunks(chunks: readonly (Buffer | string)[]): string {
-  return Buffer.concat(chunks.map((c) => (typeof c === "string" ? Buffer.from(c) : c))).toString("utf8")
-}
-
-/**
- * Async spawn that collects stdout and resolves on close. Never rejects —
- * a spawn error (missing cwd, binary not on PATH) or an abort resolves
- * with `status: null` so callers branch on status, mirroring the
- * never-throw contract of the pane-side sync git helpers it replaces.
- * The AbortSignal kills the child with SIGKILL.
- */
-export function spawnCapture(
-  cmd: string,
-  args: readonly string[],
-  opts: { readonly cwd: string; readonly env?: NodeJS.ProcessEnv; readonly signal: AbortSignal },
-): Promise<SpawnCaptureResult> {
-  return new Promise((resolve) => {
-    const chunks: (Buffer | string)[] = []
-    let settled = false
-    const finish = (status: number | null): void => {
-      if (settled) return
-      settled = true
-      resolve({ status, stdout: decodeCapturedChunks(chunks) })
-    }
-    const child = spawn(cmd, args.slice(), {
-      cwd: opts.cwd,
-      stdio: ["ignore", "pipe", "ignore"],
-      env: opts.env,
-      signal: opts.signal,
-      killSignal: "SIGKILL",
-    })
-    child.stdout?.on("data", (chunk: Buffer | string) => {
-      chunks.push(chunk)
-    })
-    child.on("error", () => finish(null))
-    child.on("close", (code) => finish(code))
-  })
-}
+export {
+  type PollCadenceConfig,
+  type PollScheduleState,
+  type SpawnCaptureResult,
+  applyJitter,
+  computeNextAllowedAt,
+  decodeCapturedChunks,
+  exponentialBackoff,
+  maybeStartScheduledRun,
+  shouldPoll,
+  spawnCapture,
+} from "@sma1lboy/kobe-daemon/daemon/poll-scheduling"

--- a/packages/kobe/test/daemon/ticker.test.ts
+++ b/packages/kobe/test/daemon/ticker.test.ts
@@ -1,0 +1,124 @@
+import { startTicker } from "@sma1lboy/kobe-daemon/daemon/ticker"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+/**
+ * The shared daemon ticker.
+ *
+ * Seven collectors used to hand-roll this skeleton, and the three ways they
+ * legitimately differ — ungated vs gated, a two-term gate, an immediate first
+ * tick — are now explicit options rather than the shape of the code. The
+ * brief that prompted the extraction warned that getting the first-tick timing
+ * or the gate wrong "changes startup timing, not correctness, and no test will
+ * catch it", so this file is that test.
+ */
+
+describe("startTicker", () => {
+  beforeEach(() => vi.useFakeTimers())
+  afterEach(() => vi.useRealTimers())
+
+  it("is a no-op at tickMs <= 0, immediate pass included", () => {
+    // The harness boots a daemon with collectors zeroed, and `setInterval(fn, 0)`
+    // is a hot loop — which is what `quota-resume` and `quota-usage-cache` armed
+    // before they shared this guard.
+    const run = vi.fn()
+    const onStop = vi.fn()
+    const stop = startTicker({ name: "t", tickMs: 0, immediate: true, run, onStop })
+    vi.advanceTimersByTime(10_000)
+    expect(run).not.toHaveBeenCalled()
+    stop()
+    // A disabled ticker never started the collector, so it must not stop one.
+    expect(onStop).not.toHaveBeenCalled()
+  })
+
+  it("waits for the first interval unless `immediate` says otherwise", () => {
+    const lazy = vi.fn()
+    const eager = vi.fn()
+    startTicker({ name: "lazy", tickMs: 100, run: lazy })
+    startTicker({ name: "eager", tickMs: 100, immediate: true, run: eager })
+
+    expect(lazy).toHaveBeenCalledTimes(0)
+    expect(eager).toHaveBeenCalledTimes(1)
+    vi.advanceTimersByTime(100)
+    expect(lazy).toHaveBeenCalledTimes(1)
+    expect(eager).toHaveBeenCalledTimes(2)
+  })
+
+  it("checks the gate on every pass, the immediate one included", () => {
+    let open = false
+    const run = vi.fn()
+    startTicker({ name: "t", tickMs: 100, immediate: true, gate: () => open, run })
+
+    expect(run).not.toHaveBeenCalled() // immediate pass, gate shut
+    vi.advanceTimersByTime(100)
+    expect(run).not.toHaveBeenCalled()
+    open = true
+    vi.advanceTimersByTime(100)
+    expect(run).toHaveBeenCalledTimes(1)
+  })
+
+  it("runs ungated when no gate is supplied", () => {
+    // `quota-resume`, the automation sweep and the deferred-prompt TTL are
+    // ungated ON PURPOSE — a schedule that requires an audience is not a
+    // schedule — so the helper must never default one on.
+    const run = vi.fn()
+    startTicker({ name: "t", tickMs: 100, run })
+    vi.advanceTimersByTime(300)
+    expect(run).toHaveBeenCalledTimes(3)
+  })
+
+  it("drops a tick that lands while the previous pass is still running", async () => {
+    let release: (() => void) | undefined
+    const run = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          release = resolve
+        }),
+    )
+    startTicker({ name: "t", tickMs: 100, run })
+
+    await vi.advanceTimersByTimeAsync(300)
+    expect(run).toHaveBeenCalledTimes(1)
+
+    release?.()
+    await vi.advanceTimersByTimeAsync(100)
+    expect(run).toHaveBeenCalledTimes(2)
+  })
+
+  it("keeps ticking after a pass throws", async () => {
+    // A wedged reentrancy flag would silently stop the collector for the rest
+    // of the daemon's life, with only one log line to show for it.
+    const run = vi.fn().mockRejectedValueOnce(new Error("boom")).mockResolvedValue(undefined)
+    startTicker({ name: "t", tickMs: 100, immediate: true, run })
+
+    expect(run).toHaveBeenCalledTimes(1)
+    await vi.advanceTimersByTimeAsync(100)
+    expect(run).toHaveBeenCalledTimes(2)
+  })
+
+  it("stops the interval and runs onStop", () => {
+    const run = vi.fn()
+    const onStop = vi.fn()
+    const stop = startTicker({ name: "t", tickMs: 100, run, onStop })
+    vi.advanceTimersByTime(100)
+    expect(run).toHaveBeenCalledTimes(1)
+
+    stop()
+    expect(onStop).toHaveBeenCalledTimes(1)
+    vi.advanceTimersByTime(1000)
+    expect(run).toHaveBeenCalledTimes(1)
+  })
+
+  it("unrefs the timer", () => {
+    // Without this a gui-less daemon never exits and `rove daemon restart`
+    // hangs — the one property here whose absence is invisible in tests that
+    // only count passes.
+    const unref = vi.fn()
+    const spy = vi.spyOn(globalThis, "setInterval").mockReturnValue({ unref } as unknown as NodeJS.Timeout)
+    try {
+      startTicker({ name: "t", tickMs: 100, run: () => {} })
+      expect(unref).toHaveBeenCalledTimes(1)
+    } finally {
+      spy.mockRestore()
+    }
+  })
+})


### PR DESCRIPTION
> **CI does not run on this PR yet.** `ci.yml` triggers on `pull_request: branches: [main]`, and this
> one targets `fix/rpc-deadline-deferred-ttl-grace`. GitHub retargets it to `main` automatically when
> #825 merges, and CI runs then. The gates below were run locally on the exact post-merge tree (this
> branch already contains #825's commit).

Two behavior-preserving refactors. **Stacked on #825** (`fix/rpc-deadline-deferred-ttl-grace`) —
G3 there added an eighth daemon ticker, and G6 folds it into the same helper rather than leaving a
new hand-rolled skeleton behind. Review/merge #825 first.

---

## G5 — `maybeStartScheduledRun` existed three times

`packages/kobe-daemon` does not depend on `@sma1lboy/rove`; the arrow runs the other way. So the
daemon's two collectors physically could not import `kobe/src/lib/poll-scheduling.ts` and each
carried its own copy — **byte-identical to each other** — while the owner's module doc still claimed
they "reuse the EXACT guards". The types were duplicated too (`runtime.ts` restated
`PollCadenceConfig` and `PollScheduleState`).

**Fix:** move the module DOWN the dependency graph into
`packages/kobe-daemon/src/daemon/poll-scheduling.ts`, add the package export, and leave
`kobe/src/lib/poll-scheduling.ts` as a re-export so all four kobe-side import paths, the
`background-poll.ts` re-export layer, and `test/lib/poll-scheduling.test.ts` are untouched. Both
copies deleted; `runtime.ts` re-exports the two types instead of restating them.

**The shim is kept rather than deleted** (the lazier-looking option) because
`test/engine/claude-quota.test.ts` does `vi.mock("../../src/lib/poll-scheduling.ts", …)` — the shim
is the module identity that mock targets, and repointing an ESM mock across a package boundary is
more risk than the 21 lines save.

Per-collector constants (`WORKTREE_CHANGES_*` 2000/4000/60000/1500 and the `TRANSCRIPT_ACTIVITY_*`
trio) stay in their own files — separately tuned, not unified. `GIT_OPTIONAL_LOCKS=0` untouched. No
new runtime dependency on `kobe-daemon`.

### PASS

| criterion | result |
|---|---|
| vitest green, specifically `test/lib/poll-scheduling.test.ts` (pins the run wrapper: in-flight dedupe, timeout → hard backoff, failures-never-deliver) | ✅ 14 tests |
| socket green, specifically `worktree-changes-collector.test.ts` + `transcript-activity-collector.test.ts` | ✅ 23 tests |
| `kobe-daemon` typecheck + `kobe` typecheck clean (the new package export is what breaks silently at build time) | ✅ |
| end-to-end: same `worktree.changes` counts for the same dirty tree | ✅ below |
| net line reduction ≥ 60 | ⚠️ **not met — see Line accounting** |

---

## G6 — seven daemon tickers, seven hand-rolled skeletons

Every background loop re-implemented the same parts: a `tickMs <= 0` no-op guard, a reentrancy
flag, an optional subscriber gate, a `setInterval`, `timer.unref?.()`, a `logDaemonError(<scope>)`
catch, and a `clearInterval` teardown. The guard line appeared verbatim in five files — and its
absence from `quota-resume` and `quota-usage-cache` meant a zero there armed a **hot loop** rather
than disabling the poll.

New `daemon/ticker.ts`. The three real variations the brief enumerated are explicit options, not
lost:

| collector | gate | immediate | onStop |
|---|---|---|---|
| `auto-title-poller` | `hasSubscribers` (optional) | — | — |
| `pr-status-collector` | `hasSubscribers() \|\| hasWorkingAgent?.()` — the two-term gate | — | — |
| `quota-resume` | **none, deliberately** | — | — |
| `automation-runner` | **none, deliberately** | — | — |
| `deferred-prompt-sweep` (from #825) | **none, deliberately** | ✅ | — |
| `quota-usage-cache` | `hasSubscribers` (required) | ✅ | — |
| `worktree-changes-collector` | inside `collector.tick()` | ✅ | `collector.stop()` |
| `transcript-activity-collector` | inside `collector.tick()` | ✅ | `collector.stop()` |

`activity-observer.ts` stays hand-rolled, as the brief specified. `collectors.ts` wiring and its
order-sensitive teardown are unchanged. Every `logDaemonError` scope string is verbatim
(`"auto-title-poller"`, `"pr-status-poller"`, `"quota-resume"`, `"automation-sweep"`, …) — they are
grepped in `daemon.log` during triage.

**One subtlety worth flagging.** The first version of `startTicker` set the reentrancy flag for
every pass and cleared it in a microtask. That silently changed behavior for the three passes that
were **synchronous** (`quota-usage-cache` and both `collector.tick()` calls had no outer flag at
all) — under back-to-back ticks the flag could outlive the pass and drop one. It now guards only a
pass that actually returns a promise, which is exactly the shape the other five hand-rolled. The
test `drops a tick that lands while the previous pass is still running` is what caught it.

**Behavior ADD, called out as the brief requires:** `quota-usage-cache` gains the `tickMs <= 0`
guard it was missing, where a zero previously armed a hot loop. (`quota-resume` picked the same
guard up independently in #821 while this branch was in flight; the rebase kept that commit's
reasoning as a comment on the `startTicker` call.) Nothing passes 0 to either today — grepped
`quotaResumeTickMs` / `quotaUsageTickMs` across `packages/kobe/test` and `kobe-daemon/src`; the
only call sites are `collectors.ts` (defaults) and three tests passing `5`. `bootDaemonHarness`
zeroes seven other collectors but not these two. A zero now means "disabled", including no
immediate pass.

### PASS

| criterion | result |
|---|---|
| socket green (owning runner for `test/daemon/**`) | ✅ **93 files / 774 tests** |
| vitest green | ✅ (6 pre-existing env failures, baselined) |
| `bun --filter @sma1lboy/kobe-daemon typecheck` clean | ✅ |
| end-to-end: same daemon activity block, no new `daemon.log` lines, `daemon stop` < 2s | ✅ below |
| net line reduction ≥ 55 | ❌ **not met — see Line accounting** |

---

## End-to-end identity check

Same isolated `ROVE_HOME_DIR` recipe, same repo, same dirty worktree (1 modified + 2 untracked),
`origin/main` build vs this branch:

```
### BEFORE (origin/main 0.9.96)
  worktree.changes (via api collect):
    {"base": {"ahead": 0, "baseRef": "main", "diff": {...}}, "changes": {"added": 3, "deleted": 0}}
  daemon activity block (api inspect top-level shape):
    ['at', 'daemon', 'sessionExits', 'sessions', 'tabs']
  daemon.log lines beyond the startup banner:
    [11:21:46] daemon [idle]: autospawned — arming 60000ms first-gui grace
  daemon stop returned in 0.16s (unref proof, must be < 2s)

### AFTER (this branch)
  worktree.changes (via api collect):
    {"base": {"ahead": 0, "baseRef": "main", "diff": {...}}, "changes": {"added": 3, "deleted": 0}}
  daemon activity block (api inspect top-level shape):
    ['at', 'daemon', 'sessionExits', 'sessions', 'tabs']
  daemon.log lines beyond the startup banner:
    [11:21:59] daemon [idle]: autospawned — arming 60000ms first-gui grace
  daemon stop returned in 0.16s (unref proof, must be < 2s)
```

Identical on all four axes. Full transcript: `.scratch/g5-g6-evidence/identity.txt`.

## Ticker contract test + mutations

The brief warned that first-tick timing and gate behavior "changes startup timing, not correctness,
and no test will catch it". `test/daemon/ticker.test.ts` is that test — 8 cases covering the
`tickMs<=0` no-op, immediate-vs-first-interval, the gate on every pass including the immediate one,
ungated-when-omitted, reentrancy, recovery after a throwing pass, `onStop`, and `unref`.

| mutation | result |
|---|---|
| default a gate on when none is supplied | 5 failed |
| drop the immediate first tick | 2 failed |
| drop `timer.unref?.()` | 1 failed |

## Line accounting — honest numbers

| file | before | after | delta |
|---|---:|---:|---:|
| `kobe/src/lib/poll-scheduling.ts` (→ re-export shim) | 183 | 21 | −162 |
| `kobe-daemon/src/daemon/poll-scheduling.ts` (moved in) | 0 | 186 | +186 |
| `kobe-daemon/src/daemon/runtime.ts` | 232 | 226 | −6 |
| `auto-title-poller.ts` | 138 | 129 | −9 |
| `automation-runner.ts` | 296 | 286 | −10 |
| `deferred-prompt-sweep.ts` | 111 | 101 | −10 |
| `pr-status-collector.ts` | 430 | 425 | −5 |
| `quota-resume.ts` | 157 | 154 | −3 |
| `quota-usage-cache.ts` | 144 | 146 | **+2** |
| `transcript-activity-collector.ts` | 356 | 326 | −30 |
| `worktree-changes-collector.ts` | 300 | 276 | −24 |
| `ticker.ts` (new) | 0 | 74 | +74 |
| **net, source only** | | | **+3** |

**G5** removes **52 lines of byte-identical duplicated logic** (2 × 26) plus 6 of duplicated types,
and nets **−34** after the 21-line shim. The brief's ≥60 assumed a ~3-line shim.

**G6 does not reduce line count — it is roughly +40.** The brief estimated "seven skeletons of
10-18 lines collapse to ~35 shared", which assumed the call sites collapse to almost nothing. With
an options-object API each site is 6-12 lines, and much of what the old code spent lines on was
per-collector *comments* explaining why a gate is or isn't there — I preserved those rather than
deleting them to hit a number, since the brief explicitly required the variations stay visible.

So G6's actual win is not size, it is: one place owns cadence/reentrancy/unref/teardown, the two
missing `tickMs<=0` guards are fixed, the gate/immediate/scope decisions are named options instead
of implied by code shape, and the outer loop now has a contract test it never had. **If that trade
isn't worth +40 lines, drop the second commit and take G5 alone — they are independent.**

## Gates

- repo-root `bun run lint` — clean
- repo-root `bun run typecheck` — clean (4 packages)
- `bun run test:socket` — **93 files / 774 tests passed**
- `bun run test:fast` — 4264 passed, **6 pre-existing environmental failures** (`project-eligibility`,
  `open-dir-cmd`, `continue-live-vendor`), identical on a detached `origin/main` worktree at the
  same `~/.rove/worktrees/...` path shape.

No changeset: both commits are internal refactors with no user-visible behavior change. The one
behavior add (`tickMs <= 0` on two collectors) is unreachable from any shipped configuration.
