### PR TITLE
fix: pre-trust a Rove worktree for copilot

### DIFF
--- a/.changeset/copilot-worktree-pre-trust.md
+++ b/.changeset/copilot-worktree-pre-trust.md
@@ -1,0 +1,24 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Pre-trust a Rove worktree for Copilot, so a copilot task reaches its prompt
+instead of a dialog nobody can answer.
+
+Claude, Codex and Kimi each got a `trustWorktree` hook; Copilot never did, and
+nothing recorded whether that was a decision or an omission. It was an
+omission. Copilot CLI gates a first launch in a never-seen directory behind
+"Confirm folder trust", and a Rove-created worktree is always such a directory,
+so a hosted copilot session sat at the dialog. Worse than the other three: its
+cursor sits on "1. Yes", which grants trust for that session only — so even a
+human answering it is asked again on every relaunch.
+
+Rove now writes the path into `trustedFolders` in Copilot's own
+`<COPILOT_HOME>/config.json`, the same list its "remember this folder" answer
+writes, merging into existing entries and preserving the JSONC header Copilot
+puts at the top of that file. Verified against Copilot CLI v1.0.82: the dialog
+appears in a fresh worktree, and after the pre-trust write the same worktree
+launches straight to the prompt.
+
+A registry-level test now fails if any builtin engine ships without a
+`trustWorktree` hook, so the next engine added cannot omit it in silence.

--- a/docs/ENGINES.md
+++ b/docs/ENGINES.md
@@ -85,16 +85,23 @@ one.
 
 ### Workspace trust
 
-Claude, Codex, and Kimi each gate a first launch in a never-seen directory
-behind a trust dialog, and every task worktree is such a directory, so a
-hosted session can't answer it (Kimi's dialog even exits the process when a
-pasted first message lands on "Don't trust"). Before spawning an engine into
-a Rove-created worktree, Rove writes the vendor's own trust record for that
-path (`~/.claude.json` `projects[<path>].hasTrustDialogAccepted`,
-`~/.codex/config.toml` `[projects."<path>"] trust_level = "trusted"`, or
-`~/.kimi-code/workspace-trust/`), merging into existing entries, never
-clobbering. This only ever fires for worktrees Rove itself created from a
-repo you already work in; your own directories are untouched.
+All four builtin engines gate a first launch in a never-seen directory behind
+a trust dialog, and every task worktree is such a directory, so a hosted
+session can't answer it (Kimi's dialog even exits the process when a pasted
+first message lands on "Don't trust"; Copilot's cursor sits on a
+session-only "Yes", so it returns every launch). Before spawning an engine
+into a Rove-created worktree, Rove writes that vendor's own trust record for
+the path, merging into existing entries, never clobbering:
+
+| Engine | Trust record |
+| --- | --- |
+| Claude | `~/.claude.json` → `projects[<path>].hasTrustDialogAccepted` |
+| Codex | `~/.codex/config.toml` → `[projects."<path>"] trust_level = "trusted"` |
+| Copilot | `~/.copilot/config.json` → `trustedFolders` |
+| Kimi | `~/.kimi-code/workspace-trust/<record>` |
+
+This only ever fires for worktrees Rove itself created from a repo you already
+work in; your own directories are untouched.
 
 ### Custom launch commands
 

--- a/packages/kobe/src/engine/builtin-engines.ts
+++ b/packages/kobe/src/engine/builtin-engines.ts
@@ -38,6 +38,7 @@ import { CODEX_SCREEN_MANIFEST } from "./codex-local/screen.ts"
 import { codexSessionIdFromTitle } from "./codex-local/terminal-title.ts"
 import { trustCodexWorktree } from "./codex-local/trust.ts"
 import { COPILOT_SCREEN_MANIFEST } from "./copilot-local/screen.ts"
