### PR TITLE
Exit on a readiness signal, and make the behavior harness wait for it

### DIFF
--- a/.changeset/exit-on-readiness-not-a-timer.md
+++ b/.changeset/exit-on-readiness-not-a-timer.md
@@ -1,0 +1,13 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Quit promptly on SIGHUP/SIGTERM/SIGINT instead of always sitting for five
+seconds. The signal backstop used a flat five-second sleep as a stand-in for
+"in-flight work has finished", so `kill <pid>` on an idle Rove host took five
+seconds — long enough that a supervisor with a shorter grace escalated to
+SIGKILL, which skips the exit handler that flushes pending UI state to disk.
+The exit now follows a readiness signal that the flows which kill their own
+session can hold open, and the five seconds survives only as a ceiling that
+says in the log when it fires. Measured on the behavior suite: SIGTERM to
+process gone went from ~5,030ms to ~50ms.

--- a/packages/kobe/src/tui/lib/host-render-options.ts
+++ b/packages/kobe/src/tui/lib/host-render-options.ts
@@ -111,6 +111,47 @@ export function installBracketedPasteMode(stdout: NodeJS.WriteStream = process.s
 }
 
 /**
+ * Work a signal-triggered exit must not truncate.
+ *
+ * The backstop below used to stand in for this set with a flat five-second
+ * sleep, because some flows kill the session their own pane lives in and
+ * then keep orchestrating. A constant cannot know when that finished: it is
+ * simultaneously too long (an idle host sat there for five seconds doing
+ * nothing, and anything reading its state file raced its exit-flush) and too
+ * short (a slower rebuild is truncated anyway). Register the actual work
+ * instead and the exit follows it.
+ *
+ * Synchronous exit-time work — the KV flush, the bracketed-paste restore —
+ * needs nothing here: it runs on `process.on("exit")`, inside `process.exit`
+ * itself. Nothing holds this set today: the two flows the delay was written
+ * for (`togglePreview`, `ensureSession`) left with the tmux host, so the five
+ * seconds had become pure latency. This is the seam they would use.
+ */
+const exitCriticalWork = new Set<Promise<unknown>>()
+
+/**
+ * Hold a signal-triggered exit open until `work` settles. Returns `work`
+ * unchanged, so it wraps a call in place: `await holdExitFor(rebuild())`.
+ */
+export function holdExitFor<T>(work: Promise<T>): Promise<T> {
+  exitCriticalWork.add(work)
+  const forget = (): void => {
+    exitCriticalWork.delete(work)
+  }
+  work.then(forget, forget)
+  return work
+}
+
+/**
+ * Resolves once nothing is in flight. Work registered WHILE waiting still
+ * counts — a rebuild that kicks off a follow-up must not be cut in half —
+ * hence the loop rather than a single `allSettled`.
+ */
+export async function whenExitReady(): Promise<void> {
+  while (exitCriticalWork.size > 0) await Promise.allSettled([...exitCriticalWork])
+}
+
+/**
  * Exit-signal backstop (orphaned-helper leak): opentui's own exit handler
  * for SIGHUP/SIGTERM only destroys the renderer — it never calls
  * process.exit — and installing that listener replaced the signals' default
@@ -120,19 +161,37 @@ export function installBracketedPasteMode(stdout: NodeJS.WriteStream = process.s
  * tty, reparented to launchd. Register AFTER render resolves so opentui's
  * handler (terminal restore + onDestroy) runs first.
  *
- * The exit is DELAYED, not immediate: some flows kill the session their own
- * pane lives in and then keep orchestrating (togglePreview's
- * kill→rebuild→switch, ensureSession's vendor-switch rebuild) — an instant
- * exit on the incoming SIGHUP would truncate them. Five seconds is enough
- * for any in-flight tmux sequence; the pane is already gone from the
- * screen, so the tail is invisible.
+ * The exit waits on `whenExitReady()`, not on the clock. `ceilingMs` is a
+ * watchdog for work that never settles, and it says so in the log — a silent
+ * cap is indistinguishable from the fixed delay it replaced.
  */
