### PR TITLE
fix: failure messages that send the user the wrong way (doctor label, CLI failure frame, force-delete danger, uncatalogued strings)

### DIFF
--- a/.changeset/cli-failures-name-the-command-that-failed.md
+++ b/.changeset/cli-failures-name-the-command-that-failed.md
@@ -1,0 +1,24 @@
+---
+"@sma1lboy/rove": patch
+---
+
+A failed subcommand is reported as itself, not as a failed launch.
+
+Every uncaught subcommand error was prefixed `rove failed to start:`, which is
+false for everything that started fine and then failed doing its job. Running
+`rove adopt` outside a repository printed the raw git invocation with it:
+
+```
+rove failed to start: git worktree list --porcelain (cwd=/private/tmp) exited with code 128: fatal: not a git repository (or any of the parent directories): .git
+```
+
+It now names the command that failed and says what to do, matching the prefix
+the subcommands that handle their own errors already print:
+
+```
+rove adopt: /private/tmp is not a git repository — run this inside one, or pass a repo path.
+```
+
+`KOBE_DEBUG=1` still prints the raw throw, argv and all, so bug reports lose
+nothing. Unrecognized messages pass through verbatim rather than being
+flattened into a guess.

--- a/.changeset/doctor-resetpty-names-one-condition.md
+++ b/.changeset/doctor-resetpty-names-one-condition.md
@@ -1,0 +1,12 @@
+---
+"@sma1lboy/rove": patch
+---
+
+`doctor.fix.resetPty` names the condition that actually fired.
+
+The label read "the PTY host is unreachable or not running" — two conditions,
+so it was true whichever one produced it. Since a host that is merely not
+running no longer proposes anything, the surviving case is the other one, and
+the label now says so: "the PTY host process is alive but its socket is
+unreachable (wedged)". It matches the shape of `resetDaemonWedged`, which was
+already specific.

--- a/.changeset/force-delete-says-work-is-salvaged.md
+++ b/.changeset/force-delete-says-work-is-salvaged.md
@@ -1,0 +1,15 @@
+---
+"@sma1lboy/rove": patch
+---
+
+The force-delete confirm stops overstating the danger.
+
+Both force-delete confirms said uncommitted work would be `PERMANENTLY LOST`.
+It is not: every force path snapshots the worktree to `refs/rove/salvage/…`
+before `git worktree remove --force` runs. Warning about a loss the product is
+about to prevent pushes people to cancel a safe operation, and teaches them to
+discount the warnings that are real.
+
+Both sites now share one wording that names the snapshot and the command that
+lists it (`git for-each-ref refs/rove/salvage`) — one event described once,
+instead of two wordings for the same thing, one of them shouting.

--- a/.changeset/task-dialogs-and-toasts-are-translated.md
+++ b/.changeset/task-dialogs-and-toasts-are-translated.md
@@ -1,0 +1,30 @@
+---
+"@sma1lboy/rove": patch
+---
+
+The task confirm dialogs and action toasts are translated.
+
+Around two dozen user-facing strings — all three destructive confirms on a task
+row, and the failure toasts behind delete, create, fork, rename, pin, move,
+engine and status changes, the issue chat and the attention inbox — were
+written as English literals rather than catalog keys. `check-i18n` compares the
+two catalogs, so strings in neither were invisible to it: the gate passed while
+a Chinese user got an English dialog mid-delete.
+
+They are catalog keys now, in both locales. While moving them, each failure
+also gained the thing it was missing — the state that survived it, so the
+message answers whether to retry or to stop worrying:
+
+```
+Couldn't delete "web-refactor" — the task and its worktree are untouched: …
+Couldn't rename the branch — it stays "feat/parser": …
+Couldn't dismiss it — it stays in the inbox: …
+```
+
+The onboarding wizard's environment page also picks up the action line the CLI
+path already printed. Both halves run the same check; only one said what
+unblocks you.
+
+Crossing a breaking version now says what the required `rove reset` costs —
+Rove refuses to start until it runs, it stops every live session, and tasks and
+worktrees are kept.

--- a/packages/kobe/src/cli/cli-failure.ts
+++ b/packages/kobe/src/cli/cli-failure.ts
@@ -1,0 +1,66 @@
+/**
+ * How an uncaught subcommand failure is spelled to the user.
+ *
+ * The top-level `main().catch()` is the fallback for EVERY subcommand, so
+ * whatever it prints is what a user sees for `adopt`, `add`, `export`, `land`
+ * and the rest. Two rules follow from that:
+ *
+ * - **Name the command that failed, not the process.** A fixed "failed to
+ *   start" prefix is false for every subcommand that started fine and then
+ *   failed doing its job, which is nearly all of them. `rove adopt: …` also
+ *   matches the prefix the subcommands that DO handle their own errors
+ *   already print (`rove add: …`, `rove remove: …`).
+ * - **Boil a raw git invocation down to a sentence.** `runGit` throws
+ *   `git worktree list --porcelain (cwd=/private/tmp) exited with code 128:
+ *   fatal: not a git repository …` — the argv, the cwd and the exit code are
+ *   debugging detail the user did not ask for and cannot act on. The TUI's
+ *   file tree solved this already ({@link summarizeGitError}); this is the
+ *   CLI's half, and unlike the TUI's short labels it ends in an action,
+ *   because a CLI user has a shell in front of them.
+ *
+ * Unrecognized messages pass through verbatim: a boil-down that swallows an
+ * error it does not understand is worse than a noisy one.
+ */
+
+import { errorMessage } from "@/lib/error-message"
+
+/** `KOBE_DEBUG=1` keeps the raw throw (stack included) for bug reports. */
+function debugEnabled(env: NodeJS.ProcessEnv): boolean {
+  return env.KOBE_DEBUG === "1" || env.ROVE_DEBUG === "1"
+}
+
+/**
+ * The subject a failure is attributed to: `rove adopt` when argv named a
+ * subcommand, plain `rove` when it did not (the bare TUI launch, which really
+ * can fail at startup).
+ */
+export function failureSubject(cliName: string, argv: readonly string[]): string {
+  const verb = argv[2]
+  // Flags and paths are not subcommands — `rove --help` / `rove ~/repo` land
+  // in the TUI/open-directory paths, so attributing to `rove` is the truth.
+  return verb && !verb.startsWith("-") && !verb.includes("/") ? `${cliName} ${verb}` : cliName
+}
+
+/**
+ * A user-facing sentence for a raw git failure, or null when the shape is not
+ * one we can say anything better about.
+ *
+ * Only the not-a-repository case is mapped: it is the one a user hits by
+ * running a Rove command in the wrong directory, and the remedy is a
+ * directory change rather than anything about git.
+ */
+export function summarizeCliGitError(message: string, cwd: string): string | null {
+  if (!/not a git repository/i.test(message)) return null
+  return `${cwd} is not a git repository — run this inside one, or pass a repo path.`
+}
+
+/** The single line the top-level catch prints. Never throws. */
+export function formatCliFailure(
+  err: unknown,
+  opts: { cliName: string; argv: readonly string[]; cwd: string; env: NodeJS.ProcessEnv },
+): string {
+  const subject = failureSubject(opts.cliName, opts.argv)
+  if (debugEnabled(opts.env)) return `${subject}: ${String(err instanceof Error ? (err.stack ?? err) : err)}`
+  const raw = errorMessage(err)
+  return `${subject}: ${summarizeCliGitError(raw, opts.cwd) ?? raw}`
+}