+import { trustCopilotWorktree } from "./copilot-local/trust.ts"
 import {
   EMPTY_HISTORY,
   claudeHistoryReader,
@@ -167,6 +168,7 @@ export const BUILTIN_ENGINES: Record<"claude" | "codex" | "copilot" | "kimi", En
     createHookAdapter: () => new NoopHookAdapter("copilot"),
     // Copilot persists no turn-completion marker kobe can read yet.
     createTurnDetector: () => new UnknownTurnDetector("copilot"),
+    trustWorktree: trustCopilotWorktree,
     screenManifest: COPILOT_SCREEN_MANIFEST,
   },
   kimi: {

--- a/packages/kobe/src/engine/copilot-local/trust.ts
+++ b/packages/kobe/src/engine/copilot-local/trust.ts
@@ -1,0 +1,71 @@
+/**
+ * Copilot CLI workspace trust. Copilot gates a first launch in a never-seen
+ * directory behind a "Confirm folder trust" dialog whose cursor sits on
+ * "1. Yes" — session-only, so it comes back every launch — with
+ * "2. Yes, and remember this folder for future sessions" one row below. A
+ * hosted session can answer neither, so a Rove worktree without pre-trust sits
+ * at the dialog. Rove created that worktree from a repo the user already runs
+ * sessions in; pre-accepting is the same trust domain and the only
+ * headless-viable answer, exactly as for claude/codex/kimi.
+ *
+ * The store is `<COPILOT_HOME>/config.json` (default `~/.copilot/config.json`)
+ * → `trustedFolders`, an array of absolute paths. Verified against Copilot CLI
+ * v1.0.82: answering "remember this folder" appends the path there, and a
+ * pre-written entry boots straight to the prompt with no dialog.
+ *
+ * Two wrinkles the siblings do not have:
+ *
+ *   - The file is JSONC. Copilot writes a two-line `//` header ("User settings
+ *     belong in settings.json. / This file is managed automatically."), so a
+ *     plain `JSON.parse` throws on a config copilot itself wrote. The header is
+ *     stripped to parse and replayed verbatim on write, so the note copilot
+ *     puts there for the user survives our merge.
+ *   - Copilot rewrites the whole document on its own saves, which is the same
+ *     race `~/.claude.json` has — hence `updateSharedJsonSync`. Read that
+ *     module's doc before changing this write.
+ */
+
+import { homedir } from "node:os"
+import { updateSharedJsonSync } from "../shared-config-write.ts"
+import { copilotConfigPath } from "../vendor-home.ts"
+
+/** Leading `//` lines (and blanks) copilot puts above the JSON body. Only the
+ *  header is treated as comments — `//` inside the body would be inside a
+ *  string, where stripping it would corrupt a path. */
+function splitJsoncHeader(raw: string): { header: string; body: string } {
+  const lines = raw.split("\n")
+  let i = 0
+  while (i < lines.length && (lines[i].trim().startsWith("//") || lines[i].trim() === "")) i++
+  return { header: lines.slice(0, i).join("\n"), body: lines.slice(i).join("\n") }
+}
+
+export function trustCopilotWorktree(worktreePath: string, home: string = homedir()): void {
+  // Carried from load to build so the JSON we emit stays JSONC-shaped the way
+  // copilot wrote it. Per call, not module-level: a retry re-runs load first,
+  // so the header always matches the bytes this attempt is merging onto.
+  let carriedHeader = ""
+  updateSharedJsonSync(
+    copilotConfigPath((name) => process.env[name], home),
+    (raw) => {
+      carriedHeader = ""
+      if (raw === undefined) return {}
+      const { header, body } = splitJsoncHeader(raw)
+      carriedHeader = header
+      try {
+        return JSON.parse(body) as Record<string, unknown>
+      } catch {
+        // Corrupt — start from an empty doc, as claude's trust does. Copilot
+        // rewrites this file wholesale on every save, so it recovers the same
+        // way.
+        return {}
+      }
+    },
+    (doc) => {
+      const existing = Array.isArray(doc.trustedFolders) ? (doc.trustedFolders as unknown[]) : []
+      if (existing.some((entry) => entry === worktreePath)) return undefined
+      const merged = { ...doc, trustedFolders: [...existing, worktreePath] }
+      const body = JSON.stringify(merged, null, 2)
+      return carriedHeader ? `${carriedHeader}\n${body}\n` : `${body}\n`
+    },
+  )
+}

--- a/packages/kobe/src/engine/trust-worktree.ts
+++ b/packages/kobe/src/engine/trust-worktree.ts
@@ -3,7 +3,8 @@
  * a directory the engine has never seen, and every vendor gates that behind
  * a first-run trust dialog a hosted session cannot answer — kimi's dialog
  * even EXITS the process when the pasted first message's Enter lands on
- * "Don't trust"; claude/codex sit at the prompt forever. The vendor-specific
+ * "Don't trust"; claude/codex/copilot sit at the prompt forever. The
+ * vendor-specific
  * store writes live behind the registry's `trustWorktree` hook; THIS wrapper
  * owns the call policy every spawn path shares: best-effort, never blocks a
  * launch (a failed write just leaves the dialog in the user's way).

--- a/packages/kobe/test/engine/trust-worktree.test.ts
+++ b/packages/kobe/test/engine/trust-worktree.test.ts
@@ -13,7 +13,13 @@ import path from "node:path"
 import { afterEach, describe, expect, it } from "vitest"
 import { trustClaudeWorktree } from "../../src/engine/claude-code-local/trust.ts"
 import { trustCodexWorktree } from "../../src/engine/codex-local/trust.ts"
+import { trustCopilotWorktree } from "../../src/engine/copilot-local/trust.ts"
 import { kimiTrustFilePath, trustKimiWorktree } from "../../src/engine/kimi-local/trust.ts"
+// Static, and deliberately: `registry.ts` and `builtin-engines.ts` form an
+// import cycle, and registry reads BUILTIN_ENGINES at module init. Entering
+// that cycle through builtin-engines resolves it to undefined and throws;
+// entering through registry initializes both. See the guard below.
+import "../../src/engine/registry.ts"
 
 const tempDirs: string[] = []
 
@@ -192,4 +198,69 @@ describe("trustCodexWorktree", () => {
     expect(text.split(`[projects.${JSON.stringify(WORKTREE)}]`)).toHaveLength(2)
     expect(fs.existsSync(path.join(home, ".codex", "config.toml.rove.lock"))).toBe(false)
   }, 30_000)
+})
+
+describe("trustCopilotWorktree", () => {
+  const configOf = (home: string) => path.join(home, ".copilot", "config.json")
+
+  it("appends to trustedFolders, preserving other keys and copilot's JSONC header", () => {
+    const home = tempHome()
+    fs.mkdirSync(path.join(home, ".copilot"), { recursive: true })
+    // Byte-for-byte what Copilot CLI v1.0.82 writes: two `//` lines above the
+    // body, which plain JSON.parse chokes on.
+    fs.writeFileSync(
+      configOf(home),
+      `// User settings belong in settings.json.\n// This file is managed automatically.\n${JSON.stringify({ firstLaunchAt: "2026-01-01T00:00:00.000Z", trustedFolders: ["/repo"] }, null, 2)}`,
+    )
+    trustCopilotWorktree(WORKTREE, home)
+    const raw = fs.readFileSync(configOf(home), "utf8")
+    expect(raw.startsWith("// User settings belong in settings.json.")).toBe(true)
+    const doc = JSON.parse(
+      raw
+        .split("\n")
+        .filter((l) => !l.trim().startsWith("//"))
+        .join("\n"),
+    )
+    expect(doc.firstLaunchAt).toBe("2026-01-01T00:00:00.000Z")
+    expect(doc.trustedFolders).toEqual(["/repo", WORKTREE])
+  })
+
+  it("creates the config when absent and never double-appends", () => {
+    const home = tempHome()
+    trustCopilotWorktree(WORKTREE, home)
+    expect(JSON.parse(fs.readFileSync(configOf(home), "utf8")).trustedFolders).toEqual([WORKTREE])
+    const before = fs.readFileSync(configOf(home), "utf8")
+    trustCopilotWorktree(WORKTREE, home)
+    expect(fs.readFileSync(configOf(home), "utf8")).toBe(before)
+  })
+
+  it("treats a corrupt config as empty rather than refusing to trust", () => {
+    const home = tempHome()
+    fs.mkdirSync(path.join(home, ".copilot"), { recursive: true })
+    fs.writeFileSync(configOf(home), "{ not json")
+    trustCopilotWorktree(WORKTREE, home)
+    expect(JSON.parse(fs.readFileSync(configOf(home), "utf8")).trustedFolders).toEqual([WORKTREE])
+  })
+})
+
+/**
+ * The registry-level guard. Every builtin gates a never-seen directory behind a
+ * first-run dialog a hosted session cannot answer, so an entry without
+ * `trustWorktree` launches into that dialog and hangs — which looks like the
+ * engine being slow, not like a missing hook. Copilot shipped that way.
+ *
+ * If a future engine genuinely has no trust gate, do not just delete its name
+ * here: say WHY on the registry entry, then relax this with that reason. The
+ * failure this catches is silence, not the absence itself.
+ */
+describe("BUILTIN_ENGINES trust coverage", () => {
+  it("every builtin engine pre-trusts a Rove worktree", async () => {
+    const { BUILTIN_ENGINES } = await import("../../src/engine/builtin-engines.ts")
+    const missing = Object.entries(BUILTIN_ENGINES)
+      .filter(([, entry]) => typeof entry.trustWorktree !== "function")
+      .map(([vendor]) => vendor)
+    expect(missing, `no trustWorktree hook: ${missing.join(", ")}`).toEqual([])
+    // Guard the guard: an empty registry would satisfy the assertion above.
+    expect(Object.keys(BUILTIN_ENGINES).sort()).toEqual(["claude", "codex", "copilot", "kimi"])
+  })
 })


