### PR TITLE
fix: record repo-init's outcome in the marker and restore its env every session

### DIFF
--- a/.changeset/repo-init-marker-and-env.md
+++ b/.changeset/repo-init-marker-and-env.md
@@ -1,0 +1,14 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Repo init: record the outcome in the marker, and restore its exports for every
+session. A `.rove/init.sh` that failed or timed out wrote no marker at all, so
+the paste-delivery spawner (kimi) could not tell "init failed" from "init still
+running" and sat out its whole 120s budget before delivering a task's first
+message; the marker now carries init's exit code, and a recorded failure still
+re-runs init on the next launch. The env restore has also moved outside the
+once-per-worktree marker guard and into a durable `0600` dump next to the
+marker, so a second engine tab — and a restart of the first — gets the PATH,
+venv and API-key exports init set, instead of only the very first session in
+the worktree ever seeing them.

--- a/packages/kobe/src/engine/hosted-session.ts
+++ b/packages/kobe/src/engine/hosted-session.ts
@@ -408,7 +408,10 @@ export interface PasteFirstMessageOptions extends HostedPromptDeliveryOpts {
   readonly sleep?: (ms: number) => Promise<void>
   /** When the launch includes a repo-init script, wait for this marker file
    *  before budgeting the engine-startup wait. Prevents a short paste-delivery
-   *  window from expiring while dependencies are still installing. */
+   *  window from expiring while dependencies are still installing. The launch
+   *  script writes it when init FINISHES, whatever the outcome — a
+   *  success-only marker made "init failed" indistinguishable from "init is
+   *  still running", and the loop below then sat out the whole budget. */
   readonly initMarkerPath?: string
   /** How long to wait for {@link initMarkerPath} to appear (ms). */
   readonly initTimeoutMs?: number

--- a/packages/kobe/src/engine/session-launch.ts
+++ b/packages/kobe/src/engine/session-launch.ts
@@ -36,19 +36,38 @@ export function resolveRepoInitTimeoutSeconds(raw?: string | number | null): num
   return Math.max(REPO_INIT_TIMEOUT_MIN_SECONDS, Math.min(REPO_INIT_TIMEOUT_MAX_SECONDS, Math.round(n)))
 }
 