--- a/packages/kobe/src/cli/index.ts
+++ b/packages/kobe/src/cli/index.ts
@@ -9,6 +9,7 @@ import { type VendorId, coerceVendorId } from "../types/vendor.ts"
 import type { AdoptableWorktree } from "../types/worktree.ts"
 // Static: open-dir-cmd's own imports are cheap (node builtins); the heavy
 // orchestrator/TUI imports stay dynamic inside runOpenDirectory itself.
+import { formatCliFailure } from "./cli-failure.ts"
 import { type CommandHandler, DYNAMIC_COMMANDS } from "./index-commands.ts"
 import { isPathLikeArg, runOpenDirectory } from "./open-dir-cmd.ts"
 import { openLocalOrchestrator, withDaemonOrLocal } from "./orchestrator-bridge.ts"
@@ -389,6 +390,6 @@ async function main(): Promise<void> {
 }
 
 main().catch((err) => {
-  console.error(`${CLI_NAME} failed to start:`, process.env.KOBE_DEBUG === "1" ? err : errorMessage(err))
+  console.error(formatCliFailure(err, { cliName: CLI_NAME, argv: process.argv, cwd: process.cwd(), env: process.env }))
   process.exit(1)
 })

--- a/packages/kobe/src/tui-react/onboarding/host.tsx
+++ b/packages/kobe/src/tui-react/onboarding/host.tsx
@@ -161,10 +161,20 @@ export function WizardPage(props: {
                 </text>
               ))}
             </box>
-            <box paddingTop={1}>
+            <box flexDirection="column" paddingTop={1}>
               <text fg={ready ? theme.success : theme.error} wrapMode="word">
                 {ready ? t("onboarding.envReady") : t("onboarding.envNotReady")}
               </text>
+              {/* The CLI path of this same wizard (`cli/onboarding.ts`) prints
+                  these action lines under the same verdict. Without them the
+                  TUI tells a blocked user they are blocked and not what
+                  unblocks them — same wizard, two amounts of help. */}
+              {!ready && !props.env.engines.anyUsable ? (
+                <text fg={theme.textMuted} wrapMode="word">{`→ ${t("doctor.fix.noEngineAction")}`}</text>
+              ) : null}
+              {!ready && !props.env.git.found ? (
+                <text fg={theme.textMuted} wrapMode="word">{`→ ${t("doctor.fix.gitAction")}`}</text>
+              ) : null}
             </box>
           </box>
         ) : null}

--- a/packages/kobe/src/tui-react/workspace/host-task-actions.ts
+++ b/packages/kobe/src/tui-react/workspace/host-task-actions.ts
@@ -18,6 +18,7 @@ import { errorMessage } from "@/lib/error-message"
 import { useRenderer } from "@opentui/react"
 import type { RemoteOrchestrator } from "../../client/remote-orchestrator.ts"
 import { availableEngineIds } from "../../engine/account-detect"
+import { t } from "../../tui/i18n"
 import { copyTextToSystemClipboard } from "../../tui/lib/clipboard-copy"
 import {
   applyVendorChange,
@@ -137,13 +138,13 @@ export function useWorkspaceTaskActions(deps: WorkspaceTaskActionDeps): Workspac
     const task = tasks().find((t) => t.id === id)
     if (!task) return
     await orchestrator.setPinned(id, !task.pinned).catch((err) => {
-      notifyError(`Couldn't pin: ${errorMessage(err)}`)
+      notifyError(t("tasks.toast.pinFailed", { error: errorMessage(err) }))
     })
   }
 
   async function moveTask(id: string, delta: -1 | 1): Promise<void> {
     await orchestrator.moveTask(id, delta).catch((err) => {
-      notifyError(`Couldn't move: ${errorMessage(err)}`)
+      notifyError(t("tasks.toast.moveFailed", { error: errorMessage(err) }))
     })
   }
 
@@ -159,7 +160,7 @@ export function useWorkspaceTaskActions(deps: WorkspaceTaskActionDeps): Workspac
     const next = await BranchPickerDialog.show(dialog, { currentBranch: task.branch, repo: task.repo })
     if (!next) return
     await orchestrator.setBranch(id, next).catch((err) => {
-      notifyError(`Couldn't rename branch: ${errorMessage(err)}`)
+      notifyError(t("tasks.toast.renameBranchFailed", { branch: task.branch, error: errorMessage(err) }))
     })
   }
 

--- a/packages/kobe/src/tui-react/workspace/inbox-rpc-errors.ts
+++ b/packages/kobe/src/tui-react/workspace/inbox-rpc-errors.ts
@@ -1,11 +1,23 @@
 import { errorMessage } from "@/lib/error-message"
+import { t } from "../../tui/i18n"
 
 export type InboxRpcAction = "mark read" | "dismiss"
+
+/**
+ * The action is a KEY, not an interpolated English verb. Splicing "mark read"
+ * or "dismiss" into a sentence produces a half-translated toast in every
+ * locale but English, and the two failures also survive differently phrased —
+ * so each gets its own string.
+ */
+const FAILURE_KEY: Record<InboxRpcAction, string> = {
+  "mark read": "tasks.toast.inboxMarkReadFailed",
+  dismiss: "tasks.toast.inboxDismissFailed",
+}
 
 export function notifyInboxRpcFailure(
   request: Promise<unknown>,
   action: InboxRpcAction,
   notifyError: (message: string) => void,
 ): void {
-  void request.catch((err) => notifyError(`Couldn't ${action}: ${errorMessage(err)}`))
+  void request.catch((err) => notifyError(t(FAILURE_KEY[action], { error: errorMessage(err) })))
 }

--- a/packages/kobe/src/tui-react/workspace/open-task-worktree.ts
+++ b/packages/kobe/src/tui-react/workspace/open-task-worktree.ts
@@ -19,7 +19,7 @@ export async function requestTaskWorktreeOpen(id: string, deps: OpenTaskWorktree
       path = await deps.ensureWorktree(id)
     } catch (error) {
       const reason = error instanceof Error ? error.message : String(error)
-      deps.notifyError(`Couldn't create worktree: ${reason}`)
+      deps.notifyError(t("tasks.toast.worktreeErrorGeneric", { message: reason }))
       return
     }
   }

