### PR TITLE
test: isolate the vitest tracks from the developer's shell and home

### DIFF
--- a/packages/kobe/test/cli/onboarding.test.ts
+++ b/packages/kobe/test/cli/onboarding.test.ts
@@ -84,7 +84,9 @@ function emptyEnv(): OnboardingEnvReport {
 
 function setProduct(name: "rove" | "kobe"): void {
   if (name === "rove") process.env.ROVE_INVOKED_AS = "rove"
-  else process.env.ROVE_INVOKED_AS = undefined
+  // Assigning `undefined` stores the literal string "undefined", which reads
+  // as legacy only by accident. Delete it so the legacy case is the real one.
+  else Reflect.deleteProperty(process.env, "ROVE_INVOKED_AS")
 }
 
 function stdoutLines(spy: MockInstance<typeof process.stdout.write>): string[] {

--- a/packages/kobe/test/setup-env.ts
+++ b/packages/kobe/test/setup-env.ts
@@ -1,0 +1,68 @@
+/**
+ * Ambient-environment isolation for every vitest track (fast, socket,
+ * behavior). Runs once per test FILE, before that file's own hooks, so a
+ * test that wants a specific home keeps setting it in `beforeEach` and still
+ * wins.
+ *
+ * Without this the suite's result depends on the developer's shell and on
+ * where the checkout physically sits. Measured on `main` @ 0.9.103, all three
+ * at once from a Rove-managed worktree: 53 failures, 0 of them about the code.
+ *
+ *   - `ROVE_INVOKED_AS=rove` (every agent session inherits it) flips
+ *     `activeCliName()` and 47 `test/cli` assertions on the product name.
+ *   - The real `~/.config/rove/state.json` answers `getEngineProtocol()`, so
+ *     a registered `claudecpa` preset fails 2 cases in
+ *     `test/tui/continue-live-vendor.test.ts` that a fresh machine passes.
+ *   - A checkout under `~/.rove/worktrees/` is `roveInternal` to
+ *     `pathRejection()`, failing 4 cases across `project-eligibility` and
+ *     `open-dir-cmd` — which is where every dispatched worker runs.
+ *
+ * The home is redirected via `KOBE_HOME_DIR` and `ROVE_HOME_DIR` is DELETED
+ * rather than set: `readRoveEnv()` reads `ROVE_*` first, so an ambient
+ * `ROVE_HOME_DIR` would shadow the ~288 tests that set only `KOBE_HOME_DIR`
+ * in their own hooks (measured: 180 failures when both are set here).
+ */
+
+import { mkdirSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+/**
+ * Ambient `KOBE_*` / `ROVE_*` names a run may legitimately read from the
+ * developer's shell. Every other one is deleted — a list of what to keep
+ * cannot rot the way a list of what to strip does.
+ */
+const AMBIENT_KEEP = new Set([
+  "KOBE_UPDATE_GOLDEN", // regenerates golden files on purpose
+  "KOBE_INCLUDE_SOCKET",
+  "KOBE_INCLUDE_BEHAVIOR",
+  "KOBE_COVERAGE_DAEMON",
+])
+
+for (const key of Object.keys(process.env)) {
+  if ((key.startsWith("KOBE_") || key.startsWith("ROVE_")) && !AMBIENT_KEEP.has(key)) {
+    Reflect.deleteProperty(process.env, key)
+  }
+}
+
+// Engine config roots. Not `ROVE_*`-prefixed, but they steer which transcript
+// store the history readers see, so an agent shell that exports one would
+// point unit tests at real sessions.
+Reflect.deleteProperty(process.env, "CLAUDE_CONFIG_DIR")
+Reflect.deleteProperty(process.env, "CODEX_HOME")
+
+// One empty home per worker process — enough isolation that no test reads the
+// developer's saved repos or presets, few enough directories that a run does
+// not litter tmpdir with one per test file. `tmpdir()`, never a literal
+// `/tmp`: `pathRejection()` decides `roveInternal` before `temporary`, so a
+// home under a temp root still reports the specific reason.
+const home = join(tmpdir(), `rove-vitest-home-${process.pid}`)
+mkdirSync(home, { recursive: true })
+process.env.KOBE_HOME_DIR = home
+
+// Fixture repos run `git init && git commit` inheriting `process.env`, so the
+// developer's `~/.gitconfig` applied: `commit.gpgsign = true` passes only
+// while a gpg agent answers. One variable each covers signing, hooks,
+// templates, `core.autocrlf` and `init.defaultBranch`.
+process.env.GIT_CONFIG_GLOBAL = "/dev/null"
+process.env.GIT_CONFIG_SYSTEM = "/dev/null"

--- a/packages/kobe/test/state/project-eligibility.test.ts
+++ b/packages/kobe/test/state/project-eligibility.test.ts
@@ -13,6 +13,11 @@ import { describe, expect, it } from "vitest"
 /** The repo this test runs in — a real checkout at a durable path. */
 const REPO_ROOT = new URL("../..", import.meta.url).pathname.replace(/\/$/, "")
 
+/** Where Rove's own state lives for this run — see test/setup-env.ts. */
+function injectedHome(): string {
+  return process.env.KOBE_HOME_DIR ?? homedir()
+}
+
 describe("pathRejection", () => {
   it("rejects the four shapes that leaked into the real sidebar", () => {
     expect(pathRejection("/private/tmp/rove-fixture-probe/repo")).toBe("temporary")
@@ -20,7 +25,9 @@ describe("pathRejection", () => {
     expect(pathRejection("/Users/x/i/kobe/packages/kobe/.dev-sandbox/named/ex-gif/home/smoke-repo")).toBe(
       "insideSandbox",
     )
-    expect(pathRejection(join(homedir(), ".rove/worktrees/kobe-0aff/manatee/fixture"))).toBe("roveInternal")
+    // The home the run was given, not `homedir()`: `roveStateDir()` follows
+    // `KOBE_HOME_DIR`, which test/setup-env.ts points at an empty tmpdir.
+    expect(pathRejection(join(injectedHome(), ".rove/worktrees/kobe-0aff/manatee/fixture"))).toBe("roveInternal")
   })
 
   it("rejects a .scratch checkout wherever it sits", () => {

--- a/packages/kobe/vitest.config.ts
+++ b/packages/kobe/vitest.config.ts
@@ -34,6 +34,11 @@ export default defineConfig({
     include: ["test/**/*.test.ts", "test/**/*.test.tsx"],
     exclude,
     environment: "node",
+    // Strips the ambient ROVE_*/KOBE_* identity vars and redirects the home
+    // at an empty tmpdir before any test file's own hooks run, so a result
+    // cannot depend on the developer's shell, saved presets, or where the
+    // checkout sits. See the header of that file for the measured numbers.
+    setupFiles: ["test/setup-env.ts"],
     // `bun run coverage` / --coverage. v8 provider; json-summary feeds the
     // per-touched-file CI gate (scripts/coverage-gate.mjs), text is for humans.
     // No global % thresholds — the gate is per-file on files a PR touches.


### PR DESCRIPTION
## O1 — one vitest setup file ends the whole "works on my machine" failure class

The fast track's result depended on the developer's shell, on
`~/.config/rove/state.json`, and on where the checkout physically sits. All
three measured, not inferred, on `main` @ 0.9.103 from a Rove-managed worktree:

```
$ bun run test:fast                                     # ambient agent shell
 Test Files  21 failed | 417 passed (438)
      Tests  53 failed | 4305 passed (4358)
```

53 = 47 (`ROVE_INVOKED_AS=rove` inherited by every agent session flips
`activeCliName()` and every `test/cli` assertion on the product name) + 4 (a
checkout under `~/.rove/worktrees/` is `roveInternal` to `pathRejection()`) + 2
(a registered `claudecpa` preset in the real `state.json` makes
`getEngineProtocol()` truthy, so `liveSourceProtocol` short-circuits).

### What changed

`packages/kobe/test/setup-env.ts` (new, wired via `setupFiles` in
`vitest.config.ts`) runs once per test file, before that file's own hooks:

- deletes every ambient `KOBE_*` / `ROVE_*` var except a four-name keep-list
  (`KOBE_UPDATE_GOLDEN` plus the three runner selectors) — a keep-list cannot
  rot the way a strip-list does — plus `CLAUDE_CONFIG_DIR` and `CODEX_HOME`;
- points `KOBE_HOME_DIR` at a per-worker empty `tmpdir()` directory;
- pins `GIT_CONFIG_GLOBAL` / `GIT_CONFIG_SYSTEM` at `/dev/null`, so the ~8
  fixture helpers that run `git init && git commit` with `...process.env` stop
  reading the developer's `~/.gitconfig` (this machine has
  `commit.gpgsign = true`; those tests pass only while a gpg agent answers).
  One place instead of eight env objects — every one of them spreads
  `process.env`, and `test/state/repos.test.ts` spawns bare `git`.

Two assertions this exposes:

- `test/state/project-eligibility.test.ts:23` built its `roveInternal` case
  from `homedir()` while the module reads the injected home — now from
  `process.env.KOBE_HOME_DIR`. Line 60's `~/Documents/not-a-repo` is left
  alone: under the injected temp home it would read as `temporary`.
- `test/cli/onboarding.test.ts:88` assigned `process.env.ROVE_INVOKED_AS =
  undefined`, which stores the literal string `"undefined"` and read as legacy
  only by accident — now `Reflect.deleteProperty`.

**One correction to the brief, from measurement.** It said to set both
`KOBE_HOME_DIR` and `ROVE_HOME_DIR`. `readRoveEnv()` prefers `ROVE_*`, so an
ambient `ROVE_HOME_DIR` shadows the ~288 tests that inject only
`KOBE_HOME_DIR` in their own hooks:

```
$ ROVE_HOME_DIR=<tmp> KOBE_HOME_DIR=<tmp> bun run test:fast     # what the brief proposed
      Tests  180 failed | 4178 passed (4358)
```

So `ROVE_HOME_DIR` is deleted rather than set, and the setup file says why.

### PASS criterion and proof

**Criterion:** 0 failures from a `~/.rove/worktrees` checkout, from a durable
checkout with presets registered, and with `ROVE_INVOKED_AS=rove` exported;
render and socket runners unaffected.

**Run 1 — this Rove-managed worktree.** Hostile on all three axes at once:
path under `~/.rove/worktrees/`, the real `~/.config/rove/state.json` carrying
`"engineProtocol.claudecpa":"claude"` and four `customEngineIds`, and an agent
shell exporting `ROVE_INVOKED_AS=rove` + `ROVE_TASK_ID` + `KOBE_TAB_ID`.

```
BEFORE (main @ 3e13ab6b3)          AFTER (this branch)
 Test Files  21 failed | 417 …      Test Files  438 passed (438)
      Tests  53 failed | 4305 …          Tests  4358 passed (4358)
```

**Run 2 — a durable checkout (`~/i/kobe`-shaped) with presets registered.**
A detached worktree at `/Users/jacksonc/i/rove-o1-durable-check`, same shell,
same real `state.json`; only the path shape differs from run 1.

```
BEFORE (main @ 3e13ab6b3)          AFTER (this branch)
 Test Files  19 failed | 419 …      Test Files  438 passed (438)
      Tests  49 failed | 4309 …          Tests  4358 passed (4358)
```

**Run 3 — `ROVE_INVOKED_AS=rove` exported explicitly, `test/cli` only.**

```
$ ROVE_INVOKED_AS=rove bun x vitest run test/cli
 Test Files  78 passed (78)          # was 18 failed | 60 passed
      Tests  919 passed (919)        # was 47 failed | 872 passed
```

**Which config each runner reads, and its result:**

| runner | config | affected by `setupFiles`? | result |
| --- | --- | --- | --- |
| `bun run test:fast` | `packages/kobe/vitest.config.ts` | yes | 438 files / 4358 tests, 0 fail |
| `bun run test:socket` | same file (`KOBE_INCLUDE_SOCKET=1`) | yes | 94 files / 789 tests, 0 fail |
| `bun run test:behavior` | same file (`KOBE_INCLUDE_BEHAVIOR=1`) | yes | 11 files / 32 tests, 0 fail |
| `bun test test/render` | Bun's own runner — reads **no** vitest config | no | 455 tests / 102 files, 0 fail |

The behavior harness strips every `KOBE_*`/`ROVE_*` and injects its own
(`test/behavior/harness.ts:86`), so it is untouched by the deletions; the
`GIT_CONFIG_*` pins do reach its spawned CLIs, which only makes it more
deterministic. Re-run, not assumed.

```
bun run lint         Checked 1400 files. No fixes applied.
bun run typecheck    Exited with code 0
```

Coverage gate is a no-op — this PR touches no `src/` file. No changeset for the
same reason (`changeset-cap` only fires on `packages/kobe*/src`).

No screenshots: nothing renders. The diff is one new setup file, one line of
vitest config, and two test assertions.

### One artifact left behind

Run 2 needed a checkout at a non-Rove path, so I created a detached worktree at
`/Users/jacksonc/i/rove-o1-durable-check` (`git worktree add --detach`). It is
measurement scrap and should be removed — I left it in place rather than delete
something the repo's rules reserve for you.
