### PR TITLE
fix: seven plugin-system fixes — first task.created, ROVE_BIN_PATH, notify --body, dir modes, platforms, TOML defaults

### DIFF
--- a/.agents/skills/kobe/references/api-flags.md
+++ b/.agents/skills/kobe/references/api-flags.md
@@ -106,7 +106,7 @@ pane-open      --task-id --tab --command --direction{right|down}(right)
                --placement{split|tab}(split) --title
 pane-close     --task-id --title(REQ) --tab
 tab-close      --task-id(REQ) --tab(REQ)
-notify         --title(REQ) --kind(done) --task-id --source
+notify         --title(REQ) --body --kind(done) --task-id --source
 prompt         --title(REQ) --placeholder --initial --timeout
 engine-report  --task-id --kind(REQ) --engine --tab --detail
 set-active     --task-id --none

--- a/.changeset/notify-body.md
+++ b/.changeset/notify-body.md
@@ -1,0 +1,11 @@
+---
+"@sma1lboy/rove": patch
+---
+
+`rove api notify` takes `--body`, so the SDK's `notify(title, body)` works.
+The SDK has shipped that two-argument signature since it existed — the README
+example, the PLUGIN-SDK reference and the `turn-notify` example plugin all use
+it — but the verb had no such flag, so every hook that called it exited 1 with
+`unknown flag --body`. The body now rides the `notice.event` channel into the
+toast's second line, a slot the TUI already rendered for engine-side
+notifications.

--- a/.changeset/plugin-bin-path.md
+++ b/.changeset/plugin-bin-path.md
@@ -1,0 +1,14 @@
+---
+"@sma1lboy/rove": patch
+---
+
+`$ROVE_BIN_PATH` now points at the Rove that is actually running. The daemon
+handed plugins the literal name `kobe` — even when started as `rove` — so a
+hook resolved whichever install happened to sit first on `PATH`. On a machine
+with two of them (a global npm install beside a `bun add -g` or a worktree
+build) hooks silently drove the wrong version, and a plugin calling
+`listTasks()` could autospawn that other version's daemon into this daemon's
+home. Both the daemon and `rove plugin action invoke` now resolve one absolute
+path where the entry point is runnable on its own — an npm install, a compiled
+binary — and fall back to the invoked name only for a dev checkout, which has
+no single token to exec. Documented in the plugin env table.

--- a/.changeset/plugin-dirs-owner-only.md
+++ b/.changeset/plugin-dirs-owner-only.md
@@ -1,0 +1,9 @@
+---
+"@sma1lboy/rove": patch
+---
+
+`rove plugin link` / `install` create a plugin's config and state directories
+0700, as the docs promise. They were 0755, and because `mkdirSync` never
+chmods a directory that already exists, the CLI's mode won permanently — the
+daemon's own 0700 could never take effect on a plugin the CLI had registered
+first. The config directory is where the docs tell users to paste API keys.

--- a/.changeset/plugin-first-task-created.md
+++ b/.changeset/plugin-first-task-created.md
@@ -1,0 +1,14 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Plugins now see the FIRST `task.created` after a daemon start. The daemon
+publishes its baseline task snapshot while wiring the orchestrator, minutes of
+code before the plugin host exists, so the first snapshot the host's reducer
+ever saw was the first real mutation — and the reducer's "the first snapshot is
+the pre-existing list, not a burst of creates" rule swallowed it. Every daemon
+lifetime silently lost its first `task.created` / `worktree.created` /
+`task.changed`; the second task onwards worked, which is why the smoketest
+missed it (it fired `issue.changed`, which is reported directly and never
+passes through that reducer). The host now seeds itself from the bus's
+last-value cache, and the sandbox smoketest asserts `task.created` first.

--- a/.changeset/plugin-platforms-cli.md
+++ b/.changeset/plugin-platforms-cli.md
@@ -1,0 +1,11 @@
+---
+"@sma1lboy/rove": patch
+---
+
+`rove plugin action invoke` and `plugin pane open` honour `platforms`. The
+daemon's event host and the TUI's pane picker have always skipped a plugin the
+manifest excludes from this machine; from a shell it ran anyway, so a
+Windows-only plugin executed happily on macOS. Both now refuse with the
+platforms the manifest declares, and `plugin link` warns when it registers
+something nothing on this machine will run (a refusal would be wrong there —
+developing a Windows plugin on a Mac is legitimate).

--- a/.changeset/plugin-sdk-usage-context.md
+++ b/.changeset/plugin-sdk-usage-context.md
@@ -1,0 +1,10 @@
+---
+"@sma1lboy/rove-plugin-sdk": patch
+---
+
+`usage.context` joins the SDK's `DAEMON_CHANNELS`. The channel shipped in the
+daemon but the published SDK never learned the name, so a plugin typed against
+it could not subscribe — and the daemon drops unknown channel names from a
+filter rather than rejecting them, so the subscribe succeeded and the channel
+simply never arrived, with no error anywhere. Documented alongside the drop
+behaviour in the SDK's channel list.

--- a/.changeset/plugin-setting-default-toml.md
+++ b/.changeset/plugin-setting-default-toml.md
@@ -1,0 +1,10 @@
+---
+"@sma1lboy/rove": patch
+---
+
+`[[settings]] default` accepts TOML booleans and numbers. `type = "boolean"`
+invites writing `default = true`, which failed the whole manifest with
+"`settings[0].default` must be a non-empty string" — and nothing in the
+reference said the value had to be quoted. `true` now stores as `"1"` (the
+spelling a boolean setting is read back as), `false` as no default, and a
+number as its decimal spelling.

--- a/claude-plugin/skills/rove/references/api-flags.md
+++ b/claude-plugin/skills/rove/references/api-flags.md
@@ -106,7 +106,7 @@ pane-open      --task-id --tab --command --direction{right|down}(right)
                --placement{split|tab}(split) --title
 pane-close     --task-id --title(REQ) --tab
 tab-close      --task-id(REQ) --tab(REQ)
-notify         --title(REQ) --kind(done) --task-id --source
+notify         --title(REQ) --body --kind(done) --task-id --source
 prompt         --title(REQ) --placeholder --initial --timeout
 engine-report  --task-id --kind(REQ) --engine --tab --detail
 set-active     --task-id --none

--- a/docs/API.md
+++ b/docs/API.md
@@ -404,10 +404,12 @@ branch included, live in the Rove agent skill. Prompts into existing sessions
   open with no session, matching ctrl+w. A tab that still exists in the
   snapshot may be closed after its process dies; an absent or already-closed
   id returns `TAB_NOT_FOUND` with a `get-task` recovery command.
-- `notify --title TEXT [--kind KIND] [--task-id ID] [--source TAG]`: show
-  a toast in every attached Rove UI. `done` / `needs_input` / `error` get
-  severity styling; any other kind renders neutrally. The result's `clients`
-  is the reach signal: `0` = no attached UI showed the toast (headless).
+- `notify --title TEXT [--body TEXT] [--kind KIND] [--task-id ID]
+  [--source TAG]`: show a toast in every attached Rove UI. `--body` adds a
+  second, muted line under the title — context, not a second message.
+  `done` / `needs_input` / `error` get severity styling; any other kind
+  renders neutrally. The result's `clients` is the reach signal: `0` = no
+  attached UI showed the toast (headless).
 - `prompt --title TEXT [--placeholder T] [--initial T] [--timeout MS]`:
   ask the human for a line of text through the attached TUI's input dialog;
   blocks until answered/cancelled/timeout (default 120000 ms, max 600000)

