### PR TITLE
fix: plugins installed before the .kobe rename load again

### DIFF
--- a/.changeset/plugin-root-after-rename.md
+++ b/.changeset/plugin-root-after-rename.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Plugins installed before the `.kobe` → `.rove` rename load again. The layout migration moved every checkout under `~/.rove/plugins/` but the registry kept naming the old tree, so Settings › Plugins showed "manifest unreadable" for all of them and the daemon enabled none. A managed root recorded under `~/.kobe/plugins/` is re-anchored on read; user-facing copy names the new path.

--- a/packages/kobe-daemon/src/plugins/plugin-paths.ts
+++ b/packages/kobe-daemon/src/plugins/plugin-paths.ts
@@ -41,6 +41,12 @@ export function pluginsRootDir(homeDir?: string): string {
   return join(stateRoot(homeDir), "plugins")
 }
 
+/** Where the plugin tree lived before the `.kobe` → `.rove` rename. */
+export function legacyPluginsRootDir(homeDir?: string): string {
+  const home = homeDir ?? readRoveEnv("HOME_DIR") ?? homedir()
+  return join(home, COMPAT_STATE_DIR_BASENAME, "plugins")
+}
+
 export function pluginDataDir(id: string, homeDir?: string): string {
   return join(pluginsRootDir(homeDir), id)
 }

