### PR TITLE
loop-r10 U: seven dead exports, two dead imports, one orphan i18n key, and host.tsx's four toast paths

### DIFF
--- a/.changeset/host-notifiers-and-dead-weight.md
+++ b/.changeset/host-notifiers-and-dead-weight.md
@@ -1,0 +1,13 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Internal cleanup, no behavior change. The workspace host's five toast paths
+collapse into one `useHostNotifiers` hook: two of them existed only as
+hand-declared workarounds for hook ordering — each carrying a comment saying
+so — because they needed `selectedId`, which a later hook produces. Passing
+`selectedId` as a getter removes the constraint, and with it both workarounds
+and a third notifier built inline in an argument list. Alongside it, seven
+exports whose only reference was inside their own file lose the `export`
+keyword, `product.ts` loses two unused imports, and the one message key
+nothing renders (`worktrees.row.linkedTask`) is deleted from both locales.

--- a/packages/kobe/src/engine/binary-discovery.ts
+++ b/packages/kobe/src/engine/binary-discovery.ts
@@ -35,7 +35,7 @@ export interface BinaryDiscoveryDeps {
   platform?(): NodeJS.Platform
 }
 
-export const defaultBinaryDeps: BinaryDiscoveryDeps = {
+const defaultBinaryDeps: BinaryDiscoveryDeps = {
   fileExists(p) {
     try {
       return statSync(p).isFile()
@@ -95,7 +95,7 @@ export class BinaryNotFoundError extends Error {
 }
 
 /** What a vendor's candidate list gets to look at. */
-export interface BinaryCandidateContext {
+interface BinaryCandidateContext {
   readonly deps: BinaryDiscoveryDeps
   /** `deps.home()`, resolved once. */
   readonly home: string

--- a/packages/kobe/src/engine/kimi-local/binary.ts
+++ b/packages/kobe/src/engine/kimi-local/binary.ts
@@ -10,7 +10,7 @@ import { BinaryNotFoundError, createBinaryFinder } from "../binary-discovery.ts"
 
 export type { BinaryDiscoveryDeps } from "../binary-discovery.ts"
 
-export class KimiBinaryNotFoundError extends BinaryNotFoundError {
+class KimiBinaryNotFoundError extends BinaryNotFoundError {
   constructor(checkedPaths: readonly string[]) {
     super("Kimi Code CLI binary", "Ensure 'kimi' is on PATH or installed at ~/.kimi-code/bin/kimi.", checkedPaths)
     this.name = "KimiBinaryNotFoundError"

--- a/packages/kobe/src/orchestrator/sync-base.ts
+++ b/packages/kobe/src/orchestrator/sync-base.ts
@@ -61,7 +61,7 @@ export function parseConflictedPaths(stdout: string): string[] {
  * Paths from `git status --porcelain=v1`, with the two-character XY status and
  * its separating space stripped. Same shape as landing's `porcelainPaths`.
  */
-export function parseDirtyPaths(stdout: string): string[] {
+function parseDirtyPaths(stdout: string): string[] {
   return stdout
     .split("\n")
     .filter((line) => line.length > 3)

--- a/packages/kobe/src/product.ts
+++ b/packages/kobe/src/product.ts
@@ -1,7 +1,5 @@
 /** Stable names used while the product moves from kobe to rove. */
 import {
-  COMPAT_CONFIG_DIR_BASENAME,
-  COMPAT_STATE_DIR_BASENAME,
   LEGACY_KOBE_CONFIG_DIR_BASENAME,
   LEGACY_KOBE_PRODUCT_NAME,
   LEGACY_KOBE_STATE_DIR_BASENAME,

--- a/packages/kobe/src/tui-react/component/kanban-board.tsx
+++ b/packages/kobe/src/tui-react/component/kanban-board.tsx
@@ -23,7 +23,7 @@ import type { CursorFollow } from "../lib/use-cursor-follow"
 import { FRAME } from "../ui/frame"
 import { KanbanCard } from "./kanban-card"
 
-export const COLUMN_LABEL_KEY: Record<BoardColumnKey, string> = {
+const COLUMN_LABEL_KEY: Record<BoardColumnKey, string> = {
   backlog: "kanban.column.backlog",
   in_progress: "kanban.column.inProgress",
   parked: "kanban.column.parked",

--- a/packages/kobe/src/tui-react/panes/sidebar/use-sidebar-host-state.tsx
+++ b/packages/kobe/src/tui-react/panes/sidebar/use-sidebar-host-state.tsx
@@ -1,9 +1,10 @@
 /**
- * Shared Sidebar-host state — the wiring both hosts that mount the shared
- * `Sidebar` (the tmux Tasks pane and the pure-TUI workspace) had
- * copy-pasted: the error/info toast helpers, the global sort pref
- * (kv-persisted, fanned out by the daemon's ui-prefs watcher), and the
- * move-mode toggle behind the sidebar's local-merge/move request.
+ * Sidebar-host state: the global sort pref (kv-persisted, fanned out by the
+ * daemon's ui-prefs watcher) and the move-mode toggle behind the sidebar's
+ * local-merge/move request. The host's toast helpers used to live here too;
+ * they are `use-host-notifiers.ts` now, because every one of the host's
+ * notifiers wants the same `selectedId` and only some of them are
+ * sidebar-adjacent.
  *
  * KNOWN DRIFT (deliberate, not hidden here): the Tasks pane FOLLOWS live
  * `ui-prefs` pushes for sortMode/projectFilter, the workspace host does
@@ -15,7 +16,6 @@ import { useState } from "react"
 import type { TaskSortMode } from "../../../tui/panes/sidebar/groups"
 import type { Task } from "../../../types/task.ts"
 import type { KVContext } from "../../context/kv"
-import type { NotificationsContext } from "../../context/notifications"
 
 export interface SidebarHostState {
   readonly sortMode: TaskSortMode
@@ -30,23 +30,6 @@ export interface SidebarHostState {
   readonly moveMode: boolean
   readonly setMoveMode: (next: boolean) => void
   /**
-   * Surface a user-action FAILURE as a red error toast. Under an alternate
-   * screen a bare `console.error` is invisible (it only reaches the daemon
-   * log), so a failed key press would otherwise look like a silent no-op.
-   * Call sites KEEP their matching `console.error` for log forensics — this
-   * is the on-screen half. The notifications context is per-ChatTab
-   * (taskId/tabId-keyed); a host action isn't tab-scoped, so it's tagged
-   * with the selected task and an empty tab — only the toast queue is
-   * consumed, the unread-dot map is harmless side state never rendered.
-   */
-  readonly notifyError: (message: string) => void
-  /**
-   * Neutral (non-error) toast — same on-screen surfacing as notifyError but
-   * green/`done` styling, for "this happened" confirmations (engine cycled,
-   * creating task, already up to date) that aren't failures.
-   */
-  readonly notifyInfo: (message: string) => void
-  /**
    * The Sidebar's move-mode request (`shift+m`): select a row and toggle
    * move mode. The tree then routes j/k by the cursor row's LEVEL: a tab
    * moves within its task, a task within its repo group, and a `main` row
@@ -57,19 +40,10 @@ export interface SidebarHostState {
 
 export function useSidebarHostState(args: {
   readonly kv: KVContext
-  readonly notif: NotificationsContext
   readonly tasks: readonly Task[]
-  readonly selectedId: string | null
   readonly setSelectedId: (id: string) => void
 }): SidebarHostState {
-  const { kv, notif, tasks, selectedId, setSelectedId } = args
-
-  function notifyError(message: string): void {
-    notif.notify({ kind: "error", taskId: selectedId ?? "", tabId: "", title: message })
-  }
-  function notifyInfo(message: string): void {
-    notif.notify({ kind: "done", taskId: selectedId ?? "", tabId: "", title: message })
-  }
+  const { kv, tasks, setSelectedId } = args
 
   // Sort mode is a GLOBAL pref, fanned out like theme/appearance: the toggle
   // writes `activeSortMode` to state.json and the daemon's ui-prefs watcher
@@ -90,5 +64,5 @@ export function useSidebarHostState(args: {
     setMoveMode((cur) => !cur)
   }
 
-  return { sortMode, setSortMode, toggleSortMode, moveMode, setMoveMode, notifyError, notifyInfo, onLocalMergeRequest }
+  return { sortMode, setSortMode, toggleSortMode, moveMode, setMoveMode, onLocalMergeRequest }
 }

--- a/packages/kobe/src/tui-react/workspace/host.tsx
+++ b/packages/kobe/src/tui-react/workspace/host.tsx
@@ -40,10 +40,11 @@ import { useAttention } from "./use-attention"
 import { requestCreatePR } from "./use-create-pr"
 import { useDaemonState } from "./use-daemon-state"
 import { useEditorHandles } from "./use-editor-handles"
+import { useHostNotifiers } from "./use-host-notifiers"
 import { useInboxHost } from "./use-inbox-host"
 import { useIssueChat } from "./use-issue-chat"
 import { useScratchShell } from "./use-scratch-shell"
-import { type WorktreeGoneEvent, useWorkspaceSelection } from "./use-workspace-selection"
+import { useWorkspaceSelection } from "./use-workspace-selection"
 import { useZenMode } from "./use-zen-mode"
 
 /** Exported for the render track: the banner wiring can only be proven by
@@ -76,7 +77,7 @@ export function WorkspaceRoot(props: { orchestrator: RemoteOrchestrator }) {
   } = useDaemonState(orch)
 
   // Sidebar-search gate: mutes the host's letter chords while typing. Move
-  // mode / toasts live in useSidebarHostState below.
+  // mode lives in useSidebarHostState below.
   const [searchActive, setSearchActive] = useState(false)
 
   // Selection + adopt-first-focus + the deleting-task PTY sweep — one hook in
@@ -84,26 +85,14 @@ export function WorkspaceRoot(props: { orchestrator: RemoteOrchestrator }) {
   // the user on" and get it wrong together if they drift apart.
   const t = useT()
 
-  // Declared before useWorkspaceSelection so its worktree-gone callback can
-  // reach the toast surface; `notif.notify` is stable and the sidebar hook's
-  // notifyError/notifyInfo below need `selectedId`, which the selection hook
-  // produces. Same shape those two use (see use-sidebar-host-state).
-  const notifyWorktreeGone = (event: WorktreeGoneEvent): void => {
-    notif.notify({
-      kind: "error",
-      taskId: event.taskId,
-      tabId: "",
-      title: t("tasks.toast.worktreeGoneTitle", { title: event.title }),
-      body: t("tasks.toast.worktreeGoneBody", { count: String(event.closed), branch: event.branch || "—" }),
-    })
-  }
-
-  // Same pre-declaration reason as notifyWorktreeGone above: a refused
-  // activation must reach the toast surface, and `useSidebarHostState`'s
-  // notifyError can't be built yet (it needs `selectedId` from this hook).
-  const notifyActivationError = (message: string): void => {
-    notif.notify({ kind: "error", taskId: "", tabId: "", title: message })
-  }
+  // Every toast this host raises. It sits above the hooks that take one
+  // because `selectedId` reaches it as a getter, so nothing here has to be
+  // ordered against the selection hook below — see use-host-notifiers.ts.
+  const { notifyError, notifyInfo, notifyNeedsInput, notifyWorktreeGone } = useHostNotifiers({
+    notif,
+    t,
+    selectedId: () => selectedId,
+  })
 
   const { selectedId, setSelectedId, selectedTask, selectTask, activateTask } = useWorkspaceSelection({
     orch,
@@ -112,14 +101,17 @@ export function WorkspaceRoot(props: { orchestrator: RemoteOrchestrator }) {
     focusWorkspace: () => focus.setFocused("workspace"),
     kv,
     notifyWorktreeGone,
-    notifyError: notifyActivationError,
+    notifyError,
   })
   const worktree = selectedTask?.worktreePath || null
 
-  // Toasts + global sort pref + move-mode — the sidebar-adjacent wiring,
-  // extracted to the hook next to the Sidebar itself.
-  const { sortMode, toggleSortMode, moveMode, setMoveMode, notifyError, notifyInfo, onLocalMergeRequest } =
-    useSidebarHostState({ kv, notif, tasks, selectedId, setSelectedId })
+  // Global sort pref + move-mode — the sidebar-adjacent wiring, extracted to
+  // the hook next to the Sidebar itself.
+  const { sortMode, toggleSortMode, moveMode, setMoveMode, onLocalMergeRequest } = useSidebarHostState({
+    kv,
+    tasks,
+    setSelectedId,
+  })
 
   const inbox = useInboxHost({
     orchestrator: orch,
@@ -159,7 +151,7 @@ export function WorkspaceRoot(props: { orchestrator: RemoteOrchestrator }) {
     dialog,
     notifyError,
     notifyInfo,
-    notifyNeedsInput: (message) => notif.notify({ kind: "needs_input", taskId: "", tabId: "", title: message }),
+    notifyNeedsInput,
     t,
     selectedId: () => selectedId,
     setSelectedId,

--- a/packages/kobe/src/tui-react/workspace/use-fix-ci.ts
+++ b/packages/kobe/src/tui-react/workspace/use-fix-ci.ts
@@ -26,7 +26,7 @@ import { type CIFailingCheck, buildCIPromptForWorktree } from "../../tui/ops/ci-
 import { useT } from "../i18n"
 
 /** The row facts the prompt names — read at call time, not captured. */
-export interface FixCITask {
+interface FixCITask {
   readonly branch: string
   readonly prNumber?: number
 }

--- a/packages/kobe/src/tui-react/workspace/use-host-notifiers.ts
+++ b/packages/kobe/src/tui-react/workspace/use-host-notifiers.ts
@@ -1,0 +1,71 @@
+/**
+ * Every toast `WorkspaceRoot` raises, in one place.
+ *
+ * The ordering problem this settles: three of these are wanted by hooks the
+ * host calls BEFORE `useWorkspaceSelection`, which produces the `selectedId`
+ * they tag with. That used to be handled by declaring two notifiers by hand
+ * ahead of the selection hook, each carrying a comment explaining why. Taking
+ * `selectedId` as a GETTER settles it once — the closure reads the current
+ * render's value at the moment a toast fires, which is always later than the
+ * render that built it.
+ *
+ * `taskId`/`tabId` are bookkeeping, not display: `ToastOverlay` draws kind,
+ * title and body only, and nothing reads the notifications context's unread
+ * map. A host action is not tab-scoped, so these carry the selected task and
+ * an empty tab.
+ */
+
+import type { NotificationKind, NotificationsContext } from "../context/notifications"
+import type { WorktreeGoneEvent } from "./use-workspace-selection"
+
+export interface HostNotifiers {
+  /**
+   * Surface a user-action FAILURE as a red error toast. Under an alternate
+   * screen a bare `console.error` is invisible (it only reaches the daemon
+   * log), so a failed key press would otherwise look like a silent no-op.
+   * Call sites KEEP their matching `console.error` for log forensics — this
+   * is the on-screen half.
+   */
+  readonly notifyError: (message: string) => void
+  /**
+   * Neutral (non-error) toast — same on-screen surfacing as notifyError but
+   * green/`done` styling, for "this happened" confirmations (engine cycled,
+   * creating task, already up to date) that aren't failures.
+   */
+  readonly notifyInfo: (message: string) => void
+  /** Amber "over to you" — an action stopped on something only the user can
+   *  settle (a land conflict, a dirty base, a kept worktree). */
+  readonly notifyNeedsInput: (message: string) => void
+  /**
+   * A task's worktree vanished out-of-band and its tabs went with it. Carries
+   * the affected task's id rather than the selection: the user may well be
+   * looking at a different task when another client removes this one's
+   * worktree.
+   */
+  readonly notifyWorktreeGone: (event: WorktreeGoneEvent) => void
+}
+
+export function useHostNotifiers(args: {
+  readonly notif: NotificationsContext
+  readonly t: (key: string, params?: Record<string, string | number>) => string
+  /** Read at fire time, not at build time — see the module header. */
+  readonly selectedId: () => string | null
+}): HostNotifiers {
+  const { notif, t, selectedId } = args
+  const post = (kind: NotificationKind, title: string): void => {
+    notif.notify({ kind, taskId: selectedId() ?? "", tabId: "", title })
+  }
+  return {
+    notifyError: (message) => post("error", message),
+    notifyInfo: (message) => post("done", message),
+    notifyNeedsInput: (message) => post("needs_input", message),
+    notifyWorktreeGone: (event) =>
+      notif.notify({
+        kind: "error",
+        taskId: event.taskId,
+        tabId: "",
+        title: t("tasks.toast.worktreeGoneTitle", { title: event.title }),
+        body: t("tasks.toast.worktreeGoneBody", { count: String(event.closed), branch: event.branch || "—" }),
+      }),
+  }
+}

--- a/packages/kobe/src/tui/i18n/messages/worktrees.ts
+++ b/packages/kobe/src/tui/i18n/messages/worktrees.ts
@@ -29,7 +29,6 @@ export const en = {
   row: {
     detached: "(detached)",
     created: "created {age} ago",
-    linkedTask: "task: {title}",
   },
 
   delete: {
@@ -88,7 +87,6 @@ export const zh: typeof en = {
   row: {
     detached: "(游离状态)",
     created: "{age}前创建",
-    linkedTask: "任务：{title}",
   },
 
   delete: {

--- a/packages/kobe/src/tui/ops/ci-prompt.ts
+++ b/packages/kobe/src/tui/ops/ci-prompt.ts
@@ -33,7 +33,7 @@ export interface CIPromptState {
   readonly totalFailing?: number
 }
 
-export const DEFAULT_CI_PROMPT_TEMPLATE = `CI is failing on this branch and the user wants it green.
+const DEFAULT_CI_PROMPT_TEMPLATE = `CI is failing on this branch and the user wants it green.
 
 The current branch is {{branch}}.
 {{prSentence}}

--- a/packages/kobe/test/render/host-worktree-gone-toast.test.tsx
+++ b/packages/kobe/test/render/host-worktree-gone-toast.test.tsx
@@ -1,0 +1,136 @@
+/** @jsxImportSource @opentui/react */
+/**
+ * The worktree-gone toast's WIRING, through the real host.
+ *
+ * `useWorkspaceSelection` takes `notifyWorktreeGone` as an OPTIONAL argument,
+ * so dropping the host's wire is not a type error — it is a toast that
+ * silently stops appearing, for an event the user did not cause and has
+ * nothing else to look at. (Its siblings notifyError/notifyInfo/
+ * notifyNeedsInput are required parameters on every consumer, so those wires
+ * are held by the typechecker; this one is not.) A test against
+ * `useHostNotifiers` alone would stay green with the wire deleted, which is
+ * why this mounts `WorkspaceRoot` and drives the tasks signal the daemon
+ * writes.
+ *
+ * The selected task deliberately has NO worktree: `ShowWorkspace` mounts
+ * TerminalTabs (PTYs, fs watchers) as soon as one is selected with a
+ * worktree path, and those outlive the test in this single-process track.
+ * A second task losing its worktree while you sit on another is also the
+ * shape the toast is written for — the event arrives from somewhere else.
+ */
+
+import { afterAll, afterEach, beforeAll, expect, test } from "bun:test"
+import { mkdtempSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import type { RemoteOrchestrator } from "../../src/client/remote-orchestrator"
+import { createStateCell } from "../../src/lib/external-store"
+import { WorkspaceRoot } from "../../src/tui-react/workspace/host"
+import { setUiEventReporter } from "../../src/tui-react/workspace/terminal-tabs-shared"
+import { type Task, toTaskId } from "../../src/types/task"
+import { act, renderComponent, settle } from "./harness"
+
+// Same per-FILE env capture as host-version-skew-banner: KVProvider persists
+// to `$KOBE_HOME_DIR`, which is the real ~/.rove without this.
+let previousHome: string | undefined
+
+beforeAll(() => {
+  previousHome = process.env.KOBE_HOME_DIR
+  process.env.KOBE_HOME_DIR = mkdtempSync(join(tmpdir(), "kobe-worktree-gone-"))
+})
+
+afterAll(() => {
+  if (previousHome === undefined) Reflect.deleteProperty(process.env, "KOBE_HOME_DIR")
+  else process.env.KOBE_HOME_DIR = previousHome
+})
+
+// The host installs a module-level reporter closed over ITS orchestrator,
+// and it outlives the unmount.
+afterEach(() => {
+  setUiEventReporter(null)
+})
+
+// `useAccessor` re-renders on snapshot IDENTITY change, so a getter returning
+// a fresh value each call spins forever. Every constant below is hoisted.
+const NULL_CELL = createStateCell(null)
+const EMPTY_MAP = createStateCell(new Map())
+const EMPTY_ARR = createStateCell(Object.freeze([]))
+
+function task(id: string, over: Partial<Task> = {}): Task {
+  return {
+    id: toTaskId(id),
+    title: id,
+    repo: "/repos/rove",
+    branch: `feat/${id}`,
+    worktreePath: `/wt/${id}`,
+    kind: "task",
+    status: "in_progress",
+    createdAt: "2026-08-01T00:00:00.000Z",
+    updatedAt: "2026-08-01T00:00:00.000Z",
+    ...over,
+  }
+}
+
+/** The task the user is sitting on. No worktree, so no TerminalTabs mount. */
+const HELD = task("held", { worktreePath: "" })
+
+function fakeOrchestrator(initial: readonly Task[]) {
+  const tasks = createStateCell<readonly Task[]>(initial)
+  const orchestrator = {
+    tasksSignal: () => tasks,
+    listTasks: () => tasks(),
+    // Pin the selection: without a replayed focus the adopt effect picks by
+    // recency, and which task is selected decides whether TerminalTabs mounts.
+    activeTaskSignal: () => createStateCell<string | null>(HELD.id),
+    setActiveTask: async () => {},
+    connectionStateSignal: () => createStateCell("online"),
+    staleInstallSignal: () => NULL_CELL,
+    daemonStaleSignal: () => createStateCell(false),
+    daemonVersionSignal: () => NULL_CELL,
+    engineStateSignal: () => EMPTY_MAP,
+    engineLifecycleSignal: () => EMPTY_MAP,
+    engineTabStatesSignal: () => EMPTY_MAP,
+    attentionInboxSignal: () => EMPTY_ARR,
+    taskJobsSignal: () => EMPTY_MAP,
+    worktreeChangesSignal: () => NULL_CELL,
+    transcriptActivitySignal: () => NULL_CELL,
+    transcriptActivityStore: () => NULL_CELL,
+    usageSnapshotSignal: () => NULL_CELL,
+    contextUsageSignal: () => NULL_CELL,
+    uiPrefsSignal: () => NULL_CELL,
+    keybindingsRevSignal: () => NULL_CELL,
+    updateSignal: () => NULL_CELL,
+    tabOpenStore: () => NULL_CELL,
+    tabCloseStore: () => NULL_CELL,
+    uiPromptStore: () => NULL_CELL,
+    noticeStore: () => NULL_CELL,
+    reportUiEvent: () => {},
+    reportEngineInterrupt: () => {},
+  } as unknown as RemoteOrchestrator
+  return { orchestrator, tasks }
+}
+
+test("a worktree vanishing under an unselected task raises the host's toast", async () => {
+  const { orchestrator, tasks } = fakeOrchestrator([HELD, task("beta")])
+  const { frame } = await renderComponent(<WorkspaceRoot orchestrator={orchestrator} />, {
+    width: 80,
+    height: 24,
+    providers: { kv: true, focus: true, dialog: true, notifications: true },
+  })
+  await settle(120)
+  // Negative control: the toast must be raised BY the transition, not by
+  // mounting a task that happens to have a worktree.
+  expect(await frame()).not.toContain("is gone")
+
+  // What the daemon actually sends when another client removes the worktree:
+  // the task survives, its `worktreePath` empties.
+  await act(async () => {
+    tasks.set([HELD, task("beta", { worktreePath: "" })])
+  })
+  await settle(120)
+  const text = await frame()
+  expect(text).toContain('Worktree for "beta" is gone')
+  // The remedy half of the message: the tabs are gone but the branch is not,
+  // which is the only reason this is a toast and not a confirm.
+  expect(text).toContain("Closed 0 tab")
+})


### PR DESCRIPTION
Batch U from `.scratch/loop-r10/arch.md`: batch B dead weight (B1, B3, B5) plus
batch D's D1. **B2 was skipped on instruction** — it edits `base-ref-cache.ts`,
which another worker holds this round. That also takes `BASE_REF_TTL_MS` off the
B1 list (it lives in that same file), which is why B1 lands as **seven** symbols
and not the eight the brief's table shows.

`TerminalTabs.tsx` (D2) untouched. Nothing outside the named files was deleted.

---

## B1 — seven exports downgraded to file-local

Each symbol's only reference is inside its own defining file, so the `export`
widened the public surface for nobody. Dropping the keyword rather than the
symbol keeps the code and shrinks the surface.

`defaultBinaryDeps`, `BinaryCandidateContext`, `KimiBinaryNotFoundError`,
`parseDirtyPaths`, `COLUMN_LABEL_KEY`, `DEFAULT_CI_PROMPT_TEMPLATE`, `FixCITask`.

**PASS criterion:** a real importer makes the build fail with "has no exported
member", so a green root `typecheck` after the change is the proof.

**Proof.** Re-ran the brief's grep per symbol; hits outside the defining file:

```
defaultBinaryDeps: 1 hits outside its own file
BinaryCandidateContext: 0 hits outside its own file
KimiBinaryNotFoundError: 0 hits outside its own file
parseDirtyPaths: 0 hits outside its own file
COLUMN_LABEL_KEY: 0 hits outside its own file
DEFAULT_CI_PROMPT_TEMPLATE: 0 hits outside its own file
FixCITask: 0 hits outside its own file
```

The one `defaultBinaryDeps` hit is the comment the brief warned about —
`test/engine/binary-default-deps.test.ts:141`, prose, not an import. Confirmed
it is still a comment, and `typecheck` agrees:

```
@sma1lboy/kobe-daemon typecheck: Exited with code 0
@sma1lboy/rove typecheck: Exited with code 0
@sma1lboy/rove-plugin-sdk typecheck: Exited with code 0
```

## B3 — two unused imports in `product.ts`

`COMPAT_CONFIG_DIR_BASENAME` / `COMPAT_STATE_DIR_BASENAME` were imported,
never used, and absent from the re-export block. The daemon's three real
consumers import them straight from `compat-env.ts` and are untouched.

**PASS criterion:** the grep the brief names returns nothing, typecheck green.

```
$ grep -n "COMPAT_STATE_DIR_BASENAME\|COMPAT_CONFIG_DIR_BASENAME" packages/kobe/src/product.ts
[exit 1]
```

## B5 — orphan i18n key: **I took fork (b), delete**

`worktrees.row.linkedTask` is gone from **both** locales in one commit.

Why (b) and not (a): the row it was written for was never built, and the TUI
worktrees page already answers "which task is this" with the branch name and
the Rove-managed badge. Adding a task-title row is a UI call for the owner, not
a byproduct of a dead-key sweep — and `git` keeps the string for whoever builds
that row. (Fork (a) is not expensive if it is ever wanted: `worktrees-page.tsx`
already has `taskIdForPath` for its delete flow, so it is a few lines plus the
harness screenshot pair.)

**PASS criterion:** the key is absent from both locales, and no `worktrees.row`
call site references it.

```
$ grep -rn "linkedTask" packages/kobe/src/tui/i18n/messages/worktrees.ts
[exit 1]

$ grep -rn 'worktrees\.row' packages/kobe/src --include='*.ts' --include='*.tsx' | grep -v i18n/messages
worktrees-page.tsx:328:  {row.branch || t("worktrees.row.detached")}
worktrees-page.tsx:342:  {t("worktrees.row.created", { age: relativeAge(row.createdAtMs) })}

$ bun scripts/check-i18n.ts
i18n check OK — 775 keys × 2 locales in sync
```

No screenshots: fork (b) renders nothing, so nothing changed on screen.

## B4 — recorded, nothing deleted

The knip false positives (fixture auth path `FIXTURE_WEB_TOKEN` /
`fixtureAuthHeaders` / `writeFixtureWebToken`, `BinaryDiscoveryDeps`,
`PollCadenceConfig` / `SpawnCaptureResult`) are untouched, as instructed.

---

## D1 — `host.tsx`: one notifiers hook for five toast paths

New `src/tui-react/workspace/use-host-notifiers.ts`. The host had five toast
paths and two of them existed only to work around hook ordering, each carrying
a comment admitting it: they wanted `selectedId`, which `useWorkspaceSelection`
produces below them. Passing `selectedId` as a **getter** removes the
constraint, so all of them build in one place:

- `notifyWorktreeGone` and `notifyActivationError` — both hand-declared early,
  both comments deleted with the workaround they explained.
- `notifyNeedsInput` — was constructed inline inside the `useWorkspaceTaskActions`
  argument list.
- `notifyError` / `notifyInfo` — moved out of `useSidebarHostState`, which now
  keeps only the sort pref and move mode and no longer takes `notif` or
  `selectedId`.

`notifyActivationError` **collapsed into `notifyError`** rather than being
carried over. They differed in one field, `taskId` (`""` vs the selection), and
that field is bookkeeping: `ToastOverlay` draws kind, title and body only, and
`grep` finds no consumer of the notifications context's `unread` map anywhere.
So the two are identical on screen, and the separate one only existed because
`notifyError` could not be built yet.

`host.tsx` 452 → **444** lines. No file crosses the cap; no seam claim beyond
this one — the file is a composition root and splitting it would make two.

### PASS criterion and proof

The brief's criterion: the mounted-host test, because `WorkspaceRoot` is
exported precisely so the render track can prove wiring a hook-level test would
miss. New `test/render/host-worktree-gone-toast.test.tsx` mounts the REAL
`WorkspaceRoot` and drives the tasks signal the daemon writes — a task's
`worktreePath` going non-empty → empty — then asserts the toast text on the
frame.

That path specifically, because `useWorkspaceSelection` takes
`notifyWorktreeGone` and `notifyError` as **optional** arguments: dropping
those wires is not a type error, it is a toast that silently stops appearing.
Every other notifier is a **required** parameter on its consumer
(`use-inbox-host`, `host-task-actions`, `use-scratch-shell`, `use-issue-chat`,
`quick-fork`, `use-editor-handles`, `open-task-worktree`), so those wires are
held by the typechecker.

**Mutation-verified at two different sites** — the test is red without the fix,
in both halves:

| mutation | site | result |
|---|---|---|
| drop `notifyWorktreeGone,` from the `useWorkspaceSelection` call | the wire | `0 pass / 1 fail` |
| remove `<ToastOverlay />` from the render tree | the render half | `0 pass / 1 fail` |

Both restored; `host.tsx` verified byte-identical to the fixed version after.

### Gates

```
bun run lint                    Checked 1412 files. No fixes applied.
bun run typecheck               all four packages exit 0
bun test test/render            464 pass, 0 fail   (baseline 463 — the +1 is this test)
bun run test:fast               Test Files 440 passed (440) / Tests 4377 passed (4377)
bun scripts/check-changeset.mjs OK
```

### Coverage — no exemption needed

Measured on a pristine tree before starting, and again after. The render-track
floor is 50% lines; all three touched `tui-react` files clear it, and the two I
changed went **up**:

| file | before | after |
|---|---|---|
| `workspace/host.tsx` | 270/310 = 87.1% | **277/309 = 89.6%** |
| `workspace/use-host-notifiers.ts` | *(new)* | **17/18 = 94.4%** |
| `panes/sidebar/use-sidebar-host-state.tsx` | 11/20 = 55.0% | **9/16 = 56.3%** |

### Screenshots: none, and why

No toast changes appearance. `ToastOverlay` reads only `kind`, `title` and
`body`; every notifier keeps the kind and the string it had, and the one field
that moved (`taskId`) is not read by anything that renders. The frame assertions
in the mounted-host test are the pixel-level claim. Per the task contract's
"if any toast's appearance changes at all" clause, there was nothing to
photograph — say so rather than attach a decorative pair.

---

## Not done / surfaced rather than fixed

- **B2 skipped on instruction** (`base-ref-cache.ts` is held by another worker),
  which also excludes `BASE_REF_TTL_MS` from B1. Both need re-dispatch.
- **Observation, deliberately not acted on:** `useSidebarHostState` still
  exports a raw `setSortMode` on its interface, and its header documents a
  "KNOWN DRIFT" between the tmux Tasks pane and the workspace host. `grep`
  finds no production consumer of `setSortMode` and the hook now has exactly
  one caller (`host.tsx`), so the second host that comment describes appears to
  be gone. That is the same shape as B1 but was not in the brief, and telling
  the difference between a stale comment and a missing follow effect needs more
  than a grep — leaving it for a round that can own the question.
