### PR TITLE
loop-r10 Y: root-cause the shortcut-reveal flake, and stop rendering a failed git read as a clean one

### DIFF
--- a/.changeset/honest-unknown-git-reads.md
+++ b/.changeset/honest-unknown-git-reads.md
@@ -3,3 +3,5 @@
 ---
 
 A failed git read no longer renders as a clean one. `rove api collect` reports `changes: null` when a worktree's git could not be read at all — it used to report `{added: 0, deleted: 0}`, the same answer a genuinely clean worktree gives, while `collect`'s own summary tells you non-zero means the attempt cannot land. The sidebar's `+N −M` chip now shows a muted `?` for a worktree whose `git status` failed or has not been read yet, instead of hiding the chip and reading as "nothing uncommitted here" — the signal a user checks right before deleting a task. `discover-adoptable`, the Worktrees page and the adopt picker report `dirty: null` / a `dirty?` badge when the probe failed, rather than `false`.
+
+The daemon's worktree-changes channel now names the worktrees it tracked but could not read, instead of omitting them: an absent key means "not collected" and draws no chip, so an unreadable worktree used to arrive at every pane looking exactly like a clean one. A worktree that has read cleanly before keeps its last counts, as it always has.

--- a/.changeset/honest-unknown-git-reads.md
+++ b/.changeset/honest-unknown-git-reads.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+A failed git read no longer renders as a clean one. `rove api collect` reports `changes: null` when a worktree's git could not be read at all — it used to report `{added: 0, deleted: 0}`, the same answer a genuinely clean worktree gives, while `collect`'s own summary tells you non-zero means the attempt cannot land. The sidebar's `+N −M` chip now shows a muted `?` for a worktree whose `git status` failed or has not been read yet, instead of hiding the chip and reading as "nothing uncommitted here" — the signal a user checks right before deleting a task. `discover-adoptable`, the Worktrees page and the adopt picker report `dirty: null` / a `dirty?` badge when the probe failed, rather than `false`.

--- a/packages/kobe-daemon/src/daemon/channels.ts
+++ b/packages/kobe-daemon/src/daemon/channels.ts
@@ -172,6 +172,16 @@ export interface ChannelPayloads {
    */
   "worktree.changes": {
     changes: Record<string, { added: number; deleted: number }>
+    /**
+     * Tracked worktrees whose `git status` FAILED — absent from `changes`
+     * because there are no counts, but present here so a subscriber can tell
+     * "could not read" from "not collected". Without it both look like an
+     * absent key, which the sidebar renders as a clean row: exactly the
+     * signal a user checks before deleting a task. Additive: an older client
+     * ignores the field and keeps today's behaviour, and an older DAEMON
+     * omits it, which a newer client reads as "nothing unreadable".
+     */
+    unreadable?: string[]
   }
   /**
    * Engine-transcript activity for every collected worktree (perf —

--- a/packages/kobe-daemon/src/daemon/contracts.ts
+++ b/packages/kobe-daemon/src/daemon/contracts.ts
@@ -195,7 +195,10 @@ export interface AdoptableWorktree {
   readonly path: string
   readonly branch: string
   readonly head: string
-  readonly dirty: boolean
+  /** `null` = the `git status` probe FAILED (unreadable `.git`, worktree
+   *  gone mid-scan), not "clean". A worktree holding uncommitted work whose
+   *  status answers "Permission denied" must not be reported as `false`. */
+  readonly dirty: boolean | null
   readonly kobeManaged: boolean
   readonly lastActivityMs: number
 }

--- a/packages/kobe-daemon/src/daemon/worktree-changes-collector.ts
+++ b/packages/kobe-daemon/src/daemon/worktree-changes-collector.ts
@@ -233,9 +233,16 @@ export function trackedWorktreePaths(tasks: readonly Task[]): Map<string, string
   return paths
 }
 
