### PR TITLE
fix: failure messages that name an action, not just a cause (batches 2 + 3)

### DIFF
--- a/.changeset/loop-r13-ah-messages.md
+++ b/.changeset/loop-r13-ah-messages.md
@@ -1,0 +1,21 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Failure messages that name an action instead of stopping at the cause.
+
+The file-tree error labels each carry their own fix now — `not a git
+repository — run \`git init\` here, or open a task in a repo`, `git is not on
+PATH — install it with your OS package manager` — and `press r to retry` is
+hidden beside the two of them a retry can never resolve. "No daemon running"
+names `rove daemon restart`, the same command `rove doctor` prescribes for it.
+The two terminal-unavailable lines say which shell (`$SHELL`) and where its
+error is (`~/.rove/pty.log`). The onboarding wizard's environment page shows
+the same `→ install an engine CLI …` line in the TUI that the CLI wizard
+already printed.
+
+Worktree toasts no longer stutter: a failed create said `Couldn't create the
+worktree: create(): …`, leaking the function that threw. The four routine
+failures were a bare passthrough of the daemon's message with no hint of which
+of create/delete/toggle/run had failed; each now names the action and what
+survived it — `"nightly audit" stays enabled and will keep firing on schedule`.

--- a/.changeset/loop-r13-ah-messages.md
+++ b/.changeset/loop-r13-ah-messages.md
@@ -10,12 +10,11 @@ PATH — install it with your OS package manager` — and `press r to retry` is
 hidden beside the two of them a retry can never resolve. "No daemon running"
 names `rove daemon restart`, the same command `rove doctor` prescribes for it.
 The two terminal-unavailable lines say which shell (`$SHELL`) and where its
-error is (`~/.rove/pty.log`). The onboarding wizard's environment page shows
-the same `→ install an engine CLI …` line in the TUI that the CLI wizard
-already printed.
+error is (`~/.rove/pty.log`).
 
-Worktree toasts no longer stutter: a failed create said `Couldn't create the
-worktree: create(): …`, leaking the function that threw. The four routine
-failures were a bare passthrough of the daemon's message with no hint of which
-of create/delete/toggle/run had failed; each now names the action and what
-survived it — `"nightly audit" stays enabled and will keep firing on schedule`.
+Worktree, fork and branch toasts no longer stutter: a failed create said
+`Couldn't create the worktree: create(): …`, leaking the function that threw.
+The four routine failures were a bare passthrough of the daemon's message with
+no hint of which of create/delete/toggle/run had failed; each now names the
+action and what survived it — `"nightly audit" stays enabled and will keep
+firing on schedule`.

--- a/packages/kobe-web/e2e/visual-fixture.ts
+++ b/packages/kobe-web/e2e/visual-fixture.ts
@@ -102,6 +102,13 @@ export const VISUAL_PTY_COMMAND = `${[
   "KOBE_TASK_ID=",
   "ROVE_TAB_ID=",
   "KOBE_TAB_ID=",
+  // Opt-in PATH override for capturing the "nothing installed" states. Only
+  // the contrib engines resolve through `Bun.which`, so a stripped PATH is the
+  // one lever that hides them; the built-ins have their own finders and stay
+  // visible as installed-but-not-logged-in, which is what the onboarding
+  // wizard's not-ready verdict needs. Absent by default — a fixture with no
+  // engines is not the state most journeys want.
+  ...(process.env.KOBE_VISUAL_MIN_PATH ? [`PATH=${process.env.KOBE_VISUAL_MIN_PATH}`] : []),
 ].join(" ")} bun run dev:sandbox`
 
 /** Bump when the fixture shape changes so warm reuse rebuilds. */

--- a/packages/kobe/src/lib/error-message.ts
+++ b/packages/kobe/src/lib/error-message.ts
@@ -6,3 +6,24 @@
 export function errorMessage(err: unknown): string {
   return err instanceof Error ? err.message : String(err)
 }
+
+/**
+ * A thrown message with its throw-site prefix removed, for text a USER reads.
+ *
+ * The worktree/task layers prefix their throws with the function that raised
+ * them (`create(): <path> exists but is not a registered git worktree`,
+ * `setBranch: branch is required`). That prefix earns its keep in
+ * `client.log`, but interpolated into a toast it reads as a second, stuttered
+ * verb — "Couldn't create the worktree: create(): …" — and names an internal
+ * symbol the user cannot act on.
+ *
+ * Stripped only when the prefix is unmistakably an identifier: it ends in
+ * `()`, or it is camelCase with an internal capital. Prose prefixes stay —
+ * git's own `fatal: not a git repository` is all-lowercase and parenless, and
+ * losing its `fatal:` would change what the line means.
+ */
+const THROW_SITE_PREFIX = /^(?:[a-z][A-Za-z0-9]*\(\)|[a-z][a-z0-9]*(?:[A-Z][A-Za-z0-9]*)+): /
+
+export function userFacingErrorMessage(err: unknown): string {
+  return errorMessage(err).replace(THROW_SITE_PREFIX, "")
+}

