### PR TITLE
One binary finder and one vendor-home resolver for the engine adapters

### DIFF
--- a/.changeset/engine-binary-finder-vendor-home.md
+++ b/.changeset/engine-binary-finder-vendor-home.md
@@ -1,0 +1,11 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Internal: the engine adapters stop re-deriving two things they had each written out by hand.
+
+CLI-binary discovery was four copies of the same probe — a `BinaryDiscoveryDeps` interface, a `defaultDeps` implementation, a not-found error class and a `tryPath` walk, in `claude-code-local`, `codex-local`, `kimi-local` and `copilot-local`. `engine/binary-discovery.ts` now owns *how* to probe (the `which` call and its macOS alias unwrapping, the stat check, the ordered ledger of checked paths that ends up in the error message) and each vendor file owns only *where* to look. Every search order, every checked-path list and its order, every error message and every `error.name` is byte-identical — 420 lines of duplication out, 112 back.
+
+One deliberate behaviour change falls out of it: `kimi` now unwraps a macOS `which` alias line the way the other three already did. An aliased `kimi` used to resolve to the literal `"kimi: aliased to /path"` string, fail the file check, and fall through to the install dirs for no reason.
+
+Vendor config-home resolution — `$CLAUDE_CONFIG_DIR`/`$CODEX_HOME`/`$COPILOT_HOME`/`$KIMI_CODE_HOME` and their default dotdirs — was written nine times across six files, and the copies had already drifted: three treated a blank override as a real path, so `CODEX_HOME="  "` resolved to `/auth.json` at the filesystem root. `engine/vendor-home.ts` is now the single derivation, blank means unset everywhere, and claude's genuine asymmetry (`~/.claude.json` sits at the home root when unset, inside the dir when set) is preserved and documented.

--- a/packages/kobe/src/engine/account-detect.ts
+++ b/packages/kobe/src/engine/account-detect.ts
@@ -44,12 +44,14 @@ import path from "node:path"
 import { errorMessage } from "@/lib/error-message"
 import { getCustomEngineIds, getDisabledEngineIds } from "@/state/repos"
 import type { VendorId } from "@/types/vendor"
-import { ClaudeBinaryNotFoundError, findClaudeBinary } from "./claude-code-local/binary"
-import { CodexBinaryNotFoundError, findCodexBinary } from "./codex-local/binary"
+import { BinaryNotFoundError } from "./binary-discovery"
+import { findClaudeBinary } from "./claude-code-local/binary"
+import { findCodexBinary } from "./codex-local/binary"
 import { CONTRIB_ENGINES, CONTRIB_ENGINE_IDS, pluginEngineIds } from "./contrib-engines"
-import { CopilotBinaryNotFoundError, findCopilotBinary } from "./copilot-local/binary"
+import { findCopilotBinary } from "./copilot-local/binary"
 import { readTextFileSyncBounded } from "./file-bounds"
-import { KimiBinaryNotFoundError, findKimiBinary } from "./kimi-local/binary"
+import { findKimiBinary } from "./kimi-local/binary"
+import { claudeGlobalConfigPath, codexAuthPath, copilotConfigPath, kimiCredentialsPath } from "./vendor-home"
 
 export type ClaudeAccount =
   | {
@@ -125,33 +127,6 @@ const defaultDeps: DetectDeps = {
   },
 }
 
-/** Resolve the path to claude-code's global config (`~/.claude.json` by default). */
-export function claudeGlobalConfigPath(env: (k: string) => string | undefined, home: string): string {
-  const override = env("CLAUDE_CONFIG_DIR")?.trim()
-  if (override) return path.join(override, ".claude.json")
-  return path.join(home, ".claude.json")
-}
-
-/** Resolve the path to codex's auth file (`~/.codex/auth.json` by default). */
-export function codexAuthPath(env: (k: string) => string | undefined, home: string): string {
-  const override = env("CODEX_HOME")?.trim()
-  const dir = override ?? path.join(home, ".codex")
-  return path.join(dir, "auth.json")
-}
-
-export function copilotConfigPath(env: (k: string) => string | undefined, home: string): string {
-  const override = env("COPILOT_HOME")?.trim()
-  const dir = override ?? path.join(home, ".copilot")
-  return path.join(dir, "config.json")
-}
-
-/** Resolve kimi's OAuth credential file (`~/.kimi-code/credentials/kimi-code.json`). */
-function kimiCredentialsPath(env: (k: string) => string | undefined, home: string): string {
-  const override = env("KIMI_CODE_HOME")?.trim()
-  const dir = override ?? path.join(home, ".kimi-code")
-  return path.join(dir, "credentials", "kimi-code.json")
-}
-
 /**
  * Decode the payload of a JWT (header.payload.signature) without
  * verifying the signature. We're not authenticating the user — we're
@@ -180,14 +155,9 @@ async function probeBinary(probe: () => Promise<string>): Promise<BinaryStatus> 
     const p = await probe()
     return { found: true, path: p }
   } catch (err) {
-    if (
-      err instanceof ClaudeBinaryNotFoundError ||
-      err instanceof CodexBinaryNotFoundError ||
-      err instanceof CopilotBinaryNotFoundError ||
-      err instanceof KimiBinaryNotFoundError
-    ) {
-      return { found: false, error: "not found on PATH" }
-    }
+    // Every vendor's not-found error derives from this one, so "no binary
+    // anywhere we look" reads the same regardless of which CLI was probed.
+    if (err instanceof BinaryNotFoundError) return { found: false, error: "not found on PATH" }
     return { found: false, error: errorMessage(err) }
   }
 }

--- a/packages/kobe/src/engine/binary-discovery.ts
+++ b/packages/kobe/src/engine/binary-discovery.ts
@@ -1,0 +1,140 @@
+/**
+ * How to probe for a vendor's CLI binary. Each `<vendor>-local/binary.ts`
+ * owns only WHERE to look; this file owns the probing itself — the `which`
+ * call and its macOS alias unwrapping, the stat-based existence check, the
+ * `checkedPaths` ledger that ends up in the user-facing error, and the
+ * injection seam the tests drive.
+ *
+ * Every vendor's search ORDER is different and deliberately so (claude walks
+ * `~/.nvm/versions/node/*` newest-first, codex tries homebrew before NVM,
+ * kimi looks in its installer's own dir first, copilot expands `.exe`/`.cmd`
+ * spellings on Windows). Those lists stay in the vendor files, verbatim.
+ */
+
+import { spawnSync } from "node:child_process"
+import { existsSync, statSync } from "node:fs"
+import { homedir } from "node:os"
+
+/**
+ * Optional FS/env injection for tests. Real callers don't need to pass this.
+ * `readdir` and `platform` are optional because only claude and copilot
+ * respectively consult them.
+ */
+export interface BinaryDiscoveryDeps {
+  /** Returns true if the path exists and is a regular file (or symlink to one). */
+  fileExists(p: string): boolean
+  /** Returns the value of a process env var, or undefined. */
+  env(name: string): string | undefined
+  /** Returns the user's home directory. */
+  home(): string
+  /** Runs `which <name>` (or `where` on Windows) and returns the first matching path, or undefined. */
+  which(name: string): string | undefined
+  /** Lists immediate child names of a directory, or returns []. */
+  readdir?(p: string): string[]
+  /** The host platform, for vendors whose candidate list is platform-shaped. */
+  platform?(): NodeJS.Platform
+}
+
+export const defaultBinaryDeps: BinaryDiscoveryDeps = {
+  fileExists(p) {
+    try {
+      return statSync(p).isFile()
+    } catch {
+      return false
+    }
+  },
+  env(name) {
+    return process.env[name]
+  },
+  home() {
+    return homedir()
+  },
+  which(name) {
+    // We deliberately use `command -v` style via `which`/`where` rather
+    // than scanning PATH ourselves: shells often have aliases or
+    // shims that show up under `which` but not under a naive PATH walk.
+    const cmd = process.platform === "win32" ? "where" : "which"
+    const out = spawnSync(cmd, [name], { encoding: "utf8" })
+    if (out.status !== 0) return undefined
+    const first = out.stdout
+      .split("\n")
+      .map((l) => l.trim())
+      .filter(Boolean)[0]
+    if (!first) return undefined
+    // macOS `which` may print "<name>: aliased to /path" for shell aliases.
+    if (first.startsWith(`${name}:`) && first.includes("aliased to")) {
+      const aliasTarget = first.split("aliased to")[1]?.trim()
+      return aliasTarget && existsSync(aliasTarget) ? aliasTarget : undefined
+    }
+    return first
+  },
+  readdir(p) {
+    try {
+      // A lazy `require` rather than a static import: the nvm scan must list
+      // the REAL disk even in suites that virtualize `node:fs` for statSync.
+      const fs = require("node:fs") as typeof import("node:fs")
+      return fs.readdirSync(p)
+    } catch {
+      return []
+    }
+  },
+}
+
+/**
+ * Base of the four per-vendor not-found errors. The message lists every path
+ * that was checked, in probe order, so a user can see why discovery failed;
+ * subclasses supply the label and the install hint and keep their own `name`.
+ */
+export class BinaryNotFoundError extends Error {
+  readonly checkedPaths: readonly string[]
+  constructor(label: string, hint: string, checkedPaths: readonly string[]) {
+    super(`${label} not found. Checked: ${checkedPaths.join(", ")}. ${hint}`)
+    this.name = "BinaryNotFoundError"
+    this.checkedPaths = checkedPaths
+  }
+}
+
+/** What a vendor's candidate list gets to look at. */
+export interface BinaryCandidateContext {
+  readonly deps: BinaryDiscoveryDeps
+  /** `deps.home()`, resolved once. */
+  readonly home: string
+}
+
+export interface BinaryFinderSpec {
+  /** The binary name handed to `which`. */
+  readonly name: string
+  /** Absolute paths to stat, in probe order, after the `which` hit fails. */
+  candidates(ctx: BinaryCandidateContext): readonly string[]
+  /** Built when nothing matched, from the ordered ledger of probed paths. */
+  notFound(checkedPaths: readonly string[]): BinaryNotFoundError
+}
+
+/**
+ * Build a vendor's finder. The returned function resolves with an absolute
+ * path, or rejects with the vendor's {@link BinaryNotFoundError}.
+ *
+ * Cheap (one `which`, a handful of stats) and pure aside from filesystem
+ * reads — safe to call once per spawn. Callers wanting caching can wrap it.
+ */
+export function createBinaryFinder(spec: BinaryFinderSpec): (deps?: BinaryDiscoveryDeps) => Promise<string> {
+  return async function findBinary(deps: BinaryDiscoveryDeps = defaultBinaryDeps): Promise<string> {
+    const checked: string[] = []
+
+    // 1. $PATH via `which` (user's shell PATH, including aliases). The
+    //    `which:` sentinel distinguishes it from a plain stat in the ledger.
+    const whichResult = deps.which(spec.name)
+    if (whichResult) {
+      checked.push(`which:${whichResult}`)
+      if (deps.fileExists(whichResult)) return whichResult
+    }
+
+    // 2. The vendor's own list, first hit wins.
+    for (const candidate of spec.candidates({ deps, home: deps.home() })) {
+      checked.push(candidate)
+      if (deps.fileExists(candidate)) return candidate
+    }
+
+    throw spec.notFound(checked)
+  }
+}

