### PR TITLE
fix: undo a task-index mutation whose save failed, and claim the home

### DIFF
--- a/.changeset/store-rollback-and-home-claim.md
+++ b/.changeset/store-rollback-and-home-claim.md
@@ -1,0 +1,37 @@
+---
+"@sma1lboy/rove": patch
+---
+
+A task index mutation that reported failure no longer lands on disk minutes
+later. `create`/`update`/`move` apply to the in-memory cache first and persist
+second, and never undid the cache change when the write failed — so the id
+stayed dirty and the next unrelated successful save flushed it. Measured, with
+the index lock held past the 5s deadline: `rove api rename` exited 1 while
+`get-task` reported the new title, and one unrelated `rove add` later disk
+carried it too; a `rove add` that exited 1 was listed immediately and appeared
+on disk the same way. For `add --prompt` that is a task materialising after the
+caller gave up, with no worktree, no branch and no engine. Now the failed
+mutation is reverted and the caller's error is the whole story: the same runs
+report exit 1, the old title everywhere, and a disk count that moves by one
+instead of two.
+
+Two smaller halves of the same disagreement, in the same file. A store never
+dropped a task a peer deleted: the merge correctly omitted it from the bytes
+but folded the result into the cache additively, so the process listed a
+phantom row forever and kept writing a file without it — the eviction is now
+part of the fold, and subscribers hear about it. And `store.remove()` on an id
+the cache never saw returned `void`, making "deleted" and "there was nothing
+here" the same answer; it returns a boolean. It still does not throw the way
+`update`/`move` do, because the daemon replays a queued deletion after a
+restart and a replay finding nothing is success.
+
+Rove also refuses to start a second daemon on a home another daemon already
+serves, naming the socket that owns it. The daemon singleton is keyed on the
+socket path, not the home, and the ownership guard watches only its own path —
+so overriding `ROVE_DAEMON_SOCKET_PATH` while leaving `ROVE_HOME_DIR` alone
+(what the harness and capture isolation recipes do) put two daemons on one
+state root, each invisible to the other. Their task lists diverged permanently,
+the project-main row was written twice, and `automations.json` and
+`.config/rove/state.json` were raced as well. The claim lives in
+`<home>/.rove/daemon.owner`; liveness is decided by asking the recorded socket,
+not by trusting a pid, so a crashed daemon's claim never blocks a restart.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -225,6 +225,34 @@ the restart instead of unsetting it. Do not point two homes at one daemon
 socket: the server refuses a live takeover, and clients reject the wrong
 owner.
 
+## Rove refuses to start a second daemon on one home
+
+The mirror of the case above: two socket paths, one state home. Rove refuses
+the second daemon and names the socket that already owns the home.
+
+```
+rove daemon: /Users/me is already served by the daemon on
+/Users/me/.rove/daemon.sock (pid 61439) — refusing to start a second daemon on
+one home.
+```
+
+This happens when a shell overrides `ROVE_DAEMON_SOCKET_PATH` but leaves
+`ROVE_HOME_DIR` pointing at a home another daemon is already serving. Letting
+both run is worse than the refusal: neither can see the other, so their task
+lists diverge permanently, the project-main row gets written twice, and
+`automations.json` and `.config/rove/state.json` are raced as well.
+
+Either stop the incumbent, or give the new daemon its own home:
+
+```bash
+rove daemon stop                       # from the incumbent's environment
+# …or, to run both:
+export ROVE_HOME_DIR=/path/to/other-home
+```
+
+A crashed daemon's claim never blocks a restart: the check asks the recorded
+socket whether anything still answers there, so a dead one is just replaced.
+
 ## Claude or Codex activity badges do not update
 
 Rove installs its own merge-safe, global activity hooks when the TUI launches:

--- a/docs/design/daemon.md
+++ b/docs/design/daemon.md
@@ -224,6 +224,21 @@ TUI may show any task at any time.
 >   serving another home's data silently corrupts what the user sees. The
 >   reconnect loop keeps retrying, so re-syncing needs no TUI restart. A daemon
 >   predating the field omits it and is never falsely rejected.
