### PR TITLE
fix: report and reclaim processes a dead PTY session left behind

### DIFF
--- a/.changeset/orphan-pty-descendants.md
+++ b/.changeset/orphan-pty-descendants.md
@@ -1,0 +1,19 @@
+---
+"@sma1lboy/rove": patch
+---
+
+`rove doctor` now reports processes that outlived the PTY session that spawned them, and `--kill-orphans` reclaims them.
+
+Rove ends a session by signalling the child's whole process group, so a normal
+close takes the shell, the engine, and everything they spawned with it. Nothing
+covered the case where the kill comes from OUTSIDE Rove — a `kill -9`, an OOM
+reaper, a crashed PTY host — because then Rove is never told and never signals
+the group, and the engine's children run until you reboot. One developer machine
+had eight of them, aged two to five days, still burning CPU.
+
+Doctor lists a process only when it carries the marker the PTY host sets on every
+child, its parent is init, its process group has no leader left, and that group is
+not one the PTY host still reports as live — so a healthy task, and anything
+started outside Rove, can never appear. Killing is a separate `--kill-orphans`
+flag rather than a `doctor --fix` entry, because a dev server you backgrounded
+from a Rove terminal and then closed the tab on looks exactly like a leak.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -276,12 +276,13 @@ Changes apply to a running daemon without a restart. Writing one:
 ## doctor
 
 ```bash
-rove doctor [--report] [--fix]
+rove doctor [--report] [--fix] [--kill-orphans]
 ```
 
 Read-only check of your build (including install integrity and a stale bundled
 Bun), terminal, git, engine CLIs and logins, the engine hook channel, daemon,
-running sessions, leftover pre-v0.8 tmux sessions, node-pty's macOS
+running sessions, processes left behind by a PTY session that died without
+Rove seeing it, leftover pre-v0.8 tmux sessions, node-pty's macOS
 `spawn-helper` exec bit, agent skill, and state files. The terminal section names
 `TERM`/`TERM_PROGRAM`/`COLORTERM`, whether you are inside a multiplexer (tmux,
 zellij, screen — all three rewrite keys on the way in), and asks the terminal
@@ -306,6 +307,13 @@ and prints its path; attach that to bug reports.
   sessions (`rove reset`, closing engine tabs) or needs a human (installing
   git/Node.js, engine logins) is shown with the step and why doctor won't run
   it. Without a TTY (`--fix` in a script), nothing at all is executed.
+
+`--kill-orphans` ends the process groups listed under `orphans:` — SIGTERM,
+then SIGKILL on whatever survives. It is a separate flag rather than a `--fix`
+entry because the report cannot tell a leak from a process you backgrounded on
+purpose from a Rove terminal and then closed the tab on: both are reparented to
+init with a dead group leader. Run the plain report, read the list, then pass
+the flag. See [Troubleshooting](./TROUBLESHOOTING.md).
 
 The remedies mirror [Troubleshooting](./TROUBLESHOOTING.md) — `--fix` is that
 page's executable half.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -99,6 +99,38 @@ The raw logs live under the active Rove home (normally your OS home):
 | `~/.rove/pty.log` | Hosted PTY startup and session-host failures |
 | `~/.rove/client.log` | TUI/pane connection, disconnect, and reconnect diagnostics |
 
+## Processes keep running days after their task is gone
+
+Ending a session in Rove ends its whole subtree: the PTY host signals the
+child's process *group*, which reaches the shell, the engine, and everything
+they spawned. That only happens when Rove is the one doing the killing. Kill an
+engine from outside — `kill -9`, an OOM reaper, a crashed PTY host — and Rove is
+never told, so it never signals the group, and whatever the engine had spawned
+is reparented to init and runs until you reboot. A machine that has been through
+a few of those accumulates test runners, dev servers, and browsers burning CPU
+for something you closed last week.
+
+`rove doctor` lists them under `orphans:`, with age, memory, and command:
+
+```text
+orphans: ⚠ 3 process(es) outlived the PTY session that spawned them (97 MB RSS)
+         pid 15752 (group 14297) up 04-21:22:21, 25 MB: bun test test/render
+```
+
+A process is listed only when its environment carries the marker the PTY host
+sets on every child it spawns, its parent is init, its process group has no
+leader left, and that group is not one the PTY host still reports as live. A
+healthy task never matches, and neither does anything you started outside Rove.
+
+Killing needs `rove doctor --kill-orphans`, and doctor never does it on its own:
+a database tunnel or dev server you deliberately backgrounded from a Rove
+terminal, whose tab you then closed, is indistinguishable from a leak. Read the
+list first.
+
+On macOS the environment of an Apple-signed system binary is unreadable without
+root, so those are never listed. What actually leaks — `bun`, `node`, a browser,
+a CLI tool — reads fine.
+
 ## Who deleted my task?
 
 Every task deletion is recorded in `~/.rove/daemon.log`, whether it succeeds