--- a/packages/kobe/src/engine/claude-code-local/binary.ts
+++ b/packages/kobe/src/engine/claude-code-local/binary.ts
@@ -1,9 +1,9 @@
 /**
- * Discovery for the local `claude` CLI binary.
+ * Where the local `claude` CLI binary lives.
  *
- * Algorithm ported from `refs/opcode/src-tauri/src/claude_binary.rs` —
+ * Search order ported from `refs/opcode/src-tauri/src/claude_binary.rs` —
  * we strip the version-comparison + DB-preference machinery (opcode
- * stores a chosen path in SQLite) and keep just the search order:
+ * stores a chosen path in SQLite) and keep just the order:
  *
  *   1. `$PATH` (the user's shell — `which claude`).
  *   2. `~/.claude/local/claude`  (Claude Code's bundled-update install).
@@ -20,159 +20,45 @@
  * almost always the right answer. If the user has a strong preference
  * they can put it on PATH.
  *
- * The function throws a typed {@link ClaudeBinaryNotFoundError} on
- * miss. The error message lists every path that was checked so the
- * user can see why discovery failed.
+ * The probing itself (`which`, stat, the checked-path ledger) lives in
+ * `../binary-discovery.ts`.
  */
 
-import { spawnSync } from "node:child_process"
-import { existsSync, statSync } from "node:fs"
-import { homedir } from "node:os"
 import path from "node:path"
+import { BinaryNotFoundError, createBinaryFinder } from "../binary-discovery.ts"
+
+export type { BinaryDiscoveryDeps } from "../binary-discovery.ts"
 
 /** Thrown when `findClaudeBinary` cannot locate `claude` anywhere we look. */
