### PR TITLE
test: isolate the kv store in the wrapper-preset continuation tests

### DIFF
--- a/.changeset/continue-live-vendor-isolation.md
+++ b/.changeset/continue-live-vendor-isolation.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+The wrapper-preset continuation tests isolate the kv store, so a machine whose daemon has already learned `engineProtocol.claudecpa` no longer fails them.

--- a/packages/kobe/test/tui/continue-live-vendor.test.ts
+++ b/packages/kobe/test/tui/continue-live-vendor.test.ts
@@ -45,8 +45,14 @@ const wrapperTab = (over: Partial<EngineTab> = {}): EngineTab => ({
 
 let claudeDir: string
 let prevConfigDir: string | undefined
+let prevHome: string | undefined
 
 beforeAll(() => {
+  // Every case here assumes `claudecpa` has NO declared protocol. The real
+  // state.json can say otherwise (the daemon writes `engineProtocol.<id>`
+  // back once it has walked the wrapper), so the kv store is isolated.
+  prevHome = process.env.KOBE_HOME_DIR
+  process.env.KOBE_HOME_DIR = mkdtempSync(join(tmpdir(), "rove-claudecpa-home-"))
   // A real claude transcript store, so the history read under test is the
   // real reader rather than a stub that could agree with a broken caller.
   claudeDir = mkdtempSync(join(tmpdir(), "rove-claudecpa-"))
@@ -61,6 +67,9 @@ afterAll(() => {
   // Empty restores the real store: the reader falls back on a blank value.
   process.env.CLAUDE_CONFIG_DIR = prevConfigDir ?? ""
   rmSync(claudeDir, { recursive: true, force: true })
+  rmSync(process.env.KOBE_HOME_DIR ?? "", { recursive: true, force: true })
+  if (prevHome === undefined) Reflect.deleteProperty(process.env, "KOBE_HOME_DIR")
+  else process.env.KOBE_HOME_DIR = prevHome
 })
 
 describe("liveSourceProtocol", () => {


### PR DESCRIPTION
## What

\`test/tui/continue-live-vendor.test.ts\` assumes \`claudecpa\` has no declared protocol. On a machine where the daemon has already walked the wrapper and written \`engineProtocol.claudecpa: claude\` into \`~/.config/rove/state.json\` (the owner's), two cases failed: \`liveSourceProtocol\` returned the declared id and \`planChatContinuation\` found a session. The file now points \`KOBE_HOME_DIR\` at a temp dir in \`beforeAll\`, the same recipe \`test/engine/engine-presets.test.ts\` uses.

## Evidence

Before: 2 failed / 5 passed on this machine, 7/7 with an isolated \`KOBE_HOME_DIR\` on the command line. After: 7/7 with no env override.