--- a/packages/kobe/src/cli/doctor-cmd.ts
+++ b/packages/kobe/src/cli/doctor-cmd.ts
@@ -30,6 +30,7 @@ import {
   defaultFixRuntime,
   engineTabsManualFix,
   humanOnlyFix,
+  killOrphansManualFix,
   reinstallManualFix,
   resetManualFix,
   skillInstallFix,
@@ -37,6 +38,7 @@ import {
 } from "./doctor-fix.ts"
 import { classifyHookChannel, hookChannelDoctorLines } from "./doctor-hook-channel.ts"
 import { installedSpawnHelpers, spawnHelperDoctorLines } from "./doctor-node-pty.ts"
+import { type Orphan, collectOrphans, killOrphanGroups, orphanDoctorLines } from "./doctor-orphans.ts"
 import { terminalDoctorLines } from "./doctor-terminal.ts"
 import { probeEngines, probeGit } from "./env-checks.ts"
 import { inspectLegacyTmux, legacyTmuxDoctorLines } from "./legacy-tmux.ts"
@@ -44,7 +46,7 @@ import { activeCliName } from "./rename-compat.ts"
 
 const CLI_NAME = activeCliName()
 
-type PtySessionStatus = { alive?: boolean; parked?: boolean }
+type PtySessionStatus = { alive?: boolean; parked?: boolean; pid?: number | null }
 
 /** The slice of `debug.inspect` the hook-channel check reads. */
 type InspectSnapshot = {
@@ -169,7 +171,7 @@ async function appendUnavailableProcess(
  * Assemble the full read-only diagnosis as printable lines, plus the fixes
  * each failing check proposes (collected, never executed here).
  */
-async function collectDoctor(): Promise<{ lines: string[]; fixes: DoctorFix[] }> {
+async function collectDoctor(): Promise<{ lines: string[]; fixes: DoctorFix[]; orphans: Orphan[] }> {
   const daemonSocket = defaultDaemonSocketPath()
   const daemonLog = defaultDaemonLogPath()
   const ptySocket = defaultPtyHostSocketPath()
@@ -321,6 +323,17 @@ async function collectDoctor(): Promise<{ lines: string[]; fixes: DoctorFix[] }>
   }
   out.push("")
 
+  // Processes a PTY session left behind when something OUTSIDE Rove killed it.
+  // Read-only here by design: the predicate cannot tell a leak from a process
+  // the user deliberately backgrounded, so `--kill-orphans` is the consent.
+  const liveSessionPids = new Set<number>()
+  for (const session of inventory?.sessions ?? []) {
+    if (session.alive && typeof session.pid === "number") liveSessionPids.add(session.pid)
+  }
+  const orphaned = await collectOrphans(liveSessionPids)
+  out.push(...orphanDoctorLines(orphaned.orphans, orphaned.error, CLI_NAME), "")
+  if (orphaned.orphans.length > 0) fixes.push(killOrphansManualFix(CLI_NAME, orphaned.orphans.length))
+
   const legacy = await inspectLegacyTmux()
   out.push(...legacyTmuxDoctorLines(legacy), "")
   if (legacy.sessions.length > 0) fixes.push(resetManualFix(CLI_NAME, "resetLegacy"))
@@ -347,22 +360,39 @@ async function collectDoctor(): Promise<{ lines: string[]; fixes: DoctorFix[] }>
   out.push(`state.json: ${describeFile(statePath)}`)
   out.push(`daemon.log: ${describeFile(daemonLog)}`)
   out.push(`pty.log: ${describeFile(ptyLog)}`)
-  return { lines: out, fixes }
+  return { lines: out, fixes, orphans: orphaned.orphans }
+}
+
+/**
+ * `--kill-orphans`: end every process group the report just listed. Prints the
+ * groups it signalled and any that outlived SIGKILL, so "nothing changed" can
+ * never be mistaken for "nothing was there".
+ */
+async function sweepOrphans(orphans: readonly Orphan[]): Promise<string[]> {
+  if (orphans.length === 0) return ["orphans: nothing to kill"]
+  const { groups, survivors } = await killOrphanGroups(orphans)
+  const lines = [`orphans: signalled ${groups.length} process group(s) covering ${orphans.length} process(es)`]
+  if (survivors.length > 0) {
+    lines.push(`         ✗ still alive after SIGKILL: group(s) ${survivors.join(", ")} — inspect with \`ps -g <pgid>\``)
+  } else lines.push("         ✓ all of them are gone")
+  return lines
 }
 
 export async function runDoctorSubcommand(argv: readonly string[] = []): Promise<void> {
   if (argv.some((arg) => arg === "--help" || arg === "-h" || arg === "help")) {
     process.stdout.write(
       [
-        `Usage: ${CLI_NAME} doctor [--report] [--fix]`,
+        `Usage: ${CLI_NAME} doctor [--report] [--fix] [--kill-orphans]`,
         "",
         "Read-only diagnosis of the daemon / Hosted PTY / engines / git / legacy tmux / state.",
         "",
         "Options:",
-        "  --report      Also write a bug bundle (diagnosis + recent logs + env) to a file",
-        "  --fix         Review the fixes one by one: safe ones run after a per-fix y/N,",
-        "                risky ones (kill sessions, install software) are printed only",
-        "  -h, --help    Print this help",
+        "  --report        Also write a bug bundle (diagnosis + recent logs + env) to a file",
+        "  --fix           Review the fixes one by one: safe ones run after a per-fix y/N,",
+        "                  risky ones (kill sessions, install software) are printed only",
+        "  --kill-orphans  End the process groups listed under `orphans:` (SIGTERM, then",
+        "                  SIGKILL). Not undoable — run plain `doctor` and read the list first",
+        "  -h, --help      Print this help",
         "",
       ].join("\n"),
     )
@@ -370,19 +400,22 @@ export async function runDoctorSubcommand(argv: readonly string[] = []): Promise
   }
   const report = argv.some((arg) => arg === "--report")
   const fix = argv.some((arg) => arg === "--fix")
-  const unknown = argv.find((arg) => arg.length > 0 && arg !== "--report" && arg !== "--fix")
+  const kill = argv.some((arg) => arg === "--kill-orphans")
+  const known = new Set(["--report", "--fix", "--kill-orphans"])
+  const unknown = argv.find((arg) => arg.length > 0 && !known.has(arg))
   if (unknown !== undefined) {
     process.stderr.write(
-      `${CLI_NAME} doctor: unexpected argument "${unknown}"\n\nUsage: ${CLI_NAME} doctor [--report] [--fix]\n`,
+      `${CLI_NAME} doctor: unexpected argument "${unknown}"\n\nUsage: ${CLI_NAME} doctor [--report] [--fix] [--kill-orphans]\n`,
     )
     process.exit(2)
   }
 
-  const { lines, fixes } = await collectDoctor()
+  const { lines, fixes, orphans } = await collectDoctor()
   if (!fix && fixes.length > 0) {
     lines.push("", t("doctor.fix.hint", { count: fixes.length, command: `${CLI_NAME} doctor --fix` }))
   }
   console.log(lines.join("\n"))
+  if (kill) console.log(`\n${(await sweepOrphans(orphans)).join("\n")}`)
   if (fix) await applyFixes(fixes, defaultFixRuntime())
   if (report) {
     const { writeReportBundle } = await import("./doctor-report.ts")

--- a/packages/kobe/src/cli/doctor-fix.ts
+++ b/packages/kobe/src/cli/doctor-fix.ts
@@ -80,6 +80,22 @@ export function resetManualFix(cliName: string, reason: ResetReason): DoctorFix 
   }
 }
 
+/**
+ * Orphaned PTY descendants: print-only, because the list can contain a process
+ * the user deliberately backgrounded. Killing it is not undoable, and only the
+ * user can tell those apart from a leak — so doctor shows the command and the
+ * list, and never runs it behind a y/N.
+ */
+export function killOrphansManualFix(cliName: string, count: number): DoctorFix {
+  return {
+    kind: "manual",
+    id: "kill-orphans",
+    label: t("doctor.fix.orphans", { count }),
+    action: `${cliName} doctor --kill-orphans`,
+    why: t("doctor.fix.orphansWhy"),
+  }
+}
+
 /** The user-owned half of a dead hook channel: restarting the engine tabs. */
 export function engineTabsManualFix(): DoctorFix {
   return {

--- a/packages/kobe/src/cli/doctor-orphans.ts
+++ b/packages/kobe/src/cli/doctor-orphans.ts
@@ -1,0 +1,246 @@
+/**
+ * Processes a dead PTY session left behind, and how to reclaim them.
+ *
+ * Rove's own killing is complete: `terminatePtyChild` signals the child's
+ * whole process GROUP, so ending a session ends its subtree. The leak is the
+ * path Rove never gets to run. When something OUTSIDE Rove kills an engine —
+ * a `kill -9`, an OOM reaper, a crashed terminal — the host is never told, so
+ * it never signals the group, and everything the engine had spawned is
+ * reparented to init and runs forever. Measured on one developer machine:
+ * eight survivors aged two to five days, several of them still burning CPU.
+ *
+ * ## The predicate
+ *
+ * A process is reported here only when ALL of these hold:
+ *
+ *   1. `KOBE_TERMINAL_PTY=1` is in its environment. The PTY host sets that
+ *      variable on every child it spawns (`pty-child-controller.ts`) and
+ *      nothing else on the machine does, so it marks the whole subtree as
+ *      descended from a Rove terminal. This is what keeps the sweep off a
+ *      process the user started themselves.
+ *   2. Its parent is init (`ppid === 1`). Its parent died and nothing is
+ *      coming to reap it.
+ *   3. Its process group has no leader left. The leader of a hosted session's
+ *      group IS the PTY child, so a leaderless group is a session that ended.
+ *      This also excludes every ordinary daemon, which is its own leader.
+ *   4. Its group is not a session the PTY host currently lists as alive, and
+ *      is not this process's own group. A healthy task can never match.
+ *
+ * ## Why this reports instead of killing
+ *
+ * The predicate cannot read intent. A process deliberately backgrounded from
+ * a Rove terminal whose tab was then closed satisfies every clause — on the
+ * machine this was written against, two of the eight matches were database
+ * tunnels. So a plain `doctor` run only ever LISTS them, with age and command
+ * so the user can tell a leak from something they meant to keep, and killing
+ * needs the explicit `--kill-orphans` flag. Typing that flag is the consent;
+ * nothing sweeps on a timer, at host boot, or behind a y/N.
+ *
+ * POSIX only: Windows has no process groups to orphan a subtree into. And on
+ * macOS the kernel refuses to hand a process's environment to a non-root
+ * reader when the binary is SIP-protected, so a system binary (`/bin/sleep`
+ * and friends) can never satisfy clause 1 there and is never reported. That
+ * failure is closed by construction — the sweep skips what it cannot verify —
+ * and it costs nothing in practice, because what actually leaks is the
+ * long-running third-party program (`bun`, `node`, a browser, a CLI tool),
+ * whose environment reads fine.
+ */
+
+import { readFileSync } from "node:fs"
+
+/** Set by the PTY host on every child it spawns; inherited by the subtree. */
+const PTY_MARKER = "KOBE_TERMINAL_PTY=1"
+
+/** One row of the structural `ps` pass. */
+export interface PsRow {
+  readonly pid: number
+  readonly ppid: number
+  readonly pgid: number
+  /** `ps` elapsed time, verbatim (`04-22:42:56`) — the age that makes a leak obvious. */
+  readonly etime: string
+  readonly rssKb: number
+  readonly command: string
+}
+
+export interface Orphan extends PsRow {
+  /** The dead session's pid: the group to signal to reach the whole subtree. */
+  readonly pgid: number
+}
+
+async function run(argv: readonly string[]): Promise<{ code: number; stdout: string }> {
+  try {
+    const proc = Bun.spawn([...argv], { stdin: "ignore", stdout: "pipe", stderr: "ignore" })
+    const [stdout, code] = await Promise.all([new Response(proc.stdout).text().catch(() => ""), proc.exited])
+    return { code, stdout }
+  } catch {
+    return { code: 127, stdout: "" }
+  }
+}
+
+/** Parse `ps -A -o pid=,ppid=,pgid=,etime=,rss=,command=`. Command may contain spaces. */
+export function parsePsRows(output: string): PsRow[] {
+  const rows: PsRow[] = []
+  for (const line of output.split("\n")) {
+    const parts = line.trim().split(/\s+/)
+    if (parts.length < 6) continue
+    const [pid, ppid, pgid] = [parts[0], parts[1], parts[2]].map((value) => Number.parseInt(value ?? "", 10))
+    const rssKb = Number.parseInt(parts[4] ?? "", 10)
+    if (!Number.isFinite(pid) || !Number.isFinite(ppid) || !Number.isFinite(pgid) || !Number.isFinite(rssKb)) continue
+    rows.push({ pid, ppid, pgid, etime: parts[3] ?? "", rssKb, command: parts.slice(5).join(" ") })
+  }
+  return rows
+}
+
+/** True while any member of the group is still running (a live leader included). */
+function pidAlive(pid: number, rows: readonly PsRow[]): boolean {
+  return rows.some((row) => row.pid === pid)
+}
+
+/**
+ * Clauses 2-4 of the predicate, over the process table alone. Runs BEFORE the
+ * environment read because reading environments is the expensive half: this
+ * cuts ~900 processes to a handful, and only those get inspected.
+ */
+export function orphanCandidates(
+  rows: readonly PsRow[],
+  selfPgid: number,
+  liveSessionPids: ReadonlySet<number>,
+): PsRow[] {
+  return rows.filter(
+    (row) => row.ppid === 1 && row.pgid !== selfPgid && !liveSessionPids.has(row.pgid) && !pidAlive(row.pgid, rows),
+  )
+}
+
+/**
+ * Clause 1: does this pid's environment carry the PTY marker?
+ *
+ * Linux exposes `/proc/<pid>/environ` exactly (NUL-separated), so read it
+ * directly. macOS has no procfs and only surfaces environments through `ps
+ * eww`, which appends them to the command column — hence the batched call and
+ * the word-boundary match, so an argv that merely CONTAINS the marker text
+ * cannot pass for the variable itself.
+ */
+async function markedPids(pids: readonly number[]): Promise<Set<number>> {
+  const marked = new Set<number>()
+  if (pids.length === 0) return marked
+  if (process.platform === "linux") {
+    for (const pid of pids) {
+      try {
+        if (readFileSync(`/proc/${pid}/environ`, "utf8").split("\0").includes(PTY_MARKER)) marked.add(pid)
+      } catch {
+        // Gone between the two passes, or not ours to read — not a finding.
+      }
+    }
+    return marked
+  }
+  const result = await run(["ps", "eww", "-o", "pid=,command=", "-p", pids.join(",")])
+  const marker = new RegExp(`(^|\\s)${PTY_MARKER}(\\s|$)`)
+  for (const line of result.stdout.split("\n")) {
+    const pid = Number.parseInt(line.trim().split(/\s+/)[0] ?? "", 10)
+    if (Number.isFinite(pid) && marker.test(line)) marked.add(pid)
+  }
+  return marked
+}
+
+/** Our own process group, so the sweep can never signal the shell running it. */
+async function ownPgid(): Promise<number> {
+  const result = await run(["ps", "-o", "pgid=", "-p", String(process.pid)])
+  const pgid = Number.parseInt(result.stdout.trim(), 10)
+  return Number.isFinite(pgid) ? pgid : -1
+}
+
+/**
+ * The full predicate against the live process table. `liveSessionPids` are the
+ * PTY host's currently-alive session pids (`pty.list`); an empty set is safe —
+ * clause 3 already excludes any group whose leader is still running, and a
+ * live session's leader always is.
+ */
+export async function collectOrphans(
+  liveSessionPids: ReadonlySet<number>,
+): Promise<{ orphans: Orphan[]; error: string | null }> {
+  if (process.platform === "win32") return { orphans: [], error: null }
+  const ps = await run(["ps", "-A", "-o", "pid=,ppid=,pgid=,etime=,rss=,command="])
+  if (ps.code !== 0) return { orphans: [], error: `ps exited ${ps.code}` }
+  const rows = parsePsRows(ps.stdout)
+  const candidates = orphanCandidates(rows, await ownPgid(), liveSessionPids)
+  const marked = await markedPids(candidates.map((row) => row.pid))
+  return { orphans: candidates.filter((row) => marked.has(row.pid)), error: null }
+}
+
+function formatMb(rssKb: number): string {
+  return `${(rssKb / 1024).toFixed(0)} MB`
+}
+
+/** The `orphans:` section of the doctor report. */
+export function orphanDoctorLines(
+  orphans: readonly Orphan[],
+  error: string | null,
+  cliName: string,
+  killing = false,
+): string[] {
+  if (error) return [`orphans: ✗ could not inspect the process table — ${error}`]
+  if (orphans.length === 0) return ["orphans: ✓ none — no processes left behind by a dead PTY session"]
+  const totalMb = orphans.reduce((sum, row) => sum + row.rssKb, 0) / 1024
+  const lines = [
+    `orphans: ⚠ ${orphans.length} process(es) outlived the PTY session that spawned them (${totalMb.toFixed(0)} MB RSS)`,
+    "         each is reparented to init, carries Rove's PTY marker, and its process",
+    "         group leader is gone — no live task owns them",
+  ]
+  for (const row of [...orphans].sort((a, b) => b.rssKb - a.rssKb)) {
+    lines.push(
+      `         pid ${row.pid} (group ${row.pgid}) up ${row.etime}, ${formatMb(row.rssKb)}: ${row.command.slice(0, 90)}`,
+    )
+  }
+  if (!killing) {
+    lines.push(
+      `         → \`${cliName} doctor --kill-orphans\` ends those process groups (SIGTERM, then SIGKILL)`,
+      "         read the list first: something you backgrounded from a Rove terminal and then",
+      "         closed the tab on looks exactly like a leak, and doctor cannot tell them apart",
+    )
+  }
+  return lines
+}
+
+const GROUP_EXIT_GRACE_MS = 2_000
+const GROUP_POLL_MS = 100
+
+function groupAlive(pgid: number): boolean {
+  try {
+    process.kill(-pgid, 0)
+    return true
+  } catch (err) {
+    return (err as NodeJS.ErrnoException).code !== "ESRCH"
+  }
+}
+
+/**
+ * SIGTERM every orphaned group, then SIGKILL whatever is still there past a
+ * short grace. Signals the GROUP rather than each pid for the same reason
+ * `terminatePtyChild` does: the survivors are a subtree, and a per-pid kill
+ * would leave the grandchildren to re-orphan on the next sweep.
+ */
+export async function killOrphanGroups(orphans: readonly Orphan[]): Promise<{ groups: number[]; survivors: number[] }> {
+  const groups = [...new Set(orphans.map((row) => row.pgid))]
+  for (const pgid of groups) {
+    try {
+      process.kill(-pgid, "SIGTERM")
+    } catch {
+      // Already gone, or the last member exited between listing and signalling.
+    }
+  }
+  const deadline = Date.now() + GROUP_EXIT_GRACE_MS
+  let survivors = groups.filter(groupAlive)
+  while (survivors.length > 0 && Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, GROUP_POLL_MS))
+    survivors = survivors.filter(groupAlive)
+  }
+  for (const pgid of survivors) {
+    try {
+      process.kill(-pgid, "SIGKILL")
+    } catch {
+      // Raced with its own exit — the next liveness check is the verdict.
+    }
+  }
+  await new Promise((resolve) => setTimeout(resolve, GROUP_POLL_MS))
+  return { groups, survivors: survivors.filter(groupAlive) }
+}

--- a/packages/kobe/src/tui/i18n/messages/doctor.ts
+++ b/packages/kobe/src/tui/i18n/messages/doctor.ts
@@ -60,6 +60,12 @@ export const en = {
     /** Pre-v0.8 tmux sessions still resident */
     resetLegacy: "pre-v0.8 tmux sessions are still holding processes and memory",
 
+    /** Processes left behind by a PTY session something outside Rove killed; {count} of them */
+    orphans: "{count} process(es) outlived the PTY session that spawned them and are still running",
+    /** Why the orphan sweep is print-only */
+    orphansWhy:
+      "kills processes, which is not undoable — and a task you backgrounded on purpose looks the same; read the list, then run it yourself",
+
     /** Hook channel down: the other half of the remedy, owned by the user */
     engineTabs: "engine tabs may hold a stale daemon socket path",
     /** The in-TUI action for {@link engineTabs} */
@@ -126,6 +132,9 @@ export const zh: typeof en = {
     resetDaemonWedged: "daemon 进程存活但无法连接 (卡死)",
     resetPty: "PTY host 无法连接或没有在运行",
     resetLegacy: "v0.8 之前的 tmux 会话仍占用进程和内存",
+
+    orphans: "有 {count} 个进程比启动它们的 PTY 会话活得更久, 现在还在运行",
+    orphansWhy: "会杀进程, 不可撤销 — 而且你故意放后台的任务看起来一模一样; 先看清单, 再自己执行",
 
     engineTabs: "引擎 tab 可能持有过期的 daemon socket 路径",
     engineTabsAction: "在 TUI 里关闭并重开受影响的引擎 tab",

--- a/packages/kobe/test/cli/doctor-orphans.test.ts
+++ b/packages/kobe/test/cli/doctor-orphans.test.ts
@@ -1,0 +1,103 @@
+/**
+ * The orphan predicate's branches, held against the shapes a live machine
+ * cannot stage on demand — a group whose leader is still running, a live
+ * session's group, our own group. Each row here is a way the sweep could kill
+ * something it must not.
+ */
+
+import { describe, expect, it } from "vitest"
+import { orphanCandidates, orphanDoctorLines, parsePsRows } from "../../src/cli/doctor-orphans.ts"
+
+const PS = [
+  //  pid  ppid  pgid  etime         rss    command
+  "  100     1   100   05-01:00:00   4096   /usr/libexec/some-daemon",
+  "  200     1   150   04-22:42:56  25600   bun test test/render",
+  "  300   250   150   04-22:42:56  25600   bun --coverage test/render",
+  "  400     1   350   00:31:00     20480   node server.js",
+  // 500's group is one `pty.list` still calls alive, and its leader row is
+  // ABSENT — the window between a child dying and the host recording it. Only
+  // the live-session clause spares this one.
+  "  500     1   600   01:00:00      1024   sh -c worker",
+  // 800's leader IS in the table, so the dead-leader clause spares it.
+  "  800     1   850   01:00:00      1024   sh -c another worker",
+  "  850   840   850   01:00:00      1024   /bin/sh -c trap '' HUP; worker",
+  "  700     1   900   02:00:00      2048   my own shell's child",
+].join("\n")
+
+const rows = parsePsRows(PS)
+
+describe("parsePsRows", () => {
+  it("keeps a command containing spaces intact", () => {
+    expect(rows.find((row) => row.pid === 200)).toEqual({
+      pid: 200,
+      ppid: 1,
+      pgid: 150,
+      etime: "04-22:42:56",
+      rssKb: 25600,
+      command: "bun test test/render",
+    })
+  })
+
+  it("drops lines that are not a process row", () => {
+    expect(parsePsRows("  PID  PPID\ngarbage\n")).toEqual([])
+  })
+})
+
+describe("orphanCandidates", () => {
+  const candidates = orphanCandidates(rows, 900, new Set([600]))
+  const pids = candidates.map((row) => row.pid)
+
+  it("takes a reparented process whose group leader is gone", () => {
+    expect(pids).toContain(200)
+    expect(pids).toContain(400)
+  })
+
+  it("spares a process whose parent is still alive", () => {
+    // 300's parent (250) never died, so nothing about it is abandoned.
+    expect(pids).not.toContain(300)
+  })
+
+  it("spares an ordinary daemon, which is its own group leader", () => {
+    expect(pids).not.toContain(100)
+  })
+
+  it("spares a reparented process whose group the PTY host still calls live", () => {
+    // The tab is on screen; the user owns what is in it. Load-bearing on its
+    // own here — 600 has no row, so only `liveSessionPids` rules 500 out.
+    expect(pids).not.toContain(500)
+  })
+
+  it("spares a reparented process whose group leader is still running", () => {
+    expect(pids).not.toContain(800)
+  })
+
+  it("spares our own process group", () => {
+    expect(pids).not.toContain(700)
+  })
+
+  it("returns nothing when every group still has a leader", () => {
+    expect(
+      orphanCandidates(
+        rows.filter((row) => row.pgid === 850),
+        -1,
+        new Set(),
+      ),
+    ).toEqual([])
+  })
+})
+
+describe("orphanDoctorLines", () => {
+  it("says the sweep is a command to run, never something doctor did", () => {
+    const lines = orphanDoctorLines(orphanCandidates(rows, 900, new Set([600])), null, "rove").join("\n")
+    expect(lines).toContain("rove doctor --kill-orphans")
+    expect(lines).toContain("bun test test/render")
+  })
+
+  it("reports an inspection failure instead of a clean bill of health", () => {
+    expect(orphanDoctorLines([], "ps exited 1", "rove")[0]).toContain("could not inspect")
+  })
+
+  it("is a ✓ line when nothing is orphaned", () => {
+    expect(orphanDoctorLines([], null, "rove")[0]).toContain("✓ none")
+  })
+})


### PR DESCRIPTION
## Task AA — a killed engine leaves its grandchildren running forever

Rove's own killing is complete: `terminatePtyChild` signals the child's whole
process **group**, so closing a session takes the shell, the engine, and
everything they spawned. The gap is the path Rove never gets to run — an engine
killed from OUTSIDE Rove (`kill -9`, an OOM reaper, a crashed PTY host) is never
reported, so the group is never signalled and the engine's children are
reparented to init and run until reboot.

This adds an `orphans:` section to `rove doctor` and a `--kill-orphans` flag
that reclaims them. `signalProcessGroup` is untouched.

### 1. Where the sweep belongs — `rove doctor`

On demand, at the moment the user notices the machine is slow. The alternatives
each miss the cases that actually happened here: a sweep at **task deletion**
never sees an orphan from a task that was never deleted (all eight real ones on
this machine); a sweep at **PTY-host boot** only runs when the host restarts; a
**daemon collector** kills on a timer, which is the too-eager failure mode the
third answer below rules out. Doctor already runs `pty.list`, already frames
itself as diagnose-then-optionally-fix, and already has a print-only fix class.

**Not covered:** nothing runs automatically, so orphans accumulate until someone
runs `doctor`. Windows is excluded (no process groups). And on macOS the kernel
will not hand a non-root reader the environment of a SIP-protected system binary
(`/bin/sleep` and friends), so those can never satisfy the marker clause and are
never listed — the sweep fails closed on what it cannot verify. What actually
leaks (`bun`, `node`, a browser, a CLI tool) reads fine.

### 2. The predicate — stated exactly

A process is reported only when **all four** hold:

1. `KOBE_TERMINAL_PTY=1` is in its environment. The PTY host sets it on every
   child it spawns (`pty-child-controller.ts:74`) and nothing else on the machine
   does, so it marks the subtree as descended from a Rove terminal. Read from
   `/proc/<pid>/environ` on Linux, `ps eww` on macOS with a word-boundary match
   so an argv containing the text cannot pass for the variable.
2. `ppid === 1` — its parent died and nothing is coming to reap it.
3. Its process group has no leader left in the process table. The leader of a
   hosted session's group IS the PTY child, so a leaderless group is a session
   that ended. This also excludes every ordinary daemon (its own leader).
4. Its group is neither one `pty.list` still reports alive, nor this process's
   own group.

A cwd-under-a-worktree clause was considered and rejected: the measured orphans
included a `railway` tunnel and a browser with cwds elsewhere, and clause 1 is
strictly tighter.

Clause ordering is deliberate — 2/3/4 run over one `ps` pass first, cutting ~900
processes to a handful, and only those get their environment read.

A fifth clause (`pgid !== pid`) was written and then **deleted**: mutation
testing showed it can never fire independently of clause 3.

### 3. Kill or report — report, with an explicit flag to kill

**Report.** Empirically decided: the predicate cannot read intent, and on the
machine this was written against, the eight real matches included two live
`railway connect --tunnel-only` database tunnels. A sweep that auto-killed would
have destroyed the owner's work. A plain `doctor` run only lists them, with age,
memory, and command so the user can judge; `--kill-orphans` is a separate flag
rather than a `doctor --fix` entry because typing the flag is stronger consent
than a y/N, and the existing fix contract puts anything undoable in the
print-only class anyway.

### PASS criteria — all three proven

Isolated home throughout (`ROVE_/KOBE_ {HOME_DIR, DAEMON_SOCKET_PATH,
DAEMON_PID_PATH, PTY_SOCKET_PATH, PTY_PID_PATH, DAEMON_WEB_PORT}` inlined, home
`/tmp/orphan-proof-home`). The real `~/.rove` was never targeted.

Full transcript: `/tmp/orphan-proof-PROOF.md` (also at
`.scratch/orphan-proof/PROOF.md` in the worktree).

Three real hosted PTY sessions opened over the isolated host's `pty.open`, each
`shell → engine → worker`. `trap "" HUP` on the shell makes the workers inherit
an ignored SIGHUP — which is how the real survivors escaped the terminal hangup;
without it the first repro attempt was cleaned up correctly by the kernel and
proved nothing.

**Prove the leak exists.** `kill -9` on A's engine and shell:

```
$ ps -o pid=,ppid=,pgid=,etime= -p 38542
  38542     1 38537   00:18
  cwd:          /private/tmp/orphan-proof-home/work
  group leader: gone — group 38537 has no leader
  Rove PTY env: KOBE_TERMINAL_PTY=1
```

`rove doctor` from the **installed unfixed build (0.9.105)**, same isolated home,
says nothing about it:

```
pty host: ✓ running (3 session(s), 1 live, 0 parked)
         pid 32805, 48.2 MB RSS
         ...
legacy tmux: tmux 3.5a — no sessions on `kobe`
```

This branch:

```
orphans: ⚠ 12 process(es) outlived the PTY session that spawned them (244 MB RSS)
         pid 379 (group 105) up 03-08:56:55, 47 MB: bun src/server.ts
         pid 15752 (group 14297) up 04-21:22:21, 25 MB: bun .scratch/live/sub.ts
         pid 38542 (group 38537) up 00:19, 22 MB: bun -e setInterval(()=>{},1e9)
         pid 87048 (group 87030) up 04-22:42:43, 10 MB: railway connect Postgres --tunnel-only -P 55432
         ... (10 real ones on this machine, aged 2–5 days, plus the 2 fixture ones)
         → `rove doctor --kill-orphans` ends those process groups (SIGTERM, then SIGKILL)
```

**Prove the fix reclaims it.** Through the exact functions the flag calls
(`collectOrphans` + `killOrphanGroups`), restricted to the fixture's group:

```
live PTY session pids: 38538, 38541
orphans in fixture group 38537: 38540, 38542
{"groups":[38537],"survivors":[]}

$ ps -o pid= -p 38540,38542
  38540, 38542: no such processes
```

**Prove it is safe.** Session B fully healthy, session C with only its engine
killed so its worker is at `ppid=1` while its session leader lives:

```
=== healthy session B untouched ===
38538 38536 38538 /bin/sh -c trap "" HUP; ...
38544 38538 38538 sh -c trap '' HUP; bun -e ...
38545 38538 38538 bun -e setInterval(()=>{},1e9)
38546 38544 38538 bun -e setInterval(()=>{},1e9)

=== session C (live leader, one ppid=1 worker) untouched ===
38541 38536 38541 /bin/sh -c trap "" HUP; ...
38548 38541 38541 bun -e setInterval(()=>{},1e9)
38549     1 38541 bun -e setInterval(()=>{},1e9)
```

C is the hard case — 38549 IS reparented to init, but its group leader is a live
PTY session, so it is neither listed nor signalled. None of B's or C's seven pids
appear in the report.

### Test

`test/cli/doctor-orphans.test.ts` — 12 tests over the pure predicate, for the
shapes a live machine cannot stage on demand. Every clause deleted in turn:

| mutation | result |
|---|---|
| drop `ppid === 1` | 1 failed |
| drop `pgid !== selfPgid` | 1 failed |
| drop `!liveSessionPids.has(pgid)` | 1 failed |
| drop `!pidAlive(pgid)` | 1 failed |
| drop `pgid !== pid` | **12 passed** → dead code, removed |

The first pass at this test had a fixture that made the live-session clause pass
for the wrong reason; the fixture was rebuilt so each clause is load-bearing on
its own.

### Not proven

The unrestricted `rove doctor --kill-orphans` end-to-end run. The report on this
machine legitimately contains ten multi-day orphans belonging to the owner
(database tunnels among them), and killing those to make a nicer transcript is
not mine to decide. The predicate and the group-kill were exercised through the
identical functions; what is unexercised is the four-line `sweepOrphans` printer
in `doctor-cmd.ts` that formats the counts.

No screenshots: this is CLI output, not TUI — the `/harness` path renders
OpenTUI and cannot show `rove doctor`. The BEFORE/AFTER pair above is the real
command output from the installed unfixed build and from this branch, against
the same machine state.

### Gates

`bun run lint` clean · `bun run typecheck` clean · `bun run check-i18n` 777 keys ×
2 locales in sync · `vitest` 447 files / 4407 tests passed · touched files 246 /
426 / 239 / 103 lines, all under the cap.
