### PR TITLE
fix: a prompt sent to a dead engine no longer runs as shell commands, and liveness stops lying in both directions

### DIFF
--- a/.agents/skills/kobe/SKILL.md
+++ b/.agents/skills/kobe/SKILL.md
@@ -313,8 +313,13 @@ a failure to deliver. Retrying stacks a duplicate — and the second send fails
 `DEFERRED_PROMPT_PENDING` until the Inbox item is released, dismissed, or
 expires. Read the `delivered` / `deferred` keys, not just the exit code.
 
-`.running` means any hosted engine tab on the task is alive; a live shell,
-command, or content tab alone does not count. It is process truth, not
+`.running` is `true` / `false` / `null`. It means an ENGINE PROCESS is alive
+in one of the task's engine tabs — a live shell, command, or content tab alone
+does not count, and neither does an engine tab whose engine exited (the PTY
+survives it as a login shell; each tab reports that as `engineAlive`). `null`
+means the pty host could not be asked: "couldn't look", NOT "nothing is
+running". **Never act on `null` as if it were `false`** — deleting a task on it
+destroys a worktree that may hold live work. It is process truth, not
 progress: a task whose work is merged and whose worker has signed off still
 reads `true` until somebody deletes it (see "A task is finished when it is
 GONE").

--- a/.changeset/dispatch-refuses-a-dead-engine.md
+++ b/.changeset/dispatch-refuses-a-dead-engine.md
@@ -1,0 +1,27 @@
+---
+"@sma1lboy/rove": patch
+---
+
+A prompt sent to a task whose engine has died is no longer executed as shell
+commands. When an engine exits, keepAlive `exec`s a login shell in its place
+and the PTY stays alive, so the session keeps matching the launch argv that
+resolves a delivery target. `rove api dispatch` into such a tab returned
+`delivered: true` — and zsh ran the text: with the engine killed and the
+wrapper shell alive, `dispatch --prompt "touch /tmp/PROOF"` created the file.
+The guard for this already existed and `send` already applied it; two of the
+three delivery adapters did not, and the two without it are the ones the
+routine runner and the quota-resume runner use. So a persistent-session
+routine whose engine died overnight typed its daily prompt at a shell prompt,
+unattended, and recorded the run as `dispatched`. Both now refuse: `dispatch`
+returns `delivered: false, reason: "no-engine"` and broadcasts nothing, and a
+routine treats it as the revive trigger it always was, recording `revived`.
+Delivery into a live engine is unchanged.
+
+`rove api send` also stops killing a fleet to deliver one message. An
+unreachable pty host was reaped off a single 3-second probe — taking every
+engine hosted on it — and the payload said nothing: measured, four processes
+across three sessions became one, and `send` returned a bare `ok: true`. A
+host whose PROCESS is alive now gets the same 15s grace the daemon path
+already gives one, and a host still holding live sessions after it is refused
+out loud instead of reaped. An idle-exited host is still resurrected silently,
+which is what that path was for. — [@Sma1lboy](https://github.com/Sma1lboy)

--- a/.changeset/running-is-engine-truth.md
+++ b/.changeset/running-is-engine-truth.md
@@ -1,0 +1,33 @@
+---
+"@sma1lboy/rove": patch
+---
+
+`.running` on `get-task`, `collect` and `read-output` was wrong in both
+directions, and both directions cost something.
+
+It read `true` for a task whose engine was reaped hours earlier, because it
+asked whether the PTY SESSION was alive and keepAlive keeps that alive on
+purpose. It now joins the inventory with a live `ps` walk of each session's
+tree — the same predicate delivery gates on — and every tab carries its own
+`engineAlive`, so `alive: true, engineAlive: false` names a tab holding a bare
+shell. Passing the task's own launch command means a custom engine (a wrapper
+script no vendor table knows) still reads as running.
+
+The other direction was the dangerous one: with the pty host merely
+unreachable and four engines running, `get-task` and `collect` reported
+`running: false` with every tab `alive: false`, and `read-output` warned "no
+live terminal session". Connecting to a stopped host succeeds — only the
+request fails — and that failure was being swallowed into an empty inventory.
+`running` is now `true | false | null`, `alive` and `engineAlive` go `null`
+alongside it, and `read-output` reports
+`fallbackReason: "pty_host_unreachable"`. `null` means "could not look", never
+"nothing is running"; an autonomous cleanup loop acting on the old `false`
+would delete worktrees holding live work.
+
+The daemon's engine-death observer also ran only while something was
+subscribed to its event channel, which only an attached TUI ever is. Headless
+callers therefore got `.activity: null` forever and not one `layer: "engine"`
+exit record, however many engines died inside live PTYs in front of them.
+Subscribers now choose the CADENCE rather than whether the loop runs: every
+tick with one, every ~60s without. A daemon whose host owns no live sessions
+still does no per-session work. — [@Sma1lboy](https://github.com/Sma1lboy)

--- a/claude-plugin/skills/rove/SKILL.md
+++ b/claude-plugin/skills/rove/SKILL.md
@@ -313,8 +313,13 @@ a failure to deliver. Retrying stacks a duplicate — and the second send fails
 `DEFERRED_PROMPT_PENDING` until the Inbox item is released, dismissed, or
 expires. Read the `delivered` / `deferred` keys, not just the exit code.
 
-`.running` means any hosted engine tab on the task is alive; a live shell,
-command, or content tab alone does not count. It is process truth, not
+`.running` is `true` / `false` / `null`. It means an ENGINE PROCESS is alive
+in one of the task's engine tabs — a live shell, command, or content tab alone
+does not count, and neither does an engine tab whose engine exited (the PTY
+survives it as a login shell; each tab reports that as `engineAlive`). `null`
+means the pty host could not be asked: "couldn't look", NOT "nothing is
+running". **Never act on `null` as if it were `false`** — deleting a task on it
+destroys a worktree that may hold live work. It is process truth, not
 progress: a task whose work is merged and whose worker has signed off still
 reads `true` until somebody deletes it (see "A task is finished when it is
 GONE").

--- a/docs/API.md
+++ b/docs/API.md
@@ -164,9 +164,17 @@ replacement in `nextCommandArgs`.
 
   Per task: identity, branch, lineage (`.dispatcher`, `.groupId`), plus
 
-  - `.running` — is an engine ALIVE, from the pty host's live session
-    inventory. This is process truth, not the cached status field `list`
-    reports, which lags and will happily call a working fleet idle.
+  - `.running` — `true` / `false` / `null`. Is an ENGINE PROCESS alive in
+    any of the task's engine tabs: the pty host's session inventory joined
+    with a live `ps` walk of each session's tree. Both halves are load
+    bearing. A session outlives its engine (keepAlive drops the tab into a
+    login shell), so the inventory alone reported a task as running for
+    hours after its engine was reaped. And `null` means the pty host could
+    not be asked at all — "couldn't look", never "nothing is running", the
+    same distinction `pty-list` publishes as `sessions: null`. **Never treat
+    `null` as `false`**: a cleanup loop that does will delete worktrees
+    holding live work. Still process truth, not the cached status field
+    `list` reports, which lags and will happily call a working fleet idle.
   - `.activity` — `{state, at, forMs}` from the daemon's activity registry:
     the engine's state (`running` / `idle` / `permission_needed` /
     `rate_limited` / `error` / `turn_complete`) and how long it has been in
@@ -174,7 +182,9 @@ replacement in `nextCommandArgs`.
     registry cannot answer (daemon restarted, task never observed) — an
     honest unknown, never a fabricated idle. `.activity.state` disagreeing
     with `.running` is itself the signal: `running: false` with a
-    `permission_needed` state is a worker that died at a prompt.
+    `permission_needed` state is a worker that died at a prompt. The daemon
+    observes this without an attached TUI, on a slower cadence (~60s) than
+    it uses for one.
   - `.tabs` — the same per-tab join as `get-task` (pick a `send --tab`
     target without a second hop). A tab whose session died abnormally
     carries `.exit` with `code`/`signal`/`at` **and** `tail`, the last lines

--- a/packages/kobe-daemon/src/client/pty-process.ts
+++ b/packages/kobe-daemon/src/client/pty-process.ts
@@ -6,12 +6,14 @@
  * shape against the pty host's own socket.
  */
 
+import { spawn } from "node:child_process"
 import { existsSync } from "node:fs"
 import { rename, rm } from "node:fs/promises"
 import { basename, delimiter, dirname, join, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
-import { stopDaemonProcess } from "../daemon/lifecycle.ts"
+import { isProcessAlive, stopDaemonProcess } from "../daemon/lifecycle.ts"
 import { defaultPtyHostLogPath, defaultPtyHostPidPath, defaultPtyHostSocketPath } from "../daemon/paths.ts"
+import { readPidFile } from "../daemon/socket-guard.ts"
 import { resolveKobeSpawn, spawnDetachedDaemon, testDaemonResponds } from "./daemon-process.ts"
 import { KobeDaemonClient } from "./index.ts"
 
@@ -158,14 +160,74 @@ export async function resolveNodePtyHostSpawn(deps: NodePtyHostResolution = {}):
 }
 
 /**
+ * How long a pty host whose PROCESS is alive gets to answer `hello` before it
+ * counts as wedged. The twin of `daemon-process.ts`'s `BUSY_DAEMON_GRACE_MS`,
+ * and for the same reason: one 3s probe decides "is this host quick", and
+ * only a sustained silence may license a kill. The pty host had no such
+ * window, so a host merely busy for three seconds was reaped — along with
+ * every engine it hosted.
+ */
+const BUSY_PTY_HOST_GRACE_MS = 15_000
+
+/** Live child processes of `pid` — the pty host's sessions, each a shell
+ *  leader. One `ps`; unreadable output counts as zero, which only ever
+ *  makes the reap below MORE permissive, never less. */
+async function liveChildCount(pid: number): Promise<number> {
+  try {
+    const proc = spawn("/bin/ps", ["-A", "-o", "ppid="], { stdio: ["ignore", "pipe", "ignore"] })
+    const text = await new Promise<string>((done) => {
+      let out = ""
+      proc.stdout.on("data", (chunk) => {
+        out += String(chunk)
+      })
+      proc.on("close", () => done(out))
+      proc.on("error", () => done(""))
+    })
+    return text.split("\n").filter((row) => Number(row.trim()) === pid).length
+  } catch {
+    return 0
+  }
+}
+
+/**
  * If the pty host socket already answers `hello`, do nothing. Otherwise
  * clear any wedged process and spawn a detached `kobe pty-host`, polling
  * until reachable. Returns the socket path. The terminal pane is the
  * product — it may resurrect an idle-exited host.
+ *
+ * "Idle-exited" is the whole licence. A host that EXITED owns nothing, so
+ * clearing its stale socket and pidfile is free. A host that is ALIVE and
+ * merely slow is a different thing entirely: killing it kills every hosted
+ * engine with it, and `send` used to do exactly that off ONE 3s probe and
+ * then report a bare `ok: true` — a caller asked to deliver one prompt got
+ * its whole fleet reaped and was told nothing. So a live host gets the grace
+ * window first, and a live host still holding sessions after it is refused
+ * out loud rather than reaped silently: N engines with running work must not
+ * be spent to deliver one message.
  */
 export async function ensurePtyHostReachable(): Promise<string> {
   const socketPath = defaultPtyHostSocketPath()
   if (await testDaemonResponds(socketPath)) return socketPath
+
+  const hostPid = await readPidFile(defaultPtyHostPidPath())
+  if (hostPid !== null && hostPid !== process.pid && isProcessAlive(hostPid)) {
+    const deadline = Date.now() + BUSY_PTY_HOST_GRACE_MS
+    while (Date.now() < deadline) {
+      await new Promise((resolveTimer) => setTimeout(resolveTimer, 250))
+      if (await testDaemonResponds(socketPath)) return socketPath
+      // It died on its own while we waited: the pid is gone, so the
+      // stop+spawn below is now the free idle-exit path.
+      if (!isProcessAlive(hostPid)) break
+    }
+    if (isProcessAlive(hostPid)) {
+      const sessions = await liveChildCount(hostPid)
+      if (sessions > 0) {
+        throw new Error(
+          `rove: the pty host (pid ${hostPid}) is not answering but still holds ${sessions} live session(s) — refusing to restart it, which would kill every engine running in them. Inspect it with \`rove api pty-list\`, or kill ${hostPid} yourself once you have accepted losing those sessions.`,
+        )
+      }
+    }
+  }
 
   await stopDaemonProcess(socketPath, defaultPtyHostPidPath()).catch(() => {})
 

--- a/packages/kobe-daemon/src/daemon/activity-observer.ts
+++ b/packages/kobe-daemon/src/daemon/activity-observer.ts
@@ -34,6 +34,10 @@
  *
  * Findings fold into the registry via `observeTab` (hook events outrank
  * observation; only a stale hook `running` is ever corrected — see there).
+ * The loop runs on a SLOW lane when nothing is subscribed rather than
+ * stopping: an agent fleet never attaches a TUI, and gating the walk on a
+ * subscriber made the death edge invisible to precisely the caller that
+ * cannot look at a screen.
  * The FIRST tick runs immediately and includes a walk, so a daemon restart
  * re-seeds busy sessions' dots within seconds instead of at the next
  * turn boundary.
@@ -57,6 +61,18 @@ export const DEFAULT_OBSERVER_POLL_MS = 10_000
 export const DEFAULT_SILENCE_MS = 30_000
 /** Walk cadence in ticks (~60s at the default poll — the foreground reconciler). */
 export const DEFAULT_WALK_EVERY_TICKS = 6
+/**
+ * Tick cadence for the UNSUBSCRIBED lane (~60s at the default poll). The
+ * subscriber gate is a cost control for a parked daemon, not a correctness
+ * boundary: skipping the tick outright also skipped the engine-death edge,
+ * which is the only place an engine dying inside a live PTY is observable —
+ * so every headless caller (an agent fleet has no attached TUI, by
+ * definition) got `.activity: null` and zero `layer:"engine"` records while
+ * engines died in front of it. The slow lane restores the fact and keeps the
+ * saving: one `pty.list` a minute, and a host owning no live sessions still
+ * does no per-session work.
+ */
+export const DEFAULT_UNSUBSCRIBED_EVERY_TICKS = 6
 /**
  * Never correct a hook-claimed `running` younger than this: at a turn
  * boundary the title/output evidence can trail the hook by one poll, and a
@@ -107,6 +123,9 @@ export interface ActivityObserverOptions {
   readonly pollMs?: number
   readonly silenceMs?: number
   readonly walkEveryTicks?: number
+  /** Tick cadence when nothing is subscribed. See
+   *  {@link DEFAULT_UNSUBSCRIBED_EVERY_TICKS}; 1 makes every tick run. */
+  readonly unsubscribedEveryTicks?: number
   readonly correctAfterMs?: number
   readonly log?: (event: string, message: string) => void
 }
@@ -133,8 +152,10 @@ interface SessionTrack {
 
 /**
  * Start the observer loop. First tick fires immediately (with a walk, which
- * is the restart seeding); per-tick work is gated on `hasSubscribers` like the
- * other collectors, so a parked daemon polls nobody. Returns stop().
+ * is the restart seeding). `hasSubscribers` chooses the CADENCE, not whether
+ * the loop runs: subscribed = every tick, unsubscribed = every
+ * `unsubscribedEveryTicks`. A parked daemon whose host owns no live sessions
+ * still does no per-session work either way. Returns stop().
  */
 export function startActivityObserver(
   activity: DaemonActivityRegistry,
@@ -145,10 +166,12 @@ export function startActivityObserver(
   const pollMs = options.pollMs ?? DEFAULT_OBSERVER_POLL_MS
   const silenceMs = options.silenceMs ?? DEFAULT_SILENCE_MS
   const walkEvery = Math.max(1, options.walkEveryTicks ?? DEFAULT_WALK_EVERY_TICKS)
+  const unsubscribedEvery = Math.max(1, options.unsubscribedEveryTicks ?? DEFAULT_UNSUBSCRIBED_EVERY_TICKS)
   const correctAfterMs = options.correctAfterMs ?? DEFAULT_CORRECT_AFTER_MS
   const log = options.log ?? logDaemonInfo
   const tracks = new Map<string, SessionTrack>()
   let tickCount = 0
+  let unsubscribedTicks = 0
   let inFlight = false
 
   const applyRest = (track: Pick<SessionTrack, "taskId" | "tabId" | "vendor">, why: string): void => {
@@ -165,8 +188,16 @@ export function startActivityObserver(
     if (inFlight) return
     inFlight = true
     try {
-      if (!hasSubscribers()) return
-      const walkTick = tickCount % walkEvery === 0
+      // Two lanes, not a gate. A subscriber (an attached TUI wanting its dots
+      // now) gets every tick; nobody subscribed drops to
+      // `unsubscribedEvery` — which still runs the walk, because the
+      // engine-death edge below is the ONLY report of an engine dying inside
+      // a live PTY and a headless fleet is exactly who needs it. The saving
+      // survives: `listSessions` on a host owning nothing returns `[]` and
+      // every loop below is empty.
+      const subscribed = hasSubscribers()
+      if (!subscribed && unsubscribedTicks++ % unsubscribedEvery !== 0) return
+      const walkTick = !subscribed || tickCount % walkEvery === 0
       tickCount++
       const listed = await io.listSessions()
       if (listed === null) {

--- a/packages/kobe-daemon/src/daemon/automation-dispatch.ts
+++ b/packages/kobe-daemon/src/daemon/automation-dispatch.ts
@@ -230,8 +230,13 @@ export async function dispatchAutomation(deps: DispatchDeps, automation: Automat
   if (result.outcome === "busy") {
     return await deferBlockedPrompt(deps, automation, task.id, result.tabId, result.layer)
   }
-  // The engine died between firings (an overnight gap is the normal case).
+  // `no-session` (the tab is gone) and `no-engine` (the tab is alive but
+  // keepAlive left a login shell where the engine exited) both land here: the
+  // engine died between firings, an overnight gap being the normal case.
   // Respawn it in the SAME worktree: the files carry over, the transcript
   // does not — recorded as `revived` so the run history says which it was.
+  // `no-engine` reaching this branch is what stops a daily prompt from being
+  // typed at a zsh prompt and RUN as shell commands while the run records
+  // `dispatched`.
   return await spawnWithPrompt(deps, automation, task.id, "revived")
 }

--- a/packages/kobe-daemon/src/daemon/handlers-ui.ts
+++ b/packages/kobe-daemon/src/daemon/handlers-ui.ts
@@ -91,7 +91,9 @@ export const UI_HANDLERS: readonly DaemonRequestHandler[] = [
       })
       // `delivered` is OBSERVED, not claimed: true only when a paste actually
       // landed in a live engine session. `false` with `reason: "busy"` means a
-      // human is mid-message and the text was deliberately not written; false
+      // human is mid-message and the text was deliberately not written;
+      // `reason: "no-engine"` means the tab is alive but its engine died into
+      // a login shell, which would EXECUTE the text rather than read it; false
       // with `reason: "broadcast"` means no hosted session answered and the
       // event went out for a browser to pick up, which nothing can confirm —
       // `clients` (raw CONNECTION count, the calling CLI included) is the only
@@ -105,6 +107,18 @@ export const UI_HANDLERS: readonly DaemonRequestHandler[] = [
           delivered: false,
           reason: "busy",
           layer: outcome.layer,
+          tabId: outcome.tabId,
+          clients: ctx.daemon.clientCount(),
+        }
+      }
+      // The tab is alive with no engine in it: keepAlive `exec`ed a login
+      // shell where the engine exited, so the text would not be READ, it
+      // would be RUN. Nothing was written and nothing was broadcast.
+      if (outcome.outcome === "no-engine") {
+        return {
+          ok: true,
+          delivered: false,
+          reason: "no-engine",
           tabId: outcome.tabId,
           clients: ctx.daemon.clientCount(),
         }

--- a/packages/kobe-daemon/src/daemon/runtime.ts
+++ b/packages/kobe-daemon/src/daemon/runtime.ts
@@ -181,6 +181,11 @@ export interface DaemonRuntimeAdapter {
    *
    * `tabId` names which tab the live engine was found on, so the deferral and
    * its Inbox episode point at the tab a human will actually open.
+   *
+   * `no-engine` is a session that is alive with no engine IN it — keepAlive
+   * left a login shell where the engine exited. It is separate from
+   * `no-session` because pasting there would have the shell EXECUTE the
+   * prompt; the caller must revive, never deliver.
    */
   deliverPromptToLiveEngineDetailed(
     task: {
@@ -193,6 +198,7 @@ export interface DaemonRuntimeAdapter {
   ): Promise<
     | { readonly outcome: "delivered"; readonly tabId: string }
     | { readonly outcome: "no-session" }
+    | { readonly outcome: "no-engine"; readonly tabId: string }
     | {
         readonly outcome: "busy"
         readonly tabId: string
@@ -215,6 +221,7 @@ export interface DaemonRuntimeAdapter {
   ): Promise<
     | { readonly outcome: "delivered"; readonly tabId: string }
     | { readonly outcome: "no-session" }
+    | { readonly outcome: "no-engine"; readonly tabId: string }
     | {
         readonly outcome: "busy"
         readonly tabId: string

--- a/packages/kobe/src/cli/api/handlers-fanout.ts
+++ b/packages/kobe/src/cli/api/handlers-fanout.ts
@@ -8,6 +8,7 @@
 import type { SerializedTask } from "@sma1lboy/kobe-daemon/daemon/protocol"
 import { DEFAULT_FEEDBACK_CATEGORY_SLUG, submitFeedback } from "../../lib/feedback.ts"
 import { daemonOf } from "./handler-helpers.ts"
+import { taskEngineArgv } from "./tab-snapshot.ts"
 import { ApiError, type VerbContext } from "./types.ts"
 
 /** One entry of the daemon activity registry's task dump (`debug.inspect`). */
@@ -59,7 +60,7 @@ export async function collect(ctx: VerbContext): Promise<unknown> {
     // One liveness read serves both `running` and the per-tab list a
     // coordinator needs to pick a `send --tab tab-N` target without a
     // second get-task hop (same join as get-task).
-    const { tabs, running } = await runtime.taskTabs(taskId)
+    const { tabs, running } = await runtime.taskTabs(taskId, taskEngineArgv(task))
     // `changes` is the UNCOMMITTED view; `base` is the committed one (ahead
     // and behind counts + diffstat vs the merge-base). Both matter when
     // picking a parallel-round winner: an attempt that commits its work reads

--- a/packages/kobe/src/cli/api/handlers-tasks.ts
+++ b/packages/kobe/src/cli/api/handlers-tasks.ts
@@ -16,6 +16,7 @@ import { readOwnDispatcher, resolveDispatcherTab, verifiedSelfSession, withPeerP
 import { F } from "./flags.ts"
 import { daemonOf, simpleRpc } from "./handler-helpers.ts"
 import { resolveActiveTaskId } from "./runtime.ts"
+import { taskEngineArgv } from "./tab-snapshot.ts"
 import { ApiError, type VerbContext, type VerbSpec, helpStep } from "./types.ts"
 
 /** How long `delete --wait` follows a deletion before reporting `pending`.
@@ -298,7 +299,7 @@ export async function getTask(ctx: VerbContext): Promise<unknown> {
   const res = await daemon.request<{ task: SerializedTask }>("task.get", { taskId })
   // One liveness read serves both: `.running` (any live engine tab) and the
   // per-tab `.alive` an agent needs to pick a `send --tab tab-N` target.
-  const { tabs, running } = await ctx.runtime.taskTabs(taskId)
+  const { tabs, running } = await ctx.runtime.taskTabs(taskId, taskEngineArgv(res.task))
   return { task: res.task, running, tabs }
 }
 

--- a/packages/kobe/src/cli/api/pty-delivery.ts
+++ b/packages/kobe/src/cli/api/pty-delivery.ts
@@ -26,6 +26,7 @@ import {
   isHostedTaskKey,
   killHostedSessions,
   listHostedSessions,
+  listHostedSessionsOrNull,
   openHostedSessionHost,
   pastePromptWhenEngineUp,
   writeHostedPrompt,
@@ -79,6 +80,7 @@ export const ensurePtyHost = ensureHostedSessionHost
 
 /** Session inventory from the pty host; `[]` on any RPC hiccup. */
 export const listSessions = listHostedSessions
+export const listSessionsOrNull = listHostedSessionsOrNull
 
 /**
  * Deliver `prompt` into an existing hosted engine session and submit it —

--- a/packages/kobe/src/cli/api/read-output-page.ts
+++ b/packages/kobe/src/cli/api/read-output-page.ts
@@ -31,7 +31,14 @@ export const TERMINAL_TAIL_BYTES = 64 * 1024
 
 type ReadSource = "history" | "terminal"
 export type ReadSourceArg = "auto" | ReadSource
-export type FallbackReason = "engine_unsupported" | "history_missing" | "history_unreadable"
+export type FallbackReason =
+  | "engine_unsupported"
+  | "history_missing"
+  | "history_unreadable"
+  /** The pty host could not be asked — "couldn't look", not "no session".
+   *  Same distinction `pty-list`'s `sessions: null` publishes; without it an
+   *  unreachable host and a task that never started read identically. */
+  | "pty_host_unreachable"
 
 export interface ReadOutputEnvelope {
   readonly taskId: string

--- a/packages/kobe/src/cli/api/read-output.ts
+++ b/packages/kobe/src/cli/api/read-output.ts
@@ -40,7 +40,7 @@ import { type EngineHistoryReader, supportsStructuredHistory } from "../../engin
 import type { Message } from "../../types/engine.ts"
 import type { VendorId } from "../../types/vendor.ts"
 import { daemonOf } from "./handler-helpers.ts"
-import { findEngineKey, listSessions, openPtyHost } from "./pty-delivery.ts"
+import { findEngineKey, listSessionsOrNull, openPtyHost } from "./pty-delivery.ts"
 import {
   type Cursor,
   DEFAULT_PAGE_MESSAGES,
@@ -57,6 +57,7 @@ import {
   encodeCursor,
 } from "./read-output-page.ts"
 import { resolveActiveTaskId } from "./runtime.ts"
+import { taskEngineArgv } from "./tab-snapshot.ts"
 import { ApiError, type VerbContext, type VerbSpec } from "./types.ts"
 
 // The paging/shaping half lives in `read-output-page.ts` — pure functions with
@@ -83,9 +84,11 @@ export interface ReadOutputDeps {
   /** The engine adapter's transcript reader; null = engine ships none. */
   readonly history: EngineHistoryReader | null
   /** Bounded ring peek of one hosted session; `tab` selects the exact tab
-   *  (`undefined` = the task's canonical engine tab). null = no host / no
-   *  session. */
-  peekTerminal(tab: string | undefined, sinceOffset?: number): Promise<TerminalPeekPage | null>
+   *  (`undefined` = the task's canonical engine tab). `null` = the host
+   *  answered and holds no such session; `"host-unreachable"` = it could not
+   *  be asked at all, which is a different fact and must not render as an
+   *  empty read. */
+  peekTerminal(tab: string | undefined, sinceOffset?: number): Promise<TerminalPeekPage | null | "host-unreachable">
 }
 
 export interface ReadOutputInput {
@@ -231,14 +234,23 @@ async function firstTerminalPage(
   fallbackReason: FallbackReason | null,
 ): Promise<ReadOutputEnvelope> {
   const t = await deps.peekTerminal(input.tab)
-  if (!t) {
+  if (!t || t === "host-unreachable") {
+    // An unreachable host is not an empty task. Saying "no live terminal
+    // session" there asserts something nobody checked, and `live: false`
+    // beside it reads as a verdict — so the host's own state wins the
+    // fallbackReason, and the warning says which question went unanswered.
+    const unreachable = t === "host-unreachable"
     return {
       taskId: input.taskId,
       source: "terminal",
       terminal: { tail: [], truncated: false, live: false, tab: input.tab },
       cursor: null,
-      fallbackReason,
-      warnings: ["no live terminal session for this task"],
+      fallbackReason: unreachable ? "pty_host_unreachable" : fallbackReason,
+      warnings: [
+        unreachable
+          ? "the pty host could not be reached — this is 'could not look', not 'no session'"
+          : "no live terminal session for this task",
+      ],
     }
   }
   const { tail, truncated } = boundedTail(t.text)
@@ -266,6 +278,7 @@ async function continueTerminal(
   cursor: TerminalCursor,
 ): Promise<ReadOutputEnvelope> {
   const t = await deps.peekTerminal(cursor.tab, cursor.off)
+  if (t === "host-unreachable") throw sourceChanged("the pty host could not be reached")
   if (!t) throw sourceChanged("the terminal session is gone")
   if (t.pid !== cursor.pid) throw sourceChanged("the terminal session restarted (new process)")
   const warnings = t.sinceValid ? [] : ["scrollback trimmed — there is a gap before this page"]
@@ -298,20 +311,31 @@ async function peekTaskTerminal(
   vendor: VendorId | undefined,
   tab: string | undefined,
   sinceOffset?: number,
-): Promise<TerminalPeekPage | null> {
+): Promise<TerminalPeekPage | null | "host-unreachable"> {
   const host = await openPtyHost()
-  if (!host) return null
+  if (!host) return "host-unreachable"
   try {
     let key: string | undefined
     if (tab) {
       key = `${taskId}::${tab}`
     } else {
       const engineBin = vendor ? engineLaunchArgv({ vendor })[0] : undefined
-      const sessions = await listSessions(host.rpc)
+      // Tri-state: a host that cannot be asked must not render as a task with
+      // no sessions — see `listHostedSessionsOrNull`.
+      const sessions = await listSessionsOrNull(host.rpc)
+      if (sessions === null) return "host-unreachable"
       key = findEngineKey(sessions, taskId, engineBin) ?? sessions.find((s) => s.key === `${taskId}::tab-1`)?.key
     }
     if (!key) return null
-    const res = await host.rpc.request<PtyPeekResult>("pty.peek", { key, sinceOffset })
+    // An explicit --tab skips the listing above, so this is the first request
+    // that can discover an unreachable host. A raw RPC failure here is that,
+    // not an empty tab.
+    let res: PtyPeekResult
+    try {
+      res = await host.rpc.request<PtyPeekResult>("pty.peek", { key, sinceOffset })
+    } catch {
+      return "host-unreachable"
+    }
     if (!res.exists) {
       if (tab) {
         throw new ApiError(
@@ -365,7 +389,7 @@ async function handleReadOutput(ctx: VerbContext): Promise<unknown> {
     },
     deps,
   )
-  const running = await ctx.runtime.isTaskRunning(taskId)
+  const running = await ctx.runtime.isTaskRunning(taskId, taskEngineArgv(task))
   return { vendor: vendor ?? null, running, ...envelope }
 }
 

--- a/packages/kobe/src/cli/api/runtime.ts
+++ b/packages/kobe/src/cli/api/runtime.ts
@@ -23,6 +23,7 @@ import {
   ensurePtyHost,
   killTaskSessions,
   listSessions,
+  listSessionsOrNull,
   openPtyHost,
   taskKeys,
 } from "./pty-delivery.ts"
@@ -249,33 +250,55 @@ export async function deliverPrompt(
 }
 
 export const defaultApiRuntime: ApiRuntime = {
-  isTaskRunning: async (taskId) => (await defaultApiRuntime.taskTabs(taskId)).running,
-  taskTabs: async (taskId) => {
-    // No host = no sessions, an honest "nothing alive"; the persisted tabs
+  isTaskRunning: async (taskId, engineArgv) => (await defaultApiRuntime.taskTabs(taskId, engineArgv)).running,
+  taskTabs: async (taskId, engineArgv) => {
+    // No host is "couldn't ask", NOT "nothing alive" — the host idle-exits and
+    // it can be merely unreachable while every engine it hosts keeps running.
+    // Publishing that as `false` is what would have an unattended cleanup loop
+    // delete worktrees holding live work, so it travels as `null` all the way
+    // out, the same tri-state `pty-list` already publishes. The persisted tabs
     // still return so a stopped task's layout stays inspectable.
-    let sessions: readonly (TaskSessionRow & { pid?: number | null })[] = []
+    let listed: readonly (TaskSessionRow & { pid?: number | null })[] | null = null
     const host = await openPtyHost()
     if (host) {
       try {
-        sessions = await listSessions(host.rpc)
+        // The tri-state listing, NOT `listSessions`: connecting to a stopped
+        // host succeeds and only the request fails, so `host !== null` is not
+        // evidence anybody answered.
+        listed = await listSessionsOrNull(host.rpc)
       } finally {
         host.close()
       }
     }
-    // Live foreground-walk verdicts per session: ONE ps snapshot,
-    // the same shallowest-engine walk inspect/live-engine run — so get-task's
-    // `liveVendor` reflects what runs NOW, not what a mounted TUI last
-    // recorded. Best-effort: a failed ps just keeps the recorded values.
+    const sessions = listed ?? []
+    const hostReachable = listed !== null
+    // Live per-session walk verdicts: ONE ps snapshot answering two
+    // questions — which vendor is in the foreground (`liveVendor`, the same
+    // shallowest-engine walk inspect/live-engine run) and whether ANY engine
+    // is in the tree at all (`engineAlive`, the predicate delivery gates on).
+    // The second is what separates a working engine from the login shell
+    // keepAlive leaves in its place, which `alive` cannot see.
+    // Best-effort: a failed ps keeps the recorded liveVendor and leaves
+    // `engineAlive` unknown rather than guessing it false.
     let liveVendors: Map<string, string | null> | undefined
+    let engineAlive: Map<string, boolean> | undefined
     try {
-      const { foregroundEngineIn, parsePsSnapshot, psSnapshot } = await import("../../engine/foreground.ts")
+      const { engineProcessIn, foregroundEngineIn, parsePsSnapshot, psSnapshot } = await import(
+        "../../engine/foreground.ts"
+      )
       const walkable = sessions.filter((s) => s.alive && typeof s.pid === "number" && s.pid > 0)
       if (walkable.length > 0) {
         const rows = parsePsSnapshot(await psSnapshot())
         liveVendors = new Map(walkable.map((s) => [s.key, foregroundEngineIn(rows, s.pid as number)?.vendor ?? null]))
+        // `engineArgv` is the task's own launch command: without it a custom
+        // engine (a wrapper script no vendor table names) walks as "no
+        // engine" and the task reads stopped while it works.
+        engineAlive = new Map(walkable.map((s) => [s.key, engineProcessIn(rows, s.pid as number, engineArgv)]))
+      } else {
+        engineAlive = new Map()
       }
     } catch {
-      /* recorded liveVendor stays */
+      /* recorded liveVendor stays; engineAlive stays unknown */
     }
     // Durable death records outlive the host's idle-exit — a crashed tab
     // still reports its cause here. Best-effort: unreadable = none.
@@ -287,8 +310,8 @@ export const defaultApiRuntime: ApiRuntime = {
     }
     const snapshot = readTabsSnapshot(taskId)
     return {
-      tabs: joinTaskTabs(snapshot, taskId, sessions, exits, liveVendors),
-      running: hasLiveEngineTab(snapshot, taskId, sessions),
+      tabs: joinTaskTabs(snapshot, taskId, listed, exits, liveVendors, engineAlive),
+      running: hostReachable ? hasLiveEngineTab(snapshot, taskId, sessions, engineAlive) : null,
     }
   },
   closeTerminalTab: closeHeadlessTerminalTab,

--- a/packages/kobe/src/cli/api/tab-snapshot.ts
+++ b/packages/kobe/src/cli/api/tab-snapshot.ts
@@ -22,6 +22,7 @@
  */
 
 import type { PtySessionExit } from "@sma1lboy/kobe-daemon/daemon/protocol"
+import { engineLaunchArgv } from "../../engine/engine-presets.ts"
 import { loadStateFile, patchStateFile, updateStateFile } from "../../state/store.ts"
 import { terminalTabsKey } from "../../tui-react/workspace/terminal-tabs-persist.ts"
 import { type TabsState, type TerminalTab, closeTab, initialTabs } from "../../tui/workspace/terminal-tabs-core.ts"
@@ -41,7 +42,17 @@ export interface TaskTabRow {
   readonly liveVendor: string | null
   readonly lastTitle: string | null
   readonly autoTitle: string | null
-  readonly alive: boolean
+  /** Is the tab's hosted PTY SESSION alive. `null` means the pty host could
+   *  not be asked, which is "couldn't look" and not a dead tab — the whole
+   *  inventory is unknown then, and a caller acting on `false` here would be
+   *  acting on a fact nobody established. */
+  readonly alive: boolean | null
+  /** Is an ENGINE PROCESS running inside this tab's session tree — the fact
+   *  `alive` cannot report. keepAlive `exec`s a login shell where an engine
+   *  exits, so `alive: true, engineAlive: false` is a tab holding a bare
+   *  zsh prompt. `null` means nothing walked it (a `ps` that failed), never
+   *  "no engine": a reader must not turn "couldn't look" into a verdict. */
+  readonly engineAlive: boolean | null
   /** How the tab's session died — ABNORMAL exits only (clean exit 0 stays
    *  null, by the no-noise rule); null while alive/unknown. Joined
    *  from the live host when present, else the durable exit records —
@@ -53,6 +64,16 @@ export interface TaskTabRow {
    *  snapshot is a record of intent; the pty host holds the truth, and a
    *  divergence must render as a row, not vanish. */
   readonly unregistered?: true
+}
+
+/**
+ * The task's own engine launch argv, for the liveness walk. Passing it is
+ * what lets a CUSTOM engine — a wrapper script no vendor table names — read
+ * as running; without it that task walks as "no engine" and an unattended
+ * cleanup loop would treat live work as finished.
+ */
+export function taskEngineArgv(task: { readonly command?: string; readonly vendor?: string }): readonly string[] {
+  return engineLaunchArgv({ command: task.command, vendor: task.vendor as VendorId | undefined })
 }
 
 /** The slice of a `pty.list` row the liveness joins below need. */
@@ -148,12 +169,17 @@ const abnormalExit = (exit: PtySessionExit | null | undefined): PtySessionExit |
 export function joinTaskTabs(
   snapshot: TabsState | undefined,
   taskId: string,
-  sessions: readonly TaskSessionRow[],
+  /** `null` = the pty host could not be asked; every liveness field on every
+   *  row then reports `null` rather than a verdict nobody checked. */
+  sessions: readonly TaskSessionRow[] | null,
   persistedExits: Readonly<Record<string, PtySessionExit & { tail?: readonly string[] }>> = {},
   liveVendors?: ReadonlyMap<string, string | null>,
+  engineAlive?: ReadonlyMap<string, boolean>,
 ): TaskTabRow[] {
-  const alive = aliveKeysOf(sessions)
-  const sessionExits = new Map(sessions.map((s) => [s.key, s.exit]))
+  const unknown = sessions === null
+  const rows0 = sessions ?? []
+  const alive = aliveKeysOf(rows0)
+  const sessionExits = new Map(rows0.map((s) => [s.key, s.exit]))
   // Death cause + tail for one dead tab. The live host's in-memory exit wins
   // (fresher when the key was reopened) but carries no output; the durable
   // record has the exit-time tail — merge it in only when both describe the
@@ -167,8 +193,8 @@ export function joinTaskTabs(
   }
   const rows: TaskTabRow[] = (snapshot?.tabs ?? []).map((t) => {
     const key = `${taskId}::${t.id}`
-    const isAlive = alive.has(key)
-    const walked = isAlive && liveVendors?.has(key) === true ? (liveVendors.get(key) ?? null) : undefined
+    const isAlive = unknown ? null : alive.has(key)
+    const walked = isAlive === true && liveVendors?.has(key) === true ? (liveVendors.get(key) ?? null) : undefined
     return {
       id: t.id,
       kind: t.kind,
@@ -178,14 +204,15 @@ export function joinTaskTabs(
       lastTitle: t.lastTitle ?? null,
       autoTitle: t.autoTitle ?? null,
       alive: isAlive,
-      exit: isAlive ? null : deadExit(key),
+      engineAlive: engineAliveOf(key, isAlive, engineAlive),
+      exit: isAlive === false ? deadExit(key) : null,
     }
   })
   // Live sessions the snapshot doesn't know still get a row — the discovery
   // read must show every engine that exists, not just the registered ones.
   // "engine" is the same assumption the sidebar's orphan backstop documents:
   // headless paths only ever start engines.
-  for (const tabId of unregisteredTabIds(snapshot, taskId, sessions)) {
+  for (const tabId of unregisteredTabIds(snapshot, taskId, rows0)) {
     rows.push({
       id: tabId,
       kind: "engine",
@@ -195,6 +222,7 @@ export function joinTaskTabs(
       lastTitle: null,
       autoTitle: null,
       alive: true,
+      engineAlive: engineAliveOf(`${taskId}::${tabId}`, true, engineAlive),
       exit: null,
       unregistered: true,
     })
@@ -203,22 +231,47 @@ export function joinTaskTabs(
 }
 
 /**
- * A task is RUNNING when ANY of its engine tabs has a live hosted session —
- * not just the canonical first one. The old `tab-1`-only rule reported
- * `running:false` while later engine tabs (`send --tab new`, a TUI tab
- * opened after tab-1 closed) were happily alive. The `tab-1` key stays as a
- * snapshot-free floor: it is always an engine tab by construction
- * (`initialTabs`), so it counts even when the snapshot write failed.
- * Non-engine tabs (command/content) never count — same rule delivery uses.
+ * Was an ENGINE PROCESS found inside this tab's session tree — `null` when
+ * nothing walked it (a dead tab, or a `ps` that failed). Distinct from
+ * `alive`, which is the SESSION's liveness: keepAlive leaves a login shell
+ * where an engine exited, so a tab can be `alive: true, engineAlive: false`
+ * for as long as nobody closes it.
+ */
+function engineAliveOf(
+  key: string,
+  isAlive: boolean | null,
+  engineAlive: ReadonlyMap<string, boolean> | undefined,
+): boolean | null {
+  if (isAlive === null) return null
+  if (!isAlive) return false
+  return engineAlive?.has(key) === true ? (engineAlive.get(key) ?? null) : null
+}
+
+/**
+ * A task is RUNNING when ANY of its engine tabs has a live hosted session
+ * WITH AN ENGINE IN IT — not just the canonical first one, and not merely a
+ * live PTY. The old `tab-1`-only rule reported `running:false` while later
+ * engine tabs (`send --tab new`, a TUI tab opened after tab-1 closed) were
+ * happily alive. The `tab-1` key stays as a snapshot-free floor: it is
+ * always an engine tab by construction (`initialTabs`), so it counts even
+ * when the snapshot write failed. Non-engine tabs (command/content) never
+ * count — same rule delivery uses.
+ *
+ * `engineAlive` is the process half. Session liveness alone answered `true`
+ * for a task whose engine had been reaped hours earlier, because keepAlive
+ * keeps the PTY. A tab nothing could walk (`null`) still counts as running:
+ * "couldn't look" must never read as stopped.
  */
 export function hasLiveEngineTab(
   snapshot: TabsState | undefined,
   taskId: string,
   sessions: readonly TaskSessionRow[],
+  engineAlive?: ReadonlyMap<string, boolean>,
 ): boolean {
   const alive = aliveKeysOf(sessions)
-  if (alive.has(`${taskId}::tab-1`)) return true
-  return (snapshot?.tabs ?? []).some((t) => t.kind === "engine" && alive.has(`${taskId}::${t.id}`))
+  const counts = (key: string): boolean => alive.has(key) && engineAlive?.get(key) !== false
+  if (counts(`${taskId}::tab-1`)) return true
+  return (snapshot?.tabs ?? []).some((t) => t.kind === "engine" && counts(`${taskId}::${t.id}`))
 }
 
 /**

--- a/packages/kobe/src/cli/api/types.ts
+++ b/packages/kobe/src/cli/api/types.ts
@@ -247,14 +247,28 @@ export interface PromptDeliveryOps {
  * git.
  */
 export interface ApiRuntime {
-  /** True iff ANY of the task's hosted engine tabs is live (not just tab-1). */
-  isTaskRunning(taskId: string): Promise<boolean>
+  /** {@link taskTabs}'s `.running`, for callers that need nothing else. */
+  isTaskRunning(taskId: string, engineArgv?: readonly string[]): Promise<boolean | null>
   /**
    * The task's persisted terminal tabs joined with hosted-session liveness,
    * plus the derived `.running` — the same answer {@link isTaskRunning}
    * gives, from the same read (`get-task` needs both, one host round-trip).
+   *
+   * `running` is TRI-STATE. `true`/`false` are verdicts about engine
+   * processes; `null` means the pty host could not be asked, which is
+   * "couldn't look" and not "nothing is running" — the distinction
+   * `pty-list` already publishes as `sessions: null`, and the one an
+   * unattended cleanup loop needs before it deletes a worktree.
+   *
+   * `engineArgv` is the task's own launch command. Without it a custom
+   * engine — a wrapper script no vendor table names — walks as "no engine"
+   * and its task reads stopped while it works; callers holding the task
+   * should pass `engineLaunchArgv({command, vendor})`.
    */
-  taskTabs(taskId: string): Promise<{ tabs: readonly TaskTabRow[]; running: boolean }>
+  taskTabs(
+    taskId: string,
+    engineArgv?: readonly string[],
+  ): Promise<{ tabs: readonly TaskTabRow[]; running: boolean | null }>
   /** Close one exact Terminal Tab without a mounted TUI. */
   closeTerminalTab(taskId: string, tabId: string): Promise<{ kind: TaskTabRow["kind"]; wasAlive: boolean }>
   /** Deliver a prompt into a task's engine pane (building the session if needed). */

--- a/packages/kobe/src/core/daemon-session-adapter.ts
+++ b/packages/kobe/src/core/daemon-session-adapter.ts
@@ -190,6 +190,14 @@ export async function terminalSpecAdapter(link: DaemonRpcClient, taskId: string)
  * spawns one. Used by the daemon's quota-resume runner: resuming a dead
  * engine would start a fresh context-less session and burn quota on it, so
  * "no alive engine" returns false and the schedule is dropped instead.
+ *
+ * "Alive engine" is a PROCESS fact, not a session one. `findHostedEngineKey`
+ * matches the session's spawn argv, which keeps matching long after the
+ * engine exited: keepAlive `exec`s a login shell in its place, the session
+ * stays alive, and a paste into it is EXECUTED as shell commands in the
+ * task's worktree. `sessionHasEngine` is the same gate `send` applies before
+ * writing a byte (`cli/api/pty-delivery.ts`), and every path that writes
+ * needs it — this one delivers unattended, on a timer.
  */
 export async function deliverPromptToLiveEngineAdapter(
   task: {
@@ -204,12 +212,13 @@ export async function deliverPromptToLiveEngineAdapter(
   if (!host) return false
   try {
     const sessions = await listHostedSessions(host.rpc)
-    const engineBin = engineLaunchArgv({
+    const engineArgv = engineLaunchArgv({
       command: task.command,
       vendor: task.vendor,
-    })[0]
-    const key = findHostedEngineKey(sessions, task.id, engineBin)
+    })
+    const key = findHostedEngineKey(sessions, task.id, engineArgv[0])
     if (!key) return false
+    if (!(await sessionHasEngine(sessions.find((s) => s.key === key)?.pid, engineArgv))) return false
     const manifest = task.vendor ? engineEntry(task.vendor).screenManifest : undefined
     return (
       (await deliverToHostedKey(host.rpc, key, prompt, {
@@ -239,6 +248,12 @@ function tabIdFromHostedKey(key: string): string {
  * never ran look identical to the user. It needs the busy layer and the tab
  * to file a deferral, and the daemon cannot catch `ComposerBusyError` by type
  * across the package boundary — so the outcome crosses as data.
+ *
+ * `no-engine` is the same fact as {@link deliverPromptToLiveEngineAdapter}'s
+ * refusal, kept distinct from `no-session` because the caller acts on it
+ * differently: a routine that finds its overnight engine dead must respawn
+ * and record `revived`, not paste a natural-language instruction at a zsh
+ * prompt and record `dispatched`.
  */
 export async function deliverPromptToLiveEngineDetailedAdapter(
   task: {
@@ -251,6 +266,7 @@ export async function deliverPromptToLiveEngineDetailedAdapter(
 ): Promise<
   | { outcome: "delivered"; tabId: string }
   | { outcome: "no-session" }
+  | { outcome: "no-engine"; tabId: string }
   | {
       outcome: "busy"
       tabId: string
@@ -261,12 +277,15 @@ export async function deliverPromptToLiveEngineDetailedAdapter(
   if (!host) return { outcome: "no-session" }
   try {
     const sessions = await listHostedSessions(host.rpc)
-    const engineBin = engineLaunchArgv({
+    const engineArgv = engineLaunchArgv({
       command: task.command,
       vendor: task.vendor,
-    })[0]
-    const key = findHostedEngineKey(sessions, task.id, engineBin)
+    })
+    const key = findHostedEngineKey(sessions, task.id, engineArgv[0])
     if (!key) return { outcome: "no-session" }
+    if (!(await sessionHasEngine(sessions.find((s) => s.key === key)?.pid, engineArgv))) {
+      return { outcome: "no-engine", tabId: tabIdFromHostedKey(key) }
+    }
     const manifest = task.vendor ? engineEntry(task.vendor).screenManifest : undefined
     try {
       const delivered = await deliverToHostedKey(host.rpc, key, prompt, {
@@ -305,6 +324,7 @@ export async function deliverPromptToLiveEngineTabDetailedAdapter(
 ): Promise<
   | { outcome: "delivered"; tabId: string }
   | { outcome: "no-session" }
+  | { outcome: "no-engine"; tabId: string }
   | {
       outcome: "busy"
       tabId: string
@@ -327,7 +347,7 @@ export async function deliverPromptToLiveEngineTabDetailedAdapter(
       command: target.command,
       vendor: target.vendor,
     })
-    if (!(await sessionHasEngine(session.pid, engineArgv))) return { outcome: "no-session" }
+    if (!(await sessionHasEngine(session.pid, engineArgv))) return { outcome: "no-engine", tabId: target.tabId }
     const manifest = target.vendor ? engineEntry(target.vendor).screenManifest : undefined
     try {
       const delivered = await deliverToHostedKey(host.rpc, key, prompt, {

--- a/packages/kobe/src/engine/hosted-session-readiness.ts
+++ b/packages/kobe/src/engine/hosted-session-readiness.ts
@@ -15,7 +15,7 @@
 import { existsSync } from "node:fs"
 import type { PtyPeekResult } from "@sma1lboy/kobe-daemon/daemon/protocol"
 import type { PtySessionInfo } from "@sma1lboy/kobe-daemon/daemon/pty-host"
-import { type PsSnapshot, engineProcessIn, parsePsSnapshot, psSnapshot } from "./foreground.ts"
+import type { PsSnapshot } from "./foreground.ts"
 import {
   type HostedPromptDeliveryOpts,
   type HostedSessionRpc,
@@ -23,6 +23,7 @@ import {
   awaitPasteReady,
   writeHostedPromptIfClear,
 } from "./hosted-session.ts"
+import { sessionHasEngine } from "./session-engine-presence.ts"
 import { ENGINE_EXIT_BANNER, REPO_INIT_TIMEOUT_SECONDS } from "./session-launch.ts"
 
 /** Bounds for the first-message readiness wait (paste-delivery vendors). */
@@ -79,7 +80,8 @@ export async function awaitEngineProcess(
   opts: PasteFirstMessageOptions = {},
 ): Promise<number | null> {
   const sleep = opts.sleep ?? ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)))
-  const snapshot = opts.snapshot ?? psSnapshot
+  // Undefined falls through to `sessionHasEngine`'s own default.
+  const snapshot = opts.snapshot
 
   // If the session was launched with a repo-init script, the engine child does
   // not appear until init finishes. Wait for the init marker before starting
@@ -101,15 +103,10 @@ export async function awaitEngineProcess(
     const { sessions = [] } = await rpc.request<{ sessions?: PtySessionInfo[] }>("pty.list", {})
     const session = sessions.find((s) => s.key === key)
     if (!session?.alive) return null
-    if (session.pid) {
-      let up = false
-      try {
-        up = engineProcessIn(parsePsSnapshot(await snapshot()), session.pid, engineBin)
-      } catch {
-        up = false // ps hiccup — treat as "not yet", keep polling
-      }
-      if (up) return session.pid
-    }
+    // Same predicate the delivery gates use, in a loop: one implementation of
+    // "is the engine actually there", and a ps hiccup reads as "not yet" and
+    // keeps polling.
+    if (session.pid && (await sessionHasEngine(session.pid, engineBin, snapshot))) return session.pid
     await sleep(opts.intervalMs ?? FIRST_MESSAGE_POLL_INTERVAL_MS)
   }
   return null

--- a/packages/kobe/src/engine/hosted-session.ts
+++ b/packages/kobe/src/engine/hosted-session.ts
@@ -50,13 +50,34 @@ export async function ensureHostedSessionHost(): Promise<HostedSessionClient> {
   return connectHostedSessionClient(await ensurePtyHostReachable())
 }
 
-export async function listHostedSessions(rpc: HostedSessionRpc): Promise<PtySessionInfo[]> {
+/**
+ * `pty.list`, keeping the ASKING distinct from the ANSWER: `null` means the
+ * host could not be asked (gone, wedged, any RPC failure), `[]` means it
+ * answered and holds nothing.
+ *
+ * A liveness READ needs that difference and nothing else can recover it —
+ * connecting to a stopped host SUCCEEDS (the kernel accepts into the listen
+ * backlog) and only the request times out, so "the socket opened" is not
+ * evidence the host is answering. Collapsing the two is how four running
+ * engines rendered as a stopped task with every tab `alive: false`.
+ */
+export async function listHostedSessionsOrNull(rpc: HostedSessionRpc): Promise<PtySessionInfo[] | null> {
   try {
     const { sessions } = await rpc.request<{ sessions: PtySessionInfo[] }>("pty.list", {})
     return sessions ?? []
   } catch {
-    return []
+    return null
   }
+}
+
+/**
+ * {@link listHostedSessionsOrNull} collapsed for callers that ACT on the
+ * inventory (deliver into a key, kill a task's sessions, resolve a tab):
+ * "couldn't ask" and "nothing there" both mean there is nothing to act on.
+ * Readers must use the tri-state version instead.
+ */
+export async function listHostedSessions(rpc: HostedSessionRpc): Promise<PtySessionInfo[]> {
+  return (await listHostedSessionsOrNull(rpc)) ?? []
 }
 
 export function isHostedTaskKey(key: string, taskId: string): boolean {

--- a/packages/kobe/src/engine/session-engine-presence.ts
+++ b/packages/kobe/src/engine/session-engine-presence.ts
@@ -1,9 +1,21 @@
 import { type PsSnapshot, engineProcessIn, parsePsSnapshot, psSnapshot } from "./foreground.ts"
 
 /**
- * A hosted PTY can remain alive after its engine exits because keepAlive drops
- * it into a fallback shell. Delivery must therefore verify the current process
- * tree instead of trusting the session's original launch command.
+ * Is an engine process running inside this hosted session's tree right now?
+ *
+ * The one answer to "is the engine actually there", shared by every gate that
+ * writes into a session and by the readiness poll that waits for one
+ * ({@link import("./hosted-session-readiness.ts").awaitEngineProcess}, which
+ * is this call in a loop). A hosted PTY stays alive after its engine exits —
+ * keepAlive `exec`s a login shell in its place — so the session's own
+ * liveness answers a different question, and a paste into that shell is
+ * EXECUTED as shell commands rather than read.
+ *
+ * A failed `ps` reads as `false` here on purpose: for a gate, only a positive
+ * walk may license a write. Readers must NOT reuse this — `false` from a
+ * failed look would tell a cleanup loop a live task had stopped. They walk
+ * one shared snapshot with {@link engineProcessIn} and publish the failure as
+ * `null` (see `cli/api/runtime.ts`'s `taskTabs`).
  */
 export async function sessionHasEngine(
   pid: number | null | undefined,

--- a/packages/kobe/test/cli/api-cmd-runtime.test.ts
+++ b/packages/kobe/test/cli/api-cmd-runtime.test.ts
@@ -74,6 +74,10 @@ vi.mock("../../src/cli/api/pty-delivery.ts", () => ({
   ensurePtyHost: mocks.ensurePtyHost,
   deliverHostedPrompt: mocks.deliverHostedPrompt,
   listSessions: mocks.listSessions,
+  // Same stub behind both: the tri-state reader is what `taskTabs` calls now,
+  // and every `mocks.listSessions.mockResolvedValue([...])` below is still
+  // "the host answered with this inventory".
+  listSessionsOrNull: mocks.listSessions,
   findEngineKey: mocks.findEngineKey,
   taskKeys: mocks.taskKeys,
   killTaskSessions: mocks.killTaskSessions,
@@ -147,9 +151,11 @@ describe("defaultApiRuntime", () => {
     await expect(defaultApiRuntime.isTaskRunning("t1")).resolves.toBe(false)
   })
 
-  it("isTaskRunning is false when no PTY Host is running", async () => {
+  // An unreachable host is "could not look", and a caller that deletes
+  // worktrees on `running:false` must never be handed one for it.
+  it("isTaskRunning is null — not false — when the PTY host cannot be reached", async () => {
     mocks.openPtyHost.mockResolvedValueOnce(null)
-    await expect(defaultApiRuntime.isTaskRunning("t1")).resolves.toBe(false)
+    await expect(defaultApiRuntime.isTaskRunning("t1")).resolves.toBeNull()
   })
 
   it("taskTabs joins the persisted snapshot with per-tab session liveness", async () => {
@@ -177,6 +183,7 @@ describe("defaultApiRuntime", () => {
         lastTitle: "boot",
         autoTitle: null,
         alive: false,
+        engineAlive: false,
         exit: null,
       },
       {
@@ -188,6 +195,9 @@ describe("defaultApiRuntime", () => {
         lastTitle: null,
         autoTitle: null,
         alive: true,
+        // These rows carry no pid, so nothing walked them: `null` is
+        // "couldn't look", and `running` still reads true because of it.
+        engineAlive: null,
         exit: null,
       },
     ])

--- a/packages/kobe/test/cli/api-handlers-lifecycle.test.ts
+++ b/packages/kobe/test/cli/api-handlers-lifecycle.test.ts
@@ -44,6 +44,7 @@ describe("collect handler", () => {
               lastTitle: null,
               autoTitle: null,
               alive: id === "a",
+              engineAlive: id === "a",
               exit: null,
             },
           ],
@@ -216,6 +217,7 @@ describe("task lifecycle handlers", () => {
         lastTitle: null,
         autoTitle: null,
         alive: false,
+        engineAlive: false,
         exit: { code: 1, signal: null, at: "2026-08-11T00:00:00.000Z" },
       },
       {
@@ -227,6 +229,7 @@ describe("task lifecycle handlers", () => {
         lastTitle: "wiring tests",
         autoTitle: null,
         alive: true,
+        engineAlive: true,
         exit: null,
       },
     ] as const

--- a/packages/kobe/test/cli/api-tab-snapshot.test.ts
+++ b/packages/kobe/test/cli/api-tab-snapshot.test.ts
@@ -228,6 +228,21 @@ describe("hasLiveEngineTab (the get-task/collect .running rule)", () => {
     const snap = snapshot([{ kind: "engine", id: "tab-2", title: null, ordinal: 2 }])
     expect(hasLiveEngineTab(snap, "t1", [{ key: "t1::tab-2::leaf-2", alive: true }])).toBe(false)
   })
+
+  // keepAlive `exec`s a login shell where an engine exits, so the PTY outlives
+  // the engine by hours. Session liveness alone reported those tasks as
+  // running the whole time.
+  it("a live PTY whose ENGINE is gone does not count as running", () => {
+    const snap = snapshot([{ kind: "engine", id: "tab-1", title: null, ordinal: 1 }])
+    const sessions = [{ key: "t1::tab-1", alive: true }]
+    expect(hasLiveEngineTab(snap, "t1", sessions, new Map([["t1::tab-1", false]]))).toBe(false)
+    expect(hasLiveEngineTab(snap, "t1", sessions, new Map([["t1::tab-1", true]]))).toBe(true)
+  })
+
+  it("a tab nothing walked still counts — 'couldn't look' is not 'stopped'", () => {
+    const snap = snapshot([{ kind: "engine", id: "tab-1", title: null, ordinal: 1 }])
+    expect(hasLiveEngineTab(snap, "t1", [{ key: "t1::tab-1", alive: true }], new Map())).toBe(true)
+  })
 })
 
 describe("joinTaskTabs", () => {
@@ -254,6 +269,7 @@ describe("joinTaskTabs", () => {
         lastTitle: "building",
         autoTitle: "first prompt",
         alive: false,
+        engineAlive: false,
         exit: null,
       },
       {
@@ -265,6 +281,7 @@ describe("joinTaskTabs", () => {
         lastTitle: null,
         autoTitle: null,
         alive: true,
+        engineAlive: null,
         exit: null,
       },
     ])
@@ -303,6 +320,18 @@ describe("joinTaskTabs", () => {
     expect(rows[0]?.liveVendor).toBe("claude")
   })
 
+  // An unreachable pty host answers nothing. Rendering that as `alive: false`
+  // asserts a death nobody observed, and a cleanup loop deletes worktrees on
+  // it — so every liveness field on every row goes to `null` instead.
+  it("an unasked pty host leaves every liveness field null, not false", () => {
+    const snap = { tabs: [{ kind: "engine", id: "tab-1", title: null, ordinal: 1 }] } as unknown as TabsState
+    const rows = joinTaskTabs(snap, "t1", null)
+    expect(rows).toHaveLength(1)
+    expect(rows[0]?.alive).toBeNull()
+    expect(rows[0]?.engineAlive).toBeNull()
+    expect(rows[0]?.exit).toBeNull()
+  })
+
   it("a task with no snapshot still lists its live sessions as unregistered rows", () => {
     // Returning [] here would make an alive engine invisible to the
     // discovery read.
@@ -316,6 +345,7 @@ describe("joinTaskTabs", () => {
         lastTitle: null,
         autoTitle: null,
         alive: true,
+        engineAlive: null,
         exit: null,
         unregistered: true,
       },

--- a/packages/kobe/test/core/daemon-session-adapter.test.ts
+++ b/packages/kobe/test/core/daemon-session-adapter.test.ts
@@ -16,6 +16,13 @@ const mocks = vi.hoisted(() => ({
   openHost: vi.fn(),
   ensureEngine: vi.fn(async () => ({ alive: true, created: true })),
   listSessions: vi.fn(async () => [{ key: "task-3::tab-1", alive: true }]),
+  // Same rule as the real resolver for these fixtures: the task's first alive
+  // session. What matters here is that it resolves a key from the SPAWN argv
+  // and therefore keeps resolving one after the engine is gone.
+  findEngineKey: vi.fn(
+    (sessions: readonly { key: string; alive?: boolean }[], taskId: string) =>
+      sessions.find((s) => s.alive && s.key.startsWith(`${taskId}::`))?.key ?? null,
+  ),
   taskKeys: vi.fn(() => ["task-3::tab-1"]),
   killSessions: vi.fn(async () => {}),
   deliver: vi.fn(async () => ({ bytes: 1 })),
@@ -34,6 +41,7 @@ vi.mock("../../src/engine/hosted-session.ts", () => ({
   openHostedSessionHost: mocks.openHost,
   ensureHostedEngine: mocks.ensureEngine,
   listHostedSessions: mocks.listSessions,
+  findHostedEngineKey: mocks.findEngineKey,
   hostedTaskKeys: mocks.taskKeys,
   killHostedSessions: mocks.killSessions,
   deliverToHostedKey: mocks.deliver,
@@ -44,6 +52,8 @@ vi.mock("../../src/engine/session-launch.ts", () => ({ buildEngineSessionLaunch:
 vi.mock("../../src/engine/session-engine-presence.ts", () => ({ sessionHasEngine: mocks.sessionHasEngine }))
 
 import {
+  deliverPromptToLiveEngineAdapter,
+  deliverPromptToLiveEngineDetailedAdapter,
   deliverPromptToLiveEngineTabDetailedAdapter,
   engineSpecAdapter,
   ensureTaskSessionAdapter,
@@ -207,9 +217,52 @@ describe("daemon session adapter", () => {
         { id: "task-3", tabId: "tab-1", vendor: "claude", worktreePath: "/worktrees/story" },
         "do not run this in zsh",
       ),
-    ).resolves.toEqual({ outcome: "no-session" })
+    ).resolves.toEqual({ outcome: "no-engine", tabId: "tab-1" })
     expect(mocks.sessionHasEngine).toHaveBeenCalledWith(4242, expect.arrayContaining(["claude"]))
     expect(mocks.deliver).not.toHaveBeenCalled()
+  })
+
+  // The two adapters below resolve their tab by matching the session's SPAWN
+  // argv, which keeps matching after the engine exits — keepAlive leaves a
+  // login shell in its place. Delivering there does not paste text into an
+  // engine, it hands zsh a natural-language instruction to RUN. Both must
+  // refuse for the same reason the exact-tab sibling already does.
+  it("the routine runner refuses a tab whose engine exited to the fallback shell", async () => {
+    mocks.listSessions.mockResolvedValueOnce([{ key: "task-3::tab-1", alive: true, pid: 4242 } as never])
+    mocks.sessionHasEngine.mockResolvedValueOnce(false)
+
+    await expect(
+      deliverPromptToLiveEngineDetailedAdapter(
+        { id: "task-3", vendor: "claude", worktreePath: "/worktrees/story" },
+        "clean up the stale branches",
+      ),
+    ).resolves.toEqual({ outcome: "no-engine", tabId: "tab-1" })
+    expect(mocks.deliver).not.toHaveBeenCalled()
+  })
+
+  it("the quota-resume runner refuses the same tab", async () => {
+    mocks.listSessions.mockResolvedValueOnce([{ key: "task-3::tab-1", alive: true, pid: 4242 } as never])
+    mocks.sessionHasEngine.mockResolvedValueOnce(false)
+
+    await expect(
+      deliverPromptToLiveEngineAdapter(
+        { id: "task-3", vendor: "claude", worktreePath: "/worktrees/story" },
+        "continue",
+      ),
+    ).resolves.toBe(false)
+    expect(mocks.deliver).not.toHaveBeenCalled()
+  })
+
+  it("a LIVE engine still receives the routine's prompt", async () => {
+    mocks.listSessions.mockResolvedValueOnce([{ key: "task-3::tab-1", alive: true, pid: 4242 } as never])
+
+    await expect(
+      deliverPromptToLiveEngineDetailedAdapter(
+        { id: "task-3", vendor: "claude", worktreePath: "/worktrees/story" },
+        "daily report please",
+      ),
+    ).resolves.toEqual({ outcome: "delivered", tabId: "tab-1" })
+    expect(mocks.deliver).toHaveBeenCalled()
   })
 
   it("passes the custom engine's complete launch argv to the foreground gate", async () => {


### PR DESCRIPTION
Four defects from `.scratch/loop-r13-api/api.md`'s highest-severity group. Every payload below is a live capture in an isolated home (`.scratch/loop-r13-ai/`, all twelve `ROVE_`/`KOBE_` isolation vars set as separate assignments), against a fake engine named `claude` so the foreground walk sees a real vendor. `~/.rove/tasks.json` was checked after every destructive step: **zero** occurrences of any of the eight task ids created here.

There is no UI surface to screenshot — every item is an API/daemon-layer contract. The proof standard the task set for this batch (the command, the payload, and what was actually true, before and after) is what is below.

---

## 1. `dispatch` executed the prompt as shell commands — A1/A2

**PASS (a negative):** with the engine killed and the wrapper shell alive, `dispatch --prompt "touch <sentinel>"` refuses and the sentinel does not exist afterwards; delivery into a healthy engine still works.

BEFORE (engine pid killed, session pid is now a bare `/bin/zsh`):
```
$ ./R api dispatch --task-id 01M1P1BR83Y99T20WQ2HFNMBFT --prompt "touch /tmp/R13AI_SHELL_EXEC_BEFORE_29076"
{"ok":true,"tabId":"tab-1","routed":"session.deliver","delivered":true,"clients":1}
$ ls -la /tmp/R13AI_SHELL_EXEC_BEFORE_29076
-rw-r--r--@ 1 jacksonc wheel 0 Sep 4 04:03 /tmp/R13AI_SHELL_EXEC_BEFORE_29076
```

AFTER, on the final build:
```
# healthy engine — must still deliver
$ ./R api dispatch --task-id 01M1P3S1H87M31BZE6PX6487AW --prompt "still lands"
{"ok":true,"tabId":"tab-1","routed":"session.deliver","delivered":true,"clients":1}
  running= True engineAlive= True

# engine killed, wrapper shell alive
$ ./R api dispatch --task-id 01M1P3S1H87M31BZE6PX6487AW --prompt "touch /tmp/R13AI_FINAL_29076"
{"ok":true,"tabId":"tab-1","routed":"session.deliver","delivered":false,"reason":"no-engine","clients":1}
  running= False alive= True engineAlive= False
$ ls -la /tmp/R13AI_FINAL_29076
ls: /tmp/R13AI_FINAL_29076: No such file or directory
```

`sessionHasEngine` was already the model — `send` applied it, and so did `deliverPromptToLiveEngineTabDetailedAdapter`. The two that did not are the ones the **routine runner** and the **quota-resume runner** use. `no-engine` is a new outcome distinct from `no-session` because the daemon acts on it differently: it does not broadcast (`broadcast` keys on `no-session` only), and `automation-dispatch` falls through to the existing `revived` respawn instead of recording `dispatched`.

**On `awaitEngineProcess` (from #865):** it is not a competing mechanism — its loop body *was* `sessionHasEngine`, duplicated with a different catch verdict. `awaitEngineProcess` now calls it, so "is the engine actually there" has one implementation; the difference that remains is polling (wait for a spawn) vs one-shot (gate a write), which is real.

Unit cover: three tests in `daemon-session-adapter.test.ts` (routine refuses / quota-resume refuses / a live engine still receives). Mutation-verified twice at different sites — removing the routine guard reds the first, removing the quota-resume guard reds the second.

---

## 2. `send` reaped the whole fleet and returned `ok: true` — A4

**PASS:** with a SIGSTOPped host owning live sessions, `send` never returns a bare `ok:true` after killing them; a host with zero live sessions is still reaped silently.

BEFORE:
```
BEFORE send: host pid=29572  fleet procs=4 (2 wrappers + 2 engines)  sessions=3
$ ./R api send --task-id … --prompt "hello again"
{"ok":true,"started":true,"engineReady":true,"delivered":true}
AFTER  send: host pid=38566 (new)  fleet procs=2  old host 29572 = gone
```

AFTER:
```
BEFORE send: host=53310 stat=Ts  fleet procs=4  host children=4
$ ./R api send --task-id 01M1P2GYNM6GDWJDFR9YDBQ9KS --prompt "hello again"
{"error":{"message":"failed to start PTY host for …: rove: the pty host (pid 53310) is not
 answering but still holds 4 live session(s) — refusing to restart it, which would kill every
 engine running in them. Inspect it with `rove api pty-list`, or kill 53310 yourself once you
 have accepted losing those sessions.","code":"SESSION_FAILED"}}
AFTER  send: host=53310 alive=YES  fleet procs=4  host children=4
```

Both preserved behaviours checked too:
```
(a) host process GONE (the documented idle-exit resurrect)
    old host 53310 alive=NO → {"ok":true,…,"delivered":true}; new host 58312 alive=YES
(b) host alive+SIGSTOPped with ZERO children
    host 58312 children=0 → {"ok":true,…,"delivered":true}; old host gone, new host 61267
```

I chose **refuse** over the brief's suggested `hostRestarted: {killedSessions: N}`: the brief's PASS allows either ("succeeds after retry or fails loud"), and reporting a fleet death after the fact still spends N running engines to deliver one message. `ptyHostHasLiveSessions` could not have been the guard — it goes through the same socket and returns `false` for an unreachable host — so the count comes from the host's live children. The 15s grace is the twin of `daemon-process.ts`'s existing `BUSY_DAEMON_GRACE_MS`, which the pty host path simply never had.

---

## 3. `running` was wrong in both directions — B1/B2

**PASS:** engine dead + shell alive → `running:false, alive:true, engineAlive:false`; a live engine → `running:true, engineAlive:true`; host unreachable → `running:null` with nothing claiming a tab is dead, and `read-output` naming the reason.

BEFORE / AFTER, engine dead:
```
BEFORE  {"running": true,  "tabs":[{"alive":true,"liveVendor":null,"exit":null}]}
AFTER   {"running": false, "tabs":[{"alive":true,"engineAlive":false,"liveVendor":null}]}
AFTER   {"running": true,  "tabs":[{"alive":true,"engineAlive":true,"liveVendor":"claude"}]}   ← live engine
```

BEFORE / AFTER, host SIGSTOPped with **2 engine processes running**:
```
BEFORE  get-task     {"running": false, "tabs":[{"alive":false,"exit":null}]}
        read-output  {"fallbackReason":"history_missing","warnings":["no live terminal session for this task"]}
        pty-list     {"sessions":null}      ← the only honest one

AFTER   get-task     {"running": null, "tabs":[{"alive":null,"engineAlive":null,"exit":null}]}
        collect      {"running": null, "tabs":[{"alive":null,"engineAlive":null}]}
        read-output  {"running":null,"fallbackReason":"pty_host_unreachable",
                      "warnings":["the pty host could not be reached — this is 'could not look', not 'no session'"]}
        pty-list     {"sessions":null}      ← unchanged
```

Two things had to change, and the first fix alone was **not enough** — I captured a failed intermediate: connecting to a SIGSTOPped host **succeeds** (the kernel accepts into the listen backlog) and only the request times out, so `openPtyHost() !== null` is not evidence anybody answered. `listHostedSessions` was swallowing that into `[]`. `listHostedSessionsOrNull` now keeps the asking distinct from the answer; the collapsing wrapper stays for callers that *act* on the inventory, where "couldn't ask" and "nothing there" genuinely coincide.

`engineArgv` is threaded from the three callers that hold the task, so a **custom engine** (a wrapper script no vendor table names) does not walk as "no engine" and read as stopped — without it the fix would have introduced a new false negative of exactly the kind B2 is about.

`resolveDispatcherTab` reads `running` as a truthy gate, so `null` falls through to its existing loud `DISPATCHER_UNREACHABLE` rather than cold-starting an engine — the right answer for "we could not look".

---

## 4. The engine-death observer was dark headless — B3

**PASS:** headless, kill an engine inside a live PTY, wait one slow interval → `inspect.sessionExits` carries a `layer:"engine"` record with `parentAlive:true`, and activity is non-null.

BEFORE (two engines had died inside live PTYs):
```
{"activity":{"tasks":{},"tabs":{}},"sessionExits":[],
 "sessions":[{"alive":true,"pid":29577,"foreground":null}]}
```

AFTER (`attachedClients: 0` throughout — no TUI ever attached):
```
{"attachedClients":0,
 "sessionExits":[{"key":"01M1P295Z51ZTAVS8D339XGRVK::tab-1","pid":54230,"code":143,
   "at":"2026-09-04T11:21:50.196Z","layer":"engine","vendor":"claude","parentAlive":true,
   "tail":["…","zsh: terminated  --session-id … hello","",
           "  ⚠ Engine exited (code 143). Check Settings → Engines and fix the launch command.","…"]}]}
```
and `.activity.tabs` populated for both tasks (`state: "idle"`, `source: "observed"`).

The gate is now a **cadence**, not a switch: every tick with a subscriber, every ~60s without. A daemon whose host owns no live sessions still does no per-session work — `listSessions` returns `[]`/`null` and every loop is empty.

One thing worth naming: reaching this record needs a walk that *saw* the vendor before the one that does not. My first attempt looked like a failure because that task's engine died before its first walk ever recorded a vendor. The capture above is against a task whose track already read `vendor: "claude"`.

---

## 5. The three documented liveness claims — C3

The brief scopes C3 as "must ship WITH B1/B2/B3", so it is here rather than left to rot. `docs/API.md` (both passages) and the skill copy now describe `running` as `true|false|null` with the meaning implemented above, and say explicitly that `null` must not be acted on as `false`. `bun scripts/gen-skill-api-flags.ts --check` → `api-flags.md is up to date`. The canonical `.agents/skills/kobe/SKILL.md` and the bundled `claude-plugin/skills/rove/SKILL.md` are byte-identical (`claude-plugin.test.ts` enforces it and passes).

---

## Gates

```
bun run lint          clean (1431 files)
bun run typecheck     clean, both packages
bun run test:fast     448 files / 4435 tests passed
bun run test:socket   99 files / 802 tests passed   (KOBE_INCLUDE_SOCKET=1)
bun test test/render  474 pass, 0 fail
```

File-size cap: every touched `.ts` is ≤462 lines. No exemptions needed.

## Left for a later worker

Deliberately **not** taken from `api.md`, all lower severity than this group:

- **A3** — `add` / `send --tab new` report `engineReady: true` for a binary that does not exist. Related but separate: it is about a spawn that never produced an engine, not about writing into one that died. #865 moved the routine path toward this already.
- **B4** — `exit.code: null` while the tail in the same payload says `Engine exited (code 143)`; `engineExitCodeFromTail` exists and `recordPtyExit` does not call it. Also `exit` omits `layer`.
- **C1** — deferred prompts have no API verb, so headless nothing releases them (24h TTL, then silently dropped).
- **C2** — daemon error codes collapse to `RPC_ERROR`; `DIRTY_WORKTREE` in particular is the one an unattended cleanup loop hits most.

## Not proved

Nothing in this PR is claimed beyond what is captured above. Two honest caveats:

- The A1 regression tests are at the adapter seam with a mocked host, not driving a real PTY as `api.md` suggested. The real-PTY evidence is the live capture in §1 (fake engine, `kill -TERM`, sentinel absent), reproduced on the final build after the `awaitEngineProcess` dedup.
- In the §4 tail you can see `zsh: command not found: this` — my fake engine does not drain stdin, so bytes pasted while it was alive sat in the tty and zsh ran them once keepAlive took over. That is an artifact of the fixture, not of the delivery path, and it is not evidence for the A1 fix; the sentinel test is.

The explorer's leftovers (the detached worktree at `.scratch/loop-r13-api/src`, `/tmp/ROVE_SHELL_EXEC_PROOF`, and its running isolated daemon) are untouched.
