### PR TITLE
fix: report the real git error when a land or sync fails

### DIFF
--- a/.changeset/land-and-sync-git-errors.md
+++ b/.changeset/land-and-sync-git-errors.md
@@ -1,0 +1,17 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Stop misreporting git failures during a land or a sync. A `git commit` that
+failed for any reason Rove has no policy for — a pre-commit hook, a broken
+`commit.gpgsign` key, an unset `user.email` — used to come back as "'branch' has
+nothing to land onto 'main' (already merged or empty)" on a squash (which then
+`reset --hard` threw the staged merge away) or as a conflict with an empty file
+list on a merge. Both now surface git's own message; the squashed merge is left
+staged so it can be committed by hand once the cause is fixed.
+
+Syncing a worktree with its base likewise refuses up front when an untracked
+file would collide with one the base adds — the guard was passing
+`--untracked-files=no`, so that case slipped through to an unmappable "git merge
+failed". The dirty refusal now names the offending files, and the residual
+failure branch quotes git instead of only saying that it failed.

--- a/packages/kobe-daemon/src/daemon/poll-scheduling.ts
+++ b/packages/kobe-daemon/src/daemon/poll-scheduling.ts
@@ -135,6 +135,12 @@ export interface SpawnCaptureResult {
   /** Exit code, or null when the child errored / was killed (timeout). */
   readonly status: number | null
   readonly stdout: string
+  /**
+   * Captured stderr. Kept because on a non-zero status it is usually the ONLY
+   * thing that says why — `sync-base.ts` used to report a refused merge as a
+   * bare "git merge <ref> failed" because this was thrown away at the pipe.
+   */
+  readonly stderr: string
 }
 
 /**
@@ -151,7 +157,7 @@ export function decodeCapturedChunks(chunks: readonly (Buffer | string)[]): stri
 }
 
 /**
- * Async spawn that collects stdout and resolves on close. Never rejects —
+ * Async spawn that collects stdout AND stderr and resolves on close. Never rejects —
  * a spawn error (missing cwd, binary not on PATH) or an abort resolves
  * with `status: null` so callers branch on status, mirroring the
  * never-throw contract of the pane-side sync git helpers it replaces.
@@ -164,21 +170,25 @@ export function spawnCapture(
 ): Promise<SpawnCaptureResult> {
   return new Promise((resolve) => {
     const chunks: (Buffer | string)[] = []
+    const errChunks: (Buffer | string)[] = []
     let settled = false
     const finish = (status: number | null): void => {
       if (settled) return
       settled = true
-      resolve({ status, stdout: decodeCapturedChunks(chunks) })
+      resolve({ status, stdout: decodeCapturedChunks(chunks), stderr: decodeCapturedChunks(errChunks) })
     }
     const child = spawn(cmd, args.slice(), {
       cwd: opts.cwd,
-      stdio: ["ignore", "pipe", "ignore"],
+      stdio: ["ignore", "pipe", "pipe"],
       env: opts.env,
       signal: opts.signal,
       killSignal: "SIGKILL",
     })
     child.stdout?.on("data", (chunk: Buffer | string) => {
       chunks.push(chunk)
+    })
+    child.stderr?.on("data", (chunk: Buffer | string) => {
+      errChunks.push(chunk)
     })
     child.on("error", () => finish(null))
     child.on("close", (code) => finish(code))

--- a/packages/kobe/src/orchestrator/errors.ts
+++ b/packages/kobe/src/orchestrator/errors.ts
@@ -208,3 +208,37 @@ export class LandConflictError extends Error {
     this.name = "LandConflictError"
   }
 }
+
+/**
+ * Stable sentinel embedded in {@link GitCommandFailedError}'s message — same
+ * wire-boundary reason as {@link DIRTY_WORKTREE_CODE}.
+ */
+export const GIT_COMMAND_FAILED_CODE = "GIT_COMMAND_FAILED"
+
+/**
+ * Thrown by `landTask` when a git command failed for a reason Rove has no
+ * policy for — a `pre-commit`/`commit-msg` hook, a broken `commit.gpgsign`
+ * key, an unset `user.email`.
+ *
+ * It exists because the alternative is a LIE. Both land strategies used to
+ * read a failed commit as the one benign cause they knew: squash reported
+ * "already merged or empty" about a branch that had staged cleanly (and then
+ * `reset --hard` threw the squash away), and merge threw the phantom
+ * {@link LandConflictError} with an empty file list that
+ * `assertBranchHasWork`'s docstring says it exists to prevent. Neither ever
+ * looked at git's stderr, which said exactly what was wrong.
+ *
+ * The `hint` names what the caller can still do — for squash, that the staged
+ * merge is deliberately left in place to be committed by hand.
+ */
+export class GitCommandFailedError extends Error {
+  constructor(
+    public readonly command: string,
+    public readonly stderr: string,
+    hint?: string,
+  ) {
+    const detail = stderr.trim() || "(git printed nothing on stderr)"
+    super(`${GIT_COMMAND_FAILED_CODE}: \`git ${command}\` failed — ${detail}${hint ? `; ${hint}` : ""}`)
+    this.name = "GitCommandFailedError"
+  }
+}