--- a/packages/kobe/src/tui-react/component/automations-page.tsx
+++ b/packages/kobe/src/tui-react/component/automations-page.tsx
@@ -176,7 +176,14 @@ export function AutomationsPage(props: {
       refetch()
     } catch (err) {
       console.error("[rove automations] toggle failed:", err)
-      notifyError(t("automations.failed", { error: errorMessage(err) }))
+      // The routine is unchanged, so the surviving state is the one it had
+      // BEFORE the click — name that, not the state the user asked for.
+      notifyError(
+        t(selected.enabled ? "automations.disableFailed" : "automations.enableFailed", {
+          name: selected.name,
+          error: errorMessage(err),
+        }),
+      )
     } finally {
       setBusyId(null)
     }
@@ -193,7 +200,7 @@ export function AutomationsPage(props: {
       refetch()
     } catch (err) {
       console.error("[rove automations] run now failed:", err)
-      notifyError(t("automations.failed", { error: errorMessage(err) }))
+      notifyError(t("automations.runFailed", { name: selected.name, error: errorMessage(err) }))
     } finally {
       setBusyId(null)
     }
@@ -224,10 +231,10 @@ export function AutomationsPage(props: {
       await orch.createAutomation(draft)
       refetch()
     } catch (err) {
-      // The daemon re-validates the cron; its message names the fix, so it
-      // leads the error toast.
+      // The daemon re-validates the cron and its message names the fix, so it
+      // is carried verbatim after the action this toast failed at.
       console.error("[rove automations] create failed:", err)
-      notifyError(t("automations.failed", { error: errorMessage(err) }))
+      notifyError(t("automations.createFailed", { error: errorMessage(err) }))
     } finally {
       setBusyId(null)
     }
@@ -251,7 +258,7 @@ export function AutomationsPage(props: {
       refetch()
     } catch (err) {
       console.error("[rove automations] delete failed:", err)
-      notifyError(t("automations.failed", { error: errorMessage(err) }))
+      notifyError(t("automations.deleteFailed", { name: selected.name, error: errorMessage(err) }))
     } finally {
       setBusyId(null)
     }

--- a/packages/kobe/src/tui-react/onboarding/host.tsx
+++ b/packages/kobe/src/tui-react/onboarding/host.tsx
@@ -42,7 +42,25 @@ import { pageCloseBindings, useBindings } from "../lib/keymap"
  * `env.engines.lines` IS the rendered array, so this cannot drift from it.
  */
 function inlineRowsFor(env: OnboardingEnvReport): number {
-  return 15 + env.engines.lines.length
+  return 15 + env.engines.lines.length + envActionKeys(env).length
+}
+
+/**
+ * The `→ <action>` lines the environment page prints under a failing verdict,
+ * as i18n keys. Same conditions the CLI wizard branches on in
+ * `cli/onboarding.ts`, so a user is never told less for having run the wizard
+ * in the TUI.
+ *
+ * A list rather than two inline conditions so {@link inlineRowsFor} can COUNT
+ * them: they are the only rows on this page that the budget did not know
+ * about, and one row of overflow is the corrupted repaint that function's own
+ * note describes.
+ */
+function envActionKeys(env: OnboardingEnvReport): string[] {
+  const keys: string[] = []
+  if (!env.engines.anyUsable) keys.push("doctor.fix.noEngineAction")
+  if (!env.git.found) keys.push("doctor.fix.gitAction")
+  return keys
 }
 
 type StepId = "completions" | "skill"
@@ -161,20 +179,15 @@ export function WizardPage(props: {
                 </text>
               ))}
             </box>
-            <box flexDirection="column" paddingTop={1}>
+            <box paddingTop={1} flexDirection="column">
               <text fg={ready ? theme.success : theme.error} wrapMode="word">
                 {ready ? t("onboarding.envReady") : t("onboarding.envNotReady")}
               </text>
-              {/* The CLI path of this same wizard (`cli/onboarding.ts`) prints
-                  these action lines under the same verdict. Without them the
-                  TUI tells a blocked user they are blocked and not what
-                  unblocks them — same wizard, two amounts of help. */}
-              {!ready && !props.env.engines.anyUsable ? (
-                <text fg={theme.textMuted} wrapMode="word">{`→ ${t("doctor.fix.noEngineAction")}`}</text>
-              ) : null}
-              {!ready && !props.env.git.found ? (
-                <text fg={theme.textMuted} wrapMode="word">{`→ ${t("doctor.fix.gitAction")}`}</text>
-              ) : null}
+              {/* The verdict names the blocker; without these the TUI wizard
+                  stops there while the CLI wizard goes on to print the action. */}
+              {envActionKeys(props.env).map((key) => (
+                <text key={key} fg={theme.textMuted} wrapMode="word">{`→ ${t(key)}`}</text>
+              ))}
             </box>
           </box>
         ) : null}

--- a/packages/kobe/src/tui-react/panes/filetree/FileTree.tsx
+++ b/packages/kobe/src/tui-react/panes/filetree/FileTree.tsx
@@ -40,6 +40,7 @@ import {
   computeStatWidths,
   expandOrDescendAction,
   followScrollTop,
+  gitErrorIsRetryable,
   summarizeGitError,
   toggleDir,
   watchWorktree,
@@ -449,9 +450,11 @@ export function FileTree(props: FileTreeProps) {
             <text fg={theme.error} wrapMode="word">
               {summarizeGitError(error, t)}
             </text>
-            <text fg={theme.textMuted} wrapMode="word">
-              {t("files.error.retryHint")}
-            </text>
+            {gitErrorIsRetryable(error) ? (
+              <text fg={theme.textMuted} wrapMode="word">
+                {t("files.error.retryHint")}
+              </text>
+            ) : null}
           </box>
         ) : rows.length === 0 && loaded ? (
           <box paddingTop={1} paddingLeft={1}>

--- a/packages/kobe/src/tui-react/workspace/host-task-actions.ts
+++ b/packages/kobe/src/tui-react/workspace/host-task-actions.ts
@@ -14,7 +14,7 @@
  * (`TaskActionContext.tasks` is `() => readonly Task[]`).
  */
 
-import { errorMessage } from "@/lib/error-message"
+import { userFacingErrorMessage } from "@/lib/error-message"
 import { useRenderer } from "@opentui/react"
 import type { RemoteOrchestrator } from "../../client/remote-orchestrator.ts"
 import { availableEngineIds } from "../../engine/account-detect"
@@ -138,13 +138,13 @@ export function useWorkspaceTaskActions(deps: WorkspaceTaskActionDeps): Workspac
     const task = tasks().find((t) => t.id === id)
     if (!task) return
     await orchestrator.setPinned(id, !task.pinned).catch((err) => {
-      notifyError(t("tasks.toast.pinFailed", { error: errorMessage(err) }))
+      notifyError(t("tasks.toast.pinFailed", { error: userFacingErrorMessage(err) }))
     })
   }
 
   async function moveTask(id: string, delta: -1 | 1): Promise<void> {
     await orchestrator.moveTask(id, delta).catch((err) => {
-      notifyError(t("tasks.toast.moveFailed", { error: errorMessage(err) }))
+      notifyError(t("tasks.toast.moveFailed", { error: userFacingErrorMessage(err) }))
     })
   }
 
@@ -160,7 +160,7 @@ export function useWorkspaceTaskActions(deps: WorkspaceTaskActionDeps): Workspac
     const next = await BranchPickerDialog.show(dialog, { currentBranch: task.branch, repo: task.repo })
     if (!next) return
     await orchestrator.setBranch(id, next).catch((err) => {
-      notifyError(t("tasks.toast.renameBranchFailed", { branch: task.branch, error: errorMessage(err) }))
+      notifyError(t("tasks.toast.renameBranchFailed", { branch: task.branch, error: userFacingErrorMessage(err) }))
     })
   }
 

--- a/packages/kobe/src/tui-react/workspace/inbox-rpc-errors.ts
+++ b/packages/kobe/src/tui-react/workspace/inbox-rpc-errors.ts
@@ -1,4 +1,4 @@
-import { errorMessage } from "@/lib/error-message"
+import { userFacingErrorMessage } from "@/lib/error-message"
 import { t } from "../../tui/i18n"
 
 export type InboxRpcAction = "mark read" | "dismiss"
@@ -19,5 +19,5 @@ export function notifyInboxRpcFailure(
   action: InboxRpcAction,
   notifyError: (message: string) => void,
 ): void {
-  void request.catch((err) => notifyError(t(FAILURE_KEY[action], { error: errorMessage(err) })))
+  void request.catch((err) => notifyError(t(FAILURE_KEY[action], { error: userFacingErrorMessage(err) })))
 }

--- a/packages/kobe/src/tui-react/workspace/open-task-worktree.ts
+++ b/packages/kobe/src/tui-react/workspace/open-task-worktree.ts
@@ -1,4 +1,5 @@
 import { existsSync } from "node:fs"
+import { userFacingErrorMessage } from "@/lib/error-message"
 import { t } from "../../tui/i18n"
 import { detectWorktreeOpener, openWorktree } from "../../tui/lib/worktree-opener"
 import type { Task } from "../../types/task"
@@ -18,8 +19,7 @@ export async function requestTaskWorktreeOpen(id: string, deps: OpenTaskWorktree
     try {
       path = await deps.ensureWorktree(id)
     } catch (error) {
-      const reason = error instanceof Error ? error.message : String(error)
-      deps.notifyError(t("tasks.toast.worktreeErrorGeneric", { message: reason }))
+      deps.notifyError(t("tasks.toast.worktreeErrorGeneric", { message: userFacingErrorMessage(error) }))
       return
     }
   }

--- a/packages/kobe/src/tui-react/workspace/quick-fork.ts
+++ b/packages/kobe/src/tui-react/workspace/quick-fork.ts
@@ -13,7 +13,7 @@
  * two entry points diverge on the side effects above.
  */
 
-import { errorMessage } from "@/lib/error-message"
+import { userFacingErrorMessage } from "@/lib/error-message"
 import { useState } from "react"
 import { engineDisplayName } from "../../engine/interactive-command"
 import { addSavedRepo } from "../../state/repos"
@@ -104,7 +104,7 @@ async function runQuickFork(
     return task.id
   } catch (err) {
     console.error("[rove workspace] quick-fork task.create failed:", err)
-    hooks.notifyError(t("tasks.toast.forkFailed", { error: errorMessage(err) }))
+    hooks.notifyError(t("tasks.toast.forkFailed", { error: userFacingErrorMessage(err) }))
     return undefined
   }
 }

