### PR TITLE
Floor every relative-time step from one module; collapse git-snapshot's four spawns into one

### DIFF
--- a/.changeset/relative-time-floors.md
+++ b/.changeset/relative-time-floors.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+One relative-time clock, and it floors. The Routines page rounded while every other surface floored, so the same instant read two ways: a routine firing in 1h40m previewed as `in 2h` and fired twenty minutes early, and a run 100 seconds old showed `2m ago` on the Routines page while the Inbox called it `1m`. `relativeBuckets` in `lib/relative-time.ts` now floors and owns the label too — `relativeAgeMs` is gone from `tui/history/message-core.ts` and its six consumers read `relativeAge` from the one module. A sub-minute run also now reads `now` / `just now` instead of `1m ago`.

--- a/packages/kobe/src/lib/relative-time.ts
+++ b/packages/kobe/src/lib/relative-time.ts
@@ -1,17 +1,31 @@
 /**
- * Stepwise coarse buckets for a relative-time delta: minutes from the raw
- * millisecond delta, hours from minutes, days from hours. Both TUI consumers
- * (the Routines schedule preview's `formatRelative` and the Automations
- * page's `formatWhen`) derive their units from here so the two can't drift
- * apart — independent copies are how one screen ends up flooring while its
- * neighbor rounds.
+ * The product's one relative-time clock: coarse buckets for a millisecond
+ * delta, and the compact `3m` / `2h` / `4d` label built on them. Every TUI
+ * surface that prints an age or a countdown derives its units here — the
+ * Routines schedule preview (`formatRelative`), the Automations page
+ * (`formatWhen`), the attention inbox, the worktrees page, the issue event
+ * list, and the plugins section — so two screens cannot disagree about the
+ * same instant.
  *
- * Every step uses Math.round. Floor-vs-round is a display-convention call
- * (a countdown that floors never overstates headroom); when
- * that's decided, change it HERE so every consumer moves together.
+ * Every step FLOORS. Two reasons the rounding variant lost: a countdown that
+ * rounds up overstates headroom (a routine 1h40m out rendered `in 2h` and
+ * then fired twenty minutes early), and `relativeAge`'s seconds step has no
+ * rounding rule anyone wants (a 45-second-old event is not `1m ago`). Flooring
+ * makes both read early rather than late.
  */
 export function relativeBuckets(absMs: number): { minutes: number; hours: number; days: number } {
-  const minutes = Math.round(absMs / 60_000)
-  const hours = Math.round(minutes / 60)
-  return { minutes, hours, days: Math.round(hours / 24) }
+  const minutes = Math.floor(absMs / 60_000)
+  const hours = Math.floor(minutes / 60)
+  return { minutes, hours, days: Math.floor(hours / 24) }
+}
+
+/** Relative age of an epoch-ms timestamp ("3m", "2h", "4d"); negative deltas clamp to "0s". */
+export function relativeAge(ms: number, nowMs: number = Date.now()): string {
+  const delta = Math.max(0, nowMs - ms)
+  const secs = Math.floor(delta / 1000)
+  if (secs < 60) return `${secs}s`
+  const { minutes, hours, days } = relativeBuckets(delta)
+  if (minutes < 60) return `${minutes}m`
+  if (hours < 24) return `${hours}h`
+  return `${days}d`
 }

--- a/packages/kobe/src/tui-react/component/issue-detail-parts.tsx
+++ b/packages/kobe/src/tui-react/component/issue-detail-parts.tsx
@@ -16,7 +16,7 @@ import { useT } from "../i18n"
 import { DialogLabel } from "../ui/dialog-parts"
 import { EVENT_FEED_LIMIT, type EventRow, eventRows } from "./issue-events-core"
 
