### PR TITLE
fix: read a missing tmux socket as a missing server in rove doctor

### DIFF
--- a/.changeset/doctor-legacy-tmux-missing-socket.md
+++ b/.changeset/doctor-legacy-tmux-missing-socket.md
@@ -1,0 +1,25 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Stop `rove doctor` reporting a red ✗ for the healthiest possible machine.
+
+The legacy-tmux row exists to find leftover pre-v0.8 sessions. It classifies a
+failed `tmux list-sessions` as either "no server" (fine) or "inspection failed"
+(a ✗), by matching tmux's message — and the phrasing tmux 3.5 uses when the
+socket file does not exist at all, `error connecting to <path> (No such file or
+directory)`, was not in the list. So every install that never ran pre-v0.8 Rove
+— which is every new install — was told something was wrong:
+
+```
+legacy tmux: ✗ inspection failed — tmux list-sessions failed: error connecting to /private/tmp/tmux-501/kobe (No such file or directory)
+```
+
+A missing socket is a missing server. That machine now gets the healthy line:
+
+```
+legacy tmux: tmux 3.5a — no sessions on `kobe`
+```
+
+The same wording covers a stale socket whose server has died, and a genuine
+inspection failure still reports one.

--- a/packages/kobe/src/cli/legacy-tmux.ts
+++ b/packages/kobe/src/cli/legacy-tmux.ts
@@ -2,7 +2,7 @@
 
 const LEGACY_TMUX_SOCKET = "kobe"
 