-/** Run repo init without allowing a hung setup command to block engine entry. */
+/**
+ * Run repo init without allowing a hung setup command to block engine entry.
+ *
+ * Leaves the caller two things: `$__kobe_init_rc` (the outcome — `124` on
+ * timeout) and, on success only, an env dump at `$__kobe_init_env` for the
+ * caller to source. The caller owns both the path and the sourcing, because
+ * the dump outlives this run — see {@link engineLaunchLine}.
+ *
+ * The dump is the DELTA of `export -p` across the script, not the whole
+ * environment. It is sourced by EVERY session in the worktree, and a whole
+ * dump would re-export the first session's `ROVE_TASK_ID` / `ROVE_TAB_ID`
+ * over each later tab's own identity — hooks would then attribute every
+ * tab's events to tab-1 — besides carrying its `PWD`/`SHLVL` along. Written
+ * under `umask 077`: an init script's exports are exactly where an API key
+ * would be.
+ */
 function boundedInitGroup(script: string, timeoutSeconds: number): string {
   const seconds = String(timeoutSeconds)
   const timeoutBanner = "\\n  ⚠ Repo init script timed out after %ss and was killed; continuing to the engine.\\n\\n"
   const failBanner = "\\n  ⚠ Repo init script failed (code %s); continuing to the engine.\\n\\n"
   return [
-    `__kobe_init_env="\${TMPDIR:-/tmp}/kobe-init-env.$$"`,
+    `__kobe_init_pre="\${TMPDIR:-/tmp}/kobe-init-pre.$$"`,
     `__kobe_init_to="\${TMPDIR:-/tmp}/kobe-init-timeout.$$"`,
-    `rm -f "$__kobe_init_env" "$__kobe_init_to" 2>/dev/null`,
+    `rm -f "$__kobe_init_env" "$__kobe_init_pre" "$__kobe_init_to" 2>/dev/null`,
     "(",
+    `export -p > "$__kobe_init_pre" 2>/dev/null`,
     script,
     "__kobe_init_ec=$?",
-    `export -p > "$__kobe_init_env" 2>/dev/null`,
+    "umask 077",
+    // No pre-image means no way to tell the script's exports from the
+    // session's own, so write nothing rather than clobber tab identity.
+    `[ -s "$__kobe_init_pre" ] && export -p 2>/dev/null | grep -vxF -f "$__kobe_init_pre" > "$__kobe_init_env" 2>/dev/null`,
     "exit $__kobe_init_ec",
     ") </dev/null &",
     "__kobe_init_pid=$!",
@@ -56,10 +75,9 @@ function boundedInitGroup(script: string, timeoutSeconds: number): string {
     "__kobe_init_wd=$!",
     `wait "$__kobe_init_pid" 2>/dev/null; __kobe_init_rc=$?`,
     `kill "$__kobe_init_wd" 2>/dev/null; wait "$__kobe_init_wd" 2>/dev/null`,
-    `if [ -f "$__kobe_init_to" ]; then __kobe_init_rc=124; printf '${timeoutBanner}' '${seconds}';`,
-    `elif [ "$__kobe_init_rc" -eq 0 ]; then [ -f "$__kobe_init_env" ] && . "$__kobe_init_env" 2>/dev/null;`,
-    `else printf '${failBanner}' "$__kobe_init_rc"; fi`,
-    `rm -f "$__kobe_init_env" "$__kobe_init_to" 2>/dev/null`,
+    `if [ -f "$__kobe_init_to" ]; then __kobe_init_rc=124; printf '${timeoutBanner}' '${seconds}'; rm -f "$__kobe_init_env" 2>/dev/null;`,
+    `elif [ "$__kobe_init_rc" -ne 0 ]; then printf '${failBanner}' "$__kobe_init_rc"; rm -f "$__kobe_init_env" 2>/dev/null; fi`,
+    `rm -f "$__kobe_init_pre" "$__kobe_init_to" 2>/dev/null`,
   ].join("\n")
 }
 
@@ -74,19 +92,49 @@ export function engineLaunchLine(engineCommand: string, init?: EngineInitLaunch)
   const script = init?.initScript?.trim()
   if (!script) return tail
   const group = boundedInitGroup(script, resolveRepoInitTimeoutSeconds(init?.timeoutSeconds))
+  // Restoring the init script's exports sits OUTSIDE the once-per-worktree
+  // marker guard. The marker is per-WORKTREE, so keeping the restore inside it
+  // meant only the first session in a worktree ever saw what `.rove/init.sh`
+  // exported — every later tab, and every restart of the first one, exec'd the
+  // engine with none of its PATH/venv/API-key exports and no banner saying why.
+  // `repo-init.ts`'s own contract says the exports reach the engine; this is
+  // the half of it the guard was eating.
+  const restore = `[ -f "$__kobe_init_env" ] && . "$__kobe_init_env" 2>/dev/null`
   // The marker is interpolated INTO the script, so it must be in the form the
   // shell reads paths in — Git Bash rejects a backslash path in `[ -f ]`.
   const markerPath = init?.markerPath && toPosixPath(init.markerPath, init.platform)
-  if (!markerPath) return SIGINT_GUARD + [group, tail].join("\n")
+  if (!markerPath) {
+    // No durable home for the dump — keep it per-shell and drop it after the
+    // restore. Only reachable from direct callers; every spawner passes a marker.
+    const tmpEnv = `__kobe_init_env="\${TMPDIR:-/tmp}/kobe-init-env.$$"`
+    return SIGINT_GUARD + [tmpEnv, group, restore, `rm -f "$__kobe_init_env" 2>/dev/null`, tail].join("\n")
+  }
   const marker = quoteShellArg(markerPath)
   const markerDir = quoteShellArg(markerDirOf(markerPath))
   return (
     SIGINT_GUARD +
     [
-      `if [ ! -f ${marker} ]; then`,
+      // Durable and per-worktree, next to the marker — NOT `$TMPDIR/…$$`,
+      // which is per-shell and was deleted the moment the first session's
+      // init finished, leaving later sessions nothing to source.
+      `__kobe_init_env=${quoteShellArg(`${markerPath}.env`)}`,
+      // The marker RECORDS the outcome instead of only existing on success.
+      // "Init never ran" and "init finished badly" used to look identical from
+      // outside, and the paste-delivery spawner that waits on this file
+      // therefore burned its whole 120s budget on any repo whose init.sh exits
+      // non-zero. Re-run gating is unchanged in effect: a recorded non-zero
+      // code retries, exactly as a missing marker did.
+      `if [ ! -f ${marker} ] || [ "$(cat ${marker} 2>/dev/null)" != "0" ]; then`,
+      `mkdir -p ${markerDir} 2>/dev/null`,
+      // This run owns the marker while it runs: absent means "init is still
+      // going", which is the question the spawner is asking. Without the
+      // delete a retry would leave the previous run's code on disk and the
+      // spawner would paste into an engine that has not started yet.
+      `rm -f ${marker} 2>/dev/null`,
       group,
-      `if [ "$__kobe_init_rc" -eq 0 ]; then mkdir -p ${markerDir} && : > ${marker}; fi`,
+      `printf '%s' "$__kobe_init_rc" > ${marker}`,
       "fi",
+      restore,
       tail,
     ].join("\n")
   )
@@ -140,8 +188,9 @@ export interface EngineSessionLaunch {
   readonly firstMessage?: string
   /**
    * When the launch includes a repo-init script, this is the marker file the
-   * script creates on success. Paste-delivery spawners wait for it before
-   * starting the engine-startup timer.
+   * script writes when init FINISHES — carrying its exit code, so a failed or
+   * timed-out init still marks completion. Paste-delivery spawners wait for it
+   * before starting the engine-startup timer.
    */
   readonly initMarkerPath?: string
   /**

--- a/packages/kobe/test/engine/hosted-session.test.ts
+++ b/packages/kobe/test/engine/hosted-session.test.ts
@@ -197,6 +197,57 @@ describe("pastePromptWhenEngineUp (first-message paste delivery)", () => {
     fs.rmSync(tmp, { recursive: true, force: true })
   })
 
+  // The marker records the init OUTCOME, so it appears on a failing init too.
+  // While it only appeared on success, "init failed" and "init still running"
+  // were the same observation from here and this loop sat out its whole
+  // 120s budget before the prompt was ever pasted.
+  it("stops waiting on the first poll after a FAILING init records its outcome", async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "kobe-hosted-init-failed-"))
+    const marker = path.join(tmp, "marker")
+    let written = ""
+    const request = vi.fn().mockImplementation((name: string, payload: unknown) => {
+      if (name === "pty.peek")
+        return Promise.resolve({
+          exists: true,
+          alive: true,
+          offset: 0,
+          data: Buffer.from(`\x1b[?2004h${written}`).toString("base64"),
+        })
+      if (name === "pty.write") {
+        written += (payload as { data?: string })?.data ?? ""
+        return Promise.resolve({})
+      }
+      return Promise.resolve({ sessions: [session("task-a::tab-1")] })
+    })
+    const rpc: HostedSessionRpc = { request }
+
+    // Two marker-loop sleeps, then the launch script records `1` (init failed).
+    let markerSleeps = 0
+    let markerLanded = false
+    const sleep = vi.fn().mockImplementation(async () => {
+      if (markerLanded) return
+      markerSleeps += 1
+      if (markerSleeps === 2) {
+        fs.writeFileSync(marker, "1")
+        markerLanded = true
+      }
+    })
+
+    const delivered = await pastePromptWhenEngineUp(rpc, "task-a::tab-1", "kimi", "fix it", {
+      initMarkerPath: marker,
+      // A budget far larger than the marker wait: if the loop ran to the
+      // deadline instead of reacting to the sentinel, `markerSleeps` would
+      // keep climbing.
+      initTimeoutMs: 600_000,
+      sleep,
+      snapshot: async () => withEngine,
+    })
+
+    expect(delivered).not.toBeNull()
+    expect(markerSleeps).toBe(2) // exited on the poll right after it appeared
+    fs.rmSync(tmp, { recursive: true, force: true })
+  })
+
   it("returns false if the session dies while waiting for the init marker", async () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "kobe-hosted-init-marker-"))
     const marker = path.join(tmp, "marker")

--- a/packages/kobe/test/engine/session-launch.test.ts
+++ b/packages/kobe/test/engine/session-launch.test.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from "node:child_process"
 import fs from "node:fs"
 import os from "node:os"
 import path from "node:path"
@@ -147,6 +148,110 @@ describe("hosted engine session launch", () => {
 
     expect(script).toContain("[ ! -f '/repo/.kobe/worktree-init/ab12' ]")
     expect(script).toContain("mkdir -p '/repo/.kobe/worktree-init'")
+  })
+
+  // These run the GENERATED script for real. The bugs here are both about
+  // what an outside observer (the paste spawner; the next tab's shell) can
+  // see afterwards, which a substring assertion on the script text cannot
+  // settle — only executing it and looking at the filesystem can.
+  describe("running the generated init script", () => {
+    function launchScript(initScript: string, markerPath: string): string {
+      return engineLaunchLine("printenv ROVE_INIT_PROBE || echo UNSET", {
+        initScript,
+        markerPath,
+        timeoutSeconds: 10,
+        platform: "linux",
+      })
+    }
+
+    let runSeq = 0
+    // The launch script leaves its `sleep <timeout>` watchdog child running
+    // after init returns. Handed our stdout PIPE it keeps that pipe open, and
+    // execFileSync then blocks for the WHOLE init budget after the shell
+    // itself is long gone — so route the script's output to a file and wait
+    // on the shell only.
+    function runLaunch(cwd: string, script: string, env?: NodeJS.ProcessEnv): string {
+      runSeq += 1
+      const out = path.join(cwd, `run-${runSeq}.log`)
+      execFileSync("/bin/sh", ["-c", `{ ${script}\n} > ${JSON.stringify(out)} 2>&1`], {
+        cwd,
+        stdio: "ignore",
+        ...(env ? { env } : {}),
+      })
+      return fs.readFileSync(out, "utf8")
+    }
+
+    function scratch(): { dir: string; marker: string } {
+      const dir = fs.mkdtempSync(path.join(os.tmpdir(), "kobe-init-run-"))
+      tempDirs.push(dir)
+      return { dir, marker: path.join(dir, "state", "worktree-init", "abc123") }
+    }
+
+    // B1: while the marker only appeared on a zero exit, a repo whose init
+    // script fails left the paste-delivery spawner polling a file that would
+    // never exist — two minutes of empty composer per fresh task.
+    test("records the init outcome in the marker on BOTH the success and failure branches", () => {
+      for (const [initScript, expected] of [
+        ["echo ok", "0"],
+        ["echo nope; exit 3", "3"],
+      ] as const) {
+        const { dir, marker } = scratch()
+        runLaunch(dir, launchScript(initScript, marker))
+        expect(fs.existsSync(marker)).toBe(true)
+        expect(fs.readFileSync(marker, "utf8")).toBe(expected)
+      }
+    })
+
+    // A recorded failure must still retry on the next launch, which is what
+    // an absent marker used to mean.
+    test("re-runs init after a recorded failure, and stops re-running after a success", () => {
+      const { dir, marker } = scratch()
+      const counter = path.join(dir, "runs")
+      const bump = `printf x >> ${JSON.stringify(counter)}`
+      const runs = () => (fs.existsSync(counter) ? fs.readFileSync(counter, "utf8").length : 0)
+
+      runLaunch(dir, launchScript(`${bump}; exit 1`, marker))
+      expect(runs()).toBe(1)
+      runLaunch(dir, launchScript(`${bump}; exit 1`, marker)) // failure recorded → retry
+      expect(runs()).toBe(2)
+      runLaunch(dir, launchScript(bump, marker)) // succeeds this time
+      expect(runs()).toBe(3)
+      runLaunch(dir, launchScript(bump, marker)) // success recorded → skipped
+      expect(runs()).toBe(3)
+    })
+
+    // B2: the marker is per-WORKTREE, so restoring the env inside its guard
+    // meant only the first session in a worktree ever saw what init exported.
+    test("restores the init script's exports for EVERY session, not just the first", () => {
+      const { dir, marker } = scratch()
+      const script = launchScript("export ROVE_INIT_PROBE=1", marker)
+      expect(runLaunch(dir, script).trim()).toBe("1")
+      expect(runLaunch(dir, script).trim()).toBe("1")
+      expect(runLaunch(dir, script).trim()).toBe("1")
+    })
+
+    test("keeps the env dump 0600 — an init script's exports are where a key would be", () => {
+      const { dir, marker } = scratch()
+      runLaunch(dir, launchScript("export ROVE_INIT_PROBE=1", marker))
+      expect(fs.statSync(`${marker}.env`).mode & 0o777).toBe(0o600)
+    })
+
+    // The dump is the DELTA of `export -p`, not the whole environment: it is
+    // sourced by every later tab, and a whole dump would re-export tab-1's
+    // ROVE_TAB_ID over each of them (hooks would misattribute every event).
+    test("carries only what init exported — never the first session's own identity", () => {
+      const { dir, marker } = scratch()
+      runLaunch(dir, launchScript("export ROVE_INIT_PROBE=1", marker), { ...process.env, ROVE_TAB_ID: "tab-1" })
+      const dump = fs.readFileSync(`${marker}.env`, "utf8")
+      expect(dump).toContain("ROVE_INIT_PROBE")
+      expect(dump).not.toContain("ROVE_TAB_ID")
+    })
+
+    test("a failed init leaves no env dump behind", () => {
+      const { dir, marker } = scratch()
+      runLaunch(dir, launchScript("export ROVE_INIT_PROBE=1; exit 1", marker))
+      expect(fs.existsSync(`${marker}.env`)).toBe(false)
+    })
   })
 
   test("injects the worktree protocol only for regular tasks", () => {


### PR DESCRIPTION
Batch K, items **K2** and **K3** (loop-r4 bugs.md Group B). One PR — both live in
the same generated launch script and the second's fix depends on the first's shape.

## K2 — a failing `.rove/init.sh` stalled a paste-delivery first message for 120s

`engineLaunchLine` wrote the init marker only on a zero exit, so from outside
"init never ran" and "init finished, badly" were the same observation. The
paste-delivery spawner (`pastePromptWhenEngineUp`, kimi's path) polls exactly
that file, and its loop has no other way out — on any repo whose init script
exits non-zero, every fresh task sat with an empty composer for the full
`REPO_INIT_TIMEOUT_SECONDS` before its prompt arrived. Same for the
timeout path, which sets `__kobe_init_rc=124` and also skipped the marker.

**Fix** (the brief's preferred option): the marker now RECORDS the outcome —
`printf '%s' "$__kobe_init_rc" > MARKER`, unconditionally, after the init group.
The marker means "init finished", which is the question the spawner is actually
asking, so `hosted-session.ts` needs no logic change at all. Re-run gating keeps
today's semantics: the guard is now `! -f MARKER || contents != "0"`, so a
recorded failure retries exactly as a missing marker did. The guarded block also
`rm -f`s the marker before running, so "absent" keeps meaning "init is still
going" on a retry — without that, a retry would leave the previous run's code on
disk and the spawner would paste into an engine that had not started yet.

## K3 — init.sh's exports reached only the FIRST engine session in a worktree

The env restore sat inside the once-per-worktree marker guard. The marker is
per-WORKTREE (sha1 of the path), not per session, so tab 2 — and every restart
of tab 1 — exec'd the engine with none of the PATH/venv/API-key exports init
set, and with no banner saying why, because the whole group was skipped. That
contradicts `repo-init.ts`'s own stated contract.

**Fix**: the restore moved outside the guard, and the dump moved from
`$TMPDIR/kobe-init-env.$$` (per-shell, deleted the moment the first session's
init finished) to a durable `<marker>.env` next to the marker.

Two things the brief flagged, both handled:

- **The dump is the DELTA of `export -p` across the script, not the whole
  environment.** This matters more now that it is sourced by every later
  session: a whole dump re-exports the FIRST session's `ROVE_TASK_ID` /
  `ROVE_TAB_ID` over each new tab's own identity, and hooks would then
  attribute every tab's events to tab-1. It also drops `PWD`/`SHLVL` noise.
  When the pre-image cannot be taken the dump is skipped entirely rather than
  written unfiltered.
- **Mode `0600`**, via `umask 077` in the subshell — an init script's exports
  are exactly where an API key would be, and the file now lives in Rove's
  state dir instead of a private temp path.

## PASS criteria and proof

### K2-1 / K2-3 — the marker records the outcome on both branches

Real execution of the generated script, `init.sh` = `echo "init running"; exit 1`,
120s budget:

```
############ BEFORE (origin/main) ############
init running
  ⚠ Repo init script failed (code 1); continuing to the engine.
completion marker: ABSENT (spawner would wait the full 120s)

############ AFTER (this branch) ############
init running
  ⚠ Repo init script failed (code 1); continuing to the engine.
completion marker: PRESENT, contents=[1]
```

Unit-tested in `test/engine/session-launch.test.ts` → *records the init outcome
in the marker on BOTH the success and failure branches* (asserts `0` and `3`),
and *re-runs init after a recorded failure, and stops re-running after a
success* (counts actual init invocations across four launches: 1, 2, 3, 3).

### K2-2 — the spawner exits on the first poll after the sentinel appears

`test/engine/hosted-session.test.ts` → *stops waiting on the first poll after a
FAILING init records its outcome*: injected `sleep`/`rpc`/`snapshot`, the
sentinel lands carrying `"1"` on the 2nd marker-loop sleep, `initTimeoutMs` set
to 600 000 so a deadline-driven loop would keep counting. Asserts
`markerSleeps === 2`.

### K3-1 — the repro prints the value on EVERY launch

The brief's repro, run across the three shapes an init script can take
(`initScript` is what `repo-init.ts` resolves):

```
############ BEFORE (origin/main) ############        ############ AFTER ############
initScript = . ./.rove/init.sh                        initScript = . ./.rove/init.sh
  launch 1: hello                                       launch 1: hello
  launch 2: UNSET                                       launch 2: hello
  launch 3: UNSET                                       launch 3: hello
initScript = export ROVE_B2_MARKER=hello              initScript = export ROVE_B2_MARKER=hello
  launch 1: hello                                       launch 1: hello
  launch 2: UNSET                                       launch 2: hello
  launch 3: UNSET                                       launch 3: hello
initScript = sh .rove/init.sh                         initScript = sh .rove/init.sh
  launch 1: UNSET                                       launch 1: UNSET
  launch 2: UNSET                                       launch 2: UNSET
  launch 3: UNSET                                       launch 3: UNSET
```

**The third row is a separate bug this PR does not fix — see "Found but not
fixed" below.** The brief's repro used `sh .rove/init.sh` and predicted `hello`
on the first launch; it does not, and never did.

### K3-2 / K3-5 and the mutation checks

`test/engine/session-launch.test.ts` gained a `running the generated init
script` block that EXECUTES the script instead of asserting on its text — both
bugs are about what an outside observer (the spawner; the next tab's shell) can
see afterwards, which a substring match cannot settle. Covers: the outcome on
both branches, retry-then-stop, *restores the init script's exports for EVERY
session*, the `0600` mode, delta-not-whole-environment, and no dump left behind
after a failure. Its runner sends the script's output to a file rather than an
inherited pipe — the launch script leaves its `sleep <timeout>` watchdog child
running, and through a pipe `execFileSync` blocked for the entire init budget
(90s → 0.55s for the file).

Four mutation sites, four distinct reds:

| mutation | result |
|---|---|
| back to the success-only marker write | `2 failed \| 18 passed` — *records the init outcome…*, *re-runs init after a recorded failure…* |
| move the env restore back inside the marker guard | `1 failed \| 19 passed` — *restores the init script's exports for EVERY session…* |
| dump the whole environment instead of the delta | `1 failed \| 19 passed` — *carries only what init exported…* |
| drop `umask 077` | `1 failed \| 19 passed` — *keeps the env dump 0600…* |

Restored after each; 20/20 green.

### K3-4 — harness BEFORE/AFTER, two engine tabs in one worktree

Ground-truth path: `/harness` browser → xterm.js → PTY sidecar → real OpenTUI,
isolated fixture on port base 5980. `rove repo set <fixture-repo> --init-script
'export ROVE_INIT_PROBE=1'`; the marker directory is cleared; then two engine
tabs are opened in the same worktree with `rove api send --tab new --command`,
both running a sentinel "engine" that prints the probe variable. The screenshot
is of the **second** tab.

| shot | shows |
|---|---|
| `/Users/jacksonc/i/kobe/.scratch/loop-r4-k/k23-before.png` | `sentinel engine: ROVE_INIT_PROBE=[]` — empty |
| `/Users/jacksonc/i/kobe/.scratch/loop-r4-k/k23-after.png` | `sentinel engine: ROVE_INIT_PROBE=[1]` |

Only `src/engine/session-launch.ts` was swapped between the two runs (the rest
of the tree stays at HEAD), the fixture stack was restarted for each, and the
tabs were closed in between — hence the differing tab numbers (`shell 6/7`
vs `shell 8/9`). The on-disk state matches:

```
BEFORE   -rw-r--r--  0 bytes  4c4857d4a5b3ede0          (no .env at all)
AFTER    -rw-r--r--  1 byte   4c4857d4a5b3ede0          contents [0]
         -rw-------  25 bytes 4c4857d4a5b3ede0.env      export ROVE_INIT_PROBE=1
```

### Suites

- `bun x vitest run test/engine/session-launch.test.ts test/engine/hosted-session.test.ts` — 36/36
- `bun test test/render` — 455 pass, 0 fail
- repo-root `bun run lint` / `bun run typecheck` — clean
- `bun run test:fast` — `6 failed | 4306 passed`, the same six pre-existing
  environment-shaped failures documented on #830 (project-eligibility judges
  `roveInternal`/`temporary` by path shape, and this checkout lives under
  `~/.rove/worktrees`). Nothing here touches those paths.

## Found but not fixed — `.rove/init.sh`'s exports never reach the engine at all

`repo-init.ts:116-129` resolves a committed init file to the command
**`sh .rove/init.sh`** — a CHILD shell. Its `export`s therefore die with that
child and reach neither the env dump nor the engine, on the first session or any
other. That is why the third row of the K3 table reads `UNSET` on both sides,
and it means `repo-init.ts:16-20`'s "runs in the SAME shell that execs the
engine, so `export`s reach the engine" is false for the very case it names. The
per-user `state.json` override (`rove repo set --init-script`) is an inline
snippet and does run in that shell, which is the path proven above.

The one-line direction is `sh .rove/init.sh` → `. ./.rove/init.sh`, but that
changes which interpreter every repo's init script gets (the launch shell is the
user's `$SHELL -ilc`, so a `#!/bin/bash` script would silently be read by zsh) —
a product call, not something to slip into this PR. Surfacing rather than
widening scope.