+>
+> **One home, two sockets (2026-09-04):** both guards above defend one socket
+> against the wrong home. The inverse — one home behind two sockets — had
+> nothing watching it, because the singleton is keyed on the socket path and
+> `socket-guard.ts` watches only its own. Override `*_DAEMON_SOCKET_PATH` while
+> leaving `*_HOME_DIR` alone (what the harness and capture isolation recipes
+> do) and two daemons serve one state root, invisible to each other: their task
+> lists diverge permanently, `ensureMainTask` writes the project-main row
+> twice, and `automations.json` and `.config/rove/state.json` race as well — so
+> a lock around the task index would not have been enough. `home-owner.ts`
+> claims the home in `<home>/.rove/daemon.owner` as `pid:socketPath`; a boot
+> that finds a claim naming a DIFFERENT socket asks that socket whether anyone
+> still answers there, and refuses with the incumbent's path if so. Liveness is
+> the socket, not the pid — pids get reused, and a crashed daemon's claim is
+> then simply overwritten rather than needing a sweep.
 
 ```bash
 $ kobed start            # binds ~/.kobe/daemon.sock, writes pidfile

--- a/packages/kobe-daemon/src/daemon/home-owner.ts
+++ b/packages/kobe-daemon/src/daemon/home-owner.ts
@@ -1,0 +1,104 @@
+/**
+ * Exclusive claim on a HOME, independent of the socket path.
+ *
+ * The daemon singleton is keyed on its socket: `defaultDaemonSocketPath`
+ * returns the `ROVE_DAEMON_SOCKET_PATH` override before it ever looks at the
+ * home (`paths.ts`), and `socket-guard.ts` watches only its OWN path. So two
+ * daemons pointed at one home through two different socket overrides cannot
+ * see each other at all — which is an ordinary accident, because this repo's
+ * own harness/capture isolation recipes override the socket while leaving
+ * `ROVE_HOME_DIR` alone.
+ *
+ * What that costs is not one racy file. Both daemons run the full state root:
+ * `tasks.json` (their task lists diverge permanently and `ensureMainTask`
+ * writes the project-main row twice), `automations.json`, and
+ * `.config/rove/state.json` — observed in the field with one daemon's repo
+ * path landing inside the `state.json` the other wrote. That is why the claim
+ * is on the HOME rather than an extra lock around the task index: the index
+ * is one of several things a second daemon would corrupt.
+ *
+ * The claim is a file, `<home>/.rove/daemon.owner`, holding `pid:socketPath`.
+ * Verification does NOT trust the pid — pids get reused, and a crashed daemon
+ * leaves its claim behind. It asks the recorded SOCKET whether a daemon is
+ * still answering there, which is the same question `startDaemonServer`
+ * already asks of its own path. A stale claim therefore needs no sweeping:
+ * its socket is absent, so it is simply overwritten.
+ */
+
+import { mkdir, readFile, unlink, writeFile } from "node:fs/promises"
+import { dirname, join } from "node:path"
+import { probeDaemonSocket } from "../client/daemon-process.ts"
+import { ROVE_STATE_DIR_BASENAME } from "../compat-env.ts"
+
+/** Probe used to decide whether a recorded claim is still live. */
+export type SocketLivenessProbe = (socketPath: string) => Promise<boolean>
+
+const defaultProbe: SocketLivenessProbe = async (socketPath) => (await probeDaemonSocket(socketPath)) === "alive"
+
+export interface HomeOwnerClaim {
+  readonly pid: number
+  readonly socketPath: string
+}
+
+export function daemonHomeOwnerPath(homeDir: string): string {
+  return join(homeDir, ROVE_STATE_DIR_BASENAME, "daemon.owner")
+}
+
+/** Parse `<pid>:<socketPath>`. Split on the FIRST colon only — the rest is a
+ *  filesystem path and may contain more. Returns null for anything unreadable
+ *  or malformed: an unusable claim must never block a boot. */
+export function parseHomeOwnerClaim(raw: string): HomeOwnerClaim | null {
+  const text = raw.trim()
+  const at = text.indexOf(":")
+  if (at <= 0) return null
+  const pid = Number.parseInt(text.slice(0, at), 10)
+  const socketPath = text.slice(at + 1)
+  if (!Number.isFinite(pid) || pid <= 0 || socketPath.length === 0) return null
+  return { pid, socketPath }
+}
+
+export async function readHomeOwnerClaim(homeDir: string): Promise<HomeOwnerClaim | null> {
+  try {
+    return parseHomeOwnerClaim(await readFile(daemonHomeOwnerPath(homeDir), "utf8"))
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Refuse to boot a second daemon on a home a live one already owns.
+ *
+ * Only a claim naming a DIFFERENT socket can refuse: our own socket path was
+ * already probed by `startDaemonServer` (a live owner there throws first), so
+ * a claim naming it is our own crashed predecessor.
+ */
+export async function assertHomeUnclaimed(options: {
+  readonly homeDir: string
+  readonly socketPath: string
+  readonly probe?: SocketLivenessProbe
+}): Promise<void> {
+  const claim = await readHomeOwnerClaim(options.homeDir)
+  if (!claim || claim.socketPath === options.socketPath) return
+  if (!(await (options.probe ?? defaultProbe)(claim.socketPath))) return
+  const remedy = "Stop that daemon, or point ROVE_HOME_DIR at a different home."
+  throw new Error(
+    `rove daemon: ${options.homeDir} is already served by the daemon on ${claim.socketPath} (pid ${claim.pid}) — refusing to start a second daemon on one home. ${remedy}`,
+  )
+}
+
+/** Record this process as the home's owner. Call after bind, next to the
+ *  pidfile write, so a refused boot never overwrites the incumbent's claim. */
+export async function claimHome(homeDir: string, socketPath: string): Promise<void> {
+  const path = daemonHomeOwnerPath(homeDir)
+  await mkdir(dirname(path), { recursive: true })
+  await writeFile(path, `${process.pid}:${socketPath}\n`, "utf8")
+}
+
+/** Drop the claim on shutdown, and ONLY while it still names us — same
+ *  fail-closed rule as `socket-guard.ts#release`: a superseded daemon exiting
+ *  late must not delete the new owner's claim. */
+export async function releaseHomeClaim(homeDir: string, socketPath: string): Promise<void> {
+  const claim = await readHomeOwnerClaim(homeDir)
+  if (!claim || claim.pid !== process.pid || claim.socketPath !== socketPath) return
+  await unlink(daemonHomeOwnerPath(homeDir)).catch(() => {})
+}

--- a/packages/kobe-daemon/src/daemon/server.ts
+++ b/packages/kobe-daemon/src/daemon/server.ts
@@ -26,6 +26,7 @@ import {
   objectPayload,
   shapeDaemonError,
 } from "./handlers.ts"
+import { assertHomeUnclaimed, claimHome, releaseHomeClaim } from "./home-owner.ts"
 import { IssuesStore, defaultIssuesStorePath } from "./issues-store.ts"
 import { DaemonLifetime, FIRST_GUI_GRACE_MS, resolveIdleGraceMs } from "./lifetime.ts"
 import { NotesStore, defaultNotesStorePath } from "./notes-store.ts"
@@ -82,6 +83,12 @@ export async function startDaemonServer(orch: DaemonOrchestrator, options: Daemo
   if ((await probeDaemonSocket(socketPath)) === "alive") {
     throw new Error(`rove daemon: another daemon is already serving ${socketPath} — refusing to replace it`)
   }
+  // …and the same question keyed on the HOME rather than the socket. The probe
+  // above only defends the path THIS daemon binds; a peer that overrode the
+  // socket while leaving the home alone binds somewhere else entirely and then
+  // races us over tasks.json, automations.json and state.json with neither
+  // side able to see the other. See home-owner.ts.
+  await assertHomeUnclaimed({ homeDir, socketPath })
   const clients = new Set<ClientState>()
   let nextClientId = 1
 
@@ -327,6 +334,7 @@ export async function startDaemonServer(orch: DaemonOrchestrator, options: Daemo
         // Ownership-aware teardown: a superseded daemon must neither close the
         // listener nor unlink files another daemon owns — see socket-guard.ts.
         await sockGuard.release(server)
+        await releaseHomeClaim(homeDir, socketPath)
       }
     },
   }