-interface CommandResult {
+export interface CommandResult {
   code: number
   stdout: string
   stderr: string
@@ -60,8 +60,32 @@ function commandFailure(label: string, result: CommandResult): string {
   return `${label} failed: ${result.stderr.trim() || `exit ${result.code}`}`
 }
 
-function isMissingServer(result: CommandResult): boolean {
-  return /no server running|failed to connect to server|no sessions/i.test(`${result.stdout}\n${result.stderr}`)
+/**
+ * Whether a failed `tmux list-sessions` means "there is no legacy server" —
+ * the healthy answer on every machine that never ran pre-v0.8 Rove — rather
+ * than "the inspection itself broke", which `rove doctor` renders as a red ✗.
+ *
+ * tmux exits 1 for both, and offers no machine-readable distinction, so this
+ * matches on its message. The four phrasings below are the ways it says the
+ * server is not there:
+ *
+ *   no server running on <path>            server never started (socket present)
+ *   error connecting to <path> (…)         socket ABSENT (ENOENT) or stale
+ *                                          (ECONNREFUSED) — tmux 3.5's wording
+ *                                          for a machine that never ran Rove
+ *   failed to connect to server            older tmux
+ *   no sessions                            server up, nothing in it
+ *
+ * `error connecting to` was the missing one, so a brand-new install — the
+ * healthiest possible machine — reported a ✗ every time. Adding a phrasing is
+ * the whole mechanism tmux gives us; deriving the socket path ourselves and
+ * stat-ing it would trade this false ✗ for a worse failure, since a wrong
+ * guess would report "no sessions" while real ones were running.
+ */
+export function isMissingServer(result: CommandResult): boolean {
+  return /no server running|error connecting to|failed to connect to server|no sessions/i.test(
+    `${result.stdout}\n${result.stderr}`,
+  )
 }
 
 function parsePositiveInts(output: string): number[] {

--- a/packages/kobe/test/cli/legacy-tmux.test.ts
+++ b/packages/kobe/test/cli/legacy-tmux.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest"
 import {
   inspectLegacyTmux,
+  isMissingServer,
   legacyPaneProcesses,
   legacyTmuxDoctorLines,
   parseLegacyPsRows,
@@ -18,6 +19,36 @@ function result(stdout = "", code = 0, stderr = "") {
 afterEach(() => {
   vi.restoreAllMocks()
   vi.unstubAllGlobals()
+})
+
+/**
+ * The classifier `rove doctor`'s legacy-tmux row hangs on. tmux exits 1 both
+ * when there is no server and when the inspection genuinely broke, so getting
+ * this wrong shows a red ✗ to a machine with nothing wrong with it.
+ */
+describe("isMissingServer", () => {
+  const failure = (stderr: string) => ({ code: 1, stdout: "", stderr, missing: false })
+
+  it.each([
+    // tmux 3.5a (Apple Git build and Homebrew) when the socket file is absent
+    // — every machine that never ran pre-v0.8 Rove. This is the one that was
+    // missing, and it turned a healthy install into `✗ inspection failed`.
+    "error connecting to /private/tmp/tmux-501/kobe (No such file or directory)",
+    // Same wording when the socket is there but its server died.
+    "error connecting to /private/tmp/tmux-501/kobe (Connection refused)",
+    "no server running on /tmp/tmux-501/kobe",
+    "failed to connect to server",
+    "no sessions",
+  ])("reads %j as an absent server", (stderr) => {
+    expect(isMissingServer(failure(stderr))).toBe(true)
+  })
+
+  it.each(["permission denied", "lost server", "can't create socket: Operation not permitted"])(
+    "reads %j as a real inspection failure",
+    (stderr) => {
+      expect(isMissingServer(failure(stderr))).toBe(false)
+    },
+  )
 })
 
 describe("legacy tmux process inspection", () => {
@@ -49,6 +80,23 @@ describe("legacy tmux process inspection", () => {
       processes: [],
       error: null,
     })
+  })
+
+  it("reports the healthy no-sessions line when the socket file does not exist", async () => {
+    // End to end from the tmux message to the doctor line: this exact stderr
+    // is what a machine that never ran pre-v0.8 Rove produces.
+    vi.stubGlobal("Bun", {
+      spawn: vi.fn((argv: readonly string[]) =>
+        argv.join(" ") === "tmux -V"
+          ? result("tmux 3.5a\n")
+          : result("", 1, "error connecting to /private/tmp/tmux-501/kobe (No such file or directory)\n"),
+      ),
+    })
+
+    const report = await inspectLegacyTmux()
+    expect(report.error).toBeNull()
+    expect(report.sessions).toEqual([])
+    expect(legacyTmuxDoctorLines(report)).toEqual(["legacy tmux: tmux 3.5a — no sessions on `kobe`"])
   })
 
   it("keeps the installed version when no legacy server is running", async () => {


### PR DESCRIPTION
## M3 — `rove doctor` reports a red ✗ for the healthiest possible machine

**PASS criterion:** `rove doctor` against an isolated home on a machine with tmux installed but no `kobe` socket — BEFORE `legacy tmux: ✗ inspection failed …`, AFTER `legacy tmux: tmux 3.5a — no sessions on \`kobe\``; both pasted, plus a unit test on the classifier.

### Root cause

`isMissingServer` decides whether a failed `tmux list-sessions` means "there is no legacy server" (fine) or "the inspection broke" (a red ✗). tmux exits 1 for both and offers no machine-readable distinction, so the classifier matches on tmux's message — and it enumerated only three phrasings:

```
/no server running|failed to connect to server|no sessions/i
```

tmux 3.5 (Apple Git build and Homebrew) uses none of them when the socket file does not exist. It says `error connecting to <path> (No such file or directory)`. Verified on this machine:

```
$ tmux -V
tmux 3.5a
$ tmux -L kobe list-sessions
error connecting to /private/tmp/tmux-501/kobe (No such file or directory)
exit=1
```

So the guard missed, `inspectLegacyTmux` returned an `error` report, and `legacyTmuxDoctorLines` rendered a failure — on every machine that never ran pre-v0.8 Rove, which is every new install.

### Fix

`error connecting to` joins the pattern. That wording also covers a stale socket whose server died (`(Connection refused)`), and a genuine failure still reports one.

**On the alternative the brief offered** (stat the socket path instead of matching text): I did not take it. The socket path is tmux's to resolve (`$TMUX_TMPDIR`, `tmux-$UID`, platform fallbacks), and reimplementing that resolution trades a visible false ✗ for a worse, silent failure — a wrong guess would report "no sessions" while real pre-v0.8 sessions were running, and `stopLegacyTmux` would then report "absent" for a server it never looked at. The classifier's doc now says that out loud, along with each phrasing and what it means, so the next person hitting a new tmux wording knows what they are editing and why it is a list.

### Proof — `rove doctor` against an isolated home

`tmux 3.5a` installed, no `kobe` socket, fresh `mktemp -d` home with every inherited control unset.

**BEFORE** (`origin/main`, `b1c5519ef`):

```
legacy tmux: ✗ inspection failed — tmux list-sessions failed: error connecting to /private/tmp/tmux-501/kobe (No such file or directory)
```

**AFTER** (this branch):

```
legacy tmux: tmux 3.5a — no sessions on `kobe`
```

A `diff` of the two full doctor runs is exactly this one line (plus the mktemp home path):

```
23c23
< legacy tmux: ✗ inspection failed — tmux list-sessions failed: error connecting to /private/tmp/tmux-501/kobe (No such file or directory)
---
> legacy tmux: tmux 3.5a — no sessions on `kobe`
```

**One correction to the brief:** it predicted the trailing count would drop from `4 finding(s)` to `3`. It reads `3 finding(s)` both before and after — that line counts findings with a `--fix` recipe, and the legacy-tmux row never had one. The ✗ was noise in the report, not a counted finding.

### Tests

`isMissingServer` is now exported and covered directly (the brief's "tightest proof"): five absent-server phrasings including the exact tmux 3.5 stderr, and three real failures that must stay classified as failures. Plus one end-to-end case driving that stderr through `inspectLegacyTmux` into `legacyTmuxDoctorLines`.

Mutation-verified — reverting the regex to its three-phrasing form turns exactly the new cases red:

```
× isMissingServer > reads "error connecting to /private/tmp/tmux-501/kobe (No such file or directory)" as an absent server
× isMissingServer > reads "error connecting to /private/tmp/tmux-501/kobe (Connection refused)" as an absent server
× legacy tmux process inspection > reports the healthy no-sessions line when the socket file does not exist
Tests  3 failed | 15 passed (18)
```

No screenshots: this is CLI stdout, and the two blocks above are the artifact a screenshot would contain.

### Gates

| gate | result |
|---|---|
| repo-root `bun run lint` | pass (1397 files) |
| repo-root `bun run typecheck` | pass |
| `bun run test:fast` | 4343 passed, 6 pre-existing failures (same set as #837/#838) |
| `bun x vitest run test/cli/` | 815 passed, 2 pre-existing (`open-dir-cmd`) |
| `bun x vitest run test/cli/legacy-tmux.test.ts` | 18 passed |

The pre-existing failures: `open-dir-cmd` (2) and `project-eligibility` (2) pass on a clean `origin/main` worktree under `~/i` and fail here only because this worktree lives under `~/.rove/worktrees`, whose path shape those tests classify as rove-internal; `continue-live-vendor` (2) fails on pristine `origin/main` too.