--- a/packages/kobe-daemon/src/plugins/registry.ts
+++ b/packages/kobe-daemon/src/plugins/registry.ts
@@ -7,8 +7,8 @@
  */
 
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs"
-import { dirname } from "node:path"
-import { pluginRegistryPath } from "./plugin-paths.ts"
+import { dirname, join, relative } from "node:path"
+import { legacyPluginsRootDir, pluginRegistryPath, pluginsRootDir } from "./plugin-paths.ts"
 
 export interface PluginRegistryEntry {
   readonly id: string
@@ -37,12 +37,30 @@ export function loadPluginRegistry(homeDir?: string): PluginRegistry {
   try {
     const raw = JSON.parse(text) as { plugins?: unknown }
     if (!Array.isArray(raw.plugins)) return EMPTY
-    return { plugins: raw.plugins.filter(isEntry) }
+    return { plugins: raw.plugins.filter(isEntry).map((entry) => withCanonicalRoot(entry, homeDir)) }
   } catch {
     // A corrupt registry disables plugins rather than crashing the daemon;
     // the next CLI mutation rewrites it whole.
     return EMPTY
   }
+}
+
+/**
+ * A managed checkout's `root` is an absolute path recorded at install time.
+ * The `.kobe` → `.rove` layout migration moves the checkout tree but the
+ * registry still names the old tree, so every manifest read fails with
+ * "no rove-plugin.toml found at ~/.kobe/plugins/…". Re-anchor a root that
+ * sits under the legacy plugins dir onto the canonical one; the next save
+ * writes the corrected path. Linked plugins keep the author's root as-is.
+ */
+function withCanonicalRoot(entry: PluginRegistryEntry, homeDir?: string): PluginRegistryEntry {
+  if (entry.source.kind !== "github") return entry
+  const legacy = legacyPluginsRootDir(homeDir)
+  const canonical = pluginsRootDir(homeDir)
+  if (legacy === canonical) return entry
+  const inside = relative(legacy, entry.root)
+  if (inside === "" || inside.startsWith("..") || inside.startsWith("/")) return entry
+  return { ...entry, root: join(canonical, inside) }
 }
 
 function isEntry(v: unknown): v is PluginRegistryEntry {

--- a/packages/kobe/src/cli/plugin-cmd.ts
+++ b/packages/kobe/src/cli/plugin-cmd.ts
@@ -4,7 +4,7 @@
  * A plugin is a directory with a `rove-plugin.toml` manifest (the legacy
  * `kobe-plugin.toml` spelling remains accepted); the whole Rove CLI is the
  * plugin API. This command owns
- * the registry (`~/.kobe/plugins.json`); the daemon's PluginHost watches
+ * the registry (`~/.rove/plugins.json`); the daemon's PluginHost watches
  * that file, so mutations here apply to a running daemon without a restart.
  */
 
@@ -118,7 +118,7 @@ function uninstall(idOrSpec: string): void {
   savePluginRegistry(removePluginEntry(registry, entry.id))
   // Managed checkout goes; config/ and state/ stay so a reinstall keeps user data.
   rmSync(pluginCheckoutDir(entry.id), { recursive: true, force: true })
-  console.log(`uninstalled ${entry.id} (config/state kept under ~/.kobe/plugins/${entry.id}/)`)
+  console.log(`uninstalled ${entry.id} (config/state kept under ~/.rove/plugins/${entry.id}/)`)
 }
 
 function listActions(pluginFilter?: string): void {

--- a/packages/kobe/src/cli/plugin-install.ts
+++ b/packages/kobe/src/cli/plugin-install.ts
@@ -3,7 +3,7 @@
  *
  * Install accepts GitHub shorthand only (`owner/repo[/subdir...]`): clone,
  * parse + preview the manifest, confirm (unless --yes), run supported
- * [[build]] commands, then move the checkout under `~/.kobe/plugins/<id>/`
+ * [[build]] commands, then move the checkout under `~/.rove/plugins/<id>/`
  * and register it. Link registers a local working directory as-is and runs
  * no build — authors build their own tree. Both work with no daemon running;
  * the daemon file-watches the registry and picks changes up live.

--- a/packages/kobe/src/tui-react/component/settings-dialog/plugins-core.ts
+++ b/packages/kobe/src/tui-react/component/settings-dialog/plugins-core.ts
@@ -1,6 +1,6 @@
 /**
  * Framework-free view model for the Settings → Plugins section: turns a
- * `~/.kobe/plugins.json` entry plus its `rove-plugin.toml` and the tail of
+ * `~/.rove/plugins.json` entry plus its `rove-plugin.toml` and the tail of
  * its `log.jsonl` into one displayable row. Both canonical and legacy
  * manifest spellings are accepted. Pure except for
  * `readPluginRows`, the thin disk wrapper the React section calls.

--- a/packages/kobe/src/tui/component/settings-dialog/model.ts
+++ b/packages/kobe/src/tui/component/settings-dialog/model.ts
@@ -117,7 +117,7 @@ export type SettingsRowsInput = {
   focusAccentSlots: readonly FocusAccentSlot[]
   /** Built-ins + user-registered custom engines, in display order. */
   engineList: readonly VendorId[]
-  /** Registered plugins (`~/.kobe/plugins.json`), in registry order. */
+  /** Registered plugins (`~/.rove/plugins.json`), in registry order. */
   plugins: readonly PluginRowsEntry[]
   hasDaemon: boolean
   /** False while `keybindings.yaml` is absent — the section then offers to write it. */

--- a/packages/kobe/src/tui/i18n/messages/settings.ts
+++ b/packages/kobe/src/tui/i18n/messages/settings.ts
@@ -109,7 +109,7 @@ export const en = {
   },
   plugins: {
     title: "Plugins",
-    hint: "Plugins registered in ~/.kobe/plugins.json. enter (or click) toggles one on or off — the daemon watches the file, so the change applies live. Rows indented under a plugin are the settings it declares; enter edits one, and the value reaches the plugin on its next run. Install and remove them from the shell: `rove plugin install <owner/repo>`, `rove plugin link <dir>`.",
+    hint: "Plugins registered in ~/.rove/plugins.json. enter (or click) toggles one on or off — the daemon watches the file, so the change applies live. Rows indented under a plugin are the settings it declares; enter edits one, and the value reaches the plugin on its next run. Install and remove them from the shell: `rove plugin install <owner/repo>`, `rove plugin link <dir>`.",
     empty:
       "No plugins registered. Install one with `rove plugin install <owner/repo>` — browse the `rove-plugin` topic on GitHub.",
     sourceLink: "linked {path}",
@@ -292,7 +292,7 @@ export const zh: typeof en = {
   },
   plugins: {
     title: "插件",
-    hint: "在 ~/.kobe/plugins.json 里注册的插件。enter（或点击）切换启用/禁用——daemon 监听该文件，改动实时生效。插件下方缩进的行是它声明的设置项，enter 编辑，新值在插件下次运行时生效。安装与移除在 shell 里做：`rove plugin install <owner/repo>`、`rove plugin link <dir>`。",
+    hint: "在 ~/.rove/plugins.json 里注册的插件。enter（或点击）切换启用/禁用——daemon 监听该文件，改动实时生效。插件下方缩进的行是它声明的设置项，enter 编辑，新值在插件下次运行时生效。安装与移除在 shell 里做：`rove plugin install <owner/repo>`、`rove plugin link <dir>`。",
     empty:
       "尚未注册任何插件。用 `rove plugin install <owner/repo>` 安装一个——可在 GitHub 的 `rove-plugin` 话题下浏览。",
     sourceLink: "本地链接 {path}",

--- a/packages/kobe/test/plugins/registry.test.ts
+++ b/packages/kobe/test/plugins/registry.test.ts
@@ -55,4 +55,22 @@ describe("plugin registry", () => {
     writeFileSync(pluginRegistryPath(dir), JSON.stringify({ plugins: [{ id: 1 }] }))
     expect(loadPluginRegistry(dir).plugins).toEqual([])
   })
+
+  it("re-anchors a managed root recorded under the legacy .kobe tree onto .rove", () => {
+    const dir = home()
+    mkdirSync(join(dir, ".rove"), { recursive: true })
+    const legacyRoot = join(dir, ".kobe", "plugins", "kobe.notify", "checkout", "notify")
+    writeFileSync(
+      join(dir, ".rove", "plugins.json"),
+      JSON.stringify({
+        plugins: [
+          { ...entry, id: "kobe.notify", root: legacyRoot },
+          { ...entry, id: "local.dev", source: { kind: "link" }, root: join(dir, ".kobe", "plugins", "elsewhere") },
+        ],
+      }),
+    )
+    const [managed, linked] = loadPluginRegistry(dir).plugins
+    expect(managed?.root).toBe(join(dir, ".rove", "plugins", "kobe.notify", "checkout", "notify"))
+    expect(linked?.root).toBe(join(dir, ".kobe", "plugins", "elsewhere"))
+  })
 })


### PR DESCRIPTION
## Symptom

Settings › Plugins lists every plugin as `manifest unreadable · no hooks declared`; `rove plugin list` says `[manifest unreadable]` for all; daemon log: `plugin registry reloaded (0 enabled)` after `no rove-plugin.toml or kobe-plugin.toml found at ~/.kobe/plugins/<id>/checkout/<name>`.

## Root cause

\`migrateLegacyPluginTree\` renames \`~/.kobe/plugins\` → \`~/.rove/plugins\` (and the marker proves it ran on the owner's machine, 2026-08-25), but \`plugins.json\` records each managed checkout's **absolute** \`root\` and nothing rewrites it. Every manifest read still targets the old tree. The compatibility symlink the migration tries to leave behind isn't there either (the parent \`~/.kobe/plugins\` no longer exists after the rename, so \`symlinkSync\` fails silently by design).

## Fix

- \`loadPluginRegistry\` re-anchors a \`github\`-sourced root that sits under the legacy plugins dir onto the canonical one (\`withCanonicalRoot\`). Linked plugins keep the author's path. The next \`savePluginRegistry\` (any enable/disable/install) persists the corrected root.
- \`legacyPluginsRootDir\` added to \`plugin-paths.ts\`.
- User-facing copy (Settings hint en/zh, CLI messages, doc comments) says \`~/.rove/plugins\` instead of \`~/.kobe/plugins\`.

## Evidence

- BEFORE \`.scratch/prefix-n/before-plugins-settings.png\`: harness home seeded with the owner's real \`kobe.notify\` checkout under \`.rove\` and a registry root under \`.kobe\` → "manifest unreadable · no hooks declared".
- AFTER \`.scratch/prefix-n/after-plugins-settings.png\`: same home → "1 actions · 4 events · 0 panes · never run" plus the plugin's declared \`ntfy push URL\` setting row.
- \`bun src/cli/index.ts plugin list\` against the owner's real \`~/.rove\`: all seven rows lose \`[manifest unreadable]\`.
- \`test/plugins/registry.test.ts\`: new case, legacy managed root re-anchored, linked root untouched.