### PR TITLE
fix: routines refuse config that can never work, and their docs stop describing a product that is not there

### DIFF
--- a/.changeset/routines-refuse-unusable-config.md
+++ b/.changeset/routines-refuse-unusable-config.md
@@ -1,0 +1,27 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Routines: refuse a schedule that can never work, at the moment you create it.
+
+`routine-create` accepted a repo that does not exist, a directory that is not a
+git checkout, and a `--base-branch` that resolves to nothing. All three are
+stored, listed, and then fail identically at every firing — which for a
+`0 3 * * *` routine you find out tomorrow morning. Both are now checked when
+the routine is saved, with a message naming the value; `routine-update
+--base-branch` gets the same check. Remote (`ssh://`) projects are passed
+through unprobed.
+
+`routine-update --precheck-timeout 5` on its own used to return the routine
+with its OLD timeout and no error — the flag was dropped before the call was
+built. It is now refused with `--precheck-timeout requires --precheck`.
+
+The Routines composer's repo picker offers your saved projects, not just the
+repos your existing tasks sit in, so a project you have added but not yet
+opened a task in can be scheduled.
+
+`Automation.lastRunAt` is renamed `lastOccurrenceAt`. It was never the last
+run: it is the occurrence the sweep consumed, stamped before dispatch and set
+for skips too, so a routine that had only ever recorded `skipped_unavailable`
+still reported a `lastRunAt` in `routine-list`. Existing `automations.json`
+files keep their value.

--- a/docs/ROUTINES.md
+++ b/docs/ROUTINES.md
@@ -80,6 +80,16 @@ Reply via `rove api send --task-id $ROVE_TASK_ID` with what changed overnight.
 EOF
 ```
 
+`--repo` and `--base-branch` are checked when the routine is saved, not when it
+fires: a path that is not a git repository, or a base ref that does not resolve
+in it, is refused with a message naming the value. The check is not a guarantee
+— a repo deleted after the routine was saved still fails at 03:00 — it just
+catches the typo while you are still at the keyboard.
+
+`--precheck-timeout` only means something alongside `--precheck`; on its own it
+is refused rather than quietly ignored. To change just the timeout, pass the
+command again.
+
 Full flag list: `rove api schema --group routine`, or [rove api](API.md).
 
 ## Reading the page

--- a/docs/design/automations.md
+++ b/docs/design/automations.md
@@ -187,11 +187,14 @@ says whether an enabled automation is currently holding the daemon open.
 its precheck), `d` deletes, `enter` opens the task from the most recent run,
 `r` refreshes.
 
-`n` runs four single-field prompts in sequence (name → repo → prompt →
-schedule) rather than one multi-field form: the rename dialog already does a
-labelled field with validation, and four strings did not justify a new widget.
-Cancelling any step aborts. A precheck is CLI-only — it is the one field that
-is genuinely optional.
+`n` opens ONE card with Tab between its four fields (name → repo → prompt →
+schedule), replacing the four chained single-field prompts it started as. A
+schedule is a set of decisions you make together — the cron you want depends on
+what the prompt does — and a chain of prompts has no way back to reconsider a
+step. The schedule field carries a live preview ("weekdays at 09:00 · in 23h"),
+because cron is the one input you cannot verify by re-reading it. The repo
+picker offers your saved projects; `esc` aborts the whole card. A precheck is
+CLI-only — it is the one field that is genuinely optional.
 
 ## CLI
 
@@ -208,17 +211,36 @@ rove api routine-set-enabled --id <id> --enabled false
 rove api routine-delete --id <id>
 ```
 
-Full flag list: `rove api schema --group automation`.
+Full flag list: `rove api schema --group routine`. (The group is named for the
+UI vocabulary, not the on-disk `automation` one.)
 
 ## Prompt delivery
 
