### PR TITLE
loop-r10 Z: five reads that reported a failure as a fact

### DIFF
--- a/.changeset/loop-r10-z-silent-degradations.md
+++ b/.changeset/loop-r10-z-silent-degradations.md
@@ -1,0 +1,27 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Five reads that reported a failure as a fact.
+
+- **Kanban** kept a project on the board when its story read failed. A rejected
+  `issue.list` used to drop the whole project from the tab strip, so a user
+  with two repos saw one, with no error, no glyph, and no reason to think the
+  other existed. The project now keeps its slot, states the read failure where
+  its columns would be, and raises a toast naming the repo.
+- **`issue-list`** reports `skipped`, the number of entries on disk it could
+  not read (an issue whose `id` is not a number is dropped). A short list is no
+  longer indistinguishable from the whole board, and the drop is logged with
+  the repo key. A corrupt `nextId` now resumes at `max(id) + 1` instead of `1`,
+  which used to hand `create` an id that already existed in the same file.
+- **`pty-list`** answers `sessions: null` when there is no PTY host to ask.
+  `[]` used to mean both that and "a live host with nothing running", so an
+  agent could read a running fleet as idle. `[]` now means only the latter,
+  matching what `inspect` has always returned.
+- **`add --prompt`** reports `promptPersisted: false` when the brief was
+  delivered but the store refused to record it. The task still succeeds, but an
+  unpersisted brief silently removes **Run again** from that task's menu.
+- **`discover-adoptable`** reports `unreadable`: worktrees whose admin dir
+  `git worktree list` omitted without an error or a non-zero exit. An empty
+  `worktrees` array no longer hides a worktree that exists on disk, holds
+  uncommitted work, and has no path to adoption.

--- a/docs/API.md
+++ b/docs/API.md
@@ -196,7 +196,9 @@ replacement in `nextCommandArgs`.
   transcript and stored by the daemon on `turn-complete`; engines without a
   turn reader contribute nothing. Read-only.
 - `pty-list` *(offline)*: hosted PTY sessions (key, alive, pid, command,
-  live window title). Empty when no PTY host runs.
+  live window title). `sessions: []` means a live PTY host with nothing
+  running; `sessions: null` means there was no host to ask — "couldn't look",
+  not an idle fleet. Never read `null` as "no sessions running".
 - `read-output [--task-id ID] [--tab TAB] [--source auto|history|terminal]
   [--cursor C] [--limit N]`: a task's engine output as bounded, cursor-paged
   JSON: structured history when the engine has it, else a labeled terminal
@@ -592,7 +594,12 @@ nothing to do), `skipped_missed`, `skipped_unavailable`, and
 - `ensure-worktree --task-id ID`: materialize a task's git worktree on
   disk now (without starting an engine). Returns `{ worktreePath }`.
 - `discover-adoptable --repo PATH`: list existing git worktrees not yet
-  tracked as Rove tasks.
+  tracked as Rove tasks. Returns `{ worktrees, unreadable }`. `unreadable` is
+  the admin-dir names under `<repo>/.git/worktrees/` that `git worktree list`
+  omitted without an error — a worktree that exists on disk (uncommitted work
+  and all) but cannot be read, and so cannot be adopted until the permissions
+  are fixed. `worktrees: []` with `unreadable: []` is the only combination that
+  means "this repo has nothing to adopt".
 - `adopt --repo PATH --worktree PATH [--branch B] [--command CMD] [--title T]`:
   import an existing git worktree as a Rove task.
 

