### PR TITLE
fix(engine): the non-Claude engines were misreporting themselves

### DIFF
--- a/.changeset/non-claude-engine-facts.md
+++ b/.changeset/non-claude-engine-facts.md
@@ -1,0 +1,9 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Fix four ways the non-Claude engines misreported themselves, and refresh five stale vendor facts.
+
+OpenCode's positional argument is a project directory, so `rove add --engine opencode --prompt …` was handing it the prompt as a path and the engine died before it started — it now takes its first message by paste, the way Kimi already does. OpenCode 0.6.3 also prints `esc interrupt` rather than the `esc to interrupt` its activity rules looked for, so an OpenCode task never showed running; it now reads working while a turn runs and idle at rest. A Cursor task sitting on the login wall classified exactly like a healthy resting one — it now reads as blocked on you, so a task that cannot run at all stops looking fine.
+
+Codex's effort picker gains `max`. Kimi's selection-dialog rules learn 0.40.1's `↑↓ navigate · Enter select · Esc exit` footer while keeping 0.37.2's, and its worktree pre-trust now hashes the resolved path and lowercases the directory name the way Kimi itself does — a worktree reached through a symlink was getting a trust record Kimi never looked at, so the dialog still blocked the launch.

--- a/docs/ENGINES.md
+++ b/docs/ENGINES.md
@@ -37,8 +37,9 @@ well-known coding CLIs (`gemini`, `opencode`, `cursor`, `grok`, `droid`,
 PATH, with a proper name, a launch command, and screen-based activity
 badges. A catalog entry also declares how its CLI takes a first message:
 OpenCode's positional argument is a project directory, so Rove pastes the
-prompt after launch instead of appending it to the command line. Settings → Engines lists them (and your own registered engines) with
-their binary discovery, and that is all detection can answer for them. No
+prompt after launch instead of appending it to the command line.
+Settings → Engines lists them (and your own registered engines) with their
+binary discovery, and that is all detection can answer for them. No
 login state, history, or model picker; those need a real adapter, which is
 what promotes an engine to built-in.
 
@@ -91,11 +92,11 @@ All four builtin engines gate a first launch in a never-seen directory behind
 a trust dialog, and every task worktree is such a directory, so a hosted
 session can't answer it — nobody is at the pane to press a key, so the launch
 sits on the dialog instead of starting the turn (and with Kimi, whether a
-stray Enter accepts or exits the process depends on the Kimi version; Copilot's
-cursor sits on a session-only "Yes", so it returns every launch). Before
-spawning an engine
-into a Rove-created worktree, Rove writes that vendor's own trust record for
-the path, merging into existing entries, never clobbering:
+stray Enter accepts or exits the process depends on the Kimi version;
+Copilot's cursor sits on a session-only "Yes", so it returns every launch).
+Before spawning an engine into a Rove-created worktree, Rove writes that
+vendor's own trust record for the path, merging into existing entries, never
+clobbering:
 
 | Engine | Trust record |
 | --- | --- |

--- a/docs/ENGINES.md
+++ b/docs/ENGINES.md
@@ -19,7 +19,7 @@ you need git-level isolation and a separate branch.
 | Engine | Id | Account detect | Activity badge | History | Effort levels |
 |---|---|---|---|---|---|
 | Claude Code | `claude` | ✓ | ✓ | ✓ | — |
-| Codex | `codex` | ✓ | ✓ (after you trust hooks) | ✓ | `none`/`low`/`medium`/`high`/`xhigh` |
+| Codex | `codex` | ✓ | ✓ (after you trust hooks) | ✓ | `none`/`low`/`medium`/`high`/`xhigh`/`max` |
 | GitHub Copilot | `copilot` | ✓ | ✓ (screen-based) | ✓ | — |
 | Kimi Code | `kimi` | ✓ | ✓ | handoff only | — |
 | Gemini CLI, OpenCode, Cursor Agent, Grok CLI, Droid, Amp | contrib | binary only | ✓ (screen-based) | — | — |
@@ -35,7 +35,9 @@ rate-limit auto-resume and the Settings usage dashboard.
 well-known coding CLIs (`gemini`, `opencode`, `cursor`, `grok`, `droid`,
 `amp`) so they appear in the engine selector whenever the binary is on your
 PATH, with a proper name, a launch command, and screen-based activity
-badges. Settings → Engines lists them (and your own registered engines) with
+badges. A catalog entry also declares how its CLI takes a first message:
+OpenCode's positional argument is a project directory, so Rove pastes the
+prompt after launch instead of appending it to the command line. Settings → Engines lists them (and your own registered engines) with
 their binary discovery, and that is all detection can answer for them. No
 login state, history, or model picker; those need a real adapter, which is
 what promotes an engine to built-in.
@@ -87,9 +89,11 @@ one.
 
 All four builtin engines gate a first launch in a never-seen directory behind
 a trust dialog, and every task worktree is such a directory, so a hosted
-session can't answer it (Kimi's dialog even exits the process when a pasted
-first message lands on "Don't trust"; Copilot's cursor sits on a
-session-only "Yes", so it returns every launch). Before spawning an engine
+session can't answer it — nobody is at the pane to press a key, so the launch
+sits on the dialog instead of starting the turn (and with Kimi, whether a
+stray Enter accepts or exits the process depends on the Kimi version; Copilot's
+cursor sits on a session-only "Yes", so it returns every launch). Before
+spawning an engine
 into a Rove-created worktree, Rove writes that vendor's own trust record for
 the path, merging into existing entries, never clobbering:
 
