### PR TITLE
fix: tab completes the new task dialog's path fields instead of leaving them

### DIFF
--- a/.changeset/tab-completes-repo-field.md
+++ b/.changeset/tab-completes-repo-field.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+`tab` in the New task dialog's repo field now COMPLETES the highlighted suggestion instead of leaving the field. Typing `a`, seeing `academic-…` under it and pressing the key that finishes things in every shell used to land you on `from branch` with `a` still in the repo box — the dropdown had no key that finished a suggestion and stayed, so continuing meant clicking back. A second `tab`, with nothing left to complete, advances as before. Browsed directories complete one level DOWN and keep their trailing slash, so repeated `tab` walks a path the way a shell does; saved repos complete to their name and close the dropdown. The Clone tab's parent-directory field walks the same way, since it is the same picker. The walking slash no longer travels with the value, so `/i/rove/` and `/i/rove` file one repo rather than two.

--- a/docs/TUI.md
+++ b/docs/TUI.md
@@ -245,13 +245,21 @@ that carry it.
 
 Focus the sidebar and press `n`. The New task dialog starts on a mode selector
 and an engine selector; `tab` walks every field and the bottom-right Create
-button, while `ctrl+e` cycles the detected engines from anywhere in the
-dialog. Use `ctrl+[` / `ctrl+]` to move between its three modes, or focus the
+button — except in the two path fields (the repo, and the Clone tab's parent
+directory), where it first completes the highlighted suggestion in place,
+exactly as a shell would, and only moves on once there is nothing left to
+complete. `ctrl+e` cycles the detected engines from anywhere in
+the dialog. Use `ctrl+[` / `ctrl+]` to move between its three modes, or focus the
 mode selector and use the left/right arrows.
 
 - **For Existing** picks a local repository and the ref to branch from. Rove
   creates a new task branch and worktree, then opens it ready for the first
   prompt. The current repository and its checked-out branch are the defaults.
+  Type a name to filter your saved repositories, or a path (`/` or `~/`) to
+  browse directories instead; `↑`/`↓` moves the highlight. `tab` completes the
+  highlighted row without leaving the field — a browsed directory keeps its
+  trailing slash, so the next `tab` walks one level deeper — while `enter`
+  takes the highlighted row and moves on to the branch field.
   For a repository Rove already tracks as a project, an extra **opens** row
   appears: leave it on "a new task worktree" for the behaviour above, or
   choose "the project itself" to open that repository's own checkout instead
@@ -260,7 +268,8 @@ mode selector and use the left/right arrows.
   because opening a checkout forks from nothing.
 - **For New Repo** clones a Git URL into a chosen parent directory, derives an
   available folder name, then creates a task from the requested base branch.
-  The parent directory is remembered for the next clone.
+  The parent-directory field browses the same way the repo field does, `tab`
+  included. The parent directory is remembered for the next clone.
 - **Adopt Worktree** imports existing git worktrees that are not already
   tasks. The path-glob field filters by absolute path or basename; `enter`
   toggles the highlighted row and `ctrl+a` selects or clears all filtered

--- a/docs/design/keybinding-decisions.md
+++ b/docs/design/keybinding-decisions.md
@@ -8,6 +8,35 @@ reasoning is recorded so the next agent has the context.
 The user-facing vocabulary lives in [`../KEYBINDINGS.md`](../KEYBINDINGS.md).
 `F1` renders the live keymap and is authoritative over both.
 
+## Tab in the New task dialog's repo field
+
+**2026-09-03 — `tab` completes the highlighted suggestion in place; a second
+`tab`, with nothing left to complete, advances the field as before.** Owner
+call, made from the report that drove it: the dialog had no key that finished
+a suggestion and STAYED. `enter` picked-and-advanced, `tab` advanced, so a
+user who typed `a`, saw `academic-…` under it and pressed the key that
+finishes things in every shell they own landed on `from branch` with `a`
+still in the repo box — and had to click back to keep typing.
+
+Why `tab` rather than a new chord (the two alternatives the owner weighed
+were `→`-at-end-of-line, fish-style, and a dedicated chord): the shell
+bargain is already `tab`'s, and layering completion under advance costs no
+new key and no muscle memory — a key that means "finish this for me" ends by
+finishing the field when there is nothing else to finish. `→` was rejected as
+the more hidden of the two (it means cursor-right inside an input every other
+moment), and a dedicated chord as one more thing to remember for a dialog
+that should feel like a prompt.
+
+Scope: both of the dialog's path fields — the Existing tab's repo and the
+Clone tab's parent dir, which are the same drill-down picker; a key that
+walked one but not the other would mean two things inside one dialog. Only
+while the dropdown is on screen, though: the guard is the picker's own render
+condition, so `tab` keeps its plain meaning everywhere else. Browse rows complete one directory DOWN, with
+the trailing slash that re-points the picker at the children (the walk is the
+point); saved rows complete to the repo name and close the dropdown, because
+nothing lives under a repo. Both modes complete toward the row the cursor is
+ON, which is what `enter` and `↑`/`↓` already meant.
+
 ## New task from anywhere
 
 **2026-09-03 — `prefix+n` opens New task from anywhere; the sidebar keeps

--- a/packages/kobe/src/tui-react/component/new-task-dialog/use-branch-field.ts
+++ b/packages/kobe/src/tui-react/component/new-task-dialog/use-branch-field.ts
@@ -1,0 +1,109 @@
+/**
+ * The existing tab's "from branch" cluster — the dialog's OTHER picker,
+ * sibling to `./use-clone-state.ts` and `./use-adopt-state.ts`.
+ *
+ * The seam: `./view-model.ts` owns which repo you are talking about; this
+ * hook owns which ref that repo forks from. The dependency runs one way —
+ * the branch list is a function of the resolved repo path, and nothing here
+ * is read back to decide the repo — so the whole cluster (the ref text, its
+ * "touched" latch, the filtered branch list, its cursor and window, and the
+ * Enter-commits behavior of the tab's last field) travels together and
+ * leaves the view-model with tabs, engine, repo and commit dispatch.
+ *
+ * `listLocalBranches` / `getCurrentBranch` are the sync git snapshots from
+ * `src/tui/lib/git-snapshot.ts`, memoized on the expanded repo path.
+ */
+
+import { useEffect, useMemo, useState } from "react"
+import {
+  type PickerWindow,
+  clampCursor,
+  filterBranches,
+  resolveBaseRef,
+  stripNewlines,
+  windowAround,
+} from "../../../tui/component/new-task-dialog/state"
+import { DEFAULT_BASE_REF, getCurrentBranch, listLocalBranches } from "../../../tui/lib/git-snapshot"
+import { expandHome } from "../../../tui/lib/path-helpers"
+
+export type BranchFieldOpts = {
+  /** Absolute repo path the branch list is read from; "" while unresolved. */
+  expandedRepo: string
+  /** Rows the picker may paint — the terminal-height budget from the caller. */
+  pickerRows: number
+  /** Seeds the ref before any repo is resolved (the caller's cwd). */
+  defaultRepo: string
+  /** Enter on this field is the tab's last stop: resolve, then create. */
+  commit: () => void
+  /** Focus lands on Create once a branch is clicked out of the picker. */
+  onPicked: () => void
+}
+
+export function useBranchField(opts: BranchFieldOpts) {
+  // Initial baseRef tracks the cwd's current branch (a worktree forked from a
+  // feature branch defaults to it, not a hardcoded "main").
+  const [baseRef, setBaseRef] = useState(
+    () => getCurrentBranch(expandHome(opts.defaultRepo.trim())) ?? DEFAULT_BASE_REF,
+  )
+  // Once the user has typed here we stop auto-syncing from the repo's current
+  // branch — the manual override wins.
+  const [baseRefTouched, setBaseRefTouched] = useState(false)
+  const [branchCursor, setBranchCursor] = useState(0)
+
+  const branches = useMemo(() => listLocalBranches(opts.expandedRepo), [opts.expandedRepo])
+  const branchFiltered = useMemo(() => filterBranches(branches, baseRef), [branches, baseRef])
+  const branchWindow: PickerWindow = windowAround(branchFiltered, branchCursor, opts.pickerRows)
+
+  // Auto-sync baseRef to the picked repo's current branch until touched.
+  useEffect(() => {
+    if (!opts.expandedRepo || baseRefTouched) return
+    const current = getCurrentBranch(opts.expandedRepo)
+    if (current) setBaseRef(current)
+  }, [opts.expandedRepo, baseRefTouched])
+
+  function setBaseRefText(v: string): void {
+    setBaseRefTouched(true)
+    setBaseRef(stripNewlines(v))
+    setBranchCursor(0)
+  }
+
+  function pickBranchAt(absoluteIndex: number): void {
+    const name = branchFiltered[absoluteIndex]
+    if (!name) return
+    setBaseRef(name)
+    setBaseRefTouched(true)
+    setBranchCursor(absoluteIndex)
+    opts.onPicked()
+  }
+
+  // Last field on the existing tab — Enter resolves the highlighted branch
+  // and creates straight away.
+  function onBaseRefSubmit(): void {
+    setBaseRef(resolveBaseRef(baseRef, branchFiltered, branchCursor))
+    setBaseRefTouched(true)
+    opts.commit()
+  }
+
+  function moveBranchCursor(delta: 1 | -1): void {
+    if (branchFiltered.length === 0) return
+    setBranchCursor((c) => clampCursor(c + delta, branchFiltered.length))
+  }
+
+  /** A repo change invalidates the highlight — the list underneath changed. */
+  function resetBranchCursor(): void {
+    setBranchCursor(0)
+  }
+
+  return {
+    baseRef,
+    branches,
+    branchFiltered,
+    branchWindow,
+    branchCursor,
+    setBaseRefText,
+    pickBranchAt,
+    onBaseRefSubmit,
+    moveBranchCursor,
+    resetBranchCursor,
+  }
+}