+/** A run whose `git status` failed: no counts exist, and the path must be
+ *  published as UNREADABLE rather than silently omitted. Returned in place of
+ *  a throw so the scheduler's success path can carry it — `onValue` never
+ *  fires for a rejected run, which is how an unreadable worktree used to leave
+ *  the map entirely and read as clean on every subscriber. */
+const UNREADABLE = Symbol("worktree-changes-unreadable")
+
 interface CollectorEntry extends PollScheduleState {
   /** Last successful counts, absent until the first run lands. */
-  value?: WorktreeChanges
+  value?: WorktreeChanges | typeof UNREADABLE
   /** Change fingerprint sampled when the last run STARTED (before it, so a
    *  write landing mid-run is not swallowed). `null` = it was unreadable. */
   probe?: string | null
@@ -370,7 +377,13 @@ export class WorktreeChangesCollector {
         // recorded for a run that never happened would suppress the next one.
         entry.probe = probe
         entry.quietUntil = Date.now() + quietIntervalMs
-        return run(worktreePath, signal, baseRef)
+        // Resolve, don't reject, on a failed status: `maybeStartScheduledRun`
+        // only calls back on success, so a rejection would drop the path from
+        // the published map — and an absent key is what the sidebar draws as a
+        // clean row. A TIMEOUT still rejects the run (the signal aborts and the
+        // callback is skipped either way), so a slow repo keeps its last value
+        // and backs off exactly as before.
+        return run(worktreePath, signal, baseRef).catch((): typeof UNREADABLE => UNREADABLE)
       },
       (value) => {
         if (this.stopped) return
@@ -378,9 +391,22 @@ export class WorktreeChangesCollector {
         // status ran — a completion for an untracked path must not resurrect
         // it in the published map.
         if (this.entries.get(worktreePath) !== entry) return
+        // A failed status on a worktree that HAS read cleanly keeps its last
+        // counts, the same "stale, not wrong" contract the PR chip keeps for a
+        // provider it could not reach. UNREADABLE is published only when there
+        // is no good value to go stale from — which is the case that used to
+        // fall out of the map and read as a clean row.
+        if (value === UNREADABLE && entry.value !== undefined && entry.value !== UNREADABLE) return
         // Publish-on-change only: a status returning the same counts is a
         // no-op for every subscriber.
-        if (entry.value && sameWorktreeChanges(entry.value, value)) return
+        if (entry.value === value) return
+        if (
+          entry.value &&
+          entry.value !== UNREADABLE &&
+          value !== UNREADABLE &&
+          sameWorktreeChanges(entry.value, value)
+        )
+          return
         entry.value = value
         this.publish()
       },
@@ -389,10 +415,14 @@ export class WorktreeChangesCollector {
 
   private publish(): void {
     const changes: WorktreeChangesPayload["changes"] = {}
+    const unreadable: string[] = []
     for (const [path, entry] of this.entries) {
-      if (entry.value) changes[path] = entry.value
+      if (entry.value === UNREADABLE) unreadable.push(path)
+      else if (entry.value) changes[path] = entry.value
     }
-    this.bus.publish("worktree.changes", { changes })
+    // `unreadable` only rides when non-empty, so the common payload is byte-
+    // identical to what this channel has always published.
+    this.bus.publish("worktree.changes", unreadable.length > 0 ? { changes, unreadable } : { changes })
   }
 }
 

--- a/packages/kobe/src/cli/api/handlers-fanout.ts
+++ b/packages/kobe/src/cli/api/handlers-fanout.ts
@@ -65,7 +65,12 @@ export async function collect(ctx: VerbContext): Promise<unknown> {
     // picking a parallel-round winner: an attempt that commits its work reads
     // +0/−0 here, and `base.behind` says whether it was building against a
     // base that has since moved.
-    const changes = task.worktreePath ? await runtime.readWorktreeChanges(task.worktreePath) : { added: 0, deleted: 0 }
+    //
+    // `null` when there is nothing to read (no worktree) or the read failed —
+    // the same honest-unknown `base` has always emitted beside it. Never
+    // `{0,0}`: this verb's summary tells the caller non-zero means the attempt
+    // cannot land, so a fabricated zero is a claim the caller acts on.
+    const changes = task.worktreePath ? await runtime.readWorktreeChanges(task.worktreePath) : null
     const base = task.worktreePath
       ? await runtime.readBranchSignals(task.worktreePath, task.baseRef)
       : { baseRef: null, ahead: null, behind: null, diff: null }

--- a/packages/kobe/src/cli/api/types.ts
+++ b/packages/kobe/src/cli/api/types.ts
@@ -263,8 +263,13 @@ export interface ApiRuntime {
   resolveRepoRoot(absPath: string): Promise<string>
   /** Preferred engine for new tasks in `repo`; undefined delegates to daemon defaults. */
   defaultVendor(repo?: string): Promise<VendorId | undefined>
-  /** Uncommitted +/− counts for a worktree. */
-  readWorktreeChanges(worktreePath: string): Promise<{ added: number; deleted: number }>
+  /** Uncommitted +/− counts for a worktree; `null` when git could not be
+   *  read at all (unreadable admin dir, git off PATH, worktree gone). NOT
+   *  `{0,0}` — that is the answer for a genuinely clean worktree, and
+   *  `collect`'s own summary says non-zero means the attempt cannot land, so
+   *  a fabricated zero reads as "safe to land / safe to delete". Mirrors the
+   *  all-null contract `readBranchSignals` already keeps for `base`. */
+  readWorktreeChanges(worktreePath: string): Promise<{ added: number; deleted: number } | null>
   /** Committed work vs the branch's base: ahead/behind counts + diffstat (`collect`).
    *  `recordedBaseRef` is the task's persisted fork point (`add --base-branch`);
    *  when present it wins over the base guess; absent/unresolvable falls back. */

--- a/packages/kobe/src/cli/api/verbs-read.ts
+++ b/packages/kobe/src/cli/api/verbs-read.ts
@@ -52,7 +52,7 @@ export const READ_VERBS: readonly VerbSpec[] = [
     name: "collect",
     group: "read",
     summary:
-      "Read-only health snapshot of a parallel round: identity, branch, lineage (.dispatcher, .groupId), .running (pty-host process truth, not a cached status), .activity (daemon engine state + how long it has been in it, null when unknowable), per-tab .tabs with a dead tab's exit cause AND output tail, uncommitted .changes (non-zero = it cannot land), and committed .base (ahead count + diffstat — ahead:0 is the `succeeded but committed nothing` tell). Select with --group (one fan-out round), --repo, or --task-ids.",
+      "Read-only health snapshot of a parallel round: identity, branch, lineage (.dispatcher, .groupId), .running (pty-host process truth, not a cached status), .activity (daemon engine state + how long it has been in it, null when unknowable), per-tab .tabs with a dead tab's exit cause AND output tail, uncommitted .changes (non-zero = it cannot land; null = could not read git — do NOT treat as clean), and committed .base (ahead count + diffstat — ahead:0 is the `succeeded but committed nothing` tell). Select with --group (one fan-out round), --repo, or --task-ids.",
     flags: [
       { name: "task-ids", type: "csv", placeholder: "a,b,c", description: "Comma-separated task ids." },
       {

--- a/packages/kobe/src/cli/index.ts
+++ b/packages/kobe/src/cli/index.ts
@@ -289,7 +289,9 @@ async function runAdoptSubcommand(args: readonly string[]): Promise<void> {
   console.log(`adoptable worktrees in ${repo}:`)
   for (const w of worktrees) {
     const hit = glob ? (isMatch(w) ? "*" : " ") : "-"
-    const tags = [w.dirty ? "dirty" : "", w.kobeManaged ? "" : "external"].filter(Boolean).join(",")
+    // `dirty?` — the probe failed; not the same claim as a clean worktree.
+    const dirtyTag = w.dirty === true ? "dirty" : w.dirty === null ? "dirty?" : ""
+    const tags = [dirtyTag, w.kobeManaged ? "" : "external"].filter(Boolean).join(",")
     console.log(`  ${hit} ${w.branch}\t${w.path}${tags ? `  (${tags})` : ""}`)
   }
 

--- a/packages/kobe/src/client/remote-orchestrator-payloads.ts
+++ b/packages/kobe/src/client/remote-orchestrator-payloads.ts
@@ -83,7 +83,11 @@ export interface TaskJobState {
  * `hello.capabilities`) or `init()` hasn't completed — the sidebar then
  * falls back to its local poller.
  */
-export type WorktreeChangesMap = ReadonlyMap<string, WorktreeChanges>
+/** Path → counts, or `null` for a worktree the daemon TRACKED but could not
+ *  read. A `null` entry and an absent key are different facts: absent means
+ *  "not collected" (remote project, just-created task) and draws no chip;
+ *  `null` means the read failed and draws the unknown mark. */
+export type WorktreeChangesMap = ReadonlyMap<string, WorktreeChanges | null>
 
 /**
  * Compact, bounded description of a dropped event payload for `client.log` —
@@ -110,10 +114,10 @@ export function describePayload(value: unknown): string {
  * Returns `null` for a malformed payload (the event is then ignored —
  * never clobber a good map with garbage). Exported for unit tests.
  */
-export function parseWorktreeChangesPayload(payload: unknown): Map<string, WorktreeChanges> | null {
+export function parseWorktreeChangesPayload(payload: unknown): Map<string, WorktreeChanges | null> | null {
   const changes = (payload as { changes?: unknown } | undefined)?.changes
   if (!changes || typeof changes !== "object" || Array.isArray(changes)) return null
-  const map = new Map<string, WorktreeChanges>()
+  const map = new Map<string, WorktreeChanges | null>()
   for (const [path, value] of Object.entries(changes as Record<string, unknown>)) {
     const counts = value as { added?: unknown; deleted?: unknown; behind?: unknown; ahead?: unknown } | undefined
     if (typeof counts?.added !== "number" || typeof counts.deleted !== "number") return null
@@ -125,6 +129,13 @@ export function parseWorktreeChangesPayload(payload: unknown): Map<string, Workt
       ...(typeof counts.behind === "number" ? { behind: counts.behind } : {}),
       ...(typeof counts.ahead === "number" ? { ahead: counts.ahead } : {}),
     })
+  }
+  // Worktrees the daemon tracked but could not read. Additive, so an older
+  // daemon that omits the field simply contributes no unknowns. Mapped to
+  // `null` — NOT left absent, which the row would draw as a clean chip.
+  const unreadable = (payload as { unreadable?: unknown } | undefined)?.unreadable
+  if (Array.isArray(unreadable)) {
+    for (const path of unreadable) if (typeof path === "string" && path.length > 0) map.set(path, null)
   }
   return map
 }
@@ -166,8 +177,8 @@ export function decodeUiPrefsPayload(payload: unknown): UiPrefsPayload | null {
 export function sameWorktreeChangesMap(a: WorktreeChangesMap, b: WorktreeChangesMap): boolean {
   if (a.size !== b.size) return false
   for (const [path, counts] of a) {
-    const other = b.get(path)
-    if (!other || !sameWorktreeChanges(counts, other)) return false
+    if (!b.has(path)) return false
+    if (!sameWorktreeChanges(counts, b.get(path) ?? null)) return false
   }
   return true
 }

--- a/packages/kobe/src/client/remote-orchestrator-payloads.ts
+++ b/packages/kobe/src/client/remote-orchestrator-payloads.ts
@@ -63,6 +63,16 @@ export type EngineTabStateMap = ReadonlyMap<string, ReadonlyMap<string, TaskEngi
 /** Durable daemon-owned attention episode, pushed as a full snapshot. */
 export type AttentionInboxItem = ChannelPayloads["attention.inbox"]["items"][number]
 
+// The `worktree.changes` wire contract lives in its own module (its payload
+// carries two facts per key); re-exported here so existing importers keep
+// naming it through this one.
+import type { WorktreeChangesMap } from "./remote-orchestrator-worktree-changes.ts"
+export {
+  type WorktreeChangesMap,
+  parseWorktreeChangesPayload,
+  sameWorktreeChangesMap,
+} from "./remote-orchestrator-worktree-changes.ts"
+
 /**
  * A long daemon operation currently IN FLIGHT for a task, accumulated from
  * the `task.jobs` channel (today: `ensureWorktree` — `git worktree add` is
@@ -74,20 +84,6 @@ export type AttentionInboxItem = ChannelPayloads["attention.inbox"]["items"][num
 export interface TaskJobState {
   readonly kind: "ensureWorktree"
 }
-
-/**
- * Daemon-collected `+N −M` counts keyed by worktree path, from the
- * `worktree.changes` channel (one collector in the daemon
- * instead of per-pane git polling). `null` means "no daemon-collected
- * data": either the daemon predates the channel (absent from
- * `hello.capabilities`) or `init()` hasn't completed — the sidebar then
- * falls back to its local poller.
- */
-/** Path → counts, or `null` for a worktree the daemon TRACKED but could not
- *  read. A `null` entry and an absent key are different facts: absent means
- *  "not collected" (remote project, just-created task) and draws no chip;
- *  `null` means the read failed and draws the unknown mark. */
-export type WorktreeChangesMap = ReadonlyMap<string, WorktreeChanges | null>
 
 /**
  * Compact, bounded description of a dropped event payload for `client.log` —
@@ -107,37 +103,6 @@ export function describePayload(value: unknown): string {
   }
   if (text.length > 120) text = `${text.slice(0, 120)}…`
   return `${type}:${text}`
-}
-
-/**
- * Parse a `worktree.changes` wire payload into a path→counts map.
- * Returns `null` for a malformed payload (the event is then ignored —
- * never clobber a good map with garbage). Exported for unit tests.
- */
-export function parseWorktreeChangesPayload(payload: unknown): Map<string, WorktreeChanges | null> | null {
-  const changes = (payload as { changes?: unknown } | undefined)?.changes
-  if (!changes || typeof changes !== "object" || Array.isArray(changes)) return null
-  const map = new Map<string, WorktreeChanges | null>()
-  for (const [path, value] of Object.entries(changes as Record<string, unknown>)) {
-    const counts = value as { added?: unknown; deleted?: unknown; behind?: unknown; ahead?: unknown } | undefined
-    if (typeof counts?.added !== "number" || typeof counts.deleted !== "number") return null
-    // `behind` and `ahead` are both additive: an older daemon omits them, and
-    // the chip then simply does not draw — never a fabricated zero.
-    map.set(path, {
-      added: counts.added,
-      deleted: counts.deleted,
-      ...(typeof counts.behind === "number" ? { behind: counts.behind } : {}),
-      ...(typeof counts.ahead === "number" ? { ahead: counts.ahead } : {}),
-    })
-  }
-  // Worktrees the daemon tracked but could not read. Additive, so an older
-  // daemon that omits the field simply contributes no unknowns. Mapped to
-  // `null` — NOT left absent, which the row would draw as a clean chip.
-  const unreadable = (payload as { unreadable?: unknown } | undefined)?.unreadable
-  if (Array.isArray(unreadable)) {
-    for (const path of unreadable) if (typeof path === "string" && path.length > 0) map.set(path, null)
-  }
-  return map
 }
 
 /**
@@ -167,20 +132,6 @@ export function decodeUiPrefsPayload(payload: unknown): UiPrefsPayload | null {
     keysCollapsed: p.keysCollapsed === true,
     projectFilter: typeof p.projectFilter === "string" && p.projectFilter.length > 0 ? p.projectFilter : null,
   }
-}
-
-/**
- * Entry-wise equality for two changes maps — an unchanged republish (e.g.
- * the bus replaying its last value across a reconnect) must not churn the
- * signal and re-render every sidebar row. Exported for unit tests.
- */
-export function sameWorktreeChangesMap(a: WorktreeChangesMap, b: WorktreeChangesMap): boolean {
-  if (a.size !== b.size) return false
-  for (const [path, counts] of a) {
-    if (!b.has(path)) return false
-    if (!sameWorktreeChanges(counts, b.get(path) ?? null)) return false
-  }
-  return true
 }
 
 /**

--- a/packages/kobe/src/client/remote-orchestrator-worktree-changes.ts
+++ b/packages/kobe/src/client/remote-orchestrator-worktree-changes.ts
@@ -1,0 +1,74 @@
+/**
+ * The `worktree.changes` channel's wire contract, in one place: its map type,
+ * its payload parser, and the equality that gates a re-render.
+ *
+ * Split out of `remote-orchestrator-payloads.ts` because this is the one
+ * channel whose payload carries TWO facts about the same key. `changes` holds
+ * counts; `unreadable` names the worktrees the daemon tracked and could not
+ * read. Absent-from-both and present-in-`unreadable` are different answers —
+ * "not collected" draws no chip, "could not read" draws the unknown mark —
+ * and collapsing them is what made an unreadable worktree arrive at every
+ * pane looking exactly like a clean one. The rest of that module is
+ * one-shape-per-channel parsers with no such distinction to keep straight.
+ */
+
+import { type WorktreeChanges, sameWorktreeChanges } from "../tui/panes/sidebar/worktree-changes.ts"
+
+/**
+ * Daemon-collected `+N −M` counts keyed by worktree path, from the
+ * `worktree.changes` channel (one collector in the daemon
+ * instead of per-pane git polling). `null` means "no daemon-collected
+ * data": either the daemon predates the channel (absent from
+ * `hello.capabilities`) or `init()` hasn't completed — the sidebar then
+ * falls back to its local poller.
+ */
+/** Path → counts, or `null` for a worktree the daemon TRACKED but could not
+ *  read. A `null` entry and an absent key are different facts: absent means
+ *  "not collected" (remote project, just-created task) and draws no chip;
+ *  `null` means the read failed and draws the unknown mark. */
+export type WorktreeChangesMap = ReadonlyMap<string, WorktreeChanges | null>
+
+/**
+ * Parse a `worktree.changes` wire payload into a path→counts map.
+ * Returns `null` for a malformed payload (the event is then ignored —
+ * never clobber a good map with garbage). Exported for unit tests.
+ */
+export function parseWorktreeChangesPayload(payload: unknown): Map<string, WorktreeChanges | null> | null {
+  const changes = (payload as { changes?: unknown } | undefined)?.changes
+  if (!changes || typeof changes !== "object" || Array.isArray(changes)) return null
+  const map = new Map<string, WorktreeChanges | null>()
+  for (const [path, value] of Object.entries(changes as Record<string, unknown>)) {
+    const counts = value as { added?: unknown; deleted?: unknown; behind?: unknown; ahead?: unknown } | undefined
+    if (typeof counts?.added !== "number" || typeof counts.deleted !== "number") return null
+    // `behind` and `ahead` are both additive: an older daemon omits them, and
+    // the chip then simply does not draw — never a fabricated zero.
+    map.set(path, {
+      added: counts.added,
+      deleted: counts.deleted,
+      ...(typeof counts.behind === "number" ? { behind: counts.behind } : {}),
+      ...(typeof counts.ahead === "number" ? { ahead: counts.ahead } : {}),
+    })
+  }
+  // Worktrees the daemon tracked but could not read. Additive, so an older
+  // daemon that omits the field simply contributes no unknowns. Mapped to
+  // `null` — NOT left absent, which the row would draw as a clean chip.
+  const unreadable = (payload as { unreadable?: unknown } | undefined)?.unreadable
+  if (Array.isArray(unreadable)) {
+    for (const path of unreadable) if (typeof path === "string" && path.length > 0) map.set(path, null)
+  }
+  return map
+}
+
+/**
+ * Entry-wise equality for two changes maps — an unchanged republish (e.g.
+ * the bus replaying its last value across a reconnect) must not churn the
+ * signal and re-render every sidebar row. Exported for unit tests.
+ */
+export function sameWorktreeChangesMap(a: WorktreeChangesMap, b: WorktreeChangesMap): boolean {
+  if (a.size !== b.size) return false
+  for (const [path, counts] of a) {
+    if (!b.has(path)) return false
+    if (!sameWorktreeChanges(counts, b.get(path) ?? null)) return false
+  }
+  return true
+}

--- a/packages/kobe/src/core/daemon-worktree-adapter.ts
+++ b/packages/kobe/src/core/daemon-worktree-adapter.ts
@@ -84,7 +84,14 @@ export async function listWorktreeProjectsAdapter(network: boolean): Promise<Wor
           ])
           const judgement = judgeWorktree(
             {
-              dirty: worktree.dirty,
+              // The staleness cascade's `dirty` signal stays a boolean: an
+              // UNREADABLE probe reads as not-dirty here, exactly as it did
+              // before `dirty` grew a null. Safe because the destructive path
+              // does not consult this verdict — `manager-remove.ts` calls
+              // `isDirty` UNCAUGHT, so removing an unreadable worktree throws
+              // rather than proceeding. The honest `null` still reaches the
+              // row, which is where the user reads it.
+              dirty: worktree.dirty === true,
               prState: states?.get(worktree.branch) ?? null,
               aheadOfDefault: aheadBy,
               lastActivityMs: worktree.lastActivityMs,

--- a/packages/kobe/src/orchestrator/worktree/manager-list.ts
+++ b/packages/kobe/src/orchestrator/worktree/manager-list.ts
@@ -132,8 +132,11 @@ export async function listManaged(deps: ListDeps, repo: string): Promise<readonl
     head: e.head,
     // A worktree can vanish between the porcelain snapshot and this probe, and
     // an unguarded throw here fails the WHOLE list — the entire sidebar goes
-    // dark over one stale row. Unknown reads as clean, like the sibling probe.
-    dirty: await deps.isDirty(e.probePath).catch(() => false),
+    // dark over one stale row. So the catch stays; what changed is its VALUE:
+    // `null` (unknown), never `false`. A worktree whose `git status` answers
+    // "Permission denied" holds whatever it held, and listing it as clean is
+    // the one answer that reads as safe to delete.
+    dirty: await deps.isDirty(e.probePath).catch(() => null),
   }))
 }
 
@@ -145,7 +148,10 @@ export async function listAllAdoptable(deps: ListDeps, repo: string): Promise<re
   // git spawns / ssh round-trips each, the slow part of this call.
   const infos = await mapWithLimit(adoptable, PROBE_CONCURRENCY, async (entry) => {
     const [dirty, activityMs] = await Promise.all([
-      deps.isDirty(entry.path).catch(() => false),
+      // Same as the sibling probe above: unknown is `null`, not clean.
+      deps
+        .isDirty(entry.path)
+        .catch(() => null),
       lastActivityMs(deps, ctx, entry.path),
     ])
     return {

--- a/packages/kobe/src/tui-react/component/new-task-dialog/tab-adopt.tsx
+++ b/packages/kobe/src/tui-react/component/new-task-dialog/tab-adopt.tsx
@@ -16,7 +16,9 @@ export function AdoptTab({ vm }: { vm: NewTaskVm }) {
   const t = useT()
 
   const rows = vm.adoptVisible.map((w) => {
-    const tags = [w.dirty ? "dirty" : "", w.kobeManaged ? "" : "external"].filter(Boolean).join(",")
+    // `dirty?` — the probe failed; not the same claim as a clean worktree.
+    const dirtyTag = w.dirty === true ? "dirty" : w.dirty === null ? "dirty?" : ""
+    const tags = [dirtyTag, w.kobeManaged ? "" : "external"].filter(Boolean).join(",")
     return {
       key: w.path,
       body: `${vm.adoptSelected.has(w.path) ? "[x] " : "[ ] "}${w.branch}${tags ? `  (${tags})` : ""}`,

--- a/packages/kobe/src/tui-react/component/prefix-hud.tsx
+++ b/packages/kobe/src/tui-react/component/prefix-hud.tsx
@@ -15,7 +15,7 @@ import { useEffect, useState } from "react"
 import { displayWidth } from "../../lib/display-width"
 import { KobeKeymap, findBinding } from "../../tui/context/keybindings"
 import { currentPrefixConfiguration } from "../../tui/lib/keymap-dispatch"
-import { PREFIX_GUIDE_DELAY_MS, PREFIX_HUD_TTL_MS, prefixHudState } from "../../tui/lib/prefix-hud"
+import { PREFIX_GUIDE_DELAY_MS, PREFIX_HUD_TTL_MS, prefixHudClock, prefixHudState } from "../../tui/lib/prefix-hud"
 import { DIRECT_GUIDE_PREFIX_ACTION_ID } from "../../tui/lib/shortcut-reveal"
 import { truncateEnd } from "../../tui/lib/truncate"
 import { useTheme } from "../context/theme"
@@ -91,27 +91,29 @@ export function PrefixHud(props: { left: number; width: number }) {
   const showCommandGuide = guide?.kind === "direct" || showPrefixGuide
   const [, setFlushTick] = useState(0)
 
-  const now = Date.now()
+  // Every read of "now" and every expiry timer below goes through the HUD
+  // clock, never the globals: that is the seam render tests advance so the
+  // delayed reveal is deterministic instead of a race (src/tui/lib/prefix-hud).
+  const clock = prefixHudClock()
+  const now = clock.now()
   const fresh = hud.entries.filter((entry) => now - entry.at < PREFIX_HUD_TTL_MS)
 
   // Wake up when the oldest visible line crosses its TTL so it flushes out.
   const oldestAt = fresh[0]?.at
   useEffect(() => {
     if (oldestAt === undefined) return
-    const timer = setTimeout(
+    return clock.schedule(
       () => setFlushTick((tick) => tick + 1),
-      Math.max(30, oldestAt + PREFIX_HUD_TTL_MS - Date.now()),
+      Math.max(30, oldestAt + PREFIX_HUD_TTL_MS - clock.now()),
     )
-    return () => clearTimeout(timer)
-  }, [oldestAt])
+  }, [oldestAt, clock])
 
   useEffect(() => {
     if (!showPrefixGuide || guide?.kind !== "prefix") return
-    const remaining = guide.armedAt + PREFIX_GUIDE_DELAY_MS - Date.now()
+    const remaining = guide.armedAt + PREFIX_GUIDE_DELAY_MS - clock.now()
     if (remaining <= 0) return
-    const timer = setTimeout(() => setFlushTick((tick) => tick + 1), remaining)
-    return () => clearTimeout(timer)
-  }, [showPrefixGuide, guide])
+    return clock.schedule(() => setFlushTick((tick) => tick + 1), remaining)
+  }, [showPrefixGuide, guide, clock])
 
   const lineCount = fresh.length + (showCommandGuide ? 1 : 0)
   if (lineCount === 0) return null

--- a/packages/kobe/src/tui-react/component/worktrees-page.tsx
+++ b/packages/kobe/src/tui-react/component/worktrees-page.tsx
@@ -329,7 +329,14 @@ export function WorktreesPage(props: { orchestrator: RemoteOrchestrator | null; 
                           {row.branch || t("worktrees.row.detached")}
                         </text>
                         {row.kobeManaged ? <text fg={theme.textMuted}> {t("worktrees.badge.kobeManaged")}</text> : null}
-                        {row.dirty ? <text fg={theme.warning}> {t("worktrees.badge.dirty")}</text> : null}
+                        {row.dirty === true ? <text fg={theme.warning}> {t("worktrees.badge.dirty")}</text> : null}
+                        {/* `null` = the status probe FAILED. It reads as its own
+                            badge, not as the absence of "dirty": a worktree whose
+                            git answers "Permission denied" still holds whatever it
+                            held, and this row is where a user decides to delete it. */}
+                        {row.dirty === null ? (
+                          <text fg={theme.textMuted}> {t("worktrees.badge.dirtyUnknown")}</text>
+                        ) : null}
                         {remoteBadge(row.branchOnRemote)}
                         {verdictBadge(row)}
                         {busyPath === row.path ? <text fg={theme.textMuted}> …</text> : null}

--- a/packages/kobe/src/tui-react/panes/sidebar/row-cards.tsx
+++ b/packages/kobe/src/tui-react/panes/sidebar/row-cards.tsx
@@ -43,10 +43,12 @@ export function useSpinnerFrame(active: boolean): number {
  * poller cache (poll scheduled in an effect). The param is structural —
  * the tree's row props carry exactly the two fields it reads.
  */
+const NO_CHANGES: WorktreeChanges = { added: 0, deleted: 0 }
+
 export function useChanges(
   sources: { readonly branchTick: number; readonly worktreeChanges?: ReadonlyMap<string, WorktreeChanges> | null },
   task: SidebarRow["task"],
-): WorktreeChanges {
+): WorktreeChanges | null {
   const pushed = pickPushedChanges(sources.worktreeChanges, task.worktreePath)
   const hasPushed = pushed !== null
   useEffect(() => {
@@ -55,8 +57,17 @@ export function useChanges(
     if (hasPushed) return
     pollWorktreeChanges(task.worktreePath)
   }, [hasPushed, task.worktreePath, sources.branchTick])
+  // A row with NO worktree yet (task created, not yet materialized) has no
+  // uncommitted worktree work — that is a fact, not an unknown, so it draws no
+  // chip. Only a worktree that EXISTS and could not be read reads as unknown;
+  // otherwise every fresh task would wear a `?` while its job is still running,
+  // which the materializing spinner already says better.
+  if (!task.worktreePath) return NO_CHANGES
   return pushed ?? worktreeChanges(task.worktreePath)
 }
+
+/** Cells the unknown mark occupies — one, same as any single chip glyph. */
+export const UNKNOWN_CHANGES_MARK = "?"
 
 /** Right-edge git metrics stay one non-shrinking cluster while metadata takes
  * the flexible middle column. This keeps every row scannable at the same
@@ -75,8 +86,21 @@ export function useChanges(
  *
  * `↑`/`↓` are U+2191/U+2193 (Arrows) — single-width in every monospace font we
  * target, same coverage rule the `row-view.ts` glyph comments record. */
-export function ChangeStats(props: { readonly changes: WorktreeChanges }) {
+export function ChangeStats(props: { readonly changes: WorktreeChanges | null }) {
   const { theme } = useTheme()
+  // `null` = the git read failed or has not landed yet. It must NOT render
+  // like a clean row: hiding the cluster is what let an unreadable worktree
+  // read as "nothing uncommitted here" right before the user deleted it. A
+  // muted `?` says the counts are unknown — the same muted-tone vocabulary
+  // `prCheckChip` already uses for a value nothing is confirming any more,
+  // and `?` is free in the glyph set this cluster shares.
+  if (props.changes === null) {
+    return (
+      <text fg={theme.textMuted} wrapMode="none" flexShrink={0}>
+        {UNKNOWN_CHANGES_MARK}
+      </text>
+    )
+  }
   const ahead = props.changes.ahead ?? 0
   const behind = props.changes.behind ?? 0
   if (props.changes.added <= 0 && props.changes.deleted <= 0 && ahead <= 0 && behind <= 0) return null

--- a/packages/kobe/src/tui-react/panes/sidebar/row-cards.tsx
+++ b/packages/kobe/src/tui-react/panes/sidebar/row-cards.tsx
@@ -46,7 +46,10 @@ export function useSpinnerFrame(active: boolean): number {
 const NO_CHANGES: WorktreeChanges = { added: 0, deleted: 0 }
 
 export function useChanges(
-  sources: { readonly branchTick: number; readonly worktreeChanges?: ReadonlyMap<string, WorktreeChanges> | null },
+  sources: {
+    readonly branchTick: number
+    readonly worktreeChanges?: ReadonlyMap<string, WorktreeChanges | null> | null
+  },
   task: SidebarRow["task"],
 ): WorktreeChanges | null {
   const pushed = pickPushedChanges(sources.worktreeChanges, task.worktreePath)
@@ -63,6 +66,10 @@ export function useChanges(
   // otherwise every fresh task would wear a `?` while its job is still running,
   // which the materializing spinner already says better.
   if (!task.worktreePath) return NO_CHANGES
+  // `"unknown"` = the DAEMON tracked this worktree and its git read failed;
+  // `null` from the poller = the same fact on the no-daemon path. Both render
+  // as the unknown mark, so they collapse here.
+  if (pushed === "unknown") return null
   return pushed ?? worktreeChanges(task.worktreePath)
 }
 

--- a/packages/kobe/src/tui-react/panes/sidebar/tree-rows.tsx
+++ b/packages/kobe/src/tui-react/panes/sidebar/tree-rows.tsx
@@ -74,7 +74,7 @@ export type TreeRowShared = {
   readonly engineTabState?: ReadonlyMap<string, ReadonlyMap<string, TaskEngineState>>
   readonly engineLifecycle?: ReadonlyMap<string, { readonly subagents: number }>
   readonly taskJobs?: ReadonlyMap<string, TaskJobState>
-  readonly worktreeChanges?: ReadonlyMap<string, WorktreeChanges> | null
+  readonly worktreeChanges?: ReadonlyMap<string, WorktreeChanges | null> | null
 }
 
 /**

--- a/packages/kobe/src/tui-react/panes/sidebar/tree-rows.tsx
+++ b/packages/kobe/src/tui-react/panes/sidebar/tree-rows.tsx
@@ -32,6 +32,7 @@ import { resolveRowSelectionChrome } from "../../ui/row-selection-chrome"
 import {
   ChangeStats,
   JumpDigit,
+  UNKNOWN_CHANGES_MARK,
   completionSeenFor,
   completionStampOf,
   useChanges,
@@ -239,10 +240,13 @@ export function WorktreeTreeRow(props: {
     (conflict ? 2 : 0) +
     (review ? 2 : 0) +
     (status ? 2 : 0) +
-    ((changes.ahead ?? 0) > 0 ? clusterCells(`↑${changes.ahead}`) : 0) +
-    (changes.added > 0 ? clusterCells(`+${changes.added}`) : 0) +
-    (changes.deleted > 0 ? clusterCells(`−${changes.deleted}`) : 0) +
-    ((changes.behind ?? 0) > 0 ? clusterCells(`↓${changes.behind}`) : 0) +
+    // `changes === null` is the unknown mark, one cell like any chip glyph —
+    // it replaces the whole ↑/+/−/↓ cluster rather than sitting beside it.
+    (changes === null ? clusterCells(UNKNOWN_CHANGES_MARK) : 0) +
+    ((changes?.ahead ?? 0) > 0 ? clusterCells(`↑${changes?.ahead}`) : 0) +
+    ((changes?.added ?? 0) > 0 ? clusterCells(`+${changes?.added}`) : 0) +
+    ((changes?.deleted ?? 0) > 0 ? clusterCells(`−${changes?.deleted}`) : 0) +
+    ((changes?.behind ?? 0) > 0 ? clusterCells(`↓${changes?.behind}`) : 0) +
     (moving ? clusterCells(t("tasks.moveChip").trim()) : 0)
   return (
     <RowShell rowId={props.rowId} flatIndex={props.flatIndex} depth={1} shared={shared}>

--- a/packages/kobe/src/tui-react/panes/sidebar/types.ts
+++ b/packages/kobe/src/tui-react/panes/sidebar/types.ts
@@ -110,7 +110,7 @@ export type SidebarProps = SidebarTaskCallbacks & {
   /** Transient per-task lifecycle marks (subagent activity). */
   engineLifecycle?: ReadonlyMap<string, { readonly subagents: number }>
   taskJobs?: ReadonlyMap<string, TaskJobState>
-  worktreeChanges?: ReadonlyMap<string, WorktreeChanges> | null
+  worktreeChanges?: ReadonlyMap<string, WorktreeChanges | null> | null
   /** Daemon-collected transcript facts keyed by WORKTREE path — proves a
    * "complete" turn whose engine is still writing (hook-silent phases). */
   transcriptActivity?: ReadonlyMap<string, { readonly mtimeMs: number }> | null

--- a/packages/kobe/src/tui-react/workspace/host-sidebar.tsx
+++ b/packages/kobe/src/tui-react/workspace/host-sidebar.tsx
@@ -48,7 +48,7 @@ export interface HostSidebarProps
   readonly engineTabState?: ReadonlyMap<string, ReadonlyMap<string, TaskEngineState>>
   readonly engineLifecycle?: ReadonlyMap<string, { readonly subagents: number }>
   readonly taskJobs?: ReadonlyMap<string, TaskJobState>
-  readonly worktreeChanges?: ReadonlyMap<string, WorktreeChanges> | null
+  readonly worktreeChanges?: ReadonlyMap<string, WorktreeChanges | null> | null
   readonly transcriptActivity?: ReadonlyMap<string, { readonly mtimeMs: number }> | null
   readonly onAddTask: () => void
   readonly onSearchActiveChange: (active: boolean) => void

--- a/packages/kobe/src/tui/i18n/messages/worktrees.ts
+++ b/packages/kobe/src/tui/i18n/messages/worktrees.ts
@@ -13,6 +13,7 @@ export const en = {
   badge: {
     kobeManaged: "rove",
     dirty: "dirty",
+    dirtyUnknown: "dirty?",
     remoteOn: "on remote",
     remoteOff: "not pushed",
     remoteUnknown: "remote unknown",
@@ -81,6 +82,7 @@ export const zh: typeof en = {
   badge: {
     kobeManaged: "rove",
     dirty: "有改动",
+    dirtyUnknown: "改动未知",
     remoteOn: "已推送",
     remoteOff: "未推送",
     remoteUnknown: "远端未知",

--- a/packages/kobe/src/tui/lib/prefix-hud.ts
+++ b/packages/kobe/src/tui/lib/prefix-hud.ts
@@ -5,7 +5,9 @@
  * chords (`prefixKey: ""`). Keeps the last three plus the active prefix or
  * direct-shortcut guide;
  * entries carry a timestamp and the OVERLAY enforces expiry, so this module
- * owns no timers and stays inert for headless/unit-test dispatch.
+ * owns no timers and stays inert for headless/unit-test dispatch. It does own
+ * the CLOCK those overlay timers read, so a render test can drive the delayed
+ * reveal instead of racing a real setTimeout — see {@link setPrefixHudClock}.
  */
 
 import { type ReadableState, createStateCell } from "../../lib/external-store"
@@ -50,6 +52,40 @@ type PrefixHudGuide =
       readonly options: readonly PrefixHudOption[]
     }
 
+/**
+ * Clock the HUD overlay reads for `now` and for its expiry timers. Real
+ * timers make the PREFIX_GUIDE_DELAY_MS reveal a race: the render suite
+ * saturates the event loop, and the armed prefix cancels itself
+ * DEFAULT_PREFIX_CONFIGURATION.timeoutMs after the tap, so a slipped timer
+ * deletes the answer rather than merely delaying it. Tests swap in a manual
+ * clock and advance it.
+ */
+export type PrefixHudClock = {
+  now(): number
+  /** Run `fn` after `ms`; returns a cancel function. */
+  schedule(fn: () => void, ms: number): () => void
+}
+
+const realClock: PrefixHudClock = {
+  now: () => Date.now(),
+  schedule: (fn, ms) => {
+    const timer = setTimeout(fn, ms)
+    return () => clearTimeout(timer)
+  },
+}
+
+let clock: PrefixHudClock = realClock
+
+/** Clock the overlay must use for timestamps and expiry timers. */
+export function prefixHudClock(): PrefixHudClock {
+  return clock
+}
+
+/** Test seam — install a manual clock, or `null` to restore real time. */
+export function setPrefixHudClock(next: PrefixHudClock | null): void {
+  clock = next ?? realClock
+}
+
 const cell = createStateCell<PrefixHudSnapshot>({ guide: null, entries: [] })
 let nextEntryId = 1
 
@@ -62,7 +98,7 @@ export function prefixHudSetArmed(
 ): void {
   cell.update((current) => {
     if (!armed) return current.guide?.kind === "prefix" ? { ...current, guide: null } : current
-    return { ...current, guide: { kind: "prefix", armedAt: armedAt ?? Date.now(), options } }
+    return { ...current, guide: { kind: "prefix", armedAt: armedAt ?? clock.now(), options } }
   })
 }
 

--- a/packages/kobe/src/tui/panes/sidebar/worktree-changes-poller.ts
+++ b/packages/kobe/src/tui/panes/sidebar/worktree-changes-poller.ts
@@ -12,9 +12,12 @@
  * cadence, timeout + hard backoff) is the generic
  * `src/tui/lib/background-poll.ts` — this module is the worktree-changes
  * binding: one async `git status --porcelain=v1` per worktree, parsed
- * into `+N −M` counts. Failure / timeout keeps the last value — the chip
- * goes stale or stays hidden rather than flashing a bogus zero, the same
- * "never error, just hide" contract as the sync helper.
+ * into `+N −M` counts. Failure / timeout keeps the LAST value; a worktree
+ * that has never read cleanly reads `null`, which the row renders as
+ * UNKNOWN. Deliberately not zeros: an EACCES `.git`, a repo whose status
+ * walk blows POLL_TIMEOUT_MS (then sits out SLOW_REPO_RETRY_MS), and git
+ * off PATH would otherwise all be indistinguishable from a clean worktree
+ * — and this chip is what a user checks before deleting a task.
  *
  * Deleted rows never call `poll()` at all (the Sidebar shows only live
  * tasks): a deleted task must not pay git-status for worktrees that no
@@ -42,10 +45,9 @@ export const SLOW_REPO_RETRY_MS = 60_000
 /** Floor between successful polls — matches the sidebar's ~2s tick. */
 export const MIN_POLL_INTERVAL_MS = 1_500
 
-const ZERO: WorktreeChanges = { added: 0, deleted: 0 }
-
-const poller = createBackgroundPoller<WorktreeChanges>({
-  initial: ZERO,
+const poller = createBackgroundPoller<WorktreeChanges | null>({
+  /** Unknown until a poll lands — see the header: never zeros. */
+  initial: null,
   // Value-equality so a poll returning the same counts doesn't
   // re-render every visible row each tick.
   equals: sameWorktreeChanges,
@@ -68,9 +70,10 @@ const poller = createBackgroundPoller<WorktreeChanges>({
 
 /**
  * Reactive read of the last known change counts for `worktreePath`.
- * Returns zeros (chip hidden) until a poll has completed.
+ * `null` until a poll has completed successfully — the row renders that as
+ * unknown, not as clean.
  */
-export function worktreeChanges(worktreePath: string): WorktreeChanges {
+export function worktreeChanges(worktreePath: string): WorktreeChanges | null {
   return poller.read(worktreePath)
 }
 

--- a/packages/kobe/src/tui/panes/sidebar/worktree-changes.ts
+++ b/packages/kobe/src/tui/panes/sidebar/worktree-changes.ts
@@ -84,11 +84,15 @@ export function sameWorktreeChanges(a: WorktreeChanges | null, b: WorktreeChange
  * exactly the rows the daemon deliberately skips. Pure — unit-tested.
  */
 export function pickPushedChanges(
-  pushed: ReadonlyMap<string, WorktreeChanges> | null | undefined,
+  pushed: ReadonlyMap<string, WorktreeChanges | null> | null | undefined,
   worktreePath: string,
-): WorktreeChanges | null {
+): WorktreeChanges | "unknown" | null {
   if (!pushed) return null
-  return pushed.get(worktreePath) ?? ZERO
+  // PRESENT-with-null is the daemon saying it tried and could not read. That
+  // is not the same as an absent key, and it must not collapse into ZERO — the
+  // hidden chip is what let an unreadable worktree read as clean.
+  if (pushed.has(worktreePath)) return pushed.get(worktreePath) ?? "unknown"
+  return ZERO
 }
 
 /**

--- a/packages/kobe/src/tui/panes/sidebar/worktree-changes.ts
+++ b/packages/kobe/src/tui/panes/sidebar/worktree-changes.ts
@@ -13,10 +13,12 @@
  *
  * Implementation: a single synchronous `git status --porcelain=v1`
  * call, classified per row (any `D` in either column → `−`, anything
- * else → `+`). Falls back to all-zeros for any failure mode (missing
- * repo, EACCES, git not on PATH, worktree gone) so the chip is hidden
- * rather than showing a confusing error state. Never throws — the
- * sidebar must always render.
+ * else → `+`). Never throws — the sidebar must always render — but a
+ * failure returns `null`, NOT zeros: a missing repo, an EACCES, git off
+ * PATH or a vanished worktree all mean "could not read", and `+0 −0` is
+ * the legitimate answer for a genuinely clean worktree. Rendering the two
+ * the same is how a coordinator reads an unreadable worktree as safe to
+ * land and a user reads it as safe to delete.
  *
  * ⚠️ SYNC — one-shot CLI use ONLY (`kobe api` task queries). `git
  * status` is O(repo size); calling this from a render path froze the
@@ -67,7 +69,8 @@ const ZERO: WorktreeChanges = { added: 0, deleted: 0 }
  * pushed-map comparison, so "unchanged counts don't re-render rows"
  * (DESIGN §5.5) is one predicate everywhere.
  */
-export function sameWorktreeChanges(a: WorktreeChanges, b: WorktreeChanges): boolean {
+export function sameWorktreeChanges(a: WorktreeChanges | null, b: WorktreeChanges | null): boolean {
+  if (a === null || b === null) return a === b
   return a.added === b.added && a.deleted === b.deleted && a.behind === b.behind && a.ahead === b.ahead
 }
 
@@ -89,11 +92,13 @@ export function pickPushedChanges(
 }
 
 /**
- * Read worktree change counts for `worktreePath`. Never throws —
- * returns zeros for any failure mode so the renderer skips the chip.
+ * Read worktree change counts for `worktreePath`. Never throws; returns
+ * `null` when the counts could not be read at all — an empty path, a
+ * non-zero `git status`, or a spawn that threw. `null` is NOT `{0,0}`:
+ * callers must render/report it as unknown, never as clean.
  */
-export function readWorktreeChanges(worktreePath: string): WorktreeChanges {
-  if (!worktreePath) return ZERO
+export function readWorktreeChanges(worktreePath: string): WorktreeChanges | null {
+  if (!worktreePath) return null
   try {
     const out = spawnSync("git", ["status", "--porcelain=v1"], {
       cwd: worktreePath,
@@ -106,10 +111,10 @@ export function readWorktreeChanges(worktreePath: string): WorktreeChanges {
       // makes this read-only: inspect, don't write, never take the lock.
       env: readOnlyGitProcessEnv(),
     })
-    if (out.status !== 0 || !out.stdout) return ZERO
+    if (out.status !== 0 || out.stdout === undefined || out.stdout === null) return null
     return parsePorcelain(out.stdout)
   } catch {
-    return ZERO
+    return null
   }
 }
 

--- a/packages/kobe/src/types/worktree.ts
+++ b/packages/kobe/src/types/worktree.ts
@@ -19,13 +19,18 @@ import type { WorktreeVerdict, WorktreeVerdictReason } from "../orchestrator/wor
  * Snapshot of a worktree on disk.
  *
  * `path` is absolute; `head` is the commit SHA; `dirty` is true iff
- * `git status --porcelain` returns any entries (untracked or modified).
+ * `git status --porcelain` returns any entries (untracked or modified),
+ * and `null` when that probe FAILED (unreadable `.git`, worktree gone
+ * between the porcelain snapshot and the probe). `null` is not `false`:
+ * a worktree holding uncommitted work whose status answers "Permission
+ * denied" must not list as clean, because clean is what a user reads
+ * before deleting it.
  */
 export interface WorktreeInfo {
   readonly path: string
   readonly branch: string
   readonly head: string
-  readonly dirty: boolean
+  readonly dirty: boolean | null
 }
 
 /**
@@ -39,7 +44,8 @@ export interface AdoptableWorktree {
   readonly path: string
   readonly branch: string
   readonly head: string
-  readonly dirty: boolean
+  /** As {@link WorktreeInfo.dirty}: `null` = the probe failed, not clean. */
+  readonly dirty: boolean | null
   readonly kobeManaged: boolean
   /**
    * Last-activity time (epoch ms) — the worktree HEAD's commit time,

--- a/packages/kobe/test/cli/api-handlers-lifecycle.test.ts
+++ b/packages/kobe/test/cli/api-handlers-lifecycle.test.ts
@@ -64,7 +64,7 @@ describe("collect handler", () => {
     expect(result.tasks[0].changes).toEqual({ added: 2, deleted: 1 })
   })
 
-  it("skips changes for a task without a worktree", async () => {
+  it("reports changes as unknown, not clean, for a task without a worktree", async () => {
     const client = new FakeClient({ "task.get": () => ({ task: taskFixture({ worktreePath: "" }) }) })
     const result = (await invokeVerb("collect", ["--task-ids", "a"], {
       client,
@@ -77,7 +77,10 @@ describe("collect handler", () => {
         },
       }),
     })) as { tasks: Array<{ changes: unknown; base: unknown }> }
-    expect(result.tasks[0].changes).toEqual({ added: 0, deleted: 0 })
+    // `null`, matching the all-null `base` beside it: there was nothing to
+    // read. `{0,0}` would be a positive claim the caller acts on — the verb
+    // documents non-zero `changes` as "this attempt cannot land".
+    expect(result.tasks[0].changes).toBeNull()
     expect(result.tasks[0].base).toEqual({ baseRef: null, ahead: null, behind: null, diff: null })
   })
 

--- a/packages/kobe/test/client/remote-orchestrator-ui-prefs.test.ts
+++ b/packages/kobe/test/client/remote-orchestrator-ui-prefs.test.ts
@@ -1,0 +1,54 @@
+/**
+ * `decodeUiPrefsPayload`'s backward-compat defaults — the one owner of "an
+ * older daemon omitted this field, so resolve it to its absent-means-leave-it
+ * sentinel", pinned field by field.
+ *
+ * Split from `remote-orchestrator.test.ts` on the same line the source is
+ * split: pure payload decoding here, the orchestrator's channel plumbing
+ * (subscriptions, capability gating, malformed-event logging) there. These
+ * need no client, no bus and no harness — only the decoder and a literal.
+ */
+
+import { describe, expect, it } from "vitest"
+import { decodeUiPrefsPayload } from "../../src/client/remote-orchestrator.ts"
+
+describe("decodeUiPrefsPayload — backward-compat defaults", () => {
+  it("drops a payload with no theme string", () => {
+    expect(decodeUiPrefsPayload(undefined)).toBeNull()
+    expect(decodeUiPrefsPayload({})).toBeNull()
+    expect(decodeUiPrefsPayload({ theme: 42 })).toBeNull()
+  })
+
+  it("an older daemon's theme-only payload resolves every newer field to its absent-sentinel", () => {
+    // The footgun this owns: locale MUST be "" (skip), not "en"; sortMode
+    // "default"; keysCollapsed false; projectFilter null; transparent off.
+    expect(decodeUiPrefsPayload({ theme: "claude" })).toEqual({
+      theme: "claude",
+      transparentBackground: false,
+      focusAccent: null,
+      locale: "",
+      sortMode: "default",
+      keysCollapsed: false,
+      projectFilter: null,
+    })
+  })
+
+  it("carries real values through and normalizes odd ones", () => {
+    expect(
+      decodeUiPrefsPayload({ theme: "tokyonight", locale: "zh-CN", sortMode: "recent", keysCollapsed: true }),
+    ).toEqual({
+      theme: "tokyonight",
+      transparentBackground: false,
+      focusAccent: null,
+      locale: "zh-CN",
+      sortMode: "recent",
+      keysCollapsed: true,
+      projectFilter: null,
+    })
+    // empty projectFilter string → null (all projects); unknown sortMode → default
+    const d = decodeUiPrefsPayload({ theme: "x", projectFilter: "", sortMode: "weird", focusAccent: "#abc" })
+    expect(d?.projectFilter).toBeNull()
+    expect(d?.sortMode).toBe("default")
+    expect(d?.focusAccent).toBe("#abc")
+  })
+})

--- a/packages/kobe/test/client/remote-orchestrator-worktree-changes.test.ts
+++ b/packages/kobe/test/client/remote-orchestrator-worktree-changes.test.ts
@@ -1,0 +1,55 @@
+/**
+ * The `worktree.changes` wire contract's pure helpers — parsing a payload and
+ * comparing two maps.
+ *
+ * Split from `remote-orchestrator.test.ts` along the same seam as the source
+ * (`remote-orchestrator-worktree-changes.ts`): this channel is the one whose
+ * payload says two different things about a key, so "counts", "not collected"
+ * and "could not read" all have to stay distinguishable here. The sibling file
+ * covers the orchestrator's channel plumbing.
+ */
+
+import { describe, expect, it } from "vitest"
+import {
+  type WorktreeChangesMap,
+  parseWorktreeChangesPayload,
+  sameWorktreeChangesMap,
+} from "../../src/client/remote-orchestrator.ts"
+
+describe("worktree.changes pure helpers", () => {
+  it("parseWorktreeChangesPayload accepts an empty map and rejects malformed entries", () => {
+    expect(parseWorktreeChangesPayload({ changes: {} })?.size).toBe(0)
+    expect(parseWorktreeChangesPayload(undefined)).toBeNull()
+    expect(parseWorktreeChangesPayload({ changes: [] })).toBeNull()
+    expect(parseWorktreeChangesPayload({ changes: { "/wt": { added: 1 } } })).toBeNull()
+  })
+
+  it("parseWorktreeChangesPayload maps the daemon's unreadable paths to null", () => {
+    // `unreadable` is additive: an older daemon omits it entirely, and the
+    // parser must still accept the payload rather than reject the whole map.
+    expect(parseWorktreeChangesPayload({ changes: { "/wt": { added: 1, deleted: 0 } } })).toEqual(
+      new Map([["/wt", { added: 1, deleted: 0 }]]),
+    )
+    const withUnreadable = parseWorktreeChangesPayload({
+      changes: { "/wt": { added: 1, deleted: 0 } },
+      unreadable: ["/wt/broken"],
+    })
+    // PRESENT with a null value, not absent: absent would read as a clean row.
+    expect(withUnreadable?.has("/wt/broken")).toBe(true)
+    expect(withUnreadable?.get("/wt/broken")).toBeNull()
+  })
+
+  it("sameWorktreeChangesMap tells an unreadable entry from a missing one", () => {
+    const unreadable: WorktreeChangesMap = new Map([["/wt", null]])
+    expect(sameWorktreeChangesMap(unreadable, new Map([["/wt", null]]))).toBe(true)
+    expect(sameWorktreeChangesMap(unreadable, new Map([["/wt", { added: 0, deleted: 0 }]]))).toBe(false)
+    expect(sameWorktreeChangesMap(unreadable, new Map())).toBe(false)
+  })
+
+  it("sameWorktreeChangesMap compares entry-wise", () => {
+    const a = new Map([["/wt", { added: 1, deleted: 2 }]])
+    expect(sameWorktreeChangesMap(a, new Map([["/wt", { added: 1, deleted: 2 }]]))).toBe(true)
+    expect(sameWorktreeChangesMap(a, new Map([["/wt", { added: 1, deleted: 3 }]]))).toBe(false)
+    expect(sameWorktreeChangesMap(a, new Map())).toBe(false)
+  })
+})

--- a/packages/kobe/test/client/remote-orchestrator.test.ts
+++ b/packages/kobe/test/client/remote-orchestrator.test.ts
@@ -2,6 +2,7 @@ import type { KobeDaemonClient } from "@sma1lboy/kobe-daemon/client"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import {
   RemoteOrchestrator,
+  type WorktreeChangesMap,
   decodeUiPrefsPayload,
   parseWorktreeChangesPayload,
   sameWorktreeChangesMap,
@@ -483,6 +484,28 @@ describe("worktree.changes pure helpers", () => {
     expect(parseWorktreeChangesPayload(undefined)).toBeNull()
     expect(parseWorktreeChangesPayload({ changes: [] })).toBeNull()
     expect(parseWorktreeChangesPayload({ changes: { "/wt": { added: 1 } } })).toBeNull()
+  })
+
+  it("parseWorktreeChangesPayload maps the daemon's unreadable paths to null", () => {
+    // `unreadable` is additive: an older daemon omits it entirely, and the
+    // parser must still accept the payload rather than reject the whole map.
+    expect(parseWorktreeChangesPayload({ changes: { "/wt": { added: 1, deleted: 0 } } })).toEqual(
+      new Map([["/wt", { added: 1, deleted: 0 }]]),
+    )
+    const withUnreadable = parseWorktreeChangesPayload({
+      changes: { "/wt": { added: 1, deleted: 0 } },
+      unreadable: ["/wt/broken"],
+    })
+    // PRESENT with a null value, not absent: absent would read as a clean row.
+    expect(withUnreadable?.has("/wt/broken")).toBe(true)
+    expect(withUnreadable?.get("/wt/broken")).toBeNull()
+  })
+
+  it("sameWorktreeChangesMap tells an unreadable entry from a missing one", () => {
+    const unreadable: WorktreeChangesMap = new Map([["/wt", null]])
+    expect(sameWorktreeChangesMap(unreadable, new Map([["/wt", null]]))).toBe(true)
+    expect(sameWorktreeChangesMap(unreadable, new Map([["/wt", { added: 0, deleted: 0 }]]))).toBe(false)
+    expect(sameWorktreeChangesMap(unreadable, new Map())).toBe(false)
   })
 
   it("sameWorktreeChangesMap compares entry-wise", () => {

--- a/packages/kobe/test/client/remote-orchestrator.test.ts
+++ b/packages/kobe/test/client/remote-orchestrator.test.ts
@@ -1,12 +1,6 @@
 import type { KobeDaemonClient } from "@sma1lboy/kobe-daemon/client"
 import { beforeEach, describe, expect, it, vi } from "vitest"
-import {
-  RemoteOrchestrator,
-  type WorktreeChangesMap,
-  decodeUiPrefsPayload,
-  parseWorktreeChangesPayload,
-  sameWorktreeChangesMap,
-} from "../../src/client/remote-orchestrator.ts"
+import { RemoteOrchestrator } from "../../src/client/remote-orchestrator.ts"
 
 // Keep malformed-event drops diagnosable while preserving every other real export.
 const { logClientError } = vi.hoisted(() => ({ logClientError: vi.fn() }))
@@ -434,85 +428,6 @@ describe("worktree.changes capability gating (init)", () => {
     emit("worktree.changes", { changes: { "/wt/a": { added: 4, deleted: 2 } } })
     await orch.init()
     expect(orch.worktreeChangesSignal()()?.get("/wt/a")).toEqual({ added: 4, deleted: 2 })
-  })
-})
-
-describe("decodeUiPrefsPayload — backward-compat defaults", () => {
-  it("drops a payload with no theme string", () => {
-    expect(decodeUiPrefsPayload(undefined)).toBeNull()
-    expect(decodeUiPrefsPayload({})).toBeNull()
-    expect(decodeUiPrefsPayload({ theme: 42 })).toBeNull()
-  })
-
-  it("an older daemon's theme-only payload resolves every newer field to its absent-sentinel", () => {
-    // The footgun this owns: locale MUST be "" (skip), not "en"; sortMode
-    // "default"; keysCollapsed false; projectFilter null; transparent off.
-    expect(decodeUiPrefsPayload({ theme: "claude" })).toEqual({
-      theme: "claude",
-      transparentBackground: false,
-      focusAccent: null,
-      locale: "",
-      sortMode: "default",
-      keysCollapsed: false,
-      projectFilter: null,
-    })
-  })
-
-  it("carries real values through and normalizes odd ones", () => {
-    expect(
-      decodeUiPrefsPayload({ theme: "tokyonight", locale: "zh-CN", sortMode: "recent", keysCollapsed: true }),
-    ).toEqual({
-      theme: "tokyonight",
-      transparentBackground: false,
-      focusAccent: null,
-      locale: "zh-CN",
-      sortMode: "recent",
-      keysCollapsed: true,
-      projectFilter: null,
-    })
-    // empty projectFilter string → null (all projects); unknown sortMode → default
-    const d = decodeUiPrefsPayload({ theme: "x", projectFilter: "", sortMode: "weird", focusAccent: "#abc" })
-    expect(d?.projectFilter).toBeNull()
-    expect(d?.sortMode).toBe("default")
-    expect(d?.focusAccent).toBe("#abc")
-  })
-})
-
-describe("worktree.changes pure helpers", () => {
-  it("parseWorktreeChangesPayload accepts an empty map and rejects malformed entries", () => {
-    expect(parseWorktreeChangesPayload({ changes: {} })?.size).toBe(0)
-    expect(parseWorktreeChangesPayload(undefined)).toBeNull()
-    expect(parseWorktreeChangesPayload({ changes: [] })).toBeNull()
-    expect(parseWorktreeChangesPayload({ changes: { "/wt": { added: 1 } } })).toBeNull()
-  })
-
-  it("parseWorktreeChangesPayload maps the daemon's unreadable paths to null", () => {
-    // `unreadable` is additive: an older daemon omits it entirely, and the
-    // parser must still accept the payload rather than reject the whole map.
-    expect(parseWorktreeChangesPayload({ changes: { "/wt": { added: 1, deleted: 0 } } })).toEqual(
-      new Map([["/wt", { added: 1, deleted: 0 }]]),
-    )
-    const withUnreadable = parseWorktreeChangesPayload({
-      changes: { "/wt": { added: 1, deleted: 0 } },
-      unreadable: ["/wt/broken"],
-    })
-    // PRESENT with a null value, not absent: absent would read as a clean row.
-    expect(withUnreadable?.has("/wt/broken")).toBe(true)
-    expect(withUnreadable?.get("/wt/broken")).toBeNull()
-  })
-
-  it("sameWorktreeChangesMap tells an unreadable entry from a missing one", () => {
-    const unreadable: WorktreeChangesMap = new Map([["/wt", null]])
-    expect(sameWorktreeChangesMap(unreadable, new Map([["/wt", null]]))).toBe(true)
-    expect(sameWorktreeChangesMap(unreadable, new Map([["/wt", { added: 0, deleted: 0 }]]))).toBe(false)
-    expect(sameWorktreeChangesMap(unreadable, new Map())).toBe(false)
-  })
-
-  it("sameWorktreeChangesMap compares entry-wise", () => {
-    const a = new Map([["/wt", { added: 1, deleted: 2 }]])
-    expect(sameWorktreeChangesMap(a, new Map([["/wt", { added: 1, deleted: 2 }]]))).toBe(true)
-    expect(sameWorktreeChangesMap(a, new Map([["/wt", { added: 1, deleted: 3 }]]))).toBe(false)
-    expect(sameWorktreeChangesMap(a, new Map())).toBe(false)
   })
 })
 

--- a/packages/kobe/test/daemon/worktree-changes-collector.test.ts
+++ b/packages/kobe/test/daemon/worktree-changes-collector.test.ts
@@ -382,3 +382,62 @@ describe("the ahead-of-base count", () => {
     expect(published).toHaveLength(2)
   })
 })
+
+describe("a worktree whose git status fails", () => {
+  test("is published as unreadable, not omitted, and never blocks the readable ones", async () => {
+    // `harness`'s runner throws for any path without seeded counts — the same
+    // shape a real EACCES `.git` or a moved admin dir produces.
+    const { collector, published } = harness([task({ id: "ok" }), task({ id: "broken" })], {
+      "/wt/ok": { added: 3, deleted: 1 },
+    })
+    collector.tick()
+    await settle()
+
+    const last = published.at(-1)
+    expect(last?.changes["/wt/ok"]).toEqual({ added: 3, deleted: 1 })
+    // The whole point. Before this, a failed run reached no callback at all,
+    // so the path fell out of the map — and an absent key is indistinguishable
+    // from "not collected", which every subscriber draws as a clean row.
+    expect(last?.changes["/wt/broken"]).toBeUndefined()
+    expect(last?.unreadable).toEqual(["/wt/broken"])
+  })
+
+  test("omits the field entirely when everything read cleanly", async () => {
+    // Wire compatibility: the common payload stays byte-identical to what this
+    // channel has always published, so an older client sees no new key.
+    const { collector, published } = harness([task({ id: "ok" })], { "/wt/ok": { added: 1, deleted: 0 } })
+    collector.tick()
+    await settle()
+    expect(published.at(-1)?.unreadable).toBeUndefined()
+  })
+
+  test("republishes when an unreadable worktree becomes readable again", async () => {
+    const h = harness([task({ id: "a" })], {})
+    h.collector.tick()
+    await settle()
+    expect(h.published.at(-1)?.unreadable).toEqual(["/wt/a"])
+
+    h.counts["/wt/a"] = { added: 2, deleted: 0 }
+    h.collector.tick()
+    await settle()
+    expect(h.published.at(-1)?.unreadable).toBeUndefined()
+    expect(h.published.at(-1)?.changes["/wt/a"]).toEqual({ added: 2, deleted: 0 })
+  })
+
+  test("does NOT overwrite counts that once read cleanly", async () => {
+    // Stale beats unknown once there is a real value to go stale from — the
+    // same trade `prCheckChip` makes for a provider it could not reach. Only a
+    // worktree that has NEVER read cleanly publishes as unreadable.
+    const h = harness([task({ id: "a" })], { "/wt/a": { added: 4, deleted: 0 } })
+    h.collector.tick()
+    await settle()
+    const before = h.published.length
+
+    h.counts["/wt/a"] = undefined as unknown as WorktreeChanges
+    h.collector.tick()
+    await settle()
+    expect(h.published.length).toBe(before)
+    expect(h.published.at(-1)?.changes["/wt/a"]).toEqual({ added: 4, deleted: 0 })
+    expect(h.published.at(-1)?.unreadable).toBeUndefined()
+  })
+})

--- a/packages/kobe/test/orchestrator/worktree-list-dirty-unknown.test.ts
+++ b/packages/kobe/test/orchestrator/worktree-list-dirty-unknown.test.ts
@@ -1,0 +1,72 @@
+/**
+ * A failed `isDirty` probe must list as UNKNOWN, never as clean.
+ *
+ * `listManaged` and `listAllAdoptable` both catch the probe so one stale row
+ * cannot dark the whole list — that catch stays. What it may not do is answer
+ * `false`: a worktree holding uncommitted work whose `git status` says
+ * `Permission denied` then lists identically to an empty one, and `dirty` is
+ * what the Worktrees page and the adopt picker put in front of a user who is
+ * about to delete it.
+ */
+
+import path from "node:path"
+import { describe, expect, it } from "vitest"
+import { listAllAdoptable, listManaged } from "../../src/orchestrator/worktree/manager-list.ts"
+import { managedWorktreeRootsFor } from "../../src/orchestrator/worktree/paths.ts"
+
+const REPO = "/repo"
+
+/** Two worktrees under the managed root: `ok` probes fine, `bad` rejects. */
+function porcelain(okPath: string, badPath: string): string {
+  return [
+    `worktree ${REPO}`,
+    "HEAD 1111111111111111111111111111111111111111",
+    "branch refs/heads/main",
+    "",
+    `worktree ${okPath}`,
+    "HEAD 2222222222222222222222222222222222222222",
+    "branch refs/heads/ok",
+    "",
+    `worktree ${badPath}`,
+    "HEAD 3333333333333333333333333333333333333333",
+    "branch refs/heads/bad",
+    "",
+  ].join("\n")
+}
+
+function deps(okPath: string, badPath: string) {
+  return {
+    ctxFor: () => ({ exec: { isRemote: false } as never, dir: REPO, remote: false }),
+    runGitStdout: async () => porcelain(okPath, badPath),
+    runGitStdoutAt: async () => "1700000000",
+    isDirty: async (worktreePath: string) => {
+      if (worktreePath === badPath) throw new Error("fatal: error opening '.git': Permission denied")
+      return true
+    },
+  }
+}
+
+describe("a rejected isDirty probe", () => {
+  // `listManaged` keeps only worktrees under a Rove-managed root, so both
+  // fixtures have to live in the real one.
+  const managedRoot = managedWorktreeRootsFor(REPO)[0] ?? ""
+  const okPath = path.join(managedRoot, "ok")
+  const badPath = path.join(managedRoot, "bad")
+
+  it("lists managed worktrees with dirty: null, and keeps every other row", async () => {
+    const rows = await listManaged(deps(okPath, badPath), REPO)
+    const byBranch = new Map(rows.map((row) => [row.branch, row]))
+    expect(byBranch.get("ok")?.dirty).toBe(true)
+    // The whole point: not `false`.
+    expect(byBranch.get("bad")?.dirty).toBeNull()
+    expect(byBranch.get("bad")?.dirty).not.toBe(false)
+  })
+
+  it("lists adoptable worktrees with dirty: null, and keeps every other row", async () => {
+    const rows = await listAllAdoptable(deps(okPath, badPath), REPO)
+    const byBranch = new Map(rows.map((row) => [row.branch, row]))
+    expect(byBranch.get("ok")?.dirty).toBe(true)
+    expect(byBranch.get("bad")?.dirty).toBeNull()
+    expect(byBranch.get("bad")?.dirty).not.toBe(false)
+  })
+})

--- a/packages/kobe/test/render/golden/long-labels.frame.txt
+++ b/packages/kobe/test/render/golden/long-labels.frame.txt
@@ -10,9 +10,9 @@
 | Issues                       |
 |                              |
 | rove ─────────────────────── |
-|  refactor/tab-strip-res… ▴ ✓ |
+|  refactor/tab-strip-r… ▴ ✓ ? |
 |  · persist scrollback acros… |
-|  feat/alpha                  |
+|  feat/alpha                ? |
 |▌ · build                     |
 |                              |
 |                              |

--- a/packages/kobe/test/render/golden/move-mode.frame.txt
+++ b/packages/kobe/test/render/golden/move-mode.frame.txt
@@ -10,10 +10,10 @@
 | Issues                       |
 |                              |
 | rove ─────────────────────── |
-|  feat/alpha                  |
+|  feat/alpha                ? |
 |▌ · build                move |
 |  · review                    |
-|  feat/bravo                  |
+|  feat/bravo                ? |
 |  · tests                     |
 |                              |
 |                              |

--- a/packages/kobe/test/render/golden/recent-jump-row.frame.txt
+++ b/packages/kobe/test/render/golden/recent-jump-row.frame.txt
@@ -12,10 +12,10 @@
 |  ↩ Recent: bravo             |
 |                              |
 | rove ─────────────────────── |
-|  feat/alpha                  |
+|  feat/alpha                ? |
 |▌ · build                     |
 |  · review                    |
-|  feat/bravo                  |
+|  feat/bravo                ? |
 |  · tests                     |
 |                              |
 |                              |

--- a/packages/kobe/test/render/golden/scratch-flat.frame.txt
+++ b/packages/kobe/test/render/golden/scratch-flat.frame.txt
@@ -13,7 +13,7 @@
 |  · shell 1                   |
 |                              |
 | rove ─────────────────────── |
-|  feat/alpha                  |
+|  feat/alpha                ? |
 |▌ · build                     |
 |                              |
 |                              |

--- a/packages/kobe/test/render/golden/scratch-path-label.frame.txt
+++ b/packages/kobe/test/render/golden/scratch-path-label.frame.txt
@@ -10,10 +10,10 @@
 | Issues                       |
 |                              |
 | SCRATCH ──────────────────── |
-|  …deep/nested/project-dir    |
+|  …deep/nested/project-dir  ? |
 |                              |
 | rove ─────────────────────── |
-|  feat/alpha                  |
+|  feat/alpha                ? |
 |▌ · build                     |
 |                              |
 |                              |

--- a/packages/kobe/test/render/golden/search-pruned.frame.txt
+++ b/packages/kobe/test/render/golden/search-pruned.frame.txt
@@ -12,7 +12,7 @@
 | Issues                       |
 |                              |
 | rove ─────────────────────── |
-|▌ feat/bravo                  |
+|▌ feat/bravo                ? |
 |  · tests                     |
 |                              |
 |                              |

--- a/packages/kobe/test/render/golden/search-tab-title.frame.txt
+++ b/packages/kobe/test/render/golden/search-tab-title.frame.txt
@@ -12,7 +12,7 @@
 | Issues                       |
 |                              |
 | rove ─────────────────────── |
-|▌ feat/alpha                  |
+|▌ feat/alpha                ? |
 |  · review                    |
 |                              |
 |                              |

--- a/packages/kobe/test/render/golden/tab-error.frame.txt
+++ b/packages/kobe/test/render/golden/tab-error.frame.txt
@@ -10,10 +10,10 @@
 | Issues                       |
 |                              |
 | rove ─────────────────────── |
-|  feat/alpha                  |
+|  feat/alpha                ? |
 |▌ × build                     |
 |  · review                    |
-|  feat/bravo                  |
+|  feat/bravo                ? |
 |  · tests                     |
 |                              |
 |                              |

--- a/packages/kobe/test/render/golden/tab-idle.frame.txt
+++ b/packages/kobe/test/render/golden/tab-idle.frame.txt
@@ -10,10 +10,10 @@
 | Issues                       |
 |                              |
 | rove ─────────────────────── |
-|  feat/alpha                  |
+|  feat/alpha                ? |
 |▌ ○ build                     |
 |  · review                    |
-|  feat/bravo                  |
+|  feat/bravo                ? |
 |  · tests                     |
 |                              |
 |                              |

--- a/packages/kobe/test/render/golden/tab-non-agent.frame.txt
+++ b/packages/kobe/test/render/golden/tab-non-agent.frame.txt
@@ -10,10 +10,10 @@
 | Issues                       |
 |                              |
 | rove ─────────────────────── |
-|  feat/alpha                  |
+|  feat/alpha                ? |
 |▌ · build                     |
 |  · shell                     |
-|  feat/bravo                  |
+|  feat/bravo                ? |
 |  · tests                     |
 |                              |
 |                              |

--- a/packages/kobe/test/render/golden/tab-permission-needed.frame.txt
+++ b/packages/kobe/test/render/golden/tab-permission-needed.frame.txt
@@ -10,10 +10,10 @@
 | Issues                       |
 |                              |
 | rove ─────────────────────── |
-|  feat/alpha                  |
+|  feat/alpha                ? |
 |▌ ? build                     |
 |  · review                    |
-|  feat/bravo                  |
+|  feat/bravo                ? |
 |  · tests                     |
 |                              |
 |                              |

--- a/packages/kobe/test/render/golden/tab-rate-limited.frame.txt
+++ b/packages/kobe/test/render/golden/tab-rate-limited.frame.txt
@@ -10,10 +10,10 @@
 | Issues                       |
 |                              |
 | rove ─────────────────────── |
-|  feat/alpha                  |
+|  feat/alpha                ? |
 |▌ ◷ build                     |
 |  · review                    |
-|  feat/bravo                  |
+|  feat/bravo                ? |
 |  · tests                     |
 |                              |
 |                              |

--- a/packages/kobe/test/render/golden/tab-running-sibling.frame.txt
+++ b/packages/kobe/test/render/golden/tab-running-sibling.frame.txt
@@ -10,10 +10,10 @@
 | Issues                       |
 |                              |
 | rove ─────────────────────── |
-|  feat/alpha                  |
+|  feat/alpha                ? |
 |▌ · build                     |
 |  ~ review                    |
-|  feat/bravo                  |
+|  feat/bravo                ? |
 |  · tests                     |
 |                              |
 |                              |

--- a/packages/kobe/test/render/golden/tab-running.frame.txt
+++ b/packages/kobe/test/render/golden/tab-running.frame.txt
@@ -10,10 +10,10 @@
 | Issues                       |
 |                              |
 | rove ─────────────────────── |
-|  feat/alpha                  |
+|  feat/alpha                ? |
 |▌ ~ build                     |
 |  · review                    |
-|  feat/bravo                  |
+|  feat/bravo                ? |
 |  · tests                     |
 |                              |
 |                              |

--- a/packages/kobe/test/render/golden/tab-turn-complete.frame.txt
+++ b/packages/kobe/test/render/golden/tab-turn-complete.frame.txt
@@ -10,10 +10,10 @@
 | Issues                       |
 |                              |
 | rove ─────────────────────── |
-|  feat/alpha                  |
+|  feat/alpha                ? |
 |  ● build                     |
 |  · review                    |
-|  feat/bravo                  |
+|  feat/bravo                ? |
 |▌ · tests                     |
 |                              |
 |                              |

--- a/packages/kobe/test/render/golden/tree-unknown.frame.txt
+++ b/packages/kobe/test/render/golden/tree-unknown.frame.txt
@@ -10,10 +10,10 @@
 | Issues                       |
 |                              |
 | rove ─────────────────────── |
-|  feat/alpha                  |
+|  feat/alpha                ? |
 |▌ · build                     |
 |  · review                    |
-|  feat/bravo                  |
+|  feat/bravo                ? |
 |  · tests                     |
 |                              |
 |                              |

--- a/packages/kobe/test/render/golden/worktree-pin-and-pr.frame.txt
+++ b/packages/kobe/test/render/golden/worktree-pin-and-pr.frame.txt
@@ -10,10 +10,10 @@
 | Issues                       |
 |                              |
 | rove ─────────────────────── |
-|  feat/alpha              ▴ ✓ |
+|  feat/alpha            ▴ ✓ ? |
 |▌ · build                     |
 |  · review                    |
-|  feat/bravo                ✗ |
+|  feat/bravo              ✗ ? |
 |  · tests                     |
 |                              |
 |                              |

--- a/packages/kobe/test/render/golden/worktree-status-chip.frame.txt
+++ b/packages/kobe/test/render/golden/worktree-status-chip.frame.txt
@@ -10,11 +10,11 @@
 | Issues                       |
 |                              |
 | rove ─────────────────────── |
-|▌ feat/review             ◇ ✓ |
-|  feat/shipped              ◆ |
-|  feat/dropped              † |
-|  feat/broke                × |
-|  feat/quiet                  |
+|▌ feat/review           ◇ ✓ ? |
+|  feat/shipped            ◆ ? |
+|  feat/dropped            † ? |
+|  feat/broke              × ? |
+|  feat/quiet                ? |
 |                              |
 |                              |
 |                              |

--- a/packages/kobe/test/render/golden/zen-chip.frame.txt
+++ b/packages/kobe/test/render/golden/zen-chip.frame.txt
@@ -10,10 +10,10 @@
 | Issues                       |
 |                              |
 | rove ─────────────────────── |
-|  feat/alpha                  |
+|  feat/alpha                ? |
 |▌ · build                     |
 |  · review                    |
-|  feat/bravo                  |
+|  feat/bravo                ? |
 |  · tests                     |
 |                              |
 |                              |

--- a/packages/kobe/test/render/harness.tsx
+++ b/packages/kobe/test/render/harness.tsx
@@ -37,6 +37,7 @@ import { KVProvider } from "../../src/tui-react/context/kv"
 import { NotificationsProvider } from "../../src/tui-react/context/notifications"
 import { ThemeProvider } from "../../src/tui-react/context/theme"
 import { DialogProvider } from "../../src/tui-react/ui/dialog"
+import { setPrefixHudClock } from "../../src/tui/lib/prefix-hud"
 
 export { act }
 
@@ -100,6 +101,9 @@ let liveRenderer: TestRenderer | null = null
 EventEmitter.defaultMaxListeners = 200
 
 afterEach(() => {
+  // A manual clock is process-global; leaving one installed freezes every
+  // later file's HUD timers.
+  setPrefixHudClock(null)
   if (!liveRenderer) return
   try {
     liveRenderer.destroy()
@@ -108,6 +112,49 @@ afterEach(() => {
   }
   liveRenderer = null
 })
+
+/**
+ * Install an advanceable clock for the prefix-HUD overlay and return its
+ * handle. `advance(ms)` jumps the overlay's `now` forward and fires everything
+ * it scheduled inside that window, so a delayed reveal resolves at once
+ * instead of riding a real timer on an event loop this suite saturates. Wrap
+ * `advance` in `act()` so React flushes the resulting re-render. `afterEach`
+ * restores real time.
+ *
+ * The clock is real time PLUS an offset, not a frozen instant: the dispatch
+ * layer stamps `armedAt` with its own `Date.now()` at the moment of the key
+ * press, so a clock pinned at install time would sit BEHIND that stamp by
+ * however long the mount took, and `advance(PREFIX_GUIDE_DELAY_MS)` would land
+ * short. Riding real time keeps the offset exact however long the mount takes.
+ */
+export function installAdvanceablePrefixHudClock(): { advance(ms: number): void } {
+  let offset = 0
+  let nextId = 1
+  const pending = new Map<number, { at: number; fn: () => void }>()
+  const now = (): number => Date.now() + offset
+  setPrefixHudClock({
+    now,
+    schedule: (fn, ms) => {
+      const id = nextId++
+      pending.set(id, { at: now() + ms, fn })
+      return () => pending.delete(id)
+    },
+  })
+  return {
+    advance(ms: number) {
+      offset += ms
+      // Re-read each pass: a fired callback may schedule the next timer.
+      for (;;) {
+        const due = [...pending].filter(([, timer]) => timer.at <= now()).sort((a, b) => a[1].at - b[1].at)
+        if (due.length === 0) return
+        for (const [id, timer] of due) {
+          pending.delete(id)
+          timer.fn()
+        }
+      }
+    },
+  }
+}
 
 /** Wrap `ui` in the requested providers, innermost-to-outermost: Theme > KV > Focus > Dialog > Notifications — the same nesting the real pane hosts mount. */
 function withProviders(ui: ReactNode, flags: ProviderFlags | undefined): ReactNode {
@@ -137,12 +184,23 @@ export function settle(ms = 60): Promise<void> {
  * Poll `frame()` until the captured frame contains `text` and return that
  * frame. Throws with the last frame on timeout.
  *
- * Call sites that wait on an INTENTIONAL product delay — e.g. the prefix-HUD
- * command guide, which only opens PREFIX_GUIDE_DELAY_MS after the tap — must
- * pass a `timeoutMs` anchored to that product constant, not a bare estimate:
- * the deadline has to cover the delay plus frame latency on a loaded CI
- * runner, or the test flakes at random on unrelated changes — a 1s budget is
- * not enough for ~1.1s of test wall-clock on a slow runner.
+ * `timeoutMs` has a HARD ceiling of 5000ms, and growing past it does not buy
+ * patience — it buys silence. Two things sit exactly on 5000ms:
+ *
+ *   1. bun's default per-test timeout (no `[test] timeout` in bunfig.toml).
+ *      A budget at or above it means bun kills the test before this function
+ *      can throw, so the failure reads `this test timed out after 5000ms`
+ *      with no frame dump — the whole point of this error message is lost.
+ *   2. `DEFAULT_PREFIX_CONFIGURATION.timeoutMs` — the armed PureTUI prefix
+ *      cancels ITSELF 5000ms after the tap and tears the HUD guide down. Past
+ *      that point the answer no longer exists to be polled for.
+ *
+ * So do NOT anchor a budget to a product delay "plus room for a loaded CI
+ * runner": that reasoning is what once put this file's guide budget at
+ * PREFIX_GUIDE_DELAY_MS + 5000 = 5180ms, over both ceilings, where every
+ * failure printed a bare bun timeout and this message never fired once.
+ * When a wait depends on a product timer, drive that timer instead of racing
+ * it (see `installManualPrefixHudClock`) and keep the budget well under 5000ms.
  */
 export async function waitForFrameText(
   frame: () => Promise<string>,

--- a/packages/kobe/test/render/keyboard-hints.test.tsx
+++ b/packages/kobe/test/render/keyboard-hints.test.tsx
@@ -27,7 +27,7 @@ import { KEY_HINTS_ENABLED_KEY, PANE_HINT_USED_KEYS } from "../../src/tui/lib/ke
 import { resetPrefixState } from "../../src/tui/lib/keymap-dispatch"
 import { PREFIX_GUIDE_DELAY_MS } from "../../src/tui/lib/prefix-hud"
 import { PREFIX_TAP_PRESENTATION_KEY } from "../../src/tui/lib/prefix-tap-presentation"
-import { act, renderComponent, settle, waitForFrameText } from "./harness"
+import { act, installAdvanceablePrefixHudClock, renderComponent, settle, waitForFrameText } from "./harness"
 
 const NOOP = (): void => {}
 
@@ -145,14 +145,22 @@ function withGuideKvHome(): void {
   process.env.KOBE_HOME_DIR = home
 }
 
-// The which-key guide is a deliberate delayed reveal: PrefixHud only opens it
-// PREFIX_GUIDE_DELAY_MS after the tap, so the poll budget must cover that
-// product delay plus frame latency on a loaded CI runner (same flake
-// shortcut-reveal guards against).
-const GUIDE_REVEAL_TIMEOUT_MS = PREFIX_GUIDE_DELAY_MS + 5_000
+// The command guide is a deliberate delayed reveal: PrefixHud only opens it
+// PREFIX_GUIDE_DELAY_MS after the tap. DRIVE that product timer, never wait on
+// it — the real one rides an event loop this suite saturates, and the armed
+// prefix cancels itself (tearing the guide down) 5000ms after the tap, so a
+// slipped timer deletes the answer rather than delaying it. Waiting longer is
+// therefore not an option; the budget below covers frame latency only and must
+// stay well under 5000ms (see waitForFrameText in ./harness for both ceilings).
+const GUIDE_FRAME_TIMEOUT_MS = 2_000
 
-async function waitForGuideText(frame: () => Promise<string>, text: string): Promise<string> {
-  return waitForFrameText(frame, text, { timeoutMs: GUIDE_REVEAL_TIMEOUT_MS })
+async function waitForGuideText(
+  clock: { advance(ms: number): void },
+  frame: () => Promise<string>,
+  text: string,
+): Promise<string> {
+  act(() => clock.advance(PREFIX_GUIDE_DELAY_MS))
+  return waitForFrameText(frame, text, { timeoutMs: GUIDE_FRAME_TIMEOUT_MS })
 }
 
 describe("StatusKeyHintBar", () => {
@@ -201,8 +209,9 @@ describe("StatusKeyHintBar", () => {
     )
     await settle()
 
+    const clock = installAdvanceablePrefixHudClock()
     act(() => mockInput.pressKey("a", { ctrl: true }))
-    expect(await waitForGuideText(frame, "more Rove commands")).toContain("more Rove commands")
+    expect(await waitForGuideText(clock, frame, "more Rove commands")).toContain("more Rove commands")
 
     act(() => mockInput.pressKey("z"))
     await settle()
@@ -291,9 +300,10 @@ describe("footer hint clicks", () => {
       { width: 110, height: 30, providers: { kv: true, focus: true, dialog: true } },
     )
     await settle()
+    const clock = installAdvanceablePrefixHudClock()
     const spot = locate(await frame(), "commands")
     await mockMouse.click(spot.x + 1, spot.y)
-    expect(await waitForGuideText(frame, "more Rove commands")).toContain("more Rove commands")
+    expect(await waitForGuideText(clock, frame, "more Rove commands")).toContain("more Rove commands")
     act(() => resetPrefixState())
   })
 })

--- a/packages/kobe/test/render/shortcut-reveal.test.tsx
+++ b/packages/kobe/test/render/shortcut-reveal.test.tsx
@@ -12,7 +12,7 @@ import { bindByIds } from "../../src/tui/context/keybindings"
 import { prefixAction } from "../../src/tui/lib/keymap-dispatch"
 import { PREFIX_GUIDE_DELAY_MS } from "../../src/tui/lib/prefix-hud"
 import { PREFIX_TAP_PRESENTATION_KEY } from "../../src/tui/lib/prefix-tap-presentation"
-import { act, renderComponent, settle, waitForFrameText } from "./harness"
+import { act, installAdvanceablePrefixHudClock, renderComponent, settle, waitForFrameText } from "./harness"
 
 function locate(frame: string, text: string): { x: number; y: number } {
   const lines = frame.split("\n")
@@ -47,14 +47,22 @@ function tempHome(mode?: "local" | "guide"): string {
   return home
 }
 
-// The complete guide is a deliberate delayed reveal: PrefixHud only opens it
-// PREFIX_GUIDE_DELAY_MS after the tap, so the poll budget must cover that
-// product delay plus frame latency on a loaded CI runner — a bare 1s budget
-// flakes at ~1.1s test wall-clock.
-const GUIDE_REVEAL_TIMEOUT_MS = PREFIX_GUIDE_DELAY_MS + 5_000
+// The command guide is a deliberate delayed reveal: PrefixHud only opens it
+// PREFIX_GUIDE_DELAY_MS after the tap. DRIVE that product timer, never wait on
+// it — the real one rides an event loop this suite saturates, and the armed
+// prefix cancels itself (tearing the guide down) 5000ms after the tap, so a
+// slipped timer deletes the answer rather than delaying it. Waiting longer is
+// therefore not an option; the budget below covers frame latency only and must
+// stay well under 5000ms (see waitForFrameText in ./harness for both ceilings).
+const GUIDE_FRAME_TIMEOUT_MS = 2_000
 
-async function waitForGuideText(frame: () => Promise<string>, text: string): Promise<string> {
-  return waitForFrameText(frame, text, { timeoutMs: GUIDE_REVEAL_TIMEOUT_MS })
+async function waitForGuideText(
+  clock: { advance(ms: number): void },
+  frame: () => Promise<string>,
+  text: string,
+): Promise<string> {
+  act(() => clock.advance(PREFIX_GUIDE_DELAY_MS))
+  return waitForFrameText(frame, text, { timeoutMs: GUIDE_FRAME_TIMEOUT_MS })
 }
 
 test("the default prefix tap shows local badges and the complete command guide together", async () => {
@@ -66,8 +74,9 @@ test("the default prefix tap shows local badges and the complete command guide t
     { width: 160, height: 30, providers: { kv: true } },
   )
 
+  const clock = installAdvanceablePrefixHudClock()
   act(() => mockInput.pressKey("a", { ctrl: true }))
-  const local = await waitForGuideText(frame, "more Rove commands")
+  const local = await waitForGuideText(clock, frame, "more Rove commands")
   expect(local).toContain("⌃ A 1")
   expect(local).toContain("⌃ A 2")
   expect(local).toContain("more Rove commands")
@@ -89,8 +98,9 @@ test("a complete-guide row is a real clickable entry in local mode", async () =>
     { width: 160, height: 30, providers: { kv: true } },
   )
 
+  const clock = installAdvanceablePrefixHudClock()
   act(() => mockInput.pressKey("a", { ctrl: true }))
-  const revealed = await waitForGuideText(frame, "Open active Task directory in editor")
+  const revealed = await waitForGuideText(clock, frame, "Open active Task directory in editor")
   const at = locate(revealed, "Open active Task directory in editor")
   await mockMouse.click(at.x + 1, at.y)
   await settle()
@@ -108,8 +118,9 @@ test("the guide setting routes the same prefix tap to the global command guide",
     { width: 160, height: 30, providers: { kv: true } },
   )
 
+  const clock = installAdvanceablePrefixHudClock()
   act(() => mockInput.pressKey("a", { ctrl: true }))
-  const guide = await waitForGuideText(frame, "more Rove commands")
+  const guide = await waitForGuideText(clock, frame, "more Rove commands")
   expect(guide).toContain("more Rove commands")
   expect(guide).toContain("Open active Task directory in editor")
   expect(guide).not.toContain("⌃ A 1")

--- a/packages/kobe/test/tui/filetree-flatten.test.ts
+++ b/packages/kobe/test/tui/filetree-flatten.test.ts
@@ -109,14 +109,24 @@ describe("readWorktreeChanges", () => {
     rmSync(repo, { recursive: true, force: true })
   })
 
-  test("returns zeros for an empty path and for a non-repo dir", () => {
-    expect(readWorktreeChanges("")).toEqual({ added: 0, deleted: 0 })
+  // The three failure branches must be UNKNOWN, never `{0,0}`: `{0,0}` is the
+  // real answer for a clean worktree, and `collect` documents non-zero as
+  // "cannot land", so a fabricated zero reads as safe to land / safe to delete.
+  test("returns null — not zeros — when the counts cannot be read", () => {
+    expect(readWorktreeChanges("")).toBeNull()
     const notRepo = mkdtempSync(join(tmpdir(), "kobe-not-repo-"))
     try {
-      expect(readWorktreeChanges(notRepo)).toEqual({ added: 0, deleted: 0 })
+      // git exits non-zero outside a repo.
+      expect(readWorktreeChanges(notRepo)).toBeNull()
     } finally {
       rmSync(notRepo, { recursive: true, force: true })
     }
+    // A directory that does not exist at all makes the spawn itself throw.
+    expect(readWorktreeChanges(join(tmpdir(), "rove-definitely-not-here-xyz"))).toBeNull()
+  })
+
+  test("a genuinely clean worktree still reads as zeros, not unknown", () => {
+    expect(readWorktreeChanges(repo)).toEqual({ added: 0, deleted: 0 })
   })
 
   test("counts untracked and modified files from real porcelain output", () => {
@@ -124,7 +134,7 @@ describe("readWorktreeChanges", () => {
     mkdirSync(join(repo, "sub"), { recursive: true })
     writeFileSync(join(repo, "sub", "extra.txt"), "hi")
     const changes = readWorktreeChanges(repo)
-    expect(changes.added).toBeGreaterThan(0)
-    expect(changes.deleted).toBe(0)
+    expect(changes?.added).toBeGreaterThan(0)
+    expect(changes?.deleted).toBe(0)
   })
 })

--- a/packages/kobe/test/tui/worktree-changes-poller.test.ts
+++ b/packages/kobe/test/tui/worktree-changes-poller.test.ts
@@ -78,22 +78,23 @@ describe("pollWorktreeChanges end-to-end", () => {
     const repo = makeRepo()
     writeFileSync(join(repo, "a.txt"), "hello")
     writeFileSync(join(repo, "b.txt"), "world")
-    expect(worktreeChanges(repo)).toEqual({ added: 0, deleted: 0 }) // nothing until a poll lands
+    expect(worktreeChanges(repo)).toBeNull() // UNKNOWN until a poll lands — not "clean"
     pollWorktreeChanges(repo) // returns immediately — fire and forget
-    await waitFor(() => worktreeChanges(repo).added === 2)
+    await waitFor(() => worktreeChanges(repo)?.added === 2)
     expect(worktreeChanges(repo)).toEqual({ added: 2, deleted: 0 })
   })
 
-  test("a failing path keeps the last value instead of erroring", async () => {
+  test("a failing path reads unknown, never a fabricated clean", async () => {
     const missing = join(tmpdir(), "kobe-poller-definitely-missing")
     pollWorktreeChanges(missing)
-    // Give the spawn error a moment to settle; the value must stay zeros.
+    // Give the spawn error a moment to settle. `null`, not `{0,0}`: the row
+    // must render this differently from a worktree with nothing uncommitted.
     await new Promise((r) => setTimeout(r, 150))
-    expect(worktreeChanges(missing)).toEqual({ added: 0, deleted: 0 })
+    expect(worktreeChanges(missing)).toBeNull()
   })
 
-  test("empty path is a no-op", () => {
+  test("empty path is a no-op and reads unknown", () => {
     pollWorktreeChanges("")
-    expect(worktreeChanges("")).toEqual({ added: 0, deleted: 0 })
+    expect(worktreeChanges("")).toBeNull()
   })
 })

--- a/packages/kobe/test/tui/worktree-changes.test.ts
+++ b/packages/kobe/test/tui/worktree-changes.test.ts
@@ -68,3 +68,22 @@ describe("sameWorktreeChanges", () => {
     expect(sameWorktreeChanges({ added: 0, deleted: 0, ahead: 2 }, { added: 0, deleted: 0, ahead: 2 })).toBe(true)
   })
 })
+
+describe("pickPushedChanges and the daemon's unreadable list", () => {
+  // Three distinct facts share this one lookup, and collapsing any two of them
+  // is how an unreadable worktree came to render as a clean one.
+  test("separates counts, not-collected, and could-not-read", () => {
+    const pushed = new Map<string, { added: number; deleted: number } | null>([
+      ["/wt/ok", { added: 2, deleted: 1 }],
+      // The daemon TRACKED this one and its git status failed.
+      ["/wt/broken", null],
+    ])
+    expect(pickPushedChanges(pushed, "/wt/ok")).toEqual({ added: 2, deleted: 1 })
+    expect(pickPushedChanges(pushed, "/wt/broken")).toBe("unknown")
+    // Absent = the daemon does not collect it (remote project, fresh task).
+    // Still zeros: the row draws no chip, which is what it has always done.
+    expect(pickPushedChanges(pushed, "/wt/never-collected")).toEqual({ added: 0, deleted: 0 })
+    // No daemon at all — the caller falls back to the local poller.
+    expect(pickPushedChanges(null, "/wt/ok")).toBeNull()
+  })
+})

--- a/packages/kobe/test/types/worktree.test-d.ts
+++ b/packages/kobe/test/types/worktree.test-d.ts
@@ -9,7 +9,9 @@ describe("WorktreeInfo", () => {
     expectTypeOf<WorktreeInfo["path"]>().toEqualTypeOf<string>()
     expectTypeOf<WorktreeInfo["branch"]>().toEqualTypeOf<string>()
     expectTypeOf<WorktreeInfo["head"]>().toEqualTypeOf<string>()
-    expectTypeOf<WorktreeInfo["dirty"]>().toEqualTypeOf<boolean>()
+    // Nullable on purpose: `null` = the status probe failed, and it must not
+    // collapse into `false` (clean) anywhere a user reads it.
+    expectTypeOf<WorktreeInfo["dirty"]>().toEqualTypeOf<boolean | null>()
   })
 
   it("rejects excess properties", () => {


### PR DESCRIPTION
Four items from `loop-r10`'s failure brief: the render flake that has been costing reruns, and three surfaces of one defect — a failed git read rendered as a clean answer.

---

## Item 1 — P1: `shortcut-reveal` could not report its own failure

**What was wrong.** The test's poll budget was `PREFIX_GUIDE_DELAY_MS + 5_000` = **5180ms**, sitting above *two* 5000ms ceilings: bun's default per-test timeout (no `[test] timeout` in `bunfig.toml`), and `DEFAULT_PREFIX_CONFIGURATION.timeoutMs`, at which the armed prefix cancels itself and tears the guide down. So the test waited 180ms past the point the product had deleted the answer, and bun killed it first — which is why both CI failures printed `this test timed out after 5000ms` with no diagnostic, and why the harness's `frame did not contain …` message (added by #650) had never once fired.

**What changed.** `PrefixHud` now reads `now` and schedules its two expiry timers through an injectable clock owned by `src/tui/lib/prefix-hud.ts` (`prefixHudClock` / `setPrefixHudClock`). `test/render/harness.tsx` gains `installAdvanceablePrefixHudClock()`, and `shortcut-reveal` / `keyboard-hints` advance that clock by the product delay instead of racing a real timer on an event loop this suite saturates. Their budgets drop to 2000ms, well under both ceilings.

The clock is real time **plus an offset**, not a frozen instant: the dispatch layer stamps `armedAt` with its own `Date.now()` at the key press, so a clock pinned at install time would sit behind that stamp by however long the mount took and `advance(180)` would land short.

**PASS criterion.** A deliberately broken reveal must fail with the harness's `frame did not contain …` message and a frame dump, **not** a bare bun timeout. Same mutation (`return undefined` in place of the reveal `setTimeout`) on both sides:

```
--- broken reveal, OLD (origin/main) code ---
  ^ this test timed out after 5000ms.          <- the reported failure, matching both CI runs
error: frame did not contain "more Rove commands" within 5180ms:   (arrives after bun already killed it)
  ^ this test timed out after 5000ms.
  ^ this test timed out after 5000ms.          <- third test: bun timeout only, no harness message at all
 0 pass / 3 fail

--- broken reveal, NEW code ---
error: frame did not contain "more Rove commands" within 2000ms:      + full frame dump
error: frame did not contain "Open active Task directory in editor" within 2000ms:
error: frame did not contain "more Rove commands" within 2000ms:
 0 pass / 3 fail        (no bun timeout on any of the three)
```

Also fixed the advice at `harness.tsx:140-151` that told the next author to anchor budgets to the product delay "with room for a loaded CI runner" — the reasoning that produced 5180ms. It now names both ceilings and points at the clock.

**20 consecutive `bun test test/render` runs:** see the comment below.

**Unrelated flake seen, not caused here:** `test/render/terminal-paste-newlines.test.tsx > "a multi-line paste is delivered as one paste, never as Enter"` failed twice in ~10 full-suite runs on this branch. It shares no module with this diff and is untouched by it; 8 consecutive full-suite runs on a clean `origin/main` worktree were green, so I could not reproduce it at baseline either — recording it rather than claiming it is or isn't mine.

---

## Items 2-4 — one shape: a failed read is `null`, never a zero

`readWorktreeChanges` returned `ZERO` for an empty path, a non-zero `git status`, and a thrown spawn — and `ZERO` is also the right answer for a genuinely clean worktree. `WorktreeInfo.dirty` / `AdoptableWorktree.dirty` did the same with `false`. The honest shape already existed in the same payload (`readBranchSignals` returns nulls all the way out to `collect`'s `base`), so all three now carry it: `WorktreeChanges | null` for the counts, `boolean | null` for `dirty`. One shape covers F1 and F5 literally (same helper); F6 is a different function with a boolean, so it is the same *idea* rather than the same type — noted because the brief asked.

### F1 — `collect` (JSON only)

PASS: the brief's recipe must emit `changes: null` for the broken worktree and `{added:2,deleted:0}` for the healthy one. Replayed end to end against an isolated Rove home:

```
--- HEALTHY baseline ---
changes = {"added": 2, "deleted": 0}   base = {"baseRef": "main", "ahead": 0, "behind": 0, "diff": {...}}

--- BROKEN git (admin dir moved), feature.txt + modified README.md still on disk ---
$ git status  ->  fatal: not a git repository: .../\.git/worktrees/clam
changes = null                          base = {"baseRef": null, "ahead": null, "behind": null, "diff": null}
```

(brief's BEFORE for the same state: `changes = {"added": 0, "deleted": 0}`.)

The verb summary now documents it: `uncommitted .changes (non-zero = it cannot land; null = could not read git — do NOT treat as clean)`.

### F5 — the sidebar `+N −M` chip

PASS: a task row whose worktree git read fails renders visibly differently from a clean row. A muted `?` — the same muted-tone vocabulary `prCheckChip` already uses for a value nothing is confirming, and `?` is free in the glyph set this cluster shares. It replaces the whole `↑/+/−/↓` cluster rather than sitting beside it, so it does not fight the new `↑N` chip from #857 for reserved width.

**BEFORE/AFTER through browser `/harness` → xterm.js → PTY sidecar → real OpenTUI.** Same state on both sides: a materialized worktree holding an uncommitted `urgent.txt`, its `.git` `chmod 000`, cold daemon so nothing ever read cleanly. BEFORE captured on an `origin/main` worktree, not on a revert.

| | |
|---|---|
| BEFORE (`origin/main`) — no chip at all; the row reads as clean | `.scratch/r10y/shots/f5-before.png` |
| AFTER — muted `?` | `.scratch/r10y/shots/f5-after.png` |

**One consequence worth calling out:** the local poller is only the no-daemon fallback. While daemon-connected — the normal case — the collector wrote a value *only on success*, so an unreadable worktree dropped out of the published map entirely, and an absent key is what `pickPushedChanges` turned into zeros. Fixing only the poller would have left F5 broken on the path most users run, so the daemon channel gained an additive `unreadable: string[]` (old clients ignore it; old daemons omit it, which new clients read as "nothing unreadable"). The AFTER screenshot is the daemon path. A worktree that once read cleanly still keeps its last counts rather than going unknown — same "stale, not wrong" trade `prCheckChip` makes.

A row with **no worktree yet** draws no chip: that is a fact, not an unknown, and every fresh task would otherwise wear a `?` while its job is still running.

### F6 — `discover-adoptable` and the Worktrees page

PASS: a worktree whose `isDirty` rejects lists with `dirty: null` and renders an unknown marker, and the list still returns every other row.

```
--- baseline (readable) ---           {"branch": "adoptme", "dirty": true}
$ git status  ->  fatal: error opening '.../adoptme/.git': Permission denied
--- AFTER, urgent.txt still on disk ---  {"branch": "adoptme", "dirty": null}
```

(brief's BEFORE for the same state: `"dirty": false`.)

| | |
|---|---|
| BEFORE (`origin/main`) — `visual-fixture  rove  remote unknown`, no dirty badge | `.scratch/r10y/shots/f6-before.png` |
| AFTER — `visual-fixture  rove  dirty?  remote unknown` | `.scratch/r10y/shots/f6-after.png` |

The `.catch` stays — it exists so one stale row cannot dark the whole list; only its value changed. New unit test `test/orchestrator/worktree-list-dirty-unknown.test.ts` covers both `listManaged` and `listAllAdoptable`; reverting the two catches to `() => false` fails both.

---

## Two files split, no exemptions

`file-size-cap` flagged two touched files. They were different cases and both got the split rather than an exemption line:

- **`src/client/remote-orchestrator-payloads.ts` (490 on `main` → 501): mine, and there is a real seam.** `worktree.changes` is now the one channel whose payload says two different things about the same key, while everything else in that module is one shape per channel. Its map type, parser and equality moved to `remote-orchestrator-worktree-changes.ts`, re-exported from payloads so no importer changed. 501 → 445.
- **`test/client/remote-orchestrator.test.ts` (523 on `main` → 546): already over before this branch.** Split along the same line as the source — pure decoders out (`-worktree-changes.test.ts`, `-ui-prefs.test.ts`), orchestrator plumbing (subscriptions, capability gating, malformed-event logging) stays. 546 → 462. The `remote-orchestrator-*.test.ts` sibling family already existed, so this follows the file's own convention.

`tree-rows.tsx` sits at 493 — inside the warn band, not over, and it predates this branch.

## The sidebar frame goldens moved, deliberately

19 scenes in `test/render/golden/`, one character each: the golden scenes' worktree paths are synthetic, so their git read fails and every row picks up the unknown mark.

```
- |  feat/alpha                  |          - |▌ feat/review             ◇ ✓ |
+ |  feat/alpha                ? |          + |▌ feat/review           ◇ ✓ ? |
```

Regenerated with `KOBE_UPDATE_GOLDEN=1`; the whole diff is the `?` landing beside the existing chips with the reserved width shifting to make room, which is also the check that matters — `row-chips.ts` opens by saying these share one cell group and no glyph may mean two things. `?` appears in none of `✓ ✗ • ≠ » ≡ × † ◇ ◆ ▴`.

I did **not** add a block to `test/golden/sidebar-row-state.golden.txt`, which the brief suggested. That golden enumerates pure `Task → chip` maps, and the changes chip is derived from poller output rather than a `Task` field, so it has no place in that input space; the rendered frame golden above pins the same fact in the cell group where the constraint actually lives.

---

## What I could not prove / deliberately did not do

- **The staleness verdict still reads an unreadable probe as not-dirty.** `daemon-worktree-adapter.ts` passes `worktree.dirty === true` into `judgeWorktree`, preserving today's behaviour exactly. Widening `WorktreeVerdictReason` would need a new i18n key in every locale for a cascade the brief scoped out. Safe because the destructive path does not consult this verdict: `manager-remove.ts:273` calls `isDirty` **uncaught**, so removing an unreadable worktree throws rather than proceeding.
- **A `git status` that TIMES OUT** (the `POLL_TIMEOUT_MS` / `SLOW_REPO_RETRY_MS` case F5 also mentions) still keeps its last value and does not publish unknown — the scheduler skips the callback on an aborted run, and a timeout is genuinely "too slow", not "unreadable". A repo that has never finished a status once will read unknown, which is right.
- **F2, F3, F4, F7, F8** untouched, per the brief. None of this diff covers any of them.

## Gates

`bun run lint` · `bun run typecheck` (all four packages) · `test:fast` 4371 passed / 443 files · `KOBE_INCLUDE_SOCKET=1 test:socket` 785 passed / 96 files · `bun test test/render` 464 passed / 0 failed, ×20 — see the comment below.

## Keybindings

No new or moved chords.