### PR DESCRIPTION
## M2 — copilot was the only builtin engine with no worktree pre-trust

**PASS criterion (brief):** decide from copilot's own trust mechanism whether a pre-trust write is required. If yes, implement it in the copilot adapter and show a fresh copilot task reaching its prompt instead of a trust dialog. Plus a registry assertion so the next engine cannot omit it silently.

**The answer is yes — it was an omission, not a decision.**

### How I established that

`copilot` is not on this machine's PATH, so I installed Copilot CLI v1.0.82 into a throwaway prefix (`npm install --prefix /tmp/m2-copilot @github/copilot`; nothing global, nothing in the repo) and drove it in a real PTY against an isolated `COPILOT_HOME` and a throwaway git repo.

**A never-seen directory stops at a dialog:**

```
│ Confirm folder trust                                                         │
│ /private/tmp/m2-copilot/repo                                                 │
│ Copilot can read files in this folder and, with your permission, edit them   │
│ or run code and shell commands. It will remember your permissions for the    │
│ rest of this session.                                                        │
│ Do you trust the files in this folder?                                       │
│ ❯ 1. Yes                                                                     │
│   2. Yes, and remember this folder for future sessions                       │
│   3. No (Esc)                                                                │
│ ↑/↓ to navigate · enter to select · esc to cancel                            │
```