--- a/packages/kobe/src/tui-react/workspace/use-issue-chat.ts
+++ b/packages/kobe/src/tui-react/workspace/use-issue-chat.ts
@@ -27,7 +27,7 @@
  * so they ride the prompt as part of the story text.
  */
 
-import { errorMessage } from "@/lib/error-message"
+import { userFacingErrorMessage } from "@/lib/error-message"
 import type { Issue } from "@sma1lboy/kobe-daemon/daemon/issues-store"
 import { kobeApiInvocation } from "../../engine/interactive-command"
 import {
@@ -110,7 +110,7 @@ export function useIssueChat(
       // chat. But "not fatal" isn't "not worth saying": the card silently
       // stays in Backlog while its session runs.
       console.error("[rove kanban] issue setStatus failed:", err)
-      hooks.notifyError(t("kanban.statusFailed", { id: String(issue.id), error: errorMessage(err) }))
+      hooks.notifyError(t("kanban.statusFailed", { id: String(issue.id), error: userFacingErrorMessage(err) }))
     })
     const { tab } = appendBackgroundEngineTab(kv, main.id, defaultShell(), { vendor })
     const spawn = buildIssueTabSpawn({
@@ -144,7 +144,7 @@ export function useIssueChat(
       // story just never grows its `linked to a session` badge and the
       // drawer's "open the linked session" never appears.
       console.error("[rove kanban] issue link failed:", err)
-      hooks.notifyError(t("kanban.linkFailed", { id: String(issue.id), error: errorMessage(err) }))
+      hooks.notifyError(t("kanban.linkFailed", { id: String(issue.id), error: userFacingErrorMessage(err) }))
     })
     const worktreePath = await orch.ensureWorktree(task.id)
     const spawn = buildIssueChatBackgroundSpawn({ issue, taskId: task.id, repoRoot, worktreePath, vendor, api })
@@ -181,7 +181,7 @@ export function useIssueChat(
       }
       await finish(request, task.id)
     } catch (err) {
-      hooks.notifyError(t("tasks.toast.issueChatFailed", { error: errorMessage(err) }))
+      hooks.notifyError(t("tasks.toast.issueChatFailed", { error: userFacingErrorMessage(err) }))
     }
   }
 

--- a/packages/kobe/src/tui-react/workspace/use-scratch-shell.ts
+++ b/packages/kobe/src/tui-react/workspace/use-scratch-shell.ts
@@ -25,6 +25,7 @@
 
 import { homedir } from "node:os"
 import type { RemoteOrchestrator } from "../../client/remote-orchestrator"
+import { userFacingErrorMessage } from "../../lib/error-message"
 import { t } from "../../tui/i18n"
 import { finishDeletedTaskFlow } from "../../tui/lib/task-actions"
 import type { Task } from "../../types/task"
