### PR TITLE
fix: require the web token on the PTY sidecar's routes

### DIFF
--- a/.changeset/pty-websocket-requires-the-web-token.md
+++ b/.changeset/pty-websocket-requires-the-web-token.md
@@ -1,0 +1,34 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Require the web bearer token on the PTY sidecar, and let the sidecar present
+it to the daemon.
+
+The PTY routes were the one part of the web surface the token never reached,
+and they are the part that runs commands: `ws /pty` spawns the task's engine or
+a shell in its worktree, `POST /pty/send` types into that process, and `POST
+/pty/close` kills it. Their only gate was the Origin check, which admits a
+request with **no** `Origin` — every non-browser client — and admits **any**
+loopback origin, so a page the user happened to have open on another localhost
+port could attach as well. WebSocket upgrades get no CORS preflight, so nothing
+else stood in the way. Against a running `rove web`, a tokenless upgrade
+returned a live shell prompt and a tokenless `/pty/send` typed into it; a wrong
+token worked just as well. Exposure was limited to whatever could reach the
+sidecar's loopback port — on a shared machine, any other local user, which is
+the boundary the token file's 0600 mode exists to hold — and not reachable from
+a remote network unless the port had been bound off loopback.
+
+All three routes now require the token that every REST and SSE caller already
+sends: the browser puts it on the WebSocket URL the way the `/events` stream
+does, and the sidecar refuses an upgrade without it (`401`). The Origin check
+stays as defence in depth. The sidecar reads the same `0600` token file the
+daemon mints rather than taking the secret from whoever spawned it, so a
+launcher that forgot to forward it cannot silently reopen the gap; no readable
+file means no request is served.
+
+This also repairs the web terminal, dead since 0.9.60: the sidecar fetches each
+tab's launch spec from the daemon's `/api/*`, that route began requiring the
+token in 0.9.60, and the sidecar was never taught to send one — so every engine
+and shell tab died with `failed to start shell: unauthorized: this request
+carried no valid web token` before any PTY was spawned.

--- a/docs/design/web-dashboard.md
+++ b/docs/design/web-dashboard.md
@@ -226,10 +226,10 @@ unconditional.
 Both the daemon web transport and the PTY sidecar
 ([`pty-server.mjs`](../../packages/kobe-web/pty-server.mjs)) bind
 **`127.0.0.1` by default**. `KOBE_WEB_HOST` overrides only when a LAN bind is
-intended. A PTY WS is arbitrary command exec in the worktree, so the upgrade enforces a
-**localhost-Origin allowlist** (`localhost`/`127.0.0.1`/`[::1]`) — a browser
-cross-origin upgrade is rejected; a non-browser client (no `Origin`) is allowed
-since there's no ambient browser session to ride.
+intended. A PTY WS is arbitrary command exec in the worktree, so the upgrade
+enforces a **localhost-Origin allowlist** (`localhost`/`127.0.0.1`/`[::1]`) —
+a browser cross-origin upgrade is rejected — **and** the bearer token below,
+which is the check that stops a caller sending no `Origin` at all.
 
 The browser-facing HTTP routes live at the daemon-owned seam, so the Origin
 policy, RPC allowlist, and event-channel filtering are enforced before a browser
@@ -265,9 +265,19 @@ still refused.
   the SPA holds one it would have to be unauthenticated, which is the very hole
   the token closes.
 - **Two channels** — `Authorization: Bearer <token>` for everything on `fetch`;
-  `?token=` for the `/events` SSE stream only, because `EventSource` cannot set
-  a request header. The query channel is weaker (it lands in logs) and is
-  acceptable only because this server is loopback-bound.
+  `?token=` for the two callers that cannot set a request header, the `/events`
+  SSE stream (`EventSource`) and the `/pty` WebSocket upgrade. The query channel
+  is weaker (it lands in logs) and is acceptable only because this server is
+  loopback-bound.
+- **The PTY sidecar too** — `ws /pty`, `POST /pty/send` and `POST /pty/close`
+  each require the token
+  ([`pty-auth.mjs`](../../packages/kobe-web/pty-auth.mjs)); `ws` refuses a
+  rejected upgrade with `401`. The sidecar reads the same `0600` file rather
+  than taking the secret from whoever spawned it — it starts from four places
+  (`rove web`, `dev.ts`, Playwright, by hand) and a launcher that forgot to
+  forward it would silently reopen the hole. Missing file means every request
+  is refused. The sidecar also presents the token on its own `/api/*` hop to
+  the daemon for each tab's launch spec.
 - **Rotation** — delete the file and restart the daemon; the next read mints a
   fresh token. That is also the response to a leaked token.
 - **Exempt** — `/__kobe_web`, the health probe a starting daemon uses to detect
@@ -277,5 +287,9 @@ still refused.
   body carries a `hint` and `nextCommandArgs` naming the fix, in the shape the
   CLI's typed errors use.
 
-In `vite dev` Vite serves the HTML, so nothing injects the tag; set
-`VITE_ROVE_WEB_TOKEN` to the file's contents to exercise the real path.
+In `vite dev` Vite serves the HTML, so nothing injects the tag:
+`VITE_ROVE_WEB_TOKEN` is the browser's only channel there. `dev.ts` sets it from
+the token file, and the visual/hero fixtures pin a known one
+(`FIXTURE_WEB_TOKEN` in
+[`fixture-core.ts`](../../packages/kobe/scripts/fixture-core.ts)) written before
+their daemon starts, so the `/harness` capture path stays on the real gate.