--- a/packages/kobe-daemon/src/daemon/handlers-worktree.ts
+++ b/packages/kobe-daemon/src/daemon/handlers-worktree.ts
@@ -31,8 +31,20 @@ export const WORKTREE_HANDLERS: readonly DaemonRequestHandler[] = [
     web: true,
     async handle(payload, ctx) {
       const repo = requireString(payload, "repo")
-      const worktrees = await ctx.orch.discoverAdoptableWorktrees(repo)
-      return { worktrees }
+      // `git worktree list --porcelain` drops an entry whose admin dir it
+      // cannot read and exits 0 anyway, so `worktrees: []` alone could mean
+      // either "nothing to adopt" or "your worktree is unreadable and its
+      // uncommitted work is unreachable from here". `unreadable` separates
+      // the two. Composed from `ctx.runtime` like `list`/`remove` below —
+      // it is a git-layout fact, not an orchestrator one.
+      const [worktrees, unreadable] = await Promise.all([
+        ctx.orch.discoverAdoptableWorktrees(repo),
+        ctx.runtime.listUnreadableWorktrees(repo).catch((err) => {
+          logDaemonError("worktree-discover-unreadable", err)
+          return [] as readonly string[]
+        }),
+      ])
+      return { worktrees, unreadable }
     },
   },
   {

--- a/packages/kobe-daemon/src/daemon/issues-store.ts
+++ b/packages/kobe-daemon/src/daemon/issues-store.ts
@@ -4,6 +4,7 @@ import { homedir } from "node:os"
 import { join, resolve } from "node:path"
 import { promisify } from "node:util"
 import { ROVE_STATE_DIR_BASENAME, readRoveHomeDirEnv } from "../compat-env.ts"
+import { logDaemonError } from "./crash-log.ts"
 import { serialized, writeJsonAtomic } from "./json-file.ts"
 import { gitTopLevel, resolveRepoRoot } from "./repo-key.ts"
 
@@ -28,6 +29,13 @@ export interface RepoIssues {
   exists: boolean
   nextId: number
   issues: Issue[]
+  /**
+   * Entries in the file this read could not use — an issue whose `id` is not
+   * a number is dropped by {@link normalizeIssue}. Non-zero means the store
+   * holds stories this response does NOT list, so a short `issues` array is
+   * not the whole board. `0` is the only value that means "you have it all".
+   */
+  skipped: number
 }
 
 interface RepoIssueRecord {
@@ -76,8 +84,32 @@ function normalizeIssue(entry: unknown): Issue | null {
   }
 }
 
+/** One read of the store file, plus what that read had to throw away. */
+interface StoreRead {
+  readonly file: IssuesStoreFile
+  /** repoKey → number of unusable issue entries this read dropped. */
+  readonly skipped: ReadonlyMap<string, number>
+}
+
 function emptyStore(): IssuesStoreFile {
   return { version: 1, repos: {} }
+}
+
+/**
+ * Where to resume allocating ids when the file's `nextId` is unusable.
+ * Falling back to `1` hands `create` an id that ALREADY EXISTS in the same
+ * file — two cards, same number, and every id-keyed op (setStatus/update/
+ * delete) then hits whichever one `find` reaches first. Scans the RAW entries
+ * so even an id we could not parse into an issue still pushes the allocation
+ * point past itself.
+ */
+function nextIdFallback(entries: readonly unknown[]): number {
+  let max = 0
+  for (const entry of entries) {
+    const id = Number((entry as { id?: unknown } | null | undefined)?.id)
+    if (Number.isFinite(id) && id > max) max = Math.trunc(id)
+  }
+  return max + 1
 }
 
 function todayStamp(): string {
@@ -105,26 +137,40 @@ async function resolveRepo(raw: unknown): Promise<{ repoRoot: string; repoKey: s
   }
 }
 
-async function readStore(path: string): Promise<IssuesStoreFile> {
+async function readStore(path: string): Promise<StoreRead> {
   try {
     const raw = JSON.parse(await readFile(path, "utf8")) as Partial<IssuesStoreFile>
     const repos: Record<string, RepoIssueRecord> = {}
+    const skipped = new Map<string, number>()
     if (raw.repos && typeof raw.repos === "object") {
       for (const [key, value] of Object.entries(raw.repos)) {
         if (!value || typeof value !== "object") continue
         const record = value as Partial<RepoIssueRecord>
+        const entries: readonly unknown[] = Array.isArray(record.issues) ? record.issues : []
+        const issues = entries.map(normalizeIssue).filter((issue): issue is Issue => issue !== null)
+        // Dropping silently is what made a filed story stop existing in every
+        // read while still sitting in the file. Count it here so `list` can
+        // say so, and log it so the daemon log names the repo.
+        const dropped = entries.length - issues.length
+        if (dropped > 0) {
+          skipped.set(key, dropped)
+          logDaemonError(
+            "issues-store-read",
+            new Error(
+              `${key}: dropped ${dropped} unreadable issue entr${dropped === 1 ? "y" : "ies"} (id is not a number)`,
+            ),
+          )
+        }
         repos[key] = {
           repoRoot: typeof record.repoRoot === "string" ? record.repoRoot : "",
-          nextId: typeof record.nextId === "number" ? record.nextId : 1,
-          issues: Array.isArray(record.issues)
-            ? record.issues.map(normalizeIssue).filter((issue): issue is Issue => issue !== null)
-            : [],
+          nextId: typeof record.nextId === "number" ? record.nextId : nextIdFallback(entries),
+          issues,
         }
       }
     }
-    return { version: 1, repos }
+    return { file: { version: 1, repos }, skipped }
   } catch (err) {
-    if ((err as NodeJS.ErrnoException).code === "ENOENT") return emptyStore()
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return { file: emptyStore(), skipped: new Map() }
     throw err
   }
 }
@@ -133,12 +179,13 @@ async function writeStore(path: string, store: IssuesStoreFile): Promise<void> {
   await writeJsonAtomic(path, store)
 }
 
-function response(repoRoot: string, record: RepoIssueRecord | null): RepoIssues {
+function response(repoRoot: string, record: RepoIssueRecord | null, skipped = 0): RepoIssues {
   return {
     repoRoot,
     exists: record !== null,
     nextId: record?.nextId ?? 1,
     issues: record?.issues ?? [],
+    skipped,
   }
 }
 
@@ -148,13 +195,13 @@ export class IssuesStore {
   async list(repo: unknown): Promise<RepoIssues> {
     const { repoRoot, repoKey } = await resolveRepo(repo)
     return serialized(this.path, async () => {
-      const store = await readStore(this.path)
+      const { file: store, skipped } = await readStore(this.path)
       const record = store.repos[repoKey] ?? null
       if (record && record.repoRoot !== repoRoot) {
         record.repoRoot = repoRoot
         await writeStore(this.path, store)
       }
-      return response(repoRoot, record)
+      return response(repoRoot, record, skipped.get(repoKey) ?? 0)
     })
   }
 
@@ -172,7 +219,7 @@ export class IssuesStore {
     const { repoRoot, repoKey } = await resolveRepo(repo)
     if (!taskId) return null
     return serialized(this.path, async () => {
-      const store = await readStore(this.path)
+      const { file: store, skipped } = await readStore(this.path)
       const record = store.repos[repoKey]
       if (!record) return null
       const issue = record.issues.find((i) => i.taskId === taskId)
@@ -180,7 +227,7 @@ export class IssuesStore {
       issue.status = "done"
       record.repoRoot = repoRoot
       await writeStore(this.path, store)
-      return response(repoRoot, record)
+      return response(repoRoot, record, skipped.get(repoKey) ?? 0)
     })
   }
 
@@ -197,7 +244,7 @@ export class IssuesStore {
     const { repoRoot, repoKey } = await resolveRepo(repo)
     if (!taskId) return null
     return serialized(this.path, async () => {
-      const store = await readStore(this.path)
+      const { file: store, skipped } = await readStore(this.path)
       const record = store.repos[repoKey]
       if (!record) return null
       const issue = record.issues.find((i) => i.taskId === taskId)
@@ -205,7 +252,7 @@ export class IssuesStore {
       issue.taskId = undefined
       record.repoRoot = repoRoot
       await writeStore(this.path, store)
-      return response(repoRoot, record)
+      return response(repoRoot, record, skipped.get(repoKey) ?? 0)
     })
   }
 
@@ -215,7 +262,7 @@ export class IssuesStore {
       throw new Error("missing op")
     }
     return serialized(this.path, async () => {
-      const store = await readStore(this.path)
+      const { file: store, skipped } = await readStore(this.path)
       let record = store.repos[repoKey]
       if (!record) {
         record = { repoRoot, nextId: 1, issues: [] }
@@ -277,7 +324,7 @@ export class IssuesStore {
         throw new Error(`unknown op type: ${(typed as { type: string }).type}`)
       }
       await writeStore(this.path, store)
-      return response(repoRoot, record)
+      return response(repoRoot, record, skipped.get(repoKey) ?? 0)
     })
   }
 }

--- a/packages/kobe-daemon/src/daemon/runtime.ts
+++ b/packages/kobe-daemon/src/daemon/runtime.ts
@@ -92,6 +92,14 @@ export interface DaemonRuntimeAdapter {
   readEngineContextUsage(vendor: VendorId, sessionId: string): Promise<EngineContextUsage | null>
   maybeAutoStart(orch: DaemonOrchestrator, taskId: string): Promise<string>
   listWorktreeProjects(network: boolean): Promise<unknown[]>
+  /**
+   * Worktree admin-dir NAMES that `git worktree list --porcelain` omitted
+   * without an error or a non-zero exit — git's own silence about a worktree
+   * whose admin dir it cannot read. Names only: an unreadable admin dir takes
+   * its path/branch/head with it. Best-effort, `[]` when nothing to report or
+   * nothing could be enumerated.
+   */
+  listUnreadableWorktrees(repo: string): Promise<readonly string[]>
   /** Remove a worktree. Resolves with the leftover directory when git
    *  deregistered the worktree but could not delete it (a partial removal that
    *  no retry can advance); resolves with null on a clean removal. */

--- a/packages/kobe/src/cli/api/handler-helpers.ts
+++ b/packages/kobe/src/cli/api/handler-helpers.ts
@@ -25,8 +25,14 @@ export async function simpleRpc(ctx: VerbContext, name: string, payload: Record<
  * `pty-list` — inventory of the standalone pty host's sessions (key, pid,
  * command, live OSC window title — the same "实时进程名" stream the TUI tab
  * strip shows). Talks to the PTY HOST socket, not the daemon (offline verb),
- * and never spawns a host: no host running simply means no sessions.
- * Moved here from `verbs.ts` verbatim to keep that file under the size cap.
+ * and never spawns a host.
+ *
+ * `sessions: null` when there is no host to ask. It used to be `[]`, which is
+ * also the answer for a LIVE host running nothing — so an agent reading
+ * `{"sessions":[]}` concluded the fleet was idle and could respawn work that
+ * was already running, or call a live task dead. `inspect`'s sessions section
+ * has always returned `null` for this exact failure; the two verbs now agree.
+ * Moved here from `verbs.ts` to keep that file under the size cap.
  */
 export async function handlePtyList(): Promise<unknown> {
   const [{ KobeDaemonClient }, { defaultPtyHostSocketPath }] = await Promise.all([
@@ -38,7 +44,7 @@ export async function handlePtyList(): Promise<unknown> {
     await client.connect()
     return await client.request("pty.list", {})
   } catch {
-    return { sessions: [] }
+    return { sessions: null }
   } finally {
     client.close()
   }

--- a/packages/kobe/src/cli/api/handlers-add.ts
+++ b/packages/kobe/src/cli/api/handlers-add.ts
@@ -151,8 +151,11 @@ async function addOne(ctx: VerbContext, repo: string): Promise<unknown> {
   // with the engine. Recorded only AFTER delivery confirms, so `get-task`'s
   // `.task.prompt` always means "the engine was given exactly this text".
   // Best-effort: the engine already has the prompt, so a persist failure
-  // must not turn a delivered task into an error.
-  await daemon.request("task.setPrompt", { taskId, prompt }).catch(() => undefined)
+  // must not turn a delivered task into an error — but it must not be silent
+  // either. Without `.task.prompt` the sidebar menu drops **Run again**
+  // (`tui/panes/sidebar/tree-menu.ts` gates the verb on it), so the action is
+  // gone forever with nothing on screen or in the result explaining why.
+  const promptPersisted = await persistPrompt(daemon, taskId, prompt)
   task = (await daemon.request<{ task: SerializedTask }>("task.get", { taskId })).task
   return {
     taskId,
@@ -164,6 +167,22 @@ async function addOne(ctx: VerbContext, repo: string): Promise<unknown> {
     ...(delivered.bytes === undefined ? {} : { bytes: delivered.bytes }),
     ...(delivered.promptEcho ? { promptEcho: delivered.promptEcho } : {}),
     ...(delivered.deferred ? { deferred: delivered.deferred } : {}),
+    ...(promptPersisted ? {} : { promptPersisted: false }),
+  }
+}
+
+/**
+ * Record the brief on the task. Resolves `false` (never rejects) when the
+ * store refused it — see the call sites for why that stays best-effort and
+ * why the caller must still SAY so.
+ */
+async function persistPrompt(daemon: DaemonRpc, taskId: string, prompt: string): Promise<boolean> {
+  try {
+    await daemon.request("task.setPrompt", { taskId, prompt })
+    return true
+  } catch (err) {
+    console.error(`[rove api add] task.setPrompt failed for ${taskId} — no "Run again" for this task:`, err)
+    return false
   }
 }
 
@@ -305,7 +324,7 @@ async function addParallel(
       // that deferred prompt is released, dismissed, or expires). It
       // resolves with `delivered:false`, so route it here — not to `failures` —
       // and carry the marker through so a script can see it was queued.
-      tasks.push({
+      const row: Record<string, unknown> = {
         ok: true,
         taskId,
         vendor,
@@ -313,8 +332,17 @@ async function addParallel(
         engineReady: r.value.engineReady,
         session: r.value.session,
         ...(r.value.deferred ? { deferred: r.value.deferred } : {}),
-      })
-      persistedPrompts.push(daemon.request("task.setPrompt", { taskId, prompt }).catch(() => undefined))
+      }
+      tasks.push(row)
+      // Same contract as `addOne`: a refused persist keeps the sibling a
+      // success, and marks the row so the caller knows this one lost its
+      // **Run again**. Patched on the pushed object because the awaits below
+      // resolve after the row is already in `tasks`.
+      persistedPrompts.push(
+        persistPrompt(daemon, taskId, prompt).then((ok) => {
+          if (!ok) row.promptPersisted = false
+        }),
+      )
       return
     }
     // Either deliverPrompt threw, or it resolved un-delivered AND un-deferred

--- a/packages/kobe/src/cli/api/verbs-read.ts
+++ b/packages/kobe/src/cli/api/verbs-read.ts
@@ -43,7 +43,7 @@ export const READ_VERBS: readonly VerbSpec[] = [
     name: "pty-list",
     group: "read",
     summary:
-      "List hosted PTY sessions (key, alive, pid, command, live OSC window title). Empty when no pty host runs. Returns { sessions }.",
+      "List hosted PTY sessions (key, alive, pid, command, live OSC window title). Returns { sessions }: `[]` = a live pty host with nothing running (the fleet IS idle); `null` = no pty host to ask, so this is `couldn't look` and says NOTHING about what is running.",
     flags: [],
     offline: true,
     handler: handlePtyList,

--- a/packages/kobe/src/core/daemon-runtime.ts
+++ b/packages/kobe/src/core/daemon-runtime.ts
@@ -44,6 +44,7 @@ import {
 import { daemonSettingsPatch, daemonSettingsSnapshot } from "./daemon-settings-adapter.ts"
 import {
   handleWorktreesRequestAdapter,
+  listUnreadableWorktreesAdapter,
   listWorktreeProjectsAdapter,
   removeWorktreeAdapter,
 } from "./daemon-worktree-adapter.ts"
@@ -132,6 +133,7 @@ export const daemonRuntime: DaemonRuntimeAdapter = {
   },
   maybeAutoStart: (orch, taskId) => maybeAutoStart(orch as Orchestrator, taskId),
   listWorktreeProjects: listWorktreeProjectsAdapter,
+  listUnreadableWorktrees: listUnreadableWorktreesAdapter,
   removeWorktree: removeWorktreeAdapter,
   async syncWorktreeWithBase(worktreePath, recordedBaseRef) {
     const controller = new AbortController()

--- a/packages/kobe/src/core/daemon-worktree-adapter.ts
+++ b/packages/kobe/src/core/daemon-worktree-adapter.ts
@@ -114,6 +114,16 @@ export async function listWorktreeProjectsAdapter(network: boolean): Promise<Wor
 }
 
 /**
+ * Worktree admin dirs of `repo` that `git worktree list` omitted without an
+ * error — see `manager-list.ts`'s `unreadableWorktreeNames`. Reported next to
+ * `discover-adoptable`'s rows so an empty `worktrees` array means only "this
+ * repo has nothing to adopt", never "one of them is unreadable".
+ */
+export async function listUnreadableWorktreesAdapter(repo: string): Promise<readonly string[]> {
+  return manager.listUnreadableWorktrees(repo)
+}
+
+/**
  * The worktrees page / web DELETE path. Its force retry re-uses a `row`
  * captured BEFORE the first attempt's dirty refusal, so by the time the user
  * answers the confirm the tree may hold work the confirm never described.

--- a/packages/kobe/src/orchestrator/worktree/manager-list.ts
+++ b/packages/kobe/src/orchestrator/worktree/manager-list.ts
@@ -196,3 +196,75 @@ export async function adoptablePaths(
   }
   return kept
 }
+
+/**
+ * Worktree admin-dir names under `<git-common-dir>/worktrees/` that
+ * `git worktree list --porcelain` did NOT report.
+ *
+ * Git omits an entry whose admin dir it cannot read AND still exits 0, so
+ * without this cross-check {@link adoptablePaths} answers `[]` for a repo
+ * whose worktree is merely unreadable — a result indistinguishable from
+ * "nothing to adopt", while the directory and its uncommitted work sit
+ * untouched on disk and the user has no path to adopt it.
+ *
+ * NAMES ONLY, on purpose: with the admin dir unreadable its `gitdir` file —
+ * the one record of where that worktree lives — is unreadable too, so there
+ * is no path, branch, or head to report. Inventing one would be a second lie,
+ * and a fabricated path is a path `adopt` would try to use.
+ *
+ * Diagnostic augmentation, never a gate: any failure to enumerate returns
+ * `[]`, which leaves the caller exactly where it stood before this existed.
+ */
+export async function unreadableWorktreeNames(deps: ListDeps, ctx: ExecCtx): Promise<readonly string[]> {
+  // A remote repo's admin dirs are not on this filesystem.
+  if (ctx.remote) return []
+  requireAbsolute("repo", ctx.dir)
+  let adminRoot: string
+  try {
+    // `--git-common-dir` is relative to the cwd git ran in (usually `.git`),
+    // so resolve it against that cwd rather than assuming an absolute answer.
+    const common = (await deps.runGitStdout(ctx, ["rev-parse", "--git-common-dir"])).trim()
+    if (!common) return []
+    adminRoot = path.join(path.resolve(ctx.dir, common), "worktrees")
+  } catch {
+    return []
+  }
+  let names: string[]
+  try {
+    names = fs
+      .readdirSync(adminRoot, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name)
+  } catch {
+    return [] // no worktrees dir at all — a repo that never had one
+  }
+  if (names.length === 0) return []
+  let listed: string
+  try {
+    listed = await deps.runGitStdout(ctx, ["worktree", "list", "--porcelain"])
+  } catch {
+    return []
+  }
+  const reported = new Set(
+    parseWorktreeListPorcelain(listed)
+      .filter((entry) => entry.path)
+      .map((entry) => canonicalize(entry.path as string)),
+  )
+  const missing: string[] = []
+  for (const name of names) {
+    let gitdir: string
+    try {
+      // "<worktree>/.git" — the admin dir's own pointer back at the checkout.
+      gitdir = fs.readFileSync(path.join(adminRoot, name, "gitdir"), "utf8").trim()
+    } catch {
+      // Cannot read its own record, which is exactly why git skipped it.
+      missing.push(name)
+      continue
+    }
+    // Matching on the RESOLVED path, not the admin name: git de-duplicates
+    // colliding basenames (`foo`, `foo1`), so a name comparison would flag a
+    // perfectly healthy second `foo` as missing.
+    if (gitdir && !reported.has(canonicalize(path.dirname(gitdir)))) missing.push(name)
+  }
+  return missing
+}

--- a/packages/kobe/src/orchestrator/worktree/manager.ts
+++ b/packages/kobe/src/orchestrator/worktree/manager.ts
@@ -39,7 +39,14 @@ import {
   hasLocalBranch,
   renameBranch,
 } from "./manager-branch.ts"
-import { type ListDeps, adoptablePaths, listAllAdoptable, listBranchNames, listManaged } from "./manager-list.ts"
+import {
+  type ListDeps,
+  adoptablePaths,
+  listAllAdoptable,
+  listBranchNames,
+  listManaged,
+  unreadableWorktreeNames,
+} from "./manager-list.ts"
 import { type RemoveOpts, removeWorktree } from "./manager-remove.ts"
 import { canonicalize, remoteWorktreePathFor, requireAbsolute, worktreePathFor } from "./paths.ts"
 import { type SalvageRecord, salvageWorktree } from "./salvage.ts"
@@ -286,6 +293,12 @@ export class GitWorktreeManager implements WorktreeManager {
    */
   listAdoptablePaths(repo: string): Promise<readonly { readonly path: string; readonly branch: string }[]> {
     return adoptablePaths(this.listDeps(), this.ctxFor(repo))
+  }
+
+  /** Worktree admin-dir names `git worktree list` silently omitted — the ones
+   *  {@link listAll} cannot see. Body in `manager-list.ts`. */
+  listUnreadableWorktrees(repo: string): Promise<readonly string[]> {
+    return unreadableWorktreeNames(this.listDeps(), this.ctxFor(repo))
   }
 
   /** Branch names of `repo` (local + origin, prefix-stripped) — the input

--- a/packages/kobe/src/tui-react/component/kanban-page.tsx
+++ b/packages/kobe/src/tui-react/component/kanban-page.tsx
@@ -22,7 +22,7 @@
 
 import { type BoxRenderable, TextAttributes } from "@opentui/core"
 import { useTerminalDimensions } from "@opentui/react"
-import type { Issue, RepoIssues } from "@sma1lboy/kobe-daemon/daemon/issues-store"
+import type { Issue } from "@sma1lboy/kobe-daemon/daemon/issues-store"
 import { type ReactNode, useEffect, useRef, useState } from "react"
 import type { RemoteOrchestrator, TaskEngineState } from "../../client/remote-orchestrator"
 import { availableEngineIds } from "../../engine/account-detect"
@@ -43,7 +43,7 @@ import { quickForkDefaultVendor } from "../workspace/quick-fork"
 import type { IssueChatStart } from "../workspace/use-issue-chat"
 import { IssueDetailDialog } from "./issue-detail-dialog"
 import { KanbanBoard, needsSingleLane } from "./kanban-board"
-import { useKanbanBoards } from "./use-kanban-boards"
+import { type KanbanBoardEntry, useKanbanBoards } from "./use-kanban-boards"
 
 /** paddingLeft + paddingRight on the page root, whose width is what we measure. */
 const PAGE_PADDING_CELLS = 4
@@ -109,8 +109,28 @@ export function KanbanPage(props: {
     0,
     boardList.findIndex((board) => board.repoRoot === activeRepo),
   )
-  const activeBoard: RepoIssues | undefined = boardList[activeIndex]
+  const activeBoard: KanbanBoardEntry | undefined = boardList[activeIndex]
   const repoRoots = boardList.map((board) => board.repoRoot)
+  // One toast per DISTINCT set of read failures, not per render: the poll
+  // refetches every POLL_MS and a still-broken repo must not re-toast. The key
+  // is the errors themselves, so a NEW repo failing (or a different error on
+  // the same repo) fires again while a persisting one stays quiet.
+  const readErrorKey = boardList
+    .filter((board) => board.readError)
+    .map((board) => `${board.repoRoot}\u0000${board.readError}`)
+    .join("\n")
+  // biome-ignore lint/correctness/useExhaustiveDependencies: keyed on the error SET — notifyError/boardList are new every render and would re-toast on every frame.
+  useEffect(() => {
+    for (const board of boardList) {
+      if (!board.readError) continue
+      notifyError(
+        t("kanban.readFailedToast", {
+          repo: sidebarProjectLabel(board.repoRoot, repoRoots),
+          error: board.readError,
+        }),
+      )
+    }
+  }, [readErrorKey])
   // Rendering-only attention float: blocked-on-you cards lead In progress.
   // The task index decides In progress, not the link alone: the daemon
   // unlinks an issue when its task is deleted, but a store carried over from
@@ -317,7 +337,7 @@ export function KanbanPage(props: {
   /** One-line rolling project selector — tab/←/→ (or click) cycles, no tab
    *  row. Label stays flush with the page's left edge. The full path is a
    *  wide-layout nicety; narrow keeps only the label that identifies. */
-  function projectSelector(active: RepoIssues): ReactNode {
+  function projectSelector(active: KanbanBoardEntry): ReactNode {
     return (
       <box flexDirection="row" justifyContent="space-between" paddingTop={1}>
         <box flexDirection="row" onMouseUp={() => cycleProject(1)}>
@@ -337,7 +357,7 @@ export function KanbanPage(props: {
             </text>
           )}
         </box>
-        {active.issues.length === 0 ? (
+        {active.issues.length === 0 && !active.readError ? (
           <text fg={theme.textMuted} wrapMode="none" flexShrink={1}>
             {t("kanban.empty")}
           </text>
@@ -381,16 +401,24 @@ export function KanbanPage(props: {
       ) : (
         <>
           {projectSelector(activeBoard)}
-          <KanbanBoard
-            columns={columns}
-            attentionCount={attentionCount}
-            selectedId={selectedId}
-            singleLane={singleLane}
-            {...(props.engineStates ? { engineStates: props.engineStates } : {})}
-            follow={follow}
-            onSelect={setSelectedId}
-            onOpen={openDetail}
-          />
+          {activeBoard.readError ? (
+            // In place of the four columns, NOT in place of the project: empty
+            // lanes here would read as "this project has no stories".
+            <text fg={theme.error} wrapMode="none">
+              {t("kanban.readFailed", { error: activeBoard.readError })}
+            </text>
+          ) : (
+            <KanbanBoard
+              columns={columns}
+              attentionCount={attentionCount}
+              selectedId={selectedId}
+              singleLane={singleLane}
+              {...(props.engineStates ? { engineStates: props.engineStates } : {})}
+              follow={follow}
+              onSelect={setSelectedId}
+              onOpen={openDetail}
+            />
+          )}
         </>
       )}
     </box>

--- a/packages/kobe/src/tui-react/component/use-kanban-boards.ts
+++ b/packages/kobe/src/tui-react/component/use-kanban-boards.ts
@@ -11,14 +11,28 @@
 import type { RepoIssues } from "@sma1lboy/kobe-daemon/daemon/issues-store"
 import { useEffect, useState } from "react"
 import type { RemoteOrchestrator } from "../../client/remote-orchestrator"
+import { errorMessage } from "../../lib/error-message"
 
 /** Agent moves land within one poll; issue.list is a local JSON read, so
  *  polling while the page is open is cheap. */
 const POLL_MS = 5_000
 
+/**
+ * A project's board, plus the one thing {@link RepoIssues} cannot express:
+ * this repo's issue read REJECTED. A rejection used to drop the repo from the
+ * result, which took the project out of the selector entirely — a user with
+ * two repos saw one, with no error, no glyph, and no reason to think the
+ * other existed. The section stays; the failure rides with it.
+ */
+export interface KanbanBoardEntry extends RepoIssues {
+  /** The read's error message. Absent = the read succeeded (`issues` may
+   *  still be empty, which is a real empty board, not a failure). */
+  readonly readError?: string
+}
+
 export interface KanbanBoards {
   /** null until the first load resolves — the page shows its loading line. */
-  readonly boards: readonly RepoIssues[] | null
+  readonly boards: readonly KanbanBoardEntry[] | null
   readonly activeRepo: string | null
   readonly setActiveRepo: (next: string | null) => void
   readonly selectedId: number | null
@@ -33,7 +47,7 @@ export function useKanbanBoards(args: {
    *  card cursor on its linked story. */
   readonly focusTask?: { readonly id: string; readonly repo: string }
 }): KanbanBoards {
-  const [boards, setBoards] = useState<readonly RepoIssues[] | null>(null)
+  const [boards, setBoards] = useState<readonly KanbanBoardEntry[] | null>(null)
   const [reloadTick, setReloadTick] = useState(0)
   // Keyed by repoRoot (not index) so the poll refetch keeps the selection.
   const [activeRepo, setActiveRepo] = useState<string | null>(null)
@@ -50,11 +64,27 @@ export function useKanbanBoards(args: {
       return
     }
     const repos = [...new Set(orchestrator.listTasks().map((task) => task.repo))]
-    void Promise.all(repos.map((repo) => orchestrator.listIssues(repo).catch(() => null))).then((results) => {
+    void Promise.all(
+      repos.map((repo) =>
+        orchestrator.listIssues(repo).catch(
+          (err: unknown): KanbanBoardEntry => ({
+            // A rejected read still owns its section. `exists: false` here is
+            // NOT the empty-board case below — `readError` is what separates
+            // "no issue file yet" from "could not read the issue file".
+            repoRoot: repo,
+            exists: false,
+            nextId: 1,
+            issues: [],
+            skipped: 0,
+            readError: errorMessage(err),
+          }),
+        ),
+      ),
+    ).then((results) => {
       if (disposed) return
       // A repo whose issue file doesn't exist yet still gets a section —
       // `exists: false` just means an empty board, not an error.
-      const next = results.filter((res): res is RepoIssues => res !== null)
+      const next = [...results]
       next.sort((a, b) => a.repoRoot.localeCompare(b.repoRoot))
       setBoards(next)
       // First load lands on the focus task's project (opened via `c` on a

--- a/packages/kobe/src/tui/i18n/messages/kanban.ts
+++ b/packages/kobe/src/tui/i18n/messages/kanban.ts
@@ -12,6 +12,14 @@ export const en = {
   noRepos: "No projects yet — create a task first.",
   /** A repo section with zero issues. */
   empty: "No issues — agents file them via `rove api issue-create`.",
+  /** In place of the four columns when THIS project's issue read rejected.
+   *  The project keeps its slot in the selector: dropping it made a whole
+   *  repo — and every card in it — vanish, reading as "you only have one
+   *  project". `{error}` = the daemon's message. */
+  readFailed: "Couldn't read this project's stories: {error}",
+  /** Error toast for the same failure, naming which project it was.
+   *  `{repo}` = the project label, `{error}` = the daemon's message. */
+  readFailedToast: "Couldn't read stories for {repo}: {error}",
   /** One column with zero cards — a quiet placeholder so the empty lane
    *  reads as intentional rather than unrendered. */
   columnEmpty: "No cards",
@@ -108,6 +116,8 @@ export const zh: typeof en = {
   loading: "正在加载 issues…",
   noRepos: "还没有项目——先创建一个任务。",
   empty: "暂无 issue——agent 可通过 `rove api issue-create` 创建。",
+  readFailed: "读取该项目的 story 失败：{error}",
+  readFailedToast: "读取 {repo} 的 story 失败：{error}",
   columnEmpty: "暂无卡片",
   column: {
     backlog: "待办",

--- a/packages/kobe/test/behavior/pty-api-autostart.test.ts
+++ b/packages/kobe/test/behavior/pty-api-autostart.test.ts
@@ -58,6 +58,22 @@ describe("rove api hosted PTY lifecycle (behavior)", () => {
     await env.dispose()
   })
 
+  /**
+   * `sessions: []` used to be the answer for BOTH "a live host with nothing
+   * running" and "no host at all", so an agent reading `{"sessions":[]}`
+   * concluded the fleet was idle — and could respawn work that was actually
+   * running, or call a live task dead. `null` means "could not look", the same
+   * shape `inspect`'s sessions section has always returned for this failure.
+   *
+   * Runs FIRST, before anything spawns a host. The live-host half (an actual
+   * array) is every other `pty-list` assertion in this file.
+   */
+  it("pty-list answers null when there is no pty host to ask", () => {
+    const cold = runRove(["api", "pty-list", "--pretty"], env)
+    expect(cold.code, `pty-list failed: ${cold.stderr}`).toBe(0)
+    expect((JSON.parse(cold.stdout) as { sessions: unknown }).sessions).toBeNull()
+  }, 15_000)
+
   it("add --prompt materializes a worktree and auto-starts the canonical engine session", () => {
     const result = runRove(["api", "add", "--repo", repo, "--prompt", "hello from behavior", "--pretty"], env)
     expect(result.code).toBe(0)

--- a/packages/kobe/test/cli/api-handlers-send.test.ts
+++ b/packages/kobe/test/cli/api-handlers-send.test.ts
@@ -1,0 +1,332 @@
+/** Request-traffic tests for the `send` handler — split out of
+ *  `./api-handlers.test.ts` (which keeps single-task `add`) when that file
+ *  crossed the size cap. The seam is the verb: nothing here touches `add`. */
+
+import { mkdtempSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { ApiError, type ApiRuntime, invokeVerb } from "../../src/cli/api-cmd.ts"
+import { resetVerifiedSelfSession, verifiedSelfSession } from "../../src/cli/api/dispatcher.ts"
+import { FakeClient, expectApiError, recordingDelivery, stubRuntime, taskFixture } from "./api-handler-fixtures.ts"
+
+// Peer provenance AND dispatcher provenance both key off the caller's own
+// $KOBE_TASK_ID/$KOBE_TAB_ID — unset them file-wide so exact-payload
+// assertions stay deterministic when the runner itself lives inside a kobe
+// task. Tests that WANT provenance set them in their own beforeEach.
+const savedEnv = { taskId: process.env.KOBE_TASK_ID, tabId: process.env.KOBE_TAB_ID }
+beforeEach(() => {
+  // biome-ignore lint/performance/noDelete: env must fully unset (assigning undefined leaves the string "undefined").
+  delete process.env.KOBE_TASK_ID
+  // biome-ignore lint/performance/noDelete: env must fully unset (assigning undefined leaves the string "undefined").
+  delete process.env.KOBE_TAB_ID
+})
+afterEach(() => {
+  for (const [name, value] of [
+    ["KOBE_TASK_ID", savedEnv.taskId],
+    ["KOBE_TAB_ID", savedEnv.tabId],
+  ] as const) {
+    if (value === undefined) delete process.env[name]
+    else process.env[name] = value
+  }
+})
+
+describe("send handler", () => {
+  it("uses an explicit target without consulting active task", async () => {
+    const client = new FakeClient({ "task.get": () => ({ task: taskFixture({ id: "abc" }) }) })
+    const { calls, deliver } = recordingDelivery()
+    const result = await invokeVerb("send", ["--task-id", "abc", "--prompt", "hi"], {
+      client,
+      runtime: stubRuntime({ deliverPrompt: deliver }),
+    })
+    expect(client.subscribeCount).toBe(0)
+    expect(calls[0].prompt).toBe("hi")
+    // send targets an EXISTING task — never flagged as a new-task first
+    // prompt, so the branch-rename coda can't reach it.
+    expect(calls[0].target.newTask).toBeUndefined()
+    expect(result).toMatchObject({ ok: true, taskId: "abc", started: true })
+  })
+
+  it("falls back to the daemon active task", async () => {
+    const client = new FakeClient({ "task.get": () => ({ task: taskFixture({ id: "active-1" }) }) })
+    client.replay.push({ channel: "active-task", payload: { taskId: "active-1" } })
+    const { calls, deliver } = recordingDelivery()
+    await invokeVerb("send", ["--prompt", "hi"], { client, runtime: stubRuntime({ deliverPrompt: deliver }) })
+    expect(client.subscribeCount).toBe(1)
+    expect(calls[0].target.id).toBe("active-1")
+  })
+
+  it("reports a prompt that did not land", async () => {
+    const client = new FakeClient({ "task.get": () => ({ task: taskFixture() }) })
+    await expectApiError(
+      () =>
+        invokeVerb("send", ["--task-id", "t1", "--prompt", "hi"], {
+          client,
+          runtime: stubRuntime({ deliverPrompt: recordingDelivery({ delivered: false }).deliver }),
+        }),
+      "NOT_DELIVERED",
+    )
+  })
+
+  // docs/API.md documents `delivered`, `bytes` and `promptEcho` under `send`.
+  // The delivery layer measured all three for every path and `send` dropped
+  // them, so a successful send carried no `delivered` key at all while a
+  // deferred one reported it as the only outcome field — `add` had been
+  // emitting the same three the whole time.
+  it("reports the delivery facts it documents", async () => {
+    const client = new FakeClient({ "task.get": () => ({ task: taskFixture({ id: "abc" }) }) })
+    const { deliver } = recordingDelivery({ bytes: 42, promptEcho: "confirmed" })
+    const result = await invokeVerb("send", ["--task-id", "abc", "--prompt", "hi"], {
+      client,
+      runtime: stubRuntime({ deliverPrompt: deliver }),
+    })
+    expect(result).toMatchObject({ delivered: true, bytes: 42, promptEcho: "confirmed" })
+  })
+
+  it("reports a deferred prompt as delivered:false, not as an error", async () => {
+    const client = new FakeClient({ "task.get": () => ({ task: taskFixture({ id: "abc" }) }) })
+    const { deliver } = recordingDelivery({ delivered: false, deferred: { id: "d1", layer: "composer-not-empty" } })
+    const result = (await invokeVerb("send", ["--task-id", "abc", "--prompt", "hi"], {
+      client,
+      runtime: stubRuntime({ deliverPrompt: deliver }),
+    })) as { ok: boolean; delivered: boolean; deferred: unknown }
+    expect(result.ok).toBe(true)
+    expect(result.delivered).toBe(false)
+    expect(result.deferred).toBeDefined()
+  })
+
+  it("requires an explicit or active target", async () => {
+    await expectApiError(
+      () => invokeVerb("send", ["--prompt", "hi"], { client: new FakeClient(), runtime: stubRuntime() }),
+      "MISSING_TARGET",
+    )
+  })
+
+  it("threads --tab through to the delivery target", async () => {
+    const client = new FakeClient({ "task.get": () => ({ task: taskFixture({ id: "abc" }) }) })
+    const { calls, deliver } = recordingDelivery()
+    await invokeVerb("send", ["--task-id", "abc", "--prompt", "hi", "--tab", "new"], {
+      client,
+      runtime: stubRuntime({ deliverPrompt: deliver }),
+    })
+    expect(calls[0].target.tab).toBe("new")
+    await invokeVerb("send", ["--task-id", "abc", "--prompt", "hi", "--tab", "tab-3"], {
+      client,
+      runtime: stubRuntime({ deliverPrompt: deliver }),
+    })
+    expect(calls[1].target.tab).toBe("tab-3")
+  })
+
+  // The shell, not Rove, was eating prompts: backticks inside a double-quoted
+  // --prompt are command substitution, so the text that names a reply
+  // command (`rove api send …`) shipped as that command's OUTPUT. A file (or
+  // stdin) bypasses every quoting rule — the bytes on disk are the message.
+  it("--prompt-file delivers the file's bytes verbatim, backticks and all", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "rove-prompt-"))
+    const file = join(dir, "msg.md")
+    const body = "reply via `rove api send --task-id t1 --tab tab-2` and $(echo no)\n"
+    writeFileSync(file, body)
+    const client = new FakeClient({ "task.get": () => ({ task: taskFixture({ id: "abc" }) }) })
+    const { calls, deliver } = recordingDelivery()
+    await invokeVerb("send", ["--task-id", "abc", "--prompt-file", file], {
+      client,
+      runtime: stubRuntime({ deliverPrompt: deliver }),
+    })
+    expect(calls[0].prompt).toBe(body)
+  })
+
+  it("--prompt and --prompt-file together is a BAD_FLAG, not a silent pick", async () => {
+    await expectApiError(
+      () =>
+        invokeVerb("send", ["--task-id", "abc", "--prompt", "a", "--prompt-file", "/dev/null"], {
+          client: new FakeClient(),
+          runtime: stubRuntime(),
+        }),
+      "BAD_FLAG",
+    )
+  })
+
+  it("an empty --prompt-file is refused (a blank turn is never what was meant)", async () => {
+    await expectApiError(
+      () =>
+        invokeVerb("send", ["--task-id", "abc", "--prompt-file", "/dev/null"], {
+          client: new FakeClient(),
+          runtime: stubRuntime(),
+        }),
+      "BAD_FLAG",
+    )
+  })
+
+  it("a new tab can run a DIFFERENT engine than the task (two agents, one worktree)", async () => {
+    const client = new FakeClient({ "task.get": () => ({ task: taskFixture({ id: "abc", vendor: "claude" }) }) })
+    const { calls, deliver } = recordingDelivery()
+    await invokeVerb("send", ["--task-id", "abc", "--prompt", "hi", "--tab", "new", "--command", "codex"], {
+      client,
+      runtime: stubRuntime({ deliverPrompt: deliver }),
+    })
+    // The delivery runs codex and the tab records it (command + its resolved
+    // protocol), while the TASK's own engine is untouched — a second agent in
+    // the worktree is not a switch.
+    expect(calls[0].target).toMatchObject({ tabCommand: "codex", tabVendor: "codex" })
+    expect(client.requests.some((r) => r.name === "task.setCommand")).toBe(false)
+  })
+
+  it("refuses --command without --tab new instead of silently running the task's engine", async () => {
+    const client = new FakeClient({ "task.get": () => ({ task: taskFixture({ id: "abc" }) }) })
+    await expectApiError(
+      () =>
+        invokeVerb("send", ["--task-id", "abc", "--prompt", "hi", "--tab", "tab-3", "--command", "codex"], {
+          client,
+          runtime: stubRuntime(),
+        }),
+      "BAD_FLAG",
+    )
+  })
+
+  it("rejects a malformed --tab before any delivery", async () => {
+    const client = new FakeClient({ "task.get": () => ({ task: taskFixture({ id: "abc" }) }) })
+    await expectApiError(
+      () =>
+        invokeVerb("send", ["--task-id", "abc", "--prompt", "hi", "--tab", "3"], {
+          client,
+          runtime: stubRuntime(),
+        }),
+      "BAD_TAB",
+    )
+  })
+
+  describe("peer provenance ($KOBE_TASK_ID)", () => {
+    const saved = process.env.KOBE_TASK_ID
+    beforeEach(async () => {
+      process.env.KOBE_TASK_ID = "sender-1"
+      // Identity is the VERIFIED env pair — prime the memo with a
+      // process tree where this process really does descend from the tab's
+      // shell, so no real pty-host/ps read happens here.
+      await verifiedSelfSession(
+        { KOBE_TASK_ID: "sender-1", KOBE_TAB_ID: "tab-1" },
+        {
+          pid: 500,
+          sessions: async () => [{ key: "sender-1::tab-1", pid: 100, alive: true }],
+          ps: async () => "  100     1 /bin/zsh -il\n  500   100 bun kobe api send",
+        },
+      )
+    })
+    afterEach(() => {
+      resetVerifiedSelfSession()
+      if (saved === undefined) {
+        // biome-ignore lint/performance/noDelete: env must fully unset (assigning undefined leaves the string "undefined").
+        delete process.env.KOBE_TASK_ID
+      } else process.env.KOBE_TASK_ID = saved
+    })
+
+    const peerClient = () =>
+      new FakeClient({
+        "task.get": (payload) => {
+          const id = (payload as { taskId: string }).taskId
+          return { task: taskFixture({ id, title: id === "sender-1" ? "Auth attempt" : "T" }) }
+        },
+      })
+
+    it("prefixes cross-task sends with sender identity and a reply command", async () => {
+      const { calls, deliver } = recordingDelivery()
+      await invokeVerb("send", ["--task-id", "abc", "--prompt", "hi"], {
+        client: peerClient(),
+        runtime: stubRuntime({ deliverPrompt: deliver }),
+      })
+      expect(calls[0].prompt).toContain('[ROVE PEER] from "Auth attempt" (task sender-1')
+      expect(calls[0].prompt).toContain("registered as /rove; legacy /kobe installs still work")
+      expect(calls[0].prompt).toContain("send --task-id sender-1")
+      // The self-teach pointer: a receiver that has never seen kobe learns
+      // where the rest of the coordination verbs live.
+      expect(calls[0].prompt).toContain("Rove agent skill")
+      // The sender's text is LAST and whole, after a blank line — not the
+      // object of the provenance sentence. A model generates in the language
+      // of the tokens nearest its turn, so a non-English prompt wrapped in an
+      // English clause came back in English.
+      expect(calls[0].prompt).toMatch(/\)\n\nhi$/)
+    })
+
+    it("keeps a non-English prompt intact and last, so nothing follows it", async () => {
+      const { calls, deliver } = recordingDelivery()
+      await invokeVerb("send", ["--task-id", "abc", "--prompt", "帮我重构登录模块"], {
+        client: peerClient(),
+        runtime: stubRuntime({ deliverPrompt: deliver }),
+      })
+      expect(calls[0].prompt.endsWith("帮我重构登录模块")).toBe(true)
+      // The prompt is not spliced into the sentence: everything before it is
+      // provenance, and the last thing the receiver reads is the sender's own words.
+      const [provenance, ...rest] = calls[0].prompt.split("\n\n")
+      expect(rest.join("\n\n")).toBe("帮我重构登录模块")
+      expect(provenance).not.toContain("帮我重构登录模块")
+    })
+
+    it("gives a dispatched task the same reply address in its opening brief", async () => {
+      // `add --prompt` from inside a kobe session is agent-to-agent too, and
+      // its brief is where the reply address matters most: every report that
+      // task ever sends flows back through it. Recording the sender only as
+      // `dispatcher` on the task ROW — data a receiver has to think to go
+      // read — leaves a dispatched worker finished and sitting waiting.
+      const { calls, deliver } = recordingDelivery()
+      await invokeVerb("add", ["--repo", "/repo/x", "--prompt", "研究一下 X"], {
+        client: new FakeClient({
+          "task.create": () => ({ taskId: "child-1", task: taskFixture({ id: "child-1" }) }),
+          "task.get": (payload) => {
+            const id = (payload as { taskId: string }).taskId
+            return { task: taskFixture({ id, title: id === "sender-1" ? "Auth attempt" : "T" }) }
+          },
+        }),
+        runtime: stubRuntime({ deliverPrompt: deliver }),
+      })
+      expect(calls[0].prompt).toContain('[ROVE PEER] from "Auth attempt" (task sender-1')
+      expect(calls[0].prompt).toContain("send --task-id sender-1 --tab tab-1")
+      // Same shape as `send`: the brief is last and whole.
+      expect(calls[0].prompt.endsWith("研究一下 X")).toBe(true)
+    })
+
+    it("--plain sends verbatim", async () => {
+      const { calls, deliver } = recordingDelivery()
+      await invokeVerb("send", ["--task-id", "abc", "--prompt", "hi", "--plain"], {
+        client: peerClient(),
+        runtime: stubRuntime({ deliverPrompt: deliver }),
+      })
+      expect(calls[0].prompt).toBe("hi")
+    })
+
+    it("a send to yourself stays untouched", async () => {
+      const { calls, deliver } = recordingDelivery()
+      await invokeVerb("send", ["--task-id", "sender-1", "--prompt", "hi"], {
+        client: peerClient(),
+        runtime: stubRuntime({ deliverPrompt: deliver }),
+      })
+      expect(calls[0].prompt).toBe("hi")
+    })
+
+    it("a stale sender id degrades to id-only provenance, never a failed send", async () => {
+      const client = new FakeClient({
+        "task.get": (payload) => {
+          const id = (payload as { taskId: string }).taskId
+          if (id === "sender-1") throw new ApiError("task not found", "RPC_ERROR")
+          return { task: taskFixture({ id }) }
+        },
+      })
+      const { calls, deliver } = recordingDelivery()
+      await invokeVerb("send", ["--task-id", "abc", "--prompt", "hi"], {
+        client,
+        runtime: stubRuntime({ deliverPrompt: deliver }),
+      })
+      expect(calls[0].prompt).toContain('from "sender-1" (task sender-1')
+    })
+
+    it("a send from outside any kobe task stays untouched", async () => {
+      resetVerifiedSelfSession()
+      // biome-ignore lint/performance/noDelete: env must fully unset (assigning undefined leaves the string "undefined").
+      delete process.env.KOBE_TASK_ID
+      const { calls, deliver } = recordingDelivery()
+      await invokeVerb("send", ["--task-id", "abc", "--prompt", "hi"], {
+        client: peerClient(),
+        runtime: stubRuntime({ deliverPrompt: deliver }),
+      })
+      expect(calls[0].prompt).toBe("hi")
+    })
+  })
+})

--- a/packages/kobe/test/cli/api-handlers.test.ts
+++ b/packages/kobe/test/cli/api-handlers.test.ts
@@ -1,5 +1,6 @@
-/** Request-traffic tests for single-task `add` and the `send` handler.
- *  The parallel `add --count` round lives in `./api-add-parallel.test.ts`. */
+/** Request-traffic tests for single-task `add`. The `send` handler lives in
+ *  `./api-handlers-send.test.ts`; the parallel `add --count` round lives in
+ *  `./api-add-parallel.test.ts`. */
 
 import { mkdtempSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
@@ -142,6 +143,46 @@ describe("add handler", () => {
     expect(client.requests).toContainEqual({ name: "task.setPrompt", payload: { taskId: "t1", prompt: "do it" } })
   })
 
+  /**
+   * The persist is best-effort on purpose — the engine already HAS the prompt,
+   * so a store fault must not fail a delivered task. What it must not do is
+   * report unqualified success: without `.task.prompt` the sidebar menu drops
+   * **Run again** (`tree-menu.ts` gates the verb on it), so the action is gone
+   * with nothing anywhere saying why. This is the one trigger with no
+   * filesystem shape — an RPC/store fault — so it is stubbed rather than
+   * injected.
+   */
+  it("says so when the brief was delivered but never persisted", async () => {
+    const task = taskFixture({ kind: "task", vendor: "claude" })
+    const client = new FakeClient({
+      "task.create": () => ({ taskId: "t1", task }),
+      "task.get": () => ({ task }),
+      "task.setPrompt": () => {
+        throw new Error("issues store is read-only")
+      },
+    })
+    const result = (await invokeVerb("add", ["--repo", "/repo/x", "--prompt", "do it"], {
+      client,
+      runtime: stubRuntime({ deliverPrompt: recordingDelivery().deliver }),
+    })) as Record<string, unknown>
+    // Still a success: the task exists and the engine is burning tokens on it.
+    expect(result).toMatchObject({ taskId: "t1", delivered: true, promptPersisted: false })
+  })
+
+  it("omits promptPersisted when the brief did persist", async () => {
+    const task = taskFixture({ kind: "task", vendor: "claude" })
+    const client = new FakeClient({
+      "task.create": () => ({ taskId: "t1", task }),
+      "task.get": () => ({ task }),
+      "task.setPrompt": () => ({}),
+    })
+    const result = (await invokeVerb("add", ["--repo", "/repo/x", "--prompt", "do it"], {
+      client,
+      runtime: stubRuntime({ deliverPrompt: recordingDelivery().deliver }),
+    })) as Record<string, unknown>
+    expect(result).not.toHaveProperty("promptPersisted")
+  })
+
   it("reports a created task whose prompt never landed", async () => {
     const task = taskFixture({ kind: "task", vendor: "kimi" })
     const client = new FakeClient({
@@ -169,305 +210,5 @@ describe("add handler", () => {
       runtime: stubRuntime(),
     })) as { taskId: string }
     expect(result.taskId).toBe("t1")
-  })
-})
-
-describe("send handler", () => {
-  it("uses an explicit target without consulting active task", async () => {
-    const client = new FakeClient({ "task.get": () => ({ task: taskFixture({ id: "abc" }) }) })
-    const { calls, deliver } = recordingDelivery()
-    const result = await invokeVerb("send", ["--task-id", "abc", "--prompt", "hi"], {
-      client,
-      runtime: stubRuntime({ deliverPrompt: deliver }),
-    })
-    expect(client.subscribeCount).toBe(0)
-    expect(calls[0].prompt).toBe("hi")
-    // send targets an EXISTING task — never flagged as a new-task first
-    // prompt, so the branch-rename coda can't reach it.
-    expect(calls[0].target.newTask).toBeUndefined()
-    expect(result).toMatchObject({ ok: true, taskId: "abc", started: true })
-  })
-
-  it("falls back to the daemon active task", async () => {
-    const client = new FakeClient({ "task.get": () => ({ task: taskFixture({ id: "active-1" }) }) })
-    client.replay.push({ channel: "active-task", payload: { taskId: "active-1" } })
-    const { calls, deliver } = recordingDelivery()
-    await invokeVerb("send", ["--prompt", "hi"], { client, runtime: stubRuntime({ deliverPrompt: deliver }) })
-    expect(client.subscribeCount).toBe(1)
-    expect(calls[0].target.id).toBe("active-1")
-  })
-
-  it("reports a prompt that did not land", async () => {
-    const client = new FakeClient({ "task.get": () => ({ task: taskFixture() }) })
-    await expectApiError(
-      () =>
-        invokeVerb("send", ["--task-id", "t1", "--prompt", "hi"], {
-          client,
-          runtime: stubRuntime({ deliverPrompt: recordingDelivery({ delivered: false }).deliver }),
-        }),
-      "NOT_DELIVERED",
-    )
-  })
-
-  // docs/API.md documents `delivered`, `bytes` and `promptEcho` under `send`.
-  // The delivery layer measured all three for every path and `send` dropped
-  // them, so a successful send carried no `delivered` key at all while a
-  // deferred one reported it as the only outcome field — `add` had been
-  // emitting the same three the whole time.
-  it("reports the delivery facts it documents", async () => {
-    const client = new FakeClient({ "task.get": () => ({ task: taskFixture({ id: "abc" }) }) })
-    const { deliver } = recordingDelivery({ bytes: 42, promptEcho: "confirmed" })
-    const result = await invokeVerb("send", ["--task-id", "abc", "--prompt", "hi"], {
-      client,
-      runtime: stubRuntime({ deliverPrompt: deliver }),
-    })
-    expect(result).toMatchObject({ delivered: true, bytes: 42, promptEcho: "confirmed" })
-  })
-
-  it("reports a deferred prompt as delivered:false, not as an error", async () => {
-    const client = new FakeClient({ "task.get": () => ({ task: taskFixture({ id: "abc" }) }) })
-    const { deliver } = recordingDelivery({ delivered: false, deferred: { id: "d1", layer: "composer-not-empty" } })
-    const result = (await invokeVerb("send", ["--task-id", "abc", "--prompt", "hi"], {
-      client,
-      runtime: stubRuntime({ deliverPrompt: deliver }),
-    })) as { ok: boolean; delivered: boolean; deferred: unknown }
-    expect(result.ok).toBe(true)
-    expect(result.delivered).toBe(false)
-    expect(result.deferred).toBeDefined()
-  })
-
-  it("requires an explicit or active target", async () => {
-    await expectApiError(
-      () => invokeVerb("send", ["--prompt", "hi"], { client: new FakeClient(), runtime: stubRuntime() }),
-      "MISSING_TARGET",
-    )
-  })
-
-  it("threads --tab through to the delivery target", async () => {
-    const client = new FakeClient({ "task.get": () => ({ task: taskFixture({ id: "abc" }) }) })
-    const { calls, deliver } = recordingDelivery()
-    await invokeVerb("send", ["--task-id", "abc", "--prompt", "hi", "--tab", "new"], {
-      client,
-      runtime: stubRuntime({ deliverPrompt: deliver }),
-    })
-    expect(calls[0].target.tab).toBe("new")
-    await invokeVerb("send", ["--task-id", "abc", "--prompt", "hi", "--tab", "tab-3"], {
-      client,
-      runtime: stubRuntime({ deliverPrompt: deliver }),
-    })
-    expect(calls[1].target.tab).toBe("tab-3")
-  })
-
-  // The shell, not Rove, was eating prompts: backticks inside a double-quoted
-  // --prompt are command substitution, so the text that names a reply
-  // command (`rove api send …`) shipped as that command's OUTPUT. A file (or
-  // stdin) bypasses every quoting rule — the bytes on disk are the message.
-  it("--prompt-file delivers the file's bytes verbatim, backticks and all", async () => {
-    const dir = mkdtempSync(join(tmpdir(), "rove-prompt-"))
-    const file = join(dir, "msg.md")
-    const body = "reply via `rove api send --task-id t1 --tab tab-2` and $(echo no)\n"
-    writeFileSync(file, body)
-    const client = new FakeClient({ "task.get": () => ({ task: taskFixture({ id: "abc" }) }) })
-    const { calls, deliver } = recordingDelivery()
-    await invokeVerb("send", ["--task-id", "abc", "--prompt-file", file], {
-      client,
-      runtime: stubRuntime({ deliverPrompt: deliver }),
-    })
-    expect(calls[0].prompt).toBe(body)
-  })
-
-  it("--prompt and --prompt-file together is a BAD_FLAG, not a silent pick", async () => {
-    await expectApiError(
-      () =>
-        invokeVerb("send", ["--task-id", "abc", "--prompt", "a", "--prompt-file", "/dev/null"], {
-          client: new FakeClient(),
-          runtime: stubRuntime(),
-        }),
-      "BAD_FLAG",
-    )
-  })
-
-  it("an empty --prompt-file is refused (a blank turn is never what was meant)", async () => {
-    await expectApiError(
-      () =>
-        invokeVerb("send", ["--task-id", "abc", "--prompt-file", "/dev/null"], {
-          client: new FakeClient(),
-          runtime: stubRuntime(),
-        }),
-      "BAD_FLAG",
-    )
-  })
-
-  it("a new tab can run a DIFFERENT engine than the task (two agents, one worktree)", async () => {
-    const client = new FakeClient({ "task.get": () => ({ task: taskFixture({ id: "abc", vendor: "claude" }) }) })
-    const { calls, deliver } = recordingDelivery()
-    await invokeVerb("send", ["--task-id", "abc", "--prompt", "hi", "--tab", "new", "--command", "codex"], {
-      client,
-      runtime: stubRuntime({ deliverPrompt: deliver }),
-    })
-    // The delivery runs codex and the tab records it (command + its resolved
-    // protocol), while the TASK's own engine is untouched — a second agent in
-    // the worktree is not a switch.
-    expect(calls[0].target).toMatchObject({ tabCommand: "codex", tabVendor: "codex" })
-    expect(client.requests.some((r) => r.name === "task.setCommand")).toBe(false)
-  })
-
-  it("refuses --command without --tab new instead of silently running the task's engine", async () => {
-    const client = new FakeClient({ "task.get": () => ({ task: taskFixture({ id: "abc" }) }) })
-    await expectApiError(
-      () =>
-        invokeVerb("send", ["--task-id", "abc", "--prompt", "hi", "--tab", "tab-3", "--command", "codex"], {
-          client,
-          runtime: stubRuntime(),
-        }),
-      "BAD_FLAG",
-    )
-  })
-
-  it("rejects a malformed --tab before any delivery", async () => {
-    const client = new FakeClient({ "task.get": () => ({ task: taskFixture({ id: "abc" }) }) })
-    await expectApiError(
-      () =>
-        invokeVerb("send", ["--task-id", "abc", "--prompt", "hi", "--tab", "3"], {
-          client,
-          runtime: stubRuntime(),
-        }),
-      "BAD_TAB",
-    )
-  })
-
-  describe("peer provenance ($KOBE_TASK_ID)", () => {
-    const saved = process.env.KOBE_TASK_ID
-    beforeEach(async () => {
-      process.env.KOBE_TASK_ID = "sender-1"
-      // Identity is the VERIFIED env pair — prime the memo with a
-      // process tree where this process really does descend from the tab's
-      // shell, so no real pty-host/ps read happens here.
-      await verifiedSelfSession(
-        { KOBE_TASK_ID: "sender-1", KOBE_TAB_ID: "tab-1" },
-        {
-          pid: 500,
-          sessions: async () => [{ key: "sender-1::tab-1", pid: 100, alive: true }],
-          ps: async () => "  100     1 /bin/zsh -il\n  500   100 bun kobe api send",
-        },
-      )
-    })
-    afterEach(() => {
-      resetVerifiedSelfSession()
-      if (saved === undefined) {
-        // biome-ignore lint/performance/noDelete: env must fully unset (assigning undefined leaves the string "undefined").
-        delete process.env.KOBE_TASK_ID
-      } else process.env.KOBE_TASK_ID = saved
-    })
-
-    const peerClient = () =>
-      new FakeClient({
-        "task.get": (payload) => {
-          const id = (payload as { taskId: string }).taskId
-          return { task: taskFixture({ id, title: id === "sender-1" ? "Auth attempt" : "T" }) }
-        },
-      })
-
-    it("prefixes cross-task sends with sender identity and a reply command", async () => {
-      const { calls, deliver } = recordingDelivery()
-      await invokeVerb("send", ["--task-id", "abc", "--prompt", "hi"], {
-        client: peerClient(),
-        runtime: stubRuntime({ deliverPrompt: deliver }),
-      })
-      expect(calls[0].prompt).toContain('[ROVE PEER] from "Auth attempt" (task sender-1')
-      expect(calls[0].prompt).toContain("registered as /rove; legacy /kobe installs still work")
-      expect(calls[0].prompt).toContain("send --task-id sender-1")
-      // The self-teach pointer: a receiver that has never seen kobe learns
-      // where the rest of the coordination verbs live.
-      expect(calls[0].prompt).toContain("Rove agent skill")
-      // The sender's text is LAST and whole, after a blank line — not the
-      // object of the provenance sentence. A model generates in the language
-      // of the tokens nearest its turn, so a non-English prompt wrapped in an
-      // English clause came back in English.
-      expect(calls[0].prompt).toMatch(/\)\n\nhi$/)
-    })
-
-    it("keeps a non-English prompt intact and last, so nothing follows it", async () => {
-      const { calls, deliver } = recordingDelivery()
-      await invokeVerb("send", ["--task-id", "abc", "--prompt", "帮我重构登录模块"], {
-        client: peerClient(),
-        runtime: stubRuntime({ deliverPrompt: deliver }),
-      })
-      expect(calls[0].prompt.endsWith("帮我重构登录模块")).toBe(true)
-      // The prompt is not spliced into the sentence: everything before it is
-      // provenance, and the last thing the receiver reads is the sender's own words.
-      const [provenance, ...rest] = calls[0].prompt.split("\n\n")
-      expect(rest.join("\n\n")).toBe("帮我重构登录模块")
-      expect(provenance).not.toContain("帮我重构登录模块")
-    })
-
-    it("gives a dispatched task the same reply address in its opening brief", async () => {
-      // `add --prompt` from inside a kobe session is agent-to-agent too, and
-      // its brief is where the reply address matters most: every report that
-      // task ever sends flows back through it. Recording the sender only as
-      // `dispatcher` on the task ROW — data a receiver has to think to go
-      // read — leaves a dispatched worker finished and sitting waiting.
-      const { calls, deliver } = recordingDelivery()
-      await invokeVerb("add", ["--repo", "/repo/x", "--prompt", "研究一下 X"], {
-        client: new FakeClient({
-          "task.create": () => ({ taskId: "child-1", task: taskFixture({ id: "child-1" }) }),
-          "task.get": (payload) => {
-            const id = (payload as { taskId: string }).taskId
-            return { task: taskFixture({ id, title: id === "sender-1" ? "Auth attempt" : "T" }) }
-          },
-        }),
-        runtime: stubRuntime({ deliverPrompt: deliver }),
-      })
-      expect(calls[0].prompt).toContain('[ROVE PEER] from "Auth attempt" (task sender-1')
-      expect(calls[0].prompt).toContain("send --task-id sender-1 --tab tab-1")
-      // Same shape as `send`: the brief is last and whole.
-      expect(calls[0].prompt.endsWith("研究一下 X")).toBe(true)
-    })
-
-    it("--plain sends verbatim", async () => {
-      const { calls, deliver } = recordingDelivery()
-      await invokeVerb("send", ["--task-id", "abc", "--prompt", "hi", "--plain"], {
-        client: peerClient(),
-        runtime: stubRuntime({ deliverPrompt: deliver }),
-      })
-      expect(calls[0].prompt).toBe("hi")
-    })
-
-    it("a send to yourself stays untouched", async () => {
-      const { calls, deliver } = recordingDelivery()
-      await invokeVerb("send", ["--task-id", "sender-1", "--prompt", "hi"], {
-        client: peerClient(),
-        runtime: stubRuntime({ deliverPrompt: deliver }),
-      })
-      expect(calls[0].prompt).toBe("hi")
-    })
-
-    it("a stale sender id degrades to id-only provenance, never a failed send", async () => {
-      const client = new FakeClient({
-        "task.get": (payload) => {
-          const id = (payload as { taskId: string }).taskId
-          if (id === "sender-1") throw new ApiError("task not found", "RPC_ERROR")
-          return { task: taskFixture({ id }) }
-        },
-      })
-      const { calls, deliver } = recordingDelivery()
-      await invokeVerb("send", ["--task-id", "abc", "--prompt", "hi"], {
-        client,
-        runtime: stubRuntime({ deliverPrompt: deliver }),
-      })
-      expect(calls[0].prompt).toContain('from "sender-1" (task sender-1')
-    })
-
-    it("a send from outside any kobe task stays untouched", async () => {
-      resetVerifiedSelfSession()
-      // biome-ignore lint/performance/noDelete: env must fully unset (assigning undefined leaves the string "undefined").
-      delete process.env.KOBE_TASK_ID
-      const { calls, deliver } = recordingDelivery()
-      await invokeVerb("send", ["--task-id", "abc", "--prompt", "hi"], {
-        client: peerClient(),
-        runtime: stubRuntime({ deliverPrompt: deliver }),
-      })
-      expect(calls[0].prompt).toBe("hi")
-    })
   })
 })

--- a/packages/kobe/test/daemon/issues-store.test.ts
+++ b/packages/kobe/test/daemon/issues-store.test.ts
@@ -236,3 +236,74 @@ describe("IssuesStore", () => {
     })
   })
 })
+
+/**
+ * A read that drops entries must SAY it dropped them, and must not hand the
+ * next `create` an id that is already in the file.
+ *
+ * `normalizeIssue` returns null for a non-numeric `id` while coercing every
+ * OTHER bad field to a placeholder, and `readStore` filtered those nulls away
+ * without counting them: a story the user filed stopped existing in every
+ * read — board, CLI, everything — while still sitting on disk, with
+ * `exists: true` and no warning anywhere.
+ */
+describe("IssuesStore corrupt-record honesty", () => {
+  async function seed(entry: Record<string, unknown>, nextId: unknown): Promise<{ store: IssuesStore; repo: string }> {
+    const repo = await realpath(await makeRepo())
+    const dir = await mkdtemp(join(tmpdir(), "kobe-issues-corrupt-"))
+    cleanups.push(dir)
+    const storePath = join(dir, "issues.json")
+    const store = new IssuesStore(storePath)
+    // Create through the store so the repo key is whatever `resolveRepo`
+    // derives, then hand-edit that record — the shape a crashed write or a
+    // pre-numeric-id record leaves behind.
+    await store.mutate(repo, { type: "create", title: "ship the thing" })
+    await store.mutate(repo, { type: "create", title: "second story" })
+    const raw = JSON.parse(await readFile(storePath, "utf8")) as {
+      repos: Record<string, { nextId: unknown; issues: Record<string, unknown>[] }>
+    }
+    const key = Object.keys(raw.repos)[0]!
+    raw.repos[key]!.issues[0] = { ...raw.repos[key]!.issues[0], ...entry }
+    raw.repos[key]!.nextId = nextId
+    await writeFile(storePath, JSON.stringify(raw), "utf8")
+    return { store, repo }
+  }
+
+  it("counts an unreadable entry instead of reporting the survivors as the whole board", async () => {
+    // id 2 becomes the STRING "2" — the one field normalizeIssue refuses.
+    const { store, repo } = await seed({ id: "2" }, 3)
+    const listed = await store.list(repo)
+    expect(listed.issues).toHaveLength(1)
+    // Without this, `exists: true` + a one-item list is indistinguishable from
+    // a board that only ever had one story.
+    expect(listed.skipped).toBe(1)
+  })
+
+  it("reports skipped: 0 when every entry parsed", async () => {
+    const repo = await realpath(await makeRepo())
+    const dir = await mkdtemp(join(tmpdir(), "kobe-issues-clean-"))
+    cleanups.push(dir)
+    const store = new IssuesStore(join(dir, "issues.json"))
+    await store.mutate(repo, { type: "create", title: "ship the thing" })
+    await expect(store.list(repo)).resolves.toMatchObject({ skipped: 0 })
+  })
+
+  it("allocates past the highest id on disk when nextId is corrupt", async () => {
+    // nextId is the STRING "3": the old fallback was a flat `1`, which
+    // `create` then handed out — colliding with issue #1 already in the file,
+    // after which every id-keyed op hits whichever card `find` reaches first.
+    const { store, repo } = await seed({}, "3")
+    await expect(store.list(repo)).resolves.toMatchObject({ nextId: 3 })
+    const created = await store.mutate(repo, { type: "create", title: "collision probe" })
+    expect(created.issues[0]?.id).toBe(3)
+    expect(new Set(created.issues.map((issue) => issue.id)).size).toBe(created.issues.length)
+  })
+
+  it("counts an unusable id toward the next allocation, so the fallback cannot reuse it", async () => {
+    const { store, repo } = await seed({ id: "2" }, "nope")
+    // Issue "2" is dropped from `issues`, but its id is still spoken for on
+    // disk: deriving the fallback from the PARSED list alone would hand out 2.
+    const created = await store.mutate(repo, { type: "create", title: "after the hole" })
+    expect(created.issues[0]?.id).toBe(3)
+  })
+})

--- a/packages/kobe/test/orchestrator/worktree-unreadable.test.ts
+++ b/packages/kobe/test/orchestrator/worktree-unreadable.test.ts
@@ -1,0 +1,99 @@
+/**
+ * `git worktree list --porcelain` omits a worktree whose admin dir it cannot
+ * read — with no stderr and a ZERO exit. Passing that through made
+ * `discover-adoptable` answer `{"worktrees":[]}` for a repo that has a
+ * worktree with uncommitted work in it: a result indistinguishable from
+ * "nothing to adopt", and no path for the user to reach the work.
+ *
+ * These pin the cross-check with a STUBBED porcelain reader over a real
+ * admin-dir layout. The unreadable admin dir is modelled by a missing `gitdir`
+ * file rather than `chmod 000`: the production trigger is EACCES, the code
+ * branches on any read failure, and chmod is a coin flip under a root CI user.
+ * The real EACCES path is covered end-to-end by the CLI reproduction in the
+ * PR — this suite covers the decision logic.
+ */
+
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterAll, beforeAll, expect, it } from "vitest"
+import type { ExecCtx } from "../../src/orchestrator/worktree/exec-deps.ts"
+import { type ListDeps, unreadableWorktreeNames } from "../../src/orchestrator/worktree/manager-list.ts"
+
+let root: string
+let repo: string
+let adminRoot: string
+
+beforeAll(() => {
+  root = realpathSync(mkdtempSync(join(tmpdir(), "kobe-wt-unreadable-")))
+  repo = join(root, "repo")
+  adminRoot = join(repo, ".git", "worktrees")
+  mkdirSync(adminRoot, { recursive: true })
+})
+
+afterAll(() => {
+  rmSync(root, { recursive: true, force: true })
+})
+
+/** One admin dir. `gitdir` absent = the entry git could not read. */
+function admin(name: string, worktreePath?: string): void {
+  mkdirSync(join(adminRoot, name), { recursive: true })
+  if (worktreePath) writeFileSync(join(adminRoot, name, "gitdir"), `${join(worktreePath, ".git")}\n`, "utf8")
+}
+
+function porcelain(...paths: string[]): string {
+  return paths.map((p) => `worktree ${p}\nHEAD abc123\nbranch refs/heads/b\n`).join("\n")
+}
+
+function deps(listed: string): ListDeps {
+  return {
+    ctxFor: () => ({ dir: repo, remote: false }) as unknown as ExecCtx,
+    async runGitStdout(_ctx, args) {
+      if (args[0] === "rev-parse") return ".git\n"
+      if (args[0] === "worktree") return listed
+      throw new Error(`unexpected git ${args.join(" ")}`)
+    },
+    runGitStdoutAt: async () => "",
+    isDirty: async () => false,
+  }
+}
+
+const ctx = () => ({ dir: repo, remote: false }) as unknown as ExecCtx
+
+it("reports an admin dir git omitted from its own porcelain list", async () => {
+  admin("healthy", join(root, "healthy"))
+  admin("broken") // no gitdir — unreadable, exactly what git skips
+  const names = await unreadableWorktreeNames(deps(porcelain(repo, join(root, "healthy"))), ctx())
+  expect(names).toEqual(["broken"])
+})
+
+it("reports nothing when every admin dir is accounted for", async () => {
+  rmSync(join(adminRoot, "broken"), { recursive: true, force: true })
+  const names = await unreadableWorktreeNames(deps(porcelain(repo, join(root, "healthy"))), ctx())
+  expect(names).toEqual([])
+})
+
+/**
+ * Git de-duplicates colliding basenames (`foo`, `foo1`), so comparing admin
+ * NAMES against porcelain paths would flag a perfectly healthy second `foo` as
+ * missing. The match runs on the path each `gitdir` resolves to.
+ */
+it("does not flag a de-duplicated admin name whose worktree IS listed", async () => {
+  const other = join(root, "other", "healthy")
+  admin("healthy1", other)
+  const names = await unreadableWorktreeNames(deps(porcelain(repo, join(root, "healthy"), other)), ctx())
+  expect(names).toEqual([])
+  rmSync(join(adminRoot, "healthy1"), { recursive: true, force: true })
+})
+
+it("stays out of the way when it cannot enumerate at all", async () => {
+  // A repo with no `.git/worktrees` at all, and a remote ctx (whose admin dirs
+  // are not on this filesystem) must both answer `[]` — this check augments
+  // discovery, it must never dark it.
+  const bare = join(root, "bare")
+  mkdirSync(bare, { recursive: true })
+  const bareCtx = { dir: bare, remote: false } as unknown as ExecCtx
+  await expect(unreadableWorktreeNames(deps(porcelain(bare)), bareCtx)).resolves.toEqual([])
+  const remoteCtx = { dir: repo, remote: true } as unknown as ExecCtx
+  await expect(unreadableWorktreeNames(deps(porcelain(repo)), remoteCtx)).resolves.toEqual([])
+})

--- a/packages/kobe/test/render/silent-failure-toasts.test.tsx
+++ b/packages/kobe/test/render/silent-failure-toasts.test.tsx
@@ -29,6 +29,7 @@ import { toTaskId } from "../../src/types/task"
 import { renderComponent, settle } from "./harness"
 
 const REPO = "/repos/rove"
+const BROKEN = "/repos/broken"
 
 function issue(id: number, over: Record<string, unknown> = {}) {
   return { id, title: `story-${id}`, status: "open", created: "2026-08-01", body: "", ...over }
@@ -81,6 +82,60 @@ test("kanban: a rejected detail-drawer edit shows an error toast, not the stale 
   // like an edit that was never made.
   expect(text).toContain("✕")
   expect(text).toContain("Couldn't save story #1")
+})
+
+/**
+ * A project whose issue read REJECTS must keep its slot on the board.
+ *
+ * `listIssues(repo).catch(() => null)` + a `filter(res => res !== null)` took
+ * the whole project out of the result, so the tab strip went from two projects
+ * to one with no error, no glyph, and no toast. A user with two repos open saw
+ * one and had no reason to believe the other existed — the failure was not
+ * merely quiet, it was indistinguishable from "you only have one project".
+ */
+test("kanban: a project whose issue read rejects keeps its slot, says why, and toasts", async () => {
+  const orch = {
+    listTasks: () => [{ repo: REPO }, { repo: BROKEN }],
+    listIssues: async (repo: string) => {
+      if (repo === BROKEN) throw new Error("JSON Parse error: Unterminated string")
+      return { repoRoot: REPO, exists: true, nextId: 9, issues: [issue(1)], skipped: 0 }
+    },
+    activeTaskSignal: () => ({ get: () => null }),
+    mutateIssue: async () => {},
+  } as never
+  const { frame, mockInput } = await renderComponent(
+    <>
+      <KanbanPage
+        orchestrator={orch}
+        focused={true}
+        onClose={() => {}}
+        onStartChat={async () => {}}
+        onOpenTask={() => {}}
+      />
+      <ToastOverlay />
+    </>,
+    { width: 120, height: 30, providers: { dialog: true, kv: true, notifications: true } },
+  )
+  await settle(300)
+
+  // The counter is the proof the project was not dropped: `1/2`, not a bare
+  // single-project label. Sorted by repoRoot, `/repos/broken` leads.
+  const first = await frame()
+  expect(first).toContain("1/2")
+  expect(first).toContain("✕")
+  expect(first).toContain("Couldn't read stories for")
+
+  // …and the broken project's own section states the failure where its four
+  // columns would be. Empty lanes there would read as "no stories filed".
+  expect(first).toContain("Couldn't read this project's stories")
+  expect(first).toContain("Unterminated string")
+
+  // The healthy project is still fully reachable — tab cycles onto its board.
+  mockInput.pressTab()
+  await settle(200)
+  const second = await frame()
+  expect(second).toContain("story-1")
+  expect(second).not.toContain("Couldn't read this project's stories")
 })
 
 /**


### PR DESCRIPTION
Five items from `.scratch/loop-r10/failure.md` — F2, F3, F4, F7, F8. Each one is a read that failed (or dropped something) and a caller that reported the survivors as the whole answer.

Rebased onto `origin/main` after #858 landed. That PR is the F1/F5/F6 half of the same brief; it widened `WorktreeInfo.dirty` / `AdoptableWorktree.dirty` to `boolean | null` in `manager-list.ts`. My only change to that file is a new function appended at the end — I did not touch the `dirty` probes, `collect`'s `changes`, the sidebar chip, or `shortcut-reveal.test.tsx`.

---

## Was there one shared shape?

**No — and I looked.** Four of the five (F2/F3/F4/F8) are the same *defect*, but the honest answer has a different shape in each, across three packages:

| item | what the failure is | honest shape |
|---|---|---|
| F2 | a per-repo promise rejected | keep the entity, attach `readError` |
| F3 | N entries in a parsed file were unusable | a `skipped` **count** |
| F4 | a socket connect failed | `null` vs `[]` |
| F8 | an external tool omitted a row and exited 0 | a list of **names** we could not resolve further |

A shared helper would be one abstraction with one caller each, and the four live in `tui-react`, `kobe-daemon`, `cli/api`, and `orchestrator/worktree`. They genuinely need separate fixes. What they *do* share is the rule, which is now stated at each site in a comment: **`[]` / `0` / `false` must never be the answer for both "nothing" and "could not look".** F1's `base` (nulls all the way out) and `inspect`'s sessions section were the in-repo precedents I copied.

---

## F2 — Kanban silently dropped a whole project

**PASS:** with one repo's `listIssues` rejecting, the board still shows both projects in the selector (`1/2`), the broken one shows a read-failure message instead of empty columns, and a toast names the repo.

`use-kanban-boards.ts:53` did `listIssues(repo).catch(() => null)` and then filtered the nulls away. A rejected read took the project out of the result entirely.

**Proof — harness screenshots** (browser `/harness` → xterm.js → PTY sidecar → real OpenTUI, fixture at port base 5873, same seeded state for both frames; BEFORE captured with `use-kanban-boards.ts` + `kanban-page.tsx` reverted to `origin/main` and the TUI rebuilt):

- BEFORE: `/Users/jacksonc/i/kobe/.scratch/loop-r10-z/before.png`
- AFTER: `/Users/jacksonc/i/kobe/.scratch/loop-r10-z/after.png`

(also in this worktree at `.scratch/loop-r10-z/`, which does not survive task cleanup)

BEFORE: the **sidebar shows both projects** (`z-visual-broken-repo / Broken Project` and `fixture-repo / Visual Fixture`) while the board reads `fixture-repo` with **no counter** — one project, no error, no glyph, no toast. `tab` does nothing.

AFTER: `z-visual-broken-repo 1/2`, `Couldn't read this project's stories: repoRoot is not a git repository` where the four columns would be, and a toast `✕ Couldn't read stories for z-visual-bro…`.

Trigger: a second project whose repo directory is no longer a git repo, so `issue.list` rejects for that repo only. (First attempt put it inside the repo tree, where git walked *up* into the enclosing repo and the read succeeded — it has to live outside.)

Test: `test/render/silent-failure-toasts.test.tsx`. Mutation-verified — restoring the `filter(res => res !== null)` fails on `expect(first).toContain("1/2")`.

## F3 — a non-numeric `id` vanished from every read, and `nextId` reallocated it

**PASS:** the BEFORE recipe reports one issue **and** a non-zero `skipped` in `issue-list` JSON; a store with a corrupt `nextId` and issues `[1,2]` allocates `3`, not `1`.

BEFORE (isolated home, two issues on disk, one hand-edited to a string id, `nextId` `"3"`):

```
{"repoRoot":"/private/tmp/z-r10-repo","exists":true,"nextId":1,
 "issues":[{"id":1,"title":"ship the thing",...}]}
```

…and the second defect is worse than the brief describes. `create` did not just restart at 1, it handed out an id that **already existed**:

```
{"nextId":2,"issues":[{"id":1,"title":"collision probe",...},{"id":1,"title":"ship the thing",...}]}
```

Two cards, both `#1`. Every id-keyed op (`setStatus`/`update`/`delete`) then hits whichever one `find` reaches first.

AFTER, same recipe:

```
{"repoRoot":"/private/tmp/z-r10-repo","exists":true,"nextId":3,
 "issues":[{"id":1,"title":"ship the thing",...}],"skipped":1}
{"nextId":4,"issues":[{"id":3,"title":"collision probe",...},{"id":1,...}],"skipped":1}
```

and the daemon log names the repo:

```
daemon error [issues-store-read]: Error: /private/tmp/z-r10-repo/.git: dropped 1 unreadable issue entry (id is not a number)
```

`nextIdFallback` scans the **raw** entries, so an id we could not parse into an issue still pushes the allocation point past itself. Tests: 4 in `test/daemon/issues-store.test.ts`. Mutation-verified twice (`nextId` back to `1` → 2 red; `dropped = 0` → 1 red).

**Known, out of scope:** a `list`/`mutate` that writes the store back drops the unreadable entry from disk permanently. Preserving unparseable entries across a write is a larger change to the normalize contract; flagging rather than smuggling it in.

## F4 — `pty-list` answered `[]` whether the host was down or idle

**PASS:** no host ⇒ `"sessions": null`; a live host with zero sessions ⇒ `[]`.

```
BEFORE   $ rove api pty-list        {"sessions":[]}
         $ rove api inspect         {"sessions": null}      # same fact, opposite answer

AFTER    $ rove api pty-list        {"sessions":null}
         $ rove api inspect         {"sessions": null}
```

Test: `test/behavior/pty-api-autostart.test.ts` — a new first case for the cold read; every other `pty-list` assertion in that file already drives a real PTY host and asserts on an array, which is the live-host half. Mutation-verified (restore `{ sessions: [] }` → red).

## F7 — `add --prompt` reported full success after a refused persist

**PASS:** with `task.setPrompt` forced to reject, `add --prompt` still exits 0 and reports `"promptPersisted": false`; healthy, the field is absent.

Code-path-only, per the brief — the trigger is an RPC/store fault with no filesystem shape, so it is stubbed via the existing `FakeClient` rather than raced. That put it in the **fast** track instead of behavior: `FakeClient` is the tightest stub for "this one RPC rejects", and behavior has no way to fault a single RPC.

Two tests in `test/cli/api-handlers.test.ts` (reject → `promptPersisted: false`; healthy → field absent). Mutation-verified. Both `addOne` and every sibling of a `--count` round go through one `persistPrompt` helper, which also logs the rejection with the taskId and what it costs ("no Run again for this task").

## F8 — an unreadable worktree disappeared from adoption entirely

**PASS:** with the admin dir unreadable, `discover-adoptable` still reports the worktree, marked unreadable; `{"worktrees":[]}` again means only "nothing to adopt".

Reproduced exactly as briefed — `git worktree list --porcelain` omits the entry and **exits 0**:

```
$ chmod 000 "$R/.git/worktrees/z-adoptme"
$ (cd "$R" && git worktree list --porcelain; echo "exit=$?")
worktree /private/tmp/z-r10-repo … exit=0          # 'z-adoptme' is GONE
$ rove api discover-adoptable --repo "$R"
BEFORE  {"worktrees":[]}
AFTER   {"worktrees":[],"unreadable":["z-adoptme"]}
$ chmod 755 …                                       # healthy again
AFTER   {"worktrees":[{"path":"/private/tmp/z-adoptme",…}],"unreadable":[]}
```

(`urgent.txt` untouched on disk throughout; every `chmod 000` restored.)

**Names only, deliberately.** I checked what is actually recoverable: with the admin dir at `000`, its `gitdir` file — the one record of where that worktree lives — is unreadable too (`cat` → Permission denied), so there is no path, branch, or head. A synthesized `path` would be a second lie *and* a path `adopt` would try to use. The name is the whole honest answer.

The match runs on the path each readable `gitdir` resolves to, not on admin-dir names: git de-duplicates colliding basenames (`foo`, `foo1`), and a name comparison would flag a healthy second `foo` as missing.

Wiring goes through `ctx.runtime`, not `ctx.orch` — following the precedent already documented in `handlers-worktree.ts`'s own header ("`GitWorktreeManager` … orchestrator-independent primitives, so these compose them directly"). It is a git-layout fact, not an orchestrator one, and it keeps `orchestrator/core.ts` (already at 502 lines) untouched.

Tests: 4 in `test/orchestrator/worktree-unreadable.test.ts` with a stubbed porcelain reader over a real admin-dir layout. The unreadable dir is modelled by a **missing** `gitdir` rather than `chmod 000`: the code branches on any read failure, and chmod is a coin flip under a root CI user. The real EACCES path is the CLI reproduction above. Mutation-verified.

---

## Gates

All run after the rebase, from `packages/kobe`:

```
bun run lint          (repo root)   Checked 1419 files. No fixes applied.
bun run typecheck                   4 packages, exit 0
bun run test:fast                   446 files, 4395 tests passed
bun test test/render                473 pass, 0 fail (107 files)
bun run test:socket                  96 files, 789 tests passed
bun run test:behavior                11 files, 33 tests passed
```

Every BEFORE/AFTER above ran in an isolated home with all of `ROVE_/KOBE_ {HOME_DIR, DAEMON_SOCKET_PATH, DAEMON_PID_PATH, PTY_SOCKET_PATH, PTY_PID_PATH, DAEMON_WEB_PORT}` inlined — never `~/.rove`.

## Note on the split file

`test/cli/api-handlers.test.ts` crossed 500 lines when I added the F7 cases, so the `send` handler moved to `test/cli/api-handlers-send.test.ts`. The seam is the verb — that file's own header already declared it ("single-task `add` and the `send` handler"), and nothing in the send block touches `add`. Same 32 tests, 214 + 332 lines.

## Not proven

Nothing. Each item's PASS criterion has a re-run of the brief's own recipe above, and every fix is mutation-verified — reverting it turns its test red.