--- a/packages/kobe/src/tui-react/workspace/quick-fork.ts
+++ b/packages/kobe/src/tui-react/workspace/quick-fork.ts
@@ -18,6 +18,7 @@ import { useState } from "react"
 import { engineDisplayName } from "../../engine/interactive-command"
 import { addSavedRepo } from "../../state/repos"
 import { resolvePreferredVendor, setRepoLastActiveVendor } from "../../state/vendor-prefs"
+import { t } from "../../tui/i18n"
 import { appendAttachmentRefs } from "../../tui/lib/attachments"
 import { DEFAULT_BASE_REF, getCurrentBranch } from "../../tui/lib/git-snapshot"
 import { repoBasename } from "../../tui/panes/sidebar/groups"
@@ -103,7 +104,7 @@ async function runQuickFork(
     return task.id
   } catch (err) {
     console.error("[rove workspace] quick-fork task.create failed:", err)
-    hooks.notifyError(`Couldn't fork task: ${errorMessage(err)}`)
+    hooks.notifyError(t("tasks.toast.forkFailed", { error: errorMessage(err) }))
     return undefined
   }
 }

--- a/packages/kobe/src/tui-react/workspace/use-issue-chat.ts
+++ b/packages/kobe/src/tui-react/workspace/use-issue-chat.ts
@@ -181,7 +181,7 @@ export function useIssueChat(
       }
       await finish(request, task.id)
     } catch (err) {
-      hooks.notifyError(`Couldn't start issue chat: ${errorMessage(err)}`)
+      hooks.notifyError(t("tasks.toast.issueChatFailed", { error: errorMessage(err) }))
     }
   }
 

--- a/packages/kobe/src/tui/i18n/messages/doctor.ts
+++ b/packages/kobe/src/tui/i18n/messages/doctor.ts
@@ -55,8 +55,9 @@ export const en = {
     resetWhy: "stops the daemon, the PTY host, and every live session — not undoable, so doctor only prints it",
     /** Daemon process alive but its socket unreachable */
     resetDaemonWedged: "the daemon process is alive but unreachable (wedged)",
-    /** PTY host unreachable or down */
-    resetPty: "the PTY host is unreachable or not running",
+    /** PTY host process alive but its socket unreachable. A host that is
+        merely down is NOT a finding — it starts on demand. */
+    resetPty: "the PTY host process is alive but its socket is unreachable (wedged)",
     /** Pre-v0.8 tmux sessions still resident */
     resetLegacy: "pre-v0.8 tmux sessions are still holding processes and memory",
 
@@ -136,7 +137,7 @@ export const zh: typeof en = {
 
     resetWhy: "会停掉 daemon、PTY host 和所有活动会话 — 不可撤销, 所以 doctor 只打印",
     resetDaemonWedged: "daemon 进程存活但无法连接 (卡死)",
-    resetPty: "PTY host 无法连接或没有在运行",
+    resetPty: "PTY host 进程存活但 socket 无法连接 (卡死)",
     resetLegacy: "v0.8 之前的 tmux 会话仍占用进程和内存",
 
     orphans: "有 {count} 个进程比启动它们的 PTY 会话活得更久, 现在还在运行",

--- a/packages/kobe/src/tui/i18n/messages/tasks.ts
+++ b/packages/kobe/src/tui/i18n/messages/tasks.ts
@@ -112,6 +112,29 @@ export const en = {
     loading: "Loading…",
     footer: "↑↓ scroll · esc close",
   },
+  /** The destructive confirms on a task row (`d` on the tasks pane). Every
+   *  body says what SURVIVES, because that is the fact that decides whether
+   *  a user should press enter. */
+  confirm: {
+    cancel: "cancel",
+    /** A project row is a saved repo, not a worktree — `d` un-saves it. */
+    forgetProjectTitle: 'Remove project "{title}"?',
+    forgetProjectBody:
+      "Forgets it from the projects list. The repo, its branches, worktrees, and any tasks under it stay on disk — re-add it with `rove add`.",
+    forgetProjectConfirm: "remove",
+    deleteTitle: 'Delete "{title}"?',
+    /** A `dir` task pins the user's own directory; deletion never touches it. */
+    deleteBodyDir: "Removes the task entry. The directory itself stays on disk. Its hosted sessions are stopped.",
+    deleteBodyTask: "Removes the task entry and its worktree. The git branch stays. Its hosted sessions are stopped.",
+    deleteConfirm: "delete",
+    forceDeleteTitle: '"{title}" has uncommitted changes',
+    forceDeleteConfirm: "force delete",
+  },
+  /** Bare text prompt behind `b` on hosts without the branch picker. */
+  renameBranch: {
+    title: "Rename branch",
+    fieldLabel: "branch",
+  },
   /** Inline chip while move/reorder mode is active */
   moveChip: " move",
   /** Narrow mode's top-of-sidebar jump row back into the last-entered task */
@@ -167,6 +190,28 @@ export const en = {
       "Closed {count} tab(s). The branch {branch} is still there — reopen the task to re-create its worktree.",
     copiedBranch: "Copied branch {text}",
     copiedPath: "Copied path {text}",
+
+    /** Action failures. Each names the state that SURVIVED the failure —
+     *  the `kanban.*` block's shape, and the thing a user needs in order to
+     *  know whether to retry or to stop worrying. */
+    forgetProjectFailed: "Couldn't remove the project — it stays in the projects list: {error}",
+    deleteFailed: 'Couldn\'t delete "{title}" — the task and its worktree are untouched: {error}',
+    createFailed: "Couldn't create the task — nothing was created: {error}",
+    forkFailed: "Couldn't fork the task — the original is untouched: {error}",
+    renameFailed: "Couldn't rename the task — it keeps its old title: {error}",
+    renameBranchFailed: 'Couldn\'t rename the branch — it stays "{branch}": {error}',
+    switchEngineFailed: "Couldn't switch the engine — the task keeps the one it had: {error}",
+    setStatusFailed: "Couldn't set the status — it stays {status}: {error}",
+    pinFailed: "Couldn't change the pin — the task keeps its current place: {error}",
+    moveFailed: "Couldn't move the task — it keeps its current place: {error}",
+    issueChatFailed: "Couldn't start the issue chat — the issue is unchanged: {error}",
+    inboxMarkReadFailed: "Couldn't mark it read — it stays in the inbox: {error}",
+    inboxDismissFailed: "Couldn't dismiss it — it stays in the inbox: {error}",
+
+    /** Successes with nothing on screen to show them — both changes only
+     *  become visible later, so the toast is the only feedback. */
+    engineSwitched: "Engine → {engine} (applies on reopen)",
+    statusSet: "Status → {status}",
   },
 }
 
@@ -242,6 +287,23 @@ export const zh: typeof en = {
     confirm: "重新运行",
     footer: "\u2191\u2193 滚动 \u00B7 \u2190\u2192 选择 \u00B7 enter 运行 \u00B7 esc 取消",
   },
+  confirm: {
+    cancel: "取消",
+    forgetProjectTitle: "从列表中移除项目「{title}」？",
+    forgetProjectBody:
+      "只是把它从项目列表里忘掉。仓库、分支、worktree 以及它下面的任务都会留在磁盘上——之后可以用 `rove add` 重新加回来。",
+    forgetProjectConfirm: "移除",
+    deleteTitle: "删除「{title}」？",
+    deleteBodyDir: "只删除任务条目。目录本身会留在磁盘上。它的托管会话会被停止。",
+    deleteBodyTask: "删除任务条目和它的 worktree。git 分支会保留。它的托管会话会被停止。",
+    deleteConfirm: "删除",
+    forceDeleteTitle: "「{title}」有未提交的改动",
+    forceDeleteConfirm: "强制删除",
+  },
+  renameBranch: {
+    title: "重命名分支",
+    fieldLabel: "分支",
+  },
   fieldNotes: {
     title: "现场笔记",
     empty: "该仓库暂无现场笔记——agent 可用 `rove api note` 记录。",
@@ -291,5 +353,22 @@ export const zh: typeof en = {
     worktreeGoneBody: "已关闭 {count} 个标签页。分支 {branch} 仍在——重新打开该任务会重建 worktree。",
     copiedBranch: "已复制分支 {text}",
     copiedPath: "已复制路径 {text}",
+
+    forgetProjectFailed: "移除项目失败——它仍在项目列表里：{error}",
+    deleteFailed: "删除「{title}」失败——任务和它的 worktree 都没有被改动：{error}",
+    createFailed: "创建任务失败——什么都没有被创建：{error}",
+    forkFailed: "fork 任务失败——原任务没有被改动：{error}",
+    renameFailed: "重命名任务失败——它仍用原来的标题：{error}",
+    renameBranchFailed: "重命名分支失败——它仍是「{branch}」：{error}",
+    switchEngineFailed: "切换引擎失败——任务仍使用原来的引擎：{error}",
+    setStatusFailed: "设置状态失败——它仍是 {status}：{error}",
+    pinFailed: "修改置顶状态失败——任务仍在原来的位置：{error}",
+    moveFailed: "移动任务失败——它仍在原来的位置：{error}",
+    issueChatFailed: "启动议题会话失败——议题没有被改动：{error}",
+    inboxMarkReadFailed: "标记为已读失败——它仍留在收件箱里：{error}",
+    inboxDismissFailed: "忽略失败——它仍留在收件箱里：{error}",
+
+    engineSwitched: "引擎 → {engine}（重新打开后生效）",
+    statusSet: "状态 → {status}",
   },
 }

--- a/packages/kobe/src/tui/i18n/messages/update.ts
+++ b/packages/kobe/src/tui/i18n/messages/update.ts
@@ -45,7 +45,11 @@ export const en = {
     tagCurrent: "current",
     tagLatest: "latest",
     tagBreaking: "breaking",
-    breakingWarning: "⚠ installing this crosses breaking version(s) {versions} — run `rove reset` after the update.",
+    /** Shown before the user commits to a version. `enforceResetGate()` calls
+        `process.exit(1)` at every app entrance until the reset runs, so the
+        reset is mandatory, not advisory — and it costs live sessions. */
+    breakingWarning:
+      "⚠ installing this crosses breaking version(s) {versions}. Rove will refuse to start until you run `rove reset`, which stops the daemon, the PTY host, and every live session. Tasks and worktrees are kept.",
     footerHint: "j/k select · enter install · q close",
   },
 }