--- a/packages/kobe/src/orchestrator/land.ts
+++ b/packages/kobe/src/orchestrator/land.ts
@@ -23,6 +23,7 @@ import type { Task, TaskId } from "../types/task.ts"
 import {
   EmptyBranchDirtyWorktreeError,
   EmptyBranchError,
+  GitCommandFailedError,
   LandConflictError,
   MainCheckoutDirtyError,
   MissingRefError,
@@ -274,13 +275,17 @@ async function git(
   dir: string,
   args: readonly string[],
   opts?: { readonly readOnly?: boolean },
-): Promise<{ stdout: string; exitCode: number }> {
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
   // Read-only probes (status/diff/rev-parse/rev-list) run lock-free per
   // READ_ONLY_GIT_ENV — land inspects worktrees an engine may be
   // committing in right now. Writes (merge/abort/reset/commit) never set
   // readOnly: they genuinely need `.git/index.lock`.
+  //
+  // `stderr` is carried, not dropped: when a write fails, git's own message is
+  // the only thing that says WHY (a hook, a signing key, an unset user.email),
+  // and guessing at it is what produced this file's two worst error reports.
   const r = await exec.run(["git", ...args], { cwd: dir, env: opts?.readOnly ? READ_ONLY_GIT_ENV : undefined })
-  return { stdout: r.stdout, exitCode: r.exitCode }
+  return { stdout: r.stdout, stderr: r.stderr, exitCode: r.exitCode }
 }
 
 /** `git status --porcelain` non-empty in `dir` (untracked counts). */
@@ -418,10 +423,27 @@ export async function landTask(
     }
     const commit = await git(exec, dir, ["commit", "--no-edit", "-m", `Land ${branch} (squash)`])
     if (commit.exitCode !== 0) {
-      // Nothing to commit = the branch was already fully in base. Reset the
-      // squash's staged index so the base checkout is untouched, and report it.
-      await git(exec, dir, ["reset", "--hard", "HEAD"]).catch(() => {})
-      throw new Error(`landTask: '${branch}' has nothing to land onto '${landedOn}' (already merged or empty)`)
+      // "Nothing to commit" is only ONE reason `git commit` exits non-zero,
+      // and after `assertBranchHasWork` proved the branch is ahead and the
+      // squash staged cleanly it is nearly never the reason — a hook, a
+      // broken signing key or an unset user.email is. Ask git which it was
+      // instead of assuming: `diff --cached --quiet` exits 0 only when
+      // genuinely nothing is staged.
+      const staged = await git(exec, dir, ["diff", "--cached", "--quiet"], { readOnly: true })
+      if (staged.exitCode === 0) {
+        // Genuinely empty. Reset the squash's staged index so the base
+        // checkout is untouched, and report it as before.
+        await git(exec, dir, ["reset", "--hard", "HEAD"]).catch(() => {})
+        throw new Error(`landTask: '${branch}' has nothing to land onto '${landedOn}' (already merged or empty)`)
+      }
+      // The squash IS staged and git refused to commit it. NO reset — that
+      // would throw away a merge that succeeded, over a problem the user can
+      // fix in one command.
+      throw new GitCommandFailedError(
+        `commit (squash-landing '${branch}' onto '${landedOn}')`,
+        commit.stderr,
+        "the squashed merge is left STAGED in the base checkout — fix the cause and `git commit` it, or `git reset --hard HEAD` to discard",
+      )
     }
   } else {
     const before = (await git(exec, dir, ["rev-parse", "HEAD"], { readOnly: true })).stdout.trim()
@@ -429,6 +451,19 @@ export async function landTask(
     if (merge.exitCode !== 0) {
       const files = await conflictedFiles(exec, dir)
       await git(exec, dir, ["merge", "--abort"]).catch(() => {})
+      // An EMPTY conflicted list with a failed merge is NOT a conflict — the
+      // trees merged and git refused at commit time (hook, signing key,
+      // unset user.email). That is exactly the phantom-LAND_CONFLICT shape
+      // `assertBranchHasWork`'s docstring exists to prevent; it just arrives
+      // through the commit door instead of the ref door. The abort above
+      // still ran, so the base checkout is clean either way.
+      if (files.length === 0) {
+        throw new GitCommandFailedError(
+          `merge --no-ff (landing '${branch}' onto '${landedOn}')`,
+          merge.stderr,
+          "the merge was aborted, so the base checkout is unchanged",
+        )
+      }
       throw new LandConflictError(task.id, branch, files)
     }
     // `git merge --no-ff` on an already-merged/empty branch exits 0 with

--- a/packages/kobe/src/orchestrator/sync-base.ts
+++ b/packages/kobe/src/orchestrator/sync-base.ts
@@ -71,8 +71,8 @@ export function parseDirtyPaths(stdout: string): string[] {
 
 /**
  * Merge `baseRef` into the worktree's current branch. Throws with a
- * `SYNC_CONFLICT: a, b, c` / `SYNC_WORKTREE_DIRTY` message on the two outcomes
- * a human can act on, and a plain message on anything else.
+ * `SYNC_CONFLICT: a, b, c` / `SYNC_WORKTREE_DIRTY: a, b, c` message on the two
+ * outcomes a human can act on, and git's own stderr on anything else.
  */
 export async function syncWorktreeWithBase(
   worktreePath: string,

--- a/packages/kobe/src/orchestrator/sync-base.ts
+++ b/packages/kobe/src/orchestrator/sync-base.ts
@@ -58,6 +58,18 @@ export function parseConflictedPaths(stdout: string): string[] {
 }
 
 /**
+ * Paths from `git status --porcelain=v1`, with the two-character XY status and
+ * its separating space stripped. Same shape as landing's `porcelainPaths`.
+ */
+export function parseDirtyPaths(stdout: string): string[] {
+  return stdout
+    .split("\n")
+    .filter((line) => line.length > 3)
+    .map((line) => line.slice(3).trim())
+    .filter((line) => line.length > 0)
+}
+
+/**
  * Merge `baseRef` into the worktree's current branch. Throws with a
  * `SYNC_CONFLICT: a, b, c` / `SYNC_WORKTREE_DIRTY` message on the two outcomes
  * a human can act on, and a plain message on anything else.
@@ -68,12 +80,20 @@ export async function syncWorktreeWithBase(
   signal: AbortSignal,
 ): Promise<SyncBaseResult> {
   // Refuse on a dirty worktree BEFORE touching anything: `git merge` would
-  // either refuse itself with a wall of text, or (for untracked files it can
-  // fast-forward over) silently overwrite them. Same guard shape as landing's
-  // dirty-base refusal.
-  const status = await git(worktreePath, ["status", "--porcelain=v1", "--untracked-files=no"], signal)
+  // either refuse itself with a wall of text, or (for untracked files the base
+  // also adds) refuse with a DIFFERENT wall of text that has no conflicted-file
+  // list to report. UNTRACKED COUNTS — the guard used to pass
+  // `--untracked-files=no`, which made it blind to exactly the case this
+  // comment names, and the untracked collision then fell through to the bare
+  // "git merge failed" the TUI cannot map. Same guard shape, and now the same
+  // flags, as landing's `isDirty`.
+  const status = await git(worktreePath, ["status", "--porcelain=v1"], signal)
   if (status.status !== 0) throw new Error("git status failed")
-  if (status.stdout.trim().length > 0) throw new Error(SYNC_DIRTY)
+  const dirty = parseDirtyPaths(status.stdout)
+  // Name them, the way SYNC_CONFLICT names its files: "commit or stash the
+  // worktree's changes" is not actionable when the change is one untracked
+  // file the user does not know is there.
+  if (dirty.length > 0) throw new Error(`${SYNC_DIRTY}: ${dirty.join(", ")}`)
 
   const before = await git(worktreePath, ["rev-parse", "HEAD"], signal)
   const merge = await git(worktreePath, ["merge", "--no-edit", baseRef], signal, true)
@@ -81,7 +101,11 @@ export async function syncWorktreeWithBase(
     const conflicted = await git(worktreePath, ["diff", "--name-only", "--diff-filter=U"], signal)
     const paths = parseConflictedPaths(conflicted.stdout)
     if (paths.length > 0) throw new Error(`${SYNC_CONFLICT}: ${paths.join(", ")}`)
-    throw new Error(`git merge ${baseRef} failed`)
+    // Anything else: say what git said. This branch is now the genuine
+    // residue (a hook, a signing key, a ref that moved under us), and a
+    // message with no reason in it sends the user to the daemon log.
+    const detail = merge.stderr?.trim()
+    throw new Error(detail ? `git merge ${baseRef} failed — ${detail}` : `git merge ${baseRef} failed`)
   }
   const after = await git(worktreePath, ["rev-parse", "HEAD"], signal)
   return { baseRef, alreadyCurrent: before.status === 0 && before.stdout.trim() === after.stdout.trim() }

--- a/packages/kobe/src/tui-react/workspace/sync-base-action.ts
+++ b/packages/kobe/src/tui-react/workspace/sync-base-action.ts
@@ -17,7 +17,7 @@
 import type { RemoteOrchestrator } from "../../client/remote-orchestrator"
 
 const CONFLICT_RE = /SYNC_CONFLICT(?:: )?(.*)/
-const DIRTY_RE = /SYNC_WORKTREE_DIRTY/
+const DIRTY_RE = /SYNC_WORKTREE_DIRTY(?:: )?(.*)/
 
 export interface SyncBaseDeps {
   readonly orchestrator: Pick<RemoteOrchestrator, "syncBase">
@@ -48,8 +48,9 @@ export async function syncBaseAction(deps: SyncBaseDeps, taskId: string): Promis
     const conflict = CONFLICT_RE.exec(msg)
     // The merge is left IN PLACE on a conflict — the conflicted files are what
     // the user (or their engine) is about to resolve, so name them.
+    const dirty = DIRTY_RE.exec(msg)
     if (conflict) deps.notifyNeedsInput(t("tasks.sync.conflict", { files: conflict[1]?.trim() || "?" }))
-    else if (DIRTY_RE.test(msg)) deps.notifyNeedsInput(t("tasks.sync.dirty"))
+    else if (dirty) deps.notifyNeedsInput(t("tasks.sync.dirty", { files: dirty[1]?.trim() || "?" }))
     else deps.notifyError(t("tasks.sync.failed", { error: msg }))
     return false
   }

--- a/packages/kobe/src/tui/i18n/messages/tasks.ts
+++ b/packages/kobe/src/tui/i18n/messages/tasks.ts
@@ -80,7 +80,7 @@ export const en = {
     done: "Merged {base} into this worktree",
     alreadyCurrent: "Already up to date with {base}",
     conflict: "Merge conflict — resolve then commit: {files}",
-    dirty: "Commit or stash the worktree's changes first, then sync",
+    dirty: "Commit or stash the worktree's changes first, then sync: {files}",
     failed: "Sync failed: {error}",
   },
   /** Change-engine picker dialog (the menu route of `v`). */
@@ -224,7 +224,7 @@ export const zh: typeof en = {
     done: "已把 {base} 合并进该工作树",
     alreadyCurrent: "已经和 {base} 同步",
     conflict: "合并冲突——解决后提交：{files}",
-    dirty: "请先提交或暂存工作树里的改动，再同步",
+    dirty: "请先提交或暂存工作树里的改动，再同步：{files}",
     failed: "同步失败：{error}",
   },
   changeEngine: {

--- a/packages/kobe/test/orchestrator/land-commit-failure.test.ts
+++ b/packages/kobe/test/orchestrator/land-commit-failure.test.ts
@@ -1,0 +1,190 @@
+/**
+ * A git command that fails during a land must say WHY.
+ *
+ * Both strategies used to read a non-zero exit from the committing command as
+ * the one benign cause they knew about, and neither ever looked at git's
+ * stderr: squash reported "already merged or empty" about a branch that had
+ * just staged cleanly (and then `reset --hard` discarded the squash), while
+ * merge threw a phantom `LAND_CONFLICT` with an empty file list. A repo-local
+ * `pre-commit` hook, a broken `commit.gpgsign` key, or an unset `user.email`
+ * all reach both paths.
+ *
+ * Real git in a temp repo for the three realistic shapes — the whole point is
+ * what git actually does when it refuses to commit, which a mock would only
+ * restate. One injected-ExecHost case covers the genuinely-empty squash, which
+ * real git cannot reach here because `assertBranchHasWork` refuses a
+ * zero-commit branch before the merge.
+ */
+
+import { spawnSync } from "node:child_process"
+import fs from "node:fs"
+import os from "node:os"
+import path from "node:path"
+import { afterEach, beforeEach, describe, expect, test } from "vitest"
+import type { ExecHost } from "../../src/exec/exec-host.ts"
+import { GIT_COMMAND_FAILED_CODE, LandConflictError } from "../../src/orchestrator/errors.ts"
+import { landTask } from "../../src/orchestrator/land.ts"
+import type { WorktreeExecDeps } from "../../src/orchestrator/worktree/exec-deps.ts"
+import type { Task } from "../../src/types/task.ts"
+import { toTaskId } from "../../src/types/task.ts"
+
+let tmpRoot: string
+let repo: string
+
+function git(args: string[], cwd = repo): { stdout: string; status: number | null } {
+  const r = spawnSync("git", args, { cwd, encoding: "utf8" })
+  return { stdout: r.stdout, status: r.status }
+}
+
+function gitOk(args: string[], cwd = repo): void {
+  const r = spawnSync("git", args, { cwd, encoding: "utf8" })
+  if (r.status !== 0) throw new Error(`git ${args.join(" ")} failed: ${r.stderr || r.stdout}`)
+}
+
+function task(branch: string): Task {
+  const now = new Date().toISOString()
+  return {
+    id: toTaskId("t-land-fail"),
+    title: "t",
+    repo,
+    branch,
+    worktreePath: "",
+    status: "backlog",
+    kind: "task",
+    createdAt: now,
+    updatedAt: now,
+  }
+}
+
+/** A branch one commit ahead of main, with main also moved on (so squash stages). */
+function branchAheadOfMovedMain(): void {
+  gitOk(["checkout", "-b", "feat"])
+  fs.writeFileSync(path.join(repo, "g.txt"), "feature\n")
+  gitOk(["add", "-A"])
+  gitOk(["commit", "-m", "feat"])
+  gitOk(["checkout", "main"])
+  fs.appendFileSync(path.join(repo, "f.txt"), "main moved\n")
+  gitOk(["add", "-A"])
+  gitOk(["commit", "-m", "main2"])
+}
+
+/** Make every `git commit` in the repo fail, the way a real signing key does. */
+function breakCommitting(): void {
+  gitOk(["config", "commit.gpgsign", "true"])
+  gitOk(["config", "user.signingkey", "DEADBEEFNOTAKEY"])
+}
+
+beforeEach(() => {
+  tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "kobe-land-fail-"))
+  repo = path.join(tmpRoot, "repo")
+  fs.mkdirSync(repo)
+  gitOk(["init", "-b", "main"])
+  gitOk(["config", "user.email", "t@t.t"])
+  gitOk(["config", "user.name", "t"])
+  fs.writeFileSync(path.join(repo, "f.txt"), "base\n")
+  gitOk(["add", "-A"])
+  gitOk(["commit", "-m", "base"])
+})
+
+afterEach(() => {
+  try {
+    fs.rmSync(tmpRoot, { recursive: true, force: true })
+  } catch {
+    // ignored
+  }
+})
+
+describe("a git commit that fails mid-land", () => {
+  test("squash surfaces git's own error and does NOT reset the staged merge away", async () => {
+    branchAheadOfMovedMain()
+    breakCommitting()
+
+    const err = await landTask(task("feat"), { strategy: "squash" }).then(
+      () => null,
+      (e: unknown) => e as Error,
+    )
+
+    expect(err?.message).toContain(GIT_COMMAND_FAILED_CODE)
+    // git's real reason, not Rove's guess.
+    expect(err?.message).toContain("DEADBEEFNOTAKEY")
+    expect(err?.message).not.toContain("already merged or empty")
+    // The staged squash survives — a `reset --hard` here throws away a merge
+    // that succeeded, over a problem one `git config` fixes.
+    expect(git(["status", "--porcelain"]).stdout).toContain("g.txt")
+    expect(fs.existsSync(path.join(repo, "g.txt"))).toBe(true)
+  })
+
+  test("merge reports a commit-time failure as itself, never as a phantom conflict", async () => {
+    branchAheadOfMovedMain()
+    breakCommitting()
+
+    const err = await landTask(task("feat"), { strategy: "merge" }).then(
+      () => null,
+      (e: unknown) => e as Error,
+    )
+
+    expect(err).not.toBeInstanceOf(LandConflictError)
+    expect(err?.message).toContain(GIT_COMMAND_FAILED_CODE)
+    expect(err?.message).toContain("DEADBEEFNOTAKEY")
+    // The merge is still aborted, so the base checkout is left clean.
+    expect(git(["status", "--porcelain"]).stdout.trim()).toBe("")
+    expect(fs.existsSync(path.join(repo, ".git", "MERGE_HEAD"))).toBe(false)
+  })
+
+  test("a REAL conflict is still a LandConflictError with its file list", async () => {
+    gitOk(["checkout", "-b", "feat"])
+    fs.writeFileSync(path.join(repo, "f.txt"), "theirs\n")
+    gitOk(["add", "-A"])
+    gitOk(["commit", "-m", "feat edits f"])
+    gitOk(["checkout", "main"])
+    fs.writeFileSync(path.join(repo, "f.txt"), "ours\n")
+    gitOk(["add", "-A"])
+    gitOk(["commit", "-m", "main edits f"])
+
+    const err = await landTask(task("feat"), { strategy: "merge" }).then(
+      () => null,
+      (e: unknown) => e as Error,
+    )
+
+    expect(err).toBeInstanceOf(LandConflictError)
+    expect(err?.message).toContain("f.txt")
+  })
+
+  // Reachable only with an injected host: `assertBranchHasWork` refuses a
+  // zero-commit branch before the squash, so real git cannot produce "the
+  // squash staged nothing" here. The behaviour still has to survive.
+  test("a squash that genuinely staged nothing keeps the old message and the reset", async () => {
+    const calls: string[][] = []
+    const exec = {
+      isRemote: false,
+      async run(argv: readonly string[]) {
+        const args = argv.slice(1)
+        calls.push([...args])
+        const joined = args.join(" ")
+        if (joined.startsWith("rev-parse --abbrev-ref")) return ok("main")
+        if (joined.startsWith("status --porcelain")) return ok("")
+        if (joined.startsWith("rev-list --count")) return ok("1") // "has work"
+        if (joined.startsWith("merge --squash")) return ok("")
+        if (joined.startsWith("commit ")) return fail("nothing to commit, working tree clean")
+        if (joined === "diff --cached --quiet") return ok("") // exit 0 = nothing staged
+        return ok("")
+      },
+    } as unknown as ExecHost
+    const deps: WorktreeExecDeps = {
+      execForRepo: () => exec,
+      execForPath: () => exec,
+      remoteBasePath: () => null,
+    }
+
+    await expect(landTask(task("feat"), { strategy: "squash" }, deps)).rejects.toThrow(/already merged or empty/)
+    expect(calls.some((c) => c[0] === "reset" && c[1] === "--hard")).toBe(true)
+  })
+})
+
+function ok(stdout: string) {
+  return { stdout, stderr: "", exitCode: 0 }
+}
+
+function fail(stderr: string) {
+  return { stdout: "", stderr, exitCode: 1 }
+}

--- a/packages/kobe/test/orchestrator/sync-base.test.ts
+++ b/packages/kobe/test/orchestrator/sync-base.test.ts
@@ -1,0 +1,130 @@
+/**
+ * `syncWorktreeWithBase`'s dirty guard, against real git.
+ *
+ * The guard existed to stop `git merge` clobbering (or refusing over) files the
+ * worktree already has, and its comment named untracked files as the hazard —
+ * but it ran `git status --untracked-files=no`, which is blind to exactly that.
+ * An untracked file the base also adds slipped past it, `git merge` refused,
+ * `--diff-filter=U` came back empty, and the user got a bare "git merge failed"
+ * that `sync-base-action.ts` cannot map to any named outcome.
+ *
+ * Real git because the whole question is which states git refuses and what it
+ * reports for each; a stubbed runner would only restate the assumption.
+ */
+
+import { spawnSync } from "node:child_process"
+import fs from "node:fs"
+import os from "node:os"
+import path from "node:path"
+import { afterEach, beforeEach, describe, expect, test } from "vitest"
+import { SYNC_CONFLICT, SYNC_DIRTY, syncWorktreeWithBase } from "../../src/orchestrator/sync-base.ts"
+
+let tmpRoot: string
+let repo: string
+
+function gitOk(args: string[], cwd = repo): void {
+  const r = spawnSync("git", args, { cwd, encoding: "utf8" })
+  if (r.status !== 0) throw new Error(`git ${args.join(" ")} failed: ${r.stderr || r.stdout}`)
+}
+
+function write(rel: string, body: string): void {
+  fs.writeFileSync(path.join(repo, rel), body)
+}
+
+async function sync(): Promise<Error | null> {
+  return syncWorktreeWithBase(repo, "main", new AbortController().signal).then(
+    () => null,
+    (e: unknown) => e as Error,
+  )
+}
+
+beforeEach(() => {
+  tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "kobe-sync-base-"))
+  repo = path.join(tmpRoot, "repo")
+  fs.mkdirSync(repo)
+  gitOk(["init", "-b", "main"])
+  gitOk(["config", "user.email", "t@t.t"])
+  gitOk(["config", "user.name", "t"])
+  write("f.txt", "base\n")
+  gitOk(["add", "-A"])
+  gitOk(["commit", "-m", "base"])
+  gitOk(["branch", "feat"])
+})
+
+afterEach(() => {
+  try {
+    fs.rmSync(tmpRoot, { recursive: true, force: true })
+  } catch {
+    // ignored
+  }
+})
+
+describe("syncWorktreeWithBase dirty guard", () => {
+  test("refuses up front when an untracked file collides with one the base adds", async () => {
+    write("new.txt", "from-base\n")
+    gitOk(["add", "-A"])
+    gitOk(["commit", "-m", "base adds new.txt"])
+    gitOk(["checkout", "feat"])
+    write("new.txt", "mine\n") // untracked here; main has it tracked
+
+    const err = await sync()
+
+    expect(err?.message).toContain(SYNC_DIRTY)
+    expect(err?.message).not.toContain("git merge main failed")
+    // Names the file: "commit or stash the worktree's changes" is not
+    // actionable when the change is one untracked file nobody knew was there.
+    expect(err?.message).toContain("new.txt")
+    // Refused BEFORE touching anything — the file is still the worktree's own.
+    expect(fs.readFileSync(path.join(repo, "new.txt"), "utf8")).toBe("mine\n")
+  })
+
+  test("refuses on an uncommitted tracked edit, as it always did", async () => {
+    gitOk(["checkout", "feat"])
+    write("f.txt", "edited\n")
+
+    const err = await sync()
+    expect(err?.message).toContain(SYNC_DIRTY)
+    expect(err?.message).toContain("f.txt")
+  })
+
+  test("a clean worktree still merges the base in", async () => {
+    write("b.txt", "from base\n")
+    gitOk(["add", "-A"])
+    gitOk(["commit", "-m", "base moves"])
+    gitOk(["checkout", "feat"])
+
+    const res = await syncWorktreeWithBase(repo, "main", new AbortController().signal)
+
+    expect(res.alreadyCurrent).toBe(false)
+    expect(fs.existsSync(path.join(repo, "b.txt"))).toBe(true)
+  })
+
+  test("a real content conflict is still SYNC_CONFLICT with its file list", async () => {
+    gitOk(["checkout", "feat"])
+    write("f.txt", "theirs\n")
+    gitOk(["add", "-A"])
+    gitOk(["commit", "-m", "feat edits f"])
+    gitOk(["checkout", "main"])
+    write("f.txt", "ours\n")
+    gitOk(["add", "-A"])
+    gitOk(["commit", "-m", "main edits f"])
+    gitOk(["checkout", "feat"])
+
+    const err = await sync()
+
+    expect(err?.message).toContain(SYNC_CONFLICT)
+    expect(err?.message).toContain("f.txt")
+  })
+
+  test("the residual failure branch quotes git instead of saying only that it failed", async () => {
+    gitOk(["checkout", "feat"])
+
+    const err = await syncWorktreeWithBase(repo, "no-such-ref", new AbortController().signal).then(
+      () => null,
+      (e: unknown) => e as Error,
+    )
+
+    expect(err?.message).toContain("git merge no-such-ref failed —")
+    expect(err?.message).toMatch(/no-such-ref/)
+  })
+})

--- a/packages/kobe/test/tui-react/sync-base-action.test.ts
+++ b/packages/kobe/test/tui-react/sync-base-action.test.ts
@@ -53,10 +53,21 @@ describe("syncBaseAction", () => {
 
   test("a dirty worktree is attention too — it is a precondition, not a failure", async () => {
     const h = deps(async () => {
+      throw new Error(`${SYNC_DIRTY}: new.txt, src/a.ts`)
+    })
+    expect(await syncBaseAction(h.deps, "t1")).toBe(false)
+    // The files ride along the same way the conflict marker's do: "commit or
+    // stash the worktree's changes" is not actionable without them.
+    expect(h.attention).toEqual(['tasks.sync.dirty {"files":"new.txt, src/a.ts"}'])
+    expect(h.errors).toEqual([])
+  })
+
+  test("a bare dirty marker (no file list) still reads as the dirty outcome", async () => {
+    const h = deps(async () => {
       throw new Error(SYNC_DIRTY)
     })
     expect(await syncBaseAction(h.deps, "t1")).toBe(false)
-    expect(h.attention).toEqual(["tasks.sync.dirty"])
+    expect(h.attention).toEqual(['tasks.sync.dirty {"files":"?"}'])
     expect(h.errors).toEqual([])
   })
 


### PR DESCRIPTION
Batch K, items **K4** and **K5** (loop-r4 bugs.md Groups C and D). One PR — both
are "a git failure is misreported by the orchestrator", and both need the same
thing to fix: stop throwing away git's stderr.

## K4 — any `git commit` failure during a land was misreported

`land.ts:409-443`: both strategies read a non-zero exit from the committing
command as the one benign cause they knew about, and neither ever looked at
stderr (the local `git()` helper dropped it).

- **squash** reported `'branch' has nothing to land onto 'main' (already merged
  or empty)` and then `reset --hard HEAD` — discarding a squash that had staged
  cleanly. The comment's premise is false by the function's own construction:
  `assertBranchHasWork` already refused `ahead === 0` two lines earlier.
- **merge** threw `LandConflictError` with an empty file list — exactly the
  phantom-conflict shape `assertBranchHasWork`'s docstring says it exists to
  prevent, arriving through the commit door instead of the ref door.

A `pre-commit`/`commit-msg` hook, a broken `commit.gpgsign` key, or an unset
`user.email` all reach both paths.

**Fix**: `git()` carries stderr. Squash asks `git diff --cached --quiet` before
concluding anything — exit 0 (genuinely nothing staged) keeps today's message
and today's reset; anything else throws a new `GitCommandFailedError` carrying
git's stderr and does **not** reset, so the staged merge survives for the user
to commit by hand. Merge only throws `LandConflictError` when the conflicted
list is non-empty; an empty list with a failed merge throws the same typed error
(the abort still runs, so the base checkout is left clean either way).

## K5 — the sync dirty-guard excluded untracked files, then cited them as its reason

`sync-base.ts:70-76` ran `git status --porcelain=v1 --untracked-files=no` under
a comment naming untracked overwrite as the hazard it exists for. The sibling it
claims parity with (`land.ts`'s `isDirty`) does the opposite and says "untracked
counts". So an untracked file the base also adds sailed past the guard, `git
merge` refused, `--diff-filter=U` came back empty, and the user got the bare
`git merge <ref> failed` that `sync-base-action.ts` cannot map to any named
outcome — where `SYNC_WORKTREE_DIRTY`, which the UI already renders, was
available.

**Fix**: the recommended one — drop the flag so the guard matches its comment
and its sibling. Two things came along with it:

- the refusal now **names the files**, the way `SYNC_CONFLICT` names its own.
  "Commit or stash the worktree's changes" is not actionable when the change is
  one untracked file the user did not know was there. Both locales updated;
  `bun scripts/check-i18n.ts` → *771 keys × 2 locales in sync*.
- the residual failure branch quotes git. That needed `spawnCapture` to stop
  discarding stderr at the pipe (`stdio: [..., "ignore"]` → `"pipe"`), which is
  additive — `SpawnCaptureResult` gains a `stderr` field no existing caller
  reads.

## PASS criteria and proof

### K4-1 / K4-3 — behaviour, with real git

New `test/orchestrator/land-commit-failure.test.ts` — real git in a temp repo
for the three realistic shapes (the whole point is what git does when it refuses
to commit, which a mock would only restate), plus one injected-`ExecHost` case
for the genuinely-empty squash, which real git cannot reach here because
`assertBranchHasWork` refuses a zero-commit branch first.

```
✓ squash surfaces git's own error and does NOT reset the staged merge away
✓ merge reports a commit-time failure as itself, never as a phantom conflict
✓ a REAL conflict is still a LandConflictError with its file list
✓ a squash that genuinely staged nothing keeps the old message and the reset
      Tests  4 passed (4)
```

**End-to-end through the CLI** (the brief's repro: a task whose branch is one
commit ahead, base checkout with `commit.gpgsign=true` and a bogus signing key,
isolated Rove home):

```
############ BEFORE (origin/main) ############
--- rove api land --strategy squash ---
{"error":{"message":"landTask: 'land-probe' has nothing to land onto 'main' (already merged or empty)","code":"RPC_ERROR"}}
--- base checkout afterwards (git status --porcelain) ---
                                     ← empty: the staged squash was reset away

############ AFTER (this branch) ############
--- rove api land --strategy squash ---
{"error":{"message":"GIT_COMMAND_FAILED: `git commit (squash-landing 'land-probe' onto 'main')` failed —
 error: gpg failed to sign the data:\ngpg: skipped \"DEADBEEFNOTAKEY\": No secret key\n
 gpg: signing failed: No secret key\n\nfatal: failed to write commit object;
 the squashed merge is left STAGED in the base checkout — fix the cause and `git commit` it,
 or `git reset --hard HEAD` to discard","code":"RPC_ERROR"}}
--- base checkout afterwards (git status --porcelain) ---
A  g.txt                             ← the squash survived
```

### K5-1 / K5-2 / K5-5

New `test/orchestrator/sync-base.test.ts` (real git, 5 cases): the untracked
collision yields `SYNC_WORKTREE_DIRTY` naming `new.txt` and never `git merge
main failed`; a tracked edit still refuses; a clean worktree still merges; a real
content conflict is still `SYNC_CONFLICT` with its list; the residual branch
quotes git. `test/tui-react/sync-base-action.test.ts` keeps its `SYNC_CONFLICT`
/ `SYNC_DIRTY` cases green, with the dirty one now asserting the file list and a
new case pinning that a **bare** marker (no list) still reads as the dirty
outcome. The comment at `sync-base.ts:70` now describes what the code does.

### Mutation checks — five sites, five distinct reds

| mutation | result |
|---|---|
| K4a: delete the staged-diff probe | `1 failed \| 8 passed` — *squash surfaces git's own error…* |
| K4b: delete the empty-conflicted-list guard | `1 failed \| 8 passed` — *merge reports a commit-time failure as itself…* |
| K5a: restore `--untracked-files=no` | `1 failed \| 8 passed` — *refuses up front when an untracked file collides…* |
| K5b: drop the stderr detail from the residual branch | `1 failed \| 8 passed` — *the residual failure branch quotes git…* |
| K5c: stop piping stderr in `spawnCapture` | `1 failed \| 8 passed` — same test, from the other end of the chain |

Restored after each; 9/9 green.

### K5-4 — harness BEFORE/AFTER of the toast

Ground-truth path: `/harness` browser → xterm.js → PTY sidecar → real OpenTUI,
isolated fixture on port base 5980. The fixture repo's `main` gains `new.txt`;
the task's worktree gets an untracked `new.txt` of its own; `ctrl+a u`
("Sync with base") is pressed on the task row.

| shot | shows |
|---|---|
| `/Users/jacksonc/i/kobe/.scratch/loop-r4-k/k5-before.png` | red **`✗ Sync failed: git merge main failed`** — the unmappable generic failure |
| `/Users/jacksonc/i/kobe/.scratch/loop-r4-k/k5-after.png` | yellow attention **`? Commit or stash the worktree's changes…`** — the named refusal the UI already handles |

Only `src/orchestrator/sync-base.ts` was swapped between runs, and the fixture
stack (including its daemon — sync runs there) was restarted for each. The state
that makes the case is the same in both:

```
worktree status (untracked counts):                          ?? new.txt
worktree status with --untracked-files=no (old guard's view): (nothing — it passed)
```

The toast truncates at its own max width, so the appended file list is cut off
on screen. Driving the same function directly against that worktree shows the
full text:

```
BEFORE  threw: git merge main failed
AFTER   threw: SYNC_WORKTREE_DIRTY: new.txt
```

### Suites

- `bun x vitest run test/orchestrator/{land-commit-failure,sync-base,land}.test.ts test/tui-react/sync-base-action.test.ts` — all green
- `bun test test/render` — 455 pass, 0 fail
- `KOBE_INCLUDE_SOCKET=1 bun run test:socket` — 786 pass (run because this
  touches `kobe-daemon`'s `poll-scheduling.ts`)
- `bun scripts/check-i18n.ts` — 771 keys × 2 locales in sync
- repo-root `bun run lint` / `bun run typecheck` — clean
- `bun run test:fast` — `6 failed | 4322 passed`, the same six pre-existing
  environment-shaped failures documented on #830 and #834 (this checkout lives
  under `~/.rove/worktrees`, which `project-eligibility` judges as
  `roveInternal`/`temporary` by path shape). Nothing here touches those paths.