@@ -164,11 +168,14 @@ conversation. The two resulting tabs keep the source context and then diverge:
 | `claude` | ✓ | `--resume <src> --fork-session` |
 | `codex` | ✓ | `codex fork <src>` |
 | `copilot` | — | starts a fresh Copilot session with a transcript handoff |
-| `kimi` | — | starts a fresh Kimi session with a transcript handoff |
+| `kimi` | — | has a `kimi fork` verb, but it exits instead of opening the session — transcript handoff instead |
 | custom | — | refused, unless the preset declares a built-in protocol (then it forks like that engine) |
 
-Copilot's `--resume` and Kimi's `-S` reopen rather than branch, which would put
-two live processes on one transcript. Rove therefore uses the same transcript
+Copilot's `--resume` reopens rather than branches, which would put two live
+processes on one transcript. Kimi 0.40.1 does ship a `fork [sessionId]`
+subcommand, but it is a one-shot that prints the new session id and exits, so
+it cannot BE a tab's launch command — branching there would mean forking and
+then resuming, two launches. Rove therefore uses the same transcript
 handoff as a cross-engine continuation: the new tab is a fresh conversation
 that reads where the previous one stopped. A custom engine without a known
 session store is refused instead of silently opening a blank continuation.

--- a/packages/kobe/src/engine/builtin-engines.ts
+++ b/packages/kobe/src/engine/builtin-engines.ts
@@ -105,9 +105,15 @@ export const BUILTIN_ENGINES: Record<"claude" | "codex" | "copilot" | "kimi", En
     builtin: true,
     displayName: codexIdentity.shortName,
     defaultCommand: ["codex"],
-    // Effort levels real `codex exec` accepts; `minimal` is broken there and
-    // deliberately excluded.
-    effortLevels: ["none", "low", "medium", "high", "xhigh"],
+    // Effort levels the API accepts, per its own error on an invalid value:
+    // "Supported values are: 'none', 'minimal', 'low', 'medium', 'high',
+    // 'xhigh', and 'max'." `minimal` is excluded because it is MODEL-scoped,
+    // not globally broken — codex rejects it with "'minimal' is not supported
+    // with the 'gpt-5.6-luna' model", so offering it would hand the picker a
+    // level that fails on the default model. codex 0.149.1 also carries an
+    // `ultra` variant in its own enum, but the API has never been observed
+    // accepting it; don't offer a level nothing has answered 200 to.
+    effortLevels: ["none", "low", "medium", "high", "xhigh", "max"],
     effortArgv: (base, level) => [...base, "-c", `model_reasoning_effort=${level}`],
     history: codexHistoryReader,
 

--- a/packages/kobe/src/engine/contrib-engines.ts
+++ b/packages/kobe/src/engine/contrib-engines.ts
@@ -29,6 +29,14 @@ export interface ContribEngineSpec {
   readonly screenManifest: EngineScreenManifest
   /** Plugin-declared product identity (composer placeholder etc.). */
   readonly identity?: EngineIdentity
+  /**
+   * How this CLI accepts a session's FIRST message — same field the built-in
+   * table declares (see `registry.ts`). Contrib entries otherwise inherit the
+   * `"argv"` default, which appends the prompt as a positional; declare
+   * `"paste"` when the positional slot means something else, or the launch
+   * dies on the prompt text.
+   */
+  readonly firstMessageDelivery?: "argv" | "paste"
 }
 
 /**
@@ -63,16 +71,32 @@ const GEMINI: EngineScreenManifest = {
   ],
 }
 
+// Footer vocabulary verified against opencode 0.6.3 on 2026-09-04: a running
+// turn ends `…working...  esc interrupt` and a resting one `enter send`.
+// `esc interrupt` is the string copilot's manifest already carries; the
+// `esc to interrupt` spellings are kept so an older opencode still matches.
 const OPENCODE: EngineScreenManifest = {
   rules: [
     { state: "blocked", any: ["△ permission required"] },
     { state: "blocked", all: ["esc dismiss"], any: ["enter confirm", "enter submit", "enter toggle"] },
-    { state: "working", any: ["esc to interrupt", "ctrl+c to interrupt", "esc again to interrupt"] },
+    { state: "working", any: ["esc interrupt", "esc to interrupt", "ctrl+c to interrupt", "esc again to interrupt"] },
+    // The rest footer, LAST so a running turn (which draws `enter send` too)
+    // still reads working. Without an idle rule the badge that finally lights
+    // up on the rule above could never come back down.
+    { state: "idle", any: ["enter send"] },
   ],
 }
 
 const CURSOR: EngineScreenManifest = {
   rules: [
+    // The login wall, captured from cursor-agent 2026.04.17 in a fresh git
+    // directory. Without this rule an unauthenticated cursor task classifies
+    // exactly like a healthy resting one — no rule matches either, the
+    // classifier answers null, and the badge stays wherever it was. A task
+    // that CANNOT RUN AT ALL is blocked on a human, which is what this state
+    // means everywhere else, so it gets the same "go look at it" badge rather
+    // than a new vocabulary.
+    { state: "blocked", any: ["press any key to log in"] },
     { state: "blocked", all: ["proceed (y)"] },
     { state: "blocked", any: ["run this command?", "waiting for approval", "skip (esc or n)", "(y) (enter)"] },
     { state: "working", any: ["esc to cancel", "ctrl+c to stop"] },
@@ -119,7 +143,19 @@ const AMP: EngineScreenManifest = {
 /** The shipped catalog. Key = the engine's VendorId. */
 export const CONTRIB_ENGINES: Record<string, ContribEngineSpec> = {
   gemini: { displayName: "Gemini CLI", defaultCommand: ["gemini"], screenManifest: GEMINI },
-  opencode: { displayName: "OpenCode", defaultCommand: ["opencode"], screenManifest: OPENCODE },
+  // opencode's positional is a project DIRECTORY ("Positionals: project  path
+  // to start opencode in"), so an argv-delivered first message becomes a path:
+  // `opencode "Run the shell command: ls -la"` exits with
+  // `Failed to change directory to <cwd>/Run the shell command: ls -la`.
+  // Verified against opencode 0.6.3 on 2026-09-04. The other catalog entries
+  // keep the "argv" default — their positional semantics are UNVERIFIED here
+  // (binaries absent from the machine this was checked on).
+  opencode: {
+    displayName: "OpenCode",
+    defaultCommand: ["opencode"],
+    screenManifest: OPENCODE,
+    firstMessageDelivery: "paste",
+  },
   cursor: { displayName: "Cursor Agent", defaultCommand: ["cursor-agent"], screenManifest: CURSOR },
   grok: { displayName: "Grok CLI", defaultCommand: ["grok"], screenManifest: GROK },
   droid: { displayName: "Droid", defaultCommand: ["droid"], screenManifest: DROID },
@@ -148,5 +184,6 @@ export function contribEngineEntry(id: string, base: EngineRegistryEntry): Engin
     ...(spec.processNames ? { processNames: spec.processNames } : {}),
     screenManifest: spec.screenManifest,
     ...(spec.identity ? { identity: spec.identity } : {}),
+    ...(spec.firstMessageDelivery ? { firstMessageDelivery: spec.firstMessageDelivery } : {}),
   }
 }

