### PR TITLE
loop-r10 A: fan out a round from the TUI, and show `↑N` so its result is readable

### DIFF
--- a/.changeset/sidebar-ahead-chip.md
+++ b/.changeset/sidebar-ahead-chip.md
@@ -1,0 +1,12 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Sidebar task rows carry `↑N` — commits the worktree has that its base does not.
+Committing empties `+N` / `−N`, so a worker that shipped its work and one that
+reported success and shipped nothing rendered the identical blank row; you found
+out which at land time, as `EMPTY_BRANCH`. The collector now measures both
+directions in one `git rev-list --left-right --count <base>...HEAD` — the same
+process that already produced `↓N`, so this costs no extra fork per poll and the
+two numbers can never straddle a commit. `↑N` leads the chip group in the success
+tone, and like `↓N` it is absent rather than zero when no base ref resolves.

--- a/.changeset/tui-fan-out-round.md
+++ b/.changeset/tui-fan-out-round.md
@@ -1,0 +1,19 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Fan out a round of attempts without leaving the TUI. The fork composer
+(`ctrl+a` `f`) grows an ATTEMPTS row: pick 2-5 and the same prompt starts that
+many siblings of one round, sharing one round id, so `rove api collect --group
+<id>` reports them together — something no TUI-created task could do before,
+because `groupId` had no reach in the TUI at all. Rove's headline gesture,
+"many attempts at one prompt", existed only as a shell command until now.
+
+A round does not move you: the siblings appear in the sidebar and start working
+while focus stays on the task you fired from, the way `rove api add` is
+focus-preserving unless you pass `--activate`. A single attempt is unchanged —
+it still carries you into the child, because that one is "carry on from here".
+The chip stops at 5 where the CLI allows 10; Orchestration calls 3-4 the sweet
+spot, and past five the shell command is the better tool. Siblings that fail to
+start are named in one toast and are never deleted — their engines are already
+running.

--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -45,7 +45,7 @@ shows only actions that can run right now.
 
 | Sequence | Action |
 |---|---|
-| `ctrl+a` `f` | New-conversation dialog, preset to "fork a child task": new managed worktree, branched off this Task's branch |
+| `ctrl+a` `f` | New-conversation dialog, preset to "fork a child task": new managed worktree, branched off this Task's branch. Its ATTEMPTS row fans one prompt out to a round of up to 5 |
 | `ctrl+a` `c` | New-conversation dialog, preset to "continue this chat" in a new tab of the same Task directory |
 | `ctrl+a` `i` | Open the Inbox |
 | `ctrl+a` `h` / `l` | Move focus left / right across panes |

--- a/docs/ORCHESTRATION.md
+++ b/docs/ORCHESTRATION.md
@@ -58,7 +58,8 @@ rove api add --repo "$PWD" --agents claude:2,codex:1 \
 
 Ground rules that make rounds worth running:
 