-export function installPaneExitBackstop(): void {
+export function installPaneExitBackstop(opts: { ceilingMs?: number; exit?: (code: number) => void } = {}): void {
+  const ceilingMs = opts.ceilingMs ?? 5000
+  const exit = opts.exit ?? ((code: number) => process.exit(code))
   let exitScheduled = false
+  let exited = false
+  /** The ceiling and the readiness signal both fire on a slow hang; whichever
+   *  wins, the other must not re-enter (process.exit never returns, so this
+   *  only shows up under test — where a double exit is a false signal). */
+  const exitOnce = (): void => {
+    if (exited) return
+    exited = true
+    exit(0)
+  }
   const scheduleExit = () => {
     if (exitScheduled) return
     exitScheduled = true
-    setTimeout(() => process.exit(0), 5000)
+    const ceiling = setTimeout(() => {
+      console.error(
+        `[rove] exit backstop: ${exitCriticalWork.size} task(s) still in flight after ${ceilingMs}ms — exiting anyway`,
+      )
+      exitOnce()
+    }, ceilingMs)
+    ceiling.unref?.()
+    void whenExitReady().then(() => {
+      clearTimeout(ceiling)
+      exitOnce()
+    })
   }
   for (const signal of ["SIGHUP", "SIGTERM", "SIGINT"] as const) {
     process.on(signal, scheduleExit)

--- a/packages/kobe/test/behavior/harness.ts
+++ b/packages/kobe/test/behavior/harness.ts
@@ -22,6 +22,11 @@ const PKG_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../..")
 export const DIST_ROVE_CLI = join(PKG_ROOT, "dist/cli/rove.js")
 export const DIST_KOBE_CLI = join(PKG_ROOT, "dist/cli/kobe.js")
 
+/** Longer than the host's own exit ceiling, so SIGKILL means a real hang. */
+const CLOSE_TUI_TIMEOUT_MS = 8_000
+
+type OnExit = (listener: () => void) => { dispose(): void }
+
 export interface BehaviorEnv {
   readonly home: string
   readonly bin: string
@@ -161,6 +166,53 @@ export async function makeScratchRepo(env: BehaviorEnv): Promise<string> {
   git("add", "README.md")
   git("commit", "-q", "-m", "init")
   return repo
+}
+
+/**
+ * Terminate a TUI child and resolve only once the process is GONE.
+ *
+ * `child.kill()` is fire-and-forget, and a Rove host does not die on the
+ * signal: `installPaneExitBackstop` schedules the real exit once its
+ * exit-critical work drains. On the way out the KV provider's
+ * `process.on("exit")` flush dirty-key-merges that launch's own
+ * `terminalTabs` snapshot onto `state.json` — so a test that killed a launch
+ * and immediately rewrote that file had its write reverted by the corpse.
+ * (Same root cause as the orphaned-pane leak: opentui's own SIGHUP/SIGTERM
+ * handler destroys the renderer without ever exiting.)
+ *
+ * `onExit` is the process's own statement that it is gone and its exit
+ * handlers have run — not a sleep, and not a retry. SIGKILL is the last
+ * resort only: it skips those exit handlers, which is exactly the loss this
+ * helper exists to prevent, so it is reported rather than swallowed.
+ */
+export function closeTui(child: { pid: number; kill(signal?: string): void; onExit: OnExit }): Promise<void> {
+  return new Promise((resolve) => {
+    let settled = false
+    const finish = (): void => {
+      if (settled) return
+      settled = true
+      clearTimeout(hardTimer)
+      subscription?.dispose()
+      resolve()
+    }
+    const subscription = child.onExit(() => finish())
+    const hardTimer = setTimeout(() => {
+      console.warn(
+        `[behavior] TUI pid ${child.pid} ignored SIGTERM for ${CLOSE_TUI_TIMEOUT_MS}ms — escalating to SIGKILL`,
+      )
+      try {
+        child.kill("SIGKILL")
+      } catch {
+        // already reaped between the timeout and here
+      }
+      setTimeout(finish, 250)
+    }, CLOSE_TUI_TIMEOUT_MS)
+    try {
+      child.kill("SIGTERM")
+    } catch {
+      finish() // already gone; nothing to wait for
+    }
+  })
 }
 
 /**

--- a/packages/kobe/test/behavior/pure-tui-adopt-orphan-tab.test.ts
+++ b/packages/kobe/test/behavior/pure-tui-adopt-orphan-tab.test.ts
@@ -13,7 +13,15 @@
 import { mkdir, readFile, writeFile } from "node:fs/promises"
 import { join } from "node:path"
 import { afterAll, beforeAll, describe, expect, it } from "vitest"
-import { type BehaviorEnv, DIST_ROVE_CLI, loadNodePty, makeBehaviorEnv, makeScratchRepo, runRove } from "./harness.ts"
+import {
+  type BehaviorEnv,
+  DIST_ROVE_CLI,
+  closeTui,
+  loadNodePty,
+  makeBehaviorEnv,
+  makeScratchRepo,
+  runRove,
+} from "./harness.ts"
 
 const nodePty = await loadNodePty()
 
@@ -96,7 +104,7 @@ describe.skipIf(!nodePty)("Pure TUI adopts unregistered live sessions (behavior)
       }
       expect(adopted?.tabs?.map((tab) => tab.id)).toContain("tab-1")
     } finally {
-      child.kill()
+      await closeTui(child)
     }
   }, 90_000)
 })

--- a/packages/kobe/test/behavior/pure-tui-live-tab-title.test.ts
+++ b/packages/kobe/test/behavior/pure-tui-live-tab-title.test.ts
@@ -21,7 +21,15 @@ import { join } from "node:path"
 import { Terminal } from "@xterm/headless"
 import { afterAll, beforeAll, describe, expect, it } from "vitest"
 import { SIDEBAR_WIDTH } from "../../src/tui/panes/sidebar/view-core.ts"
-import { type BehaviorEnv, DIST_ROVE_CLI, loadNodePty, makeBehaviorEnv, makeScratchRepo, runRove } from "./harness.ts"
+import {
+  type BehaviorEnv,
+  DIST_ROVE_CLI,
+  closeTui,
+  loadNodePty,
+  makeBehaviorEnv,
+  makeScratchRepo,
+  runRove,
+} from "./harness.ts"
 
 const nodePty = await loadNodePty()
 
@@ -164,7 +172,7 @@ describe.skipIf(!nodePty)("Pure TUI sidebar shows an unselected task's live tab 
       ).toBe(STALE)
     } finally {
       data.dispose()
-      child.kill()
+      await closeTui(child)
     }
   }, 120_000)
 })

--- a/packages/kobe/test/behavior/pure-tui-open-worktree.test.ts
+++ b/packages/kobe/test/behavior/pure-tui-open-worktree.test.ts
@@ -8,7 +8,15 @@
 import { chmod, mkdir, readFile, writeFile } from "node:fs/promises"
 import { join } from "node:path"
 import { afterAll, beforeAll, describe, expect, it } from "vitest"
-import { type BehaviorEnv, DIST_ROVE_CLI, loadNodePty, makeBehaviorEnv, makeScratchRepo, runRove } from "./harness.ts"
+import {
+  type BehaviorEnv,
+  DIST_ROVE_CLI,
+  closeTui,
+  loadNodePty,
+  makeBehaviorEnv,
+  makeScratchRepo,
+  runRove,
+} from "./harness.ts"
 
 // Shared loader: skips when node-pty is missing OR cannot spawn here (a
 // sandboxed shell denies posix_spawnp) — see harness.ts.
@@ -121,7 +129,7 @@ describe.skipIf(!nodePty)("Pure TUI open-worktree keys (behavior)", () => {
       expect(new Set(prefixed)).toEqual(new Set([repo]))
     } finally {
       data.dispose()
-      child.kill()
+      await closeTui(child)
     }
   }, 45_000)
 })

--- a/packages/kobe/test/behavior/pure-tui-unread-restart.test.ts
+++ b/packages/kobe/test/behavior/pure-tui-unread-restart.test.ts
@@ -18,7 +18,15 @@ import { join } from "node:path"
 import { Terminal } from "@xterm/headless"
 import { afterAll, beforeAll, describe, expect, it } from "vitest"
 import { SIDEBAR_WIDTH } from "../../src/tui/panes/sidebar/view-core.ts"
-import { type BehaviorEnv, DIST_ROVE_CLI, loadNodePty, makeBehaviorEnv, makeScratchRepo, runRove } from "./harness.ts"
+import {
+  type BehaviorEnv,
+  DIST_ROVE_CLI,
+  closeTui,
+  loadNodePty,
+  makeBehaviorEnv,
+  makeScratchRepo,
+  runRove,
+} from "./harness.ts"
 
 const nodePty = await loadNodePty()
 
@@ -27,6 +35,16 @@ const ROWS = 40
 /** ● an unread completion, ○ one already looked at (· = no signal at all). */
 const UNREAD = "●"
 const SEEN = "○"
+
+/** Is that pid still a live process? (signal 0 = existence probe.) */
+function alive(pid: number): boolean {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch {
+    return false
+  }
+}
 
 async function poll(predicate: () => boolean | Promise<boolean>, timeoutMs: number): Promise<void> {
   const deadline = Date.now() + timeoutMs
@@ -42,6 +60,8 @@ describe.skipIf(!nodePty)("Pure TUI unread lamp across a restart (behavior)", ()
   let statePath: string
   let taskId: string
   let branch: string
+  /** The pid of the most recent `withTui` launch, for the exited-yet check. */
+  let lastTuiPid = 0
 
   const readState = async (): Promise<Record<string, unknown>> =>
     JSON.parse(await readFile(statePath, "utf8")) as Record<string, unknown>
@@ -58,6 +78,7 @@ describe.skipIf(!nodePty)("Pure TUI unread lamp across a restart (behavior)", ()
     // off under a test RUNNER — it is a real TUI in its own process.
     const { VITEST, NODE_ENV, BUN_TEST, ...tuiEnv } = env.env as Record<string, string>
     const child = nodePty.spawn("bun", [DIST_ROVE_CLI], { cols: COLS, rows: ROWS, cwd: repo, env: tuiEnv })
+    lastTuiPid = child.pid
     const data = child.onData((chunk: string) => term.write(chunk))
     try {
       return await run(() => {
@@ -68,7 +89,7 @@ describe.skipIf(!nodePty)("Pure TUI unread lamp across a restart (behavior)", ()
       })
     } finally {
       data.dispose()
-      child.kill()
+      await closeTui(child)
     }
   }
 
@@ -145,14 +166,26 @@ describe.skipIf(!nodePty)("Pure TUI unread lamp across a restart (behavior)", ()
       expect(await readState(), "launch #1 never recorded the completion as read").toHaveProperty("completionSeen")
     })
 
+    // The ordering this whole test rests on. Launch #1 flushes its KV store
+    // from `process.on("exit")`, dirty-key-merging its own `terminalTabs`
+    // snapshot onto the file — so if it is still alive here, that flush lands
+    // AFTER the rewrite below and silently reverts it.
+    expect(alive(lastTuiPid), "launch #1 was still running when the test rewrote its state").toBe(false)
+
     // Between launches the user leaves that tab: tab-2 is what the next
     // launch opens, so tab-1's row is a session nobody is looking at.
     const state = await readState()
     const snapshot = state[key] as { tabs: unknown[]; activeId: string; nextOrdinal: number }
     expect((snapshot?.tabs?.[0] as { id?: string } | undefined)?.id).toBe("tab-1")
-    snapshot.tabs.push({ kind: "engine", id: "tab-2", title: null, ordinal: 2 })
-    snapshot.activeId = "tab-2"
-    snapshot.nextOrdinal = 3
+    // Write the WHOLE snapshot rather than pushing onto whatever is there:
+    // vitest does not re-run `beforeAll` for a `--retry`, so a
+    // read-modify-write would stack a SECOND tab-2 on attempt 2 and the retry
+    // would exercise a tab list this test never described.
+    state[key] = {
+      tabs: [snapshot.tabs[0], { kind: "engine", id: "tab-2", title: null, ordinal: 2 }],
+      activeId: "tab-2",
+      nextOrdinal: 3,
+    }
     await writeFile(statePath, JSON.stringify(state))
 
     // Launch #2 — the daemon replays the very same turn_complete it never

--- a/packages/kobe/test/behavior/tui-title.test.ts
+++ b/packages/kobe/test/behavior/tui-title.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { afterAll, beforeAll, describe, expect, it } from "vitest"
-import { type BehaviorEnv, DIST_ROVE_CLI, loadNodePty, makeBehaviorEnv } from "./harness.ts"
+import { type BehaviorEnv, DIST_ROVE_CLI, closeTui, loadNodePty, makeBehaviorEnv } from "./harness.ts"
 
 // node-pty is a native addon; CI's linux runner has no prebuild for it, so a
 // top-level import fails the whole suite before skip logic can run. The
@@ -51,7 +51,7 @@ describe.skipIf(!nodePty)("Rove outer terminal title (behavior)", () => {
       })
       expect(raw).toContain(TITLE_SEQUENCE)
     } finally {
-      child.kill()
+      await closeTui(child)
     }
   }, 15_000)
 })

--- a/packages/kobe/test/tui/host-render-options.test.ts
+++ b/packages/kobe/test/tui/host-render-options.test.ts
@@ -1,8 +1,10 @@
-import { afterEach, describe, expect, it } from "vitest"
+import { afterEach, describe, expect, it, vi } from "vitest"
 import {
+  holdExitFor,
   hostRenderOptions,
   installBracketedPasteMode,
   installPaneExitBackstop,
+  whenExitReady,
 } from "../../src/tui/lib/host-render-options"
 import { createHostImeOutput } from "../../src/tui/lib/ime-anchor-output"
 
@@ -69,14 +71,67 @@ describe("installPaneExitBackstop", () => {
     for (const { signal, fn } of added.splice(0)) process.removeListener(signal, fn)
   })
 
-  it("registers one delayed-exit listener per teardown signal", () => {
+  /**
+   * Install, then hand back a trigger that calls the registered listener
+   * DIRECTLY. `process.emit("SIGTERM")` would also run vitest's own handlers
+   * and take the runner down with it.
+   */
+  function install(opts: { ceilingMs?: number; exit?: (code: number) => void }): () => void {
+    installPaneExitBackstop(opts)
+    const fn = process.listeners("SIGTERM").at(-1) as NodeJS.SignalsListener
+    for (const signal of SIGNALS) added.push({ signal, fn })
+    return () => fn("SIGTERM")
+  }
+
+  it("registers one exit listener per teardown signal", () => {
     const before = new Map(SIGNALS.map((s) => [s, process.listeners(s).length]))
-    installPaneExitBackstop()
+    install({ exit: () => {} })
     for (const signal of SIGNALS) {
-      const listeners = process.listeners(signal)
-      expect(listeners.length).toBe((before.get(signal) ?? 0) + 1)
-      added.push({ signal, fn: listeners.at(-1) as NodeJS.SignalsListener })
+      expect(process.listeners(signal).length).toBe((before.get(signal) ?? 0) + 1)
     }
+  })
+
+  it("exits as soon as nothing is in flight, rather than waiting out the ceiling", async () => {
+    const exits: number[] = []
+    // A ceiling this far out means only the readiness signal can end it.
+    install({ ceilingMs: 60_000, exit: (code) => exits.push(code) })()
+    await vi.waitFor(() => expect(exits).toEqual([0]))
+  })
+
+  it("holds the exit open until registered work settles", async () => {
+    let finishWork!: () => void
+    holdExitFor(
+      new Promise<void>((resolve) => {
+        finishWork = resolve
+      }),
+    )
+    const exits: number[] = []
+    install({ ceilingMs: 60_000, exit: (code) => exits.push(code) })()
+
+    await new Promise((resolve) => setTimeout(resolve, 50))
+    expect(exits, "exited while a kill-own-session flow was still orchestrating").toEqual([])
+
+    finishWork()
+    await vi.waitFor(() => expect(exits).toEqual([0]))
+  })
+
+  it("gives up at the ceiling and says so, instead of hanging on stuck work", async () => {
+    let abandon!: () => void
+    holdExitFor(
+      new Promise<void>((resolve) => {
+        abandon = resolve
+      }),
+    )
+    const logged = vi.spyOn(console, "error").mockImplementation(() => {})
+    const exits: number[] = []
+    install({ ceilingMs: 20, exit: (code) => exits.push(code) })()
+
+    await vi.waitFor(() => expect(exits).toEqual([0]))
+    expect(logged.mock.calls[0]?.[0]).toContain("still in flight after 20ms")
+
+    logged.mockRestore()
+    abandon() // drain the module-level set for the next test
+    await whenExitReady()
   })
 })
 


### PR DESCRIPTION
Batch N — the two timing assumptions in the PureTUI shutdown path that made
`test/behavior/pure-tui-unread-restart.test.ts` flake on PR #835.

No screenshots: **nothing here changes a rendered surface.** The behavior is
process shutdown timing and a test harness; the proof is run logs and
measurements below.

---

## N1 — `withTui` killed the TUI but never waited for it to die

**What changed.** `closeTui()` in `test/behavior/harness.ts`: sends SIGTERM,
resolves on the child's `exit` event, escalates to SIGKILL only after 8s and
logs when it does (SIGKILL skips the exit handlers, which is the loss the
helper exists to prevent). All five suites that drive a real TUI now use it —
`pure-tui-unread-restart`, `pure-tui-adopt-orphan-tab`, `pure-tui-live-tab-title`,
`pure-tui-open-worktree`, `tui-title` — because the same fire-and-forget shape
was in every one of them, each leaking a 5-second orphan into the next file's
daemon.

Same root cause as the orphaned-pane leak recorded in
`reference_opentui_sighup_swallow`: opentui's SIGHUP/SIGTERM handler destroys
the renderer and never calls `process.exit`, so the signal's default terminate
action is gone and `child.kill()` does not kill anything.

**The ordering that now guarantees launch #1's flush precedes launch #2's read.**
The KV provider registers its flush on `process.on("exit")` (`kv.tsx:51`), and
`patchStateFile` is `writeFileSync` + `rename` — all synchronous, all inside
`process.exit`. node-pty's `onExit` fires only once the OS reports the child
reaped, which is strictly after those handlers ran. So `await closeTui(child)`
returning *is* the statement that the exit-flush has landed. No sleep, no retry.

**PASS criterion.** The child has exited before the test writes state.

**Proof — a targeted assertion that fails under the old harness.**
`pure-tui-unread-restart.test.ts:171` now asserts the pid is gone at the exact
line where the race was. Against unfixed harness code:

```
× keeps a completion read after kobe is restarted 763ms
  → launch #1 was still running when the test rewrote its state: expected true to be false
```

With `closeTui`: green.

**Also fixed:** the test read-modify-wrote the fixture it depends on, and
vitest does not re-run `beforeAll` for a `--retry` — attempt 2 pushed a *second*
`tab-2` and could not pass. It now writes the whole snapshot, so a retry
re-runs the case rather than a mutated one. The suite is green at `--retry=0`.

---

## N2 — the 5-second exit delay was a fixed guess

**What changed.** `installPaneExitBackstop` waited out a flat
`setTimeout(() => process.exit(0), 5000)` standing in for "in-flight work
finished". It now awaits `whenExitReady()`; `holdExitFor(promise)` is how a
flow that kills its own session holds the exit open; the 5s survives only as a
ceiling that `console.error`s what is still in flight when it fires. Normal
(non-signal) exit paths are untouched.

Honest note: **nothing holds that set today.** The two flows the delay was
written for — `togglePreview`'s kill→rebuild→switch and `ensureSession`'s
vendor-switch rebuild — left with the tmux host (`grep` finds neither in
`src/`), so the five seconds had become pure latency. Synchronous exit-time
work needs no registration: the KV flush, the bracketed-paste restore and
`renderer.destroy()` all run on `process.on("exit")`, inside `process.exit`
itself (`destroy(): void` — verified against @opentui/core 0.4.3), so removing
the delay cannot truncate terminal restore. `holdExitFor` is the seam those
flows would use, which is what the magic number was encoding.

**PASS criterion.** `kill <pid>` on an idle host exits in well under a second.

**Proof — measured on a fully booted TUI**, by timing SIGTERM → node-pty
`onExit` inside the behavior suite (instrumentation added temporarily, then
removed):

| | launch #1 | launch #2 | test duration |
|---|---|---|---|
| fixed 5s timer (HEAD) | 5034ms | 5070ms | 11127ms |
| readiness signal | 36ms | 64ms | 1369ms |

**Unit proof** — `test/tui/host-render-options.test.ts`: exits promptly with
nothing in flight; holds the exit while registered work is pending; gives up at
the ceiling *and logs it*. Mutation-verified at two different sites:

- `whenExitReady` ignoring the set → 2 red (`holds the exit open…`, `gives up at the ceiling…`)
- dropping the readiness branch, leaving only the clock → 2 red (`exits as soon as nothing is in flight…`, `holds the exit open…`)

---

## Gates

```
bun run lint                    clean (1397 files)
bun run typecheck               clean
bun test test/render            455 pass, 0 fail (102 files)
bun run test:behavior ×5        11 files / 32 tests passed, every run
  run 1  53.82s   run 2  53.09s   run 3  54.02s   run 4  53.23s   run 5  53.40s
--retry=0 (idempotence check)   11 files / 32 tests passed
```

`bun run test:fast` → 6 failures in 3 files, **all pre-existing and
environmental**, none importing anything this PR touches. Proven by reverting
this PR's only `src/` change to HEAD and re-running: the identical 6 fail.

- `test/state/project-eligibility` ×2, `test/cli/open-dir-cmd` ×2 — `expected 'roveInternal' to be null`; the suite is running inside `~/.rove/worktrees`, which the path-shape check rejects by design.
- `test/tui/continue-live-vendor` ×2 — `expected 'claudecpa' to be 'claude'`; reads this machine's real engine presets.

## Not proven

Nothing. Both items have a runnable proof above.