Worse than the other three vendors: the cursor's default, "1. Yes", is **session-only** — even a human answering it is asked again on the next launch. Only option 2 persists.

**Where option 2 writes.** Answering it printed `● Folder /private/tmp/m2-copilot/repo has been added to trusted folders.` and the isolated home's `config.json` gained:

```json
// User settings belong in settings.json.
// This file is managed automatically.
{
  "firstLaunchAt": "2026-09-03T16:23:52.399Z",
  "appTipShown": true,
  "reasoningSummariesCleanupDone": true,
  "trustedFolders": [
    "/private/tmp/m2-copilot/repo"
  ]
}
```

Corroborated by the CLI's own help — `copilot help config`: "`trustedFolders`: list of folders where permission to read or execute files has been granted." — and by the read site in its bundle: `tn?.trustedFolders && tn.trustedFolders.some(Be => repoPathsEqual(Be, k))`. (Note: the key is camelCase `trustedFolders`; one secondary source called it `trusted_folders`, which appears zero times in the shipped binary.)

### What changed

- **`src/engine/copilot-local/trust.ts`** (new) — appends the worktree to `trustedFolders` in `<COPILOT_HOME>/config.json` (`copilotConfigPath` already existed). Two wrinkles the siblings do not have, both handled:
  - The file is **JSONC** — copilot writes a two-line `//` header, so a plain `JSON.parse` throws on a config copilot itself wrote. The header is stripped to parse and replayed verbatim on write.
  - Copilot rewrites the whole document on its own saves — the same race `~/.claude.json` has — so the write goes through the existing `updateSharedJsonSync` (lock + compare-and-swap), exactly as claude's trust does.