-- **3–4 attempts is the sweet spot.** The hard cap is 10, but comparing ten
+- **3–4 attempts is the sweet spot.** The hard cap is 10 from a shell and 5
+  from the TUI's fork composer (`ctrl+a` `f`, ATTEMPTS row), but comparing ten
   diffs costs more than it buys. Fan out wide only when attempts are cheap to
   judge (a failing test either passes or it doesn't).
 - **The prompt is the whole brief.** Workers don't share your conversation;

--- a/docs/TUI.md
+++ b/docs/TUI.md
@@ -383,9 +383,19 @@ built-in source can also hand off to a different built-in or custom target.
 A custom source has no readable transcript, so Rove refuses to continue it
 instead of opening a context-free tab.
 
-**Fork a child task** opens the quick composer (prompt, engine, branch). The
-child branches from your task's **current branch**, so committed work carries
-over. Uncommitted changes stay behind; commit first if the child needs them.
+**Fork a child task** opens the quick composer (prompt, attempts, engine,
+branch). The child branches from your task's **current branch**, so committed
+work carries over. Uncommitted changes stay behind; commit first if the child
+needs them.
+
+**Attempts** fans the same prompt out to a round of up to 5 siblings, the
+keyboard path to `rove api add --count N --prompt …`. They share one round id,
+so `rove api collect --group <id>` reports them together. A round does not move
+you: the siblings appear in the sidebar and start working while you stay on the
+task you fired from — only a single attempt still carries you into the child,
+because that one is "carry on from here". The chip stops at 5 where the CLI
+allows 10; [Orchestration](ORCHESTRATION.md) calls 3-4 the sweet spot, and past
+five the shell command is the better tool.
 
 `ctrl+a` `c` (continue in a new tab) and `ctrl+a` `f` (fork a child task)
 open the same dialog with the toggles pre-set.

--- a/docs/TUI.md
+++ b/docs/TUI.md
@@ -50,11 +50,18 @@ Task rows carry worktree-level facts:
 |---|---|
 | `▴` | Pinned Task |
 | `+N` / `−N` | Changed and deleted files in the worktree |
+| `↑N` / `↓N` | Commits this worktree has that its base does not, and the ones the base has that it does not |
 | `◇` / `◆` / `†` / `×` | Status is `in_review`, `done`, `canceled`, or `error` |
 | `✓` / `✗` / `•` | Pull-request checks passing, failing, or pending |
 | `≠` | The pull request conflicts with its base branch |
 | `»` / `≡` | The pull request is approved and clear to merge, or already merged |
 | jump digit | The `ctrl+2` … `ctrl+0` shortcut currently assigned to this row |
+
+`↑N` is the one mark that outlives a commit: committing empties `+N` / `−N`, so
+without it a worker that committed its work and one that reported success and
+delivered nothing render the same blank row — a difference you would otherwise
+meet at land time, as `EMPTY_BRANCH`. `↑N` and `↓N` are absent rather than zero
+when no base branch resolves, so a repo with no remote reads as it always did.
 
 The status mark is what a person said about the Task; the check mark next to it
 is what CI reports, so the two can disagree. `»` answers a third question the

--- a/packages/kobe-daemon/src/daemon/contracts.ts
+++ b/packages/kobe-daemon/src/daemon/contracts.ts
@@ -443,4 +443,16 @@ export interface WorktreeChanges {
    * rather than reporting a fabricated zero.
    */
   readonly behind?: number
+  /**
+   * Commits this worktree has that its base does NOT (the right half of `git
+   * rev-list --left-right --count <base>...HEAD`). Absent under exactly the
+   * same conditions as `behind` — they come off one process — so a repo with
+   * no resolvable base reports neither rather than a fabricated zero.
+   *
+   * This is the only number that separates a worker that committed (clean
+   * worktree, `ahead > 0`) from one that reported success and delivered
+   * nothing (clean worktree, `ahead === 0`); without it both rows render
+   * blank and the difference only surfaces at land time as `EMPTY_BRANCH`.
+   */
+  readonly ahead?: number
 }

--- a/packages/kobe-daemon/src/daemon/worktree-changes-collector.ts
+++ b/packages/kobe-daemon/src/daemon/worktree-changes-collector.ts
@@ -72,7 +72,11 @@ function isRemoteRepoKey(value: string): boolean {
 }
 
 function sameWorktreeChanges(a: WorktreeChanges, b: WorktreeChanges): boolean {
-  return a.added === b.added && a.deleted === b.deleted && a.behind === b.behind
+  // `ahead` belongs here for the same reason `behind` does: a field the
+  // publisher does not compare is a field whose chip freezes at whatever it
+  // read first — the row would show `↑1` forever while the worker kept
+  // committing.
+  return a.added === b.added && a.deleted === b.deleted && a.behind === b.behind && a.ahead === b.ahead
 }
 
 /** Tick cadence — matches the sidebar's ~2s `branchTick` the pane pollers rode. */
@@ -136,9 +140,10 @@ function runGit(worktreePath: string, args: readonly string[], signal: AbortSign
 }
 
 /**
- * How far the worktree is BEHIND `baseRef`. `null` when the ref does not
- * resolve or the count is unreadable — the chip then does not draw, which is
- * the honest answer for a repo with no base rather than a fabricated zero.
+ * How far the worktree has drifted from `baseRef`, both ways, in ONE process.
+ * `null` when the ref does not resolve or the counts are unreadable — the
+ * chips then do not draw, which is the honest answer for a repo with no base
+ * rather than a fabricated zero.
  *
  * The daemon does NOT own the `origin/HEAD → origin/main → main → master`
  * fallback ladder: that lives in kobe's `cli/api/branch-signals.ts`, and the
@@ -146,11 +151,36 @@ function runGit(worktreePath: string, args: readonly string[], signal: AbortSign
  * before calling in. This default runner (tests, and any daemon wired without
  * a runtime) only measures against a base it was handed.
  */
-async function countBehind(worktreePath: string, baseRef: string, signal: AbortSignal): Promise<number | null> {
-  const out = await runGit(worktreePath, ["rev-list", "--count", `HEAD..${baseRef}`], signal)
-  if (out === null) return null
-  const n = Number.parseInt(out.trim(), 10)
-  return Number.isInteger(n) && n >= 0 ? n : null
+async function countDrift(worktreePath: string, baseRef: string, signal: AbortSignal): Promise<AheadBehind | null> {
+  return parseAheadBehind(
+    await runGit(worktreePath, ["rev-list", "--left-right", "--count", `${baseRef}...HEAD`], signal),
+  )
+}
+
+/** Both halves of one drift measurement. */
+export interface AheadBehind {
+  readonly behind: number
+  readonly ahead: number
+}
+
+/**
+ * Parse `git rev-list --left-right --count <base>...HEAD`, whose one line is
+ * `<behind>\t<ahead>` — left is the base side (commits the base has that we
+ * do not), right is ours. `null` for anything that is not two non-negative
+ * integers, including the `null` a failed run hands in: a half-read line must
+ * leave BOTH numbers absent rather than let one of them be guessed.
+ *
+ * @public — imported by kobe's production runner (`core/daemon-runtime.ts`) so
+ * the two collection paths cannot disagree about what the counts mean.
+ */
+export function parseAheadBehind(stdout: string | null): AheadBehind | null {
+  if (stdout === null) return null
+  const parts = stdout.trim().split(/\s+/)
+  if (parts.length !== 2) return null
+  const behind = Number.parseInt(parts[0] ?? "", 10)
+  const ahead = Number.parseInt(parts[1] ?? "", 10)
+  if (!Number.isInteger(behind) || behind < 0 || !Number.isInteger(ahead) || ahead < 0) return null
+  return { behind, ahead }
 }
 
 /** Aggregate `git status --porcelain=v1` output into `+N −M`. */
@@ -166,7 +196,7 @@ export function countPorcelain(stdout: string): { added: number; deleted: number
 }
 
 /** The default runner: async `git status --porcelain=v1`, lock-free read,
- *  plus the behind-count when a base ref was supplied. */
+ *  plus the ahead/behind drift when a base ref was supplied. */
 export async function runGitStatus(
   worktreePath: string,
   signal: AbortSignal,
@@ -176,8 +206,8 @@ export async function runGitStatus(
   if (stdout === null) throw new Error("git status failed")
   const counts = countPorcelain(stdout)
   if (!baseRef) return counts
-  const behind = await countBehind(worktreePath, baseRef, signal)
-  return behind === null ? counts : { ...counts, behind }
+  const drift = await countDrift(worktreePath, baseRef, signal)
+  return drift === null ? counts : { ...counts, ...drift }
 }
 
 /**

--- a/packages/kobe/src/client/remote-orchestrator-payloads.ts
+++ b/packages/kobe/src/client/remote-orchestrator-payloads.ts
@@ -115,14 +115,15 @@ export function parseWorktreeChangesPayload(payload: unknown): Map<string, Workt
   if (!changes || typeof changes !== "object" || Array.isArray(changes)) return null
   const map = new Map<string, WorktreeChanges>()
   for (const [path, value] of Object.entries(changes as Record<string, unknown>)) {
-    const counts = value as { added?: unknown; deleted?: unknown; behind?: unknown } | undefined
+    const counts = value as { added?: unknown; deleted?: unknown; behind?: unknown; ahead?: unknown } | undefined
     if (typeof counts?.added !== "number" || typeof counts.deleted !== "number") return null
-    // `behind` is additive: an older daemon omits it, and the chip then simply
-    // does not draw — never a fabricated zero.
+    // `behind` and `ahead` are both additive: an older daemon omits them, and
+    // the chip then simply does not draw — never a fabricated zero.
     map.set(path, {
       added: counts.added,
       deleted: counts.deleted,
       ...(typeof counts.behind === "number" ? { behind: counts.behind } : {}),
+      ...(typeof counts.ahead === "number" ? { ahead: counts.ahead } : {}),
     })
   }
   return map

--- a/packages/kobe/src/client/remote-orchestrator.ts
+++ b/packages/kobe/src/client/remote-orchestrator.ts
@@ -15,6 +15,7 @@
 import type { KobeDaemonClient } from "@sma1lboy/kobe-daemon/client"
 import { logClient, logClientError } from "@sma1lboy/kobe-daemon/client/client-log"
 import { ensureDaemonReachable } from "@sma1lboy/kobe-daemon/client/daemon-process"
+import type { DaemonRpcClient } from "@sma1lboy/kobe-daemon/client/rpc"
 import type { RepoIssues } from "@sma1lboy/kobe-daemon/daemon/issues-store"
 import {
   type ChannelName,
@@ -312,6 +313,19 @@ export class RemoteOrchestrator {
 
   /** Latest `tab.close` request (pane or exact Terminal Tab) — consumers dedupe on `at`. */
   readonly tabCloseStore = (): ExternalStore<TabClosePayload | null> => this.tabCloseAcc
+
+  /**
+   * The bare request/response seam onto this orchestrator's daemon, for the
+   * few callers that need a verb this class does not wrap — today the
+   * quick-fork ROUND, whose siblings are delivered by `core/`'s headless
+   * session starter rather than by a mounted pane.
+   *
+   * Deliberately narrowed to {@link DaemonRpcClient}: exposing the socket
+   * client itself would hand callers `subscribe`/`close`, and a second
+   * subscriber or an accidental close would take the whole UI's event stream
+   * down with it.
+   */
+  readonly rpc: DaemonRpcClient = { request: (name, payload) => this.client.request(name, payload) }
 
   replyTerminalTabClose = (requestId: string, closed: boolean): void =>
     writes.replyTabCloseOp(this.client, requestId, closed)

--- a/packages/kobe/src/core/behind-cache.ts
+++ b/packages/kobe/src/core/behind-cache.ts
@@ -1,12 +1,15 @@
 /**
- * Behind-count memo for the daemon's per-worktree polls.
+ * Base-drift memo for the daemon's per-worktree polls.
  *
  * `git rev-list --count HEAD..<base>` was half of the collector's process
  * budget — 570 of 1280 spawns in a 62-second idle measurement, 1:1 with the
  * `git status` walks — even though the answer can only move when HEAD moves
  * or the base ref moves. Both are ref files, so this keys the count on the
  * two SHAs read straight off disk (loose ref, else `packed-refs`) and skips
- * the spawn while they are unchanged.
+ * the spawn while they are unchanged. Ahead and behind come off ONE
+ * `--left-right` process and share the key: both halves can only move when one
+ * of those two refs moves, so caching them separately would key the same fact
+ * twice.
  *
  * Fails safe in both directions: a sha that will not read (detached
  * odd states, an unreadable git dir, a ref this reader does not know how to
@@ -18,13 +21,13 @@
 
 import { readHeadSha, readRefSha, resolveGitDirs } from "@sma1lboy/kobe-daemon/daemon/worktree-probe"
 
-interface BehindEntry {
+interface DriftEntry {
   readonly head: string
   readonly base: string
-  readonly behind: number
+  readonly value: unknown
 }
 
-const cache = new Map<string, BehindEntry>()
+const cache = new Map<string, DriftEntry>()
 
 /** Test seam — the daemon keeps one process-wide cache. */
 export function resetBehindCache(): void {
@@ -41,20 +44,25 @@ function readShas(worktreePath: string, baseRef: string): { head: string; base: 
 }
 
 /**
- * The behind-count for `worktreePath` vs `baseRef`, computed by `compute`
- * only when the ref shas say it could have changed. `compute` returns `null`
- * for an unusable answer (non-zero exit, unparseable) and that is passed
- * straight through without being cached.
+ * The base drift for `worktreePath` vs `baseRef`, computed by `compute` only
+ * when the ref shas say it could have changed. `compute` returns `null` for an
+ * unusable answer (non-zero exit, unparseable) and that is passed straight
+ * through without being cached.
+ *
+ * Generic in the value because what one measurement of "how far apart are
+ * these two refs" yields is the caller's business — a lone behind-count, or
+ * the ahead/behind pair the sidebar chips need — while the invalidation rule
+ * is the same either way.
  */
-export async function behindCountCached(
+export async function driftCached<T>(
   worktreePath: string,
   baseRef: string,
-  compute: () => Promise<number | null>,
-): Promise<number | null> {
+  compute: () => Promise<T | null>,
+): Promise<T | null> {
   const shas = readShas(worktreePath, baseRef)
   const hit = shas ? cache.get(worktreePath) : undefined
-  if (shas && hit && hit.head === shas.head && hit.base === shas.base) return hit.behind
-  const behind = await compute()
-  if (shas && behind !== null) cache.set(worktreePath, { ...shas, behind })
-  return behind
+  if (shas && hit && hit.head === shas.head && hit.base === shas.base) return hit.value as T
+  const value = await compute()
+  if (shas && value !== null) cache.set(worktreePath, { ...shas, value })
+  return value
 }

--- a/packages/kobe/src/core/daemon-runtime.ts
+++ b/packages/kobe/src/core/daemon-runtime.ts
@@ -1,6 +1,7 @@
 /** Production Adapter for the daemon package's consumer-owned runtime seam. */
 
 import type { DaemonRuntimeAdapter } from "@sma1lboy/kobe-daemon/daemon/runtime"
+import { parseAheadBehind } from "@sma1lboy/kobe-daemon/daemon/worktree-changes-collector"
 import { availableEngineIds } from "../engine/account-detect.ts"
 import { engineProtocolKey } from "../engine/engine-presets.ts"
 import { foregroundEngineIn, parsePsSnapshot, psSnapshot } from "../engine/foreground.ts"
@@ -29,7 +30,7 @@ import { handleHistoryRequest } from "../web/history.ts"
 import { handleNotesRequest } from "../web/notes.ts"
 import { handleThemesRequest } from "../web/themes.ts"
 import { resolveBaseRefCached } from "./base-ref-cache.ts"
-import { behindCountCached } from "./behind-cache.ts"
+import { driftCached } from "./behind-cache.ts"
 import {
   deliverPromptToLiveEngineAdapter,
   deliverPromptToLiveEngineDetailedAdapter,
@@ -106,26 +107,28 @@ export const daemonRuntime: DaemonRuntimeAdapter = {
     })
     if (result.status !== 0) throw new Error("git status failed")
     const counts = parsePorcelain(result.stdout)
-    // The behind-base drift, on the SAME guarded run as the status walk so it
-    // inherits its in-flight dedupe, timeout and backoff. The base resolution
-    // ladder lives here rather than in the daemon: `resolveBaseRef` is kobe's,
-    // and kobe-daemon does not import kobe sources.
+    // The base drift BOTH ways, on the SAME guarded run as the status walk so
+    // it inherits its in-flight dedupe, timeout and backoff. One
+    // `--left-right --count` process yields behind and ahead together: two
+    // separate counts would cost a second fork per poll per worktree and
+    // could straddle a commit, reporting a pair that never coexisted. The
+    // base resolution ladder lives here rather than in the daemon:
+    // `resolveBaseRef` is kobe's, and kobe-daemon does not import kobe
+    // sources.
     const base = await resolveBaseRefCached(worktreePath, baseRef, signal)
     if (!base) return counts
-    // Memoised on the HEAD/base shas read from the ref files: the count can
-    // only move when one of them does, and re-deriving it every tick was half
-    // the collector's spawns.
-    const n = await behindCountCached(worktreePath, base, async () => {
-      const behind = await spawnCapture("git", ["rev-list", "--count", `HEAD..${base}`], {
+    // Memoised on the HEAD/base shas read from the ref files: the counts can
+    // only move when one of them does, and re-deriving them every tick was
+    // half the collector's spawns.
+    const drift = await driftCached(worktreePath, base, async () => {
+      const out = await spawnCapture("git", ["rev-list", "--left-right", "--count", `${base}...HEAD`], {
         cwd: worktreePath,
         env: readOnlyGitProcessEnv(),
         signal,
       })
-      if (behind.status !== 0) return null
-      const parsed = Number.parseInt(behind.stdout.trim(), 10)
-      return Number.isInteger(parsed) && parsed >= 0 ? parsed : null
+      return out.status === 0 ? parseAheadBehind(out.stdout) : null
     })
-    return n === null ? counts : { ...counts, behind: n }
+    return drift === null ? counts : { ...counts, ...drift }
   },
   maybeAutoStart: (orch, taskId) => maybeAutoStart(orch as Orchestrator, taskId),
   listWorktreeProjects: listWorktreeProjectsAdapter,

--- a/packages/kobe/src/core/round.ts
+++ b/packages/kobe/src/core/round.ts
@@ -1,0 +1,41 @@
+/**
+ * The pure half of "fan out N attempts at one prompt" — turning an attempt
+ * COUNT into the list of `createTask` inputs a round is made of.
+ *
+ * Its own module, and pure, because the round's two invariants are the ones a
+ * live run cannot show you: every sibling carries the SAME `groupId` (or
+ * `collect --group` finds nothing and the round is three loose tasks), and the
+ * `#i/N` ordinals line up with creation order. Both are asserted here rather
+ * than inferred from a screenshot.
+ *
+ * The shape deliberately matches `cli/api/handlers-add.ts`'s fan-out, so a
+ * round started from the TUI and one started by `rove api add --count` are
+ * indistinguishable on the row and to `collect`.
+ */
+
+import { ulid } from "../orchestrator/index/ulid.ts"
+
+/** One sibling's create input: what the round adds on top of the caller's own. */
+export interface RoundSibling {
+  /** Shared by every sibling of one round; absent for a single attempt. */
+  readonly groupId?: string
+  /** `<title> #i/N`, or the bare title for a single attempt; absent with no title. */
+  readonly title?: string
+}
+
+/**
+ * Plan `attempts` siblings.
+ *
+ * `attempts <= 1` returns ONE sibling with no `groupId` and an unsuffixed
+ * title: a lone fork is not a round, and marking it as one would make
+ * `collect --group` report a "round" of a single task.
+ */
+export function planRound(attempts: number, title?: string): readonly RoundSibling[] {
+  const n = Math.max(1, Math.trunc(attempts))
+  if (n === 1) return [title ? { title } : {}]
+  const groupId = ulid()
+  return Array.from({ length: n }, (_, i) => ({
+    groupId,
+    ...(title ? { title: `${title} #${i + 1}/${n}` } : {}),
+  }))
+}

--- a/packages/kobe/src/tui-react/component/quick-task-bindings.ts
+++ b/packages/kobe/src/tui-react/component/quick-task-bindings.ts
@@ -15,10 +15,11 @@
 
 import type { Binding } from "../lib/keymap"
 
-export type QuickTaskField = "prompt" | "engine" | "branch"
+export type QuickTaskField = "prompt" | "attempts" | "engine" | "branch"
 
 export interface QuickTaskBindingHandlers {
   cycleField: (dir: 1 | -1) => void
+  stepAttempts: (dir: 1 | -1) => void
   stepEngine: (dir: 1 | -1) => void
   commit: () => void
   /** ctrl+v: read the OS clipboard for an image/file attachment. */
@@ -38,10 +39,18 @@ export function quickTaskBindings(field: QuickTaskField, h: QuickTaskBindingHand
     // reach a clipboard IMAGE, which the terminal can't deliver as text.
     { key: "ctrl+v", cmd: () => h.pasteAttachment() },
     { key: "ctrl+x", cmd: () => h.removeLastAttachment() },
+    // Both chip rows claim ←/→ and enter for the same reason: a chip row has
+    // no input to move a cursor in or to fire onSubmit. The gating stays at
+    // REGISTRATION (see the header) so the text fields keep both.
+    ...(field === "attempts"
+      ? [
+          { key: "left", cmd: () => h.stepAttempts(-1) },
+          { key: "right", cmd: () => h.stepAttempts(1) },
+          { key: "return", cmd: () => h.commit() },
+        ]
+      : []),
     ...(field === "engine"
       ? [
-          // ←/→ cycle the engine; enter commits (a chip row has no input
-          // to fire onSubmit — the text fields commit via theirs).
           { key: "left", cmd: () => h.stepEngine(-1) },
           { key: "right", cmd: () => h.stepEngine(1) },
           { key: "return", cmd: () => h.commit() },

--- a/packages/kobe/src/tui-react/component/quick-task-composer.tsx
+++ b/packages/kobe/src/tui-react/component/quick-task-composer.tsx
@@ -3,10 +3,18 @@
  * Prompt-first quick-task composer (`<prefix> f`).
  *
  * The quick path is prompt-first: the PROMPT field is focused on open and
- * `enter` from it creates the task immediately. Engine and branch are right
- * there too — `tab` cycles prompt → engine → branch, `ctrl+e` (or ←/→ on the
- * engine field) switches engine — but they default from the firing task, so
- * the common path is just "type a prompt, hit enter".
+ * `enter` from it creates the task immediately. Attempts, engine and branch
+ * are right there too — `tab` cycles prompt → attempts → engine → branch,
+ * `ctrl+e` (or ←/→ on the engine field) switches engine — but they default
+ * from the firing task, so the common path is just "type a prompt, hit
+ * enter".
+ *
+ * ATTEMPTS is what makes this the product's headline gesture rather than a
+ * one-task shortcut: picking N > 1 fans the SAME prompt out to N siblings of
+ * one round. It stops at 5 while `rove api add --count` allows 10 —
+ * `docs/ORCHESTRATION.md` calls 3-4 the sweet spot, and a chip row of ten
+ * choices is a worse dialog than the shell command you would reach for to
+ * exceed five.
  *
  * This is deliberately NOT the full `NewTaskDialog` (repo picker, clone/adopt
  * tabs) and NOT `RenameTaskDialog` (whose field is literally labelled
@@ -46,10 +54,15 @@ export interface QuickTaskResult {
   readonly baseRef: string
   /** Absolute file paths (images/PDFs) to reference alongside the prompt. */
   readonly attachments: readonly string[]
+  /** How many siblings to fan this prompt out to. `1` is the plain fork. */
+  readonly attempts: number
 }
 
-type Field = "prompt" | "engine" | "branch"
-const FIELDS: readonly Field[] = ["prompt", "engine", "branch"]
+/** The choices the ATTEMPTS row offers. See the file header for why it stops at 5. */
+export const ATTEMPT_CHOICES: readonly string[] = ["1", "2", "3", "4", "5"]
+
+type Field = "prompt" | "attempts" | "engine" | "branch"
+const FIELDS: readonly Field[] = ["prompt", "attempts", "engine", "branch"]
 
 function QuickTaskComposerView(
   props: QuickTaskComposerOptions & {
@@ -63,6 +76,7 @@ function QuickTaskComposerView(
   const padX = useDialogPaddingX()
   const [field, setField] = useState<Field>("prompt")
   const [prompt, setPrompt] = useState("")
+  const [attempts, setAttempts] = useState(1)
   const [vendor, setVendor] = useState<VendorId>(props.defaultVendor)
   const [baseRef, setBaseRef] = useState(props.defaultBaseRef)
   const [attachments, setAttachments] = useState<readonly string[]>([])
@@ -92,6 +106,12 @@ function QuickTaskComposerView(
       return FIELDS[(i + dir + FIELDS.length) % FIELDS.length] ?? "prompt"
     })
   }
+  function stepAttempts(dir: 1 | -1): void {
+    // Clamped, not wrapped: ←  from 1 stays on 1. The engine row cycles because
+    // every engine is equivalent; here 1 and 5 are opposite ends of a scale, and
+    // one keypress past the end must not fan out five attempts.
+    setAttempts((n) => Math.min(ATTEMPT_CHOICES.length, Math.max(1, n + dir)))
+  }
   function stepEngine(dir: 1 | -1): void {
     const list = props.engines
     if (list.length === 0) return
@@ -117,6 +137,7 @@ function QuickTaskComposerView(
       vendor,
       baseRef: baseRef.trim() || props.defaultBaseRef,
       attachments,
+      attempts,
     })
     dialog.clear()
   }
@@ -134,6 +155,7 @@ function QuickTaskComposerView(
     enabled: true,
     bindings: quickTaskBindings(field, {
       cycleField,
+      stepAttempts,
       stepEngine,
       commit,
       pasteAttachment,
@@ -178,6 +200,22 @@ function QuickTaskComposerView(
             ))}
           </box>
         ) : null}
+
+        <DialogSection
+          label={t("quickTask.attemptsLabel")}
+          focused={field === "attempts"}
+          hint="←/→"
+          onPress={() => setField("attempts")}
+        >
+          <ChipRow
+            choices={ATTEMPT_CHOICES}
+            selected={String(attempts)}
+            onPick={(v) => {
+              setAttempts(Number(v))
+              setField("attempts")
+            }}
+          />
+        </DialogSection>
 
         <DialogSection
           label={t("quickTask.engineLabel")}

--- a/packages/kobe/src/tui-react/panes/sidebar/row-cards.tsx
+++ b/packages/kobe/src/tui-react/panes/sidebar/row-cards.tsx
@@ -62,18 +62,31 @@ export function useChanges(
  * the flexible middle column. This keeps every row scannable at the same
  * visual anchor even when a branch/title is long. Shared with the tree rows.
  *
- * `+N −M` count UNCOMMITTED files; `↓K` counts COMMITS the base has that this
- * worktree does not. It sits last and in the warning tone because it is the
- * only one of the three that is not about work the row did: main moves several
- * times a day, and an attempt that has been running for two hours is building
- * against a base that no longer exists. Absent (not zero) when no base ref
- * resolves, so a repo with no remote reads exactly as it always did. */
+ * `+N −M` count UNCOMMITTED files; `↑J` counts COMMITS this worktree has that
+ * its base does not, and `↓K` the ones the base has that it does not. `↑J`
+ * leads, in the success tone, because it is the row's own delivered work — and
+ * because committing empties `+N −M`, it is the ONLY thing that separates a
+ * worker that shipped from one that reported success and shipped nothing. `↓K`
+ * sits last and in the warning tone because it is the only one that is not
+ * about work the row did: main moves several times a day, and an attempt that
+ * has been running for two hours is building against a base that no longer
+ * exists. Both are absent (not zero) when no base ref resolves, so a repo with
+ * no remote reads exactly as it always did.
+ *
+ * `↑`/`↓` are U+2191/U+2193 (Arrows) — single-width in every monospace font we
+ * target, same coverage rule the `row-view.ts` glyph comments record. */
 export function ChangeStats(props: { readonly changes: WorktreeChanges }) {
   const { theme } = useTheme()
+  const ahead = props.changes.ahead ?? 0
   const behind = props.changes.behind ?? 0
-  if (props.changes.added <= 0 && props.changes.deleted <= 0 && behind <= 0) return null
+  if (props.changes.added <= 0 && props.changes.deleted <= 0 && ahead <= 0 && behind <= 0) return null
   return (
     <box flexDirection="row" gap={1} flexShrink={0}>
+      {ahead > 0 ? (
+        <text fg={theme.success} wrapMode="none" flexShrink={0}>
+          ↑{ahead}
+        </text>
+      ) : null}
       {props.changes.added > 0 ? (
         <text fg={theme.success} wrapMode="none" flexShrink={0}>
           +{props.changes.added}

--- a/packages/kobe/src/tui-react/panes/sidebar/tree-rows.tsx
+++ b/packages/kobe/src/tui-react/panes/sidebar/tree-rows.tsx
@@ -239,6 +239,7 @@ export function WorktreeTreeRow(props: {
     (conflict ? 2 : 0) +
     (review ? 2 : 0) +
     (status ? 2 : 0) +
+    ((changes.ahead ?? 0) > 0 ? clusterCells(`↑${changes.ahead}`) : 0) +
     (changes.added > 0 ? clusterCells(`+${changes.added}`) : 0) +
     (changes.deleted > 0 ? clusterCells(`−${changes.deleted}`) : 0) +
     ((changes.behind ?? 0) > 0 ? clusterCells(`↓${changes.behind}`) : 0) +

--- a/packages/kobe/src/tui-react/workspace/host.tsx
+++ b/packages/kobe/src/tui-react/workspace/host.tsx
@@ -168,7 +168,13 @@ export function WorkspaceRoot(props: { orchestrator: RemoteOrchestrator }) {
   // `quick-fork.ts` because the create/enter/pending-prompt shape is identical
   // regardless of host — the other caller is TerminalTabs, and both must stay
   // one implementation.
-  const quickFork = useQuickFork(orch, { selectTask: setSelectedId, enterTask: activateTask, notifyError })
+  const quickFork = useQuickFork(orch, {
+    selectTask: setSelectedId,
+    enterTask: activateTask,
+    notifyError,
+    notify: notifyInfo,
+    t,
+  })
 
   // Scratch temp shell tasks — open gesture, exit deletion, and
   // the quiet adoption loop all live in the hook.

--- a/packages/kobe/src/tui-react/workspace/quick-fork-round.ts
+++ b/packages/kobe/src/tui-react/workspace/quick-fork-round.ts
@@ -1,0 +1,116 @@
+/**
+ * Fan a quick-fork prompt out to N siblings of ONE round — the keyboard path
+ * to what `rove api add --count N --prompt …` does from a shell.
+ *
+ * Its own module because the round differs from the single fork in every
+ * respect that matters, and folding it into `quick-fork.ts` would hide that:
+ *
+ * - it mints a `groupId` and stamps it on every sibling, which is the only
+ *   thing that makes `rove api collect --group <id>` able to find them. Three
+ *   forks fired by hand are three loose tasks, not a round;
+ * - it does NOT select or enter any sibling. `rove api add` is focus-preserving
+ *   unless you pass `--activate`, and a round that yanks you into attempt #3 is
+ *   worse than one that leaves you where you were. A single fork keeps its
+ *   focus-stealing "carry on from here" behaviour, which is why that path stays
+ *   in `quick-fork.ts` untouched;
+ * - it therefore cannot use the pending-prompt slot, which pastes on the NEW
+ *   task's `TerminalTabs` mount and structurally holds at most one prompt.
+ *   Delivery goes through the headless session starter in `core/` — the same
+ *   one the daemon's automation runner and work-item start use — so a sibling
+ *   boots its engine with the prompt in its argv whether or not anything is
+ *   mounted on it.
+ *
+ * Creation is SERIAL and delivery CONCURRENT, matching
+ * `cli/api/handlers-add.ts`: `task.create` is a store write, and ordered
+ * creation keeps the siblings in the order you asked for them, while N engine
+ * cold-boots have no reason to queue behind each other.
+ */
+
+import { errorMessage } from "@/lib/error-message"
+import type { DaemonRpcClient } from "@sma1lboy/kobe-daemon/client/rpc"
+import { startTaskSessionWithPromptAdapter } from "../../core/daemon-session-adapter"
+import { planRound } from "../../core/round"
+import { addSavedRepo } from "../../state/repos"
+import { setRepoLastActiveVendor } from "../../state/vendor-prefs"
+import type { Task, VendorId } from "../../types/task"
+
+export interface RoundOrchestrator {
+  createTask(input: {
+    repo: string
+    baseRef: string
+    vendor: VendorId
+    groupId?: string
+    title?: string
+  }): Promise<Task>
+  setPrompt(id: string, prompt: string): Promise<void>
+  /** Request/response seam onto the owning daemon — what delivery needs. */
+  readonly rpc: DaemonRpcClient
+}
+
+export interface RoundOutcome {
+  /** Siblings whose engine session started with the prompt. */
+  readonly started: readonly string[]
+  /** Siblings that exist but whose engine never took the prompt, plus the
+   *  attempt that could not be created at all. Each entry is a human line. */
+  readonly failures: readonly string[]
+  /** Siblings that were created, started or not — the round's real size. */
+  readonly created: readonly string[]
+}
+
+/** Injectable delivery, so the round's own logic is testable without a PTY host. */
+export type RoundDeliver = (rpc: DaemonRpcClient, taskId: string, prompt: string) => Promise<boolean>
+
+const realDeliver: RoundDeliver = (rpc, taskId, prompt) => startTaskSessionWithPromptAdapter(rpc, taskId, prompt)
+
+/**
+ * Create `attempts` siblings sharing one `groupId`, then hand each the same
+ * prompt. Never throws: a round that half-succeeded still leaves real tasks
+ * with engines burning tokens, so every created id comes back and the caller
+ * reports rather than unwinds. Deleting a sibling because its neighbour failed
+ * would destroy work in progress.
+ */
+export async function runQuickForkRound(
+  orch: RoundOrchestrator,
+  repo: string,
+  input: { readonly baseRef: string; readonly vendor: VendorId; readonly prompt: string; readonly attempts: number },
+  deliver: RoundDeliver = realDeliver,
+): Promise<RoundOutcome> {
+  setRepoLastActiveVendor(repo, input.vendor)
+  addSavedRepo(repo)
+
+  const plan = planRound(input.attempts)
+  const created: string[] = []
+  const failures: string[] = []
+  for (const sibling of plan) {
+    try {
+      const task = await orch.createTask({ repo, baseRef: input.baseRef, vendor: input.vendor, ...sibling })
+      created.push(task.id)
+    } catch (err) {
+      // Stop at the first create failure — a store write that fails once will
+      // fail again — but keep the siblings already created.
+      failures.push(`create: ${errorMessage(err)}`)
+      break
+    }
+  }
+
+  const settled = await Promise.allSettled(created.map((id) => deliver(orch.rpc, id, input.prompt)))
+  const started: string[] = []
+  settled.forEach((result, i) => {
+    const id = created[i] ?? ""
+    if (result.status === "fulfilled" && result.value) {
+      started.push(id)
+      return
+    }
+    failures.push(
+      result.status === "rejected" ? `${id}: ${errorMessage(result.reason)}` : `${id}: prompt not delivered`,
+    )
+  })
+
+  // Record the brief on every CREATED sibling, delivered or not: "Run again"
+  // and `rove api get-task` both read it, and a sibling whose paste failed is
+  // exactly the one you want to re-run. Best-effort — a failed persist must
+  // not turn a started attempt into a failure.
+  await Promise.all(created.map((id) => orch.setPrompt(id, input.prompt).catch(() => undefined)))
+
+  return { started, failures, created }
+}

--- a/packages/kobe/src/tui-react/workspace/quick-fork.ts
+++ b/packages/kobe/src/tui-react/workspace/quick-fork.ts
@@ -23,6 +23,7 @@ import { DEFAULT_BASE_REF, getCurrentBranch } from "../../tui/lib/git-snapshot"
 import { repoBasename } from "../../tui/panes/sidebar/groups"
 import { DEFAULT_TASK_VENDOR, type Task, type VendorId } from "../../types/task"
 import type { QuickTaskComposerOptions, QuickTaskResult } from "../component/quick-task-composer"
+import { type RoundOrchestrator, runQuickForkRound } from "./quick-fork-round"
 
 /**
  * Seed the composer from the task a quick-fork chord fired in.
@@ -55,7 +56,7 @@ export function quickForkDefaultVendor(repo: string, detected: readonly VendorId
   return detected[0] ?? pref
 }
 
-export interface QuickForkOrchestrator {
+export interface QuickForkOrchestrator extends RoundOrchestrator {
   createTask(input: { repo: string; baseRef: string; vendor: VendorId }): Promise<Task>
   /** Record the brief on the created task — "Run again" only (see {@link runAgainTask}). */
   setPrompt(id: string, prompt: string): Promise<void>
@@ -179,13 +180,34 @@ export function useQuickFork(
     selectTask: (id: string) => void
     enterTask: (id: string) => Promise<void>
     notifyError: (message: string) => void
+    notify: (message: string) => void
+    t: (key: string, vars?: Record<string, string | number>) => string
   },
 ): UseQuickForkResult {
   const [pending, setPending] = useState<PendingInitialPrompt | null>(null)
 
   async function onQuickFork(repo: string, result: QuickTaskResult): Promise<void> {
+    const prompt = appendAttachmentRefs(result.prompt, result.attachments)
+    // A round (attempts > 1) is a different gesture, not a loop over this one:
+    // it does not steal focus and it cannot ride the single pending slot. See
+    // `quick-fork-round.ts`. One attempt keeps today's behaviour exactly.
+    if (result.attempts > 1) {
+      const outcome = await runQuickForkRound(orch, repo, { ...result, prompt, attempts: result.attempts })
+      if (outcome.failures.length > 0) {
+        hooks.notifyError(
+          `${hooks.t("quickTask.roundPartial", {
+            ok: outcome.started.length,
+            count: result.attempts,
+            failed: outcome.failures.length,
+          })}: ${outcome.failures.join("; ")}`,
+        )
+        return
+      }
+      hooks.notify(hooks.t("quickTask.startedRound", { count: outcome.started.length }))
+      return
+    }
     const taskId = await runQuickFork(orch, repo, result, hooks)
-    if (taskId) setPending({ taskId, prompt: appendAttachmentRefs(result.prompt, result.attachments) })
+    if (taskId) setPending({ taskId, prompt })
   }
 
   async function onRunAgain(task: Task): Promise<void> {

--- a/packages/kobe/src/tui/i18n/messages/quickTask.ts
+++ b/packages/kobe/src/tui/i18n/messages/quickTask.ts
@@ -11,19 +11,28 @@ export const en = {
   promptLabel: "PROMPT",
   /** Prompt input placeholder */
   promptPlaceholder: "what should this task do?",
+  /** Attempts field label — how many siblings this prompt fans out to */
+  attemptsLabel: "ATTEMPTS",
   /** Engine field label */
   engineLabel: "ENGINE",
   /** Branch field label */
   branchLabel: "BRANCH",
   /** Footer hint legend */
   legend: "enter create · tab fields · ctrl+e engine · ctrl+v attach · esc cancel",
+  /** Toast after a round of N > 1 is fired; focus deliberately stays put. */
+  startedRound: "Started {count} attempts",
+  /** Toast when some siblings of a round failed to start. */
+  roundPartial: "Started {ok}/{count} attempts — {failed} failed",
 }
 
 export const zh: typeof en = {
   title: "快速任务 · {repoLabel}",
   promptLabel: "提示词",
   promptPlaceholder: "这个任务要做什么？",
+  attemptsLabel: "尝试次数",
   engineLabel: "引擎",
   branchLabel: "分支",
   legend: "enter 创建 · tab 切换字段 · ctrl+e 引擎 · ctrl+v 附件 · esc 取消",
+  startedRound: "已启动 {count} 个尝试",
+  roundPartial: "已启动 {ok}/{count} 个尝试 —— {failed} 个失败",
 }

--- a/packages/kobe/src/tui/panes/sidebar/worktree-changes.ts
+++ b/packages/kobe/src/tui/panes/sidebar/worktree-changes.ts
@@ -49,6 +49,14 @@ export interface WorktreeChanges {
    * only reads `git status` and therefore knows nothing about the base.
    */
   readonly behind?: number
+  /**
+   * Commits this worktree has that its base does NOT, from the same
+   * `--left-right` read that produced `behind`. Absent under exactly the same
+   * conditions. It is the only chip that survives a commit: committing empties
+   * `added`/`deleted`, so without it a worker that shipped and one that
+   * shipped nothing render identically.
+   */
+  readonly ahead?: number
 }
 
 const ZERO: WorktreeChanges = { added: 0, deleted: 0 }
@@ -60,7 +68,7 @@ const ZERO: WorktreeChanges = { added: 0, deleted: 0 }
  * (DESIGN §5.5) is one predicate everywhere.
  */
 export function sameWorktreeChanges(a: WorktreeChanges, b: WorktreeChanges): boolean {
-  return a.added === b.added && a.deleted === b.deleted && a.behind === b.behind
+  return a.added === b.added && a.deleted === b.deleted && a.behind === b.behind && a.ahead === b.ahead
 }
 
 /**

--- a/packages/kobe/test/daemon/behind-cache.test.ts
+++ b/packages/kobe/test/daemon/behind-cache.test.ts
@@ -16,7 +16,7 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { afterEach, beforeEach, describe, expect, test } from "vitest"
-import { behindCountCached, resetBehindCache } from "../../src/core/behind-cache.ts"
+import { driftCached, resetBehindCache } from "../../src/core/behind-cache.ts"
 
 const AUTHOR = ["-c", "user.email=t@t", "-c", "user.name=t"]
 let repo: string
@@ -52,42 +52,42 @@ function counter(value: number | null) {
   }
 }
 
-describe("behindCountCached", () => {
+describe("driftCached", () => {
   test("computes once, then serves the memo while both shas hold still", async () => {
     const c = counter(3)
-    expect(await behindCountCached(repo, "main", c.compute)).toBe(3)
-    expect(await behindCountCached(repo, "main", c.compute)).toBe(3)
-    expect(await behindCountCached(repo, "main", c.compute)).toBe(3)
+    expect(await driftCached(repo, "main", c.compute)).toBe(3)
+    expect(await driftCached(repo, "main", c.compute)).toBe(3)
+    expect(await driftCached(repo, "main", c.compute)).toBe(3)
     expect(c.calls()).toBe(1)
   })
 
   test("recomputes when the BASE ref moves", async () => {
     const first = counter(0)
-    expect(await behindCountCached(repo, "main", first.compute)).toBe(0)
+    expect(await driftCached(repo, "main", first.compute)).toBe(0)
 
     git("update-ref", "refs/heads/main", git("commit-tree", "HEAD^{tree}", "-p", "HEAD", "-m", "advance"))
 
     const second = counter(1)
-    expect(await behindCountCached(repo, "main", second.compute)).toBe(1)
+    expect(await driftCached(repo, "main", second.compute)).toBe(1)
     expect(second.calls()).toBe(1)
   })
 
   test("recomputes when HEAD moves", async () => {
     const first = counter(2)
-    expect(await behindCountCached(repo, "main", first.compute)).toBe(2)
+    expect(await driftCached(repo, "main", first.compute)).toBe(2)
 
     writeFileSync(join(repo, "b.txt"), "b\n")
     git("add", "-A")
     git(...AUTHOR, "commit", "-qm", "work commit")
 
     const second = counter(5)
-    expect(await behindCountCached(repo, "main", second.compute)).toBe(5)
+    expect(await driftCached(repo, "main", second.compute)).toBe(5)
   })
 
   test("never memoises a failed compute", async () => {
     const failing = counter(null)
-    expect(await behindCountCached(repo, "main", failing.compute)).toBeNull()
-    expect(await behindCountCached(repo, "main", failing.compute)).toBeNull()
+    expect(await driftCached(repo, "main", failing.compute)).toBeNull()
+    expect(await driftCached(repo, "main", failing.compute)).toBeNull()
     expect(failing.calls()).toBe(2)
   })
 
@@ -95,16 +95,16 @@ describe("behindCountCached", () => {
     // No such ref, so the key can never be formed — the memo must not
     // silently degrade into "same worktree, same answer".
     const c = counter(7)
-    expect(await behindCountCached(repo, "origin/nope", c.compute)).toBe(7)
-    expect(await behindCountCached(repo, "origin/nope", c.compute)).toBe(7)
+    expect(await driftCached(repo, "origin/nope", c.compute)).toBe(7)
+    expect(await driftCached(repo, "origin/nope", c.compute)).toBe(7)
     expect(c.calls()).toBe(2)
   })
 
   test("falls through for a path that is not a git checkout", async () => {
     const plain = mkdtempSync(join(tmpdir(), "kobe-behind-plain-"))
     const c = counter(1)
-    expect(await behindCountCached(plain, "main", c.compute)).toBe(1)
-    expect(await behindCountCached(plain, "main", c.compute)).toBe(1)
+    expect(await driftCached(plain, "main", c.compute)).toBe(1)
+    expect(await driftCached(plain, "main", c.compute)).toBe(1)
     expect(c.calls()).toBe(2)
     rmSync(plain, { recursive: true, force: true })
   })

--- a/packages/kobe/test/daemon/worktree-changes-collector.test.ts
+++ b/packages/kobe/test/daemon/worktree-changes-collector.test.ts
@@ -22,7 +22,11 @@
 
 import { DaemonEventBus } from "@sma1lboy/kobe-daemon/daemon/event-bus"
 import type { WorktreeChangesPayload } from "@sma1lboy/kobe-daemon/daemon/protocol"
-import { WorktreeChangesCollector, trackedWorktreePaths } from "@sma1lboy/kobe-daemon/daemon/worktree-changes-collector"
+import {
+  WorktreeChangesCollector,
+  parseAheadBehind,
+  trackedWorktreePaths,
+} from "@sma1lboy/kobe-daemon/daemon/worktree-changes-collector"
 import { describe, expect, test } from "vitest"
 import type { WorktreeChanges } from "../../src/tui/panes/sidebar/worktree-changes.ts"
 import { type Task, toTaskId } from "../../src/types/task.ts"
@@ -320,5 +324,61 @@ describe("the behind-base count", () => {
     await settle()
     expect(published.at(-1)?.changes["/wt/a"]).toEqual({ added: 0, deleted: 2 })
     expect("behind" in (published.at(-1)?.changes["/wt/a"] ?? {})).toBe(false)
+  })
+})
+
+describe("parseAheadBehind", () => {
+  test("reads the left half as behind and the right half as ahead", () => {
+    // `git rev-list --left-right --count <base>...HEAD` prints one tab-joined
+    // line, base side first. Getting the halves the wrong way round would
+    // render a worker who committed as one who fell behind.
+    expect(parseAheadBehind("3\t7\n")).toEqual({ behind: 3, ahead: 7 })
+  })
+
+  test("a failed run leaves BOTH numbers absent", () => {
+    // `runGit` hands null on any non-zero exit; neither half may be guessed
+    // from the other's silence.
+    expect(parseAheadBehind(null)).toBeNull()
+  })
+
+  test("a half-read line yields nothing rather than a guess", () => {
+    // A single number is what the OLD one-way `--count` printed. Accepting it
+    // would silently reinterpret a behind-count as a pair.
+    expect(parseAheadBehind("3")).toBeNull()
+    expect(parseAheadBehind("3\t-1")).toBeNull()
+    expect(parseAheadBehind("")).toBeNull()
+    expect(parseAheadBehind("a\tb")).toBeNull()
+  })
+})
+
+describe("the ahead-of-base count", () => {
+  test("republishes when only `ahead` changed", async () => {
+    // The whole point of the chip: a committing worker leaves +N/−N at zero
+    // and moves nothing else. If `sameWorktreeChanges` ignored `ahead` the
+    // publish would be suppressed and the row would sit blank through the one
+    // event that proves the attempt delivered something.
+    const bus = new DaemonEventBus()
+    const published: WorktreeChangesPayload[] = []
+    bus.onPublish((event) => {
+      if (event.channel === "worktree.changes") published.push(event.payload as WorktreeChangesPayload)
+    })
+    let ahead = 0
+    const collector = new WorktreeChangesCollector({ listTasks: () => [task({ id: "a" })] }, bus, {
+      cadence: FAST,
+      run: async () => ({ added: 0, deleted: 0, behind: 0, ahead }),
+    })
+    collector.tick()
+    await settle()
+    expect(published.at(-1)?.changes["/wt/a"]).toEqual({ added: 0, deleted: 0, behind: 0, ahead: 0 })
+
+    ahead = 1
+    collector.tick()
+    await settle()
+    expect(published.at(-1)?.changes["/wt/a"]).toEqual({ added: 0, deleted: 0, behind: 0, ahead: 1 })
+    expect(published).toHaveLength(2)
+
+    collector.tick()
+    await settle()
+    expect(published).toHaveLength(2)
   })
 })

--- a/packages/kobe/test/tui-react/quick-fork-round.test.ts
+++ b/packages/kobe/test/tui-react/quick-fork-round.test.ts
@@ -1,0 +1,121 @@
+/**
+ * The quick-fork ROUND: the two invariants a screenshot cannot show.
+ *
+ * A round is only a round if every sibling carries the SAME `groupId` — that
+ * is the whole difference between `rove api collect --group <id>` finding
+ * three attempts and finding nothing at all. And a create that fails partway
+ * must leave the siblings already created standing: their engines are already
+ * burning tokens, so unwinding them destroys work.
+ */
+
+import { planRound } from "@/core/round"
+import { type RoundOrchestrator, runQuickForkRound } from "@/tui-react/workspace/quick-fork-round"
+import type { Task } from "@/types/task"
+import { describe, expect, it, vi } from "vitest"
+
+vi.mock("@/state/repos", () => ({ addSavedRepo: () => {} }))
+vi.mock("@/state/vendor-prefs", () => ({ setRepoLastActiveVendor: () => {} }))
+
+describe("planRound", () => {
+  it("a single attempt is not a round", () => {
+    // A lone fork with a groupId would make `collect --group` report a
+    // one-task "round", which is a lie about what the user did.
+    expect(planRound(1)).toEqual([{}])
+    expect(planRound(1, "Fix auth")).toEqual([{ title: "Fix auth" }])
+  })
+
+  it("three attempts share one groupId and carry #i/N ordinals", () => {
+    const plan = planRound(3, "Fix auth")
+    expect(plan).toHaveLength(3)
+    expect(new Set(plan.map((s) => s.groupId)).size).toBe(1)
+    expect(plan[0]?.groupId).toMatch(/^[0-9A-HJKMNP-TV-Z]{26}$/)
+    expect(plan.map((s) => s.title)).toEqual(["Fix auth #1/3", "Fix auth #2/3", "Fix auth #3/3"])
+  })
+
+  it("two calls never share a groupId", () => {
+    expect(planRound(2)[0]?.groupId).not.toBe(planRound(2)[0]?.groupId)
+  })
+
+  it("clamps a nonsense count to one attempt", () => {
+    expect(planRound(0)).toHaveLength(1)
+    expect(planRound(-3)).toHaveLength(1)
+  })
+})
+
+function orchestrator(createTask: RoundOrchestrator["createTask"]): RoundOrchestrator & { prompts: string[] } {
+  const prompts: string[] = []
+  return {
+    createTask,
+    setPrompt: async (_id, prompt) => {
+      prompts.push(prompt)
+    },
+    rpc: { request: async <T>() => ({}) as T },
+    prompts,
+  }
+}
+
+const task = (id: string) => ({ id }) as Task
+
+describe("runQuickForkRound", () => {
+  it("creates every sibling with one shared groupId, then delivers to each", async () => {
+    const seen: Array<{ groupId?: string }> = []
+    const orch = orchestrator(async (input) => {
+      seen.push({ groupId: input.groupId })
+      return task(`t${seen.length}`)
+    })
+    const delivered: string[] = []
+    const outcome = await runQuickForkRound(
+      orch,
+      "/repo",
+      { baseRef: "main", vendor: "claude", prompt: "add subtract", attempts: 3 },
+      async (_rpc, id) => {
+        delivered.push(id)
+        return true
+      },
+    )
+    expect(outcome.started).toEqual(["t1", "t2", "t3"])
+    expect(outcome.failures).toEqual([])
+    expect(delivered.sort()).toEqual(["t1", "t2", "t3"])
+    expect(new Set(seen.map((s) => s.groupId)).size).toBe(1)
+    expect(seen[0]?.groupId).toBeTruthy()
+    // The brief lands on every sibling, so each is re-runnable in turn.
+    expect(orch.prompts).toEqual(["add subtract", "add subtract", "add subtract"])
+  })
+
+  it("a create failure at i=2 keeps the first sibling and never returns nothing", async () => {
+    let n = 0
+    const orch = orchestrator(async () => {
+      n += 1
+      if (n === 2) throw new Error("store write failed")
+      return task(`t${n}`)
+    })
+    const outcome = await runQuickForkRound(
+      orch,
+      "/repo",
+      { baseRef: "main", vendor: "claude", prompt: "p", attempts: 3 },
+      async () => true,
+    )
+    expect(outcome.created).toEqual(["t1"])
+    expect(outcome.started).toEqual(["t1"])
+    expect(outcome.failures).toEqual(["create: store write failed"])
+  })
+
+  it("a sibling whose prompt never landed is a failure but still a created task", async () => {
+    let n = 0
+    const orch = orchestrator(async () => task(`t${++n}`))
+    const outcome = await runQuickForkRound(
+      orch,
+      "/repo",
+      { baseRef: "main", vendor: "claude", prompt: "p", attempts: 2 },
+      // `false` is the honest "session opened, prompt did not land" answer the
+      // headless starter gives; it must not read as success.
+      async (_rpc, id) => id !== "t2",
+    )
+    expect(outcome.created).toEqual(["t1", "t2"])
+    expect(outcome.started).toEqual(["t1"])
+    expect(outcome.failures).toEqual(["t2: prompt not delivered"])
+    // The brief still lands on the undelivered sibling — it is the one you
+    // want to re-run, and "Run again" reads `task.prompt`.
+    expect(orch.prompts).toHaveLength(2)
+  })
+})

--- a/packages/kobe/test/tui-react/quick-task-bindings.test.ts
+++ b/packages/kobe/test/tui-react/quick-task-bindings.test.ts
@@ -1,0 +1,68 @@
+/**
+ * The quick-task composer's REGISTRATION gate, now that two chip rows want the
+ * same three keys.
+ *
+ * `dispatchKeyEvent` calls `preventDefault()` on every matched binding, so a
+ * chord that exists on a text field is a chord that field's input never sees.
+ * `enter` on PROMPT is the one that matters most: it is the whole "type a
+ * prompt, hit enter" path, and it works only because `return` is absent from
+ * the list while PROMPT is focused. Adding ATTEMPTS put a second `left` /
+ * `right` / `return` triple in the file — this pins that neither triple leaks
+ * onto a text field, and that each chip row steps its OWN value.
+ */
+
+import { quickTaskBindings } from "@/tui-react/component/quick-task-bindings"
+import type { KeyEvent } from "@opentui/core"
+import { describe, expect, test } from "vitest"
+
+function handlers() {
+  const calls: string[] = []
+  return {
+    calls,
+    h: {
+      cycleField: (d: 1 | -1) => calls.push(`field${d}`),
+      stepAttempts: (d: 1 | -1) => calls.push(`attempts${d}`),
+      stepEngine: (d: 1 | -1) => calls.push(`engine${d}`),
+      commit: () => calls.push("commit"),
+      pasteAttachment: () => calls.push("paste"),
+      removeLastAttachment: () => calls.push("remove"),
+    },
+  }
+}
+
+/** The bindings under test ignore the event entirely — arrow chords carry no
+ *  payload. A bare cast keeps the call honest without faking 16 fields. */
+const KEY = {} as KeyEvent
+
+const keysOn = (field: Parameters<typeof quickTaskBindings>[0]) =>
+  quickTaskBindings(field, handlers().h).map((b) => b.key)
+
+describe("quickTaskBindings registration gating", () => {
+  test("text fields register neither arrows nor enter", () => {
+    for (const field of ["prompt", "branch"] as const) {
+      expect(keysOn(field)).not.toContain("return")
+      expect(keysOn(field)).not.toContain("left")
+      expect(keysOn(field)).not.toContain("right")
+    }
+  })
+
+  test("each chip row registers them, and steps its own value", () => {
+    for (const field of ["attempts", "engine"] as const) {
+      expect(keysOn(field)).toEqual(expect.arrayContaining(["left", "right", "return"]))
+    }
+
+    const attempts = handlers()
+    for (const b of quickTaskBindings("attempts", attempts.h)) if (b.key === "left" || b.key === "right") b.cmd(KEY)
+    expect(attempts.calls).toEqual(["attempts-1", "attempts1"])
+
+    const engine = handlers()
+    for (const b of quickTaskBindings("engine", engine.h)) if (b.key === "left" || b.key === "right") b.cmd(KEY)
+    expect(engine.calls).toEqual(["engine-1", "engine1"])
+  })
+
+  test("field-independent chords stay on every field", () => {
+    for (const field of ["prompt", "attempts", "engine", "branch"] as const) {
+      expect(keysOn(field)).toEqual(expect.arrayContaining(["tab", "shift+tab", "ctrl+e", "ctrl+v", "ctrl+x"]))
+    }
+  })
+})

--- a/packages/kobe/test/tui/worktree-changes.test.ts
+++ b/packages/kobe/test/tui/worktree-changes.test.ts
@@ -58,4 +58,13 @@ describe("sameWorktreeChanges", () => {
     expect(sameWorktreeChanges({ added: 1, deleted: 2 }, { added: 1, deleted: 3 })).toBe(false)
     expect(sameWorktreeChanges({ added: 0, deleted: 0 }, { added: 1, deleted: 0 })).toBe(false)
   })
+
+  test("a change in `ahead` alone is a change", () => {
+    // A worker that commits moves nothing but this: `added`/`deleted` drop to
+    // zero and stay there. An equality that ignored `ahead` would freeze the
+    // row's memo at the pre-commit value and the `↑N` chip would never draw.
+    expect(sameWorktreeChanges({ added: 0, deleted: 0, ahead: 0 }, { added: 0, deleted: 0, ahead: 1 })).toBe(false)
+    expect(sameWorktreeChanges({ added: 0, deleted: 0 }, { added: 0, deleted: 0, ahead: 0 })).toBe(false)
+    expect(sameWorktreeChanges({ added: 0, deleted: 0, ahead: 2 }, { added: 0, deleted: 0, ahead: 2 })).toBe(true)
+  })
 })


### PR DESCRIPTION
loop-r10 BATCH A. Two commits, A2 first (it makes A1's result readable).

## A2 — a worker that committed looked identical to one that did nothing

Committing empties the worktree, so `+N/−N` vanished and the row went blank —
the same row an attempt that delivered nothing renders. The one number that
separates them (`ahead`) was the one number the collector never took.

**What changed.** `WorktreeChanges` gains `ahead?`; the production runner's
one-way `git rev-list --count HEAD..<base>` becomes
`git rev-list --left-right --count <base>...HEAD`, which yields both halves from
one process (no extra fork per poll, and the pair can't straddle a commit);
`sameWorktreeChanges` compares it on both the daemon and TUI sides, and the
`parseWorktreeChangesPayload` wire decoder carries it (additively — an older
daemon omits it and the chip just doesn't draw). `↑N` renders first in the chip
group, success tone, with its width added to the `tree-rows.tsx` budget.
Documented in the `docs/TUI.md` glyph table (`↓N` was undocumented too; one row
covers the pair, since neither reads right alone).

Rebased onto #852, which landed a sha-keyed memo around the old behind-count.
Merged rather than reverted: `behindCountCached` is now `driftCached<T>`, generic
in the cached value, because both halves are invalidated by the same two ref
shas — caching them separately would key the same fact twice. #852's own test
file moves with the rename and still passes.

**PASS criterion + proof**

- `parseAheadBehind("3\t7")` → `{behind:3, ahead:7}`; a failed run and a
  half-read line leave BOTH absent rather than guessing one from the other.
  `sameWorktreeChanges` is false when only `ahead` differs, and the collector
  republishes on an ahead-only change (the exact case a committing worker
  produces). 4 new tests, all green.
- Live, isolated home (port base 5873, every `ROVE_/KOBE_ *_PATH` inlined):
  task created, one commit in its worktree, then
  `rove api collect --task-ids <id>` reported `base.ahead: 1` with
  `changes: {added: 0, deleted: 0}` while the row showed `↑1`. The two agree —
  that agreement is the point.

**BEFORE/AFTER** (both on a FRESH fixture; BEFORE captured before any edit)

- `/Users/jacksonc/.rove/worktrees/kobe-0aff3858ab76/stoat/.scratch/v-shots/a2/before.png` — clean worktree, one commit ahead, row blank
- `/Users/jacksonc/.rove/worktrees/kobe-0aff3858ab76/stoat/.scratch/v-shots/a2/after.png` — same row, `↑1`
- `/Users/jacksonc/.rove/worktrees/kobe-0aff3858ab76/stoat/.scratch/v-shots/a2/after-narrow.png` — ~70 columns, `↑1` intact

Honest limit on the narrow shot: the visual fixture has no pull request, so it
cannot render PR chips. What that shot proves is that `↑N` does not crowd the
label at 70 columns; that it does not push the PR chips off is carried by the
`clusterCells('↑N')` term added to the same reserved-width sum every other chip
is accounted in.

## A1 — the headline gesture had no keyboard path

`docs/CONCEPTS.md` opens with "many attempts at one prompt" and then shows a
shell command. Inside Rove no gesture produced more than one task, and `groupId`
had zero reach in either TUI tree, so even three hand-made forks could not be
found by `collect --group`.

**What changed.** An ATTEMPTS `ChipRow` (`1 · 2 · 3 · 4 · 5`, default 1) in the
quick composer, walked by `tab` as prompt → attempts → engine → branch, `←`/`→`
to pick — same `ChipRow` every other choose-one row uses. `QuickTaskResult` gains
`attempts`. `attempts > 1` runs a new round path: one `ulid()` `groupId` stamped
on every sibling, serial creation, concurrent delivery, and **no**
`selectTask`/`enterTask` on any sibling — `rove api add` is focus-preserving
unless you pass `--activate`, and a round that yanks you into attempt #3 is worse
than one that leaves you where you were. `attempts === 1` keeps today's
focus-stealing path byte for byte. A partial failure names the failed siblings in
one toast and deletes nothing: their engines are already burning tokens.

**No new chord.** This rides the existing `ctrl+a f` / `ctrl+e` fork destination.

**Two decisions, stated as decisions**

- The chip caps at 5 while the CLI cap is 10. `docs/ORCHESTRATION.md` calls 3-4
  the sweet spot, and a chip row of ten choices is a worse dialog than the shell
  command you would reach for to exceed five. Deliberate, not an accident.
- **Deviation from the brief, please read.** The brief's step 1 was to extract
  `deliverPrompt` and its `pty-delivery.ts` helpers from `cli/api/` into
  `core/deliver-prompt.ts`. I did not, and I think the brief would not have asked
  had it seen `core/daemon-session-adapter.ts`: `startTaskSessionWithPromptAdapter`
  is already exactly "put a first prompt into a hosted session, headlessly", it
  already lives in `core/`, it imports nothing from `cli/`, and the daemon's
  automation runner and work-item start both already use it. Doing the move as
  written would have dragged `pty-delivery.ts`, `tab-snapshot.ts` and `ApiError`
  (17 importers) across the boundary — a 20+ file mechanical diff with no
  user-visible change, in files two other workers are concurrently editing, to
  build a seam that exists. The round reaches the daemon through a new narrow
  `RemoteOrchestrator.rpc` (`DaemonRpcClient`, request-only: exposing the socket
  client would hand callers `subscribe`/`close`). I verified the practical worry
  this raises — that a sibling never mounted by the TUI would show no engine tab
  — is unfounded: all three siblings came back from `collect` with a live
  `tab-1`, and the sidebar shows `· claude 1` under each.

**PASS criterion + proof** — run in a fresh isolated home, never `~/.rove`:

```
$ rove api collect --group 01M1NHHBGVR643PMFX3V2H7Q6Q
tasks returned: 3
  01M1NHHBHS4MCZXHT0C2QGW3KN new-task   tabs=['tab-1'] running=True
  01M1NHHBKPF05JKZXWC25EFXKW new-task-2 tabs=['tab-1'] running=True
  01M1NHHBNCT4M8EH8962FPS6X8 new-task-3 tabs=['tab-1'] running=True
```

That is the load-bearing assertion: no TUI-created task could answer
`--group` before. `tasks.json` confirms all three carry the same `groupId` and
the same persisted prompt, and the source task carries none. `activeTaskId`
after the round is still the source task — focus did not move, and the three
rows sit unentered.

Unit tests (7 + 3, all green, both mutation-checked — see below): N=1 returns
the single-task shape with **no** `groupId`; N=3 returns three inputs sharing
one `groupId` with `#1/3 #2/3 #3/3`; a create failure at i=2 yields one created
id plus one failure and never an empty result; a sibling whose prompt did not
land is a failure but still a created task with its brief persisted. Plus the
registration-gating contract, which now matters twice: `enter` on PROMPT is the
whole "type a prompt, hit enter" path and works only because `return` is absent
from the binding list on text fields — ATTEMPTS added a second `left`/`right`/
`return` triple to that file.

Mutation-checked rather than assumed: minting a per-sibling `groupId` reddens 2
tests; unwinding created siblings on a create failure reddens 1. Restored, green.

**BEFORE/AFTER**

- `/Users/jacksonc/.rove/worktrees/kobe-0aff3858ab76/stoat/.scratch/v-shots/a1/before.png` — the composer with PROMPT / ENGINE / BRANCH only
- `/Users/jacksonc/.rove/worktrees/kobe-0aff3858ab76/stoat/.scratch/v-shots/a1/after-composer.png` — same dialog, ATTEMPTS row on `3`
- `/Users/jacksonc/.rove/worktrees/kobe-0aff3858ab76/stoat/.scratch/v-shots/a1/after-sidebar.png` — a moment after submit: three sibling
  rows each with a `claude 1` tab, cursor still on the source task

BEFORE shots were taken on the unfixed build before any edit; each AFTER used a
freshly rebuilt TUI and `KOBE_VISUAL_FRESH=1`, because hosted PTYs outlive the TUI.

## Gates

`bun run lint`, `bun run typecheck`, `bun run test:fast` (442 files / 4388),
`KOBE_INCLUDE_SOCKET=1 bun run test:socket` (95 / 798), `bun test test/render`
(464), `bun scripts/check-i18n.ts` (779 keys × 2 in sync), and the render
coverage gate — all green:

```
ok quick-task-composer.tsx — 74.1%   ok row-cards.tsx — 74.4%
ok tree-rows.tsx — 98.3%             ok host.tsx — 89.8%
ok quick-fork.ts — 76.2%
```

Every touched file is under the 500-line cap. `tree-rows.tsx` was flagged in the
brief at 488; it takes one line for the `↑N` width term and ends at 489. I did not
split it: the seam there would be an arbitrary cut through one row renderer, and
the honest answer is that this change did not create one.

**One flake to declare.** `test/render/terminal-paste-newlines.test.tsx` failed on
two of four full render runs of this branch (0 fail, 1 fail, 3 fail, 0 fail) and
passes every time in isolation. It mounts `Terminal` directly and asserts a
bracketed paste reached the pty; on the red runs `pastes` was `[]`. Nothing in
this diff touches `Terminal`, the key parser, or the paste path. Reporting it
rather than claiming a clean sweep.