@@ -82,9 +83,7 @@ export function useScratchShell(deps: {
     void orchestrator
       .openDirectoryTask({ dir: homedir(), scratch: true })
       .then((task) => enterTask(task.id))
-      .catch((err) =>
-        notifyError(t("tasks.toast.scratchOpenFailed", { message: err instanceof Error ? err.message : String(err) })),
-      )
+      .catch((err) => notifyError(t("tasks.toast.scratchOpenFailed", { message: userFacingErrorMessage(err) })))
   }
 
   const onScratchExit = (taskId: string): void => {
@@ -108,7 +107,7 @@ export function useScratchShell(deps: {
           updateActiveTask: true,
         })
       } catch (err) {
-        notifyError(t("tasks.toast.scratchCloseFailed", { message: err instanceof Error ? err.message : String(err) }))
+        notifyError(t("tasks.toast.scratchCloseFailed", { message: userFacingErrorMessage(err) }))
       }
     })()
   }

--- a/packages/kobe/src/tui-react/workspace/use-task-selection.ts
+++ b/packages/kobe/src/tui-react/workspace/use-task-selection.ts
@@ -3,7 +3,7 @@
  * create-before-snapshot path is testable without mounting the full PTY host.
  */
 
-import { errorMessage } from "../../lib/error-message.ts"
+import { errorMessage, userFacingErrorMessage } from "../../lib/error-message.ts"
 import { TASK_DELETING_CODE, TaskDeletingError } from "../../orchestrator/errors.ts"
 import type { Task } from "../../types/task.ts"
 
@@ -13,7 +13,9 @@ import type { Task } from "../../types/task.ts"
  * Three shapes reach here and they need different words:
  *  - the task is mid-delete — nothing is wrong, the answer is "wait";
  *  - the project has no git repo yet — actionable, `git init` fixes it;
- *  - anything else — carry the raw reason so the user can act on it.
+ *  - anything else — carry the reason so the user can act on it, minus the
+ *    throw-site prefix the worktree layer stamps on it (`create(): …`),
+ *    which would otherwise stutter the verb the toast already supplies.
  *
  * `TaskDeletingError` is matched on its MESSAGE, not `instanceof`: the same
  * refusal is also raised daemon-side and the RPC layer rebuilds it as a plain