--- a/packages/kobe-web/dev.ts
+++ b/packages/kobe-web/dev.ts
@@ -22,6 +22,8 @@ import { homedir } from "node:os"
 import { resolve } from "node:path"
 import { ensureDaemonReachable } from "@sma1lboy/kobe-daemon/client/daemon-process"
 import { readRoveEnv, setRoveEnv } from "@sma1lboy/kobe-daemon/compat-env"
+import { defaultWebTokenPath } from "@sma1lboy/kobe-daemon/daemon/paths"
+import { ensureWebToken } from "@sma1lboy/kobe-daemon/daemon/web-token"
 
 const DAEMON_WEB_PORT = readRoveEnv("DAEMON_WEB_PORT") ?? "45174"
 const WEB_PORT = readRoveEnv("WEB_PORT") ?? "5173"
@@ -57,6 +59,14 @@ try {
   )
 }
 
+// The daemon-hosted transport requires a bearer token on /api, /events, and
+// (since the PTY sidecar adopted it) the terminal WebSocket. Vite serves the
+// SPA here, so the daemon never gets to inject its <meta> tag — `VITE_*` is
+// the channel the browser has in dev, and without it the whole dev dashboard
+// 401s. The daemon minted the file during ensureDaemonReachable above; this
+// only reads it back. The sidecar reads the same file itself.
+const webToken = ensureWebToken(defaultWebTokenPath())
+
 // node: PTY terminal server — node-pty only works under node, not bun.
 // Needs the daemon web port to fetch each tab's engine launch spec.
 const pty = Bun.spawn(["node", "pty-server.mjs"], {
@@ -67,7 +77,12 @@ const pty = Bun.spawn(["node", "pty-server.mjs"], {
 // node (via vite): the SPA, proxying /api + /events + /pty to the above.
 const vite = Bun.spawn(["bun", "run", "vite", "dev", "--port", WEB_PORT, "--strictPort"], {
   stdio: ["inherit", "inherit", "inherit"],
-  env: { ...childEnv, KOBE_DAEMON_WEB_PORT: DAEMON_WEB_PORT, KOBE_PTY_PORT: PTY_PORT },
+  env: {
+    ...childEnv,
+    KOBE_DAEMON_WEB_PORT: DAEMON_WEB_PORT,
+    KOBE_PTY_PORT: PTY_PORT,
+    VITE_ROVE_WEB_TOKEN: webToken,
+  },
 })
 
 const shutdown = (): void => {

--- a/packages/kobe-web/e2e/atlas/shoot.ts
+++ b/packages/kobe-web/e2e/atlas/shoot.ts
@@ -16,7 +16,7 @@ import { createHash } from "node:crypto"
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs"
 import { join, resolve } from "node:path"
 import { chromium } from "@playwright/test"
-import { HERO_PTY_PORT, HERO_WEB_PORT } from "../hero-env.ts"
+import { fixtureAuthHeaders, HERO_PTY_PORT, HERO_WEB_PORT } from "../hero-env.ts"
 import { heroApi } from "../hero-fixture.ts"
 import { FLOWS, type Flow } from "./flows.ts"
 
@@ -250,7 +250,7 @@ async function shootFlow(flow: Flow): Promise<void> {
     shots.push({ flow: flow.name, step: "<boot>", index: -1, file: "", subject: flow.summary, failed: String(err) })
   } finally {
     await page.request
-      .post(`http://127.0.0.1:${HERO_PTY_PORT}/pty/close`, { data: { tab: `visual-${runId}` } })
+      .post(`http://127.0.0.1:${HERO_PTY_PORT}/pty/close`, { data: { tab: `visual-${runId}` }, headers: fixtureAuthHeaders() })
       .catch(() => {})
     await page.close().catch(() => {})
   }

--- a/packages/kobe-web/e2e/hero-capture.ts
+++ b/packages/kobe-web/e2e/hero-capture.ts
@@ -11,7 +11,7 @@
 import { mkdir, readdir, rename } from "node:fs/promises"
 import { join, resolve } from "node:path"
 import { type Page, chromium } from "@playwright/test"
-import { HERO_PTY_PORT, HERO_WEB_PORT } from "./hero-env.ts"
+import { fixtureAuthHeaders, HERO_PTY_PORT, HERO_WEB_PORT } from "./hero-env.ts"
 
 export const REPO_ROOT: string = resolve(import.meta.dirname, "../../..")
 const BRANDING = join(REPO_ROOT, "packages", "branding")
@@ -191,7 +191,7 @@ export async function record(workDir: string, storyboard: (page: Page) => Promis
       clearInterval(guard)
     }
     if (breach) throw breach
-    await page.request.post(`http://127.0.0.1:${HERO_PTY_PORT}/pty/close`, { data: { tab: `visual-${runId}` } }).catch(() => {})
+    await page.request.post(`http://127.0.0.1:${HERO_PTY_PORT}/pty/close`, { data: { tab: `visual-${runId}` }, headers: fixtureAuthHeaders() }).catch(() => {})
   } finally {
     await context.close()
     await browser.close()

--- a/packages/kobe-web/e2e/hero-env.ts
+++ b/packages/kobe-web/e2e/hero-env.ts
@@ -20,11 +20,16 @@ import {
   assertFixtureIsolation,
   buildFixtureEnv,
   CLAUDE_MARKERS,
+  fixtureAuthHeaders,
   fixturePaths,
   fixturePortBase,
   type FixturePaths,
   type FixturePorts,
 } from "../../kobe/scripts/fixture-core.ts"
+
+/** Re-exported so the capture scripts reach the hero PTY sidecar (now
+ *  token-gated) through the same module that owns its ports. */
+export { fixtureAuthHeaders }
 
 const REPO_ROOT = resolve(import.meta.dirname, "../../..")
 export const KOBE_DIR: string = join(REPO_ROOT, "packages", "kobe")

--- a/packages/kobe-web/e2e/hero-fixture.ts
+++ b/packages/kobe-web/e2e/hero-fixture.ts
@@ -11,7 +11,7 @@
 import { existsSync } from "node:fs"
 import { mkdir, readFile, rm, writeFile } from "node:fs/promises"
 import { join } from "node:path"
-import { createTaskWithChatTab, runInFixture, runRoveApi, seedGitRepo } from "../../kobe/scripts/fixture-core.ts"
+import { createTaskWithChatTab, runInFixture, runRoveApi, seedGitRepo, writeFixtureWebToken } from "../../kobe/scripts/fixture-core.ts"
 import { HERO_CLI, HERO_CONFIG, HERO_HOME, HERO_REPO, HERO_ROOT, KOBE_DIR, heroEnv } from "./hero-env.ts"
 import { HERO_COMMITS, HERO_FILES } from "./hero-repo.ts"
 
@@ -165,6 +165,9 @@ async function main(): Promise<void> {
     }
     await rm(HERO_ROOT, { recursive: true, force: true })
     await mkdir(HERO_HOME, { recursive: true })
+    // Before anything can start the hero daemon: `ensureWebToken` reuses an
+    // existing file, so this pins the whole capture run to one known token.
+    await writeFixtureWebToken(HERO_HOME)
     await seedSettings()
     await seedRepo()
     for (const task of IDLE_TASKS) {

--- a/packages/kobe-web/e2e/hero-shot.ts
+++ b/packages/kobe-web/e2e/hero-shot.ts
@@ -15,7 +15,7 @@
 
 import { resolve } from "node:path"
 import { chromium } from "@playwright/test"
-import { HERO_PTY_PORT, HERO_WEB_PORT } from "./hero-env.ts"
+import { fixtureAuthHeaders, HERO_PTY_PORT, HERO_WEB_PORT } from "./hero-env.ts"
 
 const KEY_NAMES: Record<string, string> = {
   enter: "Enter",
@@ -82,7 +82,7 @@ try {
   await page.waitForTimeout(1_200)
   await page.screenshot({ path: out })
   await page.request
-    .post(`http://127.0.0.1:${HERO_PTY_PORT}/pty/close`, { data: { tab: `visual-${runId}` } })
+    .post(`http://127.0.0.1:${HERO_PTY_PORT}/pty/close`, { data: { tab: `visual-${runId}` }, headers: fixtureAuthHeaders() })
     .catch(() => {})
   console.log(out)
 } finally {

--- a/packages/kobe-web/e2e/hero-stills.ts
+++ b/packages/kobe-web/e2e/hero-stills.ts
@@ -15,7 +15,7 @@
 
 import { join, resolve } from "node:path"
 import { chromium } from "@playwright/test"
-import { HERO_PTY_PORT, HERO_WEB_PORT } from "./hero-env.ts"
+import { fixtureAuthHeaders, HERO_PTY_PORT, HERO_WEB_PORT } from "./hero-env.ts"
 
 const REPO_ROOT = resolve(import.meta.dirname, "../../..")
 const ASSETS = join(REPO_ROOT, "docs", "assets")
@@ -209,7 +209,7 @@ try {
     const out = join(ASSETS, `${still.name}.png`)
     await page.screenshot({ path: out })
     await page.request
-      .post(`http://127.0.0.1:${HERO_PTY_PORT}/pty/close`, { data: { tab: `visual-${runId}` } })
+      .post(`http://127.0.0.1:${HERO_PTY_PORT}/pty/close`, { data: { tab: `visual-${runId}` }, headers: fixtureAuthHeaders() })
       .catch(() => {})
     await page.close()
     console.log(`${out}  — ${still.subject}`)

--- a/packages/kobe-web/e2e/sandbox.spec.ts
+++ b/packages/kobe-web/e2e/sandbox.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test, type Locator, type Page } from "@playwright/test"
-import { VISUAL_PTY_PORT, VISUAL_RUN_ID } from "./visual-fixture.ts"
+import { fixtureAuthHeaders, VISUAL_PTY_PORT, VISUAL_RUN_ID } from "./visual-fixture.ts"
 
 const TITLE = "Improve Kanban card hierarchy"
 const BODY = "Make status, project, and next action easy to scan."
@@ -72,7 +72,7 @@ async function withVisualTui(page: Page, run: VisualJourney): Promise<void> {
   } finally {
     // Kill this run's TUI so warm mode never accumulates PTY children.
     await page.request
-      .post(`http://127.0.0.1:${VISUAL_PTY_PORT}/pty/close`, { data: { tab: `visual-${runId}` } })
+      .post(`http://127.0.0.1:${VISUAL_PTY_PORT}/pty/close`, { data: { tab: `visual-${runId}` }, headers: fixtureAuthHeaders() })
       .catch(() => {})
   }
 }

--- a/packages/kobe-web/e2e/visual-fixture.ts
+++ b/packages/kobe-web/e2e/visual-fixture.ts
@@ -7,8 +7,10 @@ import {
   fixturePaths,
   fixturePortBase,
   runInFixture,
+  fixtureAuthHeaders,
   runRoveApi,
   seedGitRepo,
+  writeFixtureWebToken,
   type FixturePaths,
   type FixturePorts,
 } from "../../kobe/scripts/fixture-core.ts"
@@ -46,6 +48,10 @@ const VISUAL_TODAY = "2026-07-15"
  *  hosts reached. Deliberately absent from production and the interactive
  *  `dev:sandbox`, where a long-lived host is somebody's live environment. */
 const VISUAL_PTY_MAX_LIFETIME_MS = String(30 * 60 * 1000)
+
+/** Re-exported so the capture scripts reach the fixture's PTY sidecar (now
+ *  token-gated) through the same module that owns its ports. */
+export { fixtureAuthHeaders }
 
 export const VISUAL_ENV = buildFixtureEnv({
   root: VISUAL_ROOT,
@@ -192,7 +198,7 @@ export async function cleanupVisualFixture(): Promise<void> {
   // reset -- leaking a detached daemon whose home we are about to delete.
   await fetch(`http://127.0.0.1:${VISUAL_PTY_PORT}/pty/close`, {
     method: "POST",
-    headers: { "content-type": "application/json" },
+    headers: { "content-type": "application/json", ...fixtureAuthHeaders() },
     body: JSON.stringify({ tab: `visual-${VISUAL_RUN_ID}` }),
   }).catch(() => {})
   await new Promise((resolve) => setTimeout(resolve, 500))
@@ -246,6 +252,8 @@ export default async function setupVisualFixture(): Promise<void> {
     ),
   )
   await chmod(XDG_RUNTIME_DIR, 0o700)
+  // Before the first command that can start the fixture daemon.
+  await writeFixtureWebToken(VISUAL_HOME)
   await seedStartupState()
 
   await seedGitRepo(

--- a/packages/kobe-web/e2e/visual-shot.ts
+++ b/packages/kobe-web/e2e/visual-shot.ts
@@ -20,7 +20,7 @@
 
 import { resolve } from "node:path"
 import { chromium } from "@playwright/test"
-import { VISUAL_PTY_PORT, VISUAL_WEB_PORT } from "./visual-fixture.ts"
+import { fixtureAuthHeaders, VISUAL_PTY_PORT, VISUAL_WEB_PORT } from "./visual-fixture.ts"
 
 const KEY_NAMES: Record<string, string> = {
   enter: "Enter",
@@ -137,7 +137,7 @@ try {
   await page.waitForTimeout(600)
   await page.screenshot({ path: out })
   await page.request
-    .post(`http://127.0.0.1:${VISUAL_PTY_PORT}/pty/close`, { data: { tab: `visual-${runId}` } })
+    .post(`http://127.0.0.1:${VISUAL_PTY_PORT}/pty/close`, { data: { tab: `visual-${runId}` }, headers: fixtureAuthHeaders() })
     .catch(() => {})
   console.log(out)
 } finally {

--- a/packages/kobe-web/pty-auth.mjs
+++ b/packages/kobe-web/pty-auth.mjs
@@ -1,0 +1,93 @@
+/**
+ * Bearer-token gate for the PTY sidecar.
+ *
+ * Every other browser-facing route already requires the web token: REST goes
+ * through `withWebToken` and the SSE stream through `withWebTokenQuery`. The
+ * PTY routes never adopted it, and they are the ones that spawn a shell in the
+ * worktree — so their only gate was the Origin check, which passes for a
+ * request with NO Origin (any local process) and for ANY loopback Origin (any
+ * other page the user has open on localhost). Origin answers "which page is
+ * asking"; the token answers "is this caller entitled at all". Both apply.
+ *
+ * The expected value is the same 0600 file the daemon mints
+ * (`kobe-daemon/daemon/web-token.ts` + `defaultWebTokenPath`), read here
+ * directly rather than passed down from whoever spawned this process: the
+ * sidecar is started from four places (`rove web`, `dev.ts`, Playwright, by
+ * hand), and a launcher that forgot to forward the secret would silently
+ * reopen the hole. The path logic is duplicated instead of imported because
+ * this file runs under node — node-pty does not work under bun — and the
+ * daemon's path module is TypeScript.
+ *
+ * Fail closed: no readable token file means no request is served. That cannot
+ * strand a working install, because the daemon mints the file before the
+ * sidecar has anything to talk to.
+ */
+
+import { timingSafeEqual } from "node:crypto"
+import { existsSync, readFileSync } from "node:fs"
+import { homedir } from "node:os"
+import { join } from "node:path"
+
+const STATE_DIR = ".rove"
+const LEGACY_STATE_DIR = ".kobe"
+const TOKEN_FILE = "web-token"
+
+/** `<home>/.rove/web-token`, falling back to the legacy `.kobe` layout only
+ *  when that is where the file actually is — mirrors `runtimeDataPath`. */
+export function webTokenPath(env = process.env) {
+  const home = env.ROVE_HOME_DIR ?? env.KOBE_HOME_DIR ?? homedir()
+  const canonical = join(home, STATE_DIR, TOKEN_FILE)
+  if (existsSync(canonical)) return canonical
+  const legacy = join(home, LEGACY_STATE_DIR, TOKEN_FILE)
+  return existsSync(legacy) ? legacy : canonical
+}
+
+let cached = ""
+
+/**
+ * The token this sidecar requires.
+ *
+ * Read lazily and cached once non-empty: the sidecar and the daemon come up
+ * concurrently, so the file may not exist yet on the first request, and a
+ * one-shot read at startup would then wedge the gate shut for the whole
+ * process lifetime.
+ */
+export function expectedPtyToken(env = process.env) {
+  if (cached) return cached
+  try {
+    cached = readFileSync(webTokenPath(env), "utf8").trim()
+  } catch {
+    /* absent or unreadable — stay empty and refuse */
+  }
+  return cached
+}
+
+/** The token a request presents: `Authorization: Bearer …`, or `?token=` for
+ *  the WebSocket, which cannot set a request header. */
+export function presentedPtyToken(headers, url) {
+  const header = headers?.authorization
+  if (typeof header === "string") {
+    const match = /^Bearer\s+(.+)$/i.exec(header.trim())
+    if (match) return match[1].trim()
+  }
+  return url?.searchParams?.get("token") ?? null
+}
+
+/** Constant-time compare, so a wrong token leaks no prefix through timing. */
+export function ptyTokenAccepted(presented, expected) {
+  if (!presented || !expected) return false
+  const a = Buffer.from(presented)
+  const b = Buffer.from(expected)
+  // timingSafeEqual throws on a length mismatch, and length is not a secret.
+  return a.length === b.length && timingSafeEqual(a, b)
+}
+
+/** The whole gate for one request. */
+export function ptyRequestAuthorized(headers, url, env = process.env) {
+  return ptyTokenAccepted(presentedPtyToken(headers, url), expectedPtyToken(env))
+}
+
+/** Test seam: drop the memoized token so a case can point at another home. */
+export function resetPtyTokenCache() {
+  cached = ""
+}

--- a/packages/kobe-web/pty-server.mjs
+++ b/packages/kobe-web/pty-server.mjs
@@ -17,6 +17,7 @@ import { createServer } from "node:http"
 import { spawn } from "node-pty"
 import { WebSocketServer } from "ws"
 import { allowedHostForBindHost, originAllowed } from "./origin-policy.mjs"
+import { expectedPtyToken, ptyRequestAuthorized } from "./pty-auth.mjs"
 import { ptyEnv } from "./pty-env.mjs"
 import { createScrollback } from "./pty-scrollback.mjs"
 import { createPtySessionManager } from "./pty-session-lifecycle.mjs"
@@ -40,7 +41,13 @@ async function fetchSpec(taskId, mode) {
     }
   }
   const path = mode === "shell" ? "/api/terminal-spec" : "/api/engine-spec"
-  const res = await fetch(`http://localhost:${DAEMON_WEB_PORT}${path}?taskId=${encodeURIComponent(taskId)}`)
+  // `/api/*` on the daemon requires the bearer token like every other caller
+  // does; without it a real tab dies at "unauthorized: this request carried no
+  // valid web token" before any PTY is spawned.
+  const token = expectedPtyToken()
+  const res = await fetch(`http://localhost:${DAEMON_WEB_PORT}${path}?taskId=${encodeURIComponent(taskId)}`, {
+    headers: token ? { authorization: `Bearer ${token}` } : {},
+  })
   const json = await res.json()
   if (!res.ok || json.error) throw new Error(json.error ?? `engine-spec failed (${res.status})`)
   return json // { cwd, command: string[], firstMessage?: string }
@@ -53,6 +60,17 @@ const ptySessions = createPtySessionManager({
   scrollbackCap: SCROLLBACK_CAP,
   env: ptyEnv,
 })
+
+/**
+ * The gate every PTY route shares. Origin says which page is asking, the token
+ * says whether the caller is entitled at all — and the token is the one that
+ * stops a non-browser process, which sends no Origin. Returns the status to
+ * refuse with, or null to proceed.
+ */
+function ptyRouteDenial(req, url) {
+  if (!originAllowed(req.headers.origin, { allowedHost: ALLOWED_HOST })) return 403
+  return ptyRequestAuthorized(req.headers, url) ? null : 401
+}
 
 const server = createServer((req, res) => {
   const url = new URL(req.url ?? "/", "http://localhost")
@@ -71,11 +89,11 @@ const server = createServer((req, res) => {
     return
   }
   if (req.method === "POST" && url.pathname === "/pty/send") {
-    // Sending text DRIVES the engine like a keyboard, so unlike /pty/close
-    // (best-effort kill) this holds the same origin policy as the WS attach:
-    // localhost pages or non-browser clients only.
-    if (!originAllowed(req.headers.origin, { allowedHost: ALLOWED_HOST })) {
-      res.writeHead(403)
+    // Sending text DRIVES the engine like a keyboard, so this holds the same
+    // gate as the WS attach — the bearer token, plus the origin check.
+    const denial = ptyRouteDenial(req, url)
+    if (denial) {
+      res.writeHead(denial)
       res.end()
       return
     }
@@ -125,12 +143,12 @@ const server = createServer((req, res) => {
     return
   }
   if (req.method === "POST" && url.pathname === "/pty/close") {
-    // Killing a tab is a side effect a cross-origin local page could abuse to
-    // DoS the session (tab ids are client-generated/observable), so hold the
-    // same origin policy as /pty/send and the WS attach: localhost pages or
-    // non-browser clients (no Origin) only.
-    if (!originAllowed(req.headers.origin, { allowedHost: ALLOWED_HOST })) {
-      res.writeHead(403)
+    // Killing a tab is a side effect any caller that reached this port could
+    // abuse to DoS the session (tab ids are client-generated/observable), so
+    // hold the same gate as /pty/send and the WS attach.
+    const denial = ptyRouteDenial(req, url)
+    if (denial) {
+      res.writeHead(denial)
       res.end()
       return
     }
@@ -158,15 +176,18 @@ const server = createServer((req, res) => {
   res.end()
 })
 
-// A PTY WS is arbitrary command exec in the worktree, so reject cross-origin
-// upgrades: a browser sends an Origin header, and only loopback pages (or the
-// deliberately configured LAN host) may attach. This defends a malicious local
-// page / DNS-rebinding even on the loopback bind. Non-browser clients (no
-// Origin) are allowed — there's no browser to forge their request.
+// A PTY WS is arbitrary command exec in the worktree, so it takes both checks.
+// The origin check rejects cross-origin upgrades, which defends a malicious
+// local page / DNS-rebinding even on the loopback bind; it cannot defend
+// anything against a client that simply sends no Origin, which is why the
+// bearer token — the same one every REST and SSE caller presents — decides.
+// `ws` refuses a false verifyClient with HTTP 401.
 const wss = new WebSocketServer({
   server,
   path: "/pty",
-  verifyClient: ({ origin }) => originAllowed(origin, { allowedHost: ALLOWED_HOST }),
+  verifyClient: ({ origin, req }) =>
+    originAllowed(origin, { allowedHost: ALLOWED_HOST }) &&
+    ptyRequestAuthorized(req.headers, new URL(req.url ?? "/", "http://localhost")),
 })
 
 wss.on("connection", (ws, req) => {

--- a/packages/kobe-web/src/lib/terminal.ts
+++ b/packages/kobe-web/src/lib/terminal.ts
@@ -7,6 +7,7 @@
 
 import { ROVE_PRODUCT_NAME } from "@sma1lboy/kobe-daemon/compat-env"
 import { ApiError, api } from "./api-client.ts"
+import { withWebTokenQuery } from "./web-token.ts"
 
 export type PtyMode = "engine" | "shell"
 
@@ -35,7 +36,10 @@ export function ptyUrl(
     cols: String(cols),
     rows: String(rows),
   })
-  return `${ptyBase("ws")}/pty?${q.toString()}`
+  // A WebSocket cannot set a request header, so the token rides the query the
+  // same way the SSE stream's does. Without it the sidecar refuses the upgrade
+  // — this route spawns a shell, and it is the one route the token missed.
+  return withWebTokenQuery(`${ptyBase("ws")}/pty?${q.toString()}`)
 }
 
 /** Kill a tab's engine process server-side (when the user closes the tab). */

--- a/packages/kobe-web/test/pty-auth.test.ts
+++ b/packages/kobe-web/test/pty-auth.test.ts
@@ -1,0 +1,109 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, describe, expect, it } from "vitest"
+import {
+  expectedPtyToken,
+  presentedPtyToken,
+  ptyRequestAuthorized,
+  ptyTokenAccepted,
+  resetPtyTokenCache,
+  webTokenPath,
+} from "../pty-auth.mjs"
+
+/**
+ * The PTY routes spawn a shell in the worktree, so their gate is the one that
+ * has to fail closed. These cases pin the two properties that matter: an
+ * unauthenticated caller is refused even when it looks like a browser, and the
+ * expected value comes from the same 0600 file the daemon writes.
+ */
+
+function homeWithToken(token: string | null, dir = ".rove"): string {
+  const home = mkdtempSync(join(tmpdir(), "pty-auth-"))
+  if (token !== null) {
+    mkdirSync(join(home, dir), { recursive: true })
+    writeFileSync(join(home, dir, "web-token"), token)
+  }
+  return home
+}
+
+afterEach(() => resetPtyTokenCache())
+
+describe("presentedPtyToken", () => {
+  const url = (search: string) => new URL(`http://localhost/pty${search}`)
+
+  it("reads a bearer header case-insensitively", () => {
+    expect(presentedPtyToken({ authorization: "Bearer tok-1" }, url(""))).toBe("tok-1")
+    expect(presentedPtyToken({ authorization: "bearer  tok-2  " }, url(""))).toBe("tok-2")
+  })
+
+  it("falls back to ?token= — the only channel a WebSocket upgrade has", () => {
+    expect(presentedPtyToken({}, url("?token=tok-ws"))).toBe("tok-ws")
+  })
+
+  it("is null when neither channel carries one", () => {
+    expect(presentedPtyToken({}, url("?tab=t1"))).toBeNull()
+    expect(presentedPtyToken({ authorization: "Basic abc" }, url(""))).toBeNull()
+  })
+})
+
+describe("ptyTokenAccepted", () => {
+  it("accepts only an exact match", () => {
+    expect(ptyTokenAccepted("tok", "tok")).toBe(true)
+    expect(ptyTokenAccepted("tok", "tuk")).toBe(false)
+    expect(ptyTokenAccepted("to", "tok")).toBe(false)
+    expect(ptyTokenAccepted("tokk", "tok")).toBe(false)
+  })
+
+  it("refuses an absent token on either side rather than matching empty to empty", () => {
+    expect(ptyTokenAccepted(null, "tok")).toBe(false)
+    expect(ptyTokenAccepted("", "")).toBe(false)
+    expect(ptyTokenAccepted("tok", "")).toBe(false)
+  })
+})
+
+describe("expectedPtyToken", () => {
+  it("reads the daemon's token file under the resolved home", () => {
+    const home = homeWithToken("file-token\n")
+    expect(webTokenPath({ ROVE_HOME_DIR: home })).toBe(join(home, ".rove", "web-token"))
+    expect(expectedPtyToken({ ROVE_HOME_DIR: home })).toBe("file-token")
+  })
+
+  it("honours the legacy .kobe layout only when the file is actually there", () => {
+    const legacy = homeWithToken("legacy-token", ".kobe")
+    expect(webTokenPath({ KOBE_HOME_DIR: legacy })).toBe(join(legacy, ".kobe", "web-token"))
+    expect(expectedPtyToken({ KOBE_HOME_DIR: legacy })).toBe("legacy-token")
+  })
+
+  it("stays empty when no token file exists, so every request is refused", () => {
+    const bare = homeWithToken(null)
+    expect(expectedPtyToken({ ROVE_HOME_DIR: bare })).toBe("")
+    expect(ptyRequestAuthorized({ authorization: "Bearer anything" }, new URL("http://localhost/pty"), { ROVE_HOME_DIR: bare })).toBe(false)
+  })
+})
+
+describe("ptyRequestAuthorized", () => {
+  it("admits a caller presenting the file's token through either channel", () => {
+    const home = homeWithToken("live-token")
+    const env = { ROVE_HOME_DIR: home }
+    expect(ptyRequestAuthorized({ authorization: "Bearer live-token" }, new URL("http://localhost/pty/send"), env)).toBe(true)
+    resetPtyTokenCache()
+    expect(ptyRequestAuthorized({}, new URL("http://localhost/pty?token=live-token"), env)).toBe(true)
+  })
+
+  it("refuses the tokenless and wrong-token callers the origin check let through", () => {
+    const home = homeWithToken("live-token")
+    const env = { ROVE_HOME_DIR: home }
+    // No Origin at all — a non-browser process, which `originAllowed` admits.
+    expect(ptyRequestAuthorized({}, new URL("http://localhost/pty?tab=t1&taskId=k1"), env)).toBe(false)
+    resetPtyTokenCache()
+    // A page on another loopback port, which `originAllowed` also admits.
+    expect(
+      ptyRequestAuthorized(
+        { origin: "http://localhost:3000", authorization: "Bearer guessed" },
+        new URL("http://localhost/pty"),
+        env,
+      ),
+    ).toBe(false)
+  })
+})

--- a/packages/kobe-web/test/pty-url.test.ts
+++ b/packages/kobe-web/test/pty-url.test.ts
@@ -42,6 +42,18 @@ describe("ptyUrl", () => {
     expect(q.get("rows")).toBe("30")
   })
 
+  // The sidecar refuses an upgrade that carries no token, and a WebSocket
+  // cannot set a request header — so the query is the only channel this URL
+  // has. `web-token.ts` memoizes on first read, hence the fresh registry.
+  it("carries the web token", async () => {
+    vi.resetModules()
+    vi.stubEnv("VITE_ROVE_WEB_TOKEN", "tok pty")
+    withLocation({ port: "5173" })
+    const { ptyUrl: fresh } = await import("../src/lib/terminal.ts")
+    expect(new URL(fresh("t", "k", "shell", 80, 24)).searchParams.get("token")).toBe("tok pty")
+    vi.unstubAllEnvs()
+  })
+
   it("falls back to 5175 when the port is unparseable", () => {
     withLocation({ port: "" })
     // empty port → defaults to 5173 → +2 = 5175

--- a/packages/kobe/scripts/fixture-core.ts
+++ b/packages/kobe/scripts/fixture-core.ts
@@ -149,6 +149,35 @@ function scrubFixtureEnv(parent: NodeJS.ProcessEnv): Record<string, string> {
 }
 
 /**
+ * Bearer token for a fixture's daemon web transport and PTY sidecar.
+ *
+ * Every browser-facing route — REST, SSE, and now the PTY WebSocket that
+ * spawns the harness TUI — requires the web token. Fixtures pin it instead of
+ * letting the daemon mint one so the participants agree without ordering
+ * games: setup writes the file before the daemon starts (`ensureWebToken`
+ * reuses an existing one), Vite hands the same value to the browser through
+ * `VITE_ROVE_WEB_TOKEN` because Vite, not the daemon, serves the SPA in these
+ * stacks, and teardown can still reach `/pty/close` on a gated sidecar.
+ *
+ * Safe to hard-code: a fixture home is a throwaway under `.scratch/`,
+ * loopback-bound, and deleted at teardown. Production mints 32 random bytes.
+ */
+export const FIXTURE_WEB_TOKEN = "rove-fixture-web-token"
+
+/** `Authorization` for a fixture's own PTY-sidecar calls (teardown closes). */
+export function fixtureAuthHeaders(): Record<string, string> {
+  return { authorization: `Bearer ${FIXTURE_WEB_TOKEN}` }
+}
+
+/** Pin the fixture home's web token. Call before anything can start its
+ *  daemon — `ensureWebToken` only mints when the file is absent. */
+export async function writeFixtureWebToken(home: string): Promise<void> {
+  const dir = join(home, ".rove")
+  await mkdir(dir, { recursive: true })
+  await writeFile(join(dir, "web-token"), FIXTURE_WEB_TOKEN, { mode: 0o600 })
+}
+
+/**
  * Build a fixture child environment whose isolation invariants beat any
  * inherited production override. Both namespaces are stamped so a compatibility
  * alias can never outrank the fixture's own paths.
@@ -187,6 +216,10 @@ export function buildFixtureEnv(config: FixtureEnvConfig): Record<string, string
   setRoveEnv("PTY_SOCKET_PATH", join(runtime, "pty.sock"), env)
   setRoveEnv("DAEMON_PID_PATH", join(runtime, "daemon.pid"), env)
   setRoveEnv("PTY_PID_PATH", join(runtime, "pty.pid"), env)
+
+  // Vite serves the SPA in every fixture stack, so the daemon never injects its
+  // <meta> tag; this is the browser's only channel to the token.
+  env.VITE_ROVE_WEB_TOKEN = FIXTURE_WEB_TOKEN
 
   if (config.extra) Object.assign(env, config.extra)
   return env


### PR DESCRIPTION
## M1 — the PTY WebSocket was the one route the web token did not gate, and it is the one that executes commands

**PASS criterion:** a transcript against a `rove web` on an isolated home — BEFORE a tokenless upgrade connects and `/pty/send` accepts a body; AFTER both are refused (401) and the same requests with the token succeed. Plus a browser screenshot of `/task/<id>` showing a live terminal before and after.

### What changed

- **`packages/kobe-web/pty-auth.mjs`** (new) — the gate. Reads the same `0600` token file the daemon mints (`<home>/.rove/web-token`, legacy `.kobe` fallback) rather than taking the secret from whoever spawned the sidecar; it starts from four places (`rove web`, `dev.ts`, Playwright, by hand) and a launcher that forgot to forward it would silently reopen the hole. Constant-time compare, fail closed.
- **`pty-server.mjs`** — `ws /pty`, `POST /pty/send`, `POST /pty/close` all require the token (`ws` refuses a rejected upgrade with 401). Origin check kept as defence in depth. `fetchSpec` now presents the token on its own `/api/*` hop to the daemon.
- **`src/lib/terminal.ts`** — `ptyUrl` goes through `withWebTokenQuery`, the same channel the `/events` SSE stream uses (a WebSocket cannot set a request header).
- **`dev.ts` / `fixture-core.ts` / e2e fixtures** — Vite, not the daemon, serves the SPA in the dev and capture stacks, so the `<meta>` tag never appears there; `VITE_ROVE_WEB_TOKEN` is the browser's channel. `dev.ts` sets it from the token file; the visual/hero fixtures pin `FIXTURE_WEB_TOKEN` written before their daemon starts, and their teardown `/pty/close` calls now carry it.

### Proof — live isolated `rove web` (not read-verified)

Isolated home `/tmp/m1-pty/home`, `rove web --port 45874`, sidecar on 45876, every inherited control (`KOBE_DAEMON_SOCKET_PATH`, `ROVE_INVOKED_AS`, …) unset.

**BEFORE** (`b1c5519ef`, main):

```
ws  attach   (no token)     : CONNECTED, output="[?1034hprobe$ "
POST /pty/send  (no token)  : HTTP 200 {"sent":true,"spawned":false}
POST /pty/close (no token)  : HTTP 200 {"closed":true}
ws  attach   (wrong token)  : CONNECTED, output="[?1034hprobe$ "
```

A tokenless upgrade returns a live shell prompt, a tokenless `/pty/send` types into it, a tokenless `/pty/close` kills it, and a *wrong* token works just as well.

**AFTER** (this branch):

```
ws  attach   (no token)     : REFUSED http 401
POST /pty/send  (no token)  : HTTP 401
POST /pty/close (no token)  : HTTP 401
ws  attach   (token=…)      : CONNECTED, output="[?1034hprobe$ "
POST /pty/send  (bearer)    : HTTP 200 {"sent":true,"spawned":true}
POST /pty/close (bearer)    : HTTP 200 {"closed":true}
ws  attach   (wrong token)  : REFUSED http 401
```

Full transcripts: `/Users/jacksonc/i/kobe/.scratch/m1-pty/before.txt` and `after.txt`.

### Proof — the browser (Playwright, `/task/<id>` on the real dashboard)

Same isolated stack, entry navigation carrying `?token=` exactly as `rove web` prints it, then the in-app route change, then a shell tab opened in the task worktree.

- BEFORE — `/Users/jacksonc/i/kobe/.scratch/m1-pty/before.png`: the terminal reads **`failed to start shell: unauthorized: this request carried no valid web token`** followed by `[detached: spawn failed — reattach below]`.
- AFTER — `/Users/jacksonc/i/kobe/.scratch/m1-pty/after.png`: a live prompt, `jacksonc@Jacksons-MacBook-Pro avocet %`, in the task's own worktree.

### A regression this uncovered

The web terminal has been **dead since 0.9.60**, not merely ungated. The sidecar fetches each tab's launch spec from the daemon's `/api/terminal-spec` / `/api/engine-spec`; that route began requiring the token in 0.9.60 (#692) and the sidecar was never taught to send one. Verified directly against the isolated daemon:

```
$ curl -s -o /dev/null -w "%{http_code}\n" "http://127.0.0.1:45874/api/terminal-spec?taskId=nope"
401
$ curl -s -H "authorization: Bearer $TOK" "http://127.0.0.1:45874/api/terminal-spec?taskId=nope"
{"error":"task not found: nope"}
```

That is why the BEFORE screenshot shows a broken terminal rather than a working one. The visual harness never caught it because `KOBE_PTY_DEV_COMMAND` short-circuits `fetchSpec` before it reaches the daemon. The fix is the same credential and the same file as the gate, so it ships here; the changeset says so.

### Tests

`test/pty-auth.test.ts` (new, 12 cases) plus one case in `test/pty-url.test.ts`. Mutation-verified — reverting `withWebTokenQuery` in `ptyUrl` and flipping `ptyTokenAccepted`'s fail-closed guard turns 4 of them red:

```
FAIL test/pty-auth.test.ts > ptyTokenAccepted > refuses an absent token on either side …
FAIL test/pty-auth.test.ts > expectedPtyToken > stays empty when no token file exists …
FAIL test/pty-auth.test.ts > ptyRequestAuthorized > refuses the tokenless and wrong-token callers …
FAIL test/pty-url.test.ts  > ptyUrl > carries the web token
Tests  4 failed | 11 passed (15)
```

### Gates

| gate | result |
|---|---|
| repo-root `bun run lint` | pass (1397 files) |
| repo-root `bun run typecheck` | pass |
| `bun run test:fast` | 4336 passed, 6 pre-existing failures (below) |
| `bun test test/render` | 455 pass, 0 fail |
| `KOBE_INCLUDE_SOCKET=1 bun run test:socket` | 789 passed (94 files) |
| `packages/kobe-web` `bun run test` | 589 passed (73 files) |

The 6 `test:fast` failures are not from this branch. Measured on a clean `origin/main` worktree under `~/i`:

- `test/cli/open-dir-cmd.test.ts` (2) and `test/state/project-eligibility.test.ts` (2) **pass** there — they fail here only because this worktree lives under `~/.rove/worktrees`, whose path shape those tests classify as rove-internal.
- `test/tui/continue-live-vendor.test.ts` (2) **fails on pristine `origin/main` too** — pre-existing red on main, unrelated to this change.

### Not proven

The hero/atlas capture stacks received the same token plumbing by inspection; I ran neither, since they need real engine credentials. The visual fixture path uses the same code.