--- a/packages/kobe/src/engine/engine-presets.ts
+++ b/packages/kobe/src/engine/engine-presets.ts
@@ -269,10 +269,15 @@ export function engineResumeArgv(
 
 /**
  * True when this engine can BRANCH a conversation — declared by the adapter
- * (`EngineSessionIdentity.forkArgv`), not listed here. Claude and codex ship
- * a fork verb; copilot's `--resume` and kimi's `-S` only REOPEN a session,
- * which would put two live processes on one transcript, so Rove refuses
- * instead of pretending.
+ * (`EngineSessionIdentity.forkArgv`), not listed here. The bar is a verb that
+ * LAUNCHES the branched session, because this argv becomes a tab's command.
+ * Claude and codex clear it. Copilot's `--resume` only REOPENs a session,
+ * which would put two live processes on one transcript. Kimi 0.40.1 does have
+ * a `fork [sessionId]` subcommand, but it is a one-shot: it prints
+ * `Forked to session_<new-id> … in <n>ms` and EXITS (verified 2026-09-04), so
+ * as a tab command it would open a pane that dies on the first frame.
+ * Branching it would take fork-then-`-S <new-id>`, which is two launches and
+ * does not fit this contract. Rove refuses instead of pretending.
  *
  * Protocol-resolved like {@link withPinnedSessionId}: a preset `claudecpa`
  * declaring the claude protocol IS a claude launch, so it forks. Keying off

--- a/packages/kobe/src/engine/kimi-local/screen.ts
+++ b/packages/kobe/src/engine/kimi-local/screen.ts
@@ -3,7 +3,10 @@
  * sessions whose hooks aren't installed yet (hooks are the first
  * authority; the hook-wins merge supersedes this whenever they report).
  * Patterns observed in kimi 0.37.2's TUI (cross-checked against
- * refs/herdr src/detect/manifests/kimi.toml).
+ * refs/herdr src/detect/manifests/kimi.toml), with the selection-dialog
+ * footer re-checked against kimi 0.40.1 on 2026-09-04. The approval dialog
+ * (rule 1) has NOT been re-captured on 0.40.1 — leave its strings alone
+ * until someone drives a real tool call through it.
  */
 
 import type { EngineScreenManifest } from "../screen-state.ts"
@@ -12,7 +15,11 @@ export const KIMI_SCREEN_MANIFEST: EngineScreenManifest = {
   rules: [
     // Approval panel: "↵ confirm" beside approve/reject choices.
     { state: "blocked", all: ["↵ confirm"], any: ["approve", "reject", "revise"] },
-    // Question panel.
+    // Question panel. 0.40.1 draws `↑↓ navigate · Enter select · Esc exit`;
+    // 0.37.2 drew `↑↓ select` + `esc cancel`. Two rules rather than one
+    // widened rule, so neither version's vocabulary can half-match the
+    // other's and claim a dialog that isn't there.
+    { state: "blocked", all: ["↑↓ navigate", "esc exit"] },
     { state: "blocked", all: ["↑↓ select", "esc cancel"] },
     // Running turn: the moon-phase spinner frames, or a braille spinner
     // beside a progress verb.

--- a/packages/kobe/src/engine/kimi-local/trust.ts
+++ b/packages/kobe/src/engine/kimi-local/trust.ts
@@ -1,22 +1,44 @@
 /**
- * Kimi Code workspace trust. Kimi shows a
- * "Trust this folder?" dialog on first launch in a directory — and its
- * default cursor sits on "Don't trust", so a pasted first message's submit
- * Enter EXITS the engine ("Bye!"). The store is one file per workspace:
- * `~/.kimi-code/workspace-trust/wd_<dirname>_<sha256(abspath)[:12]>`
- * containing {"root": <abspath>, "trustedAt": <ms epoch>}. Pre-trusting a
- * Rove-created worktree
- * is the same trust domain as the repo the user already runs sessions in.
+ * Kimi Code workspace trust. Kimi shows a "Trust this folder?" dialog on
+ * first launch in a directory, and a hosted session has no one to answer it:
+ * the pane sits on the dialog instead of starting the turn. (Which option the
+ * cursor rests on is version-specific — 0.39.1 defaulted to "Don't trust", so
+ * a pasted first message's submit Enter exited the engine; 0.40.1 defaults to
+ * "Trust this folder". Don't rely on either.) Pre-writing the record is what
+ * skips the dialog outright, and a Rove-created worktree is the same trust
+ * domain as the repo the user already runs sessions in.
+ *
+ * The store is one file per workspace:
+ * `~/.kimi-code/workspace-trust/wd_<dirname>_<sha256(path)[:12]>` containing
+ * {"root": <path>, "trustedAt": <ms epoch>}.
  */
 
 import { createHash } from "node:crypto"
-import { existsSync, mkdirSync, writeFileSync } from "node:fs"
+import { existsSync, mkdirSync, realpathSync, writeFileSync } from "node:fs"
 import { homedir } from "node:os"
 import path from "node:path"
 
+/**
+ * Reproduce kimi's own filename for a workspace. Two details are load-bearing,
+ * both read off records kimi wrote itself (0.40.1, 2026-09-04): it hashes the
+ * RESOLVED path, and it LOWERCASES the basename segment. For a worktree at
+ * `/tmp/x-B` (macOS `/tmp` is a symlink to `/private/tmp`) kimi writes
+ * `wd_x-b_<sha256("/private/tmp/x-B")[:12]>` — a record keyed on the literal
+ * path suppresses no dialog at all.
+ *
+ * `realpathSync` throws on a path that isn't there yet; fall back to the given
+ * one so this stays a pure function the caller can test.
+ */
 export function kimiTrustFilePath(worktreePath: string, home: string = homedir()): string {
-  const hash = createHash("sha256").update(worktreePath).digest("hex").slice(0, 12)
-  return path.join(home, ".kimi-code", "workspace-trust", `wd_${path.basename(worktreePath)}_${hash}`)
+  let resolved = worktreePath
+  try {
+    resolved = realpathSync(worktreePath)
+  } catch {
+    /* not on disk yet — hash what we were given */
+  }
+  const hash = createHash("sha256").update(resolved).digest("hex").slice(0, 12)
+  const dir = path.basename(resolved).toLowerCase()
+  return path.join(home, ".kimi-code", "workspace-trust", `wd_${dir}_${hash}`)
 }
 
 export function trustKimiWorktree(worktreePath: string, home: string = homedir()): void {

--- a/packages/kobe/src/engine/kimi-local/trust.ts
+++ b/packages/kobe/src/engine/kimi-local/trust.ts
@@ -29,13 +29,16 @@ import path from "node:path"
  * `realpathSync` throws on a path that isn't there yet; fall back to the given
  * one so this stays a pure function the caller can test.
  */
-export function kimiTrustFilePath(worktreePath: string, home: string = homedir()): string {
-  let resolved = worktreePath
+function resolvedWorktree(worktreePath: string): string {
   try {
-    resolved = realpathSync(worktreePath)
+    return realpathSync(worktreePath)
   } catch {
-    /* not on disk yet — hash what we were given */
+    return worktreePath /* not on disk yet — use what we were given */
   }
+}
+
+export function kimiTrustFilePath(worktreePath: string, home: string = homedir()): string {
+  const resolved = resolvedWorktree(worktreePath)
   const hash = createHash("sha256").update(resolved).digest("hex").slice(0, 12)
   const dir = path.basename(resolved).toLowerCase()
   return path.join(home, ".kimi-code", "workspace-trust", `wd_${dir}_${hash}`)
@@ -45,5 +48,7 @@ export function trustKimiWorktree(worktreePath: string, home: string = homedir()
   const file = kimiTrustFilePath(worktreePath, home)
   if (existsSync(file)) return
   mkdirSync(path.dirname(file), { recursive: true, mode: 0o700 })
-  writeFileSync(file, JSON.stringify({ root: worktreePath, trustedAt: Date.now() }), { mode: 0o600 })
+  // `root` carries the resolved path too, so the record is shaped exactly like
+  // one kimi writes for itself rather than only being FILED where kimi looks.
+  writeFileSync(file, JSON.stringify({ root: resolvedWorktree(worktreePath), trustedAt: Date.now() }), { mode: 0o600 })
 }

--- a/packages/kobe/src/engine/registry.ts
+++ b/packages/kobe/src/engine/registry.ts
@@ -213,8 +213,8 @@ export interface EngineRegistryEntry {
   /**
    * Pre-trust a Rove-created worktree in the vendor's first-run trust
    * store. Every vendor gates a never-seen directory behind a
-   * modal trust dialog; hosted sessions can't answer one (kimi's even
-   * EXITS when the pasted first message's Enter lands on "Don't trust").
+   * modal trust dialog; hosted sessions can't answer one, so the pane stalls
+   * on the dialog. Writing the record is what skips it.
    * Called before a hosted spawn; must be idempotent and merge-preserving.
    * Absent = the vendor has no gate kobe knows how to pre-answer.
    */

--- a/packages/kobe/src/engine/trust-worktree.ts
+++ b/packages/kobe/src/engine/trust-worktree.ts
@@ -1,10 +1,11 @@
 /**
  * Worktree pre-trust at spawn time. A Rove-created worktree is
  * a directory the engine has never seen, and every vendor gates that behind
- * a first-run trust dialog a hosted session cannot answer — kimi's dialog
- * even EXITS the process when the pasted first message's Enter lands on
- * "Don't trust"; claude/codex/copilot sit at the prompt forever. The
- * vendor-specific
+ * a first-run trust dialog a hosted session cannot answer — nobody is at the
+ * pane to press a key, so the launch stalls on the dialog instead of starting
+ * the turn. (Kimi's is the loudest failure: whether a stray Enter accepts or
+ * EXITS the process depends on which option that kimi version defaults to.)
+ * The vendor-specific
  * store writes live behind the registry's `trustWorktree` hook; THIS wrapper
  * owns the call policy every spawn path shares: best-effort, never blocks a
  * launch (a failed write just leaves the dialog in the user's way).

--- a/packages/kobe/test/engine/contrib-engines.test.ts
+++ b/packages/kobe/test/engine/contrib-engines.test.ts
@@ -27,6 +27,18 @@ describe("contrib engine catalog", () => {
     expect(entry.screenManifest).toBeUndefined()
   })
 
+  // opencode's positional argument is a project DIRECTORY, so an argv-delivered
+  // first message becomes a path and the launch dies before the engine is up
+  // ("Failed to change directory to <cwd>/<the prompt>"). Same class as kimi,
+  // same fix: the spawner pastes it instead.
+  it("opencode declares paste delivery; the rest keep the argv default", () => {
+    expect(engineEntry("opencode").firstMessageDelivery).toBe("paste")
+    for (const id of CONTRIB_ENGINE_IDS) {
+      if (id === "opencode") continue
+      expect(engineEntry(id).firstMessageDelivery, id).toBeUndefined()
+    }
+  })
+
   it("every catalog manifest declares blocked rules before working rules", () => {
     for (const [id, spec] of Object.entries(CONTRIB_ENGINES)) {
       const states = spec.screenManifest.rules.map((r) => r.state)
@@ -36,6 +48,35 @@ describe("contrib engine catalog", () => {
         expect(lastBlocked, `${id}: blocked rules must precede working (first match wins)`).toBeLessThan(firstWorking)
       }
     }
+  })
+
+  // Footers captured from opencode 0.6.3 (2026-09-04). It prints
+  // `esc interrupt`, not the `esc to interrupt` the manifest used to look for,
+  // so nothing matched and the badge stayed "unknown" for the tab's whole
+  // life; and with no idle rule the badge could never come back down either.
+  it("classifies opencode 0.6.3's real working and resting footers", () => {
+    const oc = CONTRIB_ENGINES.opencode?.screenManifest
+    expect(oc).toBeDefined()
+    if (!oc) return
+    expect(classifyScreen(oc, "Build claude-sonnet-4-20250514 (02:01 AM)working...  esc interrupt")).toBe("working")
+    expect(classifyScreen(oc, "┃ >   ┃\n enter send \n opencode v0.6.3  /w tab ┃ BUILD AGENT")).toBe("idle")
+    // A running turn draws BOTH footers; the working rule must win.
+    expect(classifyScreen(oc, "enter send    Generating...\nworking...  esc interrupt")).toBe("working")
+  })
+
+  // Captured from cursor-agent 2026.04.17 booting in a never-seen git dir on
+  // a machine with no Cursor login. Before this rule the login wall and a
+  // healthy resting cursor screen produced the SAME classifier answer (null),
+  // so "cannot run at all" was indistinguishable from "at rest".
+  it("reads the cursor login wall as blocked, not as a resting engine", () => {
+    const cursor = CONTRIB_ENGINES.cursor?.screenManifest
+    expect(cursor).toBeDefined()
+    if (!cursor) return
+    const wall = "                    Cursor Agent\n  v2026.04.17-787b533\n  Press any key to log in..."
+    expect(classifyScreen(cursor, wall)).toBe("blocked")
+    // A running turn is still working — the new rule sits above it but only
+    // fires on the wall's own words.
+    expect(classifyScreen(cursor, "Generating...   esc to cancel")).toBe("working")
   })
 
   it("classifies representative screens (spot checks per engine)", () => {

--- a/packages/kobe/test/engine/screen-state.test.ts
+++ b/packages/kobe/test/engine/screen-state.test.ts
@@ -59,6 +59,14 @@ describe("KIMI_SCREEN_MANIFEST", () => {
   it("reads the approval panel as blocked", () => {
     expect(classifyScreen(KIMI_SCREEN_MANIFEST, "Run this command?\n▶ Approve\n  Reject\n↵ confirm")).toBe("blocked")
   })
+  // 0.40.1 renamed the selection-dialog footer to `↑↓ navigate · Enter select
+  // · Esc exit`. The old 0.37.2 vocabulary must keep matching too, or a user
+  // on the older kimi loses the badge the day we fix the newer one.
+  it("reads the selection dialog as blocked on both 0.40.1 and 0.37.2 footers", () => {
+    const trust041 = "Trust this folder?\n↑↓ navigate · Enter select · Esc exit\n❯ Trust this folder\n  Don't trust"
+    expect(classifyScreen(KIMI_SCREEN_MANIFEST, trust041)).toBe("blocked")
+    expect(classifyScreen(KIMI_SCREEN_MANIFEST, "Pick one\n❯ a\n  b\n↑↓ select  esc cancel")).toBe("blocked")
+  })
   it("reads the moon spinner as working", () => {
     expect(classifyScreen(KIMI_SCREEN_MANIFEST, "🌖\nsome output")).toBe("working")
   })

--- a/packages/kobe/test/engine/trust-worktree.test.ts
+++ b/packages/kobe/test/engine/trust-worktree.test.ts
@@ -47,6 +47,25 @@ describe("trustKimiWorktree", () => {
     expect(typeof record.trustedAt).toBe("number")
   })
 
+  // Kimi hashes the RESOLVED path and lowercases the basename — read off a
+  // record kimi 0.40.1 wrote itself. A record keyed on the literal path
+  // suppresses no dialog, which is the whole point of writing one.
+  it("hashes the resolved path and lowercases the dirname segment", () => {
+    const home = tempHome()
+    const real = fs.mkdtempSync(path.join(fs.realpathSync(os.tmpdir()), "kobe-real-"))
+    tempDirs.push(real)
+    const target = path.join(real, "Task-A")
+    fs.mkdirSync(target)
+    const link = path.join(real, "link")
+    fs.symlinkSync(real, link)
+    const viaLink = path.join(link, "Task-A")
+
+    const file = kimiTrustFilePath(viaLink, home)
+    expect(path.basename(file)).toBe(`wd_task-a_${createHash("sha256").update(target).digest("hex").slice(0, 12)}`)
+    // …and the same worktree reached the long way round lands on one record.
+    expect(kimiTrustFilePath(target, home)).toBe(file)
+  })
+
   it("is idempotent — an existing record is not rewritten", () => {
     const home = tempHome()
     trustKimiWorktree(WORKTREE, home)

--- a/packages/kobe/test/engine/trust-worktree.test.ts
+++ b/packages/kobe/test/engine/trust-worktree.test.ts
@@ -64,6 +64,10 @@ describe("trustKimiWorktree", () => {
     expect(path.basename(file)).toBe(`wd_task-a_${createHash("sha256").update(target).digest("hex").slice(0, 12)}`)
     // …and the same worktree reached the long way round lands on one record.
     expect(kimiTrustFilePath(target, home)).toBe(file)
+    // The record's own `root` resolves too, so it is shaped like one kimi
+    // writes rather than merely being FILED where kimi looks.
+    trustKimiWorktree(viaLink, home)
+    expect((JSON.parse(fs.readFileSync(file, "utf8")) as { root: string }).root).toBe(target)
   })
 
   it("is idempotent — an existing record is not rewritten", () => {


### PR DESCRIPTION
Nine items from the loop-r11 engines brief, covering the engines that are not Claude. Claude's adapter is untouched.

Every vendor claim below was re-established against the binary installed on this machine today (`codex-cli 0.149.1`→`0.153.2`, `kimi 0.40.1`, `opencode 0.6.3`, `cursor-agent 2026.04.17`). Where I could not re-run something, it says so in that item rather than borrowing the explorer's word for it. **`copilot` is not installed here, so nothing in this PR touches it.**

Screens I captured myself are in `/Users/jacksonc/.rove/worktrees/kobe-0aff3858ab76/pipefish/.scratch/r11ab/fx/` (`oc-working.txt`, `oc-idle.txt`, `kimi-trust.txt`, `cursor-login.txt`), with the PTY probe that took them beside it.

## The one-line before/after that covers A2 and A4

Same four screens, run through the real `classifyScreen`. `null` means no rule matched, which `activity-monitor.ts:100` turns into "keep the previous reading" — and the first reading is `unknown`, which the tab strip draws as no chip at all.

```
BEFORE (manifests at origin/main)        AFTER (this branch)
opencode WORKING  (0.6.3, real turn)     got=null      →  "working"
opencode IDLE     (0.6.3, composer)      got=null      →  "idle"
kimi TRUST DIALOG (0.40.1)               got=null      →  "blocked"
cursor LOGIN WALL (2026.04.17)           got=null      →  "blocked"
```

---

## A1 — `opencode` + a first message was a hard launch failure

**PASS:** `rove api add --engine opencode --prompt …` starts a live opencode session with the prompt delivered — proven by a real run, not a registry read.

Contrib entries inherited the registry's `"argv"` default, and opencode's positional is a project **directory** (`Positionals: project  path to start opencode in`, re-read from `opencode --help` today). `ContribEngineSpec` gains `firstMessageDelivery`, forwarded in `contribEngineEntry`, and opencode declares `"paste"` — the same field and the same reason kimi already uses. The other five catalog entries keep `"argv"`: **their positional semantics are unverified**, because those binaries are not on this machine.

**Proof — the same `add` command, both builds, through Rove's own path** (isolated home, every `ROVE_/KOBE_` path inlined):

```
BEFORE (origin/main build)
  add → started:true  engineReady:true  delivered:true  promptEcho:(absent)
  read-output --source terminal:
    Error: Failed to change directory to …/worktrees/ocrepo-…/bison/Reply with exactly the word PONG and nothing else.
    jacksonc@Jacksons-MacBook-Pro bison %
```

The API said `delivered: true` while the engine was already dead — that is the part a user could not see.

```
AFTER (this branch)
  add → started:true  engineReady:true  delivered:true  bytes:62  promptEcho:"confirmed"
  read-output --source terminal:
    ┃  Reply with exactly the word PONG and nothing else. ┃
    ┃  jacksonc (02:22 AM) ┃
    Generating...
    Build claude-sonnet-4-20250514 (02:22 AM)
    working.    esc interrupt
```

The prompt reached the composer, submitted, and started a turn. (The turn then hit an opencode-side provider error, `TypeError: undefined is not an object (evaluating 'response.headers')` — that is opencode's, not Rove's; delivery is what this item is about.)

## A2 — opencode's working rule never matched, so the task was badged unknown for its whole life

**PASS:** the captured working and idle screens classify as `working` and `idle`.

opencode 0.6.3's running footer is `…working...  esc interrupt` — no "to". Captured twice independently today: once by my own PTY probe, and again in the A1 run above through Rove's own launch. `esc interrupt` is the string `copilot-local/screen.ts:22` already carries, so the vocabulary is copied rather than invented; the old `esc to interrupt` spellings stay so an older opencode still matches.

I also added the **idle** rule the brief asked me to consider (`enter send`, declared last so a running turn — which draws that footer too — still reads working). Without it the badge that finally lights up could never come back down, so the working rule alone would have half-fixed the item.

## A3 — cursor worktree pre-trust: **could not do the proving step. Changed nothing.**

The brief said to prove the trust dialog first, and that "cursor does not need pre-trust" is a passing outcome. I can report neither, honestly:

- `cursor-agent` on this machine boots to `Press any key to log in...` in a fresh `git init` directory, with the **real** `$HOME`. My own capture: `.scratch/r11ab/fx/cursor-login.txt`. The login wall comes first, so a never-seen worktree never gets far enough to show a trust prompt.
- `~/.cursor/cli-config.json` **does** hold an `authInfo` block with an account email, so this is a configured install whose CLI token is not usable — the working credential is in the macOS Keychain.
- That same config holds `permissions.allow` but **no trusted-folders key**, and nothing under `~/.cursor/*.json` mentions trust at all. That is weak evidence *against* a folder-trust store living there, and it is not proof of anything.

**What would settle it:** on a machine with a logged-in Cursor, run `cursor-agent` in a fresh `git init` dir and capture the first frames; if a trust dialog appears, accept it in a copied `$HOME` and diff the tree to find the store, the way `copilot-local/trust.ts` documents. Only then add `trustWorktree` to the contrib spec.

## A4 — an unrecognised screen and an at-rest engine were the same value

**PASS:** the cursor login-wall capture classifies non-`null` (see the table above: `null` → `"blocked"`).

For any engine whose detector is `UnknownTurnDetector`, the manifest is the only state source, so a login-walled cursor task and a healthy resting one produced the *identical* classifier answer. The fix is one rule on cursor's own manifest, matching the words its login wall actually prints. A task that cannot run at all is blocked on a human, which is what `blocked` already means everywhere else, so it borrows that badge rather than inventing a vocabulary.

**I did not produce the harness screenshot pair, and I want to be exact about why.** I picked the brief's option (a) — a manifest-owned rule — over option (b), surfacing "unknown" distinctly. Option (b) means changing how `unknown` renders, and that is a decision the codebase has already made twice, in writing:

- `tab-strip.tsx:157` — `turn !== "unknown"`, with "we deliberately skip absent and `unknown` readings: both are placeholders with no information".
- `row-view.ts:81` — "that last case gets no separate `unknown` glyph: it would tell the reader nothing they could act on — both `idle` and `unknown` mean open it to find out", plus a font-coverage argument against `◌`.

So this PR changes **no rendering at all**, which means there is no visual delta to photograph — the delta is the classifier's answer, and it is in the table above and in a mutation-verified unit test. Reversing those two documented decisions is a taste call for the owner, not something I should slip in behind a screenshot.

For completeness: I did try. I stood up the warm harness on port base 5873 and drove real cursor-vendor panes into it with a sentinel engine. Two things blocked a clean shot, both worth knowing: the sidebar tab-row glyph comes from the **daemon activity registry**, not from `classifyScreen`, so it does not move for this fix at all; and the tab strip (which does read `setTurnStates`) only attaches a screen manifest when the foreground walk recognises the process as that engine, so a `/bin/sh` sentinel is classified as a shell tab and gets no manifest. Naming the sentinel `cursor-agent` got past that and then the pane was killed (code 137). Both fixtures I created are torn down.

---

## Group B — five stale vendor facts

**B1 — codex `effortLevels` gains `max`** (and `docs/ENGINES.md`'s row with it). The comment now says `minimal` is rejected *by the current model*, not broken outright.

**Partly unverifiable today, stated plainly:** codex is at its usage limit on this machine until Sep 11, so I could **not** re-run `codex exec -c model_reasoning_effort=max`. What I did establish locally, on the binary itself: the native `codex` binary's own serde enum reads `minimal|low|medium|high|xhigh|max` — on `0.149.1` and again on `0.153.2`. I also confirmed codex does **not** validate the level locally (`codex sandbox -c model_reasoning_effort=bogus -- echo hi` succeeds), so the API's list is the only authority, and the explorer's live capture of it is what says `max` is in it. The binary also carries an `ultra` variant; **I did not add it** — nothing has been observed answering 200 to it, and shipping a level the API rejects is the bug class this PR is fixing.

**Incident to flag:** while driving codex's TUI to read its effort picker, the boot screen showed an "Update available" prompt and my Enter landed on it, so codex self-updated **0.149.1 → 0.153.2** on this machine. Unintended; not destructive (its own updater, its own prompt), and I re-verified B1 against the new version. Mentioning it because nobody asked for that upgrade.

**B2 — the "cursor sits on Don't trust" premise is stale.** Verified live, twice, on kimi 0.40.1 with a fresh dir and no trust record: the dialog renders `❯ Trust this folder` (default on the *safe* option), and a bare Enter **accepted** — kimi wrote the trust record. Note the explorer's own saved fixture shows `❯ Don't trust`, which is why I re-captured rather than taking it on faith; that fixture is 0.39.1. The pre-trust stays (it does real work); the *reason* in `kimi-local/trust.ts`, `trust-worktree.ts`, `registry.ts` and `docs/ENGINES.md` no longer asserts a cursor position a reader can disprove in one launch.

**B3 — kimi's `fork` verb: docs only. The suggested fix would have shipped a bug.** kimi 0.40.1 does have `fork [sessionId]`, but it is a **one-shot that exits**:

```
$ kimi fork session_7230329c-…
Forked to session_d687e0d0-e9b6-4b2f-bb92-7a4d81183a57 ("Fork: …") in 1458ms
EXIT=0
```

Confirmed under a PTY too — it never opens a TUI. `forkArgv` becomes a **tab's launch command**, so adding it would have opened a pane that dies on its first frame — exactly A1's failure mode. `engineCanFork("kimi")` stays `false`, which was already right; what was wrong was the stated reason. Branching kimi would need fork-then-`-S <new-id>`: two launches, which this contract cannot express.

**B4 — kimi's blocked-screen vocabulary.** 0.40.1 draws `↑↓ navigate · Enter select · Esc exit`; the manifest looked for `↑↓ select` + `esc cancel`. Added as a **second rule** rather than widening the existing one, so neither version's vocabulary can half-match the other's. Both are mutation-tested. Scope respected: I captured the **trust** dialog only — kimi's *approval* dialog (rule 1) is still unverified on 0.40.1 (weekly quota 403 stops every turn before a tool call), and I left it alone and said so in the file header.

**B5 — kimi trust must hash the realpath.** Established by letting kimi write its own record in an isolated `$HOME` for `/tmp/r11ab-kimi-B`:

```
kimi wrote:  wd_r11ab-kimi-b_267a622ffb72   {"root":"/private/tmp/r11ab-kimi-B"}
sha256("/private/tmp/r11ab-kimi-B")[:12] = 267a622ffb72   ← MATCH (realpath)
sha256("/tmp/r11ab-kimi-B")[:12]         = 87205e456a6b

Rove BEFORE: wd_r11ab-kimi-B_87205e456a6b   ← wrong hash AND wrong case
Rove AFTER:  wd_r11ab-kimi-b_267a622ffb72   ← matches what kimi wrote
```

So `realpathSync` before hashing, and lowercase the basename segment. The record's `root` field resolves too, so it is shaped like one kimi writes rather than merely being *filed* where kimi looks. Best-effort: `realpathSync` throws on a directory that is not there yet, and falls back to the given path so the function stays pure and testable.

**End-to-end, with the counterfactual** — same worktree (`/tmp/r11ab-symlinked-B`), same kimi 0.40.1, isolated `$HOME`, count of `Trust this folder?` in the boot capture:

```
origin/main formula → wd_r11ab-symlinked-B_5d408e18496f → dialog shown  (2 hits)
this branch         → wd_r11ab-symlinked-b_04f9614379b7 → dialog GONE   (0 hits; kimi boots to its welcome screen)
```

So the pre-trust was silently doing nothing for a symlinked worktree, and now it works. One thing worth recording: kimi is **not** internally consistent here — its *sessions* directory hashes the path as given (`sha256("/tmp/kimiprobe")` matches `wd_kimiprobe_4c9432d8e46b`), while the *trust* store hashes the resolved one. Only the trust store is what `kimiTrustFilePath` reproduces.

Blast radius today is nil — `~/.rove/worktrees` and `/Users/jacksonc/i` are already real paths. This is the symlinked-repo-root case.

---

## Gates

- Repo-root `bun run lint` — clean, 1406 files.
- `bun run typecheck` — all four packages exit 0.
- `bun run test:fast` — **438 files, 4359 tests, all passing.**
- **Mutation-verified**, one failure each, baseline green: drop opencode's `firstMessageDelivery` · drop the entry-forward line · drop `"esc interrupt"` · drop the idle rule · drop the cursor login rule · drop the 0.40.1 kimi dialog rule · drop the 0.37.2 one (regression guard) · stop resolving the path · stop lowercasing the basename · put the unresolved path back in `root`. (That last one initially survived — the assertion guarding it was added because the mutation passed.)
- Rule-ordering edges checked explicitly: opencode's permission and confirm dialogs still read `blocked` with the `enter send` footer present, a running turn still reads `working` with it present, and cursor's new login rule does not shadow its approval or working rules.
- No file crosses 500 lines (largest touched: `registry.ts`, 383).
- One changeset, `patch`.