@@ -88,7 +92,8 @@ export const zh: typeof en = {
     tagCurrent: "当前",
     tagLatest: "最新",
     tagBreaking: "breaking",
-    breakingWarning: "⚠ 安装该版本会跨过 breaking 版本 {versions}——更新后需运行 `rove reset`。",
+    breakingWarning:
+      "⚠ 安装该版本会跨过 breaking 版本 {versions}。更新后 Rove 会拒绝启动，直到你运行 `rove reset`——它会停掉 daemon、PTY host 和所有活动会话。任务和 worktree 会保留。",
     footerHint: "j/k 选择 · enter 安装 · q 关闭",
   },
 }

--- a/packages/kobe/src/tui/i18n/messages/worktrees.ts
+++ b/packages/kobe/src/tui/i18n/messages/worktrees.ts
@@ -37,7 +37,14 @@ export const en = {
     confirmTitle: "Delete worktree?",
     confirmBody: 'Delete the worktree for "{branch}"? This removes the working directory; the branch itself is kept.',
     forceTitle: "Force delete worktree?",
-    forceBody: '"{branch}" has uncommitted or untracked changes that will be PERMANENTLY LOST. Force delete anyway?',
+    /** Shared with the task force-delete confirm (`tui/lib/task-actions.ts`):
+        the same event, and it used to be described twice in different words,
+        one of them shouting. Neither said the true part — every force path
+        snapshots the work first (`orchestrator/worktree/manager-remove.ts`
+        calls `salvageWorktree` before `git worktree remove --force`), and
+        overstating the danger pushes people to cancel a safe operation. */
+    forceBody:
+      '"{branch}" has uncommitted or untracked work. Force delete removes the worktree, but the work is snapshotted first to a salvage ref — list them with `git for-each-ref refs/rove/salvage`. Force delete anyway?',
     failed: "Failed to delete worktree: {error}",
     residue:
       "Git deregistered the worktree, but couldn't delete {path} ({reason}). Rove is done with it — retrying won't help; delete the directory by hand if you want the space.",
@@ -106,7 +113,8 @@ export const zh: typeof en = {
     confirmTitle: "删除 worktree？",
     confirmBody: '确定删除 "{branch}" 对应的 worktree？工作目录会被移除，分支本身会保留。',
     forceTitle: "强制删除 worktree？",
-    forceBody: '"{branch}" 存在未提交或未跟踪的改动，强制删除后将永久丢失。仍要强制删除吗？',
+    forceBody:
+      '"{branch}" 存在未提交或未跟踪的改动。强制删除会移除 worktree，但这些改动会先被快照到一个 salvage ref——用 `git for-each-ref refs/rove/salvage` 可以列出它们。仍要强制删除吗？',
     failed: "删除 worktree 失败：{error}",
     residue:
       "Git 已注销该 worktree，但没能删掉 {path}（{reason}）。Rove 这边已经处理完了——重试没有用；想要回磁盘空间请手动删除该目录。",

--- a/packages/kobe/src/tui/lib/task-actions.ts
+++ b/packages/kobe/src/tui/lib/task-actions.ts
@@ -184,32 +184,29 @@ export async function deleteTaskFlow(ctx: TaskActionContext, taskId: string): Pr
   // leaving the repo and any real tasks under it on disk.
   if (task.kind === "main") {
     const ok = await ctx.confirm({
-      title: `Remove project "${task.title}"?`,
-      body: "Forgets it from the projects list. The repo, its branches, worktrees, and any tasks under it stay on disk — re-add it with `rove add`.",
-      cancelLabel: "cancel",
-      confirmLabel: "remove",
+      title: t("tasks.confirm.forgetProjectTitle", { title: task.title }),
+      body: t("tasks.confirm.forgetProjectBody"),
+      cancelLabel: t("tasks.confirm.cancel"),
+      confirmLabel: t("tasks.confirm.forgetProjectConfirm"),
     })
     if (!ok) return
     try {
       await ctx.orch.forgetProject(task.repo)
     } catch (err) {
       ctx.logger.error(`${ctx.logPrefix} forget project failed:`, err)
-      ctx.notifyError?.(`Couldn't remove: ${errorMessage(err)}`)
+      ctx.notifyError?.(t("tasks.toast.forgetProjectFailed", { error: errorMessage(err) }))
       return
     }
     await ctx.reload?.()
     return
   }
   const ok = await ctx.confirm({
-    title: `Delete "${task.title}"?`,
+    title: t("tasks.confirm.deleteTitle", { title: task.title }),
     // A `dir` task pins the user's own directory — deletion only drops the
     // task entry; the directory is never touched.
-    body:
-      task.kind === "dir"
-        ? "Removes the task entry. The directory itself stays on disk. Its hosted sessions are stopped."
-        : "Removes the task entry and its worktree. The git branch stays. Its hosted sessions are stopped.",
-    cancelLabel: "cancel",
-    confirmLabel: "delete",
+    body: t(task.kind === "dir" ? "tasks.confirm.deleteBodyDir" : "tasks.confirm.deleteBodyTask"),
+    cancelLabel: t("tasks.confirm.cancel"),
+    confirmLabel: t("tasks.confirm.deleteConfirm"),
     danger: true,
   })
   if (!ok) return
@@ -221,10 +218,13 @@ export async function deleteTaskFlow(ctx: TaskActionContext, taskId: string): Pr
     const message = errorMessage(err)
     if (message.includes(DIRTY_WORKTREE_CODE)) {
       const forceOk = await ctx.confirm({
-        title: `"${task.title}" has uncommitted changes`,
-        body: "Its worktree has uncommitted or untracked work that will be permanently deleted. Force delete anyway?",
-        cancelLabel: "cancel",
-        confirmLabel: "force delete",
+        title: t("tasks.confirm.forceDeleteTitle", { title: task.title }),
+        // Shared verbatim with the worktrees page's force-remove: one event,
+        // one wording, and it names the salvage snapshot every force path
+        // takes rather than promising the work is gone forever.
+        body: t("worktrees.delete.forceBody", { branch: task.branch || task.title }),
+        cancelLabel: t("tasks.confirm.cancel"),
+        confirmLabel: t("tasks.confirm.forceDeleteConfirm"),
         danger: true,
       })
       if (forceOk) {
@@ -233,12 +233,12 @@ export async function deleteTaskFlow(ctx: TaskActionContext, taskId: string): Pr
           deleted = true
         } catch (forceErr) {
           ctx.logger.error(`${ctx.logPrefix} force delete failed:`, forceErr)
-          ctx.notifyError?.(`Couldn't delete: ${errorMessage(forceErr)}`)
+          ctx.notifyError?.(t("tasks.toast.deleteFailed", { title: task.title, error: errorMessage(forceErr) }))
         }
       }
     } else {
       ctx.logger.error(`${ctx.logPrefix} delete failed:`, err)
-      ctx.notifyError?.(`Couldn't delete: ${errorMessage(err)}`)
+      ctx.notifyError?.(t("tasks.toast.deleteFailed", { title: task.title, error: errorMessage(err) }))
     }
   }
   // Only tear down the session + move selection if the task was actually