-export class ClaudeBinaryNotFoundError extends Error {
-  readonly checkedPaths: readonly string[]
+export class ClaudeBinaryNotFoundError extends BinaryNotFoundError {
   constructor(checkedPaths: readonly string[]) {
-    super(
-      `Claude Code binary not found. Checked: ${checkedPaths.join(
-        ", ",
-      )}. Ensure 'claude' is on PATH, or install at ~/.claude/local/claude.`,
-    )
+    super("Claude Code binary", "Ensure 'claude' is on PATH, or install at ~/.claude/local/claude.", checkedPaths)
     this.name = "ClaudeBinaryNotFoundError"
-    this.checkedPaths = checkedPaths
   }
 }
 
-/**
- * Optional FS injection for tests. Real callers don't need to pass this.
- * Tests pass a stubbed reader to assert the search order without
- * depending on the host filesystem.
- */
-export interface BinaryDiscoveryDeps {
-  /** Returns true if the path exists and is a regular file (or symlink to one). */
-  fileExists(p: string): boolean
-  /** Returns the value of a process env var, or undefined. */
-  env(name: string): string | undefined
-  /** Returns the user's home directory. */
-  home(): string
-  /** Runs `which <name>` (or `where` on Windows) and returns the first matching path, or undefined. */
-  which(name: string): string | undefined
-  /** Lists immediate child names of a directory, or returns []. */
-  readdir(p: string): string[]
-}
+/** Locate the `claude` binary on this machine. */
+export const findClaudeBinary = createBinaryFinder({
+  name: "claude",
+  candidates({ deps, home }) {
+    const out = [path.join(home, ".claude", "local", "claude")]
 
-const defaultDeps: BinaryDiscoveryDeps = {
-  fileExists(p) {
-    try {
-      return statSync(p).isFile()
-    } catch {
-      return false
+    const nvmBin = deps.env("NVM_BIN")
+    if (nvmBin) out.push(path.join(nvmBin, "claude"))
+
+    // All NVM-installed node versions, newest first. A plain string sort
+    // mis-orders unpadded semver dir names ("v8.17.0" sorts after "v18.20.0"),
+    // so a single-digit major would shadow newer nodes; compare numerically.
+    const nvmRoot = path.join(home, ".nvm", "versions", "node")
+    const versions = (deps.readdir?.(nvmRoot) ?? []).sort((a, b) => b.localeCompare(a, undefined, { numeric: true }))
+    for (const v of versions) out.push(path.join(nvmRoot, v, "bin", "claude"))
+
+    out.push("/opt/homebrew/bin/claude", "/usr/local/bin/claude", "/usr/bin/claude", "/bin/claude")
+
+    for (const rel of [".local/bin", ".npm-global/bin", ".yarn/bin", ".bun/bin", "bin"]) {
+      out.push(path.join(home, rel, "claude"))
     }
+    return out
   },
-  env(name) {
-    return process.env[name]
-  },
-  home() {
-    return homedir()
-  },
-  which(name) {
-    // We deliberately use `command -v` style via `which`/`where` rather
-    // than scanning PATH ourselves: shells often have aliases or
-    // shims that show up under `which` but not under a naive PATH walk.
-    const cmd = process.platform === "win32" ? "where" : "which"
-    const out = spawnSync(cmd, [name], { encoding: "utf8" })
-    if (out.status !== 0) return undefined
-    const first = out.stdout
-      .split("\n")
-      .map((l) => l.trim())
-      .filter(Boolean)[0]
-    if (!first) return undefined
-    // macOS `which` may print "claude: aliased to /path" for shell aliases.
-    if (first.startsWith("claude:") && first.includes("aliased to")) {
-      const aliasTarget = first.split("aliased to")[1]?.trim()
-      return aliasTarget && existsSync(aliasTarget) ? aliasTarget : undefined
-    }
-    return first
-  },
-  readdir(p) {
-    try {
-      // `node:fs.readdirSync` would be cleaner, but staying on a small
-      // dependency surface — we use `Bun`'s/Node's builtin.
-      const fs = require("node:fs") as typeof import("node:fs")
-      return fs.readdirSync(p)
-    } catch {
-      return []
-    }
-  },
-}
-
-/**
- * Locate the `claude` binary on this machine.
- *
- * Resolves with an absolute path on success; rejects with
- * {@link ClaudeBinaryNotFoundError} on miss.
- *
- * The function is cheap (a single `which`, a handful of stat calls)
- * and pure aside from filesystem reads — safe to call once per spawn.
- * Callers that want caching can wrap it.
- */
-export async function findClaudeBinary(deps: BinaryDiscoveryDeps = defaultDeps): Promise<string> {
-  const checked: string[] = []
-
-  const tryPath = (p: string | undefined): string | undefined => {
-    if (!p) return undefined
-    checked.push(p)
-    return deps.fileExists(p) ? p : undefined
-  }
-
-  // 1. $PATH via `which` (user's shell PATH, including aliases).
-  const whichResult = deps.which("claude")
-  if (whichResult) {
-    checked.push(`which:${whichResult}`)
-    if (deps.fileExists(whichResult)) return whichResult
-  }
-
-  const home = deps.home()
-
-  // 2. Claude Code's own ~/.claude/local install.
-  const localInstall = tryPath(path.join(home, ".claude", "local", "claude"))
-  if (localInstall) return localInstall
-
-  // 3. NVM_BIN (currently active node version).
-  const nvmBin = deps.env("NVM_BIN")
-  if (nvmBin) {
-    const candidate = tryPath(path.join(nvmBin, "claude"))
-    if (candidate) return candidate
-  }
-
-  // 4. All NVM-installed node versions, newest first. A plain string sort
-  //    mis-orders unpadded semver dir names ("v8.17.0" sorts after "v18.20.0"),
-  //    so a single-digit major would shadow newer nodes; compare numerically.
-  const nvmRoot = path.join(home, ".nvm", "versions", "node")
-  const nvmVersions = deps.readdir(nvmRoot).sort((a, b) => b.localeCompare(a, undefined, { numeric: true }))
-  for (const v of nvmVersions) {
-    const candidate = tryPath(path.join(nvmRoot, v, "bin", "claude"))
-    if (candidate) return candidate
-  }
-
-  // 5. Homebrew + system paths.
-  for (const p of ["/opt/homebrew/bin/claude", "/usr/local/bin/claude", "/usr/bin/claude", "/bin/claude"]) {
-    const candidate = tryPath(p)
-    if (candidate) return candidate
-  }
-
-  // 6. Misc per-user installs.
-  for (const rel of [
-    ".local/bin/claude",
-    ".npm-global/bin/claude",
-    ".yarn/bin/claude",
-    ".bun/bin/claude",
-    "bin/claude",
-  ]) {
-    const candidate = tryPath(path.join(home, rel))
-    if (candidate) return candidate
-  }
-
-  throw new ClaudeBinaryNotFoundError(checked)
-}
+  notFound: (checked) => new ClaudeBinaryNotFoundError(checked),
+})

--- a/packages/kobe/src/engine/claude-code-local/history.ts
+++ b/packages/kobe/src/engine/claude-code-local/history.ts
@@ -42,6 +42,7 @@ import { homedir } from "node:os"
 import path from "node:path"
 import type { EngineUsageSnapshot, Message } from "@/types/engine"
 import { isJsonlLineWithinBound, readTextFileBounded } from "../file-bounds"
+import { vendorConfigHome } from "../vendor-home"
 import { isObject, parseSessionRaw } from "./history-parse"
 
 // Parsing (JSONL → Message[], sorting, and the append-aware per-file cache)
@@ -58,18 +59,9 @@ export interface HistoryDeps {
   pathExists(p: string): Promise<boolean>
 }
 
-/**
- * The CLI's config dir: `$CLAUDE_CONFIG_DIR` when an isolated profile is
- * configured, else `~/.claude` — same contract account-detect and quota.ts
- * already honor. Read per call (never cached) so env changes apply live.
- */
-function claudeConfigDir(): string {
-  return process.env.CLAUDE_CONFIG_DIR?.trim() || path.join(homedir(), ".claude")
-}
-
 const defaultDeps: HistoryDeps = {
   projectsDir() {
-    return path.join(claudeConfigDir(), "projects")
+    return path.join(vendorConfigHome("claude"), "projects")
   },
   async readdir(p) {
     try {
@@ -137,7 +129,7 @@ export interface WorktreeSessionFile {
  */
 export async function listSessionFilesForWorktree(worktree: string): Promise<WorktreeSessionFile[]> {
   if (!worktree) return []
-  const dir = path.join(claudeConfigDir(), "projects", encodeCwd(worktree))
+  const dir = path.join(vendorConfigHome("claude"), "projects", encodeCwd(worktree))
   let entries: string[]
   try {
     entries = await readdir(dir)

--- a/packages/kobe/src/engine/claude-code-local/quota.ts
+++ b/packages/kobe/src/engine/claude-code-local/quota.ts
@@ -20,6 +20,7 @@ import { homedir, userInfo } from "node:os"
 import path from "node:path"
 import { spawnCapture } from "../../lib/poll-scheduling.ts"
 import type { EngineQuotaUsage, EngineQuotaWindow } from "../../types/engine.ts"
+import { vendorConfigHome } from "../vendor-home.ts"
 
 const OAUTH_USAGE_URL = "https://api.anthropic.com/api/oauth/usage"
 const OAUTH_BETA_HEADER = "oauth-2025-04-20"
@@ -167,7 +168,7 @@ async function readAccessToken(): Promise<string | null> {
     const fromFile = await readFileCredentials(configDir)
     return fromFile && isFresh(fromFile) ? fromFile.accessToken : null
   }
-  const candidates = [await readKeychainCredentials(), await readFileCredentials(path.join(homedir(), ".claude"))]
+  const candidates = [await readKeychainCredentials(), await readFileCredentials(vendorConfigHome("claude"))]
   return candidates.find((c): c is OAuthCredentials => c != null && isFresh(c))?.accessToken ?? null
 }
 

--- a/packages/kobe/src/engine/codex-local/binary.ts
+++ b/packages/kobe/src/engine/codex-local/binary.ts
@@ -1,108 +1,33 @@
 /**
- * Discovery for the local `codex` CLI binary.
- *
- * Mirrors `claude-code-local/binary.ts` — same search order, just with
- * the binary name swapped. The first hit wins; throws
- * {@link CodexBinaryNotFoundError} on miss with the full list of paths
- * checked.
+ * Where the local `codex` CLI binary lives: `$PATH`, then homebrew and the
+ * system dirs, then the active nvm bin, then the usual per-user dirs.
+ * Probing itself lives in `../binary-discovery.ts`.
  */
 
-import { spawnSync } from "node:child_process"
-import { existsSync, statSync } from "node:fs"
-import { homedir } from "node:os"
 import path from "node:path"
+import { BinaryNotFoundError, createBinaryFinder } from "../binary-discovery.ts"
 
-export class CodexBinaryNotFoundError extends Error {
-  readonly checkedPaths: readonly string[]
+export type { BinaryDiscoveryDeps } from "../binary-discovery.ts"
+
+export class CodexBinaryNotFoundError extends BinaryNotFoundError {
   constructor(checkedPaths: readonly string[]) {
     super(
-      `Codex CLI binary not found. Checked: ${checkedPaths.join(
-        ", ",
-      )}. Ensure 'codex' is on PATH (e.g. \`brew install codex\` or the official installer).`,
+      "Codex CLI binary",
+      "Ensure 'codex' is on PATH (e.g. `brew install codex` or the official installer).",
+      checkedPaths,
     )
     this.name = "CodexBinaryNotFoundError"
-    this.checkedPaths = checkedPaths
   }
 }
 
-export interface BinaryDiscoveryDeps {
-  fileExists(p: string): boolean
-  env(name: string): string | undefined
-  home(): string
-  which(name: string): string | undefined
-  readdir(p: string): string[]
-}
-
-const defaultDeps: BinaryDiscoveryDeps = {
-  fileExists(p) {
-    try {
-      return statSync(p).isFile()
-    } catch {
-      return false
-    }
+export const findCodexBinary = createBinaryFinder({
+  name: "codex",
+  candidates({ deps, home }) {
+    const out = ["/opt/homebrew/bin/codex", "/usr/local/bin/codex", "/usr/bin/codex", "/bin/codex"]
+    const nvmBin = deps.env("NVM_BIN")
+    if (nvmBin) out.push(path.join(nvmBin, "codex"))
+    for (const rel of [".local/bin", ".bun/bin", "bin"]) out.push(path.join(home, rel, "codex"))
+    return out
   },
-  env(name) {
-    return process.env[name]
-  },
-  home() {
-    return homedir()
-  },
-  which(name) {
-    const cmd = process.platform === "win32" ? "where" : "which"
-    const out = spawnSync(cmd, [name], { encoding: "utf8" })
-    if (out.status !== 0) return undefined
-    const first = out.stdout
-      .split("\n")
-      .map((l) => l.trim())
-      .filter(Boolean)[0]
-    if (!first) return undefined
-    if (first.startsWith("codex:") && first.includes("aliased to")) {
-      const aliasTarget = first.split("aliased to")[1]?.trim()
-      return aliasTarget && existsSync(aliasTarget) ? aliasTarget : undefined
-    }
-    return first
-  },
-  readdir(p) {
-    try {
-      const fs = require("node:fs") as typeof import("node:fs")
-      return fs.readdirSync(p)
-    } catch {
-      return []
-    }
-  },
-}
-
-export async function findCodexBinary(deps: BinaryDiscoveryDeps = defaultDeps): Promise<string> {
-  const checked: string[] = []
-  const tryPath = (p: string | undefined): string | undefined => {
-    if (!p) return undefined
-    checked.push(p)
-    return deps.fileExists(p) ? p : undefined
-  }
-
-  const whichResult = deps.which("codex")
-  if (whichResult) {
-    checked.push(`which:${whichResult}`)
-    if (deps.fileExists(whichResult)) return whichResult
-  }
-
-  const home = deps.home()
-
-  for (const p of ["/opt/homebrew/bin/codex", "/usr/local/bin/codex", "/usr/bin/codex", "/bin/codex"]) {
-    const candidate = tryPath(p)
-    if (candidate) return candidate
-  }
-
-  const nvmBin = deps.env("NVM_BIN")
-  if (nvmBin) {
-    const candidate = tryPath(path.join(nvmBin, "codex"))
-    if (candidate) return candidate
-  }
-
-  for (const rel of [".local/bin/codex", ".bun/bin/codex", "bin/codex"]) {
-    const candidate = tryPath(path.join(home, rel))
-    if (candidate) return candidate
-  }
-
-  throw new CodexBinaryNotFoundError(checked)
-}
+  notFound: (checked) => new CodexBinaryNotFoundError(checked),
+})

--- a/packages/kobe/src/engine/codex-local/history.ts
+++ b/packages/kobe/src/engine/codex-local/history.ts
@@ -31,6 +31,7 @@ import { homedir } from "node:os"
 import path from "node:path"
 import type { EngineHistory, Message } from "@/types/engine"
 import { isJsonlLineWithinBound, readTextFileBounded } from "../file-bounds"
+import { vendorConfigHome } from "../vendor-home"
 import { parseRolloutRaw } from "./history-parse"
 
 export { deriveCodexUsageMetrics, parseJsonl } from "./history-parse"
@@ -46,10 +47,7 @@ export interface HistoryDeps {
 
 export const defaultHistoryDeps: HistoryDeps = {
   sessionsDir() {
-    // `$CODEX_HOME` relocates the whole `~/.codex` dir (same contract
-    // account-detect's codexAuthPath honors); read per call, never cached.
-    const override = process.env.CODEX_HOME?.trim()
-    return path.join(override || path.join(homedir(), ".codex"), "sessions")
+    return path.join(vendorConfigHome("codex"), "sessions")
   },
   async readdir(p) {
     try {

--- a/packages/kobe/src/engine/copilot-local/binary.ts
+++ b/packages/kobe/src/engine/copilot-local/binary.ts
@@ -1,116 +1,51 @@
-import { spawnSync } from "node:child_process"
-import { existsSync, statSync } from "node:fs"
-import { homedir } from "node:os"
-import path from "node:path"
+/**
+ * Where the GitHub Copilot CLI binary lives: `$PATH`, the system dirs, the
+ * active nvm bin, then the per-user npm dirs — each probed under every
+ * spelling the platform uses (`.exe`/`.cmd` on Windows). Probing itself
+ * lives in `../binary-discovery.ts`.
+ */
 
-export class CopilotBinaryNotFoundError extends Error {
-  readonly checkedPaths: readonly string[]
+import path from "node:path"
+import { BinaryNotFoundError, createBinaryFinder } from "../binary-discovery.ts"
+
+export type { BinaryDiscoveryDeps } from "../binary-discovery.ts"
+
+export class CopilotBinaryNotFoundError extends BinaryNotFoundError {
   constructor(checkedPaths: readonly string[]) {
     super(
-      `GitHub Copilot CLI binary not found. Checked: ${checkedPaths.join(
-        ", ",
-      )}. Ensure 'copilot' is on PATH (for example \`npm install -g @github/copilot\` or \`brew install copilot-cli\`).`,
+      "GitHub Copilot CLI binary",
+      "Ensure 'copilot' is on PATH (for example `npm install -g @github/copilot` or `brew install copilot-cli`).",
+      checkedPaths,
     )
     this.name = "CopilotBinaryNotFoundError"
-    this.checkedPaths = checkedPaths
   }
 }
 
-export interface BinaryDiscoveryDeps {
-  fileExists(p: string): boolean
-  env(name: string): string | undefined
-  home(): string
-  which(name: string): string | undefined
-  platform(): NodeJS.Platform
-}
+export const findCopilotBinary = createBinaryFinder({
+  name: "copilot",
+  candidates({ deps, home }) {
+    const win32 = (deps.platform?.() ?? process.platform) === "win32"
+    const names = win32 ? ["copilot.exe", "copilot.cmd", "copilot"] : ["copilot"]
 
-const defaultDeps: BinaryDiscoveryDeps = {
-  fileExists(p) {
-    try {
-      return statSync(p).isFile()
-    } catch {
-      return false
+    const dirs = ["/opt/homebrew/bin", "/usr/local/bin", "/usr/bin", "/bin"]
+    const nvmBin = deps.env("NVM_BIN")
+    if (nvmBin) dirs.push(nvmBin)
+
+    const homeDirs = [
+      path.join(home, ".npm-global/bin"),
+      path.join(home, ".local/bin"),
+      path.join(home, ".bun/bin"),
+      path.join(home, "bin"),
+    ]
+    if (win32) {
+      const appData = deps.env("APPDATA")
+      const localAppData = deps.env("LOCALAPPDATA")
+      homeDirs.unshift(path.join(home, "AppData/Roaming/npm"))
+      if (appData) homeDirs.unshift(path.join(appData, "npm"))
+      if (localAppData) homeDirs.unshift(path.join(localAppData, "npm"))
     }
+
+    return [...dirs, ...homeDirs].flatMap((dir) => names.map((name) => path.join(dir, name)))
   },
-  env(name) {
-    return process.env[name]
-  },
-  home() {
-    return homedir()
-  },
-  which(name) {
-    const cmd = process.platform === "win32" ? "where" : "which"
-    const out = spawnSync(cmd, [name], { encoding: "utf8" })
-    if (out.status !== 0) return undefined
-    const first = out.stdout
-      .split("\n")
-      .map((l) => l.trim())
-      .filter(Boolean)[0]
-    if (!first) return undefined
-    if (first.startsWith("copilot:") && first.includes("aliased to")) {
-      const aliasTarget = first.split("aliased to")[1]?.trim()
-      return aliasTarget && existsSync(aliasTarget) ? aliasTarget : undefined
-    }
-    return first
-  },
-  platform() {
-    return process.platform
-  },
-}
-
-export async function findCopilotBinary(deps: BinaryDiscoveryDeps = defaultDeps): Promise<string> {
-  const checked: string[] = []
-  const tryPath = (p: string | undefined): string | undefined => {
-    if (!p) return undefined
-    checked.push(p)
-    return deps.fileExists(p) ? p : undefined
-  }
-
-  const whichResult = deps.which("copilot")
-  if (whichResult) {
-    checked.push(`which:${whichResult}`)
-    if (deps.fileExists(whichResult)) return whichResult
-  }
-
-  const names = deps.platform() === "win32" ? ["copilot.exe", "copilot.cmd", "copilot"] : ["copilot"]
-
-  const tryDir = (dir: string | undefined): string | undefined => {
-    if (!dir) return undefined
-    for (const name of names) {
-      const candidate = tryPath(path.join(dir, name))
-      if (candidate) return candidate
-    }
-    return undefined
-  }
-
-  for (const dir of ["/opt/homebrew/bin", "/usr/local/bin", "/usr/bin", "/bin"]) {
-    const candidate = tryDir(dir)
-    if (candidate) return candidate
-  }
-
-  const nvmBin = deps.env("NVM_BIN")
-  const nvmCandidate = tryDir(nvmBin)
-  if (nvmCandidate) return nvmCandidate
-
-  const home = deps.home()
-  const homeDirs = [
-    path.join(home, ".npm-global/bin"),
-    path.join(home, ".local/bin"),
-    path.join(home, ".bun/bin"),
-    path.join(home, "bin"),
-  ]
-  if (deps.platform() === "win32") {
-    const appData = deps.env("APPDATA")
-    const localAppData = deps.env("LOCALAPPDATA")
-    homeDirs.unshift(path.join(home, "AppData/Roaming/npm"))
-    if (appData) homeDirs.unshift(path.join(appData, "npm"))
-    if (localAppData) homeDirs.unshift(path.join(localAppData, "npm"))
-  }
-
-  for (const dir of homeDirs) {
-    const candidate = tryDir(dir)
-    if (candidate) return candidate
-  }
-
-  throw new CopilotBinaryNotFoundError(checked)
-}
+  notFound: (checked) => new CopilotBinaryNotFoundError(checked),
+})

--- a/packages/kobe/src/engine/copilot-local/history.ts
+++ b/packages/kobe/src/engine/copilot-local/history.ts
@@ -5,6 +5,7 @@ import type { ContentBlock } from "@/types/content"
 import type { EngineHistory, EngineUsageSnapshot, Message } from "@/types/engine"
 import { isJsonlLineWithinBound, readTextFileBounded } from "../file-bounds"
 import { createAppendParseCache } from "../history-cache"
+import { vendorConfigHome } from "../vendor-home"
 import { copilotUsageToSnapshot } from "./usage"
 
 export interface CopilotHistoryDeps {
@@ -17,9 +18,7 @@ export interface CopilotHistoryDeps {
 
 const defaultDeps: CopilotHistoryDeps = {
   copilotDir() {
-    const override = process.env.COPILOT_HOME?.trim()
-    if (override) return override
-    return path.join(homedir(), ".copilot")
+    return vendorConfigHome("copilot")
   },
   async readdir(p) {
     try {

--- a/packages/kobe/src/engine/kimi-local/binary.ts
+++ b/packages/kobe/src/engine/kimi-local/binary.ts
@@ -1,85 +1,31 @@
 /**
- * Kimi Code CLI binary discovery. The installer puts the launcher at
- * `~/.kimi-code/bin/kimi` and
- * users may also symlink it onto PATH — so probe `which` first, then the
- * install dir, then the usual bin directories.
+ * Where the Kimi Code CLI binary lives. The installer puts the launcher at
+ * `~/.kimi-code/bin/kimi` and users may also symlink it onto PATH — so probe
+ * `which` first, then the install dir, then the usual bin directories.
+ * Probing itself lives in `../binary-discovery.ts`.
  */
 
-import { spawnSync } from "node:child_process"
-import { statSync } from "node:fs"
-import { homedir } from "node:os"
 import path from "node:path"
+import { BinaryNotFoundError, createBinaryFinder } from "../binary-discovery.ts"
 
-export class KimiBinaryNotFoundError extends Error {
-  readonly checkedPaths: readonly string[]
+export type { BinaryDiscoveryDeps } from "../binary-discovery.ts"
+
+export class KimiBinaryNotFoundError extends BinaryNotFoundError {
   constructor(checkedPaths: readonly string[]) {
-    super(
-      `Kimi Code CLI binary not found. Checked: ${checkedPaths.join(", ")}. Ensure 'kimi' is on PATH or installed at ~/.kimi-code/bin/kimi.`,
-    )
+    super("Kimi Code CLI binary", "Ensure 'kimi' is on PATH or installed at ~/.kimi-code/bin/kimi.", checkedPaths)
     this.name = "KimiBinaryNotFoundError"
-    this.checkedPaths = checkedPaths
   }
 }
 
-export interface BinaryDiscoveryDeps {
-  fileExists(p: string): boolean
-  env(name: string): string | undefined
-  home(): string
-  which(name: string): string | undefined
-}
-
-const defaultDeps: BinaryDiscoveryDeps = {
-  fileExists(p) {
-    try {
-      return statSync(p).isFile()
-    } catch {
-      return false
-    }
-  },
-  env(name) {
-    return process.env[name]
-  },
-  home() {
-    return homedir()
-  },
-  which(name) {
-    const cmd = process.platform === "win32" ? "where" : "which"
-    const out = spawnSync(cmd, [name], { encoding: "utf8" })
-    if (out.status !== 0) return undefined
-    return (
-      out.stdout
-        .split("\n")
-        .map((l) => l.trim())
-        .filter(Boolean)[0] || undefined
-    )
-  },
-}
-
-export async function findKimiBinary(deps: BinaryDiscoveryDeps = defaultDeps): Promise<string> {
-  const checked: string[] = []
-  const tryPath = (p: string | undefined): string | undefined => {
-    if (!p) return undefined
-    checked.push(p)
-    return deps.fileExists(p) ? p : undefined
-  }
-
-  const whichResult = deps.which("kimi")
-  if (whichResult) {
-    checked.push(`which:${whichResult}`)
-    if (deps.fileExists(whichResult)) return whichResult
-  }
-
-  const home = deps.home()
-  for (const dir of [
-    path.join(home, ".kimi-code/bin"),
-    path.join(home, ".local/bin"),
-    path.join(home, "bin"),
-    "/opt/homebrew/bin",
-    "/usr/local/bin",
-  ]) {
-    const candidate = tryPath(path.join(dir, "kimi"))
-    if (candidate) return candidate
-  }
-
-  throw new KimiBinaryNotFoundError(checked)
-}
+export const findKimiBinary = createBinaryFinder({
+  name: "kimi",
+  candidates: ({ home }) =>
+    [
+      path.join(home, ".kimi-code/bin"),
+      path.join(home, ".local/bin"),
+      path.join(home, "bin"),
+      "/opt/homebrew/bin",
+      "/usr/local/bin",
+    ].map((dir) => path.join(dir, "kimi")),
+  notFound: (checked) => new KimiBinaryNotFoundError(checked),
+})

--- a/packages/kobe/src/engine/kimi-local/history.ts
+++ b/packages/kobe/src/engine/kimi-local/history.ts
@@ -23,6 +23,7 @@ import { stat } from "node:fs/promises"
 import { homedir } from "node:os"
 import path from "node:path"
 import { readTextFileBounded } from "../file-bounds"
+import { vendorConfigHome } from "../vendor-home"
 
 export interface KimiHistoryDeps {
   kimiDir(): string
@@ -32,8 +33,7 @@ export interface KimiHistoryDeps {
 
 const defaultDeps: KimiHistoryDeps = {
   kimiDir() {
-    const override = process.env.KIMI_CODE_HOME?.trim()
-    return override || path.join(homedir(), ".kimi-code")
+    return vendorConfigHome("kimi")
   },
   async readFile(p) {
     // Size-bounded like the other readers: a corrupt index degrades to ""

--- a/packages/kobe/src/engine/kimi-local/hook-adapter.ts
+++ b/packages/kobe/src/engine/kimi-local/hook-adapter.ts
@@ -37,6 +37,7 @@ import { quoteShellArgv } from "../../lib/shell-command.ts"
 import type { EngineHookAdapter, EngineSessionRef } from "../hook-adapter.ts"
 import type { EngineActivityDetail, EngineActivityKind } from "../hook-events.ts"
 import { GATED_TOOL_VERBS, type HookEventSpec } from "../json-hooks.ts"
+import { vendorConfigHome } from "../vendor-home.ts"
 
 /** Kimi hook event → normalized kobe verb. The ONE place Kimi event names live. */
 export const KIMI_HOOK_EVENT_MAP: readonly HookEventSpec[] = [
@@ -69,11 +70,9 @@ const BLOCK_END = "# <<< rove hooks"
 /** Bound each hook spawn — `kobe hook` is sub-second; Kimi's default is 30s. */
 const HOOK_TIMEOUT_SECONDS = 10
 
-/** Where Kimi reads its config (the hooks live inline in config.toml).
- *  `KIMI_CODE_HOME` is the same override `kimi-local/history.ts` honors. */
+/** Where Kimi reads its config (the hooks live inline in config.toml). */
 export function kimiConfigPath(home: string = homedir()): string {
-  const override = process.env.KIMI_CODE_HOME?.trim()
-  return join(override && override.length > 0 ? override : join(home, ".kimi-code"), "config.toml")
+  return join(vendorConfigHome("kimi", { env: (k) => process.env[k], home: () => home }), "config.toml")
 }
 
 /** Render kobe's `[[hooks]]` block. `inv` is injectable for tests. */

--- a/packages/kobe/src/engine/vendor-home.ts
+++ b/packages/kobe/src/engine/vendor-home.ts
@@ -1,0 +1,83 @@
+/**
+ * Where each vendor's CLI keeps its own state, and the files inside it that
+ * Rove reads.
+ *
+ * The env-var names below are the contract each vendor CLI honors, so a
+ * drift between two copies of this derivation is a correctness bug that only
+ * shows up under an isolated profile (a `CLAUDE_CONFIG_DIR` sandbox, the
+ * dev-sandbox `HOME`) — which is exactly where it is hardest to notice. It
+ * was written out nine times across six files before this module existed.
+ *
+ * Read per call, never cached: a module-level `const` would freeze whichever
+ * profile happened to be set at import time and silently write to the real
+ * `~/.claude`.
+ */
+
+import { homedir } from "node:os"
+import path from "node:path"
+
+/** The vendors whose CLI keeps a relocatable config home. */
+export type ConfigHomeVendor = "claude" | "codex" | "copilot" | "kimi"
+
+/** Env override + default directory name, per vendor. */
+const VENDOR_HOMES: Readonly<Record<ConfigHomeVendor, { readonly envVar: string; readonly dirName: string }>> = {
+  claude: { envVar: "CLAUDE_CONFIG_DIR", dirName: ".claude" },
+  codex: { envVar: "CODEX_HOME", dirName: ".codex" },
+  copilot: { envVar: "COPILOT_HOME", dirName: ".copilot" },
+  kimi: { envVar: "KIMI_CODE_HOME", dirName: ".kimi-code" },
+}
+
+/** Env/home injection. Defaults read the live process, which is what every
+ *  non-test caller wants. */
+export interface VendorHomeDeps {
+  env(name: string): string | undefined
+  home(): string
+}
+
+const defaultVendorHomeDeps: VendorHomeDeps = {
+  env: (name) => process.env[name],
+  home: () => homedir(),
+}
+
+/**
+ * The vendor's config directory. An override that is empty or whitespace
+ * counts as unset — `.trim()` was already reaching for that, and treating
+ * `CODEX_HOME=""` as a real path would send reads to the filesystem root.
+ */
+export function vendorConfigHome(vendor: ConfigHomeVendor, deps: VendorHomeDeps = defaultVendorHomeDeps): string {
+  const { envVar, dirName } = VENDOR_HOMES[vendor]
+  const override = deps.env(envVar)?.trim()
+  if (override) return override
+  return path.join(deps.home(), dirName)
+}
+
+/** Adapter for the `(env, home)` parameter shape account-detect's callers use. */
+function depsOf(env: (k: string) => string | undefined, home: string): VendorHomeDeps {
+  return { env, home: () => home }
+}
+
+/**
+ * claude-code's global config. Note the asymmetry, which is the CLI's own:
+ * with `CLAUDE_CONFIG_DIR` set the file sits INSIDE that dir, but with it
+ * unset the file is `~/.claude.json` at the home root — NOT inside `~/.claude`.
+ */
+export function claudeGlobalConfigPath(env: (k: string) => string | undefined, home: string): string {
+  const override = env("CLAUDE_CONFIG_DIR")?.trim()
+  if (override) return path.join(override, ".claude.json")
+  return path.join(home, ".claude.json")
+}
+
+/** codex's auth file (`~/.codex/auth.json` by default). */
+export function codexAuthPath(env: (k: string) => string | undefined, home: string): string {
+  return path.join(vendorConfigHome("codex", depsOf(env, home)), "auth.json")
+}
+
+/** copilot's config file (`~/.copilot/config.json` by default). */
+export function copilotConfigPath(env: (k: string) => string | undefined, home: string): string {
+  return path.join(vendorConfigHome("copilot", depsOf(env, home)), "config.json")
+}
+
+/** kimi's OAuth credential file (`~/.kimi-code/credentials/kimi-code.json`). */
+export function kimiCredentialsPath(env: (k: string) => string | undefined, home: string): string {
+  return path.join(vendorConfigHome("kimi", depsOf(env, home)), "credentials", "kimi-code.json")
+}

--- a/packages/kobe/test/engine/account-detect-edge-cases.test.ts
+++ b/packages/kobe/test/engine/account-detect-edge-cases.test.ts
@@ -20,13 +20,11 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest"
 import {
   type DetectDeps,
   availableEngineIds,
-  claudeGlobalConfigPath,
-  codexAuthPath,
-  copilotConfigPath,
   detectClaudeAccount,
   detectCodexAccount,
   detectCopilotAccount,
 } from "../../src/engine/account-detect.ts"
+import { claudeGlobalConfigPath, codexAuthPath, copilotConfigPath } from "../../src/engine/vendor-home.ts"
 
 function deps(over: Partial<DetectDeps> = {}): DetectDeps {
   return {

--- a/packages/kobe/test/engine/binary-default-deps.test.ts
+++ b/packages/kobe/test/engine/binary-default-deps.test.ts
@@ -60,6 +60,7 @@ import {
   type BinaryDiscoveryDeps as CopilotDeps,
   findCopilotBinary,
 } from "../../src/engine/copilot-local/binary.ts"
+import { findKimiBinary } from "../../src/engine/kimi-local/binary.ts"
 
 beforeEach(() => {
   files.clear()
@@ -133,6 +134,24 @@ describe("findCodexBinary — default deps", () => {
     const err = await findCodexBinary().catch((e: unknown) => e)
     expect(err).toBeInstanceOf(CodexBinaryNotFoundError)
     expect((err as CodexBinaryNotFoundError).checkedPaths).toContain("/opt/homebrew/bin/codex")
+  })
+})
+
+// Kimi's own `which` parser never unwrapped the alias line; the shared
+// `defaultBinaryDeps.which` does it for every vendor. Before, an aliased
+// `kimi` returned the literal "kimi: aliased to …" string, which then failed
+// the fileExists check and fell through to the install dirs for no reason.
+describe("findKimiBinary — default deps", () => {
+  it("resolves a macOS `which` alias line to its target when the target exists", async () => {
+    which = { status: 0, stdout: "kimi: aliased to /vhome/u/real-kimi\n" }
+    files.add("/vhome/u/real-kimi")
+    await expect(findKimiBinary()).resolves.toBe("/vhome/u/real-kimi")
+  })
+
+  it("discards an alias whose target is gone and falls through to ~/.kimi-code/bin", async () => {
+    which = { status: 0, stdout: "kimi: aliased to /vanished/kimi\n" }
+    files.add(path.join(HOME, ".kimi-code/bin", "kimi"))
+    await expect(findKimiBinary()).resolves.toBe(path.join(HOME, ".kimi-code/bin", "kimi"))
   })
 })
 

--- a/packages/kobe/test/engine/vendor-home.test.ts
+++ b/packages/kobe/test/engine/vendor-home.test.ts
@@ -1,0 +1,62 @@
+/**
+ * `vendorConfigHome` is the single derivation of "where does vendor X keep
+ * its state" that six engine modules used to re-write by hand. What is pinned
+ * here is the part a copy gets wrong silently: the exact env-var name per
+ * vendor, the exact default dir, and the empty-override rule.
+ *
+ * The empty-override rule mattered before this module existed: the four
+ * resolvers disagreed. `claudeGlobalConfigPath` used `override ? … : …`
+ * (treating `""` as absent) while the other three used `override ?? …` —
+ * and `.trim()` yields `""`, not `undefined`, so `CODEX_HOME="  "` resolved
+ * to `/auth.json` at the filesystem root.
+ */
+
+import { describe, expect, it } from "vitest"
+import {
+  claudeGlobalConfigPath,
+  codexAuthPath,
+  copilotConfigPath,
+  kimiCredentialsPath,
+  vendorConfigHome,
+} from "../../src/engine/vendor-home.ts"
+
+const deps = (env: Record<string, string> = {}, home = "/home/u") => ({
+  env: (k: string) => env[k],
+  home: () => home,
+})
+
+describe("vendorConfigHome", () => {
+  it("defaults to the vendor's dotdir under home", () => {
+    expect(vendorConfigHome("claude", deps())).toBe("/home/u/.claude")
+    expect(vendorConfigHome("codex", deps())).toBe("/home/u/.codex")
+    expect(vendorConfigHome("copilot", deps())).toBe("/home/u/.copilot")
+    expect(vendorConfigHome("kimi", deps())).toBe("/home/u/.kimi-code")
+  })
+
+  it("honours each vendor's own env override", () => {
+    expect(vendorConfigHome("claude", deps({ CLAUDE_CONFIG_DIR: "/profiles/c" }))).toBe("/profiles/c")
+    expect(vendorConfigHome("codex", deps({ CODEX_HOME: "/profiles/x" }))).toBe("/profiles/x")
+    expect(vendorConfigHome("copilot", deps({ COPILOT_HOME: "/profiles/p" }))).toBe("/profiles/p")
+    expect(vendorConfigHome("kimi", deps({ KIMI_CODE_HOME: "/profiles/k" }))).toBe("/profiles/k")
+  })
+
+  it("treats a blank override as unset for every vendor, not as the filesystem root", () => {
+    expect(vendorConfigHome("codex", deps({ CODEX_HOME: "   " }))).toBe("/home/u/.codex")
+    expect(vendorConfigHome("copilot", deps({ COPILOT_HOME: "" }))).toBe("/home/u/.copilot")
+    expect(vendorConfigHome("kimi", deps({ KIMI_CODE_HOME: "  " }))).toBe("/home/u/.kimi-code")
+    expect(codexAuthPath(() => "  ", "/home/u")).toBe("/home/u/.codex/auth.json")
+  })
+
+  it("keeps claude's global-config asymmetry: ~/.claude.json at the home ROOT when unset", () => {
+    expect(claudeGlobalConfigPath(() => undefined, "/home/u")).toBe("/home/u/.claude.json")
+    expect(claudeGlobalConfigPath((k) => (k === "CLAUDE_CONFIG_DIR" ? "/profiles/c" : undefined), "/home/u")).toBe(
+      "/profiles/c/.claude.json",
+    )
+  })
+
+  it("points each credential reader at the file its CLI actually writes", () => {
+    expect(codexAuthPath(() => undefined, "/home/u")).toBe("/home/u/.codex/auth.json")
+    expect(copilotConfigPath(() => undefined, "/home/u")).toBe("/home/u/.copilot/config.json")
+    expect(kimiCredentialsPath(() => undefined, "/home/u")).toBe("/home/u/.kimi-code/credentials/kimi-code.json")
+  })
+})


### PR DESCRIPTION
Two things the engine adapters had each written out by hand. Both are behaviour-preserving; the one deliberate exception is called out below.

## (a) Four copies of CLI-binary discovery → one `createBinaryFinder`

`claude-code-local`, `codex-local`, `kimi-local` and `copilot-local` each carried a `BinaryDiscoveryDeps` interface, a `defaultDeps` implementation, a `<Vendor>BinaryNotFoundError` class and a `find<Vendor>Binary` walk with an inline `tryPath` closure — 487 lines whose only real differences were the binary name, the install hint and the candidate list. Byte-level repeats included the `statSync().isFile()` probe, the `env`/`home` accessors, the `which`/`where` spawn with its macOS `"<name>: aliased to <path>"` unwrapping (in three of the four), and the `require("node:fs").readdirSync` wrapper (in two).

**The seam:** `engine/binary-discovery.ts` owns *how* to probe — the `which` call and its alias unwrapping, the stat check, the ordered `checkedPaths` ledger that ends up in the user-facing error, and the injection point the tests drive. Each `<vendor>-local/binary.ts` keeps only *where* to look, verbatim. Nothing else left the vendor directories.

The four error classes stay as one-line subclasses of a shared `BinaryNotFoundError`, so `error.name` and every message are unchanged and the existing suites needed no edits. The 4-way `instanceof` chain in `account-detect.ts:184-187` — their only non-test consumer — collapses to one `err instanceof BinaryNotFoundError`.

### One deliberate behaviour ADD

`kimi` now unwraps a macOS `which` alias line, which claude, codex and copilot already did. An aliased `kimi` previously resolved to the literal `"kimi: aliased to /path"` string, failed the file check, and fell through to the install dirs for no reason. Two tests in `binary-default-deps.test.ts` pin it; mutation-checked by gating the unwrap off for kimi:

```
FAIL  findKimiBinary — default deps > resolves a macOS `which` alias line to its target when the target exists
      Tests  1 failed | 15 passed (16)
```

## (b) Nine copies of vendor config-home resolution → `engine/vendor-home.ts`

`process.env.<VENDOR>_HOME?.trim() || path.join(homedir(), ".<vendor>")` was re-derived in six files: the four canonical resolvers in `account-detect.ts` (which nothing else imported) plus five inline re-derivations in `claude-code-local/history.ts`, `claude-code-local/quota.ts`, `codex-local/history.ts`, `kimi-local/history.ts`, `kimi-local/hook-adapter.ts` (whose own comment admitted the duplication) and `copilot-local/history.ts`.

**The seam:** `vendor-home.ts` answers "where does vendor X keep its state"; each vendor module keeps "which file inside it do I want".

**A latent divergence closed on the way:** `claudeGlobalConfigPath` used `override ? … : …` while the other three used `override ?? …`. Since `.trim()` returns `""` and not `undefined`, `CODEX_HOME="  "` resolved to `/auth.json` at the filesystem root. Blank now uniformly means unset — `test/engine/vendor-home.test.ts` pins that, along with each vendor's env-var name and default dir.

**Preserved deliberately:**
- claude's genuine asymmetry — `~/.claude.json` sits at the home *root* when `CLAUDE_CONFIG_DIR` is unset, but *inside* the dir when it is set. Documented in the helper.
- Read-per-call, never cached. A module-level `const` would freeze whichever profile was set at import time and silently write to the real `~/.claude`.
- `quota.ts:164-172` is not a plain path resolve: with `CLAUDE_CONFIG_DIR` set it consults only that profile's credentials file and skips the Keychain. That branch is untouched; only the fallback's path derivation moved.
- The `(env, home)` parameter shape of the four exported helpers, which `account-detect.test.ts` injects.

`account-detect.ts` was at **498/500** lines, four under the cap. It is now **468** — the brief asked that a PR touching it not grow it, and this buys it headroom instead.

---

## PASS criteria

### 1. Tests

```
bun run test:fast                     4310 passed, 6 failed
bun x vitest run test/engine test/architecture
                                      775 passed (72 files) — 0 failed
KOBE_INCLUDE_SOCKET=1 bun run test:socket
                                      786 passed (94 files) — 0 failed
bun run lint                          Checked 1391 files. No fixes applied.
bun run typecheck                     all four packages exit 0
```

Every suite the brief named is green and **unmodified**: `binary-discovery.test.ts` (13), `binary-default-deps.test.ts` (14 → 16, +2 for the kimi alias add), `account-detect.test.ts` (14), `account-detect-edge-cases.test.ts` (23 — import retargeted to `vendor-home.ts`, assertions untouched). `test/architecture/engine-owned-copy.test.ts` green, along with the rest of `test/architecture` (130 tests).

The 6 failures are **pre-existing and environment-shaped**, not from this branch — the same 6 fail on an unmodified `origin/main` worktree on this machine (`project-eligibility` ×2 and `open-dir-cmd` ×2 judge project eligibility by path shape and this worktree lives under `~/.rove/worktrees`; `continue-live-vendor` ×2 walks the machine's real engine presets):

```
$ cd .scratch/baseline-r3   # detached at origin/main e598d7077, unmodified
$ bun x vitest run test/state/project-eligibility.test.ts test/cli/open-dir-cmd.test.ts test/tui/continue-live-vendor.test.ts
  Test Files  3 failed (3)
       Tests  6 failed | 31 passed (37)
```

### 2. End-to-end identity — byte-identical before/after

Same machine, `origin/main` build vs this branch:

```
$ diff <(main: rove api engine-list --pretty) <(branch: …)                    → empty
$ diff <(main: rove doctor | engines section) <(branch: …)                    → empty
$ CLAUDE_CONFIG_DIR=/tmp/probe-claude KIMI_CODE_HOME=/tmp/probe-kimi \
  CODEX_HOME=/tmp/probe-codex COPILOT_HOME=/tmp/probe-copilot rove doctor
  diff <(main: engines section) <(branch: …)                                  → empty
```

All four vendor homes redirected at once still produce identical output, which is the check that would catch a dropped or renamed env var:

```
engines:
  claude  ✓ /Users/jacksonc/.nvm/versions/node/v22.23.2/bin/claude — no account
  codex   ✓ /opt/homebrew/bin/codex — no account
  copilot ✗ not found on PATH
  kimi    ✓ /Users/jacksonc/.kimi-code/bin/kimi — no account
  …
```

`doctor` reports a not-found binary as the classified `"not found on PATH"`, so the full `Checked:` message was compared separately. Driving all four finders with one stubbed deps set (`NVM_BIN`, `APPDATA`, `LOCALAPPDATA`, a 3-entry nvm dir, `platform: win32`, everything missing) and diffing the thrown errors between the two trees:

```
=== ALL FOUR: checkedPaths ORDER + message + error.name BYTE-IDENTICAL ===

## claude name=ClaudeBinaryNotFoundError
Claude Code binary not found. Checked: /home/u/.claude/local/claude, /nvm/active/bin/claude,
/home/u/.nvm/versions/node/v20.0.0/bin/claude, /home/u/.nvm/versions/node/v18.0.0/bin/claude,
/home/u/.nvm/versions/node/v8.17.0/bin/claude, /opt/homebrew/bin/claude, /usr/local/bin/claude,
/usr/bin/claude, /bin/claude, /home/u/.local/bin/claude, /home/u/.npm-global/bin/claude,
/home/u/.yarn/bin/claude, /home/u/.bun/bin/claude, /home/u/bin/claude.
Ensure 'claude' is on PATH, or install at ~/.claude/local/claude.
…
```

That covers every risk the brief flagged as must-stay-identical: per-vendor search **order** (claude's numeric newest-first nvm walk, codex's homebrew-before-NVM, kimi's install dir first, copilot's win32 name expansion and `%LOCALAPPDATA%` → `%APPDATA%` → home ordering), the `checkedPaths` content **and** order including the `which:` sentinel, the message text, and `error.name`.

### 3. Line reduction

```
the four binary.ts alone     added 112, deleted 420   → net -308
all of src/engine/**         added 358, deleted 484   → net -126
```

The 126 is after the two new shared modules land (`binary-discovery.ts` 140 + `vendor-home.ts` 83 = 223 new lines). Duplication actually removed: 484 lines.

```
140  packages/kobe/src/engine/binary-discovery.ts   (new)
 83  packages/kobe/src/engine/vendor-home.ts        (new)
468  packages/kobe/src/engine/account-detect.ts     (was 498)
```

No screenshots: this is a pure refactor with no UI surface. The behaviour-preserving proof is the byte-identical output above.