@@ -337,6 +345,7 @@ export async function startDaemonServer(orch: DaemonOrchestrator, options: Daemo
   // late meant either no stamp at all or a stamp of the usurper's inode.
   await sockGuard.arm()
   await writeFile(pidPath, `${process.pid}\n`, "utf8")
+  await claimHome(homeDir, socketPath)
   // A pre-rename binary only knows `.kobe`; without these it starts a second
   // daemon on the same task index. See compat-link.ts.
   await linkLegacyRuntimePath(socketPath, legacyDaemonSocketPath(homeDir))

--- a/packages/kobe/src/orchestrator/index/store-codec.ts
+++ b/packages/kobe/src/orchestrator/index/store-codec.ts
@@ -11,6 +11,11 @@
  *     value into a v3 task list, migrating v1/v2 manifests. The per-ROW half
  *     of that — one entry → a {@link Task}, field by field — lives in
  *     `store-codec-rows.ts`; the seam is manifest scope vs row scope.
+ *   - **Load-time recovery ladder.** {@link recoverIndexFromDisk} walks
+ *     missing file → gated legacy twin → corrupt JSON → future-build version,
+ *     each rung ending in an empty index with the original bytes copied
+ *     aside. It answers "what does this manifest mean"; the store only wants
+ *     the cache that falls out.
  *   - **Read-merge-write helpers.** {@link readDiskIndex} + {@link mergeTasksWithDisk}
  *     implement the disk side of the save protocol: a fresh read of the
  *     manifest (tasks + deletion tombstones) and the three-way merge between
@@ -302,4 +307,71 @@ export function mergeTasksWithDisk(
   }
 
   return { tasks: result, removed: [...tombstones].map(([id, at]) => ({ id, at })) }
+}
+
+/**
+ * Turn whatever is on disk into a v3 index the store can hold.
+ *
+ * The seam against `store.ts`: every branch here answers "what does this
+ * manifest mean", and every failure answers it with an EMPTY index after
+ * copying the original bytes aside. The store does not care which branch ran
+ * — it just gets a cache — so the recovery ladder (missing file, gated legacy
+ * twin, corrupt JSON, a future build's version) lives with the codec that
+ * already owns `normalizeIndex`, `backupCorruptManifest` and the recovery
+ * warnings, instead of as a third of the store class.
+ */
+export async function recoverIndexFromDisk(
+  path: string,
+  legacyPath: string,
+): Promise<{ version: typeof CURRENT_VERSION; tasks: Task[] }> {
+  let raw: string
+  let sourcePath = path
+  try {
+    raw = await readFile(path, "utf8")
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code
+    if (code !== "ENOENT") throw err
+    // Gated, not unconditional: after the daemon migration marker lands the
+    // legacy file is a stale snapshot (see readableLegacyIndexPath).
+    const legacy = readableLegacyIndexPath(path, legacyPath)
+    let legacyRaw: string | undefined
+    if (legacy) {
+      try {
+        legacyRaw = await readFile(legacy, "utf8")
+        sourcePath = legacy
+      } catch (legacyErr) {
+        if ((legacyErr as NodeJS.ErrnoException).code !== "ENOENT") throw legacyErr
+      }
+    }
+    if (legacyRaw === undefined) {
+      return { version: CURRENT_VERSION, tasks: [] }
+    }
+    raw = legacyRaw
+  }
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch (err) {
+    // Back the original bytes up FIRST: the next save read-merge-writes
+    // from this empty recovery base and replaces the corrupt file, so
+    // without a copy the user's tasks are gone for good.
+    const backup = await backupCorruptManifest(sourcePath)
+    warnManifestRecovery(
+      `[rove] tasks.json at ${sourcePath} is corrupted (${(err as Error).message}); recovering with empty index.${
+        backup ? ` Original bytes backed up to ${backup}.` : " Backup copy failed; the stale file is left in place."
+      }`,
+      sourcePath,
+    )
+    return { version: CURRENT_VERSION, tasks: [] }
+  }
+
+  // A future build's manifest empties the index just as thoroughly as a
+  // corrupt one does, and the next save replaces the file — so its bytes
+  // get the same copy-aside before we recover empty.
+  if (await recoverUnsupportedVersion(parsed, sourcePath)) {
+    return { version: CURRENT_VERSION, tasks: [] }
+  }
+
+  return normalizeIndex(parsed, sourcePath)
 }

--- a/packages/kobe/src/orchestrator/index/store.ts
+++ b/packages/kobe/src/orchestrator/index/store.ts
@@ -9,23 +9,14 @@
  * manifests normalize on load, and listeners fire after every mutation.
  */
 
-import { mkdir, open, readFile, rename, unlink, writeFile } from "node:fs/promises"
+import { mkdir, open, rename, unlink, writeFile } from "node:fs/promises"
 import { homedir } from "node:os"
 import { dirname, join } from "node:path"
 import { LEGACY_KOBE_STATE_DIR_BASENAME, ROVE_STATE_DIR_BASENAME } from "../../product.ts"
 import type { Task, TaskId, TaskIndex, TaskStatus } from "../../types/task.ts"
 import { DEFAULT_TASK_VENDOR, toTaskId } from "../../types/task.ts"
 import { release } from "./lockfile.ts"