@@ -270,7 +270,7 @@ export async function renameTaskFlow(ctx: TaskActionContext, taskId: string): Pr
     await ctx.orch.setTitle(taskId, next)
   } catch (err) {
     ctx.logger.error(`${ctx.logPrefix} task.rename failed:`, err)
-    ctx.notifyError?.(`Couldn't rename task: ${errorMessage(err)}`)
+    ctx.notifyError?.(t("tasks.toast.renameFailed", { error: errorMessage(err) }))
     return
   }
   await ctx.reload?.()
@@ -287,13 +287,16 @@ export async function renameTaskFlow(ctx: TaskActionContext, taskId: string): Pr
 export async function renameBranchFlow(ctx: TaskActionContext, taskId: string): Promise<void> {
   const task = ctx.tasks().find((t) => t.id === taskId)
   if (!task || task.kind === "main") return
-  const next = await ctx.promptText(task.branch, { dialogTitle: "Rename branch", fieldLabel: "branch" })
+  const next = await ctx.promptText(task.branch, {
+    dialogTitle: t("tasks.renameBranch.title"),
+    fieldLabel: t("tasks.renameBranch.fieldLabel"),
+  })
   if (!next || !ctx.orch) return
   try {
     await ctx.orch.setBranch(taskId, next)
   } catch (err) {
     ctx.logger.error(`${ctx.logPrefix} task.setBranch failed:`, err)
-    ctx.notifyError?.(`Couldn't rename branch: ${errorMessage(err)}`)
+    ctx.notifyError?.(t("tasks.toast.renameBranchFailed", { branch: task.branch, error: errorMessage(err) }))
     return
   }
   await ctx.reload?.()
@@ -345,14 +348,14 @@ export async function applyVendorChange(
     await ctx.orch.setVendor(taskId, next, opts.effort)
   } catch (err) {
     ctx.logger.error(`${ctx.logPrefix} task.setVendor failed:`, err)
-    ctx.notifyError?.(`Couldn't switch engine: ${errorMessage(err)}`)
+    ctx.notifyError?.(t("tasks.toast.switchEngineFailed", { error: errorMessage(err) }))
     return false
   }
   // Only for a change with nothing on screen to show it: the new vendor takes
   // effect on the task's NEXT enter (ensureSession rebuilds the pane when its
   // `@kobe_vendor` tag does not match), so `v` on a row otherwise looks
   // like a no-op.
-  if (!opts.silentSuccess) ctx.notifyInfo?.(`Engine → ${engineDisplayName(next)} (applies on reopen)`)
+  if (!opts.silentSuccess) ctx.notifyInfo?.(t("tasks.toast.engineSwitched", { engine: engineDisplayName(next) }))
   return true
 }
 
