### PR TITLE
perf: stop the daemon polling git for worktrees nothing changed in

### DIFF
--- a/.changeset/idle-daemon-git-polling.md
+++ b/.changeset/idle-daemon-git-polling.md
@@ -1,0 +1,9 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Stop the daemon burning a quarter of a core on git polls for worktrees nothing changed in. With 19 idle tasks attached, a 62-second window spawned 1280 `git` processes and 14.7s of CPU to publish 19 frames; the same window now spawns 133 and 1.0s.
+
+Three fixes: the background collectors are gated on the channels a client actually subscribed to, so a pane that asked only for `ui-prefs`/`keybindings` no longer starts every poller (194 spawns in 8 seconds became 0); the worktree-changes poll first stats the git files a change would touch and relaxes to a 15-second floor while they and the worktree root hold still; and the behind-base count is memoised on the HEAD/base SHAs read straight off the ref files, which also removes the `rev-parse` ladder the base-ref resolution used to spawn.
+
+Responsiveness is unchanged where it is watched: a worktree whose engine is working keeps the 2-second cadence, and staging, commits, fetches, ref moves and new files in the worktree root are still picked up within one tick.

--- a/packages/kobe-daemon/package.json
+++ b/packages/kobe-daemon/package.json
@@ -78,6 +78,7 @@
     "./daemon/web-token": "./src/daemon/web-token.ts",
     "./daemon/web-session": "./src/daemon/web-session.ts",
     "./daemon/worktree-changes-collector": "./src/daemon/worktree-changes-collector.ts",
+    "./daemon/worktree-probe": "./src/daemon/worktree-probe.ts",
     "./plugins/env": "./src/plugins/env.ts",
     "./plugins/events": "./src/plugins/events.ts",
     "./plugins/manifest": "./src/plugins/manifest.ts",

--- a/packages/kobe-daemon/src/daemon/collectors.ts
+++ b/packages/kobe-daemon/src/daemon/collectors.ts
@@ -12,6 +12,7 @@ import type { DaemonActivityRegistry } from "./activity-registry.ts"
 import { DEFAULT_AUTO_TITLE_POLL_MS, startAutoTitlePoller } from "./auto-title-poller.ts"
 import { DEFAULT_AUTOMATION_TICK_MS, startAutomationRunner } from "./automation-runner.ts"
 import type { AutomationsStore } from "./automations-store.ts"
+import type { ChannelName } from "./channels.ts"
 import { DEFAULT_CONTEXT_USAGE_TICK_MS, startContextUsageCollector } from "./context-usage-collector.ts"
 import type { DaemonOrchestrator, UpdateInfo } from "./contracts.ts"
 import { logDaemonError, logDaemonInfo } from "./crash-log.ts"
@@ -108,8 +109,12 @@ export function createProtocolUpgradeReporter(
 /**
  * Start every daemon-owned background collector. Returns a single `stop()`
  * that tears them down in the same order server.ts's `close()` historically
- * used. `hasSubscribers` gates the per-tick work of the pollers that would
- * otherwise burn CPU / network for nobody on a gui-less daemon.
+ * used. `hasSubscribersFor` gates the per-tick work of the pollers that would
+ * otherwise burn CPU / network for nobody: each collector is wired to the
+ * channel it PUBLISHES, so a client that filtered its subscribe down to
+ * `["ui-prefs", "keybindings"]` never starts the git/gh pollers whose frames
+ * it would drop at the socket anyway. An unfiltered subscriber (every real
+ * gui) opens all of them, as before.
  *
  * What each one is for:
  *   - update poll (KOB): poll npm once on start + on an interval and publish
@@ -145,7 +150,7 @@ export function startDaemonCollectors(
   orch: DaemonOrchestrator,
   runtime: DaemonRuntimeAdapter,
   bus: DaemonEventBus,
-  hasSubscribers: () => boolean,
+  hasSubscribersFor: (channel: ChannelName) => boolean,
   options: DaemonCollectorOptions,
   quotaUsage?: QuotaUsageCache,
   automations?: AutomationCollectorDeps,
@@ -169,7 +174,7 @@ export function startDaemonCollectors(
           ...createActivityObserverIo(options.homeDir, runtime),
           onEngineEvidence: createProtocolUpgradeReporter(orch, runtime),
         },
-        hasSubscribers,
+        () => hasSubscribersFor("engine-state"),
       )
     : () => {}
   const checkUpdate = options.checkUpdate ?? runtime.checkLatestVersion
@@ -190,7 +195,8 @@ export function startDaemonCollectors(
     orch,
     runtime,
     options.autoTitlePollMs ?? DEFAULT_AUTO_TITLE_POLL_MS,
-    hasSubscribers,
+    // A rename rides the task push, so the consumer to gate on is task.snapshot.
+    () => hasSubscribersFor("task.snapshot"),
   )
 
   const stopUiPrefsWatcher = startUiPrefsWatcher(bus, {
@@ -208,7 +214,7 @@ export function startDaemonCollectors(
     runtime,
     bus,
     options.worktreeChangesTickMs ?? DEFAULT_WORKTREE_CHANGES_TICK_MS,
-    hasSubscribers,
+    () => hasSubscribersFor("worktree.changes"),
   )
 
   const stopTranscriptActivityCollector = startTranscriptActivityCollector(
@@ -216,7 +222,7 @@ export function startDaemonCollectors(
     runtime,
     bus,
     options.transcriptActivityTickMs ?? DEFAULT_TRANSCRIPT_ACTIVITY_TICK_MS,
-    hasSubscribers,
+    () => hasSubscribersFor("transcript.activity"),
   )
 
   // Context-window occupancy per live engine session (the footer's `ctx N%`).
@@ -230,7 +236,7 @@ export function startDaemonCollectors(
         bus,
         runtime,
         options.contextUsageTickMs ?? DEFAULT_CONTEXT_USAGE_TICK_MS,
-        hasSubscribers,
+        () => hasSubscribersFor("usage.context"),
       )
     : () => {}
 
@@ -242,7 +248,8 @@ export function startDaemonCollectors(
     orch,
     runtime,
     options.prStatusPollMs ?? DEFAULT_PR_STATUS_POLL_MS,
-    hasSubscribers,
+    // prStatus rides the task push too.
+    () => hasSubscribersFor("task.snapshot"),
     undefined,
     activity ? () => activity.currentNonIdle().some((e) => e.state !== "idle") : undefined,
   )
@@ -289,7 +296,12 @@ export function startDaemonCollectors(
   // with no open task still has a number worth showing. Cadence (slow poll,
   // backoff, per-vendor floor) lives entirely in the cache.
   const stopQuotaUsagePoller = quotaUsage
-    ? startQuotaUsagePoller(quotaUsage, () => runtime.vendorsWithQuotaProbe(), hasSubscribers, options.quotaUsageTickMs)
+    ? startQuotaUsagePoller(
+        quotaUsage,
+        () => runtime.vendorsWithQuotaProbe(),
+        () => hasSubscribersFor("usage.snapshot"),
+        options.quotaUsageTickMs,
+      )
     : () => {}
 
   // Same teardown order server.ts's close() used before the extraction.

--- a/packages/kobe-daemon/src/daemon/collectors.ts
+++ b/packages/kobe-daemon/src/daemon/collectors.ts
@@ -215,6 +215,10 @@ export function startDaemonCollectors(
     bus,
     options.worktreeChangesTickMs ?? DEFAULT_WORKTREE_CHANGES_TICK_MS,
     () => hasSubscribersFor("worktree.changes"),
+    // Worktrees with a working engine keep the fast cadence — the change
+    // probe behind the collector's quiet backoff is blind to nested writes,
+    // which is exactly what a working engine produces.
+    activity ? () => activity.currentNonIdle().map((e) => e.taskId) : undefined,
   )
 
   const stopTranscriptActivityCollector = startTranscriptActivityCollector(

--- a/packages/kobe-daemon/src/daemon/lifetime.ts
+++ b/packages/kobe-daemon/src/daemon/lifetime.ts
@@ -29,6 +29,7 @@
  */
 
 import { readRoveEnv } from "../compat-env.ts"
+import type { ChannelName } from "./channels.ts"
 import { logDaemonInfo } from "./crash-log.ts"
 
 /** The slice of a client the lifetime policy reads. The server's full
@@ -36,6 +37,13 @@ import { logDaemonInfo } from "./crash-log.ts"
 export interface LifetimeClient {
   readonly subscribed: boolean
   readonly holdsLifetime: boolean
+  /**
+   * The client's per-channel subscribe filter, as `ClientState` carries it:
+   * `null` (or absent, for the web clients that have no filter) = "every
+   * channel". Read by {@link DaemonLifetime.hasSubscribersFor} so a narrow
+   * consumer only starts the collectors that feed the channels it asked for.
+   */
+  readonly channels?: ReadonlySet<ChannelName> | null
 }
 
 /**
@@ -144,9 +152,36 @@ export class DaemonLifetime {
     return n
   }
 
-  /** Any subscribed consumer (gui OR pane) — the background-collector gate. */
+  /** Any subscribed consumer (gui OR pane), whatever they asked for. Used
+   *  for the "collectors resume" log line and the subscribe-time quota wake,
+   *  neither of which is per-channel. Collectors use
+   *  {@link hasSubscribersFor} instead. */
   hasSubscribers(): boolean {
     for (const c of this.clients()) if (c.subscribed) return true
+    return false
+  }
+
+  /**
+   * The background-collector gate, per channel: is anyone subscribed who
+   * would actually RECEIVE what this collector publishes?
+   *
+   * `hasSubscribers()` alone is the wrong granularity. `client.channels` is
+   * the filter the publish path already honours (client-connection.ts's
+   * `broadcast`), so a pane subscribing to `["ui-prefs", "keybindings"]` —
+   * what the TUI's UiPrefsSync does — used to start every collector and get
+   * every frame dropped at the socket: 194 `git` spawns in 8 seconds to
+   * deliver two frames it did not ask for. A `null`/absent filter still
+   * means "all channels", so a real gui opens everything exactly as before.
+   *
+   * One walk of the client set per call, same cost as `hasSubscribers()`;
+   * each collector calls it once per tick, so there is no per-tick
+   * clients × channels scan.
+   */
+  hasSubscribersFor(channel: ChannelName): boolean {
+    for (const c of this.clients()) {
+      if (!c.subscribed) continue
+      if (!c.channels || c.channels.has(channel)) return true
+    }
     return false
   }
 