- **`builtin-engines.ts`** — `trustWorktree: trustCopilotWorktree` on the copilot entry.
- **`trust-worktree.ts` / `docs/ENGINES.md`** — the module doc listed claude/codex as the ones that "sit at the prompt forever"; copilot joins it. ENGINES.md's trust section now carries a four-row table of each vendor's record instead of prose that named three.

### Proof — end to end against the real Copilot CLI

Fresh isolated `COPILOT_HOME`, fresh git repo, banner off.

1. **BEFORE** — launch copilot: the "Confirm folder trust" dialog above.
2. Call **Rove's** writer, nothing else: `COPILOT_HOME=… bun -e 'trustCopilotWorktree(<repo>, <home>)'`. Resulting config.json:

```json
// User settings belong in settings.json.
// This file is managed automatically.
{
  "firstLaunchAt": "2026-09-03T16:27:53.231Z",
  "appTipShown": true,
  "reasoningSummariesCleanupDone": true,
  "trustedFolders": [
    "/private/tmp/m2-copilot/repo3"
  ]
}
```

Header preserved, copilot's own three keys preserved, the path appended.

3. **AFTER** — relaunch copilot in the same folder: boots straight past it. `grep -c "Confirm folder trust"` over the captured screen returns **0**.

**Not a `/harness` screenshot, deliberately.** The visual fixture's home has no copilot credentials and copilot is not on this machine's PATH, so a harness frame would photograph an engine that never starts — a picture that proves nothing. Driving the real Copilot CLI in a PTY is the same observation without the disguise. (See the repo's own note that the fixture cannot photograph engines it has no login for.)

### The registry guard

`test/engine/trust-worktree.test.ts` now asserts every `BUILTIN_ENGINES` entry supplies a `trustWorktree` function, plus a guard-the-guard that the registry still holds all four vendors (an empty registry would otherwise satisfy it). Mutation-verified — deleting the line this PR adds:

```
× BUILTIN_ENGINES trust coverage > every builtin engine pre-trusts a Rove worktree
  → no trustWorktree hook: copilot: expected [ 'copilot' ] to deeply equal []
Tests  1 failed | 13 passed (14)
```

**One deviation from the brief:** it suggested "supplies `trustWorktree` **or** carries an explicit not-required marker". Since the answer turned out to be "copilot needs it", all four builtins now supply one and such a marker would be a field with no users. The test's doc says what to do instead if a future engine genuinely has no trust gate: state the reason on its registry entry, then relax the assertion with that reason. The failure this guards against is silence, not the absence itself.

Three new adapter cases cover the merge (header + existing keys preserved), idempotence, and a corrupt config recovering rather than refusing to trust.

### Gates

| gate | result |
|---|---|
| repo-root `bun run lint` | pass (1398 files) |
| repo-root `bun run typecheck` | pass |
| `bun run test:fast` | 4343 passed, 6 pre-existing failures (same set as #837) |
| `bun test test/render` | 455 pass, 0 fail |
| `KOBE_INCLUDE_SOCKET=1 bun run test:socket` | 789 passed |
| `bun x vitest run test/engine/` | 656 passed (57 files) |

The 6 `test:fast` failures are unrelated and pre-existing: `open-dir-cmd` (2) and `project-eligibility` (2) pass on a clean `origin/main` worktree under `~/i` and only fail here because this worktree lives under `~/.rove/worktrees`; `continue-live-vendor` (2) fails on pristine `origin/main` too.

### Not proven

I did not run a copilot session through Rove itself end to end — that needs a copilot login this machine does not have. What is proven is the two halves that meet: copilot reads `trustedFolders` and skips its dialog when the path is there, and Rove's writer puts the path there without damaging the file.