@@ -27,7 +29,7 @@ export function activationErrorMessage(
   if (message.includes(TASK_DELETING_CODE)) return translate("tasks.toast.worktreeErrorDeleting")
   if (/not a git repository|does not appear to be a git repo/i.test(message))
     return translate("tasks.toast.worktreeErrorNotGit")
-  return translate("tasks.toast.worktreeErrorGeneric", { message })
+  return translate("tasks.toast.worktreeErrorGeneric", { message: userFacingErrorMessage(error) })
 }
 
 type ActivateWorkspaceTaskOptions = {

--- a/packages/kobe/src/tui/i18n/messages/automations.ts
+++ b/packages/kobe/src/tui/i18n/messages/automations.ts
@@ -56,8 +56,14 @@ export const en = {
   deleteTitle: "Delete routine?",
   deleteBody: "{name} and its run history will be removed. Tasks it already created are untouched.",
   deleteButton: "Delete",
-  /** Error-toast title for a failed create/delete/toggle/run. `{error}` = the daemon's own message. */
-  failed: "{error}",
+  /** Error toasts for a failed create/delete/toggle/run. Each names the action
+   *  that failed AND what is still true afterwards, so the user knows whether
+   *  to retry or to leave it alone. `{error}` = the daemon's own message. */
+  createFailed: "Couldn't create the routine: {error}",
+  deleteFailed: 'Couldn\'t delete "{name}" — it stays scheduled: {error}',
+  enableFailed: '"{name}" stays paused and will not fire: {error}',
+  disableFailed: '"{name}" stays enabled and will keep firing on schedule: {error}',
+  runFailed: 'Couldn\'t run "{name}" now — its schedule is unchanged: {error}',
 }
 
 export const zh: typeof en = {
@@ -112,6 +118,10 @@ export const zh: typeof en = {
   deleteTitle: "删除这条例行任务？",
   deleteBody: "将删除 {name} 及其执行记录。它已经创建的任务不受影响。",
   deleteButton: "删除",
-  /** 创建/删除/开关/立即运行失败时的错误 toast 标题。`{error}` = daemon 返回的信息。 */
-  failed: "{error}",
+  /** 创建/删除/开关/立即运行失败时的错误 toast。`{error}` = daemon 返回的信息。 */
+  createFailed: "创建例行任务失败：{error}",
+  deleteFailed: "删除“{name}”失败，它仍在排程中：{error}",
+  enableFailed: "“{name}”仍处于暂停状态，不会触发：{error}",
+  disableFailed: "“{name}”仍处于启用状态，会继续按排程触发：{error}",
+  runFailed: "无法立即运行“{name}”——它的排程未受影响：{error}",
 }

--- a/packages/kobe/src/tui/i18n/messages/automations.ts
+++ b/packages/kobe/src/tui/i18n/messages/automations.ts
@@ -57,13 +57,15 @@ export const en = {
   deleteBody: "{name} and its run history will be removed. Tasks it already created are untouched.",
   deleteButton: "Delete",
   /** Error toasts for a failed create/delete/toggle/run. Each names the action
-   *  that failed AND what is still true afterwards, so the user knows whether
-   *  to retry or to leave it alone. `{error}` = the daemon's own message. */
+   *  that failed, then carries the daemon's own `{error}`. Kept short on
+   *  purpose: the toast is ONE truncated line — about 38 cells at 90 columns —
+   *  so a longer clause buys nothing and costs the cause. The toggle pair
+   *  states the surviving state because that is what separates the two. */
   createFailed: "Couldn't create the routine: {error}",
-  deleteFailed: 'Couldn\'t delete "{name}" — it stays scheduled: {error}',
-  enableFailed: '"{name}" stays paused and will not fire: {error}',
-  disableFailed: '"{name}" stays enabled and will keep firing on schedule: {error}',
-  runFailed: 'Couldn\'t run "{name}" now — its schedule is unchanged: {error}',
+  deleteFailed: 'Couldn\'t delete "{name}": {error}',
+  enableFailed: '"{name}" stays paused: {error}',
+  disableFailed: '"{name}" stays enabled: {error}',
+  runFailed: 'Couldn\'t run "{name}" now — schedule unchanged: {error}',
 }
 
 export const zh: typeof en = {
@@ -120,8 +122,8 @@ export const zh: typeof en = {
   deleteButton: "删除",
   /** 创建/删除/开关/立即运行失败时的错误 toast。`{error}` = daemon 返回的信息。 */
   createFailed: "创建例行任务失败：{error}",
-  deleteFailed: "删除“{name}”失败，它仍在排程中：{error}",
-  enableFailed: "“{name}”仍处于暂停状态，不会触发：{error}",
-  disableFailed: "“{name}”仍处于启用状态，会继续按排程触发：{error}",
-  runFailed: "无法立即运行“{name}”——它的排程未受影响：{error}",
+  deleteFailed: "删除“{name}”失败：{error}",
+  enableFailed: "“{name}”仍处于暂停状态：{error}",
+  disableFailed: "“{name}”仍处于启用状态：{error}",
+  runFailed: "无法立即运行“{name}”——排程未受影响：{error}",
 }

--- a/packages/kobe/src/tui/i18n/messages/files.ts
+++ b/packages/kobe/src/tui/i18n/messages/files.ts
@@ -30,11 +30,16 @@ export const en = {
     noChanges: "(no changes — clean worktree)",
   },
   error: {
+    /** Only rendered for the two kinds `r` can actually resolve — see
+     *  {@link gitErrorIsRetryable}. */
     retryHint: "press r to retry",
-    notGitRepo: "not a git repository",
-    pathMissing: "worktree path is missing",
-    permissionDenied: "permission denied",
-    gitNotInstalled: "git is not installed",
+    notGitRepo: "not a git repository — run `git init` here, or open a task in a repo",
+    // Matches `tasks.toast.worktreeGoneBody`, which prescribes the same
+    // recovery for the same condition.
+    pathMissing: "the worktree directory is gone — reopen the task to re-create it",
+    permissionDenied: "permission denied reading the worktree — check the directory's owner and mode",
+    // Wording aligned with `doctor.fix.git` / `doctor.fix.gitAction`.
+    gitNotInstalled: "git is not on PATH — install it with your OS package manager",
     gitFailed: "git command failed",
   },
   toast: {
@@ -72,10 +77,10 @@ export const zh: typeof en = {
   },
   error: {
     retryHint: "按 r 重试",
-    notGitRepo: "不是 git 仓库",
-    pathMissing: "worktree 路径不存在",
-    permissionDenied: "权限不足",
-    gitNotInstalled: "未安装 git",
+    notGitRepo: "不是 git 仓库——在这里执行 `git init`，或改为打开仓库里的任务",
+    pathMissing: "worktree 目录已不存在——重新打开该任务会重建它",
+    permissionDenied: "读取 worktree 时权限不足——请检查该目录的属主和权限",
+    gitNotInstalled: "PATH 上找不到 git——请用系统包管理器安装",
     gitFailed: "git 命令失败",
   },
   toast: {

--- a/packages/kobe/src/tui/i18n/messages/tasks.ts
+++ b/packages/kobe/src/tui/i18n/messages/tasks.ts
@@ -175,7 +175,9 @@ export const en = {
   },
   /** Toast / error messages */
   toast: {
-    noDaemonWorktree: "No daemon running — can't create the worktree",
+    // `rove daemon restart` is what `doctor.fix.daemonDown` prescribes for the
+    // identical condition — the TUI and doctor must not disagree on the fix.
+    noDaemonWorktree: "No daemon running — can't create the worktree. Start it with `rove daemon restart`.",
     noEditor: "No editor found — set ROVE_OPEN_EDITOR (e.g. 'code', 'cursor', 'nvim')",
     openWorktreeFailed: "Couldn't open worktree with {label}",
     worktreeErrorDeleting: "This task is being deleted — it can't be opened",
@@ -339,7 +341,7 @@ export const zh: typeof en = {
     footer: "↑↓ 选择 · enter 设置 · esc 取消",
   },
   toast: {
-    noDaemonWorktree: "守护进程未运行——无法创建 worktree",
+    noDaemonWorktree: "守护进程未运行——无法创建 worktree。请运行 `rove daemon restart` 启动它。",
     noEditor: "未找到编辑器——请设置 ROVE_OPEN_EDITOR（如 'code'、'cursor'、'nvim'）",
     openWorktreeFailed: "无法用 {label} 打开 worktree",
     worktreeErrorDeleting: "该任务正在删除中——无法打开",

--- a/packages/kobe/src/tui/i18n/messages/terminal.ts
+++ b/packages/kobe/src/tui/i18n/messages/terminal.ts
@@ -52,8 +52,14 @@ export const en = {
     unavailable: "this app owns its own scrollback — nothing local to search (esc)",
   },
   unavailable: {
-    shellMissing: "terminal unavailable — configured shell is not available",
-    spawnFailed: "terminal unavailable — shell could not start",
+    // The PTY host resolves its shell from `$SHELL` alone (`resolveLoginShell`
+    // in kobe-daemon) — there is no Settings row for it, so `$SHELL` is the
+    // only place a user can act.
+    shellMissing:
+      "terminal unavailable — the shell named by $SHELL isn't on this machine. Point $SHELL at one that exists, or unset it to fall back to the system default.",
+    // `~/.rove/pty.log` is where session-host startup failures land
+    // (docs/TROUBLESHOOTING.md).
+    spawnFailed: "terminal unavailable — the shell exited immediately. Its error is in ~/.rove/pty.log.",
     // The pane is otherwise a dead end: there is no PTY to key into, so the
     // only way out has to be named on screen.
     retry: "F5 tries again",
@@ -102,8 +108,9 @@ export const zh: typeof en = {
     unavailable: "这个程序自己管理回滚缓冲区 —— 本地没有可搜索的内容（esc）",
   },
   unavailable: {
-    shellMissing: "终端不可用 —— 配置的 shell 不存在",
-    spawnFailed: "终端不可用 —— shell 启动失败",
+    shellMissing:
+      "终端不可用 —— $SHELL 指向的 shell 在这台机器上不存在。请把 $SHELL 指向一个真实存在的 shell，或取消设置以回退到系统默认。",
+    spawnFailed: "终端不可用 —— shell 启动后立即退出。具体错误见 ~/.rove/pty.log。",
     retry: "按 F5 重试",
   },
   reset: {

--- a/packages/kobe/src/tui/panes/filetree/pane-core.ts
+++ b/packages/kobe/src/tui/panes/filetree/pane-core.ts
@@ -44,15 +44,38 @@ export function statusToken(s: FileStatus): "warning" | "success" | "error" | "t
  * own reactive one.
  */
 export function summarizeGitError(raw: string, t: (key: string) => string): string {
-  const m = raw.toLowerCase()
-  if (m.includes("not a git repository")) return t("files.error.notGitRepo")
-  if (m.includes("does not exist") || m.includes("enoent")) return t("files.error.pathMissing")
-  if (m.includes("permission denied") || m.includes("eacces")) return t("files.error.permissionDenied")
-  if (m.includes("git: not found") || m.includes("command not found")) return t("files.error.gitNotInstalled")
+  const kind = classifyGitError(raw)
+  if (kind) return t(`files.error.${kind}`)
   // Fallback: strip the leading `git <args> (cwd=...)` boilerplate.
   const colon = raw.indexOf(": ")
   if (colon >= 0 && raw.startsWith("git ")) return raw.slice(colon + 2).trim() || t("files.error.gitFailed")
   return raw.trim() || t("files.error.gitFailed")
+}
+
+type GitErrorKind = "notGitRepo" | "pathMissing" | "permissionDenied" | "gitNotInstalled"
+
+/** The recognised shape of `raw`, or null when only the generic fallback fits. */
+function classifyGitError(raw: string): GitErrorKind | null {
+  const m = raw.toLowerCase()
+  if (m.includes("not a git repository")) return "notGitRepo"
+  if (m.includes("does not exist") || m.includes("enoent")) return "pathMissing"
+  if (m.includes("permission denied") || m.includes("eacces")) return "permissionDenied"
+  if (m.includes("git: not found") || m.includes("command not found")) return "gitNotInstalled"
+  return null
+}
+
+/**
+ * Should the pane offer `r` under this error?
+ *
+ * `r` re-runs the same git command, so it is only honest where a retry can
+ * change the answer: a transient git failure, or a permission the user just
+ * fixed. Offering it beside "not a git repository" or "git is not on PATH"
+ * invites the user to press it forever — neither `git init` nor an install
+ * happens by retrying.
+ */
+export function gitErrorIsRetryable(raw: string): boolean {
+  const kind = classifyGitError(raw)
+  return kind !== "notGitRepo" && kind !== "gitNotInstalled"
 }
 
 /**

--- a/packages/kobe/test/lib/user-facing-error-message.test.ts
+++ b/packages/kobe/test/lib/user-facing-error-message.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest"
+import { userFacingErrorMessage } from "../../src/lib/error-message.ts"
+
+/**
+ * The worktree/task layers stamp their throws with the function that raised
+ * them. That prefix belongs in `client.log`, never in a toast — see the
+ * helper's own doc. These cases are the real strings from
+ * `orchestrator/worktree/manager.ts`, `task-editor.ts`, and git itself.
+ */
+describe("userFacingErrorMessage", () => {
+  it("drops a parenthesised throw-site prefix", () => {
+    expect(userFacingErrorMessage(new Error("create(): /p exists but is not a registered git worktree"))).toBe(
+      "/p exists but is not a registered git worktree",
+    )
+    expect(userFacingErrorMessage(new Error("currentBranch(): /p is in detached-HEAD state"))).toBe(
+      "/p is in detached-HEAD state",
+    )
+  })
+
+  it("drops a camelCase throw-site prefix that has no parens", () => {
+    expect(userFacingErrorMessage(new Error("setBranch: branch is required"))).toBe("branch is required")
+    expect(userFacingErrorMessage(new Error("adoptWorktree: /p is already adopted as a task"))).toBe(
+      "/p is already adopted as a task",
+    )
+  })
+
+  it("keeps a lowercase prose prefix — dropping git's `fatal:` would change the meaning", () => {
+    expect(userFacingErrorMessage(new Error("fatal: not a git repository"))).toBe("fatal: not a git repository")
+    expect(userFacingErrorMessage(new Error("error: pathspec did not match"))).toBe("error: pathspec did not match")
+    expect(userFacingErrorMessage(new Error("ENOENT: no such file or directory"))).toBe(
+      "ENOENT: no such file or directory",
+    )
+  })
+
+  it("strips only the leading prefix, so the rest of the sentence survives", () => {
+    expect(
+      userFacingErrorMessage(new Error("create(): git reported success but /p is not a worktree: fatal: bad")),
+    ).toBe("git reported success but /p is not a worktree: fatal: bad")
+  })
+
+  it("passes non-Error throws through the same way errorMessage does", () => {
+    expect(userFacingErrorMessage("remove(): /p is not a git worktree")).toBe("/p is not a git worktree")
+    expect(userFacingErrorMessage(undefined)).toBe("undefined")
+  })
+})

--- a/packages/kobe/test/render/failure-toast.test.tsx
+++ b/packages/kobe/test/render/failure-toast.test.tsx
@@ -172,7 +172,10 @@ test("automations: a failed delete shows an error toast instead of a muted line"
   await settle()
   mockInput.pressEnter()
   await settle(150)
-  await expectErrorToast(await frame(), spans, "daemon refused", "in 1h")
+  // Assert the toast's own prefix, the way the kanban cases above do: the
+  // toast is one truncated line, so a 90-column frame cuts the daemon's
+  // message off the end. The prefix is what tells the user WHICH action died.
+  await expectErrorToast(await frame(), spans, 'Couldn\'t delete "weekday audit"', "in 1h")
 })
 
 test("automations: a failed toggle shows an error toast", async () => {
@@ -195,7 +198,9 @@ test("automations: a failed toggle shows an error toast", async () => {
   await settle(150)
   mockInput.typeText("e")
   await settle(150)
-  await expectErrorToast(await frame(), spans, "daemon refused", "in 1h")
+  // The routine was enabled, so the toast names the state it KEPT — a toggle
+  // that failed must not read as though it half-applied.
+  await expectErrorToast(await frame(), spans, '"weekday audit" stays enabled', "in 1h")
 })
 
 const WORK_ITEM = {

--- a/packages/kobe/test/tui-react/filetree-pane-core.test.ts
+++ b/packages/kobe/test/tui-react/filetree-pane-core.test.ts
@@ -13,6 +13,7 @@ import {
   computeStatWidths,
   expandOrDescendAction,
   followScrollTop,
+  gitErrorIsRetryable,
   statCell,
   statusToken,
   summarizeGitError,
@@ -76,6 +77,20 @@ describe("summarizeGitError", () => {
   test("falls back to the raw text, then the generic key", () => {
     expect(summarizeGitError("  weird failure  ", t)).toBe("weird failure")
     expect(summarizeGitError("   ", t)).toBe("<files.error.gitFailed>")
+  })
+})
+
+describe("gitErrorIsRetryable", () => {
+  test("hides `press r to retry` where pressing r can never change the answer", () => {
+    // Each label now carries its own action (`git init`, install git); the
+    // retry hint beside them contradicts it.
+    expect(gitErrorIsRetryable("fatal: not a git repository")).toBe(false)
+    expect(gitErrorIsRetryable("bash: git: not found")).toBe(false)
+  })
+  test("keeps it for the kinds a second attempt can resolve", () => {
+    expect(gitErrorIsRetryable("EACCES permission denied")).toBe(true)
+    expect(gitErrorIsRetryable("ENOENT: no such file")).toBe(true)
+    expect(gitErrorIsRetryable("git ls-files (cwd=/x) exited with code 128: something odd")).toBe(true)
   })
 })
 

--- a/packages/kobe/test/tui/workspace-task-selection.test.ts
+++ b/packages/kobe/test/tui/workspace-task-selection.test.ts
@@ -251,4 +251,15 @@ describe("activation failures map onto user-visible copy", () => {
     expect(message).toContain("tasks.toast.worktreeErrorGeneric")
     expect(message).toContain("worktree is locked")
   })
+
+  test("the worktree manager's throw-site prefix never reaches the toast", () => {
+    // Verbatim from `orchestrator/worktree/manager.ts` — the toast already
+    // says "Couldn't create the worktree", so a leading `create():` reads as
+    // the verb stuttering, and names a symbol the user cannot act on.
+    const raw = "create(): /w/slug exists but is not a registered git worktree"
+    const message = activationErrorMessage(new Error(raw), translate)
+    expect(message).toContain("tasks.toast.worktreeErrorGeneric")
+    expect(message).not.toContain("create()")
+    expect(message).toContain("exists but is not a registered git worktree")
+  })
 })


### PR DESCRIPTION
Loop r13 failure-message corpus, **BATCH 2** (minus 2.1, which was the other worker's and landed in #866) and **BATCH 3**.

Every message below was **executed**, not read. `.scratch/loop-r13-ah/proof.ts` renders each one through the real catalog and the real display functions in both locales; it was run once on `origin/main` and once on this branch. Full paired output: `.scratch/loop-r13-ah/before.txt` / `after.txt`.

---

## 2.2 — throw-site prefixes leaking into toasts

**PASS:** a `create()` failure surfaces a toast with no `():` in it; `fatal:` and other prose prefixes survive; `client.log` still records the prefixed original (nothing at a `console.error` site changed).

`userFacingErrorMessage` (`src/lib/error-message.ts`) drops a leading prefix only when it is unmistakably an identifier — it ends in `()`, or it is camelCase with an internal capital. Applied at **every** user-visible `{error}` / `{message}` hole in the workspace, which is now possible because #866 moved the last seven of them into the catalog.

| trigger | before | after |
|---|---|---|
| `create(): /w/slug exists but is not a registered git worktree` | `Couldn't create the worktree: create(): /w/slug exists but is not a registered git worktree` | `Couldn't create the worktree: /w/slug exists but is not a registered git worktree` |
| `renameBranch(): /w/slug is not a git worktree` | `Couldn't rename the branch — it stays "feat/x": renameBranch(): /w/slug is not a git worktree` | `Couldn't rename the branch — it stays "feat/x": /w/slug is not a git worktree` |
| `setBranch: a main task tracks the repo's own branch; rename it with git directly` | `… it stays "main": setBranch: a main task tracks…` | `… it stays "main": a main task tracks…` |
| `create(): …` via quick-fork | `Couldn't fork the task — the original is untouched: create(): …` | `Couldn't fork the task — the original is untouched: …` |
| `fatal: not a git repository` | *(unchanged — routed to the `git init` copy)* | *(unchanged)* |

**Mutation-verified.** Neutering the stripper to `return errorMessage(err)` fails 5 tests across `test/lib/user-facing-error-message.test.ts` and `test/tui/workspace-task-selection.test.ts`, including the `fatal:` must-not-strip case.

## 2.3 — `automations.failed` was a bare `{error}` passthrough

**PASS:** each of the four paths shows a distinct title naming the action; `check-i18n` passes.

| path | before | after |
|---|---|---|
| create | `not a five-field cron` | `Couldn't create the routine: not a five-field cron` |
| delete | `daemon unreachable` | `Couldn't delete "nightly audit": daemon unreachable` |
| enable (failed) | `daemon unreachable` | `"nightly audit" stays paused: daemon unreachable` |
| disable (failed) | `daemon unreachable` | `"nightly audit" stays enabled: daemon unreachable` |
| run now | `no engine available` | `Couldn't run "nightly audit" now — schedule unchanged: no engine available` |

**Two deviations from the brief, both forced by what the frame does to the text:**

1. The brief proposed one `toggleFailed` with a `{state}` placeholder. A placeholder holding an adjective cannot be translated (`"仍处于{state}状态"` needs the adjective inflected in Chinese), so it is two keys instead: `enableFailed` / `disableFailed`. The call site picks on `selected.enabled` — the state the routine KEPT, not the one the click asked for.
2. My first draft used the brief's longer clauses (`— it stays scheduled`, `stays enabled and will keep firing on schedule`). **The render suite caught that as a regression** and it is the most useful thing in this PR: the toast is ONE truncated line, about 38 cells at 90 columns, so the longer copy pushed the daemon's own message off the end entirely — `✕ Couldn't delete "weekday audit" — it s…`. Trimmed, the same frame reads `✕ Couldn't delete "weekday audit": daemo…`: action intact, cause started. Copy that looks fine in a string literal and lands badly in its frame, exactly as the brief warned.

`test/render/failure-toast.test.tsx` now asserts the toast's own prefix rather than the raw daemon string — the same assertion shape the kanban cases in that file already use, since a truncating one-line toast cannot show both.

## 3.1 — `files.error.*`: six labels, one wrong retry hint

**PASS:** every label names an action; `press r to retry` renders only where a retry can change the answer.

| raw | before | after |
|---|---|---|
| `fatal: not a git repository` | `not a git repository` + *press r to retry* | `not a git repository — run \`git init\` here, or open a task in a repo` |
| `ENOENT: no such file` | `worktree path is missing` + *press r* | `the worktree directory is gone — reopen the task to re-create it` + *press r* |
| `EACCES permission denied` | `permission denied` + *press r* | `permission denied reading the worktree — check the directory's owner and mode` + *press r* |
| `bash: git: not found` | `git is not installed` + *press r* | `git is not on PATH — install it with your OS package manager` |
| unknown git failure | *(raw)* + *press r* | *(raw)* + *press r* |

`gitErrorIsRetryable` shares one classifier with `summarizeGitError`, so the label and the hint cannot disagree. **Mutation-verified twice:** `return true` (main's behaviour) fails; the half-fix `kind !== "notGitRepo"` also fails.

`pathMissing`'s new wording matches `tasks.toast.worktreeGoneBody`, which already prescribes the same recovery for the same condition; `gitNotInstalled` matches `doctor.fix.git` / `gitAction`.

## 3.2 — `tasks.toast.noDaemonWorktree`

`No daemon running — can't create the worktree` → `No daemon running — can't create the worktree. Start it with \`rove daemon restart\`.`
Same command `doctor.fix.daemonDown` prescribes for the identical condition, so the TUI and doctor now agree.

## 3.3 — `terminal.unavailable.*`

| key | before | after |
|---|---|---|
| `shellMissing` | `terminal unavailable — configured shell is not available` | `terminal unavailable — the shell named by $SHELL isn't on this machine. Point $SHELL at one that exists, or unset it to fall back to the system default.` |
| `spawnFailed` | `terminal unavailable — shell could not start` | `terminal unavailable — the shell exited immediately. Its error is in ~/.rove/pty.log.` |

**The brief's "Settings → General" wording is wrong and I did not ship it.** There is no shell row in Settings — `resolveLoginShell` (`kobe-daemon/src/daemon/platform-shell.js:78`) reads `$SHELL` and nothing else, so `$SHELL` is the only place a user can act. `~/.rove/pty.log` is confirmed against `docs/TROUBLESHOOTING.md:99`.

## 3.4 — onboarding env page: **already landed in #866**

The action lines under the verdict shipped in the other worker's PR while this one was in flight, so I dropped my duplicate and kept only the part still missing: the inline **row budget**. `inlineRowsFor` counted `15 + engines.lines.length` and did not know about the up-to-2 action lines, so they ate the 2 rows of slack that function's own comment reserves. `envActionKeys()` is now the one list both the JSX and the budget read.

Not a visible bug today (the slack absorbs it), and I am **not** claiming a screenshot proves it — the two shots below are identical by design.

---

## Screenshots

Captured through `/harness` → xterm.js → PTY sidecar → real OpenTUI on **port base 6173** (never 5273, the owner's live sandbox), isolated home under `.scratch/opentui-visual-6173/`. BEFORE and AFTER differ by exactly one file, swapped from `origin/main` and back on the same warm fixture.

| | |
|---|---|
| onboarding env page, no usable engine — BEFORE | `/Users/jacksonc/.rove/worktrees/kobe-0aff3858ab76/macaque/.scratch/loop-r13-ah/shots/onboarding-rows-BEFORE.png` |
| onboarding env page, no usable engine — AFTER | `/Users/jacksonc/.rove/worktrees/kobe-0aff3858ab76/macaque/.scratch/loop-r13-ah/shots/onboarding-env-AFTER.png` |
| the same page against **pre-#866** main, showing the verdict stopping at the blocker | `.../shots/onboarding-env-BEFORE.png` |

The last one is the item as it stood when the brief was written — verdict only, no `→` line. It is included because it is the only capture that shows the defect 3.4 described; the fix that closed it is #866's.

Forcing "no usable engine" needed a PATH with no engine CLIs on it. Only the contrib engines resolve through `Bun.which`; the built-ins have their own finders and stay visible as installed-but-not-logged-in, which is the state the not-ready verdict wants. `KOBE_VISUAL_MIN_PATH` (one env-gated line in `e2e/visual-fixture.ts`, unset by default) makes that reproducible — flagged here as a deliberate harness addition outside the message slice.

## What I could NOT prove with a screenshot

**The `files.error.*` labels (3.1) are unreachable through the harness fixture, and I tried three ways.** The pane's error text comes from the git exec wrapper, and on this fixture it does not produce any of the five shapes `summarizeGitError` classifies:

- removing the worktree's `.git` file does not work — the fixture worktree lives under `.scratch/` inside this repo, so git walks up and finds the outer worktree; `git ls-files` succeeds;
- running the TUI on a **git-less PATH** renders `(no output)` + `press r to retry`, not `gitNotInstalled`;
- **parking the worktree directory** (renamed, then restored) renders the same `(no output)`.

So `files.error.*` is proven by execution — `summarizeGitError` and `gitErrorIsRetryable` driven with the real raw strings, output in `before.txt`/`after.txt` — and by the unit tests, not by a photo. Saying so rather than shipping a shot of a different state.

**Separate finding, not fixed here** (out of this batch, no item covers it): that `(no output)` IS a batch-2-shaped defect. When git fails with an empty message the file tree shows the literal string `(no output)` as its error, which tells the user nothing and hides which of the five real causes fired. Worth an issue.

## Gates

```
bun run lint                     clean (repo root, 1434 files)
bun run typecheck                clean
bun run check-i18n               827 keys × 2 locales in sync
bun run test:fast                450 files, 4444 tests, 0 fail
bun test test/render             107 files, 474 tests, 0 fail
KOBE_INCLUDE_SOCKET=1 test:socket 99 files, 802 tests, 0 fail
```

No new or moved keybinding chords. No file crossed the size cap.