-import {
-  acquireWithRetry,
-  backupCorruptManifest,
-  mergeTasksWithDisk,
-  normalizeIndex,
-  readDiskIndex,
-  readableLegacyIndexPath,
-  recoverUnsupportedVersion,
-  warnManifestRecovery,
-} from "./store-codec.ts"
+import { acquireWithRetry, mergeTasksWithDisk, readDiskIndex, recoverIndexFromDisk } from "./store-codec.ts"
 import { ulid } from "./ulid.ts"
 
 export interface TaskIndexStoreOptions {
@@ -102,75 +93,54 @@ export class TaskIndexStore {
     // pending local changes to protect during the next merge.
     this.dirtyIds.clear()
     this.removedIds.clear()
-    let raw: string
-    let sourcePath = this.path
-    try {
-      raw = await readFile(this.path, "utf8")
-    } catch (err) {
-      const code = (err as NodeJS.ErrnoException).code
-      if (code !== "ENOENT") throw err
-      // Gated, not unconditional: after the daemon migration marker lands the
-      // legacy file is a stale snapshot (see readableLegacyIndexPath).
-      const legacy = readableLegacyIndexPath(this.path, this.legacyPath)
-      let legacyRaw: string | undefined
-      if (legacy) {
-        try {
-          legacyRaw = await readFile(legacy, "utf8")
-          sourcePath = legacy
-        } catch (legacyErr) {
-          if ((legacyErr as NodeJS.ErrnoException).code !== "ENOENT") throw legacyErr
-        }
-      }
-      if (legacyRaw === undefined) {
-        this.cache = { version: CURRENT_VERSION, tasks: [] }
-        this.loaded = true
-        this.notifyListeners()
-        return this.snapshot()
-      }
-      raw = legacyRaw
-    }
-
-    let parsed: unknown
-    try {
-      parsed = JSON.parse(raw)
-    } catch (err) {
-      // Back the original bytes up FIRST: the next save read-merge-writes
-      // from this empty recovery base and replaces the corrupt file, so
-      // without a copy the user's tasks are gone for good.
-      const backup = await backupCorruptManifest(sourcePath)
-      warnManifestRecovery(
-        `[rove] tasks.json at ${sourcePath} is corrupted (${(err as Error).message}); recovering with empty index.${
-          backup ? ` Original bytes backed up to ${backup}.` : " Backup copy failed; the stale file is left in place."
-        }`,
-        sourcePath,
-      )
-      this.cache = { version: CURRENT_VERSION, tasks: [] }
-      this.loaded = true
-      this.notifyListeners()
-      return this.snapshot()
-    }
-
-    // A future build's manifest empties the index just as thoroughly as a
-    // corrupt one does, and the next save replaces the file — so its bytes
-    // get the same copy-aside before we recover empty.
-    if (await recoverUnsupportedVersion(parsed, sourcePath)) {
-      this.cache = { version: CURRENT_VERSION, tasks: [] }
-      this.loaded = true
-      this.notifyListeners()
-      return this.snapshot()
-    }
-
-    this.cache = normalizeIndex(parsed, sourcePath)
+    this.cache = await recoverIndexFromDisk(this.path, this.legacyPath)
     this.loaded = true
     this.notifyListeners()
     return this.snapshot()
   }
 
+  /**
+   * Flush pending changes, serialized behind any save already in flight.
+   *
+   * Contract the mutators rely on: **a rejection means nothing was written.**
+   * {@link doSave} upholds it by never letting a failure that happens AFTER
+   * the manifest rename escape — see the release handler there.
+   */
   async save(): Promise<void> {
     this.assertLoaded()
     const next = this.saveChain.then(() => this.doSave())
     this.saveChain = next.catch(() => {})
     return next
+  }
+
+  /**
+   * Persist a mutation that has ALREADY been applied to the cache, and undo
+   * that change when the write does not land.
+   *
+   * Without the undo a reported failure becomes a delayed success: the entry
+   * stays in the cache (so `get`/`list` and every UI reading them show it)
+   * and stays in `dirtyIds`, so the next UNRELATED successful save flushes
+   * someone else's failed write to disk minutes later. For `create --prompt`
+   * that is a task materialising after the caller gave up — no worktree, no
+   * branch, no engine, and nobody expecting it.
+   *
+   * `undo` reverts by OBJECT IDENTITY and reports whether it did: if a newer
+   * mutation has since replaced or removed our entry, that mutation owns the
+   * id (and carries its own save), so we leave both it and the dirty flag
+   * alone. Listeners are re-notified after a real undo because a concurrent
+   * mutation's successful save can already have pushed a snapshot carrying
+   * the optimistic value.
+   */
+  private async saveOrRollback(id: string, undo: () => boolean): Promise<void> {
+    try {
+      await this.save()
+    } catch (err) {
+      if (undo()) {
+        this.dirtyIds.delete(id)
+        this.notifyListeners()
+      }
+      throw err
+    }
   }
 
   private async doSave(): Promise<void> {
@@ -187,6 +157,10 @@ export class TaskIndexStore {
     // Rove instances (TUI + daemon + CLI) can't interleave and lose updates.
     // The lock is held only for this critical section, never across saves.
     const lockToken = await acquireWithRetry(this.lockPath)
+    // Set when the merge changed our own cache (a peer's create folded in, or
+    // a peer's deletion evicted). Notified after the lock is released so a
+    // slow listener never sits inside the cross-process critical section.
+    let cacheChanged = false
     try {
       const disk = await readDiskIndex(this.path, this.legacyPath)
       const merged = mergeTasksWithDisk(this.cache.tasks, disk.tasks, dirty, removed, disk.removed)
@@ -232,11 +206,42 @@ export class TaskIndexStore {
       // mutation that ran on the live cache while we were writing.
       const present = new Set(this.cache.tasks.map((t) => t.id))
       for (const task of merged.tasks) {
-        if (!present.has(task.id)) this.cache.tasks.push(task)
+        if (present.has(task.id)) continue
+        this.cache.tasks.push(task)
+        cacheChanged = true
+      }
+
+      // And drop what the merge DELETED. A task a peer tombstoned is absent
+      // from the bytes we just wrote, so keeping it in the cache leaves this
+      // process listing a row that no longer exists — and rewriting a file
+      // without it — forever, even after its own read-merge-write. Only
+      // TOMBSTONED ids are evicted: a cache entry the merge simply never saw
+      // (a create that ran on the live cache while we were writing) must
+      // survive, which is the same reason the fold above only ever adds.
+      const tombstoned = new Set(merged.removed.map((t) => t.id))
+      if (tombstoned.size > 0) {
+        for (let i = this.cache.tasks.length - 1; i >= 0; i--) {
+          const entry = this.cache.tasks[i]
+          if (!entry || !tombstoned.has(entry.id)) continue
+          this.cache.tasks.splice(i, 1)
+          cacheChanged = true
+        }
       }
     } finally {
-      await release(this.lockPath, lockToken)
+      // Releasing the lock is the ONLY thing here that can fail after the
+      // rename made the write durable, and it must never decide the save's
+      // outcome: the mutators undo their cache change when save() rejects, so
+      // rethrowing here would leave the cache contradicting a file already on
+      // disk — the exact report/state disagreement the rollback exists to end.
+      // Swallowing it is what keeps save()'s contract true: every remaining
+      // throw site sits BEFORE the rename, so a rejection means nothing was
+      // written. A stale lock is the lesser harm and the next acquirer's
+      // staleness check clears it.
+      await release(this.lockPath, lockToken).catch((err) => {
+        console.error("[rove TaskIndexStore] index lock release failed:", err)
+      })
     }
+    if (cacheChanged) this.notifyListeners()
   }
 
   get(id: TaskId | string): Task | undefined {
@@ -261,7 +266,12 @@ export class TaskIndexStore {
     }
     this.cache.tasks.push(task)
     this.dirtyIds.add(task.id)
-    await this.save()
+    await this.saveOrRollback(task.id, () => {
+      const at = this.cache.tasks.indexOf(task)
+      if (at < 0) return false
+      this.cache.tasks.splice(at, 1)
+      return true
+    })
     this.notifyListeners()
     return task
   }
@@ -290,7 +300,12 @@ export class TaskIndexStore {
     }
     this.cache.tasks[idx] = next
     this.dirtyIds.add(String(id))
-    await this.save()
+    await this.saveOrRollback(String(id), () => {
+      const at = this.cache.tasks.indexOf(next)
+      if (at < 0) return false
+      this.cache.tasks[at] = existing
+      return true
+    })
     this.notifyListeners()
     return next
   }
@@ -351,15 +366,34 @@ export class TaskIndexStore {
     const next: Task = { ...moved, updatedAt: new Date().toISOString() }
     this.cache.tasks.splice(insertAt, 0, next)
     this.dirtyIds.add(String(id))
-    await this.save()
+    await this.saveOrRollback(String(id), () => {
+      const at = this.cache.tasks.indexOf(next)
+      if (at < 0) return false
+      // Put the ORIGINAL object back (restoring `updatedAt` too) at the index
+      // it came from. A concurrent create can have shifted the tail, so clamp
+      // — position is best-effort here, the reverted value is not.
+      this.cache.tasks.splice(at, 1)
+      this.cache.tasks.splice(Math.min(fromIdx, this.cache.tasks.length), 0, moved)
+      return true
+    })
     this.notifyListeners()
     return next
   }
 
-  async remove(id: TaskId | string): Promise<void> {
+  /**
+   * Delete a task. Returns whether there was one to delete.
+   *
+   * Deliberately does NOT throw like its siblings `update`/`move` do on an
+   * unknown id: the daemon replays a queued deletion after a restart, and a
+   * replay finding nothing left is success, not an error. But returning
+   * `void` made "deleted" and "there was nothing here" the same answer — a
+   * caller working from a cache that never saw the task (a peer created it)
+   * got a silent no-op indistinguishable from a deletion. Hence the boolean.
+   */
+  async remove(id: TaskId | string): Promise<boolean> {
     this.assertLoaded()
     const idx = this.cache.tasks.findIndex((t) => t.id === id)
-    if (idx < 0) return
+    if (idx < 0) return false
     this.cache.tasks.splice(idx, 1)
     // Record the deletion so the read-merge-write doesn't resurrect this task
     // from a stale on-disk copy, and stop treating it as a pending edit. The
@@ -369,6 +403,7 @@ export class TaskIndexStore {
     this.removedIds.set(String(id), new Date().toISOString())
     await this.save()
     this.notifyListeners()
+    return true
   }
 
   /**

--- a/packages/kobe/test/daemon/home-owner.test.ts
+++ b/packages/kobe/test/daemon/home-owner.test.ts
@@ -1,0 +1,81 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import {
+  assertHomeUnclaimed,
+  claimHome,
+  daemonHomeOwnerPath,
+  parseHomeOwnerClaim,
+  releaseHomeClaim,
+} from "../../../kobe-daemon/src/daemon/home-owner.ts"
+
+/**
+ * The home claim exists because the daemon singleton is keyed on the SOCKET
+ * path, not the home: override `ROVE_DAEMON_SOCKET_PATH` while leaving
+ * `ROVE_HOME_DIR` alone — which this repo's own isolation recipes do — and two
+ * daemons serve one state root, each invisible to the other, both writing
+ * `tasks.json`, `automations.json` and `state.json`.
+ */
+describe("daemon home ownership claim", () => {
+  let home: string
+  const OURS = "/run/ours.sock"
+  const THEIRS = "/run/theirs.sock"
+  const alive = async (): Promise<boolean> => true
+  const dead = async (): Promise<boolean> => false
+
+  beforeEach(async () => {
+    home = await mkdtemp(join(tmpdir(), "kobe-home-owner-"))
+    await mkdir(join(home, ".rove"), { recursive: true })
+  })
+
+  afterEach(async () => {
+    await rm(home, { recursive: true, force: true })
+  })
+
+  it("splits a claim on the first colon only, so socket paths may contain more", () => {
+    expect(parseHomeOwnerClaim("42:/run/a:b.sock\n")).toEqual({ pid: 42, socketPath: "/run/a:b.sock" })
+    for (const bad of ["", "nonsense", ":/run/a.sock", "42:", "-1:/run/a.sock"]) {
+      expect(parseHomeOwnerClaim(bad)).toBeNull()
+    }
+  })
+
+  it("refuses a second daemon and names the incumbent's socket", async () => {
+    await writeFile(daemonHomeOwnerPath(home), `4321:${THEIRS}\n`, "utf8")
+    await expect(assertHomeUnclaimed({ homeDir: home, socketPath: OURS, probe: alive })).rejects.toThrow(THEIRS)
+  })
+
+  it("lets a boot through when nothing answers on the claimed socket", async () => {
+    // A crashed daemon leaves its claim behind. Liveness is decided by asking
+    // the recorded SOCKET, not by trusting the pid — pids get reused — so a
+    // stale claim needs no sweeping, it is simply overwritten.
+    await writeFile(daemonHomeOwnerPath(home), `4321:${THEIRS}\n`, "utf8")
+    await expect(assertHomeUnclaimed({ homeDir: home, socketPath: OURS, probe: dead })).resolves.toBeUndefined()
+  })
+
+  it("ignores a claim naming our own socket, and an absent one", async () => {
+    // Our own path is already defended by the boot probe in server.ts; a claim
+    // naming it is our own crashed predecessor, not a peer.
+    await writeFile(daemonHomeOwnerPath(home), `4321:${OURS}\n`, "utf8")
+    await expect(assertHomeUnclaimed({ homeDir: home, socketPath: OURS, probe: alive })).resolves.toBeUndefined()
+    await rm(daemonHomeOwnerPath(home))
+    await expect(assertHomeUnclaimed({ homeDir: home, socketPath: OURS, probe: alive })).resolves.toBeUndefined()
+  })
+
+  it("drops its own claim on release but never someone else's", async () => {
+    await claimHome(home, OURS)
+    expect(await readFile(daemonHomeOwnerPath(home), "utf8")).toBe(`${process.pid}:${OURS}\n`)
+
+    // Fails closed like socket-guard's release: a superseded daemon exiting
+    // late must not delete the new owner's claim.
+    await releaseHomeClaim(home, THEIRS)
+    expect(await readFile(daemonHomeOwnerPath(home), "utf8")).toContain(OURS)
+    await writeFile(daemonHomeOwnerPath(home), `${process.pid + 1}:${OURS}\n`, "utf8")
+    await releaseHomeClaim(home, OURS)
+    expect(await readFile(daemonHomeOwnerPath(home), "utf8")).toContain(OURS)
+
+    await claimHome(home, OURS)
+    await releaseHomeClaim(home, OURS)
+    await expect(readFile(daemonHomeOwnerPath(home), "utf8")).rejects.toThrow()
+  })
+})

--- a/packages/kobe/test/orchestrator/store-concurrency.test.ts
+++ b/packages/kobe/test/orchestrator/store-concurrency.test.ts
@@ -168,6 +168,48 @@ describe("TaskIndexStore multi-process consistency", () => {
     expect(disk.tasks).toHaveLength(0)
   })
 
+  it("evicts a task a peer deleted from its own cache, and tells listeners", async () => {
+    const procA = new TaskIndexStore({ homeDir: home })
+    await procA.load()
+    const doomed = await procA.create(input("doomed"))
+
+    const procB = new TaskIndexStore({ homeDir: home })
+    await procB.load()
+    expect(procB.get(doomed.id)).toBeDefined()
+
+    let sawRemoval = false
+    procB.subscribe((snapshot) => {
+      sawRemoval = !snapshot.some((t) => t.id === doomed.id)
+    })
+    sawRemoval = false // ignore subscribe's eager fire
+
+    await procA.remove(doomed.id)
+    // B's own read-merge-write correctly omits the task from the BYTES, but
+    // used to fold the merge into its cache additively only — so B kept
+    // listing a row that no longer existed, forever, and kept rewriting a
+    // file without it. The eviction has to be tombstone-scoped: an entry the
+    // merge simply never saw (a create racing the write) must survive.
+    await procB.create(input("unrelated"))
+
+    expect(procB.get(doomed.id)).toBeUndefined()
+    expect(procB.list().map((t) => t.title)).toEqual(["unrelated"])
+    expect(sawRemoval).toBe(true)
+  })
+
+  it("reports whether remove() had anything to remove", async () => {
+    const procA = new TaskIndexStore({ homeDir: home })
+    await procA.load()
+    // B's cache predates the task, exactly like a peer process that has not
+    // reloaded. `remove` used to return void either way, so "deleted" and
+    // "there was nothing here" were the same answer.
+    const procB = new TaskIndexStore({ homeDir: home })
+    await procB.load()
+    const task = await procA.create(input("unseen-by-b"))
+
+    expect(await procB.remove(task.id)).toBe(false)
+    expect(await procA.remove(task.id)).toBe(true)
+  })
+
   it("blocks the write path on the index lock", async () => {
     const store = new TaskIndexStore({ homeDir: home })
     await store.load()

--- a/packages/kobe/test/orchestrator/store-load-edge.test.ts
+++ b/packages/kobe/test/orchestrator/store-load-edge.test.ts
@@ -362,8 +362,8 @@ describe("update / move / remove edges", () => {
     await expect(store.move(t.id, 1, ["other-id"])).rejects.toThrow(/not movable/)
   })
 
-  it("remove is a silent no-op for an unknown id", async () => {
-    await expect(store.remove("missing")).resolves.toBeUndefined()
+  it("remove reports false for an unknown id instead of throwing like update/move", async () => {
+    await expect(store.remove("missing")).resolves.toBe(false)
   })
 })
 

--- a/packages/kobe/test/orchestrator/store-remove.test.ts
+++ b/packages/kobe/test/orchestrator/store-remove.test.ts
@@ -61,8 +61,11 @@ describe("TaskIndexStore.remove", () => {
     expect(store.list().some((t) => t.id === task.id)).toBe(false)
   })
 
-  it("removing an unknown id is a silent no-op", async () => {
-    await expect(store.remove("no-such-task")).resolves.toBeUndefined()
+  it("removing an unknown id reports that there was nothing to remove", async () => {
+    // Not a throw (unlike update/move): the daemon replays a queued deletion
+    // after a restart and a replay finding nothing is success. But it must be
+    // distinguishable from a real deletion, hence the boolean.
+    await expect(store.remove("no-such-task")).resolves.toBe(false)
   })
 
   it("exposes filePath + stateDir for tooling", () => {

--- a/packages/kobe/test/orchestrator/store-rollback.test.ts
+++ b/packages/kobe/test/orchestrator/store-rollback.test.ts
@@ -1,0 +1,128 @@
+import { mkdir, mkdtemp, readFile, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { type TaskCreateInput, TaskIndexStore } from "../../src/orchestrator/index/store.ts"
+
+/**
+ * What the store does when the write does NOT land.
+ *
+ * The mutators apply to the cache first and persist second, so a failed save
+ * used to leave the change sitting in the cache AND in `dirtyIds`: the caller
+ * got an error, `get`/`list` reported the new value anyway, and the next
+ * UNRELATED successful save flushed the "failed" write to disk minutes later.
+ * For `create` that means a task materialising after the caller gave up —
+ * with no worktree, no branch and no engine.
+ */
+describe("TaskIndexStore rollback on a failed save", () => {
+  let home: string
+
+  beforeEach(async () => {
+    home = await mkdtemp(join(tmpdir(), "kobe-store-rollback-"))
+    await mkdir(join(home, ".rove"), { recursive: true })
+  })
+
+  afterEach(async () => {
+    await rm(home, { recursive: true, force: true })
+  })
+
+  const lockPath = (): string => join(home, ".rove", "tasks.json.lock")
+
+  /**
+   * Break the save deterministically by putting a DIRECTORY where the
+   * lockfile goes: `acquire`'s `link` fails EEXIST, the holder read then
+   * fails EISDIR, and that is not a contention error so it propagates
+   * immediately — no 5s retry deadline, no timing, no chmod.
+   */
+  const breakSaves = async (): Promise<void> => {
+    await mkdir(lockPath(), { recursive: true })
+  }
+  const healSaves = (): Promise<void> => rm(lockPath(), { recursive: true, force: true })
+
+  function input(title: string): TaskCreateInput {
+    return {
+      title,
+      repo: "/repo",
+      branch: `kobe/${title}`,
+      worktreePath: `/repo/.kobe/worktrees/${title}`,
+      kind: "task",
+      status: "backlog",
+    }
+  }
+
+  async function diskTitles(): Promise<string[]> {
+    const raw = await readFile(join(home, ".rove", "tasks.json"), "utf8")
+    return (JSON.parse(raw) as { tasks: Array<{ title: string }> }).tasks.map((t) => t.title)
+  }
+
+  it("drops a create whose save failed, and no later save resurrects it", async () => {
+    const store = new TaskIndexStore({ homeDir: home })
+    await store.load()
+
+    await breakSaves()
+    await expect(store.create(input("ghost"))).rejects.toThrow()
+    // The caller was told no; the cache must agree.
+    expect(store.list()).toHaveLength(0)
+
+    // The specific bug: the id stayed dirty, so an UNRELATED mutation's save
+    // carried someone else's failed write to disk.
+    await healSaves()
+    await store.create(input("unrelated"))
+    expect(await diskTitles()).toEqual(["unrelated"])
+  })
+
+  it("restores the previous value of an update whose save failed", async () => {
+    const store = new TaskIndexStore({ homeDir: home })
+    await store.load()
+    const task = await store.create(input("orig"))
+
+    await breakSaves()
+    await expect(store.update(task.id, { title: "renamed" })).rejects.toThrow()
+    expect(store.get(task.id)?.title).toBe("orig")
+    expect(store.get(task.id)?.updatedAt).toBe(task.updatedAt)
+
+    await healSaves()
+    await store.create(input("unrelated"))
+    expect((await diskTitles()).sort()).toEqual(["orig", "unrelated"])
+  })
+
+  it("restores the previous order of a move whose save failed", async () => {
+    const store = new TaskIndexStore({ homeDir: home })
+    await store.load()
+    const a = await store.create(input("a"))
+    await store.create(input("b"))
+
+    await breakSaves()
+    await expect(store.move(a.id, 1)).rejects.toThrow()
+    expect(store.list().map((t) => t.title)).toEqual(["a", "b"])
+    expect(store.list()[0]?.updatedAt).toBe(a.updatedAt)
+
+    await healSaves()
+    await store.create(input("c"))
+    expect(await diskTitles()).toEqual(["a", "b", "c"])
+  })
+
+  it("never lets two failed updates on one id reach disk, whichever rolls back first", async () => {
+    const store = new TaskIndexStore({ homeDir: home })
+    await store.load()
+    const task = await store.create(input("orig"))
+
+    await breakSaves()
+    const first = store.update(task.id, { title: "first" })
+    // Queued behind it, on the SAME id: this one now owns the cache entry, so
+    // the older mutation's undo must not clobber it (it reverts by object
+    // identity and reports that it did nothing).
+    const second = store.update(task.id, { title: "second" })
+    await expect(first).rejects.toThrow()
+    await expect(second).rejects.toThrow()
+
+    // Each undo restores what IT displaced, so the cache lands on the
+    // intermediate value rather than all the way back on "orig". What has to
+    // hold regardless of unwind order is the durable half: the id is no
+    // longer dirty, so the merge takes the disk copy and no rejected title
+    // ever reaches the file.
+    await healSaves()
+    await store.create(input("unrelated"))
+    expect((await diskTitles()).sort()).toEqual(["orig", "unrelated"])
+  })
+})


### PR DESCRIPTION
Takes **C1, C4, C5, C3** from `.scratch/loop-r12/concurrency.md`. C2 and C6 are
untouched, and so is the atomic write path C7 proved sound.

Every number below was taken on a home under `.scratch/loop-r12-af/`, with all
twelve `ROVE_`/`KOBE_` path vars inlined as separate assignments and the
agent shell's `ROVE_INVOKED_AS`/`*_TASK_ID` unset. Nothing shared, and nothing
that a second explorer's daemon could have reached. BEFORE numbers were taken
either before any edit in this worktree, or on a pristine `origin/main` build
in a separate worktree (noted per item).

---

## C1 — a mutation that reports failure lands on disk anyway

**PASS criterion** (from the brief): under a squatted index lock, `rename`
exits non-zero **and** `get-task` still reports the old title, and a later
unrelated `add` does not change it; `add` under a squatted lock exits non-zero
**and** the id never appears in `api list` or on disk.

`create`/`update`/`move` mutate `this.cache` and set `dirtyIds` before
`await this.save()`. Nothing reverted that when the save threw, so the id
stayed dirty and the next *unrelated* successful save flushed it.

`saveOrRollback` now wraps the persist: on a rejection it undoes the cache
change and clears the dirty id. The undo reverts **by object identity** and
reports whether it did anything — if a newer mutation on the same id has since
replaced the entry, that mutation owns it and carries its own save, so the
older rollback stands down (fourth test below pins this).

The undo is only sound because `save()` rejecting means nothing was written,
so `doSave` now makes that true: the lock release is the one step that can
fail *after* the rename makes the write durable, and it no longer decides the
save's outcome — it is logged, not rethrown. Every remaining throw site sits
before the rename.

**Proof** — `.scratch/loop-r12-af/c1.sh`, same script both runs (isolated
daemon, a live squatter holding `tasks.json.lock` past the 5s deadline):

| | BEFORE | AFTER |
|---|---|---|
| `rename` exit | 1 | 1 |
| daemon `get-task` title | `NEW-TITLE` | `ORIG-TITLE` |
| disk title, immediately | `ORIG-TITLE` | `ORIG-TITLE` |
| `add` exit | 1 | 1 |
| ghost in `api list` | 1 | 0 |
| **disk title after an unrelated `add`** | **`NEW-TITLE`** | **`ORIG-TITLE`** |
| **ghost on disk after that `add`** | **1** | **0** |
| disk task count across the run | 1 → 3 | 1 → 2 |

**Optimistic subscribers.** `create`/`update`/`move` notify only *after* the
save resolves, so they never push the optimistic value themselves — but a
concurrent mutation's successful save can push a snapshot that contains it, and
any `get`/`list` read in the window sees it. So the rollback calls
`notifyListeners()` after a real undo, and subscribers converge on the reverted
value in the same tick the caller gets its error. Subscribers that already
rendered the optimistic value get a corrected snapshot; they are never left
holding it.

**What I could not make fully clean:** two failed updates on the *same* id,
issued without awaiting the first. Each undo restores what it displaced, so the
cache lands on the intermediate value rather than back on the original. The
durable half still holds — the id is no longer dirty, so the merge takes the
disk copy and no rejected value reaches the file — and the cache converges on
the next `load()`. Fixing the cache side too would need a per-id version
counter; it is pinned by a test rather than papered over.

## C4 — a store never drops a task a peer deleted

**PASS criterion:** `peer.ts` prints `bStillListsSeedAfterItsOwnSave: false`,
and B's `subscribe` listeners are notified of the removal.

`doSave` folded the merge into the cache additively only. The merge correctly
omits a tombstoned task from the bytes; the cache kept it forever. The fold now
also evicts ids the merge tombstoned — and only those, because an entry the
merge never saw (a create that ran on the live cache during the write) must
survive, which is the same reason the fold only ever adds.

**Proof** — `.scratch/loop-r12-af/peer.ts` (two stores, one home = two
processes; the store has no cross-instance sync):

| | BEFORE | AFTER |
|---|---|---|
| `diskHasSeed` | false | false |
| `bListedSeedBeforeItsSave` | true | true |
| **`bStillListsSeedAfterItsOwnSave`** | **true** | **false** |
| **`bListenerSawTheRemoval`** | **false** | **true** |

## C5 — `remove()` on an unseen id was a silent no-op

**PASS criterion:** `remove()` on an unknown id either throws or returns
`false`; the daemon's `queued: false` behaviour is unchanged.

It returns `boolean`, not `void`. It deliberately does **not** throw the way
`update`/`move` do: the daemon replays a queued deletion after a restart, and a
replay finding nothing left is success, not an error. The daemon path is
untouched — `handlers-task.ts` still guards with `prepareTaskDeletion` and
still answers `queued: false`; the two internal callers
(`main-task.ts#forget`, `task-deletion.ts#finish`) both work from a task they
already resolved.

**Proof** — same `peer.ts` run: `removeReturned` goes from `undefined`
(BEFORE) to `false` (AFTER) for an id B's cache never saw. The two tests that
encoded the old `void` contract were updated in place.

## C3 — two daemons can serve one home

**PASS criteria:** starting a second daemon on a home an existing live daemon
owns exits non-zero and names the incumbent's socket path; after the guard the
two-daemon repro produces exactly one project-main task.

Taken with the widened scope from the mid-task correction: the claim is on the
**home**, not on `tasks.json`. A second daemon does not only race the task
index — it runs `ensureMainTask`, the automation runner and the whole state
root, so `automations.json` and `.config/rove/state.json` race too. Refusing
the second *daemon* covers all of them by construction; an extra lock around
the index would have covered one.

`home-owner.ts` writes `<home>/.rove/daemon.owner` as `pid:socketPath` after
bind, and drops it on shutdown only while it still names us (the same
fail-closed rule as `socket-guard.ts#release`). Boot refuses when a claim names
a **different** socket that still answers. Liveness is decided by asking that
socket, never by trusting the pid: pids get reused, and it means a crashed
daemon's claim never needs sweeping — it is simply overwritten.

**Proof 1, divergence** — `.scratch/loop-r12-af/c3.sh`, two daemons on one
home with different socket/pid/pty/web paths, one `api add` through each:

| | BEFORE | AFTER |
|---|---|---|
| d2 daemon booted | yes | **no — refused** |
| d1's task list | `FROM-D1` | `FROM-D1` |
| d2's task list | `FROM-D2,FROM-D1` | (no daemon) |
| disk | `FROM-D2,FROM-D1` | `FROM-D1` |

The refusal message names the incumbent:

```
rove daemon: …/c3home is already served by the daemon on
…/c3home/.rove/daemon.sock (pid 61439) — refusing to start a second daemon on
one home. Stop that daemon, or point ROVE_HOME_DIR at a different home.
```

**Proof 2, project-main duplication** — `.scratch/loop-r12-af/c3main.sh`,
`rove add <repo>` (→ `ensureMainTask`) through each daemon. The BEFORE column
was taken on a **pristine `origin/main` build** in a separate worktree
(`.scratch/loop-r12-af/baseline`, script `c3main-baseline.sh`), not on this
branch with the guard reverted:

| | BEFORE (origin/main) | AFTER |
|---|---|---|
| **`kind:"main"` rows on disk** | **2** | **1** |

Worth stating because it is the honest boundary of the guard: in the AFTER run
d2's `rove add` still ran, because `withDaemonOrLocal` falls back to a
daemon-free local store when no daemon answers. It produced no duplicate. That
is the difference the fix is drawn along — a CLI-local store is a *merged*
writer (it goes through `tasks.json.lock` and the read-merge-write protocol,
which C7 proved sound across processes), whereas two daemons are *diverging*
writers holding long-lived independent caches over files the lock does not
cover. The claim is placed at the daemon boundary for that reason.

---

## Tests

Six new tests, all in the vitest track. Each one **fails on pristine
`origin/main`** — verified by copying them into the `origin/main` baseline
worktree and running them there, so none of them passes for the wrong reason:

```
× rollback > drops a create whose save failed, and no later save resurrects it
  → expected [ { … } ] to have a length of +0 but got 1
× rollback > restores the previous value of an update whose save failed
  → expected 'renamed' to be 'orig'
× rollback > restores the previous order of a move whose save failed
  → expected [ 'b', 'a' ] to deeply equal [ 'a', 'b' ]
× rollback > never lets two failed updates on one id reach disk
  → expected [ 'second', 'unrelated' ] to deeply equal [ 'orig', 'unrelated' ]
× multi-process > evicts a task a peer deleted from its own cache, and tells listeners
  → expected { … } to be undefined
× multi-process > reports whether remove() had anything to remove
  → expected undefined to be false
Test Files  2 failed (2)     Tests  6 failed | 6 passed (12)
```

The fourth line is the C1 bug stated as a value: on `main`, the title of an
update that *rejected* is what reached disk.

`test/orchestrator/store-rollback.test.ts` breaks the save deterministically by
putting a **directory** where the lockfile goes — `link` fails EEXIST, the
holder read then fails EISDIR, which is not a contention error so it propagates
immediately. No 5s retry deadline, no timing, no chmod.
`test/daemon/home-owner.test.ts` (5 tests) covers the claim with an injected
liveness probe.

## Gates

```
bun run lint       ✓ Checked 1409 files
bun run typecheck  ✓ all four projects exit 0
test:fast          ✓ 439 files, 4360 tests
test:socket        ✓  97 files,  782 tests
```

## Refactor

`store.ts` went past the 500-line cap with these changes (522). `load()`'s
recovery ladder moved to `store-codec.ts` — every branch there answers "what
does this manifest mean" and every failure answers it with an empty index after
copying the bytes aside, while the store keeps the mutable half. The seam shows
in the imports: five of `store-codec`'s exports were imported back into
`store.ts` for that one method and are now gone from it. store.ts 522 → 451,
store-codec.ts 305 → 377. No behavior change; covered by the existing
`store-load-edge.test.ts`.

## Docs

`docs/TROUBLESHOOTING.md` gains the mirror of its existing "daemon serves a
different home" section, and `docs/design/daemon.md`'s Home ownership note
gains the inverse case its two guards did not cover.

## Not done / out of scope

- C2 and C6 (lockfile takeover, crash leftovers) — left for the later worker.
- The atomic write path is untouched.
- No screenshots: none of this is screen-visible, per the brief.
- `.scratch/loop-r12-af/baseline` is a git worktree I registered on
  `origin/main` to take the pristine BEFORE numbers. It is inside gitignored
  `.scratch/` and I left it in place rather than removing it unasked.
