### PR TITLE
fix: the first ten minutes tell a new user things that are not true

### DIFF
--- a/.changeset/first-ten-minutes-honesty.md
+++ b/.changeset/first-ten-minutes-honesty.md
@@ -1,0 +1,51 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Stop the first ten minutes telling a new user things that are not true. On the
+most likely new-user machine — every engine CLI installed, none signed in —
+three surfaces disagreed with each other about whether Rove could run anything.
+
+The zero-task welcome pane rendered `✓ engines: claude · codex · kimi` thirty
+seconds after the setup wizard said `✗ No usable engine yet` about the same
+home: it probed binaries on `PATH` and never read account state. It now shares
+`rove doctor`'s probe and has the third state it was missing — usable /
+installed-but-not-signed-in / absent.
+
+The wizard's closing summary and `rove doctor --fix` printed "install an engine
+CLI (claude, codex, copilot, or kimi) and log in" directly under rows carrying
+those CLIs' absolute paths. The remedy now branches on which half failed and
+names the engines you actually have to log in to.
+
+`rove doctor` and the wizard walked a shorter engine catalog than the product
+launches, so a machine whose only CLI is `opencode`, `gemini`, `cursor-agent`,
+`grok`, `droid` or `amp` was told it had no usable engine while the new-task
+dialog offered that engine and ran it. Both now see every engine Rove can
+launch, and the wizard's inline height is derived from the block it prints
+instead of a flat 20 rows that a six-engine machine overflowed.
+
+`rove doctor` told a brand-new install its PTY host was broken and prescribed
+`rove reset` — the command it describes in the same breath as not undoable and
+as killing every live session. The host is started on demand by the first task
+tab, so no pidfile and no socket is the normal cold state; only a genuinely
+wedged host proposes the destructive remedy now.
+
+`rove api add` reports the `home` it wrote to. A success payload that never
+names its destination cannot be wrong about it, and an isolation override that
+collapses (an unquoted shell variable holding a whole `env` prefix does not
+word-split) reads as an ordinary success. It also refuses a `--repo` that is
+not a git repository instead of persisting a task with an empty branch and an
+empty worktree path, and seeds sibling titles from `--prompt`, so a fan-out is
+comparable the moment it returns rather than showing N identical `(new task)`
+rows at exactly the step that tells you to compare them.
+
+Codex tasks could take their name from the repo's own contributor rules: the
+filter for that envelope required a trailing `for ` in the heading, exact
+newline padding, and that the record end at `</INSTRUCTIONS>`, and had no
+predicate at all for `<recommended_plugins>`. Widened to match what live
+rollouts write.
+
+Docs: QUICKSTART says the first launch is setup only and ends by asking you to
+run `rove` again, names the full engine list, and notes that the two setup
+questions are asked once per machine; `docs/WORK-TRACKING.md` no longer sends
+users to the browser Issues page, which was removed in #855. — [@Sma1lboy](https://github.com/Sma1lboy)

--- a/docs/API.md
+++ b/docs/API.md
@@ -33,6 +33,16 @@ rove api add --repo "$PWD" \
   --prompt "Try independent approaches to simplify the auth flow."
 ```
 
+Every `add` response carries a `home` field: the Rove home the tasks were
+actually written to. A `ROVE_HOME_DIR` override that collapses (an unquoted
+shell variable holding a whole `env` prefix does not word-split) otherwise
+reads as a plain success — same `count`, same empty `failures`, different
+machine state. Compare it against the home you meant before trusting the round.
+
+Siblings with no `--title` are named from `--prompt` at creation, so a fan-out
+is comparable the moment it returns rather than showing N identical `(new
+task)` rows until the engines write their first transcripts.
+
 **Completion.** A worker spawned from another Rove task sends its outcome
 back to the dispatching engine tab: creation records the dispatcher
 (task + tab), so a bare `send` routes home without any id in hand; no

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -4,10 +4,13 @@ Rove runs many AI coding sessions side by side in your terminal. Each managed
 Task gets its own git worktree and branch, so parallel Tasks never step on
 each other. Extra tabs inside one Task share that Task's directory.
 
-You need git and at least one engine CLI (`claude`, `codex`, `copilot`, or
-`kimi`) on your `PATH`. The Rove CLI itself runs on the [Bun](https://bun.sh)
-runtime (≥ 1.3.11). You do not have to install Bun yourself; every route
-below brings it along.
+You need git and at least one engine CLI on your `PATH`. Rove ships built-in
+support for `claude`, `codex`, `copilot` and `kimi`, and launches `gemini`,
+`opencode`, `cursor-agent`, `grok`, `droid` and `amp` too — the full list, and
+how to add your own, is in [Engines](ENGINES.md).
+
+The Rove CLI itself runs on the [Bun](https://bun.sh) runtime (≥ 1.3.11). You
+do not have to install Bun yourself; every route below brings it along.
 
 **Windows also requires [Node.js](https://nodejs.org) and Git for Windows.**
 Rove uses Node.js for its Windows PTY host and Git Bash as the POSIX shell

--- a/docs/WORK-TRACKING.md
+++ b/docs/WORK-TRACKING.md
@@ -34,7 +34,7 @@ common-dir, so the source checkout and its worktrees share one issue record:
 
 - **`status`**: `open` → `doing` → `done`, plus `hold` for issues parked on purpose (waiting on a decision, blocked, deliberately deferred). `hold` is a parking lot, not a lifecycle step. Resume by flipping back to `open`. Held issues stay visible in the active file like every other status. Status is still the only dimension; don't add label/type fields.
 - **`id`**: take `nextId`, then increment `nextId`. Ids are never reused.
-- **Adding**: use the web Issues page or `rove api issue-create --repo <path> --title ...`. The daemon stores the repo's issue record under the repo's git common-dir, so a source checkout and its task worktrees share the same issues.
+- **Adding**: `rove api issue-create --repo <path> --title ...`. The daemon stores the repo's issue record under the repo's git common-dir, so a source checkout and its task worktrees share the same issues.
 - **Closing**: flip `status` to `done`. Done issues stay visible in the Done column until a future archive/export flow exists.
 - **Agent automation**: use `rove api issue-list`, `rove api issue-create`, `rove api issue-set-status`, and `rove api issue-update`. From a task worktree, `--repo .` resolves to the same daemon issue record as the source checkout.
 

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -22,7 +22,7 @@ Read the file at the referenced path. The user will normally pass the path or th
 
 This repo has two other tracking surfaces that this file does NOT replace:
 
-- **Daemon issue store** (`rove api issue-*`, web Issues page) — the product backlog, per [`../WORK-TRACKING.md`](../WORK-TRACKING.md). Long-lived "we should do X" items still belong there.
+- **Daemon issue store** (`rove api issue-*`) — the product backlog, per [`../WORK-TRACKING.md`](../WORK-TRACKING.md). Long-lived "we should do X" items still belong there.
 - **GitHub Issues** — inbound end-user bug reports only (e.g. #192). Never file agent work items there automatically.
 
 `.scratch/` is the working layer for skill-driven feature flows (PRD → issues → QA within a session/feature). When a `.scratch` issue graduates into durable backlog, move it to the daemon store.

--- a/packages/kobe/src/cli/api/handlers-add.ts
+++ b/packages/kobe/src/cli/api/handlers-add.ts
@@ -18,7 +18,9 @@
 
 import type { SerializedTask } from "@sma1lboy/kobe-daemon/daemon/protocol"
 import { resolveCommandProtocol } from "../../engine/engine-presets.ts"
+import { homeDir } from "../../env.ts"
 import { ulid } from "../../orchestrator/index/ulid.ts"
+import { deriveTitleFromPrompt } from "../../orchestrator/title.ts"
 import type { TaskStatus } from "../../types/task.ts"
 import { DEFAULT_VENDOR, type VendorId } from "../../types/vendor.ts"
 import type { DaemonRpc } from "../daemon-session.ts"
@@ -71,6 +73,20 @@ async function applyPostCreateFlags(daemon: DaemonRpc, taskId: string, args: Ver
 export async function add(ctx: VerbContext): Promise<unknown> {
   const { args, runtime } = ctx
   const repo = await runtime.resolveRepoRoot(args.requireRepo("repo"))
+  // A task's isolation unit is a git worktree + branch, so a `--repo` that is
+  // not a git repo has nothing to cut one from. Without this the create
+  // SUCCEEDS: `resolveRepoRoot` falls back to the path verbatim, the row
+  // persists with an empty branch and an empty worktreePath, and the caller
+  // gets `ok: true`. The failure surfaces minutes later when someone opens the
+  // row and lands on an empty path — by which point nothing points back at the
+  // argument that caused it.
+  if (!(await runtime.isUsableRepo(repo))) {
+    throw new ApiError(
+      `--repo ${repo} is not a git repository — a task needs one to cut its worktree and branch from (run \`git init\` there, or point --repo at a checkout)`,
+      "NOT_A_REPO",
+      helpStep("add"),
+    )
+  }
   const count = args.int("count")
   const agentsSpec = args.str("agents")
   if (count !== undefined || agentsSpec) return addParallel(ctx, repo, count, agentsSpec)
