### PR TITLE
fix: order PTY death records with a transitive comparator

### DIFF
--- a/.changeset/exit-record-ordering.md
+++ b/.changeset/exit-record-ordering.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Order the durable PTY/engine death records by a proper strict-weak comparator so `rove api inspect` and the retention cap agree on "newest first". Both read sites sorted with a non-transitive `a.at < b.at ? 1 : -1` shorthand that claimed each of two same-instant records preceded the other; a burst of engine deaths the activity observer stamps in one sweep therefore landed in an engine-defined order, and at the 50-record cap which of that tied burst survived was arbitrary. A single shared comparator ties on equal timestamps and keeps the stable order, so the two sites can no longer drift.

--- a/packages/kobe-daemon/src/daemon/pty-exit-store.ts
+++ b/packages/kobe-daemon/src/daemon/pty-exit-store.ts
@@ -87,6 +87,22 @@ export function engineExitCodeFromTail(tail: readonly string[]): number | null {
   return null
 }
 
+/**
+ * Order two records newest-first by ISO exit time. A proper strict-weak
+ * ordering: it returns 0 for equal timestamps, so it stays transitive and
+ * V8's stable sort preserves the caller's input order among ties. The naive
+ * `a.at < b.at ? 1 : -1` shorthand is non-transitive (it claims `a` precedes
+ * `b` AND `b` precedes `a` when both are equal), which leaves same-instant
+ * records — a burst of engine deaths the observer stamps in one sweep — in an
+ * engine-defined order; at the retention cap that decides which of a tied
+ * burst survives. Both the retention trim here and the `inspect` display read
+ * through this so the two can't drift.
+ */
+export function compareByExitAtDesc(a: PtyExitRecord, b: PtyExitRecord): number {
+  if (a.at === b.at) return 0
+  return a.at < b.at ? 1 : -1
+}
+
 /** All records keyed by store key; empty on missing/corrupt file. */
 export function readPtyExitRecords(path = defaultPtyExitsPath()): Record<string, PtyExitRecord> {
   try {
@@ -175,7 +191,7 @@ function writeRecord(storeKey: string, record: PtyExitRecord, path: string): voi
   const records = readPtyExitRecords(path)
   records[storeKey] = record
   const newest = Object.entries(records)
-    .sort(([, a], [, b]) => (a.at < b.at ? 1 : -1))
+    .sort(([, a], [, b]) => compareByExitAtDesc(a, b))
     .slice(0, MAX_RECORDS)
   mkdirSync(dirname(path), { recursive: true })
   // 0600: every record carries `plainTail` — the dying process's last output,

--- a/packages/kobe/src/cli/api/handlers-inspect.ts
+++ b/packages/kobe/src/cli/api/handlers-inspect.ts
@@ -112,8 +112,8 @@ async function sessionsSection(taskId: string | undefined): Promise<unknown> {
  *  today's deaths, not the file's key order. */
 async function sessionExitsSection(taskId: string | undefined): Promise<unknown> {
   try {
-    const { readPtyExitRecords } = await import("@sma1lboy/kobe-daemon/daemon/pty-exit-store")
-    const records = Object.values(readPtyExitRecords()).sort((a, b) => (a.at < b.at ? 1 : -1))
+    const { compareByExitAtDesc, readPtyExitRecords } = await import("@sma1lboy/kobe-daemon/daemon/pty-exit-store")
+    const records = Object.values(readPtyExitRecords()).sort(compareByExitAtDesc)
     return taskId ? records.filter((r) => r.key.startsWith(`${taskId}::`)) : records
   } catch (err) {
     return { error: err instanceof Error ? err.message : String(err) }

--- a/packages/kobe/test/daemon/pty-exit-store.test.ts
+++ b/packages/kobe/test/daemon/pty-exit-store.test.ts
@@ -9,7 +9,12 @@
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
-import { plainTail, readPtyExitRecords, recordPtyExit } from "@sma1lboy/kobe-daemon/daemon/pty-exit-store"
+import {
+  compareByExitAtDesc,
+  plainTail,
+  readPtyExitRecords,
+  recordPtyExit,
+} from "@sma1lboy/kobe-daemon/daemon/pty-exit-store"
 import { afterEach, beforeEach, describe, expect, it } from "vitest"
 
 let dir: string
@@ -75,6 +80,34 @@ describe("pty exit store", () => {
     // The oldest (t1::tab-1 and the first t2 tabs) were trimmed; the newest kept.
     expect(records["t1::tab-1"]).toBeUndefined()
     expect(records["t2::tab-59"]).toBeDefined()
+  })
+
+  it("orders newest-first and stays a valid strict-weak ordering across ties", () => {
+    const rec = (at: string) => ({ key: "k", pid: null, code: 1, signal: null, at, tail: [] })
+    const older = rec("2026-08-11T00:00:00.000Z")
+    const newer = rec("2026-08-11T01:00:00.000Z")
+    // Newest first.
+    expect(compareByExitAtDesc(newer, older)).toBeLessThan(0)
+    expect(compareByExitAtDesc(older, newer)).toBeGreaterThan(0)
+    // Equal timestamps tie (0) instead of the non-transitive `? 1 : -1`, which
+    // claimed each preceded the other.
+    expect(compareByExitAtDesc(rec("t"), rec("t"))).toBe(0)
+    expect(compareByExitAtDesc(newer, newer)).toBe(0)
+  })
+
+  it("caps to the 50 newest even when the newest all share one timestamp", () => {
+    // A burst the observer stamps in one sweep: 50 deaths at the same instant,
+    // plus one strictly older. The older one must be the record that is trimmed.
+    const tied = "2026-08-12T00:00:00.000Z"
+    recordPtyExit(endInfo({ key: "old::tab-1", exit: { code: 1, signal: null, at: "2026-08-11T00:00:00.000Z" } }), path)
+    for (let i = 0; i < 50; i++) {
+      recordPtyExit(endInfo({ key: `burst::tab-${i}`, exit: { code: 1, signal: null, at: tied } }), path)
+    }
+    const records = readPtyExitRecords(path)
+    expect(Object.keys(records).length).toBe(50)
+    expect(records["old::tab-1"]).toBeUndefined()
+    expect(records["burst::tab-0"]).toBeDefined()
+    expect(records["burst::tab-49"]).toBeDefined()
   })
 
   it("a corrupt or missing file reads as empty and recovers on next write", () => {


### PR DESCRIPTION
## Direction

Bugs / correctness — a self-found defect. Reviewed across (a) bugs, (b) open GitHub issues, (c) code health, (d) UX, (e) docs-vs-behavior. The two open issues were unsuitable to pick up unsolicited (#551 is an owner-reserved concurrency-semantics decision; #307 is a broad memory investigation with candidate work already discussed), and the ~30 open PRs already cover most small parsing/formatting corners. This is a distinct, self-contained correctness fix in a subsystem with no open PR.

## The problem

The durable PTY/engine death records (`pty-exits.json`, surfaced by `rove api inspect` for post-mortem triage) were sorted "newest first" at two sites with the shorthand `a.at < b.at ? 1 : -1`:

- `pty-exit-store.ts` `writeRecord` — the **retention** sort that trims the file to the 50 newest records.
- `handlers-inspect.ts` `sessionExitsSection` — the **display** sort for `inspect` output.

That comparator is not a valid strict-weak ordering: for two records with the same `at` it returns `-1` for `cmp(a, b)` **and** `-1` for `cmp(b, a)`, i.e. it claims each precedes the other. `at` is an ISO timestamp (`new Date().toISOString()` for both layers), so lexicographic order equals chronological order and distinct timestamps sort correctly — but same-instant records are left in an engine-defined order. The activity observer can stamp several engine deaths in one synchronous sweep with the same millisecond, so at the 50-record cap **which of a tied burst survives is arbitrary**, and two independent copies of the shorthand can drift.

## The fix

Add one exported `compareByExitAtDesc(a, b)` in `pty-exit-store.ts` that returns `0` on equal timestamps (and `1` / `-1` otherwise), then route both the retention trim and the `inspect` display through it. It's now a proper strict-weak ordering, so V8's stable sort preserves input order among ties, and the retention/display sites share one definition instead of duplicating the shorthand.

## How I verified

- Added unit tests pinning the comparator's strict-weak-ordering properties (newest-first, `0` on ties) and a retention test that a strictly older record is the one trimmed when the newest all share a timestamp.
- `bun x vitest run test/daemon/pty-exit-store.test.ts` — 8 passed (also under `KOBE_INCLUDE_SOCKET=1 … --pool forks`, matching CI).
- `bun run lint` — clean (1397 files). `bun run typecheck` — clean across all workspaces.
- Added a `patch` changeset.

## Follow-ups (deferred, out of scope)

- The exploration also surfaced `TASK_JUMP_DIGITS` (`tui/panes/sidebar/jump-digits.ts`) including `9`/`0` while the file's own comment says those don't encode as ctrl-chords on legacy terminals — but changing task-jump chords is an owner keybinding decision (per the repo's keybinding hard rule), so it's left for the owner rather than pre-empted here.