### PR TITLE
fix: require a turn-ending stop_reason for Claude completion markers

### DIFF
--- a/.changeset/claude-turn-completion-marker.md
+++ b/.changeset/claude-turn-completion-marker.md
@@ -1,0 +1,13 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Stop idling a working Claude engine mid-turn. The Claude turn detector treated
+every assistant transcript record as a completed turn, but Claude Code appends
+one per step and ~95% of them are `stop_reason: "tool_use"` — mid-turn. The
+daemon's lapse watchdog read the newest of those as "this turn already ended"
+and dropped the activity badge to idle at the 10-minute TTL while the engine was
+still working, with its heartbeat re-arm unreachable. The marker now requires a
+turn-ending `stop_reason` (`end_turn`, `stop_sequence`, `max_tokens`,
+`refusal`); `tool_use`, `pause_turn` and a missing reason all read as still
+running.

--- a/packages/kobe/src/engine/turn-detector.ts
+++ b/packages/kobe/src/engine/turn-detector.ts
@@ -255,6 +255,29 @@ export class UnknownTurnDetector extends EngineTurnDetector {
   }
 }
 
+/**
+ * Assistant `stop_reason` values that END the turn. Claude Code appends one
+ * assistant record per STEP, and the overwhelming majority are
+ * `stop_reason: "tool_use"` — mid-turn, the exact opposite of a completion
+ * (measured over 8 real transcripts: 1965 of 2036 assistant records).
+ * Treating any assistant record as a completion made the daemon's lapse
+ * watchdog (`activity-registry.ts` → `stillWorking`) idle a working engine at
+ * the TTL, and made its heartbeat re-arm unreachable for Claude: the
+ * `completedAt >= at` branch always won.
+ *
+ * Allowlist, not a `!== "tool_use"` denylist, for the same reason
+ * {@link CODEX_ROLLOUT_DONE_EVENTS} is one: `pause_turn` (long-running server
+ * tools) is also mid-turn, and the next mid-turn value the API adds must
+ * default to "still working" rather than silently idling the badge again.
+ *
+ * A MISSING or null `stop_reason` is NOT a completion. Real transcripts always
+ * carry one on assistant records (0 absent in the 2036 above), so the only
+ * records this drops are malformed or synthetic ones — and for those,
+ * "the turn is still running" is the recoverable guess: the watchdog just
+ * re-arms, whereas a wrong completion idles a live engine for good.
+ */
+const CLAUDE_TURN_END_STOP_REASONS = new Set(["end_turn", "stop_sequence", "max_tokens", "refusal"])
+
 export function latestClaudeCompletionMarkerFromJsonl(
   raw: string,
   sourceId = "claude",
@@ -268,7 +291,8 @@ export function latestClaudeCompletionMarkerFromJsonl(
     if (!record) continue
     const inner = isObject(record.message) ? (record.message as Record<string, unknown>) : record
     if (inner.role !== "assistant") continue
-    if (!("content" in inner)) continue
+    if (typeof inner.stop_reason !== "string") continue
+    if (!CLAUDE_TURN_END_STOP_REASONS.has(inner.stop_reason)) continue
     const timestampMs = timestampFromRecord(record, fallbackMtimeMs)
     const marker = {
       id: `claude:${sourceId}:${timestampMs}:${lineNo}`,

--- a/packages/kobe/test/engine/turn-detector.test.ts
+++ b/packages/kobe/test/engine/turn-detector.test.ts
@@ -50,22 +50,71 @@ describe("latestCodexCompletionMarkerFromJsonl", () => {
 })
 
 describe("latestClaudeCompletionMarkerFromJsonl", () => {
-  test("uses assistant transcript records as completion markers", () => {
+  const assistant = (ts: string, stopReason?: string) =>
+    JSON.stringify({
+      type: "assistant",
+      timestamp: ts,
+      message: {
+        role: "assistant",
+        ...(stopReason ? { stop_reason: stopReason } : {}),
+        content: [{ type: "text", text: "done" }],
+      },
+    })
+  const toolUse = (ts: string) =>
+    JSON.stringify({
+      type: "assistant",
+      timestamp: ts,
+      message: {
+        role: "assistant",
+        stop_reason: "tool_use",
+        content: [{ type: "tool_use", id: "tu_1", name: "Bash", input: {} }],
+      },
+    })
+
+  test("uses a turn-ending assistant record as the completion marker", () => {
     const raw = [
       JSON.stringify({
         type: "user",
         timestamp: "2026-05-29T01:00:00.000Z",
         message: { role: "user", content: "hi" },
       }),
-      JSON.stringify({
-        type: "assistant",
-        timestamp: "2026-05-29T01:00:04.000Z",
-        message: { role: "assistant", content: [{ type: "text", text: "done" }] },
-      }),
+      assistant("2026-05-29T01:00:04.000Z", "end_turn"),
     ].join("\n")
     const marker = latestClaudeCompletionMarkerFromJsonl(raw, "session")
     expect(marker?.source).toBe("claude")
     expect(marker?.timestampMs).toBe(Date.parse("2026-05-29T01:00:04.000Z"))
+  })
+
+  // The bug: Claude Code appends one assistant record per STEP, and ~95% of
+  // them are `stop_reason: "tool_use"` — mid-turn. Minting a completion for
+  // those made the daemon's lapse watchdog idle a working engine at the TTL.
+  test("a mid-turn tool_use record is NOT a completion", () => {
+    expect(latestClaudeCompletionMarkerFromJsonl(toolUse("2026-05-29T01:00:05.000Z"), "session")).toBeNull()
+  })
+
+  test("a multi-tool-use turn yields exactly one marker, at the turn end", () => {
+    const raw = [
+      JSON.stringify({ type: "user", timestamp: "2026-05-29T01:00:00.000Z", message: { role: "user", content: "go" } }),
+      toolUse("2026-05-29T01:00:01.000Z"),
+      toolUse("2026-05-29T01:00:02.000Z"),
+      assistant("2026-05-29T01:00:09.000Z", "end_turn"),
+    ].join("\n")
+    const marker = latestClaudeCompletionMarkerFromJsonl(raw, "session")
+    expect(marker?.timestampMs).toBe(Date.parse("2026-05-29T01:00:09.000Z"))
+  })
+
+  test("accepts the other turn-ending stop reasons", () => {
+    for (const reason of ["stop_sequence", "max_tokens", "refusal"]) {
+      const marker = latestClaudeCompletionMarkerFromJsonl(assistant("2026-05-29T01:00:06.000Z", reason))
+      expect(marker?.timestampMs).toBe(Date.parse("2026-05-29T01:00:06.000Z"))
+    }
+  })
+
+  // Allowlist, not `!== "tool_use"`: pause_turn is mid-turn too, and so is
+  // whatever mid-turn value the API adds next.
+  test("pause_turn and a missing stop_reason are both mid-turn", () => {
+    expect(latestClaudeCompletionMarkerFromJsonl(assistant("2026-05-29T01:00:07.000Z", "pause_turn"))).toBeNull()
+    expect(latestClaudeCompletionMarkerFromJsonl(assistant("2026-05-29T01:00:08.000Z"))).toBeNull()
   })
 })
 
@@ -83,7 +132,11 @@ describe("createEngineTurnDetector", () => {
 // invisible (same markers as a fresh parse) and keyed strictly on mtime.
 describe("ClaudeTurnDetector mtime gating", () => {
   const record = (ts: string) =>
-    JSON.stringify({ type: "assistant", timestamp: ts, message: { role: "assistant", content: [] } })
+    JSON.stringify({
+      type: "assistant",
+      timestamp: ts,
+      message: { role: "assistant", stop_reason: "end_turn", content: [] },
+    })
 
   test("skips re-reading transcripts whose mtime is unchanged, and returns the identical marker", async () => {
     const reads: string[] = []
@@ -123,7 +176,11 @@ describe("ClaudeTurnDetector mtime gating", () => {
 
 describe("ClaudeTurnDetector latestActivityInFile", () => {
   const record = (ts: string) =>
-    JSON.stringify({ type: "assistant", timestamp: ts, message: { role: "assistant", content: [] } })
+    JSON.stringify({
+      type: "assistant",
+      timestamp: ts,
+      message: { role: "assistant", stop_reason: "end_turn", content: [] },
+    })
 
   test("reads ONLY the given transcript — never the worktree listing", async () => {
     const detector = new ClaudeTurnDetector({


### PR DESCRIPTION
Batch K, item **K1** (loop-r4 bugs.md Group A).

## What changed

`latestClaudeCompletionMarkerFromJsonl` treated *any* assistant record with a
`content` key as a completed turn. Claude Code appends one assistant record per
STEP, and the overwhelming majority carry `stop_reason: "tool_use"` — mid-turn.

Consequences, all engine-side and all now fixed at the adapter (the neutral
`activity-registry.ts` is untouched):

- the daemon's lapse watchdog (`stillWorking`) found a `tool_use` marker newer
  than the turn start, concluded the turn had ended, and dropped the badge to
  idle **while the engine was mid-turn**. The heartbeat re-arm that code exists
  to provide was unreachable for Claude — the `completedAt >= at` branch always
  won;
- `completionId` advanced per tool call, so the Ops pane could publish `done`
  inside a turn and the sidebar's unseen-completion dot re-armed on every tool
  call.

The marker now requires a **turn-ending** `stop_reason`. Allowlist
(`end_turn`, `stop_sequence`, `max_tokens`, `refusal`), not a `!== "tool_use"`
denylist, for the same reason the sibling `CODEX_ROLLOUT_DONE_EVENTS` is one:
`pause_turn` is mid-turn too, and the next mid-turn value the API adds must
default to "still working" rather than silently idling the badge again. A
missing/null `stop_reason` is explicitly **not** a completion — documented in
the code with the corpus number behind the choice.

## PASS criteria and proof

### 1. The brief's repro one-liner

```
$ bun -e '…latestClaudeCompletionMarkerFromJsonl…'
tool_use  -> null
end_turn  -> {
  id: "claude:s:1767225605000:2",
  timestampMs: 1767225605000,
  source: "claude",
}
```

### 2. Unit tests (the tightest proof)

`test/engine/turn-detector.test.ts`, new cases: a `tool_use` record yields
`null`; `end_turn` yields a marker; `[user, tool_use, tool_use, end_turn]`
yields exactly one marker at the `end_turn` timestamp; the three other terminal
reasons are accepted; `pause_turn` and an absent `stop_reason` are both
mid-turn. The two pre-existing fixtures that carried no `stop_reason` now carry
`end_turn`, as the brief requires.

```
$ bun x vitest run test/engine/turn-detector.test.ts
 ✓ test/engine/turn-detector.test.ts (16 tests)
      Tests  16 passed (16)
```

### 3. Mutation checks — two distinct sites, each turns a different set red

| mutation | result |
|---|---|
| (a) replace the `stop_reason` gate with the old `"content" in inner` check | `Tests  2 failed \| 14 passed` — *tool_use is NOT a completion*, *pause_turn and a missing stop_reason are both mid-turn* |
| (b) add `"tool_use"` to the allowlist | `Tests  1 failed \| 15 passed` — *tool_use is NOT a completion* |

Restored after each; 16/16 green again.

### 4. Corpus re-run (8 most recently modified real transcripts)

```
old rule (any assistant w/ content): 2148
new rule (terminal stop_reason):       72
terminal-but-no-content records:        0
```

The absolute numbers differ from the brief's (2941 → ~161) only because the 8
newest transcripts have rotated since; the ratio is the same and the collapse is
to real turn ends. The third line is why dropping the now-redundant `content`
check is safe: no record with a terminal `stop_reason` lacks content.

### 5. Harness BEFORE/AFTER — the sidebar/board activity glyph

Ground-truth path: `/harness` browser → xterm.js → PTY sidecar → real OpenTUI,
isolated fixture on port base 5980, `KOBE_ENGINE_STATE_TTL_MS=5000`. A sentinel
transcript holding **only** a `stop_reason: "tool_use"` record is rewritten with
a current timestamp every 500 ms (the engine is demonstrably still writing),
while `rove hook turn-start` is replayed for the first ~5 s to arm the lapse
watchdog. Shot at t≈16 s, i.e. well past the TTL.

| shot | when | what it shows |
|---|---|---|
| `/Users/jacksonc/i/kobe/.scratch/loop-r4-k/k1-control-running.png` | t≈5 s, unfixed | card badge reads `working`, sidebar tab-row glyph spinning — proves the setup lights the badge at all |
| `/Users/jacksonc/i/kobe/.scratch/loop-r4-k/k1-before.png` | t≈16 s, unfixed | badge **gone**, tab-row glyph back to rest — the mid-turn engine was idled by the lapse |
| `/Users/jacksonc/i/kobe/.scratch/loop-r4-k/k1-after.png` | t≈16 s, fixed | badge still reads `working`, glyph still spinning — the heartbeat re-armed |

### 6. Suites

- `bun x vitest run test/engine/turn-detector.test.ts` — 16/16
- `bun test test/render` — 455 pass, 0 fail
- repo-root `bun run lint` — clean; `bun run typecheck` — clean
- `bun run test:fast` — `6 failed | 4303 passed`. All 6 are **pre-existing and
  environment-shaped**, proven by re-running the same three files with
  `src/engine/turn-detector.ts` and its test checked out from `origin/main`:
  identical 6 failures. They are `test/state/project-eligibility.test.ts` (2),
  `test/cli/open-dir-cmd.test.ts` (2) and `test/tui/continue-live-vendor.test.ts`
  (2) — the first four are the known false failures from running a checkout
  under `~/.rove/worktrees` (project-eligibility judges `roveInternal` /
  `temporary` by path shape). Nothing here touches those paths.