@@ -389,10 +392,10 @@ export async function setStatusFlow(ctx: TaskActionContext, taskId: string): Pro
     await ctx.orch.setStatus(taskId, next)
   } catch (err) {
     ctx.logger.error(`${ctx.logPrefix} task.status failed:`, err)
-    ctx.notifyError?.(`Couldn't set status: ${errorMessage(err)}`)
+    ctx.notifyError?.(t("tasks.toast.setStatusFailed", { status: task.status, error: errorMessage(err) }))
     return
   }
-  ctx.notifyInfo?.(`Status → ${next}`)
+  ctx.notifyInfo?.(t("tasks.toast.statusSet", { status: next }))
   await ctx.reload?.()
 }
 

--- a/packages/kobe/src/tui/lib/task-create-flow.ts
+++ b/packages/kobe/src/tui/lib/task-create-flow.ts
@@ -183,7 +183,7 @@ export async function createTaskFlow(ctx: CreateTaskContext): Promise<void> {
       createdId = task.id
     } catch (err) {
       ctx.logger.error(`${ctx.logPrefix} task.create failed:`, err)
-      ctx.notifyError?.(`Couldn't create task: ${errorMessage(err)}`)
+      ctx.notifyError?.(t("tasks.toast.createFailed", { error: errorMessage(err) }))
       return
     }
   }

--- a/packages/kobe/test/cli/cli-failure.test.ts
+++ b/packages/kobe/test/cli/cli-failure.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest"
+import { failureSubject, formatCliFailure, summarizeCliGitError } from "../../src/cli/cli-failure.ts"
+
+const GIT_THROW =
+  "git worktree list --porcelain (cwd=/private/tmp) exited with code 128: " +
+  "fatal: not a git repository (or any of the parent directories): .git"
+
+describe("failureSubject", () => {
+  it("names the subcommand that failed", () => {
+    expect(failureSubject("rove", ["bun", "/x/rove.js", "adopt"])).toBe("rove adopt")
+  })
+
+  /** A bare launch really can fail at startup, and flags/paths route to the
+   *  TUI or open-directory paths — neither is a subcommand to blame. */
+  it("falls back to the bare CLI name for a launch, a flag, or a path", () => {
+    expect(failureSubject("rove", ["bun", "/x/rove.js"])).toBe("rove")
+    expect(failureSubject("rove", ["bun", "/x/rove.js", "--help"])).toBe("rove")
+    expect(failureSubject("rove", ["bun", "/x/rove.js", "~/code/repo"])).toBe("rove")
+  })
+})
+
+describe("summarizeCliGitError", () => {
+  it("turns a raw git invocation into a sentence naming the directory and the action", () => {
+    const summary = summarizeCliGitError(GIT_THROW, "/private/tmp")
+    expect(summary).toBe("/private/tmp is not a git repository — run this inside one, or pass a repo path.")
+  })
+
+  /** A boil-down that swallows what it does not understand is worse than a
+   *  noisy one: the caller passes the original through on null. */
+  it("declines shapes it cannot improve", () => {
+    expect(summarizeCliGitError("EACCES: permission denied, open '/etc/x'", "/tmp")).toBeNull()
+    expect(summarizeCliGitError("boom", "/tmp")).toBeNull()
+  })
+})
+
+describe("formatCliFailure", () => {
+  const opts = { cliName: "rove", argv: ["bun", "/x/rove.js", "adopt"], cwd: "/private/tmp", env: {} }
+
+  it("blames the subcommand, not the process, and leaks no git argv", () => {
+    const line = formatCliFailure(new Error(GIT_THROW), opts)
+
+    expect(line).toBe("rove adopt: /private/tmp is not a git repository — run this inside one, or pass a repo path.")
+    // The three things the old "rove failed to start:" line got wrong.
+    expect(line).not.toContain("failed to start")
+    expect(line).not.toContain("(cwd=")
+    expect(line).not.toContain("exited with code")
+  })
+
+  it("passes an unrecognized message through under the subcommand prefix", () => {
+    expect(formatCliFailure(new Error("disk on fire"), opts)).toBe("rove adopt: disk on fire")
+  })
+
+  it("keeps the raw throw under KOBE_DEBUG=1 so bug reports still carry the argv", () => {
+    const line = formatCliFailure(new Error(GIT_THROW), { ...opts, env: { KOBE_DEBUG: "1" } })
+
+    expect(line).toContain("(cwd=/private/tmp)")
+    expect(line).toContain("exited with code 128")
+  })
+})