--- a/packages/kobe-daemon/src/daemon/server.ts
+++ b/packages/kobe-daemon/src/daemon/server.ts
@@ -237,7 +237,7 @@ export async function startDaemonServer(orch: DaemonOrchestrator, options: Daemo
     orch,
     runtime,
     bus,
-    () => lifetime.hasSubscribers(),
+    (channel) => lifetime.hasSubscribersFor(channel),
     options,
     quotaUsage,
     {

--- a/packages/kobe-daemon/src/daemon/worktree-changes-collector.ts
+++ b/packages/kobe-daemon/src/daemon/worktree-changes-collector.ts
@@ -25,6 +25,19 @@
  *     `max(minIntervalMs, 5 × last duration)`, so slow-but-finishing
  *     repos self-thin without a special case.
  *
+ * Those all defend against a SLOW repo. One more, on a different axis,
+ * defends against an UNCHANGED one — 19 idle tasks cost 1280 `git` processes
+ * and 14.7s of CPU per 62 seconds to publish 19 frames, because every tick
+ * re-derived an answer that had not moved:
+ *
+ *   - **quiet backoff** — before spawning anything, `worktreeFingerprint`
+ *     stats the git files an observable change would touch. While it is
+ *     unmoved AND the worktree has no working engine, the poll relaxes to
+ *     {@link WORKTREE_CHANGES_QUIET_INTERVAL_MS}. The fingerprint cannot see
+ *     a NESTED edit (see worktree-probe.ts — measured, not assumed), so it
+ *     is an accelerator, never an authority: the relaxed poll still runs, and
+ *     anything unreadable falls straight through to the real poll.
+ *
  * Collection scope: every task with a LOCAL worktree. Remote (`ssh://`)
  * projects are skipped — their worktrees aren't on this filesystem.
  * Deleted tasks' entries DROP from the published map on the next
@@ -49,6 +62,10 @@ import { type PollCadenceConfig, type PollScheduleState, maybeStartScheduledRun 
 import type { WorktreeChangesPayload } from "./protocol.ts"
 import type { DaemonRuntimeAdapter } from "./runtime.ts"
 import { startTicker } from "./ticker.ts"
+import { worktreeFingerprint } from "./worktree-probe.ts"
+
+/** Shared empty set — avoids allocating one per tick per collector. */
+const EMPTY_PATHS: ReadonlySet<string> = new Set<string>()
 
 function isRemoteRepoKey(value: string): boolean {
   return value.startsWith("ssh://")
@@ -66,6 +83,14 @@ export const WORKTREE_CHANGES_TIMEOUT_MS = 4_000
 export const WORKTREE_CHANGES_SLOW_RETRY_MS = 60_000
 /** Floor between successful polls per worktree. */
 export const WORKTREE_CHANGES_MIN_INTERVAL_MS = 1_500
+/**
+ * Poll floor for a worktree whose change probe is quiet and whose engine is
+ * idle — the safety net under {@link worktreeFingerprint}, which cannot see
+ * a nested edit. This is the WORST-CASE staleness for such a worktree; a
+ * fingerprint that moves, or an engine that starts working, drops it back to
+ * {@link WORKTREE_CHANGES_MIN_INTERVAL_MS} on the next tick.
+ */
+export const WORKTREE_CHANGES_QUIET_INTERVAL_MS = 15_000
 
 /** The task-list slice the collector needs — `Orchestrator` satisfies it. */
 export interface TaskLister {
@@ -181,6 +206,11 @@ export function trackedWorktreePaths(tasks: readonly Task[]): Map<string, string
 interface CollectorEntry extends PollScheduleState {
   /** Last successful counts, absent until the first run lands. */
   value?: WorktreeChanges
+  /** Change fingerprint sampled when the last run STARTED (before it, so a
+   *  write landing mid-run is not swallowed). `null` = it was unreadable. */
+  probe?: string | null
+  /** When a poll must happen even while the probe stays quiet. */
+  quietUntil?: number
 }
 
 export interface WorktreeChangesCollectorOptions {
@@ -198,6 +228,18 @@ export interface WorktreeChangesCollectorOptions {
    * tick — what tests that drive `tick()` directly use.
    */
   readonly hasSubscribers?: () => boolean
+  /**
+   * Task ids whose engine is currently working. Their worktrees keep the
+   * full {@link WORKTREE_CHANGES_MIN_INTERVAL_MS} cadence regardless of the
+   * change probe: an engine writing `src/**` is precisely the nested case
+   * the probe is blind to, and the sidebar chip for a task being worked on
+   * is the one people watch. Omit to treat every worktree as idle.
+   */
+  readonly activeTaskIds?: () => Iterable<string>
+  /** Poll floor for a quiet, engine-idle worktree. Tests shrink it. */
+  readonly quietIntervalMs?: number
+  /** Change probe (tests inject); defaults to {@link worktreeFingerprint}. */
+  readonly probe?: (worktreePath: string, baseRef?: string) => string | null
 }
 
 /**
@@ -228,7 +270,8 @@ export class WorktreeChangesCollector {
     // replays it to the late subscriber.
     if (this.options.hasSubscribers && !this.options.hasSubscribers()) return
     try {
-      const tracked = trackedWorktreePaths(this.orch.listTasks())
+      const tasks = this.orch.listTasks()
+      const tracked = trackedWorktreePaths(tasks)
       // Prune first: a task deleted since the last tick drops its
       // entry — and, when it had published counts, triggers a republish so
       // subscribers stop showing it.
@@ -242,7 +285,8 @@ export class WorktreeChangesCollector {
         this.entries.delete(path)
       }
       if (pruned) this.publish()
-      for (const [path, baseRef] of tracked) this.maybeCollect(path, baseRef)
+      const busy = this.busyPaths(tasks)
+      for (const [path, baseRef] of tracked) this.maybeCollect(path, baseRef, busy.has(path))
     } catch (err) {
       logDaemonError("worktree-changes", err)
     }
@@ -253,12 +297,34 @@ export class WorktreeChangesCollector {
     this.stopped = true
   }
 
-  private maybeCollect(worktreePath: string, baseRef?: string): void {
+  /** Worktrees whose task has a working engine — exempt from quiet backoff. */
+  private busyPaths(tasks: readonly Task[]): ReadonlySet<string> {
+    const ids = this.options.activeTaskIds?.()
+    if (!ids) return EMPTY_PATHS
+    const active = new Set(ids)
+    if (active.size === 0) return EMPTY_PATHS
+    const paths = new Set<string>()
+    for (const task of tasks) if (task.worktreePath && active.has(task.id)) paths.add(task.worktreePath)
+    return paths
+  }
+
+  private maybeCollect(worktreePath: string, baseRef?: string, busy = false): void {
     let entry = this.entries.get(worktreePath)
     if (!entry) {
       entry = { inFlight: false, nextAllowedAt: 0 }
       this.entries.set(worktreePath, entry)
     }
+    // Quiet backoff: skip the spawns only when the probe read cleanly, read
+    // the SAME thing as at the last run's start, no engine is writing in
+    // there, and the safety poll is not yet due. Every other case — a first
+    // tick (`probe` absent), an unreadable probe (`null`, which never equals
+    // itself here because the strict compare is against a string), a moved
+    // fingerprint — falls through and polls.
+    const now = Date.now()
+    const probe = (this.options.probe ?? worktreeFingerprint)(worktreePath, baseRef)
+    const quietUntil = entry.quietUntil ?? 0
+    if (!busy && probe !== null && probe === entry.probe && now < quietUntil) return
+    const quietIntervalMs = this.options.quietIntervalMs ?? WORKTREE_CHANGES_QUIET_INTERVAL_MS
     const cadence = this.options.cadence ?? {
       timeoutMs: WORKTREE_CHANGES_TIMEOUT_MS,
       slowRetryMs: WORKTREE_CHANGES_SLOW_RETRY_MS,
@@ -268,7 +334,14 @@ export class WorktreeChangesCollector {
     maybeStartScheduledRun(
       entry,
       cadence,
-      (signal) => run(worktreePath, signal, baseRef),
+      (signal) => {
+        // Recorded here, not above: `maybeStartScheduledRun` may decline
+        // (in flight, or inside the cadence window), and a fingerprint
+        // recorded for a run that never happened would suppress the next one.
+        entry.probe = probe
+        entry.quietUntil = Date.now() + quietIntervalMs
+        return run(worktreePath, signal, baseRef)
+      },
       (value) => {
         if (this.stopped) return
         // The entry may have been pruned (task deleted) while the
@@ -311,8 +384,14 @@ export function startWorktreeChangesCollector(
   bus: DaemonEventBus,
   tickMs: number = DEFAULT_WORKTREE_CHANGES_TICK_MS,
   hasSubscribers?: () => boolean,
+  /** Task ids with a working engine — see `activeTaskIds` on the options. */
+  activeTaskIds?: () => Iterable<string>,
 ): () => void {
-  const collector = new WorktreeChangesCollector(orch, bus, { hasSubscribers, run: runtime.runWorktreeStatus })
+  const collector = new WorktreeChangesCollector(orch, bus, {
+    hasSubscribers,
+    run: runtime.runWorktreeStatus,
+    ...(activeTaskIds ? { activeTaskIds } : {}),
+  })
   // No `gate` here: the subscriber check lives inside `collector.tick()`,
   // which also owns its own per-key in-flight state.
   return startTicker({

--- a/packages/kobe-daemon/src/daemon/worktree-probe.ts
+++ b/packages/kobe-daemon/src/daemon/worktree-probe.ts
@@ -1,0 +1,171 @@
+/**
+ * Cheap "did anything git-visible move?" probe for the worktree-changes
+ * collector, plus the ref-sha reads its behind-count cache is keyed on.
+ *
+ * The collector's cost is process spawns: `git status` + `rev-list` per
+ * worktree per 2s tick, measured at 1280 `git` processes and 14.7s of CPU
+ * in 62 seconds across 19 idle tasks, to publish 19 frames. Everything here
+ * is `stat`/small-file reads instead — no subprocess, no lock, no walk.
+ *
+ * ## What the fingerprint can and cannot see — read before trusting it
+ *
+ * It sees GIT-METADATA movement — staging (`index`), checkout/commit (`HEAD`
+ * and the branch's ref file), fetch or ref update (`FETCH_HEAD`,
+ * `packed-refs`, the base ref files) — and entries CREATED, DELETED or
+ * RENAMED directly in the worktree root.
+ *
+ * It does NOT see a content edit of an existing file, at any depth, nor a
+ * new file in a subdirectory. Measured, not assumed: appending to
+ * `src/deep/f.ts` moved neither `.git/index` nor the worktree root's mtime,
+ * and creating `src/deep/untracked.ts` moved only `src/deep`'s own mtime,
+ * which nothing here stats — `git status` reports both. (Our polls run
+ * `GIT_OPTIONAL_LOCKS=0`, so they never refresh-write the index either.)
+ * A directory's mtime tracks its entry list, not its contents, and seeing
+ * through that costs the recursive walk this exists to avoid.
+ *
+ * So this is an ACCELERATOR, not an authority: a moved fingerprint means
+ * "poll now", an unmoved one only means "the fast poll may relax". The
+ * collector keeps a safety poll behind it, and everything ambiguous — a
+ * missing file, an unreadable HEAD, a worktree that is not a git checkout —
+ * returns `null`, which the collector reads as "poll".
+ */
+
+import { readFileSync, statSync } from "node:fs"
+import { isAbsolute, join, resolve } from "node:path"
+
+/**
+ * The base branches the daemon falls back to when a task recorded none —
+ * kobe's `base-ref-cache.ts` ladder, in its order. Kept here because the
+ * fingerprint has to stat these ref files too: the collector is handed the
+ * task's RECORDED base ref, which is usually absent, and the real base is
+ * resolved later inside the runner. Without them a `git fetch` that only
+ * advanced `origin/main` was invisible to the probe (`FETCH_HEAD` catches a
+ * fetch, but not a local `update-ref` or a ref moved by another worktree).
+ */
+export const DEFAULT_BASE_REF_CANDIDATES = ["origin/main", "origin/master", "main", "master"] as const
+
+/** Where a worktree's own git dir and its repo-wide common dir live. */
+export interface GitDirs {
+  /** Per-worktree git dir: `<repo>/.git`, or `<repo>/.git/worktrees/<name>`. */
+  readonly gitDir: string
+  /** Repo-wide dir holding shared refs + `packed-refs`. Equals `gitDir` for
+   *  a primary checkout; a linked worktree points back at the main one. */
+  readonly commonDir: string
+}
+
+function mtime(path: string): number | null {
+  const st = statSync(path, { throwIfNoEntry: false })
+  return st ? st.mtimeMs : null
+}
+
+function readText(path: string): string | null {
+  try {
+    return readFileSync(path, "utf8")
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Resolve a worktree's `gitDir`/`commonDir`, without `git rev-parse`.
+ * `.git` is a directory in a primary checkout and a `gitdir: <path>` FILE in
+ * a linked worktree; the linked one names its repo-wide dir in `commondir`
+ * (usually the relative `../..`). `null` when `.git` is missing or
+ * unreadable — the caller then treats the worktree as unprobeable.
+ */
+export function resolveGitDirs(worktreePath: string): GitDirs | null {
+  const dotGit = join(worktreePath, ".git")
+  const st = statSync(dotGit, { throwIfNoEntry: false })
+  if (!st) return null
+  let gitDir = dotGit
+  if (!st.isDirectory()) {
+    const pointer = readText(dotGit)?.match(/^gitdir:\s*(.+)$/m)?.[1]?.trim()
+    if (!pointer) return null
+    gitDir = isAbsolute(pointer) ? pointer : resolve(worktreePath, pointer)
+  }
+  const common = readText(join(gitDir, "commondir"))?.trim()
+  const commonDir = common ? (isAbsolute(common) ? common : resolve(gitDir, common)) : gitDir
+  return { gitDir, commonDir }
+}
+
+/** Candidate files a ref could live in, loose, per-worktree first. */
+function looseRefPaths(dirs: GitDirs, ref: string): string[] {
+  const rel = ref.startsWith("refs/") ? ref : `refs/remotes/${ref}`
+  const alt = ref.startsWith("refs/") ? null : `refs/heads/${ref}`
+  const names = alt ? [rel, alt] : [rel]
+  const out: string[] = []
+  for (const name of names) {
+    out.push(join(dirs.gitDir, name))
+    if (dirs.commonDir !== dirs.gitDir) out.push(join(dirs.commonDir, name))
+  }
+  return out
+}
+
+/**
+ * The sha a ref currently points at, read from the loose ref file or
+ * `packed-refs`. `null` when it resolves to neither — the caller then falls
+ * back to `git`, which knows about ref namespaces, symrefs and
+ * alternates that this deliberately does not.
+ */
+export function readRefSha(dirs: GitDirs, ref: string): string | null {
+  for (const path of looseRefPaths(dirs, ref)) {
+    const raw = readText(path)?.trim()
+    if (raw && /^[0-9a-f]{40,64}$/.test(raw)) return raw
+  }
+  const packed = readText(join(dirs.commonDir, "packed-refs"))
+  if (!packed) return null
+  const wanted = new Set(looseRefPaths(dirs, ref).map((p) => p.replace(/^.*?(refs\/)/, "$1")))
+  for (const line of packed.split("\n")) {
+    if (!line || line.startsWith("#") || line.startsWith("^")) continue
+    const [sha, name] = line.split(" ", 2)
+    if (sha && name && wanted.has(name.trim())) return sha
+  }
+  return null
+}
+
+/** The sha `HEAD` points at, following one symref level. `null` if unreadable. */
+export function readHeadSha(dirs: GitDirs): string | null {
+  const head = readText(join(dirs.gitDir, "HEAD"))?.trim()
+  if (!head) return null
+  if (/^[0-9a-f]{40,64}$/.test(head)) return head
+  const ref = head.match(/^ref:\s*(.+)$/)?.[1]?.trim()
+  return ref ? readRefSha(dirs, ref) : null
+}
+
+/**
+ * A string that changes when anything the probe CAN see moved. `null` means
+ * "cannot tell" — a missing `.git`, an unreadable `HEAD`, any throw — and
+ * the caller must poll.
+ *
+ * Base refs are included because they are what moves the behind-count: a
+ * fetch that advances `origin/main` changes `packed-refs`, `FETCH_HEAD`, or
+ * that ref's own file. The {@link DEFAULT_BASE_REF_CANDIDATES} are stat'd
+ * alongside any supplied `baseRef` — a task usually records none, and the
+ * real base is only resolved later, inside the status runner.
+ */
+export function worktreeFingerprint(worktreePath: string, baseRef?: string): string | null {
+  try {
+    const dirs = resolveGitDirs(worktreePath)
+    if (!dirs) return null
+    const head = readText(join(dirs.gitDir, "HEAD"))?.trim()
+    if (!head) return null
+    const parts: (number | string | null)[] = [
+      head,
+      mtime(worktreePath),
+      mtime(join(dirs.gitDir, "index")),
+      mtime(join(dirs.gitDir, "HEAD")),
+      mtime(join(dirs.gitDir, "FETCH_HEAD")),
+      mtime(join(dirs.commonDir, "FETCH_HEAD")),
+      mtime(join(dirs.commonDir, "packed-refs")),
+    ]
+    const headRef = head.match(/^ref:\s*(.+)$/)?.[1]?.trim()
+    if (headRef) for (const path of looseRefPaths(dirs, headRef)) parts.push(mtime(path))
+    parts.push(mtime(join(dirs.commonDir, "refs/remotes/origin/HEAD")))
+    for (const ref of baseRef ? [baseRef, ...DEFAULT_BASE_REF_CANDIDATES] : DEFAULT_BASE_REF_CANDIDATES) {
+      for (const path of looseRefPaths(dirs, ref)) parts.push(mtime(path))
+    }
+    return parts.join("|")
+  } catch {
+    return null
+  }
+}

--- a/packages/kobe/src/core/base-ref-cache.ts
+++ b/packages/kobe/src/core/base-ref-cache.ts
@@ -14,8 +14,19 @@
  * reporting drift without a daemon restart. A negative answer (no base
  * resolves at all) is cached too, for the same TTL — otherwise a repo with no
  * remote pays the full five-probe ladder every tick forever.
+ *
+ * Even once per TTL, the ladder is not free: 19 worktrees paid 75 `git`
+ * processes (one `symbolic-ref` + three `rev-parse` each) every five
+ * minutes. The candidates it probes are all plain branch names, so it reads
+ * the ref FILES instead — loose refs, then `packed-refs` — and only falls
+ * back to spawning when the worktree's git dirs are unreadable. A RECORDED
+ * base ref keeps its `rev-parse` fallback: the user may have passed a tag or
+ * a sha, which a ref-file read cannot disprove.
  */
 
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+import { DEFAULT_BASE_REF_CANDIDATES, readRefSha, resolveGitDirs } from "@sma1lboy/kobe-daemon/daemon/worktree-probe"
 import { readOnlyGitProcessEnv } from "../lib/git-env.ts"
 import { spawnCapture } from "../lib/poll-scheduling.ts"
 
@@ -38,14 +49,49 @@ async function refExists(worktreePath: string, ref: string, signal: AbortSignal)
   return out.status === 0
 }
 
+/**
+ * The ladder read from ref files. Returns `undefined` — distinct from the
+ * `null` that means "no base exists" — when the worktree's git dirs cannot
+ * be resolved, which is the caller's signal to spawn `git` instead.
+ *
+ * `refs/remotes/origin/HEAD` is a symref file (`ref: refs/remotes/origin/x`)
+ * or a `packed-refs` entry; both are read here rather than through
+ * `git symbolic-ref`.
+ */
+function resolveLadderFromFiles(worktreePath: string): string | null | undefined {
+  const dirs = resolveGitDirs(worktreePath)
+  if (!dirs) return undefined
+  const originHead = readRefSymbolic(dirs, "refs/remotes/origin/HEAD")
+  if (originHead) return originHead.replace(/^refs\/remotes\//, "")
+  for (const guess of DEFAULT_BASE_REF_CANDIDATES) if (readRefSha(dirs, guess) !== null) return guess
+  return null
+}
+
+/** The ref a symref FILE points at (`ref: refs/…`), or null. */
+function readRefSymbolic(dirs: ReturnType<typeof resolveGitDirs>, ref: string): string | null {
+  if (!dirs) return null
+  for (const dir of [dirs.gitDir, dirs.commonDir]) {
+    try {
+      const raw = readFileSync(join(dir, ref), "utf8").trim()
+      const target = raw.match(/^ref:\s*(.+)$/)?.[1]?.trim()
+      if (target) return target
+    } catch {
+      // Not present here — try the common dir, then give up.
+    }
+  }
+  return null
+}
+
 async function resolveLadder(worktreePath: string, signal: AbortSignal): Promise<string | null> {
+  const fromFiles = resolveLadderFromFiles(worktreePath)
+  if (fromFiles !== undefined) return fromFiles
   const head = await spawnCapture("git", ["symbolic-ref", "--short", "refs/remotes/origin/HEAD"], {
     cwd: worktreePath,
     env: readOnlyGitProcessEnv(),
     signal,
   })
   if (head.status === 0 && head.stdout.trim()) return head.stdout.trim()
-  for (const guess of ["origin/main", "origin/master", "main", "master"]) {
+  for (const guess of DEFAULT_BASE_REF_CANDIDATES) {
     if (await refExists(worktreePath, guess, signal)) return guess
   }
   return null
@@ -66,7 +112,13 @@ export async function resolveBaseRefCached(
   signal: AbortSignal,
   now: number = Date.now(),
 ): Promise<string | null> {
-  if (recordedBaseRef && (await refExists(worktreePath, recordedBaseRef, signal))) return recordedBaseRef
+  // A recorded ref found in the ref files needs no spawn; NOT finding it
+  // proves nothing (it could be a tag or a sha), so that falls back.
+  if (recordedBaseRef) {
+    const dirs = resolveGitDirs(worktreePath)
+    if (dirs && readRefSha(dirs, recordedBaseRef) !== null) return recordedBaseRef
+    if (await refExists(worktreePath, recordedBaseRef, signal)) return recordedBaseRef
+  }
   const hit = cache.get(worktreePath)
   if (hit && now - hit.at < BASE_REF_TTL_MS) return hit.ref
   const ref = await resolveLadder(worktreePath, signal)

--- a/packages/kobe/src/core/behind-cache.ts
+++ b/packages/kobe/src/core/behind-cache.ts
@@ -1,0 +1,60 @@
+/**
+ * Behind-count memo for the daemon's per-worktree polls.
+ *
+ * `git rev-list --count HEAD..<base>` was half of the collector's process
+ * budget — 570 of 1280 spawns in a 62-second idle measurement, 1:1 with the
+ * `git status` walks — even though the answer can only move when HEAD moves
+ * or the base ref moves. Both are ref files, so this keys the count on the
+ * two SHAs read straight off disk (loose ref, else `packed-refs`) and skips
+ * the spawn while they are unchanged.
+ *
+ * Fails safe in both directions: a sha that will not read (detached
+ * odd states, an unreadable git dir, a ref this reader does not know how to
+ * follow) is `null`, which never equals a cached value, so the count is
+ * recomputed by `git` exactly as before — and a computed count is only
+ * memoised when BOTH shas read cleanly, so nothing is ever served from a key
+ * that was half-guessed.
+ */
+
+import { readHeadSha, readRefSha, resolveGitDirs } from "@sma1lboy/kobe-daemon/daemon/worktree-probe"
+
+interface BehindEntry {
+  readonly head: string
+  readonly base: string
+  readonly behind: number
+}
+
+const cache = new Map<string, BehindEntry>()
+
+/** Test seam — the daemon keeps one process-wide cache. */
+export function resetBehindCache(): void {
+  cache.clear()
+}
+
+/** The `(HEAD, base)` sha pair, or null when either will not read. */
+function readShas(worktreePath: string, baseRef: string): { head: string; base: string } | null {
+  const dirs = resolveGitDirs(worktreePath)
+  if (!dirs) return null
+  const head = readHeadSha(dirs)
+  const base = readRefSha(dirs, baseRef)
+  return head && base ? { head, base } : null
+}
+
+/**
+ * The behind-count for `worktreePath` vs `baseRef`, computed by `compute`
+ * only when the ref shas say it could have changed. `compute` returns `null`
+ * for an unusable answer (non-zero exit, unparseable) and that is passed
+ * straight through without being cached.
+ */
+export async function behindCountCached(
+  worktreePath: string,
+  baseRef: string,
+  compute: () => Promise<number | null>,
+): Promise<number | null> {
+  const shas = readShas(worktreePath, baseRef)
+  const hit = shas ? cache.get(worktreePath) : undefined
+  if (shas && hit && hit.head === shas.head && hit.base === shas.base) return hit.behind
+  const behind = await compute()
+  if (shas && behind !== null) cache.set(worktreePath, { ...shas, behind })
+  return behind
+}

--- a/packages/kobe/src/core/daemon-runtime.ts
+++ b/packages/kobe/src/core/daemon-runtime.ts
@@ -29,6 +29,7 @@ import { handleHistoryRequest } from "../web/history.ts"
 import { handleNotesRequest } from "../web/notes.ts"
 import { handleThemesRequest } from "../web/themes.ts"
 import { resolveBaseRefCached } from "./base-ref-cache.ts"
+import { behindCountCached } from "./behind-cache.ts"
 import {
   deliverPromptToLiveEngineAdapter,
   deliverPromptToLiveEngineDetailedAdapter,
@@ -111,14 +112,20 @@ export const daemonRuntime: DaemonRuntimeAdapter = {
     // and kobe-daemon does not import kobe sources.
     const base = await resolveBaseRefCached(worktreePath, baseRef, signal)
     if (!base) return counts
-    const behind = await spawnCapture("git", ["rev-list", "--count", `HEAD..${base}`], {
-      cwd: worktreePath,
-      env: readOnlyGitProcessEnv(),
-      signal,
+    // Memoised on the HEAD/base shas read from the ref files: the count can
+    // only move when one of them does, and re-deriving it every tick was half
+    // the collector's spawns.
+    const n = await behindCountCached(worktreePath, base, async () => {
+      const behind = await spawnCapture("git", ["rev-list", "--count", `HEAD..${base}`], {
+        cwd: worktreePath,
+        env: readOnlyGitProcessEnv(),
+        signal,
+      })
+      if (behind.status !== 0) return null
+      const parsed = Number.parseInt(behind.stdout.trim(), 10)
+      return Number.isInteger(parsed) && parsed >= 0 ? parsed : null
     })
-    if (behind.status !== 0) return counts
-    const n = Number.parseInt(behind.stdout.trim(), 10)
-    return Number.isInteger(n) && n >= 0 ? { ...counts, behind: n } : counts
+    return n === null ? counts : { ...counts, behind: n }
   },
   maybeAutoStart: (orch, taskId) => maybeAutoStart(orch as Orchestrator, taskId),
   listWorktreeProjects: listWorktreeProjectsAdapter,

--- a/packages/kobe/test/daemon/behind-cache.test.ts
+++ b/packages/kobe/test/daemon/behind-cache.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Behind-count memo — `git rev-list --count HEAD..<base>` was half the
+ * collector's process budget (570 of 1280 spawns in a 62-second idle
+ * measurement) for an answer that can only move when HEAD or the base ref
+ * moves. Both are ref files, so the memo is keyed on the two SHAs read off
+ * disk.
+ *
+ * What has to hold: it must serve a hit ONLY while both shas are unchanged,
+ * and it must never serve one it could not key properly — an unreadable sha
+ * or a failed `rev-list` has to fall through to the real command every time,
+ * because a stale drift count is worse than a slow one.
+ */
+
+import { execFileSync } from "node:child_process"
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, beforeEach, describe, expect, test } from "vitest"
+import { behindCountCached, resetBehindCache } from "../../src/core/behind-cache.ts"
+
+const AUTHOR = ["-c", "user.email=t@t", "-c", "user.name=t"]
+let repo: string
+
+function git(...args: string[]): string {
+  return execFileSync("git", args, { cwd: repo, encoding: "utf8" }).trim()
+}
+
+beforeEach(() => {
+  repo = mkdtempSync(join(tmpdir(), "kobe-behind-"))
+  git("init", "-q", "-b", "main", ".")
+  writeFileSync(join(repo, "a.txt"), "a\n")
+  git("add", "-A")
+  git(...AUTHOR, "commit", "-qm", "init")
+  git("checkout", "-q", "-b", "work")
+  resetBehindCache()
+})
+
+afterEach(() => {
+  rmSync(repo, { recursive: true, force: true })
+  resetBehindCache()
+})
+
+/** A `compute` that counts its calls and returns a fixed answer. */
+function counter(value: number | null) {
+  let calls = 0
+  return {
+    calls: () => calls,
+    compute: async () => {
+      calls++
+      return value
+    },
+  }
+}
+
+describe("behindCountCached", () => {
+  test("computes once, then serves the memo while both shas hold still", async () => {
+    const c = counter(3)
+    expect(await behindCountCached(repo, "main", c.compute)).toBe(3)
+    expect(await behindCountCached(repo, "main", c.compute)).toBe(3)
+    expect(await behindCountCached(repo, "main", c.compute)).toBe(3)
+    expect(c.calls()).toBe(1)
+  })
+
+  test("recomputes when the BASE ref moves", async () => {
+    const first = counter(0)
+    expect(await behindCountCached(repo, "main", first.compute)).toBe(0)
+
+    git("update-ref", "refs/heads/main", git("commit-tree", "HEAD^{tree}", "-p", "HEAD", "-m", "advance"))
+
+    const second = counter(1)
+    expect(await behindCountCached(repo, "main", second.compute)).toBe(1)
+    expect(second.calls()).toBe(1)
+  })
+
+  test("recomputes when HEAD moves", async () => {
+    const first = counter(2)
+    expect(await behindCountCached(repo, "main", first.compute)).toBe(2)
+
+    writeFileSync(join(repo, "b.txt"), "b\n")
+    git("add", "-A")
+    git(...AUTHOR, "commit", "-qm", "work commit")
+
+    const second = counter(5)
+    expect(await behindCountCached(repo, "main", second.compute)).toBe(5)
+  })
+
+  test("never memoises a failed compute", async () => {
+    const failing = counter(null)
+    expect(await behindCountCached(repo, "main", failing.compute)).toBeNull()
+    expect(await behindCountCached(repo, "main", failing.compute)).toBeNull()
+    expect(failing.calls()).toBe(2)
+  })
+
+  test("falls through every time when a sha will not read", async () => {
+    // No such ref, so the key can never be formed — the memo must not
+    // silently degrade into "same worktree, same answer".
+    const c = counter(7)
+    expect(await behindCountCached(repo, "origin/nope", c.compute)).toBe(7)
+    expect(await behindCountCached(repo, "origin/nope", c.compute)).toBe(7)
+    expect(c.calls()).toBe(2)
+  })
+
+  test("falls through for a path that is not a git checkout", async () => {
+    const plain = mkdtempSync(join(tmpdir(), "kobe-behind-plain-"))
+    const c = counter(1)
+    expect(await behindCountCached(plain, "main", c.compute)).toBe(1)
+    expect(await behindCountCached(plain, "main", c.compute)).toBe(1)
+    expect(c.calls()).toBe(2)
+    rmSync(plain, { recursive: true, force: true })
+  })
+})

--- a/packages/kobe/test/daemon/collector-channel-gate.test.ts
+++ b/packages/kobe/test/daemon/collector-channel-gate.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Per-channel collector gate — the collectors must be started by the
+ * channels a client actually subscribed to, not by "someone is connected".
+ *
+ * `hasSubscribers()` ignored `client.channels`, so a pane subscribing to
+ * `["ui-prefs", "keybindings"]` — exactly what the TUI's UiPrefsSync does —
+ * opened every collector: measured at 194 `git` spawns in 8 seconds to
+ * deliver the two frames it asked for, all of which were then dropped at
+ * the socket by the publish-side filter. The gate is now
+ * `hasSubscribersFor(channel)`, wired per collector in collectors.ts.
+ *
+ * Proven through the real socket with the worktree-changes collector, the
+ * loudest of them: the runner is a counting double, so "the poller started"
+ * is a number, not an inference.
+ */
+
+import { afterEach, describe, expect, it } from "vitest"
+import { daemonRuntime } from "../../src/core/daemon-runtime.ts"
+import { type DaemonHarness, bootDaemonHarness, fakeOrchestrator, waitFor } from "./harness.ts"
+
+/** One task with a local worktree — enough for the collector to have work. */
+const TASKS = [{ id: "t1", repo: "/repo", worktreePath: "/repo/wt" }]
+
+describe("collector gate honours the subscriber's channel filter", () => {
+  let h: DaemonHarness
+  let runs = 0
+
+  afterEach(async () => {
+    await h.close()
+  })
+
+  async function boot(): Promise<DaemonHarness> {
+    runs = 0
+    return bootDaemonHarness({
+      orchestrator: fakeOrchestrator({ listTasks: () => TASKS }),
+      server: {
+        worktreeChangesTickMs: 15,
+        runtime: {
+          ...daemonRuntime,
+          runWorktreeStatus: async () => {
+            runs++
+            return { added: 1, deleted: 0 }
+          },
+        },
+      },
+    })
+  }
+
+  it("a pane subscribed to unrelated channels never starts the worktree-changes poller", async () => {
+    h = await boot()
+
+    const pane = h.client()
+    await pane.connect()
+    await pane.subscribe({ role: "pane", channels: ["ui-prefs", "keybindings"] })
+
+    // Many ticks' worth of wall time at a 15ms tick.
+    await new Promise((r) => setTimeout(r, 300))
+    expect(runs).toBe(0)
+
+    pane.close()
+  })
+
+  it("a subscriber that DOES ask for worktree.changes starts it", async () => {
+    h = await boot()
+
+    const pane = h.client()
+    await pane.connect()
+    await pane.subscribe({ role: "pane", channels: ["worktree.changes"] })
+
+    expect(await waitFor(() => runs > 0)).toBe(true)
+    pane.close()
+  })
+
+  it("an unfiltered subscriber still starts it (back-compat)", async () => {
+    h = await boot()
+
+    const gui = h.client()
+    await gui.connect()
+    await gui.subscribe({ role: "gui" })
+
+    expect(await waitFor(() => runs > 0)).toBe(true)
+    gui.close()
+  })
+})

--- a/packages/kobe/test/daemon/worktree-probe.test.ts
+++ b/packages/kobe/test/daemon/worktree-probe.test.ts
@@ -1,0 +1,156 @@
+/**
+ * The worktree change probe, against REAL git repos — including a linked
+ * worktree, whose `.git` is a file and whose refs live in the main
+ * checkout's common dir.
+ *
+ * Two halves matter, and the second is the one that keeps the collector
+ * correct:
+ *
+ *   1. what the fingerprint DOES notice (staging, commits, ref moves, an
+ *      entry created in the worktree root) — the accelerator;
+ *   2. what it does NOT (a content edit of an existing file, a new file in a
+ *      subdirectory) — which is why the collector keeps a safety poll behind
+ *      it rather than treating a quiet probe as proof of no change.
+ *
+ * `mtime` has coarse granularity on some filesystems, so every mutation is
+ * preceded by a short sleep rather than trusting sub-millisecond stamps.
+ */
+
+import { execFileSync } from "node:child_process"
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { readHeadSha, readRefSha, resolveGitDirs, worktreeFingerprint } from "@sma1lboy/kobe-daemon/daemon/worktree-probe"
+import { afterAll, beforeAll, describe, expect, test } from "vitest"
+
+const AUTHOR = ["-c", "user.email=t@t", "-c", "user.name=t"]
+const dirs: string[] = []
+
+function git(cwd: string, ...args: string[]): string {
+  return execFileSync("git", args, { cwd, encoding: "utf8" }).trim()
+}
+
+function newRepo(): string {
+  const dir = mkdtempSync(join(tmpdir(), "kobe-probe-"))
+  dirs.push(dir)
+  git(dir, "init", "-q", "-b", "main", ".")
+  mkdirSync(join(dir, "src", "deep"), { recursive: true })
+  writeFileSync(join(dir, "src", "deep", "f.ts"), "base\n")
+  writeFileSync(join(dir, "root.txt"), "root\n")
+  git(dir, "add", "-A")
+  git(dir, ...AUTHOR, "commit", "-qm", "init")
+  return dir
+}
+
+/** mtime resolution is only guaranteed to ~1s on some filesystems. */
+function pause(): void {
+  execFileSync("sleep", ["1.1"])
+}
+
+describe("worktreeFingerprint", () => {
+  let repo: string
+
+  beforeAll(() => {
+    repo = newRepo()
+  })
+  afterAll(() => {
+    for (const dir of dirs) rmSync(dir, { recursive: true, force: true })
+  })
+
+  test("is stable across reads when nothing happens", () => {
+    expect(worktreeFingerprint(repo)).toBe(worktreeFingerprint(repo))
+  })
+
+  test("is null for a directory that is not a git checkout", () => {
+    const plain = mkdtempSync(join(tmpdir(), "kobe-probe-plain-"))
+    dirs.push(plain)
+    expect(worktreeFingerprint(plain)).toBeNull()
+  })
+
+  test("moves when a file is staged", () => {
+    const before = worktreeFingerprint(repo)
+    pause()
+    writeFileSync(join(repo, "staged.txt"), "s\n")
+    git(repo, "add", "staged.txt")
+    expect(worktreeFingerprint(repo)).not.toBe(before)
+  })
+
+  test("moves when HEAD commits", () => {
+    const before = worktreeFingerprint(repo)
+    pause()
+    git(repo, ...AUTHOR, "commit", "-qm", "second")
+    expect(worktreeFingerprint(repo)).not.toBe(before)
+  })
+
+  test("moves when a default base ref moves, even with no recorded baseRef", () => {
+    // The task usually records no base; the runner resolves `main`/`origin/main`
+    // later. The fingerprint has to watch those files anyway or a fetch that
+    // advanced the base is invisible until the safety poll.
+    git(repo, "branch", "-f", "otherbase", "HEAD")
+    git(repo, "checkout", "-q", "-b", "work")
+    const before = worktreeFingerprint(repo)
+    pause()
+    git(repo, "update-ref", "refs/heads/main", git(repo, "commit-tree", "HEAD^{tree}", "-p", "HEAD", "-m", "advance"))
+    expect(worktreeFingerprint(repo)).not.toBe(before)
+  })
+
+  test("moves when an entry is created in the worktree root", () => {
+    const before = worktreeFingerprint(repo)
+    pause()
+    writeFileSync(join(repo, "brand-new.txt"), "n\n")
+    expect(worktreeFingerprint(repo)).not.toBe(before)
+  })
+
+  test("does NOT move for a content edit of an existing file — the blind spot", () => {
+    // Both of these are real `git status` changes the probe cannot see. The
+    // collector's safety poll is what covers them; if this ever starts
+    // failing, the safety poll may be relaxed.
+    const before = worktreeFingerprint(repo)
+    pause()
+    writeFileSync(join(repo, "root.txt"), "root edited\n")
+    writeFileSync(join(repo, "src", "deep", "f.ts"), "nested edited\n")
+    expect(worktreeFingerprint(repo)).toBe(before)
+    expect(git(repo, "status", "--porcelain=v1")).toContain("root.txt")
+  })
+
+  test("works for a LINKED worktree, whose .git is a file", () => {
+    const linked = join(repo, "..", `linked-${Date.now()}`)
+    git(repo, "worktree", "add", "-q", "-b", "linkedbr", linked)
+    dirs.push(linked)
+    const probeDirs = resolveGitDirs(linked)
+    expect(probeDirs).not.toBeNull()
+    // A linked worktree keeps its own gitDir but shares the repo-wide one.
+    expect(probeDirs?.gitDir).not.toBe(probeDirs?.commonDir)
+    expect(worktreeFingerprint(linked)).not.toBeNull()
+    expect(readHeadSha(probeDirs as NonNullable<typeof probeDirs>)).toBe(git(linked, "rev-parse", "HEAD"))
+    git(repo, "worktree", "remove", "--force", linked)
+  })
+})
+
+describe("ref reads", () => {
+  let repo: string
+
+  beforeAll(() => {
+    repo = newRepo()
+  })
+
+  test("readHeadSha follows the symref, and matches rev-parse", () => {
+    const probeDirs = resolveGitDirs(repo)
+    expect(probeDirs).not.toBeNull()
+    expect(readHeadSha(probeDirs as NonNullable<typeof probeDirs>)).toBe(git(repo, "rev-parse", "HEAD"))
+  })
+
+  test("readRefSha finds a branch both loose and packed", () => {
+    const probeDirs = resolveGitDirs(repo) as NonNullable<ReturnType<typeof resolveGitDirs>>
+    const expected = git(repo, "rev-parse", "main")
+    expect(readRefSha(probeDirs, "main")).toBe(expected)
+    // `pack-refs` deletes the loose file — the packed-refs path must cover it.
+    git(repo, "pack-refs", "--all")
+    expect(readRefSha(probeDirs, "main")).toBe(expected)
+  })
+
+  test("readRefSha is null for a ref that does not exist", () => {
+    const probeDirs = resolveGitDirs(repo) as NonNullable<ReturnType<typeof resolveGitDirs>>
+    expect(readRefSha(probeDirs, "origin/nope")).toBeNull()
+  })
+})

--- a/packages/kobe/test/daemon/worktree-quiet-backoff.test.ts
+++ b/packages/kobe/test/daemon/worktree-quiet-backoff.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Quiet backoff — the collector's fourth guard, on a different axis from
+ * the three that defend against a SLOW repo (in-flight dedupe, timeout +
+ * hard backoff, adaptive cadence). This one defends against an UNCHANGED
+ * one: 19 idle tasks were costing 1280 `git` processes per 62 seconds to
+ * publish 19 frames.
+ *
+ * The rule under test: skip the spawns ONLY when the change probe read
+ * cleanly, read the same thing as at the last run's start, no engine is
+ * working in that worktree, and the safety poll is not yet due. The probe
+ * cannot see a content edit (see worktree-probe.ts), so every other case has
+ * to fall through and poll — that is what makes the optimisation safe.
+ *
+ * Only `Date` is faked: the collector's run completions are real promises,
+ * so faking `setTimeout` would stall `settle()`.
+ */
+
+import { DaemonEventBus } from "@sma1lboy/kobe-daemon/daemon/event-bus"
+import { WorktreeChangesCollector } from "@sma1lboy/kobe-daemon/daemon/worktree-changes-collector"
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest"
+import { type Task, toTaskId } from "../../src/types/task.ts"
+
+function task(id: string): Task {
+  return {
+    id: toTaskId(id),
+    title: id,
+    repo: "/repo",
+    branch: id,
+    worktreePath: `/wt/${id}`,
+    status: "backlog",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+  } as Task
+}
+
+/** Cadence with a zero floor, so only the quiet backoff can hold a tick off. */
+const FAST = { timeoutMs: 1_000, slowRetryMs: 1_000, minIntervalMs: 0 }
+const QUIET_MS = 10_000
+
+async function settle(): Promise<void> {
+  for (let i = 0; i < 5; i++) await new Promise((r) => setTimeout(r, 0))
+}
+
+interface HarnessOptions {
+  readonly probe: () => string | null
+  readonly activeTaskIds?: () => string[]
+  readonly tasks?: Task[]
+}
+
+function harness(opts: HarnessOptions) {
+  /** Runs per worktree path — "did it spawn?" as a number. */
+  const runs = new Map<string, number>()
+  const collector = new WorktreeChangesCollector({ listTasks: () => opts.tasks ?? [task("a")] }, new DaemonEventBus(), {
+    cadence: FAST,
+    quietIntervalMs: QUIET_MS,
+    probe: opts.probe,
+    ...(opts.activeTaskIds ? { activeTaskIds: opts.activeTaskIds } : {}),
+    run: async (path) => {
+      runs.set(path, (runs.get(path) ?? 0) + 1)
+      return { added: 1, deleted: 0 }
+    },
+  })
+  /** Tick at an absolute fake time and let the run settle. */
+  const tickAt = async (at: number): Promise<void> => {
+    vi.setSystemTime(at)
+    collector.tick()
+    await settle()
+  }
+  return { runs: (path = "/wt/a") => runs.get(path) ?? 0, tickAt }
+}
+
+describe("worktree-changes quiet backoff", () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ toFake: ["Date"] })
+    vi.setSystemTime(0)
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  test("an unchanged fingerprint stops the spawns until the safety poll is due", async () => {
+    const h = harness({ probe: () => "same" })
+
+    await h.tickAt(0)
+    expect(h.runs()).toBe(1)
+
+    for (let t = 1_000; t <= 9_000; t += 1_000) await h.tickAt(t)
+    expect(h.runs()).toBe(1)
+
+    // Past the safety interval it polls anyway: the probe cannot see a
+    // content edit, so the relaxed poll is what keeps the counts honest.
+    await h.tickAt(QUIET_MS + 1)
+    expect(h.runs()).toBe(2)
+  })
+
+  test("a moved fingerprint polls on the very next tick", async () => {
+    let fingerprint = "v1"
+    const h = harness({ probe: () => fingerprint })
+
+    await h.tickAt(0)
+    await h.tickAt(1_000)
+    expect(h.runs()).toBe(1)
+
+    fingerprint = "v2"
+    await h.tickAt(2_000)
+    expect(h.runs()).toBe(2)
+  })
+
+  test("an unreadable probe always polls — no fingerprint, no backoff", async () => {
+    const h = harness({ probe: () => null })
+
+    for (let t = 0; t <= 3_000; t += 1_000) await h.tickAt(t)
+    expect(h.runs()).toBe(4)
+  })
+
+  test("a worktree whose engine is working keeps the fast cadence", async () => {
+    // An engine writing `src/**` is exactly what the fingerprint is blind to.
+    const h = harness({ probe: () => "same", activeTaskIds: () => ["a"] })
+
+    for (let t = 0; t <= 3_000; t += 1_000) await h.tickAt(t)
+    expect(h.runs()).toBe(4)
+  })
+
+  test("an active task in ANOTHER worktree does not exempt this one", async () => {
+    const h = harness({ probe: () => "same", activeTaskIds: () => ["b"], tasks: [task("a"), task("b")] })
+
+    for (let t = 0; t <= 3_000; t += 1_000) await h.tickAt(t)
+    expect(h.runs("/wt/a")).toBe(1)
+    expect(h.runs("/wt/b")).toBe(4)
+  })
+})


### PR DESCRIPTION
Three fixes to the daemon's idle git polling, measured with the rig from `.scratch/loop-r9/perf` (isolated home, 19 idle tasks, `bin/git` PATH shim logging every spawn). Rig cloned to `.scratch/loop-r9-s/perf` with the paths and sockets repointed at this worktree; scripts otherwise unmodified.

**Every AFTER number below was re-measured after rebasing onto 0.9.109 (which contains #851 and #850)**, on the exact tree in this PR — #851 changed `runtimeDataPath` and the daemon's own path derivation, so pre-rebase numbers would not have described the code that merges. The rebased runs reproduce the pre-rebase ones exactly (133 spawns, phase A 0, phase B 38, 19 frames, payload 2437 bytes), and the spawn log confirms the isolated fixture was still what got polled: 20 distinct cwds = the 19 fixture worktrees + the repo root.

**Headline, `run-cpu.sh`, same 62s window and same 19-task home:**

| | before | after |
|---|---|---|
| `git` spawns | 1280 | **133** |
| child CPU (user+sys) | 14.67s | **1.15s** |
| CPU per spawn | 11.5ms | 8.6ms |
| `worktree.changes` frames published | 19 | **19** |
| daemon RSS after the run | 204 MB | 159 MB |

Spawn mix after: `76 status`, `19 rev-list`, `19 remote`, `19 config`. The last 38 are the pr-status collector's one-time `gh`-repo detection, untouched by this PR. Before: `570 status`, `570 rev-list`, `84 rev-parse`, `19 remote`, `19 config`, `18 symbolic-ref`.

---

### PERF1 — the collector gate ignored each client's channel filter

`lifetime.ts:147 hasSubscribers()` returned true for any subscribed client, so a pane asking only for `ui-prefs`/`keybindings` started every collector and had all their frames dropped at the socket by the publish-side filter. Replaced with `hasSubscribersFor(channel)`, built on the same `client.channels` set `broadcast` already honours (`null`/absent = all channels, so a real gui and the filter-less web clients are unaffected), wired in `collectors.ts` to the channel each collector publishes.

**PASS:** `run-burst.sh` phase A prints 0 spawns; phase B still non-zero with the same frame set.

```
BEFORE                                        AFTER
A: git spawns before any subscriber:    0     A: git spawns before any subscriber:  0
pane-only held 8s, received 2 frames          pane-only held 8s, received 2 frames
A: after 8s pane-only subscriber:     194     A: after 8s pane-only subscriber:     0
B: git spawns during 14s gui:         273     B: git spawns during 14s gui:        38
```

Phase B's frame set changed shape for a legitimate reason worth naming: before, phase A's pane had already filled the collector's map, so phase B's gui got 1 replayed `worktree.changes` frame. Now phase A does no work, so phase B does the real fill-in and reports `worktree.changes: 19, transcript.activity: 19` — the same 19 entries, arriving as the collector derives them instead of as one replay.

**Test:** `packages/kobe/test/daemon/collector-channel-gate.test.ts`, over the real socket with a counting `runWorktreeStatus` double. Mutation-checked — reverting the gate to ignore `channels` fails it with `expected 1 to be +0`.

### PERF2 — the poll re-derived an unchanged answer 67× per change

Added a stat-only fingerprint (`worktree-probe.ts`) over `.git/index`, `HEAD` + its ref file, the base ref files, `FETCH_HEAD`, `packed-refs` and the worktree root, checked before the spawns.

**One deviation from the brief, and it is the load-bearing decision.** The prescribed probe set does not see the case that matters most. I measured it before building on it:

```
--- after nested TRACKED edit (echo >> src/deep/f.ts)
.git/index  unchanged     .   unchanged     src/deep  unchanged
--- after nested UNTRACKED create
.git/index  unchanged     .   unchanged     src/deep  MOVED
--- git status sees:  M src/deep/f.ts   ?? src/deep/untracked.ts
```

A directory's mtime tracks its entry list, not its contents, and our polls run `GIT_OPTIONAL_LOCKS=0` so they never refresh-write the index either. Treating a quiet fingerprint as proof of no change would have frozen the sidebar chips for any worktree an engine was editing — worse than the CPU it saves. So the probe is an **accelerator, not an authority**:

- fingerprint moved, or unreadable, or first tick → poll now (unchanged 2s behaviour);
- fingerprint quiet **and** no engine working there → relax to a 15s floor, still polling;
- worktree whose task has a non-idle engine → always the full cadence, since a working engine produces exactly the nested writes the probe is blind to.

The tick interval is unchanged and the three existing guards (in-flight dedupe, timeout + SIGKILL, adaptive `5 × last duration`) are untouched — this is a fourth guard on a different axis.

**PASS — count:** 1280 → 133 (target: under 150), `worktree.changes` still exactly 19 frames.

**PASS — values identical, not just the count.** The published payload is **2437 bytes**, byte-for-byte the same size as the BEFORE run's `worktree.changes entries=19 bytes=2437`, and every entry was checked against real git rather than against the old implementation:

```
strict check: 19 worktrees, 0 mismatches; payload bytes 2437 == BEFORE run's 2437
```

**PASS — live correctness.** Live daemon on the rebased tree, a fixture repo I own, timestamps relative to subscribe:

```
                                              +0.17s  {"added":0,"deleted":0,"behind":0}   initial fill
[t=5s]  advance base branch main       ->      +6.17s  {"added":0,"deleted":0,"behind":1}   1.2s — one tick
[t=8s]  create NEW file in root        ->      +8.14s  {"added":1,"deleted":0,"behind":1}   0.1s — same tick
[t=12s] edit EXISTING nested file      ->     +24.16s  {"added":2,"deleted":0,"behind":1}   12.2s — safety poll
```

The first two are the probe firing: a ref file moving and a worktree-root entry appearing are both things it can see. The third is the honest cost — editing an *existing* file moves no directory mtime at any depth, so it waited for the safety poll, 12.2s, inside the 15s + one tick bound.

**Tests:** `worktree-probe.test.ts` (11 tests against real repos, including a linked worktree whose `.git` is a file, packed-refs, and an explicit test pinning the blind spot) and `worktree-quiet-backoff.test.ts` (5 tests). Mutation-checked at two sites: dropping the engine-active exemption fails 2 tests; dropping the default base-ref candidates from the fingerprint fails the "base ref moves with no recorded baseRef" test.

### PERF3 — needed, not skippable

PERF2 alone landed at **227** spawns, over the 150 target, so I measured what was left rather than assuming: `57 rev-list` + `57 rev-parse` + `18 symbolic-ref` — the behind-count and the base-ref ladder that resolves it, both reading refs through subprocesses.

Both now read the ref files. `behind-cache.ts` memoises the count on the `(HEAD, base)` SHAs; `base-ref-cache.ts` resolves its fixed branch candidates from loose refs / `packed-refs`. Both fall back to spawning `git` on any ambiguity — an unreadable git dir, or a *recorded* base ref that is not a branch (it could be a tag or a sha, which file absence cannot disprove).

**PASS:** 227 → **133**, and `rev-parse`/`symbolic-ref` disappear from the spawn log entirely.

**Test:** `behind-cache.test.ts`, 6 tests against real repos. Mutation-checked: serving the memo without comparing SHAs fails "recomputes when the BASE ref moves" and "recomputes when HEAD moves".

---

### What I could not prove

- The 15s quiet floor is a judgement call, not a measurement. It is the worst-case chip staleness for a worktree with an idle engine and an unmoved fingerprint; 2s is preserved wherever an engine is working. Easy to change if you want it tighter.
- `run-burst.sh` phase B is 38 rather than the brief's "same as `perf/frames-timing.txt`" — explained under PERF1; the stored file recorded a warmed collector, which phase A no longer warms.
- No screenshots: none of this is TUI-visible, as the brief noted.

### Gates

All re-run after the rebase: `bun run lint` clean · `bun run typecheck` clean · `bun run test` = 440 files / 4377 tests (fast) + 99 files / 819 tests (socket) + 5 files / 13 tests (plugin-sdk), all passing. No render-track files touched.

file-size-exemption: packages/kobe-daemon/src/daemon/server.ts — already 504 lines on `main`; this PR changes exactly one line in it (the collector gate call site). Splitting the daemon server closure is a real refactor with its own risk and does not belong in a measured perf change. A concurrent refactor task is extracting the web-transport boot out of this same file, which resolves the overage properly; `server.ts` is the overlap between the two branches.
