### PR TITLE
fix: a superseded renderer must not register bindings into the live keymap stack

### DIFF
--- a/.changeset/keymap-superseded-modal-leak.md
+++ b/.changeset/keymap-superseded-modal-leak.md
@@ -1,0 +1,16 @@
+---
+"@sma1lboy/rove": patch
+---
+
+A superseded renderer can no longer register key bindings into the live
+renderer's stack. `ensureInstalled` already refused to let a torn-down
+renderer's tree steal the `keyInput` listener back, but `useBindings`'s mount
+effect inserted unconditionally — so a component that tree mounts LATE (a
+dialog opened by a pending timer) landed in the stack *after* the
+`stack.length = 0` that was supposed to drop it. One stale `modalOwner`
+arriving that way makes `modalActive()` true with nothing left to clear it, and
+every raw `keyInput` listener gated on it goes silent — including the terminal
+pane's paste forwarder, which then drops the paste before it reaches the PTY.
+The mount effect now applies the same superseded-renderer guard as the
+listener. Production runs one renderer per process and never supersedes it, so
+this only fires where renderers are swapped in-process.

--- a/packages/kobe/src/tui-react/lib/keymap.ts
+++ b/packages/kobe/src/tui-react/lib/keymap.ts
@@ -207,6 +207,15 @@ export function useBindings(config: () => BindingsConfig, opts?: { modalOwner?: 
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: mount-once registration; scope/owner tokens are stable for the component's lifetime.
   useEffect(() => {
+    // Same guard `ensureInstalled` applies to the listener, applied to
+    // registration. A superseded renderer's tree keeps rendering after
+    // teardown, so a component it mounts LATE (a dialog opened by a pending
+    // timer) would insert into the live renderer's stack — past the
+    // `stack.length = 0` that was supposed to drop it. One stale `modalOwner`
+    // landing that way makes `modalActive()` true forever and silences every
+    // raw keyInput listener gated on it (the terminal pane's paste
+    // forwarder). No-op in production: one renderer, never superseded.
+    if (supersededRenderers.has(renderer as object)) return
     // Opening a Dialog Stack scope invalidates an in-flight prefix from the
     // surface behind it before any async/mouse transition can leak it back.
     if (opts?.modalOwner !== undefined) resetPrefixState()

--- a/packages/kobe/test/render/keymap-superseded-modal-leak.test.tsx
+++ b/packages/kobe/test/render/keymap-superseded-modal-leak.test.tsx
@@ -1,0 +1,58 @@
+/** @jsxImportSource @opentui/react */
+/**
+ * A modal barrier registered by an ABANDONED renderer's tree must never land
+ * in the live stack. The harness destroys a renderer without unmounting React
+ * (see `harness.tsx`), so a pending timer in a previous test's tree can open a
+ * dialog long after the next test mounted — after `ensureInstalled` cleared the
+ * stack. `modalActive()` then reads true forever and every raw `keyInput`
+ * listener gated on it goes silent, including the terminal pane's paste
+ * forwarder. That is the render-track paste flake, made deterministic here.
+ */
+
+import { expect, test } from "bun:test"
+import { useEffect, useState } from "react"
+import { useBindings } from "../../src/tui-react/lib/keymap"
+import { Terminal } from "../../src/tui-react/panes/terminal/Terminal"
+import { createScriptedPtyRegistry } from "../../src/tui/panes/terminal/pty-scripted"
+import { act, renderComponent, settle } from "./harness"
+
+const ABANDONED_SCOPE = Symbol("abandoned-modal-scope")
+
+function LateBarrier() {
+  useBindings(() => ({ bindings: [], modal: true }), { modalOwner: ABANDONED_SCOPE })
+  return null
+}
+
+/** Opens its barrier on a timer, so the registration lands after the next renderer took over. */
+function LateModal() {
+  // Registering at mount is what makes this renderer the installed one, so the
+  // next `renderComponent` supersedes it — the shape every render test has.
+  useBindings(() => ({ bindings: [] }))
+  const [open, setOpen] = useState(false)
+  useEffect(() => {
+    const timer = setTimeout(() => setOpen(true), 120)
+    return () => clearTimeout(timer)
+  }, [])
+  return open ? <LateBarrier /> : null
+}
+
+test("a superseded renderer's late modal barrier does not mute the live pane's paste", async () => {
+  await renderComponent(<LateModal />, { width: 40, height: 6 })
+
+  const harness = createScriptedPtyRegistry()
+  const { mockInput, frame } = await renderComponent(
+    <Terminal cwd="/wt" taskId="superseded-modal" focused registry={harness.registry} />,
+    { width: 60, height: 12, providers: { dialog: true } },
+  )
+  await frame()
+
+  // Past the abandoned tree's timer: its barrier registers here, if it can.
+  // The abandoned root updates outside `act` here by design — that is the
+  // scenario. React logs one "not wrapped in act" warning; nothing to fix.
+  await settle(300)
+
+  act(() => mockInput.pressKey("\x1b[200~first line\rsecond line\x1b[201~"))
+  await settle()
+
+  expect(harness.last().pastes).toEqual(["first line\rsecond line"])
+})


### PR DESCRIPTION
Batch L, item **L1** (loop-r5 brief B1) — the render-track paste flake that failed PRs #817 and #831.

## What changed

`packages/kobe/src/tui-react/lib/keymap.ts` — `useBindings`'s mount effect now applies the same superseded-renderer guard `ensureInstalled` already applies to the `keyInput` listener (one line + the comment explaining why).

**The bug.** `ensureInstalled` refuses to let a torn-down renderer's tree steal the listener back (`supersededRenderers`), and clears the stack (`stack.length = 0`) when a new renderer installs. But the registration effect inserted unconditionally. A superseded renderer's React tree keeps running after `renderer.destroy()` — the test harness destroys the renderer *without* unmounting React — so a component that tree mounts **late** (a dialog opened by a pending timer) inserts into the live renderer's stack, past the clear that was supposed to drop it. Nothing removes it afterwards: `modalActive()` reads true forever, and every raw `keyInput` listener gated on it goes silent, including the terminal pane's paste forwarder (`panes/terminal/keys.ts:143` returns before touching the PTY). That is exactly the CI symptom — `pty.pastes === []` in `terminal-paste-newlines.test.tsx`, only in the full-suite run.

Production runs one renderer per process and never supersedes it, so this is a no-op there; it only fires where renderers are swapped in-process.

## PASS criterion and proof

**Criterion:** the brief's deterministic probe, turned into one render test, is RED without the guard and GREEN with it; `bun test test/render` 5× green; no behavior change for a live modal.

### 1. Mutation run — the test fails for the right reason without the guard

New test: `packages/kobe/test/render/keymap-superseded-modal-leak.test.tsx`. It mounts a tree whose dialog opens on a 120 ms timer, abandons that renderer, mounts the `Terminal`, waits past the timer, pastes.

Guard removed (`if (supersededRenderers.has(renderer as object)) return` deleted from the mount effect):

```
$ bun test test/render/keymap-superseded-modal-leak.test.tsx
test/render/keymap-superseded-modal-leak.test.tsx:
57 |   expect(harness.last().pastes).toEqual(["first line\rsecond line"])
                                     ^
error: expect(received).toEqual(expected)
- [
-   "first line
- second line"
- ,
- ]
+ []
(fail) a superseded renderer's late modal barrier does not mute the live pane's paste [426.07ms]
 0 pass
 1 fail
```

`pastes === []` — the exact CI failure, not some adjacent assertion.

Guard restored:

```
$ bun test test/render/keymap-superseded-modal-leak.test.tsx
 1 pass
 0 fail
 1 expect() calls
```

### 2. `bun test test/render` — 5 consecutive green runs

```
===== RENDER RUN 1 =====   456 pass  0 fail  1371 expect() calls  [131.98s]
===== RENDER RUN 2 =====   456 pass  0 fail  1371 expect() calls  [131.55s]
===== RENDER RUN 3 =====   456 pass  0 fail  1371 expect() calls  [130.79s]
===== RENDER RUN 4 =====   456 pass  0 fail  1371 expect() calls  [130.72s]
===== RENDER RUN 5 =====   456 pass  0 fail  1371 expect() calls  [130.17s]
```

### 3. No behavior change for a live modal

The guard only skips registration for a renderer already in `supersededRenderers` — a live modal's renderer is the installed one and never in that set. The dialog suites (`dialog-stack`, `which-key-help`, `new-chat-dialog`, `run-again-dialog`, `settings-dialog`, `engine-picker-dialog`, `automations-page-keys`, `new-task-open-project`) are inside the 456 above and stay green.

### 4. Gates

```
$ bun run lint        Checked 1396 files in 323ms. No fixes applied.
$ bun run typecheck   all four filters Exited with code 0
$ BASE_REF=main KOBE_RENDER_COVERAGE=1 bun scripts/coverage-gate.mjs
ok packages/kobe/src/tui-react/lib/keymap.ts — 99.11504424778761%
```

## No screenshots

Nothing renders differently — the change is a guard on a module-global registration list, and the failure mode is a swallowed key event, not a frame. There is no BEFORE/AFTER surface to capture. The mutation run above is the proof in its place.

## What I could not prove

- **The original CI flake is not reproduced from the real test files.** The brief's 13 full-suite runs were green on this machine and mine were too. What is proven is the *mechanism*: the leak precondition is real and pervasive (the brief's instrumentation found stale `modalOwner` entries surviving teardown into the next mount from 8 test files), and the deterministic probe reproduces the exact symptom through it. Fixing this removes the mechanism; it cannot be shown to remove a failure that will not reproduce on demand.
- **The brief's B1 step 3 / B2 suggestion — an `afterEach` assertion that `modalActive()` is false — would be a false claim and is deliberately not implemented.** That leak is registrations made *while the renderer was live* and never cleaned up, because `destroy()` does not run React cleanups; the guard does not and cannot change that, and `ensureInstalled`'s `stack.length = 0` is what clears them at the next mount. Asserting zero leaked barriers in `afterEach` would fail across the eight files the brief names. The harness comment is corrected instead (item L2, separate PR).