@@ -90,7 +106,7 @@ async function addOne(ctx: VerbContext, repo: string): Promise<unknown> {
   // sub-task's bare `send` routes its outcome back to.
   const choice = await engineChoice(ctx, repo)
   const payload: Record<string, string> = { repo, ...(await dispatcherEnvPayload()), ...enginePayload(choice) }
-  const title = args.str("title")
+  const title = args.str("title") || (prompt ? deriveTitleFromPrompt(prompt) : "")
   if (title) payload.title = title
   const branch = args.str("branch")
   if (branch) payload.branch = branch
@@ -111,7 +127,7 @@ async function addOne(ctx: VerbContext, repo: string): Promise<unknown> {
     task = (await daemon.request<{ task: SerializedTask }>("task.get", { taskId })).task
   }
 
-  if (!prompt) return { taskId, task, started: false }
+  if (!prompt) return { taskId, task, home: homeDir(), started: false }
   // Same provenance prefix `send` carries: a task created from inside another
   // kobe session is agent-to-agent, and its opening brief is where the reply
   // address matters most — every report this task ever sends goes back through
@@ -160,6 +176,11 @@ async function addOne(ctx: VerbContext, repo: string): Promise<unknown> {
   return {
     taskId,
     task,
+    // The home this create actually wrote to. A success payload that never
+    // names its destination cannot be wrong about it — a collapsed isolation
+    // override reads identically to the intended one, which is how four
+    // fan-out tasks once landed in a production `~/.rove` with `failures: []`.
+    home: homeDir(),
     started: delivered.started,
     engineReady: delivered.engineReady,
     session: delivered.session,
@@ -237,7 +258,14 @@ async function addParallel(
       )
     }
   }
-  const title = args.str("title")
+  // No --title: seed from the prompt we are about to deliver. Without this a
+  // fan-out lands N rows all called `(new task)` — which is what QUICKSTART's
+  // own example produces, at exactly the step that tells the reader to compare
+  // the attempts. The daemon's auto-title pass only renames tasks still
+  // carrying the placeholder, so a seeded title is final; that is the right
+  // outcome, since it derives from the same first user message that pass would
+  // have read back out of the transcript minutes later.
+  const title = args.str("title") || deriveTitleFromPrompt(prompt)
   const baseRef = args.str("base-branch")
 
   // `--agents` names engines per sibling; `--count` repeats ONE engine, which
@@ -364,7 +392,7 @@ async function addParallel(
   if (createFailure) failures.push({ ok: false, vendor: createFailure.vendor, error: createFailure.error })
   await Promise.all(persistedPrompts)
 
-  const result = { count: created.length, requested: plan.length, groupId, tasks, failures }
+  const result = { count: created.length, requested: plan.length, groupId, home: homeDir(), tasks, failures }
   // Partial (or total) create/delivery failure must not exit 0 — carry the
   // whole result (created taskIds included) up so the dispatcher emits it to
   // stdout + exits 3.

--- a/packages/kobe/src/cli/api/runtime.ts
+++ b/packages/kobe/src/cli/api/runtime.ts
@@ -294,6 +294,10 @@ export const defaultApiRuntime: ApiRuntime = {
   closeTerminalTab: closeHeadlessTerminalTab,
   deliverPrompt: (client, target, prompt) => deliverPrompt(client, target, prompt),
   resolveRepoRoot: async (absPath) => (await import("../../state/repos.ts")).resolveMainRepoRoot(absPath),
+  isUsableRepo: async (absPath) => {
+    const { isGitRepo, isRemoteRepoKey } = await import("../../state/repos.ts")
+    return isRemoteRepoKey(absPath) || isGitRepo(absPath)
+  },
   defaultVendor: async (repo) => {
     const { getGlobalDefaultVendor, getRepoLastActiveVendor } = await import("../../state/vendor-prefs.ts")
     return (repo ? getRepoLastActiveVendor(repo) : undefined) ?? getGlobalDefaultVendor()

--- a/packages/kobe/src/cli/api/types.ts
+++ b/packages/kobe/src/cli/api/types.ts
@@ -261,6 +261,12 @@ export interface ApiRuntime {
   deliverPrompt(client: DaemonRpc, target: PromptTarget, prompt: string): Promise<DeliveredPrompt>
   /** Canonical source repo for task creation and grouping. */
   resolveRepoRoot(absPath: string): Promise<string>
+  /** Is this resolved repo something a worktree can be cut from? On the seam
+   *  beside {@link resolveRepoRoot} because it asks about the same path at the
+   *  same boundary — and because a direct `git` shell-out here would make every
+   *  handler test need a real repo on disk. Remote (`ssh://…`) keys answer true:
+   *  the remote-add flow validates those. */
+  isUsableRepo(absPath: string): Promise<boolean>
   /** Preferred engine for new tasks in `repo`; undefined delegates to daemon defaults. */
   defaultVendor(repo?: string): Promise<VendorId | undefined>
   /** Uncommitted +/− counts for a worktree; `null` when git could not be

--- a/packages/kobe/src/cli/doctor-cmd.ts
+++ b/packages/kobe/src/cli/doctor-cmd.ts
@@ -31,6 +31,7 @@ import {
   engineTabsManualFix,
   humanOnlyFix,
   killOrphansManualFix,
+  noEngineFix,
   reinstallManualFix,
   resetManualFix,
   skillInstallFix,
@@ -188,7 +189,7 @@ async function collectDoctor(): Promise<{ lines: string[]; fixes: DoctorFix[]; o
   const git = await probeGit()
   if (!git.found) fixes.push(humanOnlyFix("git"))
   const engines = await probeEngines()
-  if (!engines.anyUsable) fixes.push(humanOnlyFix("noEngine"))
+  if (!engines.anyUsable) fixes.push(noEngineFix(engines.signedOut))
   // Can this process still re-exec itself? A `bun`/`node` process holds its
   // entry open by inode, so uninstalling Rove out from under a running one
   // leaves it alive on a path that is gone — it keeps working until it needs
@@ -296,10 +297,16 @@ async function collectDoctor(): Promise<{ lines: string[]; fixes: DoctorFix[]; o
       )
     }
   } else {
-    // Both PTY-host failure shapes end in `reset` (TROUBLESHOOTING: "If the
-    // PTY host itself is wedged"), which kills live sessions — print-only.
-    await appendUnavailableProcess(out, "pty host", defaultPtyHostPidPath(), ptySocket)
-    fixes.push(resetManualFix(CLI_NAME, "resetPty"))
+    // Only a WEDGED host is a finding. The PTY host is started on demand by
+    // the first task tab, so "no pidfile, no socket" is the normal state of
+    // every home where no tab has opened yet — including a brand-new install.
+    // Proposing `reset` there told a first-time user their install was damaged
+    // and pointed them at the one command that is documented as not undoable
+    // and as killing every live session. The daemon branch above already reads
+    // this same verdict; this one used to discard it.
+    const ptyState = await appendUnavailableProcess(out, "pty host", defaultPtyHostPidPath(), ptySocket)
+    if (ptyState === "wedged") fixes.push(resetManualFix(CLI_NAME, "resetPty"))
+    else out.push("         starts on demand — the first task tab launches it; nothing to fix")
   }
   // Windows runs the PTY host under node (Bun has no PTY there). A kobe
   // installed with `bun install -g` may have no node at all, and the only

--- a/packages/kobe/src/cli/doctor-fix.ts
+++ b/packages/kobe/src/cli/doctor-fix.ts
@@ -133,17 +133,35 @@ export function spawnHelperFix(paths: readonly string[]): DoctorFix {
   }
 }
 
-type HumanOnlyReason = "git" | "noEngine" | "windowsNode" | "staleBun"
+type HumanOnlyReason = "git" | "noEngine" | "noEngineLogin" | "windowsNode" | "staleBun"
 
 /** Installs and logins: doctor can only point, a human has to act. */
-export function humanOnlyFix(reason: HumanOnlyReason): DoctorFix {
+export function humanOnlyFix(reason: HumanOnlyReason, vars?: Record<string, string>): DoctorFix {
   return {
     kind: "manual",
     id: reason,
     label: t(`doctor.fix.${reason}`),
-    action: t(`doctor.fix.${reason}Action`),
+    action: t(`doctor.fix.${reason}Action`, vars),
     why: t("doctor.fix.humanOnlyWhy"),
   }
+}
+
+/**
+ * The engine remedy, branched on WHICH half failed. Nothing installed → say
+ * install. A CLI on PATH with no account → say log in, and name the engines:
+ * "install an engine CLI" printed under a row carrying that CLI's absolute
+ * path sends the user to solve a problem they do not have.
+ */
+export function noEngineFix(signedOut: readonly string[]): DoctorFix {
+  return signedOut.length > 0 ? humanOnlyFix("noEngineLogin", { list: signedOut.join(", ") }) : humanOnlyFix("noEngine")
+}
+
+/** Just the remedy line, for surfaces that print prose rather than a fix list
+ *  (the wizard's closing banner). Same branch, so the two cannot drift. */
+export function noEngineAction(signedOut: readonly string[]): string {
+  return signedOut.length > 0
+    ? t("doctor.fix.noEngineLoginAction", { list: signedOut.join(", ") })
+    : t("doctor.fix.noEngineAction")
 }
 
 /** Drop repeat proposals of the same remedy (first occurrence wins). */

--- a/packages/kobe/src/cli/env-checks.ts
+++ b/packages/kobe/src/cli/env-checks.ts
@@ -8,8 +8,7 @@
  */
 
 import type { BinaryStatus } from "../engine/account-detect.ts"
-import { listPresetIds } from "../engine/engine-presets.ts"
-import { describeAccount, detectEngineStatuses, engineUsable } from "../engine/engine-status.ts"
+import { describeAccount, detectEngineStatuses, probeableEngineIds, summarizeEngines } from "../engine/engine-status.ts"
 
 export interface GitProbeResult {
   /** The doctor-formatted one-liner (`git: ✓ …` / `git: ✗ …`). */
@@ -22,6 +21,11 @@ export interface EngineProbeResult {
   readonly lines: string[]
   /** True when at least one engine could actually run a task right now. */
   readonly anyUsable: boolean
+  /** Engines whose CLI IS installed but whose readable login says "no account".
+   *  Empty with `anyUsable: false` means nothing is installed at all — the two
+   *  states take opposite remedies, so the caller must be able to tell them
+   *  apart before printing one. */
+  readonly signedOut: readonly string[]
 }
 
 /** What the onboarding wizard's environment page and closing banner render. */
@@ -55,12 +59,13 @@ function binaryLabel(binary: BinaryStatus): string {
  * `detectEngineStatuses` is the same probe Settings →
  * Accounts uses, so the two surfaces can't disagree.
  *
- * Order is `listPresetIds()`: the built-ins in their stable cycle order
+ * Order is `probeableEngineIds()`: the built-ins in their stable cycle order
  * (claude, codex, copilot, kimi), then the user's own presets in registration
- * order.
+ * order, then any contrib engine actually installed — so a machine whose only
+ * CLI is `opencode` gets an opencode row here instead of "no usable engine".
  */
 export async function probeEngines(): Promise<EngineProbeResult> {
-  const statuses = await detectEngineStatuses(listPresetIds())
+  const statuses = await detectEngineStatuses(await probeableEngineIds())
   const lines = ["engines:"]
   for (const status of statuses) {
     const account = describeAccount(status.account)
@@ -72,7 +77,8 @@ export async function probeEngines(): Promise<EngineProbeResult> {
   }
   // "Usable" = binary present AND some account. One usable engine is enough;
   // a missing vendor the user never launches is not a finding.
-  return { lines, anyUsable: statuses.some(engineUsable) }
+  const { usable, signedOut } = summarizeEngines(statuses)
+  return { lines, anyUsable: usable.length > 0, signedOut }
 }
 
 /**

--- a/packages/kobe/src/cli/onboarding.ts
+++ b/packages/kobe/src/cli/onboarding.ts
@@ -24,6 +24,7 @@ import { basename, join } from "node:path"
 import { isNpxMissing, markSkillHintSeen, npxSkillsArgv, npxSkillsCommand } from "../lib/skill-install.ts"
 import { getPersistedBool, loadStateFile, setPersistedBool } from "../state/store.ts"
 import { t } from "../tui/i18n"
+import { noEngineAction } from "./doctor-fix.ts"
 import { type OnboardingEnvReport, checkOnboardingEnv } from "./env-checks.ts"
 import { activeCliName } from "./rename-compat.ts"
 import { LAST_RUN_VERSION_KEY } from "./reset-gate.ts"
@@ -166,7 +167,10 @@ export function applyOnboardingChoices(
     out(t("onboarding.readyHint", { command: cli }))
   } else {
     out(t("onboarding.notReadyHeader"))
-    if (!env.engines.anyUsable) out(`  → ${t("doctor.fix.noEngineAction")}`)
+    // Same branch `rove doctor` takes (noEngineFix): the banner prints each
+    // installed CLI's absolute path immediately above, so "install one" there
+    // would answer a question the user did not ask.
+    if (!env.engines.anyUsable) out(`  → ${noEngineAction(env.engines.signedOut)}`)
     if (!env.git.found) out(`  → ${t("doctor.fix.gitAction")}`)
   }
 }

--- a/packages/kobe/src/engine/codex-local/synthetic.ts
+++ b/packages/kobe/src/engine/codex-local/synthetic.ts
@@ -15,7 +15,7 @@ export function isSyntheticCodexUserRow(blocks: readonly CodexTextLikeBlock[]): 
   for (const b of blocks) {
     if (b.type !== "text") return false
     const t = (b.text ?? "").trim()
-    if (!isEnvironmentContextEnvelope(t) && !isInstructionsEnvelope(t)) return false
+    if (!isTagEnvelope(t) && !isInstructionsEnvelope(t)) return false
   }
   return true
 }
@@ -36,14 +36,27 @@ export function visibleCodexUserText(content: unknown): string | null {
   return text.length > 0 ? text : null
 }
 
-function isEnvironmentContextEnvelope(text: string): boolean {
-  return text.startsWith("<environment_context>") && text.endsWith("</environment_context>")
+/** Codex's whole-message XML-ish envelopes: the row IS the tag. */
+const ENVELOPE_TAGS = ["environment_context", "recommended_plugins", "user_instructions"] as const
+
+function isTagEnvelope(text: string): boolean {
+  return ENVELOPE_TAGS.some((tag) => text.startsWith(`<${tag}>`) && text.endsWith(`</${tag}>`))
 }
 
+/**
+ * Codex's AGENTS.md preamble: a markdown heading followed by an
+ * `<INSTRUCTIONS>` block.
+ *
+ * Deliberately loose about everything after the heading word. The previous
+ * spelling demanded a trailing `for ` (Codex also emits the heading bare),
+ * exact `\n` padding around the tag, and that the message END at
+ * `</INSTRUCTIONS>` (real rollouts append more). Each of those made the filter
+ * miss, and a missed filter is not silent: the auto-titler takes the
+ * transcript's first `role: "user"` record, so the repo's contributor rules
+ * became the task's name in the sidebar and in `tasks.json`. The heading plus
+ * the tag is specific enough — a genuine prompt has to open with that exact
+ * heading and contain an `<INSTRUCTIONS>` block to be dropped.
+ */
 function isInstructionsEnvelope(text: string): boolean {
-  return (
-    text.startsWith("# AGENTS.md instructions for ") &&
-    text.includes("\n<INSTRUCTIONS>\n") &&
-    text.endsWith("</INSTRUCTIONS>")
-  )
+  return text.startsWith("# AGENTS.md instructions") && text.includes("<INSTRUCTIONS>")
 }

--- a/packages/kobe/src/engine/engine-status.ts
+++ b/packages/kobe/src/engine/engine-status.ts
@@ -36,6 +36,8 @@ import type {
   DetectDeps,
   KimiAccount,
 } from "./account-detect"
+import { installedEngineIds } from "./account-detect"
+import { listPresetIds } from "./engine-presets"
 import { interactiveEngineCommand } from "./interactive-command"
 import { engineEntry } from "./registry"
 
@@ -158,4 +160,45 @@ export function describeAccount(account: EngineAccount | null): string {
  *  account (no detector) does not veto — the binary is all we can know. */
 export function engineUsable(status: EngineStatus): boolean {
   return status.binary.found && status.account?.kind !== "none"
+}
+
+/**
+ * Every engine id worth probing on this machine: the registered presets
+ * (built-ins + the user's own) plus the contrib engines whose binary is
+ * actually on PATH.
+ *
+ * `listPresetIds()` alone omits the whole contrib catalog, so a user whose
+ * only CLI is `opencode` was told "no usable engine" by the two surfaces meant
+ * to diagnose exactly that — `rove doctor` and the setup wizard — while the
+ * new-task dialog offered opencode and ran it fine. Contrib engines that are
+ * NOT installed stay out: six `✗ not found on PATH` rows for engines the user
+ * never asked about is noise, not a diagnosis.
+ */
+export async function probeableEngineIds(): Promise<readonly VendorId[]> {
+  return [...new Set<VendorId>([...listPresetIds(), ...(await installedEngineIds())])]
+}
+
+/** Engine readiness split three ways, from one pass of statuses. */
+export interface EngineReadiness {
+  /** Could run a task right now (binary present, and logged in where readable). */
+  readonly usable: readonly VendorId[]
+  /** Binary on PATH, but the login Rove CAN read says there is no account.
+   *  The common new-user state, and the one that used to render as `✓`. */
+  readonly signedOut: readonly VendorId[]
+}
+
+/**
+ * Split statuses into "can run a task" and "installed but not signed in".
+ * The second bucket is the whole point: `usable.length === 0` alone cannot
+ * tell a machine with no CLI at all from one CLI away from working, and those
+ * two states need opposite remedies (install vs. run it once and log in).
+ */
+export function summarizeEngines(statuses: readonly EngineStatus[]): EngineReadiness {
+  const usable: VendorId[] = []
+  const signedOut: VendorId[] = []
+  for (const status of statuses) {
+    if (engineUsable(status)) usable.push(status.vendor)
+    else if (status.binary.found) signedOut.push(status.vendor)
+  }
+  return { usable, signedOut }
 }

--- a/packages/kobe/src/tui-react/component/new-task-dialog/dialog.tsx
+++ b/packages/kobe/src/tui-react/component/new-task-dialog/dialog.tsx
@@ -80,7 +80,14 @@ export function NewTaskDialogView(props: NewTaskDialogProps) {
           </text>
         ) : null}
       </box>
-      <DialogFooter>{t("newTask.legend")}</DialogFooter>
+      {/* Enter's caption follows the focused stop: it commits only on Create
+          and walks the form at the other four, so a static "enter create" was
+          wrong at every stop the dialog actually opens on. */}
+      <DialogFooter>
+        {t("newTask.legend", {
+          enter: t(vm.field === "confirm" ? "newTask.enterCreate" : "newTask.enterNext"),
+        })}
+      </DialogFooter>
       {/* Create commits on click; also reachable by tabbing to the confirm
           field (Enter), or Enter on the last input of the active tab. */}
       <DialogActions

--- a/packages/kobe/src/tui-react/onboarding/host.tsx
+++ b/packages/kobe/src/tui-react/onboarding/host.tsx
@@ -28,8 +28,22 @@ import { useT } from "../i18n"
 import { bootPaneHost } from "../lib/host-boot"
 import { pageCloseBindings, useBindings } from "../lib/keymap"
 
-/** header(2) + blank + answered(2) + env title/explain + git + ~5 engine rows + verdict + legend + slack */
-const INLINE_ROWS = 20
+/**
+ * Inline height for the wizard, derived from the ENGINE BLOCK it will actually
+ * print rather than guessed.
+ *
+ * Everything but that block is fixed: header(2) + blank + answered(2) + env
+ * title/explain + blank + git + blank + verdict + blank + legend = 13, plus 2
+ * rows of slack. The engine block is not: it is one row per registered engine
+ * (plus an `⚠` row for any account error), and once the contrib catalog joined
+ * the probe a normal machine reached seven. The old flat 20 budgeted "~5
+ * engine rows", and one row over it the terminal scrolls and the inline
+ * renderer repaints over stale cells — a visibly corrupted first screen.
+ * `env.engines.lines` IS the rendered array, so this cannot drift from it.
+ */
+function inlineRowsFor(env: OnboardingEnvReport): number {
+  return 15 + env.engines.lines.length
+}
 
 type StepId = "completions" | "skill"
 type WizardPageKind = "questions" | "env" | "keys"
@@ -211,7 +225,7 @@ export async function runOnboardingWizard(
 ): Promise<OnboardingChoices> {
   return await new Promise<OnboardingChoices>((resolve) => {
     void bootPaneHost({
-      inlineRows: INLINE_ROWS,
+      inlineRows: inlineRowsFor(env),
       setup: () => ({ root: () => <WizardPage shell={shell} env={env} mode={mode} onDone={resolve} /> }),
     })
   })

--- a/packages/kobe/src/tui-react/workspace/welcome-pane.tsx
+++ b/packages/kobe/src/tui-react/workspace/welcome-pane.tsx
@@ -13,7 +13,7 @@
 import { TextAttributes } from "@opentui/core"
 import type { ReactNode } from "react"
 import { useEffect, useState } from "react"
-import { installedEngineIds } from "../../engine/account-detect.ts"
+import { detectEngineStatuses, probeableEngineIds, summarizeEngines } from "../../engine/engine-status.ts"
 import { displayWidth, padEndCells } from "../../lib/display-width"
 import { formatChord } from "../../tui/lib/chord-glyphs"
 import { legendCap } from "../../tui/lib/help-groups"
@@ -22,18 +22,32 @@ import { useTheme } from "../context/theme"
 import { useT } from "../i18n"
 
 export type WelcomeEnv = {
+  /** Engines that can actually run a task: installed AND signed in. */
   readonly engines: readonly string[]
+  /** Installed, but the login Rove can read says there is no account. */
+  readonly signedOut: readonly string[]
   readonly git: boolean
 }
 
-/** Real probe: engine binaries (memoized in account-detect) + git on PATH. */
+/**
+ * Real probe: engine binary AND account, plus git on PATH.
+ *
+ * Binary-on-PATH alone is what this pane used to ask, and on the most likely
+ * new-user machine — every CLI installed, none logged in — that renders a `✓`
+ * seconds after the setup wizard said `✗ No usable engine yet` about the same
+ * home. Same probe as `rove doctor` now (`probeEngines`), so the two surfaces
+ * cannot reach opposite verdicts again.
+ */
 async function probeWelcomeEnv(): Promise<WelcomeEnv> {
-  const engines = await installedEngineIds().catch(() => [] as const)
+  const { usable, signedOut } = await probeableEngineIds()
+    .then(detectEngineStatuses)
+    .then(summarizeEngines)
+    .catch(() => ({ usable: [], signedOut: [] }))
   // ponytail: Bun.which is absent under vitest's node runtime; there we
   // assume git exists rather than shell out — a false "missing" warning on a
   // dev box is worse than skipping the check outside production.
   const git = globalThis.Bun?.which ? globalThis.Bun.which("git") !== null : true
-  return { engines, git }
+  return { engines: usable, signedOut, git }
 }
 
 type StepLine = { cap: string; msg: "stepNew" | "stepHelp" | "stepPrefix" }
@@ -73,6 +87,16 @@ export function WelcomePane(props: { probe?: () => Promise<WelcomeEnv> }): React
   // every message row.
   const capWidth = Math.max(...steps.map((s) => displayWidth(s.cap)), 0)
   const broken = env !== null && (env.engines.length === 0 || !env.git)
+  // Three states, not two. "Installed but not signed in" is the common cold
+  // state and used to have no rendering at all: it fell into the ✓ branch.
+  const engineLine =
+    env === null
+      ? null
+      : env.engines.length > 0
+        ? { key: "enginesFound" as const, fg: theme.textMuted, list: env.engines.join(" · ") }
+        : env.signedOut.length > 0
+          ? { key: "enginesSignedOut" as const, fg: theme.warning, list: env.signedOut.join(" · ") }
+          : { key: "enginesMissing" as const, fg: theme.warning, list: "" }
 
   return (
     <box flexGrow={1} alignItems="center" justifyContent="center">
@@ -102,17 +126,11 @@ export function WelcomePane(props: { probe?: () => Promise<WelcomeEnv> }): React
             {t("workspace.welcome.worktreeExplain")}
           </text>
         </box>
-        {env !== null ? (
+        {env !== null && engineLine !== null ? (
           <box flexDirection="column" paddingTop={1}>
-            {env.engines.length > 0 ? (
-              <text fg={theme.textMuted} wrapMode="word">
-                {t("workspace.welcome.enginesFound", { list: env.engines.join(" · ") })}
-              </text>
-            ) : (
-              <text fg={theme.warning} wrapMode="word">
-                {t("workspace.welcome.enginesMissing")}
-              </text>
-            )}
+            <text fg={engineLine.fg} wrapMode="word">
+              {t(`workspace.welcome.${engineLine.key}`, { list: engineLine.list })}
+            </text>
             {env.git ? null : (
               <text fg={theme.warning} wrapMode="word">
                 {t("workspace.welcome.gitMissing")}

--- a/packages/kobe/src/tui/i18n/messages/doctor.ts
+++ b/packages/kobe/src/tui/i18n/messages/doctor.ts
@@ -88,8 +88,14 @@ export const en = {
     gitAction: "install git with your OS package manager",
     /** No engine has both a CLI binary and an account */
     noEngine: "no usable engine — no engine CLI is both installed and logged in",
-    /** The manual action for {@link noEngine} */
+    /** The manual action for {@link noEngine}: nothing is installed at all */
     noEngineAction: "install an engine CLI (claude, codex, copilot, or kimi) and log in",
+    /** An engine CLI IS installed — only the login is missing */
+    noEngineLogin: "no usable engine — an engine CLI is installed but not signed in",
+    /** The manual action for {@link noEngineLogin}. `{list}` is the installed
+     *  engine CLIs; telling this user to install one would point at a binary
+     *  whose absolute path doctor printed two lines above. */
+    noEngineLoginAction: "run one of the installed engine CLIs ({list}) in a shell and complete its login",
     /** Windows only: no node, so the PTY host cannot start */
     windowsNode: "Node.js is missing — the Windows PTY host cannot start",
     /** The manual action for {@link windowsNode} */
@@ -149,6 +155,8 @@ export const zh: typeof en = {
     gitAction: "用你的系统包管理器安装 git",
     noEngine: "没有可用引擎 — 没有任何引擎 CLI 同时满足已安装且已登录",
     noEngineAction: "安装任一引擎 CLI（claude、codex、copilot 或 kimi）并登录",
+    noEngineLogin: "没有可用引擎 — 引擎 CLI 已安装, 但没有登录",
+    noEngineLoginAction: "在 shell 里运行已安装的引擎 CLI（{list}）之一并完成登录",
     windowsNode: "缺少 Node.js — Windows PTY host 无法启动",
     windowsNodeAction: "从 https://nodejs.org 安装 Node.js",
     staleBun: "运行 Rove 的 Bun 版本低于本构建的要求 — 终端不会有任何输出",

--- a/packages/kobe/src/tui/i18n/messages/newTask.ts
+++ b/packages/kobe/src/tui/i18n/messages/newTask.ts
@@ -5,7 +5,13 @@
 
 export const en = {
   title: "New task",
-  legend: "enter create · tab complete/fields · ctrl+[ ] mode · ctrl+e engine · esc cancel",
+  /** `{enter}` is whichever of the two below applies at the focused stop —
+   *  enter creates only on Create, and walks the form everywhere else. */
+  legend: "{enter} · tab complete/fields · ctrl+[ ] mode · ctrl+e engine · esc cancel",
+  /** Enter's caption while the Create button holds focus */
+  enterCreate: "enter create",
+  /** Enter's caption at every other stop, where it advances the form */
+  enterNext: "enter next field",
 
   tabs: {
     existing: "For Existing",
@@ -98,7 +104,9 @@ export const en = {
 
 export const zh: typeof en = {
   title: "新建任务",
-  legend: "enter 创建 · tab 补全/切字段 · ctrl+[ ] 切模式 · ctrl+e 引擎 · esc 取消",
+  legend: "{enter} · tab 补全/切字段 · ctrl+[ ] 切模式 · ctrl+e 引擎 · esc 取消",
+  enterCreate: "enter 创建",
+  enterNext: "enter 下一个字段",
 
   tabs: {
     existing: "已有仓库",

--- a/packages/kobe/src/tui/i18n/messages/workspace.ts
+++ b/packages/kobe/src/tui/i18n/messages/workspace.ts
@@ -33,8 +33,11 @@ export const en = {
     stepHelp: "shows every shortcut reachable from the current focus",
     /** {key} is the live prefix chord */
     stepPrefix: "opens the command menu",
-    /** {list} is the detected engine CLIs, e.g. "claude · codex" */
+    /** {list} is the engine CLIs that are installed AND signed in */
     enginesFound: "✓ engines: {list}",
+    /** {list} is the installed-but-logged-out engine CLIs. The common cold state:
+     *  the CLI is there, so "install one" would be wrong advice. */
+    enginesSignedOut: "✗ installed but not signed in: {list} — run one of them in a shell and log in",
     enginesMissing: "✗ no engine CLI found — install claude, codex, copilot, or kimi, then restart Rove",
     gitMissing: "✗ git not found on PATH — Rove needs git to create worktrees",
     doctorHint: "run `rove doctor` in a shell for the full diagnosis",
@@ -98,6 +101,7 @@ export const zh: typeof en = {
     stepHelp: "查看当前焦点下的全部快捷键",
     stepPrefix: "打开命令菜单",
     enginesFound: "✓ 已检测到引擎:{list}",
+    enginesSignedOut: "✗ 已安装但未登录:{list}——请在 shell 里运行其中之一并完成登录",
     enginesMissing: "✗ 未找到引擎 CLI——请安装 claude、codex、copilot 或 kimi 后重启 Rove",
     gitMissing: "✗ PATH 上没有 git——Rove 需要 git 来创建 worktree",
     doctorHint: "在 shell 里运行 `rove doctor` 查看完整诊断",

--- a/packages/kobe/test/cli/api-add-parallel.test.ts
+++ b/packages/kobe/test/cli/api-add-parallel.test.ts
@@ -164,10 +164,32 @@ describe("add --count (parallel round)", () => {
       Record<string, string | undefined>
     >
     expect(creates[0].title).toBe("solo")
-    // No --title → no title in the payload: the daemon's placeholder +
-    // auto-title pass (which appends the group ordinal) owns naming.
-    expect(creates[1].title).toBeUndefined()
-    expect(creates[2].title).toBeUndefined()
+    // No --title → seeded from the prompt at creation, and the existing #i/N
+    // suffix applies to it. Without this a fan-out lands N rows all reading
+    // `(new task)`, and QUICKSTART's very next step tells the reader to
+    // compare them.
+    expect(creates[1].title).toBe("go #1/2")
+    expect(creates[2].title).toBe("go #2/2")
+  })
+
+  it("names titleless siblings from the prompt so a fan-out is comparable on return", async () => {
+    const client = fanClient()
+    const { deliver } = recordingDelivery()
+    await invokeVerb(
+      "add",
+      ["--repo", "/repo/x", "--prompt", "Try independent approaches to simplify the auth flow.", "--count", "2"],
+      { client, runtime: stubRuntime({ deliverPrompt: deliver }) },
+    )
+    const titles = client.requests
+      .filter((r) => r.name === "task.create")
+      .map((r) => (r.payload as Record<string, string | undefined>).title)
+    expect(titles).toEqual([
+      "Try independent approaches to simplify t… #1/2",
+      "Try independent approaches to simplify t… #2/2",
+    ])
+    // The defect this replaces: N rows all reading `(new task)`, indistinguishable.
+    expect(new Set(titles).size).toBe(titles.length)
+    expect(titles).not.toContain(undefined)
   })
 
   it("carries already-created taskIds when a mid-loop create fails (no orphans)", async () => {

--- a/packages/kobe/test/cli/api-cmd-run.test.ts
+++ b/packages/kobe/test/cli/api-cmd-run.test.ts
@@ -179,7 +179,9 @@ describe("runApiSubcommand", () => {
       if (name === "task.create") throw new Error("create exploded")
       return { tasks: [] }
     })
-    await expect(runApiSubcommand(["add", "--repo", "/repo/x", "--prompt", "go", "--count", "2"])).rejects.toThrow(
+    // A REAL repo path: this goes through the real ApiRuntime, whose
+    // `isUsableRepo` gate rejects a non-repo before any create is attempted.
+    await expect(runApiSubcommand(["add", "--repo", process.cwd(), "--prompt", "go", "--count", "2"])).rejects.toThrow(
       "exit(3)",
     )
     expect(stderrSpy).not.toHaveBeenCalled()

--- a/packages/kobe/test/cli/api-handler-fixtures.ts
+++ b/packages/kobe/test/cli/api-handler-fixtures.ts
@@ -72,6 +72,7 @@ export function stubRuntime(overrides: Partial<ApiRuntime> = {}): ApiRuntime {
       throw new Error("deliverPrompt should not run in this test")
     },
     resolveRepoRoot: async (path) => path,
+    isUsableRepo: async () => true,
     defaultVendor: async () => undefined,
     readWorktreeChanges: async () => ({ added: 0, deleted: 0 }),
     readBranchSignals: async () => ({ baseRef: null, ahead: null, behind: null, diff: null }),

--- a/packages/kobe/test/cli/api-handlers-more.test.ts
+++ b/packages/kobe/test/cli/api-handlers-more.test.ts
@@ -52,6 +52,7 @@ function stubRuntime(): ApiRuntime {
       throw new Error("deliverPrompt should not run in this test")
     },
     resolveRepoRoot: async (p) => p,
+    isUsableRepo: async () => true,
     defaultVendor: async () => undefined,
     readWorktreeChanges: async () => ({ added: 0, deleted: 0 }),
     readBranchSignals: async () => ({ baseRef: null, ahead: null, behind: null, diff: null }),

--- a/packages/kobe/test/cli/api-handlers.test.ts
+++ b/packages/kobe/test/cli/api-handlers.test.ts
@@ -8,6 +8,7 @@ import { join } from "node:path"
 import { afterEach, beforeEach, describe, expect, it } from "vitest"
 import { ApiError, type ApiRuntime, invokeVerb } from "../../src/cli/api-cmd.ts"
 import { resetVerifiedSelfSession, verifiedSelfSession } from "../../src/cli/api/dispatcher.ts"
+import { homeDir } from "../../src/env.ts"
 import { FakeClient, expectApiError, recordingDelivery, stubRuntime, taskFixture } from "./api-handler-fixtures.ts"
 
 // Peer provenance AND dispatcher provenance both key off the caller's own
@@ -38,7 +39,33 @@ describe("add handler", () => {
     const result = await invokeVerb("add", ["--repo", "/repo/x"], { client, runtime: stubRuntime() })
     expect(client.requestNames).toEqual(["task.create"])
     expect(client.requests[0].payload).toEqual({ repo: "/repo/x" })
-    expect(result).toEqual({ taskId: "t1", task, started: false })
+    expect(result).toEqual({ taskId: "t1", task, home: homeDir(), started: false })
+  })
+
+  it("refuses a --repo that is not a git repository instead of succeeding emptily", async () => {
+    // A task IS a worktree + branch, so a non-repo has nothing to cut one
+    // from. This used to return `ok: true` with an empty branch and an empty
+    // worktreePath, and the row persisted — the failure surfaced much later,
+    // when someone opened it and landed on an empty path.
+    const client = new FakeClient({ "task.create": () => ({ taskId: "t1", task: taskFixture() }) })
+    await expect(
+      invokeVerb("add", ["--repo", "/plain/dir"], {
+        client,
+        runtime: stubRuntime({ isUsableRepo: async () => false }),
+      }),
+    ).rejects.toThrow(/not a git repository/)
+    // Nothing was created.
+    expect(client.requestNames).toEqual([])
+  })
+
+  it("names the home it wrote to, so a collapsed isolation is visible in a success", async () => {
+    // Four fan-out tasks once landed in a production `~/.rove` behind
+    // `failures: []` because the payload never said where it had written.
+    const client = new FakeClient({ "task.create": () => ({ taskId: "t1", task: taskFixture() }) })
+    const result = (await invokeVerb("add", ["--repo", "/repo/x"], { client, runtime: stubRuntime() })) as {
+      home: string
+    }
+    expect(result.home).toBe(homeDir())
   })
 
   it("sets active only when requested", async () => {

--- a/packages/kobe/test/cli/doctor-cmd.test.ts
+++ b/packages/kobe/test/cli/doctor-cmd.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs"
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
@@ -197,11 +197,35 @@ describe("runDoctorSubcommand", () => {
     // Runnable fix shown with its exact command…
     expect(output()).toContain("will run:")
     expect(output()).toContain("daemon restart")
-    // …the dangerous remedy is print-only…
-    expect(output()).toContain("reset")
+    // …and a cold home proposes NO `reset`. Nothing here is broken: the PTY
+    // host is started on demand by the first task tab, so "no pidfile, no
+    // socket" is the normal state of a brand-new install. Doctor used to
+    // prescribe `reset` — which it describes in the same breath as not
+    // undoable and as killing every live session — to a user with nothing
+    // wrong and nothing to lose yet.
+    expect(output()).not.toContain("rove reset")
+    expect(output()).not.toContain("kobe reset")
+    expect(output()).toContain("starts on demand")
     // …and nothing ran (no TTY → no confirmations → no executions).
     expect(output()).toContain("nothing was executed")
     expect(output()).not.toContain("✓ done")
+  })
+
+  it("still proposes reset for a WEDGED pty host (live pid, dead socket)", async () => {
+    // The positive control for the cold case above: same unreachable socket,
+    // but a pidfile whose process is alive. That IS broken, and `reset` is
+    // the documented remedy.
+    mocks.request.mockRejectedValue(new Error("not running"))
+    const { defaultPtyHostPidPath } = await import("@sma1lboy/kobe-daemon/daemon/paths")
+    const pidPath = defaultPtyHostPidPath()
+    mkdirSync(join(pidPath, ".."), { recursive: true })
+    writeFileSync(pidPath, String(process.pid))
+
+    await runDoctorSubcommand(["--fix"])
+
+    expect(output()).toContain("WEDGED")
+    expect(output()).toMatch(/(rove|kobe) reset/)
+    expect(output()).not.toContain("starts on demand")
   })
 
   it("--report writes a bundle file and points the user at it", async () => {

--- a/packages/kobe/test/cli/doctor-fix.test.ts
+++ b/packages/kobe/test/cli/doctor-fix.test.ts
@@ -7,6 +7,8 @@ import {
   dedupeFixes,
   engineTabsManualFix,
   humanOnlyFix,
+  noEngineAction,
+  noEngineFix,
   resetManualFix,
   skillInstallFix,
 } from "../../src/cli/doctor-fix.ts"
@@ -110,5 +112,22 @@ describe("applyFixes", () => {
     await applyFixes([] as DoctorFix[], rt)
     expect(rt.exec).not.toHaveBeenCalled()
     expect(rt.lines.join("\n")).toContain("nothing to fix")
+  })
+
+  // The engine remedy branches on WHICH half failed. The installed-but-
+  // logged-out arm is the one a cold machine actually hits, and it used to
+  // print "install an engine CLI" directly under rows carrying those CLIs'
+  // absolute paths.
+  it("tells an installed-but-logged-out machine to log in, naming the engines", () => {
+    const fix = noEngineFix(["claude", "codex"])
+    expect(fix.kind).toBe("manual")
+    expect(noEngineAction(["claude", "codex"])).toContain("claude, codex")
+    expect(noEngineAction(["claude", "codex"])).toContain("login")
+    expect(noEngineAction(["claude", "codex"])).not.toContain("install an engine CLI")
+  })
+
+  it("still says install when nothing is on the machine at all", () => {
+    expect(noEngineAction([])).toContain("install an engine CLI")
+    expect(noEngineAction([])).not.toContain("run one of the installed")
   })
 })

--- a/packages/kobe/test/cli/onboarding.test.ts
+++ b/packages/kobe/test/cli/onboarding.test.ts
@@ -62,6 +62,7 @@ function readyEnv(): OnboardingEnvReport {
     engines: {
       lines: ["engines:", "  claude  ✓ /bin/claude — logged in (a@b.c)"],
       anyUsable: true,
+      signedOut: [],
     },
   }
 }
@@ -78,6 +79,7 @@ function emptyEnv(): OnboardingEnvReport {
     engines: {
       lines: ["engines:", "  claude  ✗ not found on PATH", "  codex   ✗ not found on PATH"],
       anyUsable: false,
+      signedOut: [],
     },
   }
 }

--- a/packages/kobe/test/engine/codex-local.test.ts
+++ b/packages/kobe/test/engine/codex-local.test.ts
@@ -64,6 +64,29 @@ describe("isSyntheticCodexUserRow", () => {
     expect(isSyntheticCodexUserRow([{ type: "text", text }])).toBe(true)
   })
 
+  // Three shapes seen in live rollouts that the old predicate missed. A miss
+  // is not silent: auto-title takes the transcript's first `role: "user"`
+  // record, so the repo's contributor rules became the task's name.
+  it("detects an AGENTS.md envelope with no `for <path>` segment", () => {
+    const text = "# AGENTS.md instructions\n<INSTRUCTIONS>\nbe terse\n</INSTRUCTIONS>"
+    expect(isSyntheticCodexUserRow([{ type: "text", text }])).toBe(true)
+  })
+
+  it("detects an AGENTS.md envelope with trailing content after </INSTRUCTIONS>", () => {
+    const text = "# AGENTS.md instructions for /repo\n<INSTRUCTIONS>\nbe terse\n</INSTRUCTIONS>\n\nmore preamble"
+    expect(isSyntheticCodexUserRow([{ type: "text", text }])).toBe(true)
+  })
+
+  it("detects a recommended_plugins envelope", () => {
+    expect(isSyntheticCodexUserRow([{ type: "text", text: "<recommended_plugins>a</recommended_plugins>" }])).toBe(true)
+  })
+
+  it("still preserves a real prompt that merely mentions the envelopes", () => {
+    expect(
+      isSyntheticCodexUserRow([{ type: "text", text: "why does <INSTRUCTIONS> show up in my task titles?" }]),
+    ).toBe(false)
+  })
+
   it("is false when a real block is mixed in with an envelope", () => {
     expect(
       isSyntheticCodexUserRow([

--- a/packages/kobe/test/render/keyboard-hints.test.tsx
+++ b/packages/kobe/test/render/keyboard-hints.test.tsx
@@ -350,11 +350,12 @@ describe("onboarding wizard — environment page and keyboard basics", () => {
     engines: {
       lines: ["engines:", "  claude  ✓ /bin/claude — logged in (a@b.c)", "  kimi    ✗ not found on PATH"],
       anyUsable: true,
+      signedOut: [],
     },
   }
   const emptyEnv = {
     git: { line: "git:      ✓ git version 2.39.5", found: true },
-    engines: { lines: ["engines:", "  claude  ✗ not found on PATH"], anyUsable: false },
+    engines: { lines: ["engines:", "  claude  ✗ not found on PATH"], anyUsable: false, signedOut: [] },
   }
 
   it("shows the environment page after the questions, then the keyboard page", async () => {

--- a/packages/kobe/test/render/welcome-pane.test.tsx
+++ b/packages/kobe/test/render/welcome-pane.test.tsx
@@ -22,7 +22,7 @@ const flushProbe = () => act(async () => {})
 describe("WelcomePane", () => {
   it("teaches the live keys and lists detected engines", async () => {
     const { frame } = await renderComponent(
-      <WelcomePane probe={probeWith({ engines: ["claude", "codex"], git: true })} />,
+      <WelcomePane probe={probeWith({ engines: ["claude", "codex"], signedOut: [], git: true })} />,
     )
     await flushProbe()
     const out = await frame()
@@ -37,8 +37,26 @@ describe("WelcomePane", () => {
     expect(out).toContain("docs.rove.run")
   })
 
+  it("says installed-but-logged-out rather than a bare ✓", async () => {
+    // The likely new-user machine: every CLI present, none signed in. This
+    // used to take the ✓ branch, contradicting the wizard on the same home.
+    const { frame } = await renderComponent(
+      <WelcomePane probe={probeWith({ engines: [], signedOut: ["claude", "codex"], git: true })} />,
+    )
+    await flushProbe()
+    const out = await frame()
+    expect(out).toContain("installed but not signed in")
+    expect(out).toContain("claude · codex")
+    expect(out).not.toContain("✓ engines")
+    // Not "install one" — the CLIs are there.
+    expect(out).not.toContain("no engine CLI found")
+    expect(out).toContain("rove doctor")
+  })
+
   it("is honest when the environment is missing pieces", async () => {
-    const { frame } = await renderComponent(<WelcomePane probe={probeWith({ engines: [], git: false })} />)
+    const { frame } = await renderComponent(
+      <WelcomePane probe={probeWith({ engines: [], signedOut: [], git: false })} />,
+    )
     await flushProbe()
     const out = await frame()
     expect(out).toContain("no engine CLI found")


### PR DESCRIPTION
Eleven items from the loop-r11 cold-start briefs. Everything below was
reproduced and re-verified on a **genuinely cold home** through the cold
harness (`.scratch/loop-r11/cold-serve.ts`), not the seeded visual fixture —
that fixture writes `onboarded`, `skillHintSeen` and `savedRepos` before the
TUI boots, so it structurally cannot render any first-run screen.

**Harness discipline:** BEFORE shots were captured against a separate
`origin/main` worktree with its own build; AFTER shots against this branch,
with the harness **restarted after every rebuild**. BEFORE/AFTER pairs for A1
and A2 use a matched `PATH` (claude, codex, kimi present, none signed in) so
the only variable is the code.

Screenshots: `/Users/jacksonc/.rove/worktrees/kobe-0aff3858ab76/rook/.scratch/loop-r11/shots/`

---

## A1 — the welcome pane claimed readiness the wizard had just denied

`welcome-pane.tsx` probed binaries on `PATH` and never read account state, so a
full list of unusable engines took the `✓` branch. It now shares `rove
doctor`'s probe (`probeableEngineIds` + `summarizeEngines` in
`engine-status.ts`) and has the third render state it was missing.

**PASS:** on a cold no-login home the pane must not print a bare `✓ engines:`,
and must agree with `rove doctor`'s `anyUsable` on the same home.

**Proof —** `A1-before-welcome-noengine.png` → `A1-after-welcome-noengine.png`:

- BEFORE: `✓ engines: claude · codex · kimi`
- AFTER: `✗ installed but not signed in: claude · codex · kimi — run one of them in a shell and log in`, plus the `rove doctor` escalation

`rove doctor` on that same home reports `anyUsable: false` (see A2 below) — the
two now agree.

**Happy path re-shot** as required: `A1-after-welcome-authenticated.png` still
reads `✓ engines: claude · codex · kimi · opencode · cursor` with no doctor hint.

Unit: `test/render/welcome-pane.test.tsx` gains the middle state.

## A2 — "install an engine CLI" printed at an installed CLI

`humanOnlyFix("noEngine")` was unconditional. Now `noEngineFix` /
`noEngineAction` branch on which half failed, and the wizard's closing banner
takes the identical branch.

**PASS:** `doctor` and the banner both name a sign-in step and do not tell the
user to install a binary whose path they just printed; with nothing installed
they still say install.

**Proof —** `A2-before-wizard-banner.png` → `A2-after-wizard-banner.png`:

- BEFORE: `→ install an engine CLI (claude, codex, copilot, or kimi) and log in`
- AFTER: `→ run one of the installed engine CLIs (claude, codex, kimi) in a shell and complete its login`

Same flip on `rove doctor --fix` (CLI transcript, matched cold homes):

```
BEFORE   no usable engine — no engine CLI is both installed and logged in
           → install an engine CLI (claude, codex, copilot, or kimi) and log in
AFTER    no usable engine — an engine CLI is installed but not signed in
           → run one of the installed engine CLIs (claude, codex, kimi) in a shell and complete its login
```

**Could NOT prove end-to-end:** the "nothing installed at all" arm. Stripping
`PATH` does not work — the built-in finders (`findClaudeBinary` etc.) locate
CLIs off `PATH` by design, so on this machine those engines genuinely *are*
installed and the login message is the honest one. Proven at the unit level
instead (`test/cli/doctor-fix.test.ts`: `noEngineAction([])` still says
install), which is the tightest available proof for that arm.

## A3 — three surfaces, three engine universes

`probeEngines` walked `listPresetIds()`, which omits the contrib catalog.
`probeableEngineIds()` is now the union of the registered presets and the
contrib engines actually on `PATH` — absent contrib engines stay out so doctor
does not grow six `✗ not found` rows for engines nobody asked about.

**PASS:** a machine whose usable CLI is a contrib engine gets a row for it
rather than "no usable engine", and QUICKSTART stops promising a shorter list
than the product offers.

**Proof —** `A3-before-wizard-env.png` → `A3-after-wizard-env.png`:

- BEFORE: 4 rows (claude/codex/copilot/kimi) and `✗ No usable engine yet — Rove needs one to run tasks.`
- AFTER: 6 rows including `opencode ✓ /opt/homebrew/bin/opencode — login not detectable` and `cursor ✓ …/cursor-agent`, verdict `✓ You're set — at least one engine is ready.`

Contrib engines correctly read `login not detectable`, not a false "no account"
(the risk the brief flagged).

QUICKSTART:7 now names the full set and points at `docs/ENGINES.md`.

**One thing this uncovered and fixed:** the wizard's inline height was a flat
`INLINE_ROWS = 20` whose own comment budgeted "~5 engine rows". Seven rows
overflowed it and the terminal scrolled, repainting over stale cells — a
visibly corrupted first screen. Isolated it (same code, 4-engine `PATH` →
clean; 6-engine `PATH` → corrupt), and the height is now derived from
`env.engines.lines`, which *is* the rendered array. The first
`A3-after-wizard-env.png` I took showed the corruption; the committed one is
after the fix.

## A4 — `rove api add` reported success without naming the home it wrote to

**PASS:** the payload carries a `home` equal to the intended home, and a broken
override shows a home the caller can see is wrong.

**Proof (CLI):**

```
BEFORE  {"count":2,"requested":2,"groupId":"…","tasks":[…],"failures":[]}
AFTER   {"count":2,"requested":2,"groupId":"…","home":"/tmp/ac-a4a/home","tasks":[…],"failures":[]}
```

Collapsed-override case: intended `/tmp/ac-a4-intended`, payload reported
`/tmp/ac-a4x/home` — the mismatch is visible in the success response. Present
on both the single and parallel paths; documented in `docs/API.md`.

## B1 — `rove doctor` told a brand-new install to run `rove reset`

The PTY branch discarded `appendUnavailableProcess`'s `"wedged" | "down"`
verdict that the daemon branch 25 lines above already reads.

**PASS:** a pristine home prints no `rove reset` line and no PTY finding; a
wedged host still gets it.

**Proof (CLI, pristine home):**

```
BEFORE  pty host: ✗ not running (no pidfile)
        manual steps — doctor prints these but never runs them:
          → rove reset
AFTER   pty host: ✗ not running (no pidfile)
                 starts on demand — the first task tab launches it; nothing to fix
        (grep for "reset" over the whole report: no matches)
```

The wedged control is a new test (`doctor-cmd.test.ts`: live pidfile +
unreachable socket → `WEDGED` and the `reset` line returns), so "no reset" can
never pass by the PTY branch simply breaking.

## B2 — the footer said `enter create` while enter walked the form

The legend was one static string; enter commits only at `confirm`.

**PASS:** the legend never claims `create` at a stop where enter advances.

**Proof —** `B2-before-dialog-open.png` → `B2-after-dialog-open.png` (dialog at
open, MODE focused): `enter create` → `enter next field`. And
`B2-after-legend-on-create.png`: after four `tab`s, focus on `[ Create ]`, the
legend reads `enter create`.

Chose the legend fix over making enter commit from a pre-filled dialog — the
comment at `view-model.ts:277` says that binding is deliberately scoped away
from text inputs, and changing it is a taste call for the owner.

## B3 — QUICKSTART claimed you could keep exploring after the wizard

Doc fix only, as instructed; `cli/index.ts` untouched. QUICKSTART now says the
first launch is setup only and ends by asking you to run `rove` again.
`A2-*-wizard-banner.png` both end in `[detached: engine exited]`, which is the
evidence.

## B4 — the fan-out example produced four indistinguishable rows

**PASS:** the documented command yields rows whose titles differ, in
`tasks.json`, immediately on return.

**Proof —** same command, matched cold homes:

```
BEFORE  '(new task)'   '(new task)'
AFTER   'Try independent approaches to simplify t… #1/2'
        'Try independent approaches to simplify t… #2/2'
```

The existing `#i/N` suffix applies to the seeded title. Verified the transcript
pass is not suppressed *wrongly*: `runAutoTitlePass` only renames
still-placeholder tasks, so a seeded title is final — correct, since it derives
from the same first user message that pass would have read back minutes later.
Tasks created without a prompt still get the placeholder and the poller still
names them.

## C1 — WORK-TRACKING pointed at the deleted browser Issues page

`grep -rn "web Issues page\|rove web" docs/` → no matches. Also fixed the same
phrase in `docs/agents/issue-tracker.md`.

---

# Added after dispatch

## Codex auto-titles took the repo's contributor rules

Extended `isSyntheticCodexUserRow` rather than adding a second predicate, per
the correction. Three gaps closed: the literal required a trailing `for `
(Codex also emits the heading bare); it required exact `\n` padding and that
the record END at `</INSTRUCTIONS>` (real rollouts append more); and
`<recommended_plugins>` had no predicate. Tests in
`test/engine/codex-local.test.ts` cover all three plus a control that a real
prompt merely *mentioning* `<INSTRUCTIONS>` is still preserved.

## A non-git `--repo` produced a broken task with no useful error

**Proof:** `rove api add --repo <plain dir>` (no prompt) BEFORE returned a
plain success whose task had `branch=''` and `worktreePath=''`, and the row
persisted. AFTER: `NOT_A_REPO` with a remedy, and no `tasks.json` is created at
all.

Put behind `ApiRuntime.isUsableRepo` rather than a direct `git` shell-out in
the handler — it asks about the same path at the same boundary as
`resolveRepoRoot`, and a direct call would make every handler test need a real
repo on disk.

## Declined

**The Issues page's "No open issues" cold state.** Separate render surface, its
own BEFORE/AFTER pair, no overlap with anything here — better in the next round
than rushed into this one.

# For the owner — not implemented, deliberately

`markOnboarded()` runs before the wizard renders, so an interrupted first
launch permanently consumes the two setup questions. The brief says this is
deliberate and defensible, so **the code is untouched**; QUICKSTART now says
the questions are asked once per machine and that an interrupted first launch
counts, and names the standalone commands. If you would rather have a
`--reonboard` flag, that is your call.

# Gates

- repo-root `bun run lint` — clean
- `bun run typecheck` — clean (4/4 packages)
- `bun run test:fast` — 4417 passed / 447 files
- `bun test test/render` — passed
- `bun scripts/check-i18n.ts` — 794 keys × 2 locales in sync

Rebased onto `origin/main` at `6ae5c50c1` (0.9.115) after #860 landed in the
same PTY branch; all gates re-run post-rebase and B1 re-verified against the
rebased build.