--- a/packages/kobe/test/cli/doctor-cmd.test.ts
+++ b/packages/kobe/test/cli/doctor-cmd.test.ts
@@ -226,6 +226,10 @@ describe("runDoctorSubcommand", () => {
     expect(output()).toContain("WEDGED")
     expect(output()).toMatch(/(rove|kobe) reset/)
     expect(output()).not.toContain("starts on demand")
+    // The label must name the condition that actually fired. "unreachable or
+    // not running" read as true either way, including in the cold case above
+    // where doctor now (correctly) proposes nothing at all.
+    expect(output()).toContain("the PTY host process is alive but its socket is unreachable (wedged)")
   })
 
   it("--report writes a bundle file and points the user at it", async () => {

--- a/packages/kobe/test/tui-react/inbox-rpc-errors.test.ts
+++ b/packages/kobe/test/tui-react/inbox-rpc-errors.test.ts
@@ -3,8 +3,8 @@ import { notifyInboxRpcFailure } from "../../src/tui-react/workspace/inbox-rpc-e
 
 describe("notifyInboxRpcFailure", () => {
   it.each([
-    ["mark read", new Error("daemon exploded"), "Couldn't mark read: daemon exploded"],
-    ["dismiss", "socket closed", "Couldn't dismiss: socket closed"],
+    ["mark read", new Error("daemon exploded"), "Couldn't mark it read — it stays in the inbox: daemon exploded"],
+    ["dismiss", "socket closed", "Couldn't dismiss it — it stays in the inbox: socket closed"],
   ] as const)("turns a rejected %s request into a string error", async (action, failure, expected) => {
     const notifyError = vi.fn()
 

--- a/packages/kobe/test/tui-react/open-task-worktree.test.ts
+++ b/packages/kobe/test/tui-react/open-task-worktree.test.ts
@@ -62,7 +62,7 @@ describe("requestTaskWorktreeOpen", () => {
 
     await requestTaskWorktreeOpen("task-1", options)
 
-    expect(options.notifyError).toHaveBeenCalledWith("Couldn't create worktree: disk full")
+    expect(options.notifyError).toHaveBeenCalledWith("Couldn't create the worktree: disk full")
     expect(mocks.openWorktree).not.toHaveBeenCalled()
   })
 

--- a/packages/kobe/test/tui/apply-vendor-change.test.ts
+++ b/packages/kobe/test/tui/apply-vendor-change.test.ts
@@ -64,7 +64,7 @@ describe("applyVendorChange", () => {
     // ...but the user-visible half is the point: it must name the failure
     // and carry the underlying reason.
     const said = c.notifyError.mock.calls[0]?.[0] as string
-    expect(said).toContain("Couldn't switch engine")
+    expect(said).toContain("Couldn't switch the engine")
     expect(said).toContain("daemon refused")
     // A failure must NOT also claim success.
     expect(c.notifyInfo).not.toHaveBeenCalled()

--- a/packages/kobe/test/tui/create-task-flow.test.ts
+++ b/packages/kobe/test/tui/create-task-flow.test.ts
@@ -205,7 +205,7 @@ describe("createTaskFlow — create mode + guards", () => {
 
     await createTaskFlow(ctx)
 
-    expect(notifyError).toHaveBeenCalledWith("Couldn't create task: git worktree add failed")
+    expect(notifyError).toHaveBeenCalledWith("Couldn't create the task — nothing was created: git worktree add failed")
     expect(reload).not.toHaveBeenCalled()
     expect(selectTask).not.toHaveBeenCalled()
   })

--- a/packages/kobe/test/tui/task-actions-rename.test.ts
+++ b/packages/kobe/test/tui/task-actions-rename.test.ts
@@ -131,7 +131,7 @@ describe("renameTaskFlow", () => {
 
     await renameTaskFlow(ctx, "t1")
 
-    expect(notifyError).toHaveBeenCalledWith("Couldn't rename task: boom")
+    expect(notifyError).toHaveBeenCalledWith("Couldn't rename the task — it keeps its old title: boom")
     expect(reload).not.toHaveBeenCalled()
   })
 
@@ -193,7 +193,7 @@ describe("renameBranchFlow", () => {
 
     await renameBranchFlow(ctx, "t1")
 
-    expect(notifyError).toHaveBeenCalledWith("Couldn't rename branch: bad branch name")
+    expect(notifyError).toHaveBeenCalledWith('Couldn\'t rename the branch — it stays "kobe/t1": bad branch name')
     expect(reload).not.toHaveBeenCalled()
   })
 })
@@ -226,7 +226,7 @@ describe("cycleVendorFlow", () => {
 
     await cycleVendorFlow(ctx, "t1")
 
-    expect(notifyError).toHaveBeenCalledWith("Couldn't switch engine: nope")
+    expect(notifyError).toHaveBeenCalledWith("Couldn't switch the engine — the task keeps the one it had: nope")
     expect(notifyInfo).not.toHaveBeenCalled()
     expect(reload).not.toHaveBeenCalled()
   })
@@ -319,7 +319,7 @@ describe("setStatusFlow", () => {
 
     await setStatusFlow(ctx, "t1")
 
-    expect(notifyError).toHaveBeenCalledWith("Couldn't set status: daemon down")
+    expect(notifyError).toHaveBeenCalledWith("Couldn't set the status — it stays backlog: daemon down")
     expect(notifyInfo).not.toHaveBeenCalled()
     expect(reload).not.toHaveBeenCalled()
   })
@@ -343,7 +343,9 @@ describe("setStatusFlow", () => {
 
     await setStatusFlow(ctx, "t1")
 
-    expect(notifyError).toHaveBeenCalledWith("Couldn't set status: illegal transition for task t1: done -> error")
+    expect(notifyError).toHaveBeenCalledWith(
+      "Couldn't set the status — it stays done: illegal transition for task t1: done -> error",
+    )
     expect(reload).not.toHaveBeenCalled()
   })
 

--- a/packages/kobe/test/tui/task-actions.test.ts
+++ b/packages/kobe/test/tui/task-actions.test.ts
@@ -176,7 +176,9 @@ describe("deleteTaskFlow — dirty-worktree branch", () => {
 
     // No force re-prompt for a non-DIRTY error.
     expect(confirm).toHaveBeenCalledTimes(1)
-    expect(notifyError).toHaveBeenCalledWith("Couldn't delete: daemon exploded")
+    expect(notifyError).toHaveBeenCalledWith(
+      'Couldn\'t delete "t1" — the task and its worktree are untouched: daemon exploded',
+    )
     expect(killHostedSessions).not.toHaveBeenCalled()
     expect(onTaskDeleted).not.toHaveBeenCalled()
   })
@@ -233,7 +235,9 @@ describe("deleteTaskFlow — project (main) row", () => {
 
     await deleteTaskFlow(ctx, "m1")
 
-    expect(notifyError).toHaveBeenCalledWith("Couldn't remove: daemon exploded")
+    expect(notifyError).toHaveBeenCalledWith(
+      "Couldn't remove the project — it stays in the projects list: daemon exploded",
+    )
     expect(reload).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
Failure messages that sent the user the wrong way — the dangerous-remedy family
(BATCH 1) and the strings that never entered the catalog (BATCH 4), from
`.scratch/loop-r13-errors/errors.md`.

Evidence PNGs (this worktree, gitignored):
`/Users/jacksonc/.rove/worktrees/kobe-0aff3858ab76/anchovy/.scratch/ag/shots/{before,after}/`

---

## 1. `doctor.fix.resetPty` named both conditions at once — mostly landed upstream

**Scope change mid-flight.** #862 landed the logic half of this item on `main`
while I worked, with its own tests for both branches. I dropped my duplicate
(the rebase conflict resolved in favour of `main`) and kept only what #862 left
behind: the *label*, which still read "the PTY host is unreachable or not
running". Two conditions, so it was true whichever shape produced it — and now
that a merely-down host proposes nothing, "not running" names a case that can
no longer reach this string.

**PASS:** the wedged branch prints a label naming only the wedged condition;
the down branch proposes no reset at all.

```
$ .scratch/ag/doctor-capture.sh   # isolated home, both shapes

--- fresh install (PTY host DOWN) ---
pty host: ✗ not running (no pidfile)
         starts on demand — the first task tab launches it; nothing to fix
   … no `rove reset` anywhere in the output

--- PTY host WEDGED (live pid in the pidfile, no socket) ---
manual steps — doctor prints these but never runs them:
  the PTY host process is alive but its socket is unreachable (wedged)
    → rove reset
```

Before/after transcripts: `shots/{before,after}/doctor-{down,wedged}.txt`.
One assertion added to the existing WEDGED test pins the label.

## 2. Every subcommand failure was labelled "rove failed to start"

The top-level `main().catch()` is the fallback for *every* subcommand, so the
fixed prefix was false for all of them that started fine and then failed. It
also leaked the git argv, the cwd and the exit code, and named no action.

**PASS:** `cd /tmp && rove adopt` contains no "failed to start", no `(cwd=`, no
`exited with code`, names an action, and still exits 1.

```
BEFORE  rove failed to start: git worktree list --porcelain (cwd=/private/tmp) exited with code 128: fatal: not a git repository (or any of the parent directories): .git
AFTER   rove adopt: /private/tmp is not a git repository — run this inside one, or pass a repo path.
        EXIT=1
```

`KOBE_DEBUG=1` still prints the raw throw with the argv, so bug reports lose
nothing (verified; covered by a test). Unrecognized messages pass through
verbatim under the subcommand prefix rather than being flattened into a guess.

New module `src/cli/cli-failure.ts` + 7 unit tests. Mutation-checked: replacing
the boil-down with a passthrough turns the test red.

> Note for the dispatcher: `errors.md` files this as 2.1, but the task brief
> assigned it to me explicitly as part of the dangerous-remedy family. Flagging
> in case the BATCH 2/3 worker also picked it up.

## 3. The force-delete confirm overstated the danger (the inverted case)

Both confirms said uncommitted work would be `PERMANENTLY LOST`. It is not:
`removeWorktree` calls `salvageWorktree` before every `git worktree remove
--force`, at the one chokepoint all three force callers share. Warning about a
loss the product is about to prevent pushes people to cancel a safe operation.

One shared key (`worktrees.delete.forceBody`) now serves both call sites — the
worktrees page and the task force-delete, which previously described the same
event in two different wordings, one of them shouting and one untranslated.

**PASS:** a forced delete followed by the command the new message names
actually finds the work.

```
$ git -C <repo> for-each-ref refs/rove/salvage          # before: empty
$ rove api delete --task-id <id> --force
$ git -C <repo> for-each-ref refs/rove/salvage
refs/rove/salvage/visual-fixture-20260904T110656Z d7ae0e5
$ git -C <repo> show refs/rove/salvage/visual-fixture-20260904T110656Z:draft-notes.md
work nobody committed yet
```

That file was untracked — exactly what the old copy called permanently lost.
Verified on both paths per `errors.md`'s instruction: the salvage guard lives in
`manager-remove.ts`, above the split, so task force-delete and worktree-page
force-remove share it.

## 4. ~24 user-facing strings never entered the catalog

`check-i18n` compares the two catalogs, so strings in neither are structurally
invisible to it — the gate passed while a Chinese user got an English dialog
mid-delete. Moved in, both locales: all three destructive confirms on a task
row, the branch-rename prompt, and the failure toasts behind delete, create,
fork, rename, pin, move, engine switch, status set, issue chat and the
attention inbox.

`errors.md` lists ~17; the same defect ran to ~24 in the same two files
(`task-actions.ts` also had rename/engine/status, `task-create-flow.ts` had
create). Translating a file and leaving eight English strings in it is worse
than not starting, so the pass covers the file.

While moving them, each failure gained what it was missing — the state that
survived it, following the `kanban.*` model `errors.md` names as the gold
standard:

```
Couldn't delete "web-refactor" — the task and its worktree are untouched: …
Couldn't rename the branch — it stays "feat/parser": …
Couldn't dismiss it — it stays in the inbox: …
```

`open-task-worktree.ts:22` collapsed onto the existing
`tasks.toast.worktreeErrorGeneric` rather than becoming an eighth near-duplicate.
`inbox-rpc-errors.ts` stopped interpolating an English verb ("mark read" /
"dismiss") into a sentence — that produced a half-translated toast in every
locale but English — and takes a key per action instead.

**PASS:** both surveys come back empty, and the dialogs render Chinese.

```
$ grep -rn 'notifyError' src/tui-react src/tui --include='*.ts*' | grep -E '`[A-Z]'
(no output)
$ grep -rn 'cancelLabel: "\|confirmLabel: "' src/tui src/tui-react | grep -v i18n/messages
(no output)
$ bun run check-i18n
i18n check OK — 823 keys × 2 locales in sync
```

Screenshots, `/harness` → xterm.js → PTY sidecar → real OpenTUI, private port
base 5893, locale `zh`, a task with an untracked file in its worktree:

| | before | after |
|---|---|---|
| delete confirm | `shots/before/delete-confirm-zh.png` — English body under a Chinese UI | `shots/after/delete-confirm-zh.png` — 「删除任务条目和它的 worktree。git 分支会保留。」 |
| force delete | `shots/before/force-delete-zh.png` — English, "will be permanently deleted" | `shots/after/force-delete-zh.png` — Chinese, names the salvage ref and the `for-each-ref` command, wraps cleanly |

`origin/main` still carries every literal those BEFORE shots show
(`task-actions.ts:204,224,225`, `worktrees.ts:40`), so the pair is valid against
the merge base even though #862 moved `main` mid-flight.

## Also in this PR

- **Onboarding TUI/CLI parity** — the brief's "take it if it's a one-line
  share". It was: the env page now renders the same `→ install an engine CLI …`
  / `→ install git …` action lines the CLI path already printed, guarded on the
  same predicates. No new strings.
- **`update.versions.breakingWarning`** now says what the required reset costs
  (Rove refuses to start until it runs — `enforceResetGate()` calls
  `process.exit(1)`; every live session dies; tasks and worktrees are kept).

## What I could NOT prove

**No screenshot of the breaking-version warning.** `BREAKING_VERSIONS` in
`src/version.ts` is `readonly string[] = []`, so `breakingVersionsCrossed()`
returns empty for every pair and `crossings.length > 0` is unreachable on any
real build — the warning cannot render today. Forcing it would mean patching
that constant, which photographs a fabricated state. The row it renders in is
`wrapMode="word"` with no truncation (`versions-page.tsx:176`), so the wrapping
question the brief raised is answered structurally rather than visually. The
string is still worth fixing: it is what a user reads at the moment they choose
to cross a breaking version, whenever one is next added.

## Gates

```
bun run lint                                    clean (1433 files)
bun run typecheck                               clean
bun run check-i18n                              823 keys × 2 locales in sync
bun run test:fast                               4436 passed (449 files)
bun test test/render                            474 passed
KOBE_INCLUDE_SOCKET=1 bun run test:socket       802 passed
```

Mutation-checked at two different sites: reverting the git boil-down in
`formatCliFailure`, and reverting `if (state === "wedged")` in `doctor-cmd.ts`
before that half was superseded — each turned exactly the intended test red.

Four changesets, all `patch`.