-The prompt rides the engine's **own argv** via
-`buildEngineSessionLaunch`'s `promptIntent: {kind: "explicit"}` — it is part of
-the spawn, not a paste that follows it. A cold engine TUI can swallow a raced
-paste, and an unattended run has nobody watching to retype it.
+The prompt rides the engine's **own argv** via `taskEngineLaunch`'s
+`promptIntent` — it is part of the spawn, not a paste that follows it. A cold
+engine TUI can swallow a raced paste, and an unattended run has nobody watching
+to retype it.
+
+The intent is `{kind: "new-task", prompt}`, not `explicit`: the runner creates
+the task immediately ahead of this call, so the firing's first prompt gets the
+branch-rename coda every other new-worktree entry point gets
+([`daemon-session-adapter.ts`](../../packages/kobe/src/core/daemon-session-adapter.ts)).
+Paste-delivery vendors (kimi) are the exception — their prompt rides outside
+argv and is typed once the engine is up.
 
 ## Not implemented
 
-- Reusing an existing task instead of creating one per run
+- **Quota awareness.** A firing consults nothing about the vendor's rate limit.
+  Measured, three firings of a `* * * * *` routine on an exhausted vendor: three
+  tasks, three worktrees, three `dispatched` rows, and a `quotaResume` armed on
+  the first throwaway task for five days out — a task nobody will read, woken by
+  a timer, in a branch nobody will land. The run history says the routine is
+  healthy. A fix is a STATUS, not a scheduler: ask the quota cache's
+  `exhaustedResetAtMs` before dispatch and record a distinct run naming the
+  reset time instead of spawning. That needs `QuotaUsageCache` threaded into
+  `RunnerDeps` (the sweep holds no reference to it today) and a new row in the
+  run-status table above, which is a vocabulary call. Rescheduling the routine
+  ONTO the reset is a separate, larger question — a routine that fires hourly
+  does not want a backlog of eight deferred turns at 07:00.
 - Timezones (the daemon host's local time)
 - Cost attribution per run, remote/SSH execution targets

--- a/packages/kobe-daemon/src/daemon/automation-contracts.ts
+++ b/packages/kobe-daemon/src/daemon/automation-contracts.ts
@@ -66,7 +66,18 @@ export interface Automation {
   readonly nextRunAt: string
   /** How late a missed occurrence may still run. Older ones are skipped. */
   readonly missedRunGraceMinutes: number
-  readonly lastRunAt?: string
+  /**
+   * The scheduled time of the most recent occurrence the sweep CONSUMED —
+   * stamped by `advanceNextRun` before the dispatch is even attempted, so it
+   * is set for skips and failures exactly as it is for successes.
+   *
+   * Named for what it is. As `lastRunAt` it was in the `automation.list`
+   * payload claiming a run had happened for routines that had only ever
+   * recorded `skipped_unavailable`, which is the one conclusion that makes a
+   * reader stop looking. "When did it last actually run, and what happened" is
+   * `automation.runs`, which answers with a status attached.
+   */
+  readonly lastOccurrenceAt?: string
   readonly createdAt: string
   readonly updatedAt: string
 }

--- a/packages/kobe-daemon/src/daemon/automation-repo-check.ts
+++ b/packages/kobe-daemon/src/daemon/automation-repo-check.ts
@@ -1,0 +1,68 @@
+/**
+ * Refuse a routine whose repo or base ref cannot work — at CREATE time, while
+ * the user is present to fix it.
+ *
+ * Same reasoning as `requireSchedule` in `handlers-automations.ts`: an
+ * unusable value that is only discovered by watching the schedule not run is
+ * the expensive kind of wrong. A missing repo or an unresolvable base ref
+ * fails identically at every firing (`skipped_unavailable`, from
+ * `git worktree add`), and for a `0 3 * * *` routine the user finds out
+ * tomorrow morning — a day after the moment they could have typed the right
+ * path.
+ *
+ * What this is NOT: a guarantee. The repo is checked when the routine is
+ * saved, not when it fires; a repo deleted or a branch renamed afterwards
+ * still fails at 3am. Catching the typo the user just made is the whole claim.
+ *
+ * Deliberately here rather than in the CLI verb: the TUI composer calls
+ * `automation.create` too, and a check in one caller only covers that caller.
+ */
+
+import { execFile } from "node:child_process"
+import { stat } from "node:fs/promises"
+import { promisify } from "node:util"
+
+const execFileAsync = promisify(execFile)
+
+/** A remote project key (`ssh://…`) names a checkout on ANOTHER host, so there
+ *  is nothing local to probe — passing it through is the only correct answer,
+ *  and rejecting valid input is worse than the gap it would close. */
+function isProbeable(repo: string): boolean {
+  return !repo.startsWith("ssh://")
+}
+
+async function isGitWorkTree(repo: string): Promise<boolean> {
+  try {
+    const { stdout } = await execFileAsync("git", ["-C", repo, "rev-parse", "--is-inside-work-tree"])
+    return stdout.trim() === "true"
+  } catch {
+    return false
+  }
+}
+
+/** Throw unless `repo` is a directory holding a git work tree. */
+export async function assertRoutineRepo(repo: string): Promise<void> {
+  if (!isProbeable(repo)) return
+  const entry = await stat(repo).catch(() => null)
+  if (!entry?.isDirectory()) throw new Error(`repo does not exist: ${repo}`)
+  if (!(await isGitWorkTree(repo))) throw new Error(`not a git repository: ${repo}`)
+}
+
+/**
+ * Throw unless `ref` resolves to a commit in `repo` — the same question
+ * `git worktree add -b <branch> <ref>` asks at every firing.
+ *
+ * A repo that is not a probeable work tree is a PASS, not a failure: on the
+ * update path the repo cannot be changed, so failing here would make a routine
+ * with a bad repo also unable to accept a corrected base ref, and the message
+ * would name a problem the user was not editing.
+ */
+export async function assertRoutineBaseRef(repo: string, ref: string): Promise<void> {
+  if (!ref || !isProbeable(repo)) return
+  if (!(await isGitWorkTree(repo))) return
+  try {
+    await execFileAsync("git", ["-C", repo, "rev-parse", "--verify", "--quiet", `${ref}^{commit}`])
+  } catch {
+    throw new Error(`base branch does not resolve in ${repo}: ${ref}`)
+  }
+}

--- a/packages/kobe-daemon/src/daemon/automations-store.ts
+++ b/packages/kobe-daemon/src/daemon/automations-store.ts
@@ -54,6 +54,10 @@ function normalizeAutomation(value: unknown): Automation | null {
   if (!Number.isFinite(Date.parse(nextRunAt))) return null
 
   const precheckCommand = str(raw.precheck?.command)
+  // `lastRunAt` is the pre-rename spelling on disk (the field claimed a run
+  // had happened for occurrences that only ever skipped). Read it so an
+  // existing automations.json carries its value across the rename.
+  const lastOccurrenceAt = str(raw.lastOccurrenceAt ?? (value as { lastRunAt?: unknown }).lastRunAt)
   const grace = raw.missedRunGraceMinutes
   const now = new Date().toISOString()
   return {
@@ -80,7 +84,7 @@ function normalizeAutomation(value: unknown): Automation | null {
     ...(str(raw.baseRef) ? { baseRef: raw.baseRef } : {}),
     ...(raw.persistentSession === true ? { persistentSession: true } : {}),
     ...(str(raw.sessionTaskId) ? { sessionTaskId: raw.sessionTaskId } : {}),
-    ...(str(raw.lastRunAt) ? { lastRunAt: raw.lastRunAt } : {}),
+    ...(lastOccurrenceAt ? { lastOccurrenceAt } : {}),
     createdAt: str(raw.createdAt) ?? now,
     updatedAt: str(raw.updatedAt) ?? now,
   }
@@ -292,9 +296,10 @@ export class AutomationsStore {
   }
 
   /**
-   * Move the schedule past `afterMs` and stamp `lastRunAt`. Called BEFORE the
-   * run is dispatched so an overlapping sweep can never fire the same
-   * occurrence twice.
+   * Move the schedule past `afterMs` and stamp `lastOccurrenceAt`. Called
+   * BEFORE the run is dispatched so an overlapping sweep can never fire the
+   * same occurrence twice — which is also why the stamp is the occurrence's
+   * SCHEDULED time and says nothing about whether the run then succeeded.
    */
   async advanceNextRun(id: string, afterMs: number): Promise<Automation | null> {
     return await this.enqueue(async () => {
@@ -310,12 +315,12 @@ export class AutomationsStore {
         // once-only date now in the past) must not wedge the sweep on a
         // permanently-due row: disable it and surface it in `automation-list`.
         logDaemonError("automations-advance", err)
-        const disabled: Automation = { ...current, enabled: false, lastRunAt: iso, updatedAt: iso }
+        const disabled: Automation = { ...current, enabled: false, lastOccurrenceAt: iso, updatedAt: iso }
         this.automations = this.automations.map((a, i) => (i === index ? disabled : a))
         await this.commit()
         return disabled
       }
-      const next: Automation = { ...current, nextRunAt, lastRunAt: iso, updatedAt: iso }
+      const next: Automation = { ...current, nextRunAt, lastOccurrenceAt: iso, updatedAt: iso }
       this.automations = this.automations.map((a, i) => (i === index ? next : a))
       await this.commit()
       return next

--- a/packages/kobe-daemon/src/daemon/handlers-automations.ts
+++ b/packages/kobe-daemon/src/daemon/handlers-automations.ts
@@ -1,5 +1,6 @@
 /** Automation CRUD + manual-trigger RPC handlers. */
 
+import { assertRoutineBaseRef, assertRoutineRepo } from "./automation-repo-check.ts"
 import { runAutomationOnce } from "./automation-runner.ts"
 import type { AutomationPatch, AutomationPrecheck } from "./contracts.ts"
 import { isValidCron } from "./cron.ts"
@@ -63,15 +64,22 @@ export const AUTOMATION_HANDLERS: readonly DaemonRequestHandler[] = [
     name: "automation.create",
     async handle(payload, ctx) {
       const precheck = readPrecheck(payload)
+      const repo = requireString(payload, "repo")
+      const baseRef = optionalString(payload, "baseRef")
+      // Before persisting, not after the first firing: a routine that can
+      // never resolve its worktree is a row the user cannot tell from a
+      // healthy one until it has already failed unattended.
+      await assertRoutineRepo(repo)
+      if (baseRef) await assertRoutineBaseRef(repo, baseRef)
       const automation = await ctx.automations.create({
         name: requireString(payload, "name"),
-        repo: requireString(payload, "repo"),
+        repo,
         prompt: requireString(payload, "prompt"),
         schedule: requireSchedule(payload, "schedule"),
         missedRunGraceMinutes: readGraceMinutes(payload) ?? 60,
         ...(optionalVendor(payload, "vendor") ? { vendor: optionalVendor(payload, "vendor") } : {}),
         ...(precheck ? { precheck } : {}),
-        ...(optionalString(payload, "baseRef") ? { baseRef: optionalString(payload, "baseRef") } : {}),
+        ...(baseRef ? { baseRef } : {}),
         ...(optionalBoolean(payload, "persistentSession") === true ? { persistentSession: true } : {}),
         ...(optionalBoolean(payload, "enabled") !== undefined ? { enabled: optionalBoolean(payload, "enabled") } : {}),
       })
@@ -84,6 +92,12 @@ export const AUTOMATION_HANDLERS: readonly DaemonRequestHandler[] = [
     name: "automation.update",
     async handle(payload, ctx) {
       const id = requireString(payload, "id")
+      // A base ref set here is as permanently fatal as one set at create, and
+      // `--base-branch ''` (clear) has nothing to check. The repo is not
+      // patchable, so it is validated only where it is chosen.
+      const nextBaseRef = "baseRef" in payload ? optionalString(payload, "baseRef") : undefined
+      const currentRepo = ctx.automations.get(id)?.repo
+      if (nextBaseRef && currentRepo) await assertRoutineBaseRef(currentRepo, nextBaseRef)
       const patch: AutomationPatch = {
         ...(optionalString(payload, "name") !== undefined ? { name: optionalString(payload, "name") } : {}),
         ...(optionalString(payload, "prompt") !== undefined ? { prompt: optionalString(payload, "prompt") } : {}),

--- a/packages/kobe/src/cli/api/verbs-automations.ts
+++ b/packages/kobe/src/cli/api/verbs-automations.ts
@@ -16,7 +16,7 @@
 import { F } from "./flags.ts"
 import { simpleRpc } from "./handler-helpers.ts"
 import { requirePromptText } from "./handlers-tasks.ts"
-import type { VerbSpec } from "./types.ts"
+import { ApiError, type VerbSpec } from "./types.ts"
 
 const SCHEDULE_FLAG = {
   name: "schedule",
@@ -64,9 +64,24 @@ const PERSISTENT_FLAG = {
  * nothing to clear). The flag must be read with {@link VerbArgs.present}, not
  * `str`: `str` folds an empty value into "absent", so `--precheck ''` would
  * otherwise omit the field and silently leave the existing precheck in place.
+ *
+ * `--precheck-timeout` on its own is REFUSED rather than dropped. The daemon
+ * stores the precheck as one record, so a timeout with no command has nothing
+ * to attach to — and silently omitting it made `routine-update
+ * --precheck-timeout 5` return the routine with its OLD timeout and no error,
+ * i.e. report a change it had not made. Retyping the command is the price of
+ * the call meaning what it says.
  */
 function precheckPayload(ctx: Parameters<VerbSpec["handler"]>[0]): Record<string, unknown> {
-  if (!ctx.args.present("precheck")) return {}
+  if (!ctx.args.present("precheck")) {
+    if (ctx.args.present("precheck-timeout")) {
+      throw new ApiError(
+        "--precheck-timeout requires --precheck (pass the command again to change its timeout)",
+        "BAD_FLAG",
+      )
+    }
+    return {}
+  }
   const command = ctx.args.str("precheck")
   if (command === undefined) return { precheck: null }
   return { precheck: { command, timeoutSeconds: ctx.args.int("precheck-timeout") ?? 120 } }

--- a/packages/kobe/src/tui-react/component/automations-page.tsx
+++ b/packages/kobe/src/tui-react/component/automations-page.tsx
@@ -20,6 +20,7 @@ import type { Automation, AutomationRun } from "@sma1lboy/kobe-daemon/daemon/con
 import { type ReactNode, useEffect, useState } from "react"
 import type { RemoteOrchestrator } from "../../client/remote-orchestrator"
 import { errorMessage } from "../../lib/error-message"
+import { getSavedRepos } from "../../state/repos"
 import { clampCursor } from "../../tui/component/new-task-dialog/state"
 import { useNotifications } from "../context/notifications"
 import { useTheme } from "../context/theme"
@@ -188,7 +189,12 @@ export function AutomationsPage(props: {
   async function createAutomation(): Promise<void> {
     const orch = props.orchestrator
     if (!orch || busyId) return
-    const repos = [...new Set(orch.listTasks().map((task) => task.repo))].filter(Boolean)
+    // Saved projects UNION the repos tasks happen to sit in — the same set the
+    // New-task dialog offers (`use-repo-field.ts`) and the "scrolling picker
+    // over your projects" `docs/ROUTINES.md` promises. Task repos alone hid a
+    // project you had saved but never opened a task in, so the one repo you
+    // could not schedule was the one you had just added.
+    const repos = [...new Set([...getSavedRepos(), ...orch.listTasks().map((task) => task.repo)])].filter(Boolean)
     if (repos.length === 0) {
       setNotice(t("automations.needRepo"))
       return

--- a/packages/kobe/test/daemon/automation-repo-check.test.ts
+++ b/packages/kobe/test/daemon/automation-repo-check.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest"
+import { assertRoutineBaseRef, assertRoutineRepo } from "../../../kobe-daemon/src/daemon/automation-repo-check.ts"
+
+// The local paths are proved end to end against a real daemon (`routine-create
+// --repo /nonexistent` errors, a real repo still works). What no end-to-end run
+// on this machine can reach is the REMOTE branch: an `ssh://` project key names
+// a checkout on another host, so there is nothing here to stat or ask git
+// about, and a validator that rejected it would break the one input shape
+// `requireRepo` goes out of its way to pass through verbatim.
+describe("routine repo validation", () => {
+  it("passes a remote project key through without probing the filesystem", async () => {
+    await expect(assertRoutineRepo("ssh://me@host/srv/repo")).resolves.toBeUndefined()
+    await expect(assertRoutineBaseRef("ssh://me@host/srv/repo", "nosuchbase")).resolves.toBeUndefined()
+  })
+
+  it("rejects a local path that is not there", async () => {
+    await expect(assertRoutineRepo("/nonexistent/r12ae-no-such-repo")).rejects.toThrow(
+      "repo does not exist: /nonexistent/r12ae-no-such-repo",
+    )
+  })
+})

--- a/packages/kobe/test/daemon/automations-roundtrip-fields.test.ts
+++ b/packages/kobe/test/daemon/automations-roundtrip-fields.test.ts
@@ -42,7 +42,7 @@ const FULL: Omit<DeepRequired<Automation>, "id" | "nextRunAt" | "createdAt" | "u
   sessionTaskId: "01ARZ3NDEKTSV4RRFFQ69G5FAV",
   enabled: true,
   missedRunGraceMinutes: 15,
-  lastRunAt: "2026-07-30T09:00:00.000Z",
+  lastOccurrenceAt: "2026-07-30T09:00:00.000Z",
 }
 
 /** Every patch key, each with a value that differs from FULL. `null` keys are

--- a/packages/kobe/test/daemon/automations-store.test.ts
+++ b/packages/kobe/test/daemon/automations-store.test.ts
@@ -143,7 +143,36 @@ describe("AutomationsStore", () => {
     const advanced = await store.advanceNextRun(created.id, fired)
     // Strictly-after, or the sweep would re-fire the same occurrence forever.
     expect(Date.parse(advanced?.nextRunAt ?? "")).toBeGreaterThan(fired)
-    expect(advanced?.lastRunAt).toBe(new Date(fired).toISOString())
+    expect(advanced?.lastOccurrenceAt).toBe(new Date(fired).toISOString())
+  })
+
+  it("reads a pre-rename lastRunAt as lastOccurrenceAt", async () => {
+    const t = tempStore()
+    // The field was renamed because it never meant "last run" — it is the
+    // occurrence the sweep consumed, stamped before dispatch and set for
+    // skips too. A file written by an older Rove must keep its value.
+    writeFileSync(
+      t.path,
+      JSON.stringify({
+        version: 1,
+        automations: [
+          {
+            id: "legacy",
+            name: "n",
+            repo: "/r",
+            prompt: "p",
+            schedule: "0 9 * * *",
+            nextRunAt: "2026-08-01T09:00:00.000Z",
+            enabled: true,
+            lastRunAt: "2026-07-30T09:00:00.000Z",
+          },
+        ],
+        runs: [],
+      }),
+    )
+    store = t.store
+    await store.init()
+    expect(store.get("legacy")?.lastOccurrenceAt).toBe("2026-07-30T09:00:00.000Z")
   })
 
   it("disables an automation whose stored schedule can no longer resolve", async () => {


### PR DESCRIPTION
Batch C + D of loop-r12's routines brief. Batches A and B (run-history recording, the Inbox path, the Routines list row) belong to another worker and are untouched here.

One idea runs through C: **the product accepted input it already knew it could not honour**, and recorded the failure at 3am instead of refusing it while the user was watching.

Every proof below was run against an isolated home (`.scratch/loop-r12-ae/home`, every `ROVE_/KOBE_` isolation var inlined as a separate assignment), with a sentinel engine registered as `engineCommand.claude` so "the prompt reached an engine" is provable from a file.

---

## C1 + C4 — a repo or base branch that can never resolve

**PASS:** `routine-create --repo /nonexistent` (and a non-git directory, and a `--base-branch` that resolves to nothing) errors with a message naming the value, and nothing is written to `automations.json`; a real repo and a real base branch are unchanged.

Validated in `automation.create`, not in the CLI verb — the TUI composer calls the same RPC, and a check in one caller only covers that caller. `routine-update --base-branch` gets the same check against the stored repo. Remote (`ssh://`) project keys are passed through unprobed: there is no local checkout to stat, and rejecting them would break the one input shape `requireRepo` goes out of its way to preserve.

```
======== C1 BAD: nonexistent repo ========
{"error":{"message":"repo does not exist: /tmp/r12ae-gone-nowhere","code":"RPC_ERROR"}}
======== C1 BAD: exists, not a git repo ========
{"error":{"message":"not a git repository: /tmp/r12ae-notgit","code":"RPC_ERROR"}}
======== C4 BAD: unresolvable base branch ========
{"error":{"message":"base branch does not resolve in .../loop-r12-ae/repo: nosuchbase","code":"RPC_ERROR"}}
======== C1/C4 GOOD: real repo, real base branch ========
{"automation":{"name":"good2", ... "baseRef":"main","enabled":false, ...}}
======== nothing bad was persisted ========
['gone-repo', 'notgit', 'basebr', 'good', 'clamp', 'neverruns', 'good2']
```

(the first four names are the pre-fix baseline captured on `db3119663`, which is what the old build let through; `gone2`/`notgit2`/`basebr2` from the post-fix run are absent)

Update path, both directions:

```
======== C4 update BAD base branch ========
{"error":{"message":"base branch does not resolve in .../loop-r12-ae/repo: nosuchbase","code":"RPC_ERROR"}}
======== C4 update GOOD base branch, and '' clears ========
baseRef= main
baseRef= None
```

**Not a guarantee, and said so in the docs.** A repo that exists now can be gone at firing time. The claim is only that the typo is caught while the user is still at the keyboard.

## C2 — `--precheck-timeout` alone was a silent no-op

**PASS:** it either changes the stored timeout or fails; `--precheck` + `--precheck-timeout` still sets both.

Refused rather than merged: the daemon stores the precheck as one record, so a timeout with no command has nothing to attach to, and a merge would need the store's current value threaded into the patch for one flag. Retyping the command is the price of the call meaning what it says.

```
======== C2 BAD: --precheck-timeout alone (update) ========
{"error":{"message":"--precheck-timeout requires --precheck (pass the command again to change its timeout)","code":"BAD_FLAG"}}
======== C2 BAD: --precheck-timeout alone (create) ========
{"error":{"message":"--precheck-timeout requires --precheck (pass the command again to change its timeout)","code":"BAD_FLAG"}}
======== C2 GOOD: both flags together ========
{'command': 'true', 'timeoutSeconds': 5}
======== C2 GOOD: --precheck alone still defaults to 120 ========
{'command': 'echo hi', 'timeoutSeconds': 120}
======== C2 GOOD: --precheck '' still clears ========
precheck= None
```

## C3 — the composer's repo picker could not see a saved project

`AutomationsPage.createAutomation` built its list from `orch.listTasks()`; the New-task dialog uses `getSavedRepos()`. A project you have saved but never opened a task in was offered by one dialog and invisible to the other, while `docs/ROUTINES.md` calls the field "a scrolling picker over your projects". Now the union, the same shape `use-scratch-adopt.ts` already uses.

**PASS:** with a saved project that has zero tasks, `n` on the Routines page offers it.

Harness (`/harness` → xterm.js → PTY sidecar → real OpenTUI, port base 5873), same keys both times (`ctrl+a 2` → `n` → `tab`), with `no-task-project` added to the fixture's `savedRepos` and no task in it:

- BEFORE (on `db3119663`, captured before any edit): `/Users/jacksonc/.rove/worktrees/kobe-0aff3858ab76/guineafowl/.scratch/loop-r12-ae/shots/c3-before.png` — REPO picker lists `fixture-repo` only.
- AFTER: `/Users/jacksonc/.rove/worktrees/kobe-0aff3858ab76/guineafowl/.scratch/loop-r12-ae/shots/c3-after.png` — lists `fixture-repo` and `no-task-project`; the card grows one row, nothing else moves.

**Could not prove by running:** that the `automations.needRepo` empty state still appears when there are genuinely no projects. The harness fixture always has a repo and emptying it breaks its readiness marker. The condition is unchanged (`repos.length === 0` on the union of two sets, empty exactly when both are), so this is set algebra rather than an untested branch — but it is not a screenshot.

## A3 — `lastRunAt` decision: **renamed to `lastOccurrenceAt`**

Not deleted, not given a reader. What it stamps is the `scheduledFor` of the occurrence the sweep consumed, written by `advanceNextRun` *before* dispatch is attempted (deliberately, so a crash cannot double-fire) — so it is set for skips and failures exactly as for successes. The name was the only thing wrong with it.

- **Not deleted**, because it is the only surviving record of which occurrence has been consumed once run history prunes at 100 — and because batch A's cheapest option for the dropped-occurrence bug (A1 fix direction 3) reads exactly this field. Removing it would take away their input.
- **Not given a reader**, because `automation.runs` already answers "when did it last run, and what happened" with a status attached, which is strictly better. A second, weaker answer to the same question is what made this a lie in the first place.

Measured on a routine whose every firing was `skipped_precheck`:

```
neverruns lastRunAt= None lastOccurrenceAt= 2026-09-04T10:06:00.000Z
6 skipped_precheck sched=2026-09-04T10:06:00.000Z
5 skipped_precheck sched=2026-09-04T10:05:00.000Z
```

Same value, no longer claiming a run happened. A pre-rename file keeps its value — proved by hand-seeding `lastRunAt` into `automations.json` and restarting the daemon:

```
seeded legacy lastRunAt on 'good'
good → lastRunAt= None lastOccurrenceAt= 2026-07-30T09:00:00.000Z
```

pinned by a store test (`reads a pre-rename lastRunAt as lastOccurrenceAt`).

## B3 — quota: **established and written down, deliberately not built**

Scoped out: any code change. A `skipped_quota` status needs a row in the run-status table (a vocabulary call the owner makes) and `QuotaUsageCache` threaded into `RunnerDeps` + `collectors.ts` — files batch A/B is editing right now. Rescheduling onto the reset is a retry system and explicitly out of scope.

What I did instead is stop inferring it. **Measured**, with a sentinel engine and a `* * * * *` routine:

```
======== engine really started (sentinel log) ========
=== 2026-09-04T10:09:56Z cwd=.../worktrees/repo-bac837473164/chinchilla
argv: P-QUOTA
=== 2026-09-04T10:10:55Z cwd=.../worktrees/repo-bac837473164/hammerhead
argv: P-QUOTA
======== the engine reports it is rate-limited ========
{}
======== task state after the rate_limit report ========
status= backlog activity= None quotaResume= {'resumeAt': '2026-09-09T10:00:00.404Z', ...}
======== the routine keeps firing anyway ========
3 dispatched task=01M1NYEHJE7PT6T7DDM85E6EYA
2 dispatched task=01M1NYCQ1CR5HRNTM0VAHK2JYM
1 dispatched task=01M1NYAWHC7RCBEFRK8GQG28BT
distinct tasks: 3
======== worktrees spent ========
anteater  chinchilla  hammerhead
```

So: three firings into an exhausted vendor spend three tasks and three worktrees, record `dispatched` three times, and arm a durable `quotaResume` **on the first throwaway task** for five days out — a task nobody will read, woken by a timer, in a branch nobody will land. The run history says the routine is healthy. Structurally, `RunnerDeps` holds no reference to the quota cache at all, which is why.

That trace is now in `docs/design/automations.md` under **Not implemented**, with what a fix would take.

## D — four stale claims in `docs/design/automations.md`

Every command in the file was run as written. Only one failed:

| Was | Now |
|---|---|
| `rove api schema --group automation` — `unknown group: automation` | `--group routine` (verified: lists the 7 routine verbs) |
| "Not implemented — Reusing an existing task instead of creating one per run" | replaced; `--persistent-session` does exactly this and the same file documents it at :60-104 |
| `promptIntent: {kind: "explicit"}` | `{kind: "new-task", prompt}` — `daemon-session-adapter.ts:91-96`, with the comment's reason |
| "`n` runs four single-field prompts in sequence" | one card, Tab between fields, live schedule preview |

The other five commands (`routine-create` with the doc's own precheck, `routine-list`, `routine-runs`, `routine-run-now`, `routine-set-enabled`, `routine-delete`) all ran clean as written.

`docs/ROUTINES.md` gets the two new CLI rules (create-time validation; `--precheck-timeout` needs `--precheck`) in the same PR. Its `--precheck-timeout ... runs as 600` claim was checked and is **correct** — the clamp is at run time in `automation-precheck.ts`, not at store time, so 900 is stored and 600 is used.

---

## Gates

`bun run lint`, `bun run typecheck`, `bun run test:socket` (792 passed), `bun run test:fast` (4422 passed), all on `origin/main` @ `17ead733c`.

One thing I could not name: the **first** `test:socket` run after the rebase reported `1 failed | 791 passed` and I did not capture the test's name before the output scrolled. Three consecutive full re-runs were clean (792/792), as was `test:fast`. I am flagging it rather than calling it a flake I proved.

## Keybindings

No new or moved chords.