-/** Width of the age column — "999d" is the widest {@link relativeAgeMs} yield. */
+/** Width of the age column — "999d" is the widest {@link relativeAge} yield. */
 const AGE_CELLS = 4
 
 export function IssueEventsSection(props: { taskId: string; orchestrator: RemoteOrchestrator | null }) {

--- a/packages/kobe/src/tui-react/component/issue-events-core.ts
+++ b/packages/kobe/src/tui-react/component/issue-events-core.ts
@@ -9,7 +9,7 @@
  */
 
 import type { RecentTaskEvent } from "../../client/remote-orchestrator"
-import { relativeAgeMs } from "../../tui/history/message-core"
+import { relativeAge } from "../../lib/relative-time"
 import { truncateEnd } from "../../tui/lib/truncate"
 
 /** Rows the drawer shows — the tail of the ring, not the whole 100. */
@@ -63,7 +63,7 @@ export function eventRows(
       const tail = [detailFragment(event), str(event.vendor)].filter((part) => part.length > 0)
       return {
         key: `${event.at}:${index}`,
-        age: relativeAgeMs(event.at, nowMs),
+        age: relativeAge(event.at, nowMs),
         kind: event.kind,
         tail: tail.join(" · "),
       }

--- a/packages/kobe/src/tui-react/component/settings-dialog/sections-plugins.tsx
+++ b/packages/kobe/src/tui-react/component/settings-dialog/sections-plugins.tsx
@@ -8,7 +8,7 @@
  */
 
 import { TextAttributes } from "@opentui/core"
-import { relativeAgeMs } from "../../../tui/history/message-core"
+import { relativeAge } from "../../../lib/relative-time"
 import { useTheme } from "../../context/theme"
 import { useT } from "../../i18n"
 import { type PluginSettingRowView, displaySettingValue, isBooleanOn } from "./plugin-settings-core"
@@ -164,7 +164,7 @@ export function PluginSettingsSection(
                               : plugin.lastRun.spawnError
                                 ? t("settings.plugins.runFailed")
                                 : t("settings.plugins.runExit", { code: String(plugin.lastRun.exitCode) }),
-                            ago: relativeAgeMs(plugin.lastRun.at, now),
+                            ago: relativeAge(plugin.lastRun.at, now),
                           })
                         : // "never run" only means something when the plugin
                           // declares commands that could have run; a

--- a/packages/kobe/src/tui-react/component/worktrees-page.tsx
+++ b/packages/kobe/src/tui-react/component/worktrees-page.tsx
@@ -29,8 +29,8 @@
 import { TextAttributes } from "@opentui/core"
 import { type ReactNode, useEffect, useState } from "react"
 import type { RemoteOrchestrator } from "../../client/remote-orchestrator"
+import { relativeAge } from "../../lib/relative-time"
 import { clampCursor } from "../../tui/component/new-task-dialog/state"
-import { relativeAgeMs } from "../../tui/history/message-core"
 import type { WorktreeAuditRow, WorktreeProject } from "../../types/worktree"
 import { useNotifications } from "../context/notifications"
 import { useTheme } from "../context/theme"
@@ -339,7 +339,7 @@ export function WorktreesPage(props: { orchestrator: RemoteOrchestrator | null; 
                         </text>
                         {row.createdAtMs > 0 ? (
                           <text fg={theme.textMuted} wrapMode="none">
-                            {t("worktrees.row.created", { age: relativeAgeMs(row.createdAtMs) })}
+                            {t("worktrees.row.created", { age: relativeAge(row.createdAtMs) })}
                           </text>
                         ) : null}
                       </box>

--- a/packages/kobe/src/tui-react/workspace/AttentionInboxPane.tsx
+++ b/packages/kobe/src/tui-react/workspace/AttentionInboxPane.tsx
@@ -6,7 +6,7 @@ import { useEffect, useMemo, useState, useSyncExternalStore } from "react"
 import type { AttentionInboxItem, RemoteOrchestrator, TaskEngineState } from "../../client/remote-orchestrator"
 import { DEFAULT_SPINNER_FRAMES } from "../../engine/spinner-frames"
 import { approxCharCells } from "../../lib/display-width"
-import { relativeAgeMs } from "../../tui/history/message-core"
+import { relativeAge } from "../../lib/relative-time"
 import { spinnerFrameSnapshot, subscribeSpinnerFrame } from "../../tui/lib/spinner-frame-store"
 import { truncateEndCells } from "../../tui/lib/truncate"
 import { sidebarProjectLabel } from "../../tui/panes/sidebar/groups"
@@ -359,7 +359,7 @@ export function AttentionInboxPane(props: {
                     theme,
                     t,
                   })}
-                  age={relativeAgeMs(row.at, now)}
+                  age={relativeAge(row.at, now)}
                   active={active}
                   onOpen={openRow}
                 />
@@ -392,7 +392,7 @@ export function AttentionInboxPane(props: {
                   label: t(itemStateKey(item.state)),
                   color: itemColor(item.state, theme),
                 }}
-                age={relativeAgeMs(item.at, now)}
+                age={relativeAge(item.at, now)}
                 active={active}
                 onOpen={openRow}
               />

--- a/packages/kobe/src/tui/history/message-core.ts
+++ b/packages/kobe/src/tui/history/message-core.ts
@@ -4,6 +4,7 @@
  * formatting contracts without loading @opentui.
  */
 
+import { relativeAge } from "@/lib/relative-time"
 import { truncateEnd } from "@/tui/lib/truncate"
 import type { ContentBlock } from "@/types/content"
 import type { Message } from "@/types/engine"
@@ -13,22 +14,11 @@ const SUMMARY_MAX = 120
 
 export type ToolResultBlock = Extract<ContentBlock, { type: "tool_result" }>
 
-/** Relative age of an epoch-ms timestamp ("3m", "2h", "4d"); negative deltas clamp to "0s". */
-export function relativeAgeMs(ms: number, nowMs = Date.now()): string {
-  const secs = Math.max(0, Math.floor((nowMs - ms) / 1000))
-  if (secs < 60) return `${secs}s`
-  const mins = Math.floor(secs / 60)
-  if (mins < 60) return `${mins}m`
-  const hours = Math.floor(mins / 60)
-  if (hours < 24) return `${hours}h`
-  return `${Math.floor(hours / 24)}d`
-}
-
 /** Relative age of an ISO timestamp ("3m", "2h", "4d"), or "" when unparseable. */
 export function relativeTime(iso: string, nowMs: number = Date.now()): string {
   const ms = Date.parse(iso)
   if (Number.isNaN(ms)) return ""
-  return relativeAgeMs(ms, nowMs)
+  return relativeAge(ms, nowMs)
 }
 
 /**

--- a/packages/kobe/src/tui/lib/git-snapshot.ts
+++ b/packages/kobe/src/tui/lib/git-snapshot.ts
@@ -73,6 +73,30 @@ function isBinaryMissing(out: { error?: Error & { code?: string } }): boolean {
 }
 
 /**
+ * The module's ONLY `spawnSync`, and the exact shape the whitelist entry in
+ * `test/tui/render-path-sync-guard.test.ts` is granted for: one shot, O(refs),
+ * a 2s cap, stderr discarded. `missing` splits "git isn't on PATH" out of a
+ * non-zero exit (ENOENT reports both); `spawned` is false when the spawn
+ * itself threw, which {@link hasNoCommits} must not read as git's own answer.
+ */
+function git(
+  repo: string,
+  args: readonly string[],
+): { status: number; stdout: string; missing: boolean; spawned: boolean } {
+  try {
+    const out = spawnSync("git", args, {
+      cwd: repo,
+      encoding: "utf-8",
+      timeout: 2000,
+      stdio: ["ignore", "pipe", "ignore"],
+    })
+    return { status: out.status ?? 1, stdout: out.stdout ?? "", missing: isBinaryMissing(out), spawned: true }
+  } catch {
+    return { status: 1, stdout: "", missing: false, spawned: false }
+  }
+}
+
+/**
  * Friendly reason for a repo with an UNBORN HEAD — `git init` ran but nothing
  * was ever committed. `rev-parse --git-dir` succeeds here, so the repo check
  * above passes and the dialog happily prefills `DEFAULT_BASE_REF`; the failure
@@ -93,18 +117,8 @@ function noCommitsReason(path: string): string {
  * {@link validateRepoPath} is the only caller and it checks repo-ness first.
  */
 function hasNoCommits(repo: string): boolean {
-  try {
-    const out = spawnSync("git", ["rev-parse", "--verify", "HEAD"], {
-      cwd: repo,
-      encoding: "utf-8",
-      timeout: 2000,
-      stdio: ["ignore", "pipe", "ignore"],
-    })
-    if (isBinaryMissing(out)) return false
-    return out.status !== 0
-  } catch {
-    return false
-  }
+  const out = git(repo, ["rev-parse", "--verify", "HEAD"])
+  return out.spawned && !out.missing && out.status !== 0
 }
 
 export function validateRepoPath(repo: string): string | null {
@@ -118,18 +132,9 @@ export function validateRepoPath(repo: string): string | null {
     return `path does not exist: ${trimmed}`
   }
   if (!stat.isDirectory()) return `not a directory: ${trimmed}`
-  try {
-    const out = spawnSync("git", ["rev-parse", "--git-dir"], {
-      cwd: trimmed,
-      encoding: "utf-8",
-      timeout: 2000,
-      stdio: ["ignore", "pipe", "ignore"],
-    })
-    if (isBinaryMissing(out)) return gitMissingReason()
-    if (out.status !== 0) return notAGitRepoReason(trimmed)
-  } catch {
-    return notAGitRepoReason(trimmed)
-  }
+  const repoCheck = git(trimmed, ["rev-parse", "--git-dir"])
+  if (repoCheck.missing) return gitMissingReason()
+  if (repoCheck.status !== 0) return notAGitRepoReason(trimmed)
   // A repo with no commits passes every check above but has nothing for
   // `git worktree add <path> <baseRef>` to branch from.
   if (hasNoCommits(trimmed)) return noCommitsReason(trimmed)
@@ -146,20 +151,10 @@ export function validateRepoPath(repo: string): string | null {
  */
 export function getCurrentBranch(repo: string): string | null {
   if (!repo) return null
-  try {
-    const out = spawnSync("git", ["rev-parse", "--abbrev-ref", "HEAD"], {
-      cwd: repo,
-      encoding: "utf-8",
-      timeout: 2000,
-      stdio: ["ignore", "pipe", "ignore"],
-    })
-    if (out.status !== 0) return null
-    const name = out.stdout.trim()
-    if (!name || name === "HEAD") return null
-    return name
-  } catch {
-    return null
-  }
+  const out = git(repo, ["rev-parse", "--abbrev-ref", "HEAD"])
+  if (out.status !== 0) return null
+  const name = out.stdout.trim()
+  return !name || name === "HEAD" ? null : name
 }
 
 /**
@@ -171,26 +166,18 @@ export function getCurrentBranch(repo: string): string | null {
  */
 export function listLocalBranches(repo: string): string[] {
   if (!repo) return []
-  try {
-    const out = spawnSync("git", ["for-each-ref", "--format=%(refname:short)", "refs/heads/"], {
-      cwd: repo,
-      encoding: "utf-8",
-      timeout: 2000,
+  const out = git(repo, ["for-each-ref", "--format=%(refname:short)", "refs/heads/"])
+  if (out.status !== 0) return []
+  return out.stdout
+    .split("\n")
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .sort((a, b) => {
+      // Default branches first.
+      const score = (n: string) => (n === "main" ? 0 : n === "master" ? 1 : n === "develop" ? 2 : 3)
+      const sa = score(a)
+      const sb = score(b)
+      if (sa !== sb) return sa - sb
+      return a.localeCompare(b)
     })
-    if (out.status !== 0) return []
-    return out.stdout
-      .split("\n")
-      .map((s) => s.trim())
-      .filter(Boolean)
-      .sort((a, b) => {
-        // Default branches first.
-        const score = (n: string) => (n === "main" ? 0 : n === "master" ? 1 : n === "develop" ? 2 : 3)
-        const sa = score(a)
-        const sb = score(b)
-        if (sa !== sb) return sa - sb
-        return a.localeCompare(b)
-      })
-  } catch {
-    return []
-  }
 }

--- a/packages/kobe/test/lib/relative-time.test.ts
+++ b/packages/kobe/test/lib/relative-time.test.ts
@@ -1,23 +1,47 @@
 import { describe, expect, test } from "vitest"
-import { relativeBuckets } from "../../src/lib/relative-time.ts"
+import { relativeAge, relativeBuckets } from "../../src/lib/relative-time.ts"
 
 const MIN = 60_000
+const NOW = Date.parse("2026-07-27T12:00:00.000Z")
 
 describe("relativeBuckets", () => {
   test("steps minutes → hours → days from one delta", () => {
     expect(relativeBuckets(15 * MIN)).toEqual({ minutes: 15, hours: 0, days: 0 })
-    expect(relativeBuckets(23 * 60 * MIN)).toEqual({ minutes: 23 * 60, hours: 23, days: 1 })
+    expect(relativeBuckets(23 * 60 * MIN)).toEqual({ minutes: 23 * 60, hours: 23, days: 0 })
     expect(relativeBuckets(3 * 24 * 60 * MIN)).toMatchObject({ hours: 72, days: 3 })
   })
 
-  test("each step ROUNDS — the behavior both consumers shipped with", () => {
-    // Pinned so the two callers can't drift apart. Whether these should
-    // floor instead (a countdown that never overstates headroom) is a
-    // display-convention call; flipping it here moves every consumer.
-    expect(relativeBuckets(90 * MIN).hours).toBe(2) // 1h30m rounds up
-    expect(relativeBuckets(89 * MIN).hours).toBe(1)
-    expect(relativeBuckets(36 * 60 * MIN).days).toBe(2) // 1d12h rounds up
-    expect(relativeBuckets(29_999).minutes).toBe(0) // <30s is "now" territory
-    expect(relativeBuckets(30_000).minutes).toBe(1)
+  test("each step FLOORS, so a countdown never overstates headroom", () => {
+    // The two cases the decision turned on: a routine 1h40m out used to read
+    // `in 2h` and fire twenty minutes early, and 36h out used to read `in 2d`.
+    expect(relativeBuckets(100 * MIN).hours).toBe(1)
+    expect(relativeBuckets(36 * 60 * MIN).days).toBe(1)
+    expect(relativeBuckets(90 * MIN).hours).toBe(1)
+    expect(relativeBuckets(119 * MIN).hours).toBe(1)
+    expect(relativeBuckets(120 * MIN).hours).toBe(2)
+    // A sub-minute event is "now", not "1m ago" — the widened window that
+    // makes the Routines run list agree with the inbox's `45s`.
+    expect(relativeBuckets(59_999).minutes).toBe(0)
+    expect(relativeBuckets(60_000).minutes).toBe(1)
+  })
+})
+
+describe("relativeAge", () => {
+  test("steps through seconds, minutes, hours, and days", () => {
+    expect(relativeAge(NOW - 3_000, NOW)).toBe("3s")
+    expect(relativeAge(NOW - 5 * 60_000, NOW)).toBe("5m")
+    expect(relativeAge(NOW - 3 * 3_600_000, NOW)).toBe("3h")
+    expect(relativeAge(NOW - 2 * 86_400_000, NOW)).toBe("2d")
+  })
+
+  test("clamps a clock-skewed future stamp to 0s", () => {
+    expect(relativeAge(NOW + 5000, NOW)).toBe("0s")
+  })
+
+  test("reads the same instant as the bucket consumers do", () => {
+    // The bug this file's single ownership closes: the routines run list read
+    // `2m ago` for the event the inbox called `1m`.
+    expect(relativeAge(NOW - 100_000, NOW)).toBe("1m")
+    expect(relativeAge(NOW - 100 * MIN, NOW)).toBe("1h")
   })
 })

--- a/packages/kobe/test/render/automations-page-keys.test.tsx
+++ b/packages/kobe/test/render/automations-page-keys.test.tsx
@@ -22,7 +22,10 @@ const AUTOMATION = {
   prompt: "audit",
   schedule: "0 9 * * MON-FRI",
   enabled: true,
-  nextRunAt: new Date(NOW + 3_600_000).toISOString(),
+  // 100 minutes, not a flat hour: the preview FLOORS, so a fixture sitting on
+  // the boundary reads `59m` the moment the render takes a millisecond. 100
+  // also separates the two rules — flooring says `in 1h`, rounding said `in 2h`.
+  nextRunAt: new Date(NOW + 100 * 60_000).toISOString(),
   missedRunGraceMinutes: 60,
   createdAt: "2026-07-01T00:00:00Z",
   updatedAt: "2026-07-01T00:00:00Z",

--- a/packages/kobe/test/render/failure-toast.test.tsx
+++ b/packages/kobe/test/render/failure-toast.test.tsx
@@ -133,7 +133,9 @@ const AUTOMATION = {
   prompt: "audit",
   schedule: "0 9 * * MON-FRI",
   enabled: true,
-  nextRunAt: new Date(Date.now() + 3_600_000).toISOString(),
+  // 100 minutes, not a flat hour: the schedule preview FLOORS, so a fixture on
+  // the boundary reads `59m` and the muted needle below stops matching.
+  nextRunAt: new Date(Date.now() + 100 * 60_000).toISOString(),
   missedRunGraceMinutes: 60,
   createdAt: "2026-07-01T00:00:00Z",
   updatedAt: "2026-07-01T00:00:00Z",

--- a/packages/kobe/test/tui-react/plugins-core.test.ts
+++ b/packages/kobe/test/tui-react/plugins-core.test.ts
@@ -21,7 +21,6 @@ import {
   pluginRowView,
   setPluginEnabled,
 } from "../../src/tui-react/component/settings-dialog/plugins-core.ts"
-import { relativeAgeMs } from "../../src/tui/history/message-core"
 
 const NOW = Date.parse("2026-07-27T12:00:00.000Z")
 
@@ -218,18 +217,5 @@ describe("setPluginEnabled", () => {
     // …and re-enabling brings it back — both without a restart.
     setPluginEnabled("example.engine", true, home)
     expect(pluginEngineIds()).toEqual(["aider"])
-  })
-})
-
-describe("relativeAgeMs", () => {
-  it("steps through seconds, minutes, hours, and days", () => {
-    expect(relativeAgeMs(NOW - 3_000, NOW)).toBe("3s")
-    expect(relativeAgeMs(NOW - 5 * 60_000, NOW)).toBe("5m")
-    expect(relativeAgeMs(NOW - 3 * 3_600_000, NOW)).toBe("3h")
-    expect(relativeAgeMs(NOW - 2 * 86_400_000, NOW)).toBe("2d")
-  })
-
-  it("clamps a clock-skewed future stamp to 0s", () => {
-    expect(relativeAgeMs(NOW + 5000, NOW)).toBe("0s")
   })
 })

--- a/packages/kobe/test/tui/lib/git-snapshot.test.ts
+++ b/packages/kobe/test/tui/lib/git-snapshot.test.ts
@@ -126,6 +126,19 @@ describe("getCurrentBranch", () => {
     expect(getCurrentBranch(notRepo)).toBeNull()
     expect(getCurrentBranch("")).toBeNull()
   })
+
+  // A detached HEAD is the one case where git EXITS ZERO and still has no
+  // branch name to give: `--abbrev-ref` prints the literal "HEAD". Prefilling
+  // baseRef with that string would send `git worktree add` at a ref that moves
+  // under it, so it has to read as null and fall back to DEFAULT_BASE_REF.
+  it('degrades to null on a detached HEAD, which git reports as the name "HEAD"', () => {
+    git(repo, "checkout", "--detach")
+    try {
+      expect(getCurrentBranch(repo)).toBeNull()
+    } finally {
+      git(repo, "checkout", "zeta")
+    }
+  })
 })
 
 describe("listLocalBranches", () => {


### PR DESCRIPTION
Batch P from `.scratch/loop-r7/briefs.md` — briefs 3 and 4. Two commits, reviewable
independently; the first is a behavior change with screenshots, the second is a
behavior-preserving refactor with an identity check.

Screenshots and JSON captures are archived at
`/Users/jacksonc/.rove/worktrees/kobe-0aff3858ab76/snipe/.scratch/loop-r7-p/shots/`
(also `/tmp/loop-r7-p/`).

---

## P1 — two relative-time rules, one clock: floor is the owner

**What changed.** `relativeBuckets` (`packages/kobe/src/lib/relative-time.ts`) rounded
at every step while `relativeAgeMs` (`tui/history/message-core.ts`) floored, so the
same instant read two ways depending on which screen you were on.
`relativeBuckets` now floors and owns the `3m`/`2h`/`4d` label too, as `relativeAge`;
`relativeAgeMs` is deleted and its six consumers (worktrees page, attention inbox ×2,
issue events, plugins section, and `relativeTime`) import from the one module. The
header comment that recorded floor-vs-round as undecided now states the decision and
the two reasons for it.

**PASS criterion.** Harness BEFORE/AFTER on the Routines page and the Inbox, on a
fixture whose next run is 100 minutes out and whose newest run event is ~100 seconds
old: BEFORE `in 2h` / `2m ago`, AFTER `in 1h` / `1m ago`, with the Inbox reading the
same event as `1m` throughout. Plus `grep -rn relativeAgeMs packages/` → 0, the
existing relative-time tests updated deliberately, and fast + render green.

**Proof.**

| | BEFORE | AFTER |
| --- | --- | --- |
| Routines | `shots/routines-before.png` | `shots/routines-after.png` |
| Inbox | `shots/inbox-before.png` | `shots/inbox-after.png` |

Read off the images — three labels move, all on the Routines page:

| surface | BEFORE | AFTER |
| --- | --- | --- |
| next-run preview, 100 min out | `in 2h` | `in 1h` |
| run list, event ~100 s old | `#2 dispatched 2m ago` | `#2 dispatched 1m ago` |
| run list, event 100 min old | `#1 dispatched 2h ago` | `#1 dispatched 1h ago` |
| Inbox, the same ~100 s event | `1m` | `1m` (unchanged — it already floored) |

The Inbox pair is the point of the change: BEFORE, the Routines run list called a
100-second-old event `2m ago` while the Inbox called it `1m`. AFTER, they agree.

Captured through `/harness` → xterm.js → PTY sidecar → real OpenTUI, on a FRESH
fixture each side (`visual:serve` restarted between the two after `bun run build`), with
`KOBE_VISUAL_PORT_BASE=5873`. The fixture is seeded by
`.scratch/loop-r7-p/seed-routine.ts`, which writes the fixture daemon's
`automations.json` + `attention-inbox.json` with offsets measured from the seed instant
and restarts that daemon so its store re-reads them.

```
$ grep -rn "Math.round" packages/kobe/src/lib/relative-time.ts    # exit 1, no matches
$ grep -rn relativeAgeMs packages/kobe/src packages/kobe/test packages/kobe-web/src
(no matches)
```

The only surviving `relativeAgeMs` string in the repo is `packages/kobe/CHANGELOG.md:2709`,
a shipped release note describing history — left alone.

`relativeAge` keeps exactly one arithmetic step of its own (seconds); minutes/hours/days
come from `relativeBuckets`.

**Test changes, deliberate.**
- `test/lib/relative-time.test.ts` — the test named "each step ROUNDS — the behavior
  both consumers shipped with" (an explicit placeholder) becomes the floor contract, and
  `relativeBuckets(23h)` moves from `days: 1` to `days: 0`. Added the two cases the
  decision turned on (100 min → 1 h, 36 h → 1 d), the 119/120-minute boundary pair, the
  59.999 s/60 s minute boundary, and the `relativeAge` cases moved out of
  `test/tui-react/plugins-core.test.ts` (they had been living next to the plugins view
  model because that was the function's last consumer).
- `test/render/automations-page-keys.test.tsx` and `test/render/failure-toast.test.tsx`
  both pinned `nextRunAt` at exactly `Date.now() + 3_600_000`. Flooring makes that read
  `59m` the moment the render takes a millisecond, so both move to 100 minutes — which
  reads `in 1h` under the decided rule and would have read `in 2h` under the old one, so
  the fixtures now distinguish the two rules instead of straddling them.

**Gates.**
```
bun run lint            ok (1399 files)
bun run typecheck       ok (4 packages)
bun test test/render    455 pass, 0 fail
bun run test:fast       4354 passed, 6 failed
```
Those 6 are environment-shaped and pre-existing — `test/state/project-eligibility` ×2 and
`test/cli/open-dir-cmd` ×2 (this checkout is under `~/.rove/worktrees`, which
`pathRejection` reads as `roveInternal`) and `test/tui/continue-live-vendor` ×2 (the real
`~/.config/rove/state.json` has `claudecpa` registered). They are brief 1's evidence and
batch O's target. Proven not mine: with only my touched files reverted to HEAD, the same
3 files produce the identical 6 failures —
```
$ git checkout HEAD -- <my 9 files>
$ bun x vitest run test/cli/open-dir-cmd.test.ts test/state/project-eligibility.test.ts \
    test/tui/continue-live-vendor.test.ts
  Test Files  3 failed (3)
       Tests  6 failed | 31 passed (37)
```

---

## P2 — `git-snapshot.ts` spawns git one way now

**What changed.** Four `spawnSync("git", …)` blocks, each with its own copy of the
options and its own `try`/`catch`, collapse into one module-private `git()` helper. The
fourth call had already drifted — no `stdio`, so stderr took the default instead of
`ignore`; nothing reads `stderr` here, so unifying it is not observable. The helper's doc
names the shape the render-path sync whitelist entry is granted for (one shot, O(refs),
2 s cap, stderr discarded), so the whitelist now points at one call site instead of four.

`spawned` is the one field that keeps this exactly behavior-preserving: the four
`catch` fallbacks were NOT identical — three treated a thrown spawn as failure, but
`hasNoCommits` returned `false` ("has commits"). Mapping a throw to `status: 1` alone
would have flipped that one. No test can reach it (`spawnSync` with constant options does
not throw), which is why it is documented rather than covered.

**PASS criterion.** `bun run test:fast` green on the covering tests; an end-to-end
identity check byte-identical before/after; net line reduction stated; and the brief's
mutation check — forcing `missing` to `false` must turn the "git is not installed" vs
"not a repo" case red.

**Proof.**

Behavior fingerprint — every exported path (`validateRepoPath`, `getCurrentBranch`,
`listLocalBranches`, `DEFAULT_BASE_REF`) across 8 cases including a dirty repo, a subdir,
an unborn HEAD, a plain file, a missing path, the empty string, and git absent from PATH
(`.scratch/loop-r7-p/git-snapshot-probe.ts`):
```
$ diff git-snapshot-before.json git-snapshot-after.json && echo IDENTICAL
IDENTICAL
$ md5 -q git-snapshot-before.json git-snapshot-after.json
c5ca35336553d0871bd18b81a44a1aa4
c5ca35336553d0871bd18b81a44a1aa4
```

`rove api get-task` and `rove api collect` for a dirty fixture worktree (the sidebar's
`+N −N` chip), rebuilt CLI on both sides — `diff` clean:
```json
{
 "taskId": "01M1M3QPCX0HNNWC6WSGCHZ653",
 "branch": "visual-fixture",
 "changes": { "added": 2, "deleted": 0 },
 "base": { "baseRef": "main", "ahead": 0, "behind": 0,
           "diff": { "files": 0, "insertions": 0, "deletions": 0 } }
}
```
(That chip is daemon-computed and never routed through `git-snapshot.ts`, so this is a
nothing-else-moved check rather than a proof of the refactor; the fingerprint above is
the proof.)

```
$ wc -l packages/kobe/src/tui/lib/git-snapshot.ts     196 -> 183
$ grep -c 'spawnSync(' packages/kobe/src/tui/lib/git-snapshot.ts     1
$ bun x vitest run test/tui/lib/git-snapshot.test.ts test/tui/render-path-sync-guard.test.ts
  Test Files  2 passed (2)   (whitelist entry untouched)
```

Net −13 lines, not the brief's estimated −23: the estimate assumed a bare helper, and
the six-line doc block recording the whitelist's granted shape is the part of this change
worth keeping.

**Mutation checks, two different sites.**
1. `missing: isBinaryMissing(out)` → `missing: false`:
   `× validateRepoPath > says git is missing, not that the folder isn't a repo, when git is absent`
   → 1 failed | 8 passed. The ENOENT distinction is genuinely covered.
2. `return !name || name === "HEAD" ? null : name` → `return name`: **stayed green.**
   The brief's rule says the test is owed before the refactor lands, so this commit adds
   it — a detached HEAD is the one case where git exits zero and still has no branch name
   (`--abbrev-ref` prints the literal `HEAD`), and prefilling `baseRef` with that string
   would aim `git worktree add` at a ref that moves. With the new test, the same mutation
   goes red:
   `× getCurrentBranch > degrades to null on a detached HEAD` → 1 failed | 9 passed.

No changeset: behavior-preserving, nothing user-visible. No screenshots: no TUI surface
changes.

**Deliberately skipped** (per the brief's own re-measurement): the daemon
`task not found` shaping. Ten one-line sites plus a four-line helper is a positive net
line change with no consistency boundary to defend.

---

## Not proved

- The 6 pre-existing failures above are left for batch O; I did not fix them.
- `spawned` in `git()` has no test, by construction (see above).
- `bun run test:socket` / `test:behavior` were not run — this batch touches neither the
  daemon protocol nor the behavior harness.