--- a/docs/PLUGIN-AUTHORING.md
+++ b/docs/PLUGIN-AUTHORING.md
@@ -265,7 +265,7 @@ Every plugin command gets, on top of the user's environment:
 
 | Variable | Meaning |
 |---|---|
-| `ROVE_BIN_PATH` | exec this to call back into Rove |
+| `ROVE_BIN_PATH` | exec this to call back into Rove — the absolute path of the running install when that is a runnable file (an npm install, a compiled binary), otherwise the bare `rove`/`kobe` name resolved on `PATH`, which is what a dev checkout run through `bun` falls back to |
 | `ROVE_SOCKET_PATH` | daemon unix socket, for raw JSON requests |
 | `ROVE_HOME_DIR` | set when Rove runs against a non-default home (keep passing it through) |
 | `ROVE_PLUGIN_ID`, `ROVE_PLUGIN_ROOT` | who you are, where your files are |

--- a/docs/PLUGIN-AUTHORING.md
+++ b/docs/PLUGIN-AUTHORING.md
@@ -156,7 +156,9 @@ key = "YOU_EXAMPLE_MODE"         # stored as KEY=value in your config .env;
 label = "Mode"
 type = "enum"                    # string | number | boolean | enum | secret
 options = ["fast", "fancy"]
-default = "fast"
+default = "fast"                 # stored as a string; TOML `true` / `false` /
+                                 # numbers are accepted and become "1" /
+                                 # no default / their decimal spelling
 
 [[settings]]                     # `secret` masks the value everywhere it is
 key = "YOU_EXAMPLE_TOKEN"        # shown, for keys the user pastes in

--- a/docs/PLUGIN-SDK.md
+++ b/docs/PLUGIN-SDK.md
@@ -139,7 +139,13 @@ the shape your target Rove version actually emits. The channel names are the
 `task.snapshot`, `issue.snapshot`, `active-task`, `update`, `engine-state`,
 `attention.inbox`, `ui-prefs`, `keybindings`, `task.jobs`, `worktree.changes`,
 `transcript.activity`, `session.deliver`, `tab.open`, `tab.close`,
-`engine.lifecycle`, `notice.event`, `usage.snapshot`, `ui.prompt`.
+`engine.lifecycle`, `notice.event`, `usage.snapshot`, `usage.context`,
+`ui.prompt`.
+
+A name the daemon does not know is dropped from the filter, not rejected: the
+subscribe succeeds and that channel simply never arrives. So an SDK older than
+the Rove it talks to fails silently — check the SDK version before assuming a
+channel is dead.
 
 Your handler also receives `daemon.stopping` at daemon shutdown — not a
 channel, always delivered regardless of the filter.