--- a/packages/kobe/src/tui-react/component/new-task-dialog/use-clone-state.ts
+++ b/packages/kobe/src/tui-react/component/new-task-dialog/use-clone-state.ts
@@ -17,6 +17,7 @@ import {
   validateCloneTarget,
   validateGitUrl,
 } from "../../../tui/component/new-task-dialog/clone"
+import { completeRepoInput } from "../../../tui/component/new-task-dialog/repo-field"
 import {
   type Field,
   type NewTaskInput,
@@ -91,6 +92,30 @@ export function useCloneState(args: {
     args.setField("cloneFolder")
   }
 
+  /**
+   * Tab in the parent-dir field — the clone tab's half of the repo field's
+   * shell completion, and the same bargain: finish the highlighted row in
+   * place, and let the key mean "next field" only once there is nothing left
+   * to finish. Always a browse walk, because a parent directory is only ever
+   * a path — there is no saved-name mode on this side, so no `repoOptions`.
+   *
+   * The caller owns the focus check; this owns "is there anything to say".
+   */
+  function completeCloneParent(): boolean {
+    if (cloneParentPicked) return false
+    const done = completeRepoInput({
+      value: cloneParent,
+      mode: "browse",
+      highlighted: cloneParentFiltered[cloneParentCursor],
+      baseExpanded: cloneParentSplit.base,
+      repoOptions: [],
+    })
+    if (!done) return false
+    setCloneParent(done.value)
+    setCloneParentCursor(0)
+    return true
+  }
+
   function selectCloneParentAt(absoluteIndex: number): void {
     const picked = cloneParentFiltered[absoluteIndex]
     if (!picked) return
@@ -155,6 +180,7 @@ export function useCloneState(args: {
     cloneParentWindow,
     cloneParentCursor,
     cloneParentPicked,
+    completeCloneParent,
     setCloneUrlText,
     setCloneParentText,
     setCloneFolderText,

--- a/packages/kobe/src/tui-react/component/new-task-dialog/use-repo-field.ts
+++ b/packages/kobe/src/tui-react/component/new-task-dialog/use-repo-field.ts
@@ -1,0 +1,218 @@
+/**
+ * The Existing tab's repo cluster — the question "WHICH repository", start to
+ * finish. Sibling of `./use-branch-field.ts` (which ref it forks from) and of
+ * `./use-clone-state.ts` / `./use-adopt-state.ts`.
+ *
+ * The seam: everything about identifying a repo lives here — the field's
+ * text, what that text resolves to, both suggestion lists behind it, the
+ * cursor over them, and every route that changes the answer (typing, Tab
+ * completion, Enter, a click). `./view-model.ts` keeps what is ABOUT the
+ * dialog rather than about the repo: tabs, engine, intent, commit dispatch
+ * and key bindings.
+ *
+ * The field holds exactly what it shows — a NAME once one is chosen, free
+ * text while it is being typed — and never a display derived from some other
+ * value: an opentui `<input>` adopts its `value` prop as its edit buffer, so
+ * a field showing one string while state holds another writes the shown one
+ * back on the next keystroke and the two oscillate. One representation,
+ * translated to a path at the boundaries (`repo-field.ts`) instead.
+ */
+
+import { useMemo, useState } from "react"
+import {
+  type RepoResolution,
+  completeRepoInput,
+  nameOrPath,
+  resolveRepoInput,
+  splitRepoInput,
+} from "../../../tui/component/new-task-dialog/repo-field"
+import {
+  type PickerWindow,
+  clampCursor,
+  computeRepoOptions,
+  filterRepos,
+  pickerModeFor,
+  stripNewlines,
+  windowAround,
+} from "../../../tui/component/new-task-dialog/state"
+import { expandHome, joinPicked, stripTrailingSlash } from "../../../tui/lib/path-helpers"
+import { useDerivedDir } from "./use-derived-dir"
+
+export type RepoFieldOpts = {
+  /** The caller's cwd — seeds the field and heads the saved list. */
+  defaultRepo: string
+  /** User-curated repo list (`/add-repo`). */
+  savedRepos: readonly string[]
+  /** Rows the picker may paint — the terminal-height budget from the caller. */
+  pickerRows: number
+  /** A DIFFERENT repo is now in the field (any route). */
+  onChanged: () => void
+  /** Enter / a click has answered the field; move focus along. */
+  onAnswered: () => void
+}
+
+export function useRepoField(opts: RepoFieldOpts) {
+  // Seeded from the caller's PATH, shown as a name — the field's own grammar
+  // from the first frame rather than a path that turns into a name on first
+  // touch. `repoDir` puts the directory back beside it. Same round-trip guard
+  // as `pickRepo`: a basename shared with another saved repo would open the
+  // dialog on an ambiguous value, so that case keeps the path.
+  const [repo, setRepo] = useState(() =>
+    nameOrPath(opts.defaultRepo, computeRepoOptions(opts.defaultRepo, opts.savedRepos)),
+  )
+  const [repoCursor, setRepoCursor] = useState(0)
+  // "Selected, not drilled" latch — collapses the suggestion dropdown after
+  // Enter/click; typing resumes browsing.
+  const [repoPicked, setRepoPicked] = useState(false)
+
+  const repoOptions = useMemo(
+    () => computeRepoOptions(opts.defaultRepo, opts.savedRepos),
+    [opts.defaultRepo, opts.savedRepos],
+  )
+  const mode = pickerModeFor(repo, repoOptions)
+  const repoResolution: RepoResolution = resolveRepoInput(repo, repoOptions)
+  // The directory the chosen NAME resolves to — muted, at the row's right
+  // edge, so a bare name still says where it is. Empty whenever the field
+  // already holds a path: the directory is then in the field itself, and
+  // repeating it beside it would print the same string twice.
+  const repoDir =
+    repoResolution.kind === "path" && repoResolution.path !== repo.trim()
+      ? splitRepoInput(repoResolution.path, true).dir
+      : ""
+  const { split: subdirSplit, filtered: subdirFiltered } = useDerivedDir(repo)
+  const savedFiltered = useMemo(() => filterRepos(repoOptions, repo), [repoOptions, repo])
+  const activeList = mode === "browse" ? subdirFiltered : savedFiltered
+  const activeWindow: PickerWindow = windowAround(activeList, repoCursor, opts.pickerRows)
+
+  // Everything downstream (branch list, validation, adopt scan, the submitted
+  // `repo`) needs a PATH, and the field holds a name — so resolve first, then
+  // expand. An ambiguous name resolves to nothing until the user disambiguates.
+  // …and normalized: Tab-completing a directory leaves the walking slash in
+  // the FIELD on purpose (it is what keeps the picker pointed at the
+  // children), so this is where that slash stops travelling.
+  const expandedRepo = repoResolution.kind === "path" ? stripTrailingSlash(expandHome(repoResolution.path)) : ""
+
+  /**
+   * The repo changed — by ANY route (typing, Tab, Enter on the picker, a
+   * click). Every write to the field goes through here, because the caller
+   * hangs per-repo state off `onChanged` (the intent row) and a call site
+   * setting `repo` directly would leave that state asserting the previous
+   * repo.
+   */
+  function changeRepo(next: string): void {
+    setRepo(next)
+    opts.onChanged()
+  }
+
+  /**
+   * A repo was PICKED (dropdown Enter, click, browse-mode select) — the
+   * picker deals in paths, the field holds names, and this is the one funnel
+   * every selection route already goes through, so the conversion lives here.
+   */
+  function pickRepo(path: string): void {
+    changeRepo(nameOrPath(path, repoOptions))
+  }
+
+  function setRepoText(v: string): void {
+    setRepoPicked(false)
+    changeRepo(stripNewlines(v))
+    setRepoCursor(0)
+  }
+
+  /**
+   * Tab — shell completion, not field advance. Returns whether it consumed
+   * the key.
+   *
+   * The guard is the picker's own render condition (`tab-existing.tsx`): Tab
+   * only completes toward something the user can SEE, so a collapsed or empty
+   * dropdown leaves the key its old meaning and focus moves on. That is also
+   * what makes the SECOND Tab advance — the first collapses a saved pick, and
+   * a browse walk ends when the typed path names a directory with nothing
+   * left to offer.
+   */
+  function completeRepo(): boolean {
+    if (repoPicked) return false
+    const done = completeRepoInput({
+      value: repo,
+      mode,
+      highlighted: activeList[repoCursor],
+      baseExpanded: subdirSplit.base,
+      repoOptions,
+    })
+    if (!done) return false
+    changeRepo(done.value)
+    setRepoPicked(done.collapse)
+    setRepoCursor(0)
+    return true
+  }
+
+  // Enter on the repo field — pure selection, never commits.
+  function onRepoSubmit(): void {
+    if (!repo.trim() && mode === "saved") {
+      const picked = activeList[0]
+      if (picked) {
+        pickRepo(picked)
+        opts.onAnswered()
+        return
+      }
+    }
+    if (mode === "browse") {
+      const picked = subdirFiltered[repoCursor]
+      if (picked) {
+        // Enter = SELECT this dir as the repo and advance (no drill — that is
+        // Tab's job, and the two keys stay different on purpose).
+        pickRepo(joinPicked(repo, subdirSplit.base, picked))
+        setRepoCursor(0)
+        setRepoPicked(true)
+      }
+      opts.onAnswered()
+      return
+    }
+    const picked = activeList[repoCursor]
+    if (picked) pickRepo(picked)
+    opts.onAnswered()
+  }
+
+  function selectRepoAt(absoluteIndex: number): void {
+    const picked = activeList[absoluteIndex]
+    if (!picked) return
+    if (mode === "browse") {
+      pickRepo(joinPicked(repo, subdirSplit.base, picked))
+      setRepoPicked(true)
+    } else {
+      pickRepo(picked)
+    }
+    setRepoCursor(absoluteIndex)
+    opts.onAnswered()
+  }
+
+  function moveRepoCursor(delta: 1 | -1): void {
+    if (activeList.length === 0) return
+    setRepoCursor((c) => clampCursor(c + delta, activeList.length))
+  }
+
+  /** An ambiguous name was refused at submit — put the list back on screen,
+   *  where the directories that tell the matches apart are visible. */
+  function reopenPicker(): void {
+    setRepoPicked(false)
+  }
+
+  return {
+    repo,
+    repoDir,
+    repoOptions,
+    repoResolution,
+    mode,
+    activeList,
+    activeWindow,
+    repoCursor,
+    repoPicked,
+    expandedRepo,
+    setRepoText,
+    completeRepo,
+    onRepoSubmit,
+    selectRepoAt,
+    moveRepoCursor,
+    reopenPicker,
+  }
+}

--- a/packages/kobe/src/tui-react/component/new-task-dialog/view-model.ts
+++ b/packages/kobe/src/tui-react/component/new-task-dialog/view-model.ts
@@ -15,38 +15,28 @@
 import { type VendorId, nextVendorWithin, prevVendorWithin } from "@/types/vendor"
 import type { AdoptableWorktree } from "@/types/worktree"
 import { useTerminalDimensions } from "@opentui/react"
-import { useEffect, useMemo, useState } from "react"
-import { nameOrPath, resolveRepoInput, splitRepoInput } from "../../../tui/component/new-task-dialog/repo-field"
+import { useEffect, useState } from "react"
 import {
   type DialogTab,
   type ExistingIntent,
   type Field,
   type NewTaskInput,
-  type PickerWindow,
-  clampCursor,
-  computeRepoOptions,
-  filterBranches,
-  filterRepos,
   firstFieldFor,
   nextDialogTab,
   nextField,
   offersProjectIntent,
-  pickerModeFor,
   pickerVisibleRows,
   prevDialogTab,
-  resolveBaseRef,
-  stripNewlines,
-  windowAround,
 } from "../../../tui/component/new-task-dialog/state"
 import { t } from "../../../tui/i18n"
-import { DEFAULT_BASE_REF, getCurrentBranch, listLocalBranches, validateRepoPath } from "../../../tui/lib/git-snapshot"
-import { expandHome, joinPicked } from "../../../tui/lib/path-helpers"
+import { DEFAULT_BASE_REF, validateRepoPath } from "../../../tui/lib/git-snapshot"
 import { useBindings } from "../../lib/keymap"
 import { useDialog } from "../../ui/dialog"
 import { resolveInitialVendor, resolveVendorSet } from "./pure"
 import { useAdoptState } from "./use-adopt-state"
+import { useBranchField } from "./use-branch-field"
 import { useCloneState } from "./use-clone-state"
-import { useDerivedDir } from "./use-derived-dir"
+import { useRepoField } from "./use-repo-field"
 
 /** Prop surface of the dialog view. */
 export type NewTaskDialogProps = {
@@ -82,28 +72,6 @@ export function useNewTaskViewModel(props: NewTaskDialogProps) {
   // Open focused on the mode selector — ←/→ switches tabs immediately;
   // Tab then walks engine → repo → branch → Create.
   const [field, setField] = useState<Field>("tabs")
-  // Seeded from the caller's PATH, shown as a name — the field's own grammar
-  // from the first frame rather than a path that turns into a name on first
-  // touch. `repoDir` puts the directory back beside it. Same round-trip guard
-  // as `pickRepo`: a basename shared with another saved repo would open the
-  // dialog on an ambiguous value, so that case keeps the path.
-  const [repo, setRepo] = useState(() =>
-    nameOrPath(props.defaultRepo, computeRepoOptions(props.defaultRepo, props.savedRepos)),
-  )
-  // Initial baseRef tracks the cwd's current branch (worktree forked from a
-  // feature branch defaults to it, not hardcoded "main").
-  const [baseRef, setBaseRef] = useState(
-    () => getCurrentBranch(expandHome(props.defaultRepo.trim())) ?? DEFAULT_BASE_REF,
-  )
-  // Once the user typed into baseRef we stop auto-syncing from the repo's
-  // current branch — the manual override wins.
-  const [baseRefTouched, setBaseRefTouched] = useState(false)
-
-  const [repoCursor, setRepoCursor] = useState(0)
-  // "Selected, not drilled" latch — collapses the suggestion dropdown after
-  // Enter/click; typing resumes browsing.
-  const [repoPicked, setRepoPicked] = useState(false)
-  const [branchCursor, setBranchCursor] = useState(0)
   // Existing-tab intent. Defaults to "task"; the choice only RENDERS when the
   // picked repo already has a project checkout to open.
   const [intent, setIntent] = useState<ExistingIntent>("task")
@@ -111,47 +79,34 @@ export function useNewTaskViewModel(props: NewTaskDialogProps) {
   // Validation error shown inline on submit; cleared on any input edit.
   const [submitError, setSubmitError] = useState<string | null>(null)
 
-  /* ── Derived lists (shared pure helpers; sync fs/git reads memoized) ── */
+  /* ── Field clusters (each owns one question the dialog asks) ── */
 
-  const repoOptions = useMemo(
-    () => computeRepoOptions(props.defaultRepo, props.savedRepos),
-    [props.defaultRepo, props.savedRepos],
-  )
   // Live per render — opentui re-renders on resize, so a terminal dragged
   // short re-windows the pickers instead of clipping the Create button.
   const pickerRows = pickerVisibleRows(useTerminalDimensions().height)
-  const mode = pickerModeFor(repo, repoOptions)
-  // `repo` holds exactly what the field shows — a NAME once one is chosen,
-  // free text while it is being typed. It is never a display derived from a
-  // different underlying value: an opentui `<input>` adopts its `value` prop
-  // as its edit buffer, so a field showing one string while state holds
-  // another writes the shown one back on the next keystroke and the two
-  // oscillate.
-  // One representation, resolved to a path at the boundaries instead.
-  const repoResolution = resolveRepoInput(repo, repoOptions)
-  // The directory the chosen NAME resolves to — muted, at the row's right
-  // edge, so a bare name still says where it is. Empty whenever the field
-  // already holds a path: the directory is then in the field itself, and
-  // repeating it beside it would print the same string twice.
-  const repoDir =
-    repoResolution.kind === "path" && repoResolution.path !== repo.trim()
-      ? splitRepoInput(repoResolution.path, true).dir
-      : ""
-  const { split: subdirSplit, filtered: subdirFiltered } = useDerivedDir(repo)
-  const savedFiltered = useMemo(() => filterRepos(repoOptions, repo), [repoOptions, repo])
-  const activeList = mode === "browse" ? subdirFiltered : savedFiltered
-  const activeWindow: PickerWindow = windowAround(activeList, repoCursor, pickerRows)
-
-  // Everything downstream (branch list, validation, adopt scan, the submitted
-  // `repo`) needs a PATH, and the field holds a name — so resolve first, then
-  // expand. An ambiguous name resolves to nothing until the user disambiguates.
-  const expandedRepo = repoResolution.kind === "path" ? expandHome(repoResolution.path) : ""
+  const repoField = useRepoField({
+    defaultRepo: props.defaultRepo,
+    savedRepos: props.savedRepos,
+    pickerRows,
+    // A different repo may have no project checkout at all, and the choice is
+    // per-repo, so carrying "project" across a change leaves the row
+    // asserting something about the previous path. `commitExisting` is
+    // separately guarded on `canOpenProject`, so this is about the row
+    // telling the truth, not about safety.
+    onChanged: () => setIntent("task"),
+    onAnswered: () => setField(advanceField("repo")),
+  })
+  const expandedRepo = repoField.expandedRepo
   // Offered against the EXPANDED path: `mainRepos` holds absolute repo roots,
   // and a `~/`-typed entry would otherwise never match its own project.
   const canOpenProject = offersProjectIntent(expandedRepo, props.mainRepos ?? EMPTY_MAIN_REPOS)
-  const branches = useMemo(() => listLocalBranches(expandedRepo), [expandedRepo])
-  const branchFiltered = useMemo(() => filterBranches(branches, baseRef), [branches, baseRef])
-  const branchWindow: PickerWindow = windowAround(branchFiltered, branchCursor, pickerRows)
+  const branch = useBranchField({
+    expandedRepo,
+    pickerRows,
+    defaultRepo: props.defaultRepo,
+    commit: () => commitExisting(),
+    onPicked: () => setField("confirm"),
+  })
 
   const clone = useCloneState({
     defaultCloneParent: props.defaultCloneParent,
@@ -173,58 +128,10 @@ export function useNewTaskViewModel(props: NewTaskDialogProps) {
 
   /* ── Effects ── */
 
-  // Auto-sync baseRef to the picked repo's current branch until touched.
-  useEffect(() => {
-    if (!expandedRepo || baseRefTouched) return
-    const current = getCurrentBranch(expandedRepo)
-    if (current) setBaseRef(current)
-  }, [expandedRepo, baseRefTouched])
-
   // biome-ignore lint/correctness/useExhaustiveDependencies: the inputs are the invalidation keys — any edit clears the inline error.
   useEffect(() => {
     setSubmitError(null)
-  }, [repo, clone.cloneUrl, clone.cloneParent, clone.cloneFolder, adopt.adoptFilter])
-
-  /* ── Input handlers (strip newlines + reset the affected cursor) ── */
-
-  /**
-   * The repo changed — by ANY route (typing, Enter on the picker, a click).
-   *
-   * Owns the intent reset: a different repo may have no project checkout at
-   * all, and the choice is per-repo, so carrying "project" across a change
-   * leaves the row asserting something about the previous path. `submit` is
-   * separately guarded on `canOpenProject` (derived from the CURRENT repo),
-   * so this is about the row telling the truth, not about safety.
-   *
-   * Every repo change routes through here — a call site writing `setRepo`
-   * directly would skip the reset and leave the row asserting the previous
-   * repo's intent.
-   */
-  function changeRepo(next: string): void {
-    setRepo(next)
-    setIntent("task")
-  }
-
-  /**
-   * A repo was PICKED (dropdown Enter, click, browse-mode select) — the picker
-   * deals in paths, the field holds names, and this is the one funnel every
-   * selection route already goes through, so the conversion belongs here.
-   */
-  function pickRepo(path: string): void {
-    changeRepo(nameOrPath(path, repoOptions))
-  }
-
-  function setRepoText(v: string): void {
-    setRepoPicked(false)
-    changeRepo(stripNewlines(v))
-    setRepoCursor(0)
-    setBranchCursor(0)
-  }
-  function setBaseRefText(v: string): void {
-    setBaseRefTouched(true)
-    setBaseRef(stripNewlines(v))
-    setBranchCursor(0)
-  }
+  }, [repoField.repo, clone.cloneUrl, clone.cloneParent, clone.cloneFolder, adopt.adoptFilter])
 
   /* ── Commit paths ── */
 
@@ -233,10 +140,10 @@ export function useNewTaskViewModel(props: NewTaskDialogProps) {
     // parent makes this ordinary), and the name alone cannot say which. Send
     // the user back to the picker — where the directories that separate them
     // are on screen — rather than opening the alphabetically-first one.
-    if (repoResolution.kind === "ambiguous") {
-      setSubmitError(t("newTask.error.repoAmbiguous", { name: repoResolution.name }))
+    if (repoField.repoResolution.kind === "ambiguous") {
+      setSubmitError(t("newTask.error.repoAmbiguous", { name: repoField.repoResolution.name }))
       setField("repo")
-      setRepoPicked(false)
+      repoField.reopenPicker()
       return
     }
     const r = expandedRepo
@@ -263,7 +170,7 @@ export function useNewTaskViewModel(props: NewTaskDialogProps) {
       dialog.clear()
       return
     }
-    const b = baseRef.trim() || DEFAULT_BASE_REF
+    const b = branch.baseRef.trim() || DEFAULT_BASE_REF
     props.onSubmit({ repo: r, baseRef: b, vendor })
     dialog.clear()
   }
@@ -319,71 +226,28 @@ export function useNewTaskViewModel(props: NewTaskDialogProps) {
     setVendor((v) => (dir === 1 ? nextVendorWithin(vendors, v) : prevVendorWithin(vendors, v)))
   }
 
-  // Enter on the repo field — pure selection, never commits.
-  function onRepoSubmit(): void {
-    if (!repo.trim() && mode === "saved") {
-      const picked = activeList[0]
-      if (picked) {
-        pickRepo(picked)
-        setField(advanceField("repo"))
-        return
-      }
-    }
-    if (mode === "browse") {
-      const picked = subdirFiltered[repoCursor]
-      if (picked) {
-        // Enter = SELECT this dir as the repo and advance (no drill).
-        pickRepo(joinPicked(repo, subdirSplit.base, picked))
-        setRepoCursor(0)
-        setRepoPicked(true)
-      }
-      setField(advanceField("repo"))
-      return
-    }
-    const picked = activeList[repoCursor]
-    if (picked) pickRepo(picked)
-    setField(advanceField("repo"))
-  }
-
-  function selectRepoAt(absoluteIndex: number): void {
-    const picked = activeList[absoluteIndex]
-    if (!picked) return
-    if (mode === "browse") {
-      pickRepo(joinPicked(repo, subdirSplit.base, picked))
-      setRepoPicked(true)
-    } else {
-      pickRepo(picked)
-    }
-    setRepoCursor(absoluteIndex)
-    setField(advanceField("repo"))
-  }
-
-  function pickBranchAt(absoluteIndex: number): void {
-    const name = branchFiltered[absoluteIndex]
-    if (!name) return
-    setBaseRef(name)
-    setBaseRefTouched(true)
-    setBranchCursor(absoluteIndex)
-    setField("confirm")
-  }
-
-  // Last field on the existing tab — Enter resolves the highlighted branch
-  // and creates straight away.
-  function onBaseRefSubmit(): void {
-    setBaseRef(resolveBaseRef(baseRef, branchFiltered, branchCursor))
-    setBaseRefTouched(true)
-    commitExisting()
+  /**
+   * Tab, wherever it lands on a field that has a suggestion open: complete
+   * first, advance only when there is nothing to complete. Both path fields
+   * in this dialog answer to it — the Existing tab's repo and the Clone tab's
+   * parent dir are the same drill-down picker, and a key that walked one but
+   * not the other would be worse than a key that walked neither.
+   */
+  function completeFocusedField(): boolean {
+    if (tab === "existing" && field === "repo") return repoField.completeRepo()
+    if (tab === "clone" && field === "cloneParent") return clone.completeCloneParent()
+    return false
   }
 
   // up/down over whichever picker the focused field drives.
   function moveCursor(delta: 1 | -1): void {
     if (clone.cloneInFlight) return
-    if (tab === "existing" && field === "repo" && activeList.length > 0) {
-      setRepoCursor((c) => clampCursor(c + delta, activeList.length))
+    if (tab === "existing" && field === "repo") {
+      repoField.moveRepoCursor(delta)
       return
     }
-    if (tab === "existing" && field === "baseRef" && branchFiltered.length > 0) {
-      setBranchCursor((c) => clampCursor(c + delta, branchFiltered.length))
+    if (tab === "existing" && field === "baseRef") {
+      branch.moveBranchCursor(delta)
       return
     }
     if (tab === "clone" && field === "cloneParent") {
@@ -397,7 +261,12 @@ export function useNewTaskViewModel(props: NewTaskDialogProps) {
 
   useBindings(() => ({
     bindings: [
-      { key: "tab", cmd: () => setField(advanceField) },
+      {
+        key: "tab",
+        cmd: () => {
+          if (!completeFocusedField()) setField(advanceField)
+        },
+      },
       { key: "ctrl+]", cmd: () => switchToTab(nextDialogTab(tab)) },
       { key: "ctrl+[", cmd: () => switchToTab(prevDialogTab(tab)) },
       { key: "ctrl+e", cmd: () => cycleEngine(1) },
@@ -442,6 +311,8 @@ export function useNewTaskViewModel(props: NewTaskDialogProps) {
   return {
     ...clone,
     ...adopt,
+    ...branch,
+    ...repoField,
     defaultRepo: props.defaultRepo,
     tab,
     vendors,
@@ -449,29 +320,10 @@ export function useNewTaskViewModel(props: NewTaskDialogProps) {
     setVendor,
     field,
     setField,
-    repo,
-    repoDir,
-    mode,
-    activeList,
-    activeWindow,
-    repoCursor,
-    repoPicked,
-    expandedRepo,
-    baseRef,
-    branches,
-    branchFiltered,
-    branchWindow,
-    branchCursor,
     intent,
     setIntent,
     canOpenProject,
     submitError,
-    setRepoText,
-    setBaseRefText,
-    onRepoSubmit,
-    selectRepoAt,
-    pickBranchAt,
-    onBaseRefSubmit,
     switchToTab,
     commit,
     commitExisting,

--- a/packages/kobe/src/tui/component/new-task-dialog/repo-field.ts
+++ b/packages/kobe/src/tui/component/new-task-dialog/repo-field.ts
@@ -4,8 +4,8 @@
  * Split from `state.ts` because it answers a different question. `state.ts` is
  * the dialog's reducer layer — which field has focus, which list is open,
  * where the cursor sits. This file is the field's own vocabulary: the input
- * shows a repo NAME, everything downstream needs a PATH, and these three
- * functions are the whole translation between them.
+ * shows a repo NAME, everything downstream needs a PATH, and the translation
+ * between them — plus what Tab completes toward — lives here.
  *
  * The reason it is a translation and not a rendering: an opentui `<input>`
  * adopts its `value` prop as the text it edits, so a field displaying
@@ -13,10 +13,14 @@
  * on the next keystroke and the two oscillated. The field really does hold a
  * name; the conversion happens at the boundaries, here.
  *
- * Same rules as `state.ts`: framework-free, side-effect-free, no fs, no git.
+ * Same rules as `state.ts`: framework-free, side-effect-free, no fs of its
+ * own, no git. `joinDrill` is imported for its string arithmetic only — this
+ * file may lean on `path-helpers`, never the reverse, which is why the Tab
+ * completion (it needs `nameOrPath` too) lands here rather than beside it.
  */
 
-import { splitRepoRow } from "./state"
+import { joinDrill } from "../../lib/path-helpers"
+import { type PickerMode, splitRepoRow } from "./state"
 
 /**
  * How the repo INPUT should render a value: the repo's name, and the
@@ -92,4 +96,46 @@ export function nameOrPath(path: string, repoOptions: readonly string[]): string
   const name = splitRepoInput(path, true).name
   const back = resolveRepoInput(name, repoOptions)
   return back.kind === "path" && back.path === path ? name : path
+}
+
+/**
+ * What Tab should put in the field: the highlighted suggestion, completed
+ * IN PLACE, or `null` when there is nothing left to complete.
+ *
+ * `null` is the reason this returns an option rather than a string — it is
+ * what hands Tab back to its other job. One Tab completes; the next one,
+ * with nothing more to say, moves to the next field. That is the shell
+ * bargain: the key means "finish this for me", and finishing nothing means
+ * finishing the field.
+ *
+ * The two modes complete toward different things, because their rows are
+ * different kinds of answer:
+ *   - `browse` rows are subdirectories, so the completion is a step DOWN —
+ *     `joinDrill`'s trailing slash re-points the picker at the new
+ *     directory's children and the next Tab walks one level deeper. The
+ *     dropdown has to STAY open or the walk ends after one step.
+ *   - `saved` rows are whole repos: nothing lives under them, so the name is
+ *     the end of the road and the dropdown closes behind it.
+ *
+ * Pure — the caller passes the highlighted row and the directory it was read
+ * from (`baseExpanded`, what `splitPathForDirSuggest` gave the picker), so no
+ * fs work happens here.
+ */
+export type RepoCompletion = { value: string; collapse: boolean }
+
+export function completeRepoInput(args: {
+  value: string
+  mode: PickerMode
+  highlighted: string | undefined
+  baseExpanded: string
+  repoOptions: readonly string[]
+}): RepoCompletion | null {
+  const { value, mode, highlighted, baseExpanded, repoOptions } = args
+  if (!highlighted) return null
+  if (mode === "browse") {
+    const next = joinDrill(value, baseExpanded, highlighted)
+    return next === value ? null : { value: next, collapse: false }
+  }
+  const next = nameOrPath(highlighted, repoOptions)
+  return next === value.trim() ? null : { value: next, collapse: true }
 }

--- a/packages/kobe/src/tui/i18n/messages/newTask.ts
+++ b/packages/kobe/src/tui/i18n/messages/newTask.ts
@@ -5,7 +5,7 @@
 
 export const en = {
   title: "New task",
-  legend: "enter create · tab fields · ctrl+[ ] mode · ctrl+e engine · esc cancel",
+  legend: "enter create · tab complete/fields · ctrl+[ ] mode · ctrl+e engine · esc cancel",
 
   tabs: {
     existing: "For Existing",
@@ -98,7 +98,7 @@ export const en = {
 
 export const zh: typeof en = {
   title: "新建任务",
-  legend: "enter 创建 · tab 切字段 · ctrl+[ ] 切模式 · ctrl+e 引擎 · esc 取消",
+  legend: "enter 创建 · tab 补全/切字段 · ctrl+[ ] 切模式 · ctrl+e 引擎 · esc 取消",
 
   tabs: {
     existing: "已有仓库",

--- a/packages/kobe/src/tui/lib/path-helpers.ts
+++ b/packages/kobe/src/tui/lib/path-helpers.ts
@@ -40,6 +40,20 @@ export function expandHome(p: string): string {
   return p
 }
 
+/**
+ * Drop a path's trailing slash. `/i/rove/` and `/i/rove` name the same
+ * directory, but only one of them is a stable KEY — a task is filed under the
+ * repo path it was created with, so the two spellings would file two repos.
+ *
+ * The slash is load-bearing while the path is being TYPED (it is what points
+ * the suggestion picker at a directory's children rather than its siblings),
+ * so it is stripped where the text stops being an edit buffer and becomes an
+ * answer, never in the field itself. Root stays `/`.
+ */
+export function stripTrailingSlash(p: string): string {
+  return p.length > 1 && p.endsWith("/") ? p.slice(0, -1) : p
+}
+
 export type PathSplit = { base: string; filter: string }
 
 /**

--- a/packages/kobe/test/render/new-task-repo-name-field.test.tsx
+++ b/packages/kobe/test/render/new-task-repo-name-field.test.tsx
@@ -107,6 +107,7 @@ test("a resolved repo shows its NAME, not its path, and still submits the path",
   await settle()
   expect(h.submitted).toHaveLength(1)
   expect(h.submitted[0]?.repo).toBe(dir)
+  act(() => h.destroy())
 })
 
 test("a basename shared by two saved repos keeps the PATH — it identifies nothing", async () => {
@@ -126,6 +127,7 @@ test("a basename shared by two saved repos keeps the PATH — it identifies noth
   await settle()
   expect(h.submitted[0]?.repo).toBe(a)
   expect(h.submitted[0]?.repo).not.toBe(b)
+  act(() => h.destroy())
 })
 
 test("typing an ambiguous name refuses to guess, and says so", async () => {
@@ -156,6 +158,7 @@ test("typing an ambiguous name refuses to guess, and says so", async () => {
 
   expect(h.submitted).toHaveLength(0)
   expect(await h.frame()).toContain("more than one saved repo is named app")
+  act(() => h.destroy())
 })
 
 test("a path being typed renders VERBATIM — the field does not rewrite mid-keystroke", async () => {
@@ -188,6 +191,7 @@ test("a path being typed renders VERBATIM — the field does not rewrite mid-key
   act(() => h.mockInput.pressEnter())
   await settle()
   expect(h.submitted[0]?.repo).toBe(dir)
+  act(() => h.destroy())
 })
 
 test("picker rows right-align their directory tails into one column", async () => {
@@ -213,6 +217,7 @@ test("picker rows right-align their directory tails into one column", async () =
   // right edge; equal across rows means one column, not a ragged trail.
   const ends = new Set(rows.map((l) => l.trimEnd().length))
   expect(ends.size).toBe(1)
+  act(() => h.destroy())
 })
 
 test("a long directory never eats into the name", async () => {
@@ -227,6 +232,7 @@ test("a long directory never eats into the name", async () => {
   const row = (await h.frame()).split("\n").find((l) => l.includes("ture-repo"))
   expect(row).toBeDefined()
   expect(row).toContain("fixture-repo")
+  act(() => h.destroy())
 })
 
 test("a full-width row keeps air between the name and the directory", async () => {
@@ -243,4 +249,5 @@ test("a full-width row keeps air between the name and the directory", async () =
   const row = (await h.frame()).split("\n").find((l) => l.includes("current dir"))
   expect(row).toBeDefined()
   expect(row).not.toContain("dir)/")
+  act(() => h.destroy())
 })

--- a/packages/kobe/test/render/new-task-repo-name-field.test.tsx
+++ b/packages/kobe/test/render/new-task-repo-name-field.test.tsx
@@ -65,6 +65,16 @@ async function mount(defaultRepo: string, savedRepos: readonly string[] = [], wi
   return { ...handle, submitted }
 }
 
+/** Where a string sits in the frame — the anchor a click needs. */
+function locate(frameText: string, needle: string): { x: number; y: number } {
+  const lines = frameText.split("\n")
+  for (let y = 0; y < lines.length; y++) {
+    const x = lines[y]?.indexOf(needle) ?? -1
+    if (x >= 0) return { x, y }
+  }
+  throw new Error(`not on screen: ${needle}`)
+}
+
 /** Tab `times` stops along the field chain: tabs → engine → repo → baseRef. */
 async function pressTab(handle: { mockInput: { pressTab: () => void } }, times: number) {
   for (let i = 0; i < times; i++) {
@@ -132,7 +142,15 @@ test("typing an ambiguous name refuses to guess, and says so", async () => {
   await settle()
   await act(async () => h.mockInput.typeText("app"))
   await settle()
-  await pressTab(h, TO_BASE_REF - TO_REPO)
+
+  // Leave the field by CLICKING the next one, because Tab no longer leaves an
+  // unfinished name behind — it completes the highlighted row to its full
+  // path first, which is a different (and answered) question. The guard is
+  // about text that reaches the commit still naming two repos, and this is
+  // the route that still gets it there.
+  const label = locate(await h.frame(), "FROM BRANCH")
+  await h.mockMouse.click(label.x + 1, label.y)
+  await settle()
   act(() => h.mockInput.pressEnter())
   await settle()
 
@@ -159,10 +177,14 @@ test("a path being typed renders VERBATIM — the field does not rewrite mid-key
   // swallow the directory half mid-keystroke.
   expect(await h.frame()).toContain(partial.slice(0, 40))
 
-  // Completing it to the real repo submits that full path.
+  // Completing it to the real repo submits that full path. Two Tabs, not
+  // one: the first finishes the highlighted directory in place (that is the
+  // field's own completion), and only the second — with nothing left to
+  // finish — moves to the branch field. The trailing slash the walk leaves
+  // in the box does not travel with the value.
   await act(async () => h.mockInput.typeText("ped"))
   await settle()
-  await pressTab(h, 1)
+  await pressTab(h, 2)
   act(() => h.mockInput.pressEnter())
   await settle()
   expect(h.submitted[0]?.repo).toBe(dir)

--- a/packages/kobe/test/render/new-task-repo-tab-complete.test.tsx
+++ b/packages/kobe/test/render/new-task-repo-tab-complete.test.tsx
@@ -94,6 +94,7 @@ test("browse mode: each Tab walks one directory deeper, in place", async () => {
   // Second Tab: another step, not a repeat.
   await pressTab(h)
   expect(await h.frame()).toContain("/level1/level2/")
+  act(() => h.destroy())
 })
 
 test("saved mode: Tab finishes the name, the NEXT Tab leaves the field", async () => {
@@ -119,6 +120,7 @@ test("saved mode: Tab finishes the name, the NEXT Tab leaves the field", async (
   await settle()
   expect(h.submitted).toHaveLength(1)
   expect(h.submitted[0]?.repo).toBe(zephyr)
+  act(() => h.destroy())
 })
 
 test("Tab still advances when the dropdown has nothing to offer", async () => {
@@ -139,6 +141,7 @@ test("Tab still advances when the dropdown has nothing to offer", async () => {
   // is refused there, on screen, instead of the key vanishing.
   expect(h.submitted).toHaveLength(0)
   expect(await h.frame()).toContain("no-such-repo-anywhere")
+  act(() => h.destroy())
 })
 
 test("the Clone tab's parent dir walks the same way — one key, both path fields", async () => {
@@ -164,4 +167,5 @@ test("the Clone tab's parent dir walks the same way — one key, both path field
   expect(await h.frame()).toContain("/level1/")
   await pressTab(h)
   expect(await h.frame()).toContain("/level1/level2/")
+  act(() => h.destroy())
 })

--- a/packages/kobe/test/render/new-task-repo-tab-complete.test.tsx
+++ b/packages/kobe/test/render/new-task-repo-tab-complete.test.tsx
@@ -1,0 +1,167 @@
+/** @jsxImportSource @opentui/react */
+/**
+ * Tab in the Existing tab's repo field COMPLETES before it advances.
+ *
+ * The bug this pins: every key that could finish a suggestion also left the
+ * field. Enter picked-and-advanced, Tab advanced, and the dropdown's whole
+ * reason for existing — "keep going, one level at a time" — had no key. You
+ * saw `academic…` under your `a`, pressed the key that finishes things in
+ * every shell you own, and landed on `from branch` with `a` still in the
+ * repo box.
+ *
+ * So the contract has two halves and they only mean something together:
+ *   - complete-only → a Tab that finishes the name but never advances traps
+ *     focus, and the field costs an extra keystroke forever.
+ *   - advance-only → the old bug.
+ * Each test below therefore presses Tab twice and asserts what BOTH presses
+ * did, not just the first.
+ *
+ * Real `git init` temp dirs, same as the sibling repo-name-field tests: the
+ * tab validates the path and reads its branches synchronously.
+ */
+
+import { expect, test } from "bun:test"
+import { execSync } from "node:child_process"
+import { mkdirSync, mkdtempSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { NewTaskDialogView } from "../../src/tui-react/component/new-task-dialog/dialog"
+import type { NewTaskInput } from "../../src/tui/component/new-task-dialog/state"
+import { act, renderComponent, settle } from "./harness"
+
+function repo(name: string): string {
+  const parent = mkdtempSync(join(tmpdir(), "kobe-tabcomplete-"))
+  const dir = join(parent, name)
+  mkdirSync(dir)
+  execSync("git init -q -b main && git -c user.email=t@t -c user.name=t commit -q --allow-empty -m init", { cwd: dir })
+  return dir
+}
+
+async function mount(defaultRepo: string, savedRepos: readonly string[] = []) {
+  const submitted: NewTaskInput[] = []
+  const handle = await renderComponent(
+    <NewTaskDialogView
+      defaultRepo={defaultRepo}
+      savedRepos={savedRepos}
+      onSubmit={(v) => submitted.push(v)}
+      onCancel={() => {}}
+    />,
+    { width: 200, height: 40, providers: { kv: true, dialog: true } },
+  )
+  await settle()
+  return { ...handle, submitted }
+}
+
+async function pressTab(handle: { mockInput: { pressTab: () => void } }, times = 1) {
+  for (let i = 0; i < times; i++) {
+    act(() => handle.mockInput.pressTab())
+    await settle()
+  }
+}
+
+/** Stops from the dialog's opening field (`tabs`) to the repo input. */
+const TO_REPO = 2
+
+/** Focus the repo field and empty it — ctrl+u, because 80 backspaces is 80
+ *  renders and overruns the per-test budget. */
+async function focusEmptyRepo(h: Awaited<ReturnType<typeof mount>>) {
+  await pressTab(h, TO_REPO)
+  await act(async () => h.mockInput.typeText("\x15"))
+  await settle()
+}
+
+test("browse mode: each Tab walks one directory deeper, in place", async () => {
+  const parent = mkdtempSync(join(tmpdir(), "kobe-tabwalk-"))
+  mkdirSync(join(parent, "level1"))
+  mkdirSync(join(parent, "level1", "level2"))
+  const h = await mount(repo("origin"))
+
+  // A path with a trailing slash puts the picker in browse mode, listing the
+  // one subdirectory under it.
+  await focusEmptyRepo(h)
+  await act(async () => h.mockInput.typeText(`${parent}/`))
+  await settle()
+  expect(await h.frame()).toContain("level1/")
+
+  // First Tab: the suggestion lands IN the field, with the trailing slash
+  // that re-points the picker at what's inside it.
+  await pressTab(h)
+  expect(await h.frame()).toContain("/level1/")
+  // …and the dropdown is now showing that directory's children, which is the
+  // half that proves focus never left.
+  expect(await h.frame()).toContain("level2/")
+
+  // Second Tab: another step, not a repeat.
+  await pressTab(h)
+  expect(await h.frame()).toContain("/level1/level2/")
+})
+
+test("saved mode: Tab finishes the name, the NEXT Tab leaves the field", async () => {
+  const zephyr = repo("zephyr")
+  const other = repo("mongoose")
+  const h = await mount(repo("origin"), [zephyr, other])
+
+  // A prefix that is not a repo on its own. Under the old behavior this
+  // stayed `zeph` and the dialog carried an unresolvable value forward.
+  await focusEmptyRepo(h)
+  await act(async () => h.mockInput.typeText("zeph"))
+  await settle()
+
+  await pressTab(h)
+  expect(await h.frame()).toContain("zephyr")
+
+  // Nothing left to complete, so the second Tab means what it always meant.
+  // Enter on `from branch` is the tab's create — if the FIRST Tab had
+  // advanced instead of completing, focus would sit on Create with `zeph` in
+  // the repo box and this would fail validation rather than submit.
+  await pressTab(h)
+  act(() => h.mockInput.pressEnter())
+  await settle()
+  expect(h.submitted).toHaveLength(1)
+  expect(h.submitted[0]?.repo).toBe(zephyr)
+})
+
+test("Tab still advances when the dropdown has nothing to offer", async () => {
+  // The guard is the picker's own render condition: no visible suggestion,
+  // no completion, and the key keeps its old job. Without this the field
+  // would swallow Tab and trap focus whenever a query matched nothing.
+  const dir = repo("solo")
+  const h = await mount(dir)
+
+  await focusEmptyRepo(h)
+  await act(async () => h.mockInput.typeText("no-such-repo-anywhere"))
+  await settle()
+
+  await pressTab(h)
+  act(() => h.mockInput.pressEnter())
+  await settle()
+  // Focus reached `from branch`, whose Enter commits — and the invalid repo
+  // is refused there, on screen, instead of the key vanishing.
+  expect(h.submitted).toHaveLength(0)
+  expect(await h.frame()).toContain("no-such-repo-anywhere")
+})
+
+test("the Clone tab's parent dir walks the same way — one key, both path fields", async () => {
+  // Same drill-down picker, two tabs apart. A Tab that walked the repo field
+  // but not this one would be worse than a Tab that walked neither: the key
+  // would mean two things inside one dialog.
+  const parent = mkdtempSync(join(tmpdir(), "kobe-tabwalk-clone-"))
+  mkdirSync(join(parent, "level1"))
+  mkdirSync(join(parent, "level1", "level2"))
+  const h = await mount(repo("origin"))
+
+  // → on the mode selector switches to "For New Repo"; Tab then walks
+  // engine → git url → parent dir.
+  act(() => h.mockInput.pressArrow("right"))
+  await settle()
+  await pressTab(h, 3)
+  await act(async () => h.mockInput.typeText("\x15"))
+  await settle()
+  await act(async () => h.mockInput.typeText(`${parent}/`))
+  await settle()
+
+  await pressTab(h)
+  expect(await h.frame()).toContain("/level1/")
+  await pressTab(h)
+  expect(await h.frame()).toContain("/level1/level2/")
+})

--- a/packages/kobe/test/tui/lib/path-helpers.test.ts
+++ b/packages/kobe/test/tui/lib/path-helpers.test.ts
@@ -14,7 +14,14 @@
  */
 
 import * as os from "node:os"
-import { expandHome, filterSubdirs, joinDrill, joinPicked, splitPathForDirSuggest } from "@/tui/lib/path-helpers"
+import {
+  expandHome,
+  filterSubdirs,
+  joinDrill,
+  joinPicked,
+  splitPathForDirSuggest,
+  stripTrailingSlash,
+} from "@/tui/lib/path-helpers"
 import { describe, expect, it } from "vitest"
 
 describe("expandHome", () => {
@@ -111,5 +118,23 @@ describe("joinPicked (select, don't drill — no trailing slash)", () => {
   it("keeps absolute display when the user typed an absolute path", () => {
     const home = os.homedir()
     expect(joinPicked(`${home}/`, `${home}/`, "code")).toBe(`${home}/code`)
+  })
+})
+
+describe("stripTrailingSlash", () => {
+  it("drops the slash a directory walk leaves behind", () => {
+    // `/i/rove/` and `/i/rove` name the same repo, but a task is filed under
+    // the string it was created with — two spellings would file two repos.
+    expect(stripTrailingSlash("/i/rove/")).toBe("/i/rove")
+  })
+
+  it("leaves a path that has none alone", () => {
+    expect(stripTrailingSlash("/i/rove")).toBe("/i/rove")
+    expect(stripTrailingSlash("")).toBe("")
+  })
+
+  it("keeps root a root", () => {
+    // "/" is the one path whose trailing slash IS the path.
+    expect(stripTrailingSlash("/")).toBe("/")
   })
 })

--- a/packages/kobe/test/tui/new-task-dialog/repo-field.test.ts
+++ b/packages/kobe/test/tui/new-task-dialog/repo-field.test.ts
@@ -4,13 +4,18 @@
  *
  * These are the boundary the whole "show a name" change rests on: the field
  * holds a NAME and everything downstream needs a PATH, so every conversion
- * between the two happens in these three functions. The render tests drive the
+ * between the two happens in these functions. The render tests drive the
  * mounted dialog; these pin the rules that make it safe — above all that a
  * name shared by two saved repos is REFUSED rather than resolved to whichever
  * one sorts first.
  */
 
-import { nameOrPath, resolveRepoInput, splitRepoInput } from "@/tui/component/new-task-dialog/repo-field"
+import {
+  completeRepoInput,
+  nameOrPath,
+  resolveRepoInput,
+  splitRepoInput,
+} from "@/tui/component/new-task-dialog/repo-field"
 import { describe, expect, it } from "vitest"
 
 describe("splitRepoInput", () => {
@@ -76,5 +81,73 @@ describe("nameOrPath (what the field should hold)", () => {
     // Its basename resolves to itself, not back to the path, so the name would
     // name nothing the dialog can find.
     expect(nameOrPath("/tmp/scratch", repos)).toBe("/tmp/scratch")
+  })
+})
+
+describe("completeRepoInput", () => {
+  const repos = ["/Users/me/i/quokka", "/Users/me/i/kobe"]
+
+  it("walks browse mode one directory DOWN, dropdown still open", () => {
+    // The trailing slash is the whole mechanism: it re-points the picker at
+    // the new directory's children, which is what makes the next Tab a step
+    // rather than a repeat.
+    expect(
+      completeRepoInput({
+        value: "/Users/me/",
+        mode: "browse",
+        highlighted: "i",
+        baseExpanded: "/Users/me/",
+        repoOptions: repos,
+      }),
+    ).toEqual({ value: "/Users/me/i/", collapse: false })
+  })
+
+  it("completes a saved row to its NAME and closes behind it", () => {
+    // A saved row is a whole repo — nothing lives under it, so there is no
+    // second step to keep the dropdown open for.
+    expect(
+      completeRepoInput({
+        value: "quo",
+        mode: "saved",
+        highlighted: "/Users/me/i/quokka",
+        repoOptions: repos,
+        baseExpanded: "",
+      }),
+    ).toEqual({ value: "quokka", collapse: true })
+  })
+
+  it("keeps the PATH when the completed name would be ambiguous", () => {
+    // Same refusal as `nameOrPath`: two saved `app`s mean the name identifies
+    // neither, so completion hands back the path that does.
+    const dupes = ["/Users/me/a/app", "/Users/me/b/app"]
+    expect(
+      completeRepoInput({
+        value: "app",
+        mode: "saved",
+        highlighted: "/Users/me/a/app",
+        repoOptions: dupes,
+        baseExpanded: "",
+      }),
+    ).toEqual({ value: "/Users/me/a/app", collapse: true })
+  })
+
+  it("returns null with nothing highlighted — Tab keeps its other job", () => {
+    expect(
+      completeRepoInput({ value: "zzz", mode: "saved", highlighted: undefined, baseExpanded: "", repoOptions: repos }),
+    ).toBeNull()
+  })
+
+  it("returns null when the value ALREADY is the completion", () => {
+    // The second Tab on a finished name has nothing to say, and that silence
+    // is what advances the field.
+    expect(
+      completeRepoInput({
+        value: "quokka",
+        mode: "saved",
+        highlighted: "/Users/me/i/quokka",
+        repoOptions: repos,
+        baseExpanded: "",
+      }),
+    ).toBeNull()
   })
 })


### PR DESCRIPTION
## The report

> 我路径想到上一层，然后我要到下一个路径这时候要快速补全吗？我确实看到比如打 a 出现 acdemic 什么的，但是我发现我按 enter 就到 from branch 了，这样我又要点击 repo 继续输入就好烦，我发现 tab 也会直接到下一步。

Not a misuse — the key genuinely did not exist. In the repo field `enter` picked-and-advanced (`onRepoSubmit`), `tab` advanced (the dialog's global binding), and nothing finished a suggestion and **stayed**. The tell: `joinDrill()` — the helper that walks one directory down and appends the trailing slash — was written, tested, and called from nowhere in product code.

## What changed

`tab` now completes the highlighted row **in place**, and means "next field" only when there is nothing left to complete. That is the shell bargain, and it costs no new chord.

- **browse rows** (a typed path) complete one directory DOWN and keep the trailing slash, so the picker re-points at the children and the next `tab` walks deeper.
- **saved rows** complete to the repo name and close the dropdown — nothing lives under a repo.
- Both complete toward the row the cursor is **on**, which is what `enter` and `↑`/`↓` already meant.
- The guard is the picker's own render condition, so `tab` keeps its plain meaning everywhere else.

**Extended to the Clone tab's parent dir**, because it is literally the same drill-down picker two fields away — a key that walked one but not the other would mean two things inside one dialog.

**Trailing slash no longer travels with the value.** The walk leaves `/i/rove/` in the field on purpose; `expandedRepo` now strips it, so `/i/rove/` and `/i/rove` file one repo instead of two. (Pre-existing — you could always type the slash by hand — just far more reachable now.)

## Keybinding sign-off

`tab` is a MOVED chord in this dialog, so per AGENTS.md it was put to the owner before landing. Owner picked layered `tab` over the two alternatives (`→`-at-end-of-line fish-style, or a dedicated chord) and "completion stays in place" over "completion advances". Recorded with the reasoning in `docs/design/keybinding-decisions.md`.

## File size

`view-model.ts` was 481 lines and this pushed it past the cap, so the two clusters it had outgrown moved out along their own seams — **which repository** (`use-repo-field.ts`) and **which ref it forks from** (`use-branch-field.ts`) — leaving the view-model with tabs, engine, intent, commit dispatch and bindings. Same shape `use-clone-state` / `use-adopt-state` already had. **481 → 333.**

## Verification

- `test/render/new-task-repo-tab-complete.test.tsx` — new. Each test presses `tab` **twice** and asserts what both presses did, because complete-only (traps focus) and advance-only (the bug) each pass a one-press test. Confirmed they fail against the old binding: 2 of 4 red when reverted, and the clone case goes red when its branch is disabled.
- Two sibling tests in `new-task-repo-name-field.test.tsx` changed because their key path genuinely changed. The ambiguity guard ("more than one saved repo is named app") now reaches its commit by clicking the next field — `tab` no longer leaves an unfinished name behind, so the click is the route that still gets ambiguous text to the commit. The guard itself is untouched.
- `completeRepoInput` and `stripTrailingSlash` covered as pure units.
- typecheck ✅ · lint ✅ · `bun test test/render` 459/459 ✅ · `test:fast` 4366 pass / 2 fail — both pre-existing and environmental (`cannot run gpg: No such file or directory`; gpg isn't installed on this machine), in `test/orchestrator/land-commit-failure.test.ts`, untouched here.

Behavior was verified through the OpenTUI render harness (real component tree, real key dispatch), not screenshots — the change is key routing, not layout.

## Docs

`docs/TUI.md` (both the dialog intro and the two tab bullets), the dialog legend in `newTask.ts` (`tab fields` → `tab complete/fields`, en + zh), and the decision record.