--- a/packages/kobe-daemon/src/daemon/channels.ts
+++ b/packages/kobe-daemon/src/daemon/channels.ts
@@ -286,6 +286,8 @@ export interface ChannelPayloads {
 /** The `notice.event` channel payload — one toast for every attached UI. */
 export interface NoticeEventPayload {
   readonly title: string
+  /** Optional second line under the title — context, not a second message. */
+  readonly body?: string
   /**
    * Free-form kind tag. The TUI styles the known severities
    * ("done" / "needs_input" / "error" — its NotificationKind vocabulary)

--- a/packages/kobe-daemon/src/daemon/handlers-ui.ts
+++ b/packages/kobe-daemon/src/daemon/handlers-ui.ts
@@ -273,6 +273,9 @@ export const UI_HANDLERS: readonly DaemonRequestHandler[] = [
       // only validates + broadcasts; NotificationsProvider in each
       // subscribed host renders it (and dedupes replays on `at`).
       const title = requireString(payload, "title")
+      // Optional second line: context under the title, same slot the TUI's
+      // toast already renders for engine-side notifications.
+      const body = optionalString(payload, "body")
       // Free-form kind: known severities get styled by the TUI, anything
       // else renders neutrally — agents may invent their own vocabulary.
       const kind = optionalString(payload, "kind") ?? "done"
@@ -280,7 +283,7 @@ export const UI_HANDLERS: readonly DaemonRequestHandler[] = [
       const taskId = optionalString(payload, "taskId")
       if (taskId !== undefined && !ctx.orch.getTask(taskId)) throw new Error(`task not found: ${taskId}`)
       const source = optionalString(payload, "source")
-      ctx.bus.publish("notice.event", { title, kind, taskId, at: Date.now(), source })
+      ctx.bus.publish("notice.event", { title, body, kind, taskId, at: Date.now(), source })
       // Headless honesty: with no attached UI the toast reaches nobody, and
       // `clients` is the only signal (same reach report as session.deliver).
       return { ok: true, clients: ctx.daemon.clientCount() }

--- a/packages/kobe-daemon/src/plugins/manifest.ts
+++ b/packages/kobe-daemon/src/plugins/manifest.ts
@@ -54,7 +54,9 @@ export interface PluginSetting {
   readonly type: "string" | "number" | "boolean" | "enum" | "secret"
   /** Enum choices (required for type = "enum"). */
   readonly options?: readonly string[]
-  /** Default shown when the .env has no value; storage is always a string. */
+  /** Default shown when the .env has no value; storage is always a string —
+   *  TOML `true` / `false` / numbers are accepted and stored as `"1"` /
+   *  absent / their decimal spelling. */
   readonly default?: string
 }
 
@@ -229,6 +231,20 @@ function asString(value: unknown, field: string): string {
   return value
 }
 
+/**
+ * A setting's `default`, coerced to the string every value is stored as.
+ * TOML has real booleans and numbers and `type = "boolean"` invites writing
+ * `default = true`, which used to fail the whole manifest with "must be a
+ * non-empty string". `false` means "no default", matching the storage
+ * convention where a boolean is on iff its .env value is `"1"`.
+ */
+function asSettingDefault(value: unknown, field: string): string | undefined {
+  if (value === undefined || value === false) return undefined
+  if (value === true) return "1"
+  if (typeof value === "number" && Number.isFinite(value)) return String(value)
+  return asString(value, field)
+}
+
 function asCommand(value: unknown, field: string): string[] {
   if (!Array.isArray(value) || value.length === 0 || !value.every((v) => typeof v === "string" && v.length > 0)) {
     fail(`\`${field}\` must be a non-empty array of strings (argv form)`)
@@ -359,6 +375,7 @@ function parseCanonicalPluginManifest(text: string): ParsedPluginManifest {
           ? (t.options as string[])
           : fail(`settings[${i}].options must be an array of strings`)
     if (type === "enum" && (!options || options.length === 0)) fail(`settings[${i}] enum needs \`options\``)
+    const settingDefault = asSettingDefault(t.default, `settings[${i}].default`)
     const key = asString(t.key, `settings[${i}].key`)
     const rejection = settingKeyRejection(key)
     if (rejection) fail(`settings[${i}].key ${rejection}`)
@@ -367,7 +384,7 @@ function parseCanonicalPluginManifest(text: string): ParsedPluginManifest {
       label: asString(t.label, `settings[${i}].label`),
       type: type as PluginSetting["type"],
       ...(options ? { options } : {}),
-      ...(t.default === undefined ? {} : { default: asString(t.default, `settings[${i}].default`) }),
+      ...(settingDefault === undefined ? {} : { default: settingDefault }),
     }
   })
 

--- a/packages/kobe-daemon/src/plugins/runtime.ts
+++ b/packages/kobe-daemon/src/plugins/runtime.ts
@@ -56,20 +56,31 @@ const REGISTRY_POLL_MS = 200
 /** How long a [[shutdown]] hook may run before the host kills it. */
 const SHUTDOWN_GRACE_MS = 3_000
 
-/** Compose a host onto the daemon's bus: subscribe first, then start. */
-export function startPluginHost(
-  bus: { onPublish(sink: (event: ChannelEvent) => void): () => void },
-  opts: PluginHostOptions,
-): PluginHost {
+/** The bus surface a host needs: live fan-out plus the last-value cache. */
+interface PluginHostBus {
+  onPublish(sink: (event: ChannelEvent) => void): () => void
+  snapshot(): ChannelEvent[]
+}
+
+/** Compose a host onto the daemon's bus: subscribe, seed, then start. */
+export function startPluginHost(bus: PluginHostBus, opts: PluginHostOptions): PluginHost {
   const host = new PluginHost(opts)
   bus.onPublish((event) => host.handleChannel(event))
+  // Seed the reducer from the bus's last-value cache. The daemon publishes
+  // the baseline `task.snapshot` while wiring the orchestrator, well before
+  // this host exists, so without the replay the first snapshot the reducer
+  // sees is the first MUTATION — and its "first snapshot after daemon start
+  // is baseline" rule swallows it, losing the first task.created /
+  // worktree.created / task.changed of every daemon lifetime. The replay
+  // itself emits nothing: it IS the reducer's baseline.
+  for (const event of bus.snapshot()) host.handleChannel(event)
   host.start()
   return host
 }
 
 /** The server's one-liner: start a host iff `options.plugins` is set. */
 export function maybeStartPluginHost(
-  bus: { onPublish(sink: (event: ChannelEvent) => void): () => void },
+  bus: PluginHostBus,
   options: { readonly homeDir?: string; readonly plugins?: { readonly binPath: string } },
   socketPath: string,
   log: (line: string) => void,

--- a/packages/kobe/scripts/dev-sandbox.ts
+++ b/packages/kobe/scripts/dev-sandbox.ts
@@ -217,7 +217,9 @@ async function smoketest(): Promise<never> {
   if (created.code !== 0) fail(`issue-create exited ${created.code}`)
   if (!(await seen("issue.changed"))) fail(`no issue.changed in ${eventsFile} after 15s`)
 
-  console.log(`[rove ${label}] SMOKETEST PASS -- task.created + issue.changed reached examples.hello-events (${eventsFile})`)
+  console.log(
+    `[rove ${label}] SMOKETEST PASS -- task.created + issue.changed reached examples.hello-events (${eventsFile})`,
+  )
   await stopSandbox()
   process.exit(0)
 }

--- a/packages/kobe/scripts/dev-sandbox.ts
+++ b/packages/kobe/scripts/dev-sandbox.ts
@@ -19,7 +19,7 @@
  */
 
 import { spawnSync } from "node:child_process"
-import { existsSync, readFileSync } from "node:fs"
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs"
 import { mkdir } from "node:fs/promises"
 import { dirname, join } from "node:path"
 import { readRoveEnv } from "@sma1lboy/kobe-daemon/compat-env"
@@ -148,10 +148,10 @@ if (mode === "seed") await seed()
 
 /**
  * End-to-end plugin-event self-check: link the SDK's hello-events example
- * into this sandbox's registry, boot a fresh daemon, fire `issue.changed`
- * via `issue-create`, and assert the hook recorded it. Proves the whole
- * chain -- registry, PluginHost, event dispatch, env contract -- before a
- * task builds anything on top.
+ * into this sandbox's registry, boot a fresh daemon, fire `task.created`
+ * (via `api add`) then `issue.changed` (via `issue-create`), and assert the
+ * hook recorded both. Proves the whole chain -- registry, PluginHost, event
+ * dispatch, env contract -- before a task builds anything on top.
  */
 async function smoketest(): Promise<never> {
   const repoRoot = dirname(await gitCommonDir())
@@ -177,33 +177,49 @@ async function smoketest(): Promise<never> {
     }
   }
 
-  // Fresh daemon so the just-linked registry loads at startup.
-  await stopSandbox()
-  const created = runRove(["api", "issue-create", "--repo", repo, "--title", `smoke ${Date.now()}`], "pipe")
-  if (created.code !== 0) {
-    console.error(`[rove ${label}] SMOKETEST FAIL -- issue-create exited ${created.code}`)
+  // The hook is an async spawned process; poll its output file.
+  const seen = async (event: string): Promise<boolean> => {
+    const deadline = Date.now() + 15_000
+    while (Date.now() < deadline) {
+      try {
+        const lines = readFileSync(eventsFile, "utf8").trim().split("\n")
+        if (lines.map((l) => JSON.parse(l) as { event: string }).some((e) => e.event === event)) return true
+      } catch {
+        /* not written yet */
+      }
+      await new Promise((r) => setTimeout(r, 250))
+    }
+    return false
+  }
+  const fail = (why: string): never => {
+    console.error(`[rove ${label}] SMOKETEST FAIL -- ${why}`)
+    console.error(`[rove ${label}] check ${join(home, ".rove", "daemon.log")} and the plugin's log.jsonl`)
     process.exit(1)
   }
 
-  // The hook is an async spawned process; poll its output file.
-  const deadline = Date.now() + 15_000
-  while (Date.now() < deadline) {
-    try {
-      const lines = readFileSync(eventsFile, "utf8").trim().split("\n")
-      const hit = lines.map((l) => JSON.parse(l) as { event: string }).find((e) => e.event === "issue.changed")
-      if (hit) {
-        console.log(`[rove ${label}] SMOKETEST PASS -- issue.changed reached examples.hello-events (${eventsFile})`)
-        await stopSandbox()
-        process.exit(0)
-      }
-    } catch {
-      /* not written yet */
-    }
-    await new Promise((r) => setTimeout(r, 250))
-  }
-  console.error(`[rove ${label}] SMOKETEST FAIL -- no issue.changed in ${eventsFile} after 15s`)
-  console.error(`[rove ${label}] check ${join(home, ".rove", "daemon.log")} and the plugin's log.jsonl`)
-  process.exit(1)
+  // Fresh daemon so the just-linked registry loads at startup. Truncate the
+  // hook's output first: the file is append-only and the sandbox home
+  // survives `reset`, so a previous run's lines would satisfy every poll
+  // below and the check would pass without the daemon emitting anything.
+  await stopSandbox()
+  mkdirSync(dirname(eventsFile), { recursive: true })
+  writeFileSync(eventsFile, "")
+
+  // `task.created` FIRST and deliberately: it is snapshot-derived, so it is
+  // the one the plugin host can lose to the reducer's baseline rule if the
+  // daemon's bus cache is not replayed into it at host start. `issue.changed`
+  // is direct-reported and would pass either way -- it cannot stand in.
+  const added = runRove(["api", "add", "--repo", repo, "--title", `smoke ${Date.now()}`], "pipe")
+  if (added.code !== 0) fail(`api add exited ${added.code}`)
+  if (!(await seen("task.created"))) fail(`no task.created in ${eventsFile} after 15s`)
+
+  const created = runRove(["api", "issue-create", "--repo", repo, "--title", `smoke ${Date.now()}`], "pipe")
+  if (created.code !== 0) fail(`issue-create exited ${created.code}`)
+  if (!(await seen("issue.changed"))) fail(`no issue.changed in ${eventsFile} after 15s`)
+
+  console.log(`[rove ${label}] SMOKETEST PASS -- task.created + issue.changed reached examples.hello-events (${eventsFile})`)
+  await stopSandbox()
+  process.exit(0)
 }
 
 if (mode === "smoketest") await smoketest()

--- a/packages/kobe/src/cli/api/verbs-drive.ts
+++ b/packages/kobe/src/cli/api/verbs-drive.ts
@@ -95,6 +95,12 @@ export const DRIVE_VERBS: readonly VerbSpec[] = [
         description: "Toast text (one line).",
       },
       {
+        name: "body",
+        type: "string",
+        placeholder: "TEXT",
+        description: "Optional second line under the title — context, not a second message.",
+      },
+      {
         name: "kind",
         type: "string",
         default: "done",
@@ -113,6 +119,7 @@ export const DRIVE_VERBS: readonly VerbSpec[] = [
     handler: async (ctx) => {
       return simpleRpc(ctx, "notice.send", {
         title: ctx.args.str("title"),
+        body: ctx.args.str("body"),
         kind: ctx.args.str("kind") ?? "done",
         taskId: ctx.args.str("task-id"),
         source: ctx.args.str("source"),

--- a/packages/kobe/src/cli/daemon-cmd.ts
+++ b/packages/kobe/src/cli/daemon-cmd.ts
@@ -22,8 +22,8 @@ import {
 import { readPidFile, startDaemonServer } from "@sma1lboy/kobe-daemon/daemon/server"
 import { daemonRuntime } from "../core/daemon-runtime.ts"
 import { createKobeCore } from "../core/index.ts"
-import { LEGACY_KOBE_PRODUCT_NAME } from "../product.ts"
 import { migrateRoveDaemonStateLayout } from "../state/layout-migration.ts"
+import { resolvePluginBinPath } from "./plugin-bin-path.ts"
 import { activeCliName } from "./rename-compat.ts"
 import { SUBCOMMAND_VERBS } from "./subcommands.ts"
 
@@ -150,9 +150,9 @@ export async function runDaemonSubcommand(argv: readonly string[]): Promise<void
     webPort: resolveDaemonWebPort(),
     webHost: readRoveEnv("WEB_HOST"),
     webStaticDir: readRoveEnv("DAEMON_WEB_STATIC_DIR"),
-    // Plugin callbacks exec the packaged `kobe`, resolved on PATH at spawn
-    // time; a dev checkout without one still runs, plugins just log ENOENT.
-    plugins: { binPath: LEGACY_KOBE_PRODUCT_NAME },
+    // Plugin callbacks exec THIS Rove where that is expressible as one
+    // absolute path, else the invoked name on PATH (see plugin-bin-path.ts).
+    plugins: { binPath: resolvePluginBinPath() },
     onStop: async () => {
       await core.close()
     },

--- a/packages/kobe/src/cli/plugin-bin-path.ts
+++ b/packages/kobe/src/cli/plugin-bin-path.ts
@@ -1,0 +1,46 @@
+/**
+ * `ROVE_BIN_PATH` — the one thing a plugin execs to call back into Rove.
+ *
+ * It is a single exec token (the SDK spawns it directly), so it has to be
+ * something runnable on its own. A bare name is the wrong answer whenever the
+ * machine has more than one install: the daemon used to hand out the literal
+ * `kobe`, so a hook fired by a 0.9.108 daemon reached whichever 0.9.105 sat
+ * first on PATH — and a plugin's `listTasks()` could autospawn that other
+ * version's daemon into this daemon's home.
+ *
+ * So: prefer an absolute path to the entry point this process is running,
+ * and fall back to the name only when that entry cannot be exec'd on its own.
+ */
+
+import { accessSync, constants, statSync } from "node:fs"
+import { isAbsolute } from "node:path"
+import { activeCliName } from "./rename-compat.ts"
+
+function isRunnableFile(path: string): boolean {
+  try {
+    if (!statSync(path).isFile()) return false
+    accessSync(path, constants.X_OK)
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Absolute when resolvable, else the invoked CLI name resolved on PATH.
+ *
+ * Three shapes:
+ *  - **npm install** — `argv[1]` is `…/dist/cli/rove.js`: shebang + mode 755,
+ *    so it runs on its own. This is the case the bug bit.
+ *  - **compiled standalone** (`bun build --compile`) — the script lives in
+ *    the embedded filesystem and `process.execPath` IS Rove.
+ *  - **dev checkout** — `argv[1]` is `src/cli/rove.ts`, which needs `bun` in
+ *    front and has no exec bit, so there is no single token for it: fall back
+ *    to the name and accept that a dev daemon's hooks reach the installed CLI.
+ */
+export function resolvePluginBinPath(argv = process.argv, moduleUrl = import.meta.url): string {
+  if (moduleUrl.includes("/$bunfs/") || moduleUrl.includes("B:\\~BUN")) return process.execPath
+  const entry = argv[1]
+  if (entry && isAbsolute(entry) && isRunnableFile(entry)) return entry
+  return activeCliName()
+}

--- a/packages/kobe/src/cli/plugin-bin-path.ts
+++ b/packages/kobe/src/cli/plugin-bin-path.ts
@@ -12,7 +12,7 @@
  * and fall back to the name only when that entry cannot be exec'd on its own.
  */
 
-import { accessSync, constants, statSync } from "node:fs"
+import { constants, accessSync, statSync } from "node:fs"
 import { isAbsolute } from "node:path"
 import { activeCliName } from "./rename-compat.ts"
 

--- a/packages/kobe/src/cli/plugin-cmd.ts
+++ b/packages/kobe/src/cli/plugin-cmd.ts
@@ -13,7 +13,14 @@ import { readFileSync, rmSync } from "node:fs"
 import { errorMessage } from "@/lib/error-message"
 import { defaultDaemonSocketPath } from "@sma1lboy/kobe-daemon/daemon/paths"
 import { buildPluginEnv } from "@sma1lboy/kobe-daemon/plugins/env"
-import { type PluginManifest, qualifiedActionId, readPluginManifest } from "@sma1lboy/kobe-daemon/plugins/manifest"
+import {
+  type PluginManifest,
+  type PluginPlatform,
+  currentPluginPlatform,
+  qualifiedActionId,
+  readPluginManifest,
+  supportsPlatform,
+} from "@sma1lboy/kobe-daemon/plugins/manifest"
 import { buildPaneArgv } from "@sma1lboy/kobe-daemon/plugins/pane-command"
 import { pluginCheckoutDir, pluginConfigDir, pluginLogPath } from "@sma1lboy/kobe-daemon/plugins/plugin-paths"
 import {
@@ -140,7 +147,7 @@ function findByLongestPluginPrefix<T>(
   qualified: string,
   options: { enabledOnly?: boolean },
   findItem: (manifest: PluginManifest, suffix: string) => T | undefined,
-): { entry: PluginRegistryEntry; item: T } | undefined {
+): { entry: PluginRegistryEntry; manifest: PluginManifest; item: T } | undefined {
   type LoadedWithManifest = { readonly entry: PluginRegistryEntry; readonly manifest: PluginManifest }
   for (const { entry, manifest } of (loadAll() as LoadedWithManifest[])
     .filter(({ entry, manifest }) =>
@@ -148,9 +155,24 @@ function findByLongestPluginPrefix<T>(
     )
     .sort((a, b) => b.entry.id.length - a.entry.id.length)) {
     const item = findItem(manifest, qualified.slice(entry.id.length + 1))
-    if (item !== undefined) return { entry, item }
+    if (item !== undefined) return { entry, manifest, item }
   }
   return undefined
+}
+
+/**
+ * Refuse to run something the manifest says this machine cannot run. The
+ * daemon's host and the TUI's pane picker have always skipped these; the CLI
+ * ran them anyway, so `platforms` meant nothing from a shell.
+ */
+function assertPlatformSupported(
+  label: string,
+  item: { readonly platforms?: readonly PluginPlatform[] },
+  manifest: PluginManifest,
+): void {
+  if (supportsPlatform(item, manifest, currentPluginPlatform())) return
+  const declared = (item.platforms ?? manifest.platforms ?? []).join(", ")
+  throw new PluginCliError(`\`${label}\` is not supported on this platform (declares ${declared})`)
 }
 
 function invokeAction(qualified: string, extraArgs: string[]): void {
@@ -158,6 +180,7 @@ function invokeAction(qualified: string, extraArgs: string[]): void {
     manifest.actions.find((a) => a.id === actionId),
   )
   if (!hit) throw new PluginCliError(`no action \`${qualified}\`; see \`${CLI_NAME} plugin action list\``)
+  assertPlatformSupported(qualified, hit.item, hit.manifest)
 
   // Extra CLI args are appended to the action's argv so an action can take
   // an argument (`<active CLI> plugin action invoke p.start <url>`).
@@ -192,6 +215,7 @@ async function openPane(pluginId: string, entrypoint: string, taskFlag: string |
   if (!loaded.entry.enabled) throw new PluginCliError(`\`${pluginId}\` is disabled`)
   const pane = loaded.manifest.panes.find((p) => p.id === entrypoint)
   if (!pane) throw new PluginCliError(`no pane \`${entrypoint}\` in \`${pluginId}\`; declare it under [[panes]]`)
+  assertPlatformSupported(`${pluginId}.${pane.id}`, pane, loaded.manifest)
 
   // Shared composition with the TUI's ctrl+e picker (plugins/pane-command.ts):
   // one login-shell `-ilc` script, env contract riding an `env` prefix, cwd = worktree.

--- a/packages/kobe/src/cli/plugin-cmd.ts
+++ b/packages/kobe/src/cli/plugin-cmd.ts
@@ -23,6 +23,7 @@ import {
   savePluginRegistry,
 } from "@sma1lboy/kobe-daemon/plugins/registry"
 import { flagValue } from "./argv.ts"
+import { resolvePluginBinPath } from "./plugin-bin-path.ts"
 import { PluginCliError, installPlugin, linkPlugin } from "./plugin-install.ts"
 import { activeCliName } from "./rename-compat.ts"
 import { SUBCOMMAND_VERBS } from "./subcommands.ts"
@@ -167,7 +168,7 @@ function invokeAction(qualified: string, extraArgs: string[]): void {
     stdio: "inherit",
     env: buildPluginEnv({
       socketPath: defaultDaemonSocketPath(),
-      binPath: CLI_NAME,
+      binPath: resolvePluginBinPath(),
       pluginId: hit.entry.id,
       pluginRoot: hit.entry.root,
       extra: { ROVE_PLUGIN_ACTION_ID: action.id, ROVE_PLUGIN_INVOKE_CWD: process.cwd() },
@@ -196,7 +197,7 @@ async function openPane(pluginId: string, entrypoint: string, taskFlag: string |
   // one login-shell `-ilc` script, env contract riding an `env` prefix, cwd = worktree.
   const argv = buildPaneArgv(loaded.entry.id, loaded.entry.root, pane, {
     socketPath: defaultDaemonSocketPath(),
-    binPath: CLI_NAME,
+    binPath: resolvePluginBinPath(),
   })
 
   const { openDaemonSession, resolveActiveTaskId } = await import("./daemon-session.ts")

--- a/packages/kobe/src/cli/plugin-install.ts
+++ b/packages/kobe/src/cli/plugin-install.ts
@@ -130,8 +130,12 @@ function movePluginTree(from: string, to: string): void {
 
 function register(entry: PluginRegistryEntry): void {
   savePluginRegistry(upsertPluginEntry(loadPluginRegistry(), entry))
-  mkdirSync(pluginConfigDir(entry.id), { recursive: true })
-  mkdirSync(pluginStateDir(entry.id), { recursive: true })
+  // 0700, matching the daemon's own mkdir: config holds the settings `.env`
+  // (the documented home for API keys) and state is plugin-owned data.
+  // Whoever creates the directory FIRST sets its mode — `mkdirSync` never
+  // chmods an existing one — so a 0755 here would outlive every later 0700.
+  mkdirSync(pluginConfigDir(entry.id), { recursive: true, mode: 0o700 })
+  mkdirSync(pluginStateDir(entry.id), { recursive: true, mode: 0o700 })
 }
 
 /** Installs and returns the plugin id the manifest declared. */
@@ -205,6 +209,14 @@ export function linkPlugin(dir: string): void {
     fail(`\`${id}\` is installed from GitHub; uninstall it before linking a local copy`)
   }
   for (const w of parsed.warnings) console.log(`warning: ${w}`)
+  // A warning, not a refusal: `install` fails here, but developing a
+  // Windows-only plugin on a Mac is legitimate. What is not legitimate is
+  // registering it with no hint that nothing will ever run it.
+  if (!supportsPlatform({}, parsed.manifest, currentPluginPlatform())) {
+    console.log(
+      `warning: declares platforms [${parsed.manifest.platforms?.join(", ")}]; nothing will run on this machine`,
+    )
+  }
   register({
     id,
     source: { kind: "link" },

--- a/packages/kobe/src/tui-react/lib/use-daemon-notices.ts
+++ b/packages/kobe/src/tui-react/lib/use-daemon-notices.ts
@@ -116,6 +116,12 @@ export function useDaemonNotices(
     // Arbitrary kinds are allowed on the wire; only the known severities
     // carry styling/unread semantics — everything else renders as "done".
     const kind = notice.kind === "needs_input" || notice.kind === "error" ? notice.kind : "done"
-    notifyRef.current({ kind, taskId: notice.taskId ?? "", tabId: "", title: notice.title })
+    notifyRef.current({
+      kind,
+      taskId: notice.taskId ?? "",
+      tabId: "",
+      title: notice.title,
+      ...(notice.body ? { body: notice.body } : {}),
+    })
   }, [notice])
 }

--- a/packages/kobe/test/cli/plugin-bin-path.test.ts
+++ b/packages/kobe/test/cli/plugin-bin-path.test.ts
@@ -1,0 +1,36 @@
+/**
+ * `ROVE_BIN_PATH` must name THIS Rove, not whichever install sits first on
+ * PATH — a machine with two installs used to have hooks calling the other one.
+ */
+
+import { chmodSync, mkdtempSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { describe, expect, it } from "vitest"
+import { resolvePluginBinPath } from "../../src/cli/plugin-bin-path.ts"
+
+const dir = mkdtempSync(join(tmpdir(), "rove-binpath-"))
+
+function entry(name: string, mode: number): string {
+  const path = join(dir, name)
+  writeFileSync(path, "#!/usr/bin/env node\n")
+  chmodSync(path, mode)
+  return path
+}
+
+describe("resolvePluginBinPath", () => {
+  it("uses the running entry point when it is a runnable file", () => {
+    const packaged = entry("rove.js", 0o755)
+    expect(resolvePluginBinPath(["node", packaged, "daemon", "start"])).toBe(packaged)
+  })
+
+  it("falls back to the invoked name when the entry needs a runtime in front", () => {
+    // A dev checkout: `bun src/cli/rove.ts`, no exec bit, no single token.
+    const source = entry("rove.ts", 0o644)
+    expect(resolvePluginBinPath(["bun", source, "daemon", "start"])).toMatch(/^(rove|kobe)$/)
+  })
+
+  it("uses the executable itself when running from a compiled binary", () => {
+    expect(resolvePluginBinPath(["/opt/rove", "daemon"], "file:///$bunfs/root/rove")).toBe(process.execPath)
+  })
+})

--- a/packages/kobe/test/daemon/harness.ts
+++ b/packages/kobe/test/daemon/harness.ts
@@ -107,6 +107,9 @@ export interface DaemonHarnessOptions {
   server?: Partial<DaemonServerOptions>
   /** Env vars to set for the daemon's lifetime; restored on `close()`. */
   env?: Record<string, string>
+  /** Write into the temp home BEFORE the daemon boots — for state the daemon
+   *  only reads at start (the plugin registry, for one). */
+  seedHome?: (dir: string) => void
   /** Also build the web request handler (see module doc). */
   web?:
     | boolean
@@ -156,6 +159,7 @@ export async function bootDaemonHarness(opts: DaemonHarnessOptions = {}): Promis
   }
   setEnv("KOBE_HOME_DIR", dir)
   for (const [key, value] of Object.entries(opts.env ?? {})) setEnv(key, value)
+  opts.seedHome?.(dir)
 
   const server = await startDaemonServer(opts.orchestrator ?? fakeOrchestrator(), {
     runtime: daemonRuntime,

--- a/packages/kobe/test/daemon/plugin-first-task-created.test.ts
+++ b/packages/kobe/test/daemon/plugin-first-task-created.test.ts
@@ -1,0 +1,116 @@
+/**
+ * The FIRST task mutation after a daemon start must reach an event plugin.
+ *
+ * The daemon publishes a baseline `task.snapshot` while wiring the
+ * orchestrator, long before the plugin host exists. The host's reducer treats
+ * the first snapshot it sees as baseline, so without a replay of the bus's
+ * last-value cache the first real mutation IS that baseline and every plugin
+ * misses the first `task.created` of the daemon's life.
+ *
+ * Driven end to end: a real daemon, a real registry entry, a real spawned
+ * hook writing a real file — a reducer unit test would not have caught the
+ * bug, which lives in the wiring order, not in the reducer.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs"
+import { join } from "node:path"
+import { describe, expect, it } from "vitest"
+import type { Orchestrator } from "../../src/orchestrator/core.ts"
+import { type DaemonHarness, bootDaemonHarness, waitFor } from "./harness.ts"
+
+const PLUGIN_ID = "test.first-created"
+
+const TASK = {
+  id: "t1",
+  title: "first after start",
+  repo: "/repo",
+  branch: "b",
+  worktreePath: "/wt",
+  status: "idle",
+  vendor: "claude",
+  createdAt: 1,
+  updatedAt: 1,
+}
+
+/** Plugin root + registry entry, written into the temp home before boot. */
+function seedPlugin(dir: string): void {
+  const root = join(dir, "plugin")
+  mkdirSync(root, { recursive: true })
+  writeFileSync(
+    join(root, "rove-plugin.toml"),
+    [
+      `id = "${PLUGIN_ID}"`,
+      'name = "First Created Probe"',
+      'version = "0.0.1"',
+      'min_rove_version = "0.0.1"',
+      "",
+      "[[events]]",
+      'on = "task.created"',
+      `command = ["sh", "-c", "echo \\"$ROVE_PLUGIN_TASK_ID\\" >> \\"$ROVE_PLUGIN_STATE_DIR/hits.txt\\""]`,
+      "",
+    ].join("\n"),
+  )
+  mkdirSync(join(dir, ".rove"), { recursive: true })
+  writeFileSync(
+    join(dir, ".rove", "plugins.json"),
+    JSON.stringify({
+      version: 1,
+      plugins: [{ id: PLUGIN_ID, source: { kind: "link" }, root, enabled: true, version: "0.0.1", installedAt: 1 }],
+    }),
+  )
+}
+
+function hits(harness: DaemonHarness): string[] {
+  const file = join(harness.dir, ".rove", "plugins", PLUGIN_ID, "state", "hits.txt")
+  if (!existsSync(file)) return []
+  return readFileSync(file, "utf8").trim().split("\n").filter(Boolean)
+}
+
+/** Boot with `baseline` as the pre-existing task list; returns a pusher for
+ *  later snapshots (the real orchestrator's `subscribeTasks` shape). */
+async function bootWith(baseline: unknown[]): Promise<{ harness: DaemonHarness; push: (tasks: unknown[]) => void }> {
+  let listener: ((snapshot: unknown[]) => void) | undefined
+  const orchestrator = {
+    // The real orchestrator fires eagerly with the current list; that eager
+    // baseline is what the bug swallowed.
+    subscribeTasks: (sink: (snapshot: unknown[]) => void) => {
+      listener = sink
+      sink(baseline)
+      return () => {}
+    },
+    listTasks: () => baseline,
+    getTask: () => undefined,
+  } as unknown as Orchestrator
+  const harness = await bootDaemonHarness({
+    orchestrator,
+    seedHome: seedPlugin,
+    server: { plugins: { binPath: "sh" } },
+  })
+  return { harness, push: (tasks) => listener?.(tasks) }
+}
+
+describe("plugin events across a daemon start", () => {
+  it("fires task.created for the FIRST mutation, not just the second", async () => {
+    const { harness, push } = await bootWith([])
+    try {
+      push([TASK])
+      expect(await waitFor(() => hits(harness).length > 0, 3000)).toBe(true)
+      expect(hits(harness)).toEqual(["t1"])
+    } finally {
+      await harness.close()
+    }
+  })
+
+  it("does not replay pre-existing tasks as creates", async () => {
+    const { harness, push } = await bootWith([TASK])
+    try {
+      push([TASK, { ...TASK, id: "t2", title: "second" }])
+      expect(await waitFor(() => hits(harness).length > 0, 3000)).toBe(true)
+      // Only the new one: the seeded baseline must stay a baseline.
+      await new Promise((r) => setTimeout(r, 200))
+      expect(hits(harness)).toEqual(["t2"])
+    } finally {
+      await harness.close()
+    }
+  })
+})

--- a/packages/kobe/test/plugins/manifest.test.ts
+++ b/packages/kobe/test/plugins/manifest.test.ts
@@ -178,9 +178,7 @@ describe("settings + file handlers", () => {
       { key: "K_N", label: "N", type: "number", default: "5" },
     ])
     // Anything else still has to be a real string.
-    expect(() =>
-      settings('[[settings]]\nkey = "K_X"\nlabel = "X"\ntype = "string"\ndefault = ""'),
-    ).toThrow(/default/)
+    expect(() => settings('[[settings]]\nkey = "K_X"\nlabel = "X"\ntype = "string"\ndefault = ""')).toThrow(/default/)
   })
 
   it("rejects an enum setting without options and unknown types", () => {

--- a/packages/kobe/test/plugins/manifest.test.ts
+++ b/packages/kobe/test/plugins/manifest.test.ts
@@ -163,6 +163,26 @@ describe("settings + file handlers", () => {
     ])
   })
 
+  it("stores a TOML boolean or number default as the string it is stored as", () => {
+    // `type = "boolean"` invites `default = true`; that used to fail the whole
+    // manifest with "must be a non-empty string". `false` means no default,
+    // matching the storage convention where a boolean is on iff its value is "1".
+    const settings = (toml: string) => parsePluginManifest(`${base}${toml}`).manifest.settings
+    expect(settings('[[settings]]\nkey = "K_ON"\nlabel = "On"\ntype = "boolean"\ndefault = true')).toEqual([
+      { key: "K_ON", label: "On", type: "boolean", default: "1" },
+    ])
+    expect(settings('[[settings]]\nkey = "K_OFF"\nlabel = "Off"\ntype = "boolean"\ndefault = false')).toEqual([
+      { key: "K_OFF", label: "Off", type: "boolean" },
+    ])
+    expect(settings('[[settings]]\nkey = "K_N"\nlabel = "N"\ntype = "number"\ndefault = 5')).toEqual([
+      { key: "K_N", label: "N", type: "number", default: "5" },
+    ])
+    // Anything else still has to be a real string.
+    expect(() =>
+      settings('[[settings]]\nkey = "K_X"\nlabel = "X"\ntype = "string"\ndefault = ""'),
+    ).toThrow(/default/)
+  })
+
   it("rejects an enum setting without options and unknown types", () => {
     expect(() => parsePluginManifest(`${base}[[settings]]\nkey = "K"\nlabel = "L"\ntype = "enum"`)).toThrow(/options/)
     expect(() => parsePluginManifest(`${base}[[settings]]\nkey = "K"\nlabel = "L"\ntype = "list"`)).toThrow(/type/)

--- a/packages/kobe/test/plugins/plugin-file-modes.test.ts
+++ b/packages/kobe/test/plugins/plugin-file-modes.test.ts
@@ -22,8 +22,8 @@ import {
 } from "@sma1lboy/kobe-daemon/plugins/plugin-paths"
 import { savePluginRegistry } from "@sma1lboy/kobe-daemon/plugins/registry"
 import { PluginHost } from "@sma1lboy/kobe-daemon/plugins/runtime"
-import { linkPlugin } from "../../src/cli/plugin-install.ts"
 import { afterEach, describe, expect, it } from "vitest"
+import { linkPlugin } from "../../src/cli/plugin-install.ts"
 
 const dirs: string[] = []
 function tmp(prefix: string): string {
@@ -92,7 +92,7 @@ describe("plugin subsystem files are owner-only", () => {
       expect(mode(pluginConfigDir("example.leaky", home))).toBe(0o700)
       expect(mode(pluginStateDir("example.leaky", home))).toBe(0o700)
     } finally {
-      if (saved === undefined) delete process.env.KOBE_HOME_DIR
+      if (saved === undefined) Reflect.deleteProperty(process.env, "KOBE_HOME_DIR")
       else process.env.KOBE_HOME_DIR = saved
     }
   })

--- a/packages/kobe/test/plugins/plugin-file-modes.test.ts
+++ b/packages/kobe/test/plugins/plugin-file-modes.test.ts
@@ -22,6 +22,7 @@ import {
 } from "@sma1lboy/kobe-daemon/plugins/plugin-paths"
 import { savePluginRegistry } from "@sma1lboy/kobe-daemon/plugins/registry"
 import { PluginHost } from "@sma1lboy/kobe-daemon/plugins/runtime"
+import { linkPlugin } from "../../src/cli/plugin-install.ts"
 import { afterEach, describe, expect, it } from "vitest"
 
 const dirs: string[] = []
@@ -74,6 +75,26 @@ describe("plugin subsystem files are owner-only", () => {
     mkdirSync(join(home, ".kobe"), { recursive: true })
     savePluginRegistry({ plugins: [] }, home)
     expect(mode(pluginRegistryPath(home))).toBe(0o600)
+  })
+
+  it("creates config/state 0700 when the CLI registers the plugin first", () => {
+    // Whoever mkdirs first sets the mode: `mkdirSync` never chmods an
+    // existing directory, so a 0755 from `plugin link` survives every later
+    // 0700 the daemon asks for. The daemon-side assertion below cannot see
+    // that — it only ever runs against a home the CLI never touched.
+    const home = tmp("kobe-pmode-link-")
+    const root = tmp("kobe-pmode-link-root-")
+    writeFileSync(join(root, "rove-plugin.toml"), LEAKY)
+    const saved = process.env.KOBE_HOME_DIR
+    process.env.KOBE_HOME_DIR = home
+    try {
+      linkPlugin(root)
+      expect(mode(pluginConfigDir("example.leaky", home))).toBe(0o700)
+      expect(mode(pluginStateDir("example.leaky", home))).toBe(0o700)
+    } finally {
+      if (saved === undefined) delete process.env.KOBE_HOME_DIR
+      else process.env.KOBE_HOME_DIR = saved
+    }
   })
 
   it("writes the captured-output log as 0600 in 0700 config/state dirs", async () => {


### PR DESCRIPTION
Seven plugin-system items from the loop-r9 explorer brief, batched. Every PASS
line below was re-run against an isolated home (`.scratch/q/`, never `~/.rove`)
with the brief's demo plugin linked; raw transcripts are in
`/Users/jacksonc/.rove/worktrees/kobe-0aff3858ab76/zorilla/.scratch/q/{before,after}.txt`.

---

## P3 — the first `task.created` after a daemon start never reached any plugin

The daemon publishes its baseline `task.snapshot` while wiring the orchestrator
(`server.ts:206`), long before the plugin host subscribes (`:262`). The host's
reducer treats its first snapshot as baseline (`plugins/events.ts:127`), so that
baseline was the first real MUTATION and got swallowed — every daemon lifetime
lost its first `task.created` / `worktree.created` / `task.changed`.

**Fix:** `startPluginHost` replays `bus.snapshot()` into the host before
`start()`; the bus's last-value cache is the baseline the reducer needed.

**PASS — the BEFORE sequence prints `1` after the FIRST add:**

```
BEFORE                          AFTER
after FIRST add:  0             after FIRST add:  1
after SECOND add: 1             after SECOND add: 2
```

**Guards:**
- `packages/kobe/test/daemon/plugin-first-task-created.test.ts` — boots a real
  daemon with a linked event plugin and a real spawned hook. Two cases: the
  first mutation fires, and a pre-existing task does NOT.
  `KOBE_INCLUDE_SOCKET=1 bun x vitest run test/daemon/plugin-first-task-created.test.ts` → 2 passed.
  Mutation-checked: removing the replay line fails both.
- `dev:sandbox smoketest` now asserts `task.created` (snapshot-derived) BEFORE
  the `issue.changed` it relied on — `issue.changed` is direct-reported and
  passed either way, which is why the smoketest missed this bug. It also
  truncates the hook's append-only output file first; without that a previous
  run's lines satisfied the poll, and the check passed with the daemon emitting
  nothing (I hit exactly that while mutation-testing).
  `bun run scripts/dev-sandbox.ts --name q-smoke smoketest` → PASS; with the
  fix mutated out → `SMOKETEST FAIL -- no task.created`.
- `test/daemon/harness.ts` gained a `seedHome` hook so a test can write state
  the daemon only reads at boot (here: the plugin registry) without a second
  boot path.

## P4 — `ROVE_BIN_PATH` was a bare name, so plugins called a different Rove

`daemon-cmd.ts:155` hard-coded `LEGACY_KOBE_PRODUCT_NAME`, so a daemon started
as `rove` told plugins to exec `kobe`; `plugin-cmd.ts` passed the active name.
Two surfaces, two answers, and on a machine with two installs neither was the
running one.

**Fix:** one resolver (`src/cli/plugin-bin-path.ts`) used by both call sites:
the absolute entry point when it is runnable on its own (npm install's
`dist/cli/rove.js` — shebang + 755; or a compiled binary's `execPath`),
otherwise the invoked CLI name. Documented in the PLUGIN-AUTHORING env table.

**PASS — the daemon's own version and an absolute `WHICH=`** (dev daemon under
test is 0.9.108; the install on `PATH` is 0.9.105):

```
BEFORE (daemon path):  BIN=kobe VER=kobe 0.9.105 WHICH=/…/nvm/…/bin/kobe
BEFORE (CLI path):     BIN=rove VER=rove 0.9.105 WHICH=/…/nvm/…/bin/rove

AFTER, packaged daemon (argv[1] = dist/cli/rove.js, the npm shape):
  daemon path:  BIN=/…/packages/kobe/dist/cli/rove-run.js VER=rove 0.9.108 WHICH=/…/rove-run.js
  CLI path:     BIN=/…/packages/kobe/dist/cli/rove-run.js VER=rove 0.9.108 WHICH=/…/rove-run.js
```

**Could not prove, by construction:** a daemon run straight from a dev checkout
(`bun src/cli/rove.ts`) has no single exec token — the entry has no exec bit and
needs `bun` in front — so it still falls back to the name and its hooks reach
whatever is installed. AFTER on that path is `BIN=rove` (was `kobe`), i.e. the
two surfaces now agree, but the version is still the installed one. That
limitation is what the docs line now says out loud.

**Guard:** `test/cli/plugin-bin-path.test.ts`, three cases; mutation-checked
both ways (always-fallback fails case 1, dropping the exec-bit check fails
case 2).

**Question for the owner (from the rename.md B1 addendum, deliberately NOT
changed here):** `invocation.ts:52-56 kobeHookInvocation` persists `kobe hook
<verb>` into `~/.claude/settings.json` and the codex/kimi hook files. Should
persisted hook commands switch to the canonical `rove`? `json-hooks.ts:46`
matches on the `hook <verb>` substring, so existing entries would still be
recognised and replaced — but it rewrites files outside Rove's own state, so
it is your call, not mine.

## P1 — SDK `notify(title, body)` was broken: the verb had no `--body`

Every hook following the documented example exited 1, the shipped
`turn-notify` example included.

**PASS:**

```
BEFORE  $ rove api notify --title x --body y
        {"error":{"message":"unknown flag --body for \"notify\"","code":"BAD_FLAG"}}   exit 2
        plugin log (demo hook): "exitCode":1, stderr "notify failed: 2 … BAD_FLAG"

AFTER   $ rove api notify --title x --body y
        {"ok":true,"clients":1}                                                        exit 0
        plugin log (demo hook): "exitCode":0
        rove api schema --verb notify → ['title', 'body', 'kind', 'task-id', 'source']
```

**Harness screenshots** (browser `/harness` → xterm.js → PTY sidecar → real
OpenTUI, fixture on `KOBE_VISUAL_PORT_BASE=5873`; BEFORE captured with the four
changed files reverted to `HEAD` and the fixture daemon rebuilt from that code):

| shot | path |
|---|---|
| BEFORE — `--body` rejected, nothing toasts | `/Users/jacksonc/.rove/worktrees/kobe-0aff3858ab76/zorilla/.scratch/q/shots/before-body-rejected.png` |
| BEFORE — the most a plugin could get: title only | `/Users/jacksonc/.rove/worktrees/kobe-0aff3858ab76/zorilla/.scratch/q/shots/before-title-only.png` |
| AFTER — title + muted body line, accent bar spanning both rows | `/Users/jacksonc/.rove/worktrees/kobe-0aff3858ab76/zorilla/.scratch/q/shots/after-body.png` |

## P2 — published SDK 0.1.6 is behind the repo contract

`usage.context` reached `packages/kobe-plugin-sdk/src/contract.ts` in #823 with
no changeset, so npm's SDK cannot name the channel — and the daemon drops
unknown channel names from a filter instead of rejecting them, so the subscribe
succeeds and the channel simply never arrives.

**PASS:** `bun x changeset status` → `@sma1lboy/rove-plugin-sdk` in "Packages to
be bumped at patch". `docs/PLUGIN-SDK.md` gains `usage.context` and one
paragraph on the silent-drop behaviour. (`npm view … version > 0.1.6` is only
checkable after release.)

## P5 — link/install created config/state 0755; docs promise 0700

`mkdirSync` never chmods an existing directory, so the CLI's mode won forever —
the daemon's own 0700 could never take effect on a plugin the CLI registered.

**PASS:** `700 …/config` / `700 …/state` after a relink (was `755`/`755`).
**Guard:** a case in `test/plugins/plugin-file-modes.test.ts` driving the CLI's
own `linkPlugin`; the existing cases only ever exercised the daemon, which is
how this stayed green. Mutation-checked.

## P6 — `platforms` was ignored by the CLI

**PASS:**

```
BEFORE  $ rove plugin action invoke q.win.go     → RAN-ON-Darwin        exit 0
AFTER   $ rove plugin action invoke q.win.go
        rove plugin: `q.win.go` is not supported on this platform (declares windows)   exit 1
        $ rove plugin link …/win
        warning: declares platforms [windows]; nothing will run on this machine        exit 0
```

`link` warns rather than refuses — developing a Windows plugin on a Mac is
legitimate; registering it with no hint that nothing will run it is not.

## P7 — `[[settings]] default = true / 5` rejected as "must be a non-empty string"

**PASS:** both manifests link (exit 0) where both used to fail. `true` → `"1"`
(the spelling a boolean setting is read back as, so Settings → Plugins shows the
toggle ON via `isBooleanOn`), `false` → no default, `5` → `"5"`.
**Guard:** a case in `test/plugins/manifest.test.ts` asserting all four
coercions plus "anything else still has to be a real string"; mutation-checked.

---

## Gates

- repo-root `bun run lint` — clean
- repo-root `bun run typecheck` — clean
- `bun run test:fast` — 439 files / 4374 tests passed
- `KOBE_INCLUDE_SOCKET=1 bun run test:socket` — 95 files / 791 tests passed
- `bun test test/render` — 463 passed
- `packages/kobe-plugin-sdk` — 13 passed
- render coverage gate: `use-daemon-notices.ts` at 67.1% (floor 50)

## Notes

- `packages/kobe-daemon/src/plugins/manifest.ts` is 493 lines — inside the cap
  but in the warning band (it was 479 before this PR). The seam, when someone
  needs it, is the scalar coercers (`asString` / `asCommand` / `asPlatforms` /
  `asTableArray` / `asSettingDefault`) versus the section parsers; I left it
  alone rather than bury five bug fixes under a file split.
- No workflow files touched.
