### PR TITLE
fix: report the engine that actually ran, and clean up after a killed writer

### DIFF
--- a/.changeset/exit-code-from-the-wrapper-banner.md
+++ b/.changeset/exit-code-from-the-wrapper-banner.md
@@ -1,0 +1,17 @@
+---
+"@sma1lboy/rove": patch
+---
+
+A killed session's exit record no longer reports `code: null` next to a tail that spells the code out.
+
+```json
+"exit": { "code": null, "signal": "SIGKILL",
+          "tail": ["…", "⚠ Engine exited (code 143). Check Settings → Engines…"] }
+```
+
+A signalled session has no wait-status code, so the only exit code that exists
+at that point is the one the shell wrapper printed — and the store already had
+the parser for it, wired to the engine layer only. `recordPtyExit` now falls
+back to it, and the `exit` object in `get-task`/`collect` gains `layer`, so a
+caller can tell "the PTY was killed" from "the engine died inside it" instead of
+guessing which process `code` and `signal` describe.

--- a/.changeset/honest-engine-start-and-index-hygiene.md
+++ b/.changeset/honest-engine-start-and-index-hygiene.md
@@ -1,0 +1,24 @@
+---
+"@sma1lboy/rove": patch
+---
+
+`add` and `send --tab new` stop reporting a green launch for an engine that never ran.
+
+A hosted session stays alive after its engine exits — the wrapper `exec`s a
+login shell in its place — so `pty.open` reports `alive` identically for a
+healthy launch and for one pointing at nothing. The argv-delivery path read
+readiness straight off that flag:
+
+```json
+{ "started": true, "engineReady": true, "delivered": true }
+```
+
+for `--command /nope/does-not-exist-engine`, whose session had already printed
+`no such file or directory` and `⚠ Engine exited (code 127)`. A fan-out of N
+such tasks reported all green. The path now walks for the engine PROCESS
+(`awaitEngineProcess`, the one implementation the existing-session gate already
+uses) before claiming anything, with a 3s budget, and a launch that produces no
+engine fails as `SESSION_FAILED` carrying the task id, the session key and the
+session's own last line as `reason`. A repo whose `.rove/init.sh` is still
+running reports `engineReady: false` with that stated as the reason instead of
+holding `add` open for the install.

--- a/.changeset/stale-index-lock-takeover-verifies.md
+++ b/.changeset/stale-index-lock-takeover-verifies.md
@@ -1,0 +1,22 @@
+---
+"@sma1lboy/rove": patch
+---
+
+A stale task-index lock is no longer removable by an acquirer that stopped holding it.
+
+The takeover read the lockfile, judged its pid dead, then unlinked
+unconditionally — never re-checking that the file still held the value it
+judged. A rival that won the takeover in between had its live lock deleted, and
+the next `link` admitted a second writer to the critical section. Measured on 50
+concurrent acquires against one stale lock: 29 of 2250 created tasks were absent
+from disk (22 of 45 rounds), against 0 of 2250 with no stale lock present. The
+takeover now removes only a byte-identical match, through the same ownership
+check `release` performs, and it does so synchronously — the async pair's `await`
+was itself a scheduling point wide enough for a rival's whole takeover.
+
+Daemon boot also sweeps what a killed writer leaves in `.rove/`: a stale
+`tasks.json.lock` (every one of 20 `kill -9` trials left one) and orphaned
+`tasks.json.*.tmp` staging files, which are unique per save and so are never
+reused or noticed — 1 of those 20 trials leaked a full 11.8 MB copy of the
+manifest. A lock naming a live process and a staging file younger than five
+minutes are left alone: another Rove may be mid-save.

--- a/docs/API.md
+++ b/docs/API.md
@@ -193,9 +193,15 @@ replacement in `nextCommandArgs`.
     it uses for one.
   - `.tabs` — the same per-tab join as `get-task` (pick a `send --tab`
     target without a second hop). A tab whose session died abnormally
-    carries `.exit` with `code`/`signal`/`at` **and** `tail`, the last lines
-    the session printed, so a crash comes back with its cause attached. The
-    tail rides along only when the durable record describes that same death.
+    carries `.exit` with `code`/`signal`/`at`/`layer` **and** `tail`, the last
+    lines the session printed, so a crash comes back with its cause attached.
+    The tail rides along only when the durable record describes that same
+    death. `layer` says WHICH process the record describes (`"pty"` — the
+    tab's own session child), without which `code` and `signal` cannot be
+    read together: a signalled session has no wait-status code, so `code`
+    then comes from the wrapper's own `Engine exited (code N)` banner and
+    belongs to the ENGINE, while `signal` belongs to the session that
+    outlived it.
   - `.changes` — uncommitted files (`added`/`deleted`). Non-zero means the
     task cannot land as-is, however it reported itself.
   - `.base` — committed work: `ahead` (commits vs the base branch) and a
@@ -380,6 +386,22 @@ branch included, live in the Rove agent skill. Prompts into existing sessions
     engines that collapse a large paste into a `[Pasted text #1]` placeholder
     never echo the text, so a positive proves delivery while a negative
     merely fails to.
+  - `reason` — why nothing was confirmed. Present only with
+    `engineReady: false`.
+
+  A FRESH spawn carries the prompt on the engine's own command line, so there
+  is no write to observe; `engineReady` there reports the engine PROCESS being
+  found inside the session, and nothing else. A hosted session stays alive
+  after its engine exits — the wrapper `exec`s a login shell in its place — so
+  its liveness answers a different question, and a launch command that does not
+  exist would otherwise report a clean success on every field. A spawn that
+  produces no engine fails as `SESSION_FAILED`, carrying the already-created
+  `taskId`, the `session` key, and the session's own last line as `reason`. The
+  one non-failure that reports `engineReady: false` is a repo whose
+  `.rove/init.sh` is still running: it precedes the engine, so `delivered`
+  stays `true` (the prompt is still riding an argv that has not run yet) and
+  `reason` says so, rather than holding `add` open for the length of an
+  install.
 - `dispatch --task-id ID (--prompt TEXT | --prompt-file PATH) [--tab TAB]`: route text into a
   task's live session (the dispatcher's messenger; see
   [design/dispatcher.md](./design/dispatcher.md)). Unlike `send` it never

--- a/packages/kobe-daemon/src/daemon/pty-exit-store.ts
+++ b/packages/kobe-daemon/src/daemon/pty-exit-store.ts
@@ -43,6 +43,12 @@ export type PtyExitLayer = "pty" | "engine"
 export interface PtyExitRecord {
   readonly key: string
   readonly pid: number | null
+  /** Wait-status code where the OS gave one; otherwise the shell wrapper's
+   *  own `Engine exited (code N)` banner ({@link engineExitCodeFromTail}),
+   *  which is the only code a signalled or reaped death leaves behind. Read
+   *  it together with {@link signal} and {@link layer}: `code: 143` beside
+   *  `signal: "SIGKILL"` on a `pty` record means the ENGINE exited 143 and
+   *  the surviving session was then killed. */
   readonly code: number | null
   readonly signal: string | null
   readonly at: string
@@ -107,15 +113,21 @@ export function readPtyExitRecords(path = defaultPtyExitsPath()): Record<string,
 export function recordPtyExit(info: PtySessionEndInfo, path = defaultPtyExitsPath()): void {
   if (info.key.startsWith("::")) return
   if (info.exit.code === 0 && info.exit.signal === null) return
+  const tail = plainTail(info.tail)
   writeRecord(
     info.key,
     {
       key: info.key,
       pid: info.pid,
-      code: info.exit.code,
+      // A signalled session has no wait-status code, so `code` used to be
+      // null while the very tail in the same record spelled the number out
+      // (`Engine exited (code 143)`). The banner is the only code that
+      // exists then — publish it rather than making every caller re-parse
+      // prose the store already knows how to read.
+      code: info.exit.code ?? engineExitCodeFromTail(tail),
       signal: info.exit.signal,
       at: info.exit.at,
-      tail: plainTail(info.tail),
+      tail,
       layer: "pty",
     },
     path,

--- a/packages/kobe/src/cli/api/handlers-add.ts
+++ b/packages/kobe/src/cli/api/handlers-add.ts
@@ -187,6 +187,9 @@ async function addOne(ctx: VerbContext, repo: string): Promise<unknown> {
     delivered: delivered.delivered,
     ...(delivered.bytes === undefined ? {} : { bytes: delivered.bytes }),
     ...(delivered.promptEcho ? { promptEcho: delivered.promptEcho } : {}),
+    // Only set when nothing confirmed the engine — say WHY rather than
+    // leaving `engineReady: false` to be read as a bare failure.
+    ...(delivered.reason ? { reason: delivered.reason } : {}),
     ...(delivered.deferred ? { deferred: delivered.deferred } : {}),
     ...(promptPersisted ? {} : { promptPersisted: false }),
   }
@@ -359,6 +362,7 @@ async function addParallel(
         started: r.value.started,
         engineReady: r.value.engineReady,
         session: r.value.session,
+        ...(r.value.reason ? { reason: r.value.reason } : {}),
         ...(r.value.deferred ? { deferred: r.value.deferred } : {}),
       }
       tasks.push(row)

--- a/packages/kobe/src/cli/api/handlers-tasks.ts
+++ b/packages/kobe/src/cli/api/handlers-tasks.ts
@@ -228,6 +228,7 @@ export async function send(ctx: VerbContext): Promise<unknown> {
     delivered: delivered.delivered,
     ...(delivered.bytes === undefined ? {} : { bytes: delivered.bytes }),
     ...(delivered.promptEcho ? { promptEcho: delivered.promptEcho } : {}),
+    ...(delivered.reason ? { reason: delivered.reason } : {}), // see `DeliveredPrompt.reason`
     // The deferred outcome is a SUCCESS, not an error — say so explicitly so a
     // scripted sender does not read `deferred` as a failure and retry.
     ...(delivered.deferred ? { deferred: delivered.deferred } : {}),

--- a/packages/kobe/src/cli/api/pty-delivery.ts
+++ b/packages/kobe/src/cli/api/pty-delivery.ts
@@ -12,6 +12,7 @@
  * the vendor's own launch binary — never a hard-coded "claude"/"codex".
  */
 
+import { existsSync } from "node:fs"
 import type { PtyOpenResult } from "@sma1lboy/kobe-daemon/daemon/protocol"
 import type { PtySessionInfo } from "@sma1lboy/kobe-daemon/daemon/pty-host"
 import type { PsSnapshot } from "../../engine/foreground.ts"
@@ -19,9 +20,11 @@ import {
   ComposerBusyError,
   type HostedSessionRpc,
   type PromptWriteOutcome,
+  awaitEngineProcess,
   deliverToHostedKey,
   ensureHostedSessionHost,
   findHostedEngineKey,
+  hostedSessionFailureLine,
   hostedTaskKeys,
   isHostedTaskKey,
   killHostedSessions,
@@ -91,6 +94,18 @@ export const listSessionsOrNull = listHostedSessionsOrNull
 export const deliverToKey = deliverToHostedKey
 
 const writePrompt = writeHostedPromptIfClear
+
+/**
+ * How long a fresh argv-delivery spawn gets to put an engine in the process
+ * table before this call reports it unobserved. Short on purpose: a caller
+ * is blocked on the answer, a failed launch (`command not found`) never
+ * produces one, and an engine that is merely slow reports
+ * `engineReady: false` with the session's own output as the reason rather
+ * than a claim nobody checked.
+ */
+const ENGINE_START_PROBE_MS = 3_000
+const ENGINE_START_POLL_MS = 150
+const ENGINE_NOT_OBSERVED_REASON = `no engine process appeared in the session within ${ENGINE_START_PROBE_MS}ms`
 
 /**
  * Turn an observed write into the API's outcome fields. One place so every
@@ -262,16 +277,51 @@ export async function deliverHostedPrompt(
       return { session: launch.key, pane: launch.key, started, ...outcomeFields(outcome) }
     }
     // OUR launch carried the prompt in its argv, so no paste happened here.
-    // The engine receives the prompt from its own command line — a delivery
-    // this code never observed, and must not claim to have confirmed. It
-    // used to hardcode `delivered = true` (and copy that into engineReady),
-    // which is how a task that received nothing still reported a clean
-    // success on all three fields.
+    // The engine reads the prompt from its own command line — a delivery this
+    // code never observed, and the only thing that can confirm it is the
+    // engine PROCESS existing. `open.alive` is not that: keepAlive `exec`s a
+    // login shell where the engine exits, so a session whose launch command
+    // does not exist reports `alive` exactly like a healthy one, and
+    // `engineReady: true, delivered: true` came back for a binary that had
+    // already printed `no such file or directory`. Walk for the process —
+    // the same `sessionHasEngine` the existing-session gate above uses, in
+    // the loop `awaitEngineProcess` already owns.
+    // A repo-init script runs BEFORE the engine (`.rove/init.sh`, e.g. a
+    // `bun install`), and its marker file appears only when it finishes. So
+    // while that marker is absent "no engine yet" is not a failed launch, and
+    // neither answer the probe could give is right: waiting would hold `add`
+    // open for the length of the install, and reporting failure would reject a
+    // launch that is proceeding normally. Report it as unconfirmed instead.
+    if (launch.initMarkerPath && !existsSync(launch.initMarkerPath)) {
+      return {
+        session: launch.key,
+        pane: launch.key,
+        started,
+        engineReady: false,
+        delivered: true,
+        reason: "repo init script is still running; the engine has not started yet",
+      }
+    }
+    const enginePid = await awaitEngineProcess(rpc, launch.key, target.engineBin, {
+      timeoutMs: ENGINE_START_PROBE_MS,
+      intervalMs: ENGINE_START_POLL_MS,
+      snapshot: opts?.snapshot,
+    })
+    if (enginePid === null) {
+      return {
+        session: launch.key,
+        pane: launch.key,
+        started,
+        engineReady: false,
+        delivered: false,
+        reason: (await hostedSessionFailureLine(rpc, launch.key)) ?? ENGINE_NOT_OBSERVED_REASON,
+      }
+    }
     return {
       session: launch.key,
       pane: launch.key,
       started,
-      engineReady: open.alive,
+      engineReady: true,
       delivered: true,
     }
   } finally {

--- a/packages/kobe/src/cli/api/pty-delivery.ts
+++ b/packages/kobe/src/cli/api/pty-delivery.ts
@@ -283,10 +283,10 @@ export async function deliverHostedPrompt(
     // login shell where the engine exits, so a session whose launch command
     // does not exist reports `alive` exactly like a healthy one, and
     // `engineReady: true, delivered: true` came back for a binary that had
-    // already printed `no such file or directory`. Walk for the process —
-    // the same `sessionHasEngine` the existing-session gate above uses, in
-    // the loop `awaitEngineProcess` already owns.
-    // A repo-init script runs BEFORE the engine (`.rove/init.sh`, e.g. a
+    // already printed `no such file or directory`.
+    //
+    // First, the one case where the walk cannot answer: a repo-init script
+    // runs BEFORE the engine (`.rove/init.sh`, e.g. a
     // `bun install`), and its marker file appears only when it finishes. So
     // while that marker is absent "no engine yet" is not a failed launch, and
     // neither answer the probe could give is right: waiting would hold `add`
@@ -302,6 +302,9 @@ export async function deliverHostedPrompt(
         reason: "repo init script is still running; the engine has not started yet",
       }
     }
+    // Otherwise walk for the process — the same `sessionHasEngine` the
+    // existing-session gate above uses, in the loop `awaitEngineProcess`
+    // already owns, not a third implementation of the same question.
     const enginePid = await awaitEngineProcess(rpc, launch.key, target.engineBin, {
       timeoutMs: ENGINE_START_PROBE_MS,
       intervalMs: ENGINE_START_POLL_MS,

--- a/packages/kobe/src/cli/api/runtime.ts
+++ b/packages/kobe/src/cli/api/runtime.ts
@@ -125,8 +125,20 @@ async function deliverHosted(
     // the prompt never reached it. `engineReady` does NOT stand in for that —
     // it is an independent readiness observation, and an engine that never
     // announced bracketed paste can still have been written to.
+    //
+    // The task and its worktree EXIST by now, so the refusal has to name them:
+    // an unattended fan-out that only reads the message would otherwise lose
+    // the id of a task it just created, and every failed launch in the batch
+    // would look identical. `reason` is the session's own last line.
     if (result.started && !result.delivered && !result.deferred) {
-      throw new ApiError(`failed to start hosted engine session for ${target.id}`, "SESSION_FAILED")
+      throw new ApiError(`failed to start hosted engine session for ${target.id}`, "SESSION_FAILED", {
+        taskId: target.id,
+        session: result.session,
+        engineReady: result.engineReady,
+        ...(result.reason ? { reason: result.reason } : {}),
+        hint: "the session was created but no engine ran in it — fix the task's launch command (`api update --command`), then retry with `api send --tab new`",
+        nextCommandArgs: ["api", "read-output", "--task-id", target.id, "--source", "terminal"],
+      })
     }
     // Make the session visible to the sidebar tree, which lists a worktree's
     // tabs from the task's persisted snapshot. Without this a CLI-started

--- a/packages/kobe/src/cli/api/tab-snapshot.ts
+++ b/packages/kobe/src/cli/api/tab-snapshot.ts
@@ -57,8 +57,13 @@ export interface TaskTabRow {
    *  null, by the no-noise rule); null while alive/unknown. Joined
    *  from the live host when present, else the durable exit records —
    *  `tail` (the exit-time output lines the durable record keeps) rides
-   *  along whenever the record describes the same death. */
-  readonly exit: (PtySessionExit & { tail?: readonly string[] }) | null
+   *  along whenever the record describes the same death.
+   *
+   *  `layer` names WHICH process this describes: `"pty"` is the tab's own
+   *  session child. Without it `code`/`signal` cannot be read — a `code`
+   *  recovered from the wrapper's `Engine exited (code N)` banner belongs
+   *  to the engine, while `signal` belongs to the session that outlived it. */
+  readonly exit: (PtySessionExit & { tail?: readonly string[]; layer?: "pty" | "engine" }) | null
   /** Present (true) only on rows derived from a LIVE pty session the
    *  persisted snapshot does not list — an otherwise invisible engine. The
    *  snapshot is a record of intent; the pty host holds the truth, and a
@@ -172,7 +177,9 @@ export function joinTaskTabs(
   /** `null` = the pty host could not be asked; every liveness field on every
    *  row then reports `null` rather than a verdict nobody checked. */
   sessions: readonly TaskSessionRow[] | null,
-  persistedExits: Readonly<Record<string, PtySessionExit & { tail?: readonly string[] }>> = {},
+  persistedExits: Readonly<
+    Record<string, PtySessionExit & { tail?: readonly string[]; layer?: "pty" | "engine" }>
+  > = {},
   liveVendors?: ReadonlyMap<string, string | null>,
   engineAlive?: ReadonlyMap<string, boolean>,
 ): TaskTabRow[] {
@@ -188,8 +195,19 @@ export function joinTaskTabs(
     const ex = abnormalExit(sessionExits.get(key) ?? persistedExits[key])
     if (!ex) return null
     const record = persistedExits[key]
-    const tail = record?.at === ex.at ? record.tail : undefined
-    return { code: ex.code, signal: ex.signal, at: ex.at, ...(tail && tail.length > 0 ? { tail } : {}) }
+    const sameDeath = record?.at === ex.at
+    const tail = sameDeath ? record?.tail : undefined
+    // The live host's in-memory exit wins on freshness but carries only a
+    // wait status, and a signalled session has no code in one. The durable
+    // record for the SAME death recovered the engine's from the wrapper's
+    // banner — take that rather than report `code: null` beside a tail that
+    // spells the number out.
+    const code = ex.code ?? (sameDeath ? (record?.code ?? null) : null)
+    // Keyed by the bare session key, so this row is structurally the PTY
+    // layer (engine-layer records live under `<key>#engine`); a legacy
+    // record predating the field is PTY-layer too.
+    const layer = record?.layer ?? "pty"
+    return { code, signal: ex.signal, at: ex.at, layer, ...(tail && tail.length > 0 ? { tail } : {}) }
   }
   const rows: TaskTabRow[] = (snapshot?.tabs ?? []).map((t) => {
     const key = `${taskId}::${t.id}`

--- a/packages/kobe/src/cli/api/types.ts
+++ b/packages/kobe/src/cli/api/types.ts
@@ -224,6 +224,18 @@ export interface DeliveredPrompt {
    */
   readonly promptEcho?: "confirmed" | "unconfirmed"
   /**
+   * Why nothing was confirmed — the session's own last line (its shell's
+   * `no such file or directory`, or the wrapper's `Engine exited (code N)`
+   * banner) when a fresh spawn produced no engine process. Present only
+   * alongside `engineReady: false` on a launch that reported `started`, so a
+   * fan-out sees WHICH launch failed instead of N uniform green results.
+   *
+   * `engineReady: false` with `delivered: true` is the one non-failure it
+   * describes: a repo-init script is still running, so the engine has not
+   * started yet and the prompt is still riding its unexecuted launch argv.
+   */
+  readonly reason?: string
+  /**
    * Present when the delivery gate found the composer busy and the prompt was
    * accepted-but-deferred rather than dropped: the daemon
    * stored the text and queued a `prompt_deferred` inbox episode. This is a

--- a/packages/kobe/src/cli/daemon-cmd.ts
+++ b/packages/kobe/src/cli/daemon-cmd.ts
@@ -17,6 +17,7 @@ import { defaultDaemonLogPath, defaultDaemonPidPath, defaultDaemonSocketPath } f
 import { readPidFile, startDaemonServer } from "@sma1lboy/kobe-daemon/daemon/server"
 import { daemonRuntime } from "../core/daemon-runtime.ts"
 import { createKobeCore } from "../core/index.ts"
+import { sweepIndexLeftovers } from "../orchestrator/index/sweep.ts"
 import { migrateRoveDaemonStateLayout } from "../state/layout-migration.ts"
 import { resolvePluginBinPath } from "./plugin-bin-path.ts"
 import { activeCliName } from "./rename-compat.ts"
@@ -130,6 +131,18 @@ export async function runDaemonSubcommand(argv: readonly string[]): Promise<void
   for (const warning of migration.warnings) console.error(`[rove] daemon state migration will retry: ${warning}`)
 
   const core = await createKobeCore()
+  // A killed writer leaves the index lockfile behind every time, and ~5% of
+  // the time a full staging copy of the manifest too (11.8 MB on a 30k-task
+  // index) under a name no later run reuses. Nothing else sweeps `.rove/`,
+  // so daemon boot is where a crashed predecessor's mess gets cleaned.
+  const swept = sweepIndexLeftovers(core.store.stateDir)
+  if (swept.lock || swept.tmp.length > 0) {
+    console.error(
+      `[rove] swept crash leftovers in ${core.store.stateDir}: ` +
+        `${swept.tmp.length} orphaned staging file(s) (${swept.tmpBytes} bytes)` +
+        `${swept.lock ? ", stale task-index lockfile" : ""}`,
+    )
+  }
   const server = await startDaemonServer(core.orchestrator, {
     runtime: daemonRuntime,
     socketPath,

--- a/packages/kobe/src/orchestrator/index/lockfile.ts
+++ b/packages/kobe/src/orchestrator/index/lockfile.ts
@@ -134,12 +134,27 @@ export async function acquire(lockPath: string, opts: LockfileOptions = {}): Pro
       `[rove] removing stale lockfile at ${lockPath} (was held by pid ${holderPid}` +
         `${alive ? ", forced" : ", process gone"})`,
     )
-    try {
-      await unlink(lockPath)
-    } catch (err) {
-      // Race: another acquirer also unlinked. ENOENT is fine here.
-      if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err
-    }
+    // Delete only the lock we JUDGED. An unconditional unlink here was the
+    // whole bug: between our read of `holder` and this line a rival can win
+    // the takeover and link its own lock in, and unlinking that admits a
+    // second holder into the critical section. `releaseSync` is that check —
+    // re-read, unlink only on a byte-identical match — so a lock that
+    // changed hands is left alone and the next loop rejects against it.
+    //
+    // SYNC on purpose inside an async function: the async `release` awaits
+    // between its read and its unlink, and that await is a scheduling point
+    // a rival's entire takeover fits inside, so the verify still passed for
+    // two acquirers at once (measured: N=50 concurrent acquires still
+    // produced 2-5 double owners per 20 rounds). Nothing in this process can
+    // interleave the sync pair.
+    //
+    // ponytail: cross-process this is two back-to-back syscalls, not an
+    // atomic compare-and-unlink — POSIX has no unlink-if-unchanged, and the
+    // constructions that emulate one (a second "steal" lockfile) deadlock
+    // takeover the moment their own holder is killed, which is the exact
+    // event this whole path exists to recover from. Pay for one only if a
+    // cross-process double takeover is ever OBSERVED.
+    releaseSync(lockPath, holder)
   }
 }
 
@@ -217,13 +232,11 @@ export function acquireSync(lockPath: string, timeoutMs = 5_000): string {
       continue
     }
     // Stale holder — same takeover as the async path, warned for the same
-    // reason (a silent takeover in a concurrent context is scary).
+    // reason (a silent takeover in a concurrent context is scary), and
+    // verified for the same reason: never unlink a lock that changed hands
+    // since we judged it.
     console.warn(`[rove] removing stale lockfile at ${lockPath} (was held by pid ${holderPid}, process gone)`)
-    try {
-      unlinkSync(lockPath)
-    } catch (err) {
-      if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err
-    }
+    releaseSync(lockPath, holder)
   }
 }
 

--- a/packages/kobe/src/orchestrator/index/sweep.ts
+++ b/packages/kobe/src/orchestrator/index/sweep.ts
@@ -1,0 +1,92 @@
+/**
+ * Startup hygiene for the task index directory.
+ *
+ * Two things a `kill -9` leaves behind, both invisible to every later run:
+ *
+ *   - **The lockfile.** 20 of 20 measured crash trials during a save left
+ *     `tasks.json.lock` on disk. Nothing clears it at boot; it is removed
+ *     only opportunistically, by whichever acquirer next trips over it —
+ *     so the first save of the day is the thing that discovers it, through
+ *     the takeover path in `lockfile.ts`.
+ *   - **The staging file.** `doSave` stages to `tasks.json.<pid>.<ulid>.tmp`
+ *     (unique per save on purpose, so a second writer cannot clobber the
+ *     first's), and its unlink lives in a `catch` that a SIGKILL never runs.
+ *     1 of 20 trials left one: a full 11.8 MB copy of a 30k-task manifest,
+ *     under a name no later run will ever reuse or notice. The leak is
+ *     unbounded because the names never repeat.
+ *
+ * Deliberately NOT in the save path: this is a directory scan, and `doSave`
+ * runs inside the cross-process critical section. It belongs at daemon boot,
+ * which is also the moment a crashed predecessor's mess is newest.
+ */
+
+import { existsSync, readFileSync, readdirSync, statSync, unlinkSync } from "node:fs"
+import { join } from "node:path"
+import { isProcessAlive, releaseSync } from "./lockfile.ts"
+
+/** Staging files younger than this may belong to a save running RIGHT NOW in
+ *  another process — a real save writes and renames in well under a second,
+ *  so anything this old is a corpse. */
+const TMP_MAX_AGE_MS = 5 * 60_000
+
+export interface IndexSweepResult {
+  /** Orphaned staging files removed (absolute paths). */
+  readonly tmp: readonly string[]
+  /** Bytes reclaimed from those staging files. */
+  readonly tmpBytes: number
+  /** Whether a stale `tasks.json.lock` was cleared. */
+  readonly lock: boolean
+}
+
+/**
+ * Remove a crashed writer's leftovers from `stateDir`. Best-effort by
+ * contract: every removal is independently guarded, and an unreadable
+ * directory reports nothing swept rather than throwing into daemon boot.
+ *
+ * The lockfile is removed only when its recorded pid is gone AND the file
+ * still holds exactly what we judged — the same verified takeover `acquire`
+ * performs, so a lock a live Rove took between our read and our unlink
+ * survives.
+ */
+export function sweepIndexLeftovers(stateDir: string, now = Date.now()): IndexSweepResult {
+  const tmp: string[] = []
+  let tmpBytes = 0
+  let entries: string[]
+  try {
+    entries = readdirSync(stateDir)
+  } catch {
+    return { tmp, tmpBytes, lock: false }
+  }
+
+  for (const name of entries) {
+    if (!name.startsWith("tasks.json.") || !name.endsWith(".tmp")) continue
+    const path = join(stateDir, name)
+    try {
+      const stat = statSync(path)
+      if (now - stat.mtimeMs < TMP_MAX_AGE_MS) continue
+      unlinkSync(path)
+      tmp.push(path)
+      tmpBytes += stat.size
+    } catch {
+      /* vanished, or not ours to remove — either way nothing to report */
+    }
+  }
+
+  return { tmp, tmpBytes, lock: clearStaleLock(join(stateDir, "tasks.json.lock")) }
+}
+
+/** True when a lockfile naming a dead process was cleared. */
+function clearStaleLock(lockPath: string): boolean {
+  let holder: string
+  try {
+    holder = readFileSync(lockPath, "utf8").trim()
+  } catch {
+    return false
+  }
+  const pid = Number.parseInt(holder, 10)
+  if (Number.isFinite(pid) && pid > 0 && isProcessAlive(pid)) return false
+  releaseSync(lockPath, holder)
+  // `releaseSync` is a no-op when the lock changed hands under us, so ask the
+  // filesystem rather than reporting the removal we merely attempted.
+  return !existsSync(lockPath)
+}

--- a/packages/kobe/test/cli/api-tab-snapshot.test.ts
+++ b/packages/kobe/test/cli/api-tab-snapshot.test.ts
@@ -399,6 +399,32 @@ describe("joinTaskTabs", () => {
     expect(rows[0]).toMatchObject({ alive: false, exit })
   })
 
+  it("takes the durable record's banner code when the live host's exit has none", () => {
+    // The host's in-memory exit is fresher but carries only a wait status, and
+    // a SIGKILLed session has no code in one. The record for the same death
+    // recovered the engine's from the wrapper banner.
+    const at = "2026-08-11T00:00:00.000Z"
+    const rows = joinTaskTabs(
+      oneTabSnap("tab-1"),
+      "t1",
+      [{ key: "t1::tab-1", alive: false, exit: { code: null, signal: "SIGKILL", at } }],
+      {
+        "t1::tab-1": { code: 143, signal: null, at, layer: "pty", tail: ["Engine exited (code 143)."] },
+      },
+    )
+    expect(rows[0]?.exit).toMatchObject({ code: 143, signal: "SIGKILL", layer: "pty" })
+  })
+
+  it("does not borrow a code from a record describing a DIFFERENT death", () => {
+    const rows = joinTaskTabs(
+      oneTabSnap("tab-1"),
+      "t1",
+      [{ key: "t1::tab-1", alive: false, exit: { code: null, signal: "SIGKILL", at: "2026-08-11T02:00:00.000Z" } }],
+      { "t1::tab-1": { code: 143, signal: null, at: "2026-08-11T00:00:00.000Z", layer: "pty" } },
+    )
+    expect(rows[0]?.exit).toMatchObject({ code: null, signal: "SIGKILL" })
+  })
+
   it("keeps clean exits quiet: code 0 reports exit null — the no-noise rule", () => {
     const exit = { code: 0, signal: null, at: "2026-08-11T00:00:00.000Z" }
     const rows = joinTaskTabs(oneTabSnap("tab-1"), "t1", [{ key: "t1::tab-1", alive: false, exit }])
@@ -419,7 +445,8 @@ describe("joinTaskTabs", () => {
       tail: ["Error: ENOSPC: no space left on device", "  at write (node:fs)"],
     }
     const rows = joinTaskTabs(oneTabSnap("tab-1"), "t1", [], { "t1::tab-1": record })
-    expect(rows[0]?.exit).toEqual(record)
+    // `layer` is added by the join: this key is structurally the PTY layer.
+    expect(rows[0]?.exit).toEqual({ ...record, layer: "pty" })
   })
 
   it("a stale record never captions a NEWER death — different `at`, no tail borrowed", () => {
@@ -431,7 +458,7 @@ describe("joinTaskTabs", () => {
     const rows = joinTaskTabs(oneTabSnap("tab-1"), "t1", [{ key: "t1::tab-1", alive: false, exit: fresh }], {
       "t1::tab-1": older,
     })
-    expect(rows[0]?.exit).toEqual(fresh)
+    expect(rows[0]?.exit).toEqual({ ...fresh, layer: "pty" })
     expect(rows[0]?.exit).not.toHaveProperty("tail")
   })
 

--- a/packages/kobe/test/cli/daemon-cmd.test.ts
+++ b/packages/kobe/test/cli/daemon-cmd.test.ts
@@ -165,7 +165,13 @@ describe("kobe daemon restart", () => {
 
 describe("kobe daemon start", () => {
   it("installs crash handlers, creates the core, and starts the server", async () => {
-    const core = { orchestrator: { tag: "orch" }, homeDir: home, close: vi.fn() }
+    // `store.stateDir` is where boot sweeps a crashed predecessor's leftovers.
+    const core = {
+      orchestrator: { tag: "orch" },
+      homeDir: home,
+      store: { stateDir: join(home, ".rove") },
+      close: vi.fn(),
+    }
     mocks.createKobeCore.mockResolvedValue(core)
     mocks.startDaemonServer.mockResolvedValue({ socketPath: "/tmp/x.sock", close: vi.fn() })
 

--- a/packages/kobe/test/cli/pty-delivery.test.ts
+++ b/packages/kobe/test/cli/pty-delivery.test.ts
@@ -93,21 +93,31 @@ describe("deliverToKey", () => {
 describe("deliverHostedPrompt", () => {
   it("starts the canonical engine session with the explicit prompt already in its launch argv", async () => {
     const calls: Array<{ name: string; payload: unknown }> = []
+    let opened = false
     const rpc = {
       request: async <T>(name: string, payload?: unknown): Promise<T> => {
         calls.push({ name, payload })
-        if (name === "pty.list") return { sessions: [] } as T
-        if (name === "pty.open") return { replay: "", alive: true, created: true } as T
+        // The post-open list is the readiness walk: nothing confirms an
+        // argv-carried prompt except the engine PROCESS being there.
+        if (name === "pty.list") return { sessions: opened ? [session("t1::tab-1", ["claude 'fix it'"])] : [] } as T
+        if (name === "pty.open") {
+          opened = true
+          return { replay: "", alive: true, created: true } as T
+        }
         return {} as T
       },
     }
 
-    const result = await deliverHostedPrompt(rpc, { id: "t1", engineBin: "claude" }, "/wt/t1", "fix it", {
-      key: "t1::tab-1",
-      command: ["/bin/zsh", "-ilc", "claude 'fix it'"],
-    })
+    const result = await deliverHostedPrompt(
+      rpc,
+      { id: "t1", engineBin: "claude" },
+      "/wt/t1",
+      "fix it",
+      { key: "t1::tab-1", command: ["/bin/zsh", "-ilc", "claude 'fix it'"] },
+      { snapshot: psWith("claude") },
+    )
 
-    expect(calls.map((call) => call.name)).toEqual(["pty.list", "pty.open", "pty.detach"])
+    expect(calls.map((call) => call.name)).toEqual(["pty.list", "pty.open", "pty.list", "pty.detach"])
     expect(calls[1].payload).toMatchObject({
       key: "t1::tab-1",
       cwd: "/wt/t1",
@@ -120,6 +130,40 @@ describe("deliverHostedPrompt", () => {
       engineReady: true,
       delivered: true,
     })
+  })
+
+  it("does not report engineReady/delivered from a session that holds no engine", async () => {
+    // `pty.open` reports `alive` for a launch command that does not exist —
+    // keepAlive drops into a login shell where the engine should be — so
+    // `engineReady: open.alive` reported a clean success for a spawn that
+    // ran nothing. The walk is the only thing that separates the two.
+    const rpc = {
+      request: async <T>(name: string): Promise<T> => {
+        // The spawn died; the readiness walk sees it and stops immediately.
+        if (name === "pty.list") return { sessions: [session("t1::tab-1", ["claude 'go'"], false)] } as T
+        if (name === "pty.open") return { replay: "", alive: true, created: true } as T
+        if (name === "pty.peek")
+          return {
+            exists: true,
+            alive: false,
+            data: Buffer.from("⚠ Engine exited (code 127). Check Settings → Engines.").toString("base64"),
+            offset: 0,
+          } as T
+        return {} as T
+      },
+    }
+    const result = await deliverHostedPrompt(
+      rpc,
+      { id: "t1", engineBin: "claude" },
+      "/wt/t1",
+      "go",
+      { key: "t1::tab-1", command: ["/nope/does-not-exist"] },
+      { snapshot: psWith("/bin/zsh") },
+    )
+    expect(result).toMatchObject({ started: true, engineReady: false, delivered: false })
+    // …and it says WHY, in the session's own words, so a fan-out of N bad
+    // launches is not N identical green rows.
+    expect(result.reason).toContain("Engine exited (code 127)")
   })
 
   it("delivers once when another caller wins the create race", async () => {
@@ -275,40 +319,60 @@ describe("deliverHostedPrompt", () => {
     // keeping the pre-restart scrollback) and must NOT writePrompt after
     // the respawn (the prompt already rode the launch argv).
     const calls: Array<{ name: string; payload?: unknown }> = []
+    let opened = false
     const rpc = {
       request: async <T>(name: string, payload?: unknown): Promise<T> => {
         calls.push({ name, payload })
         if (name === "pty.list")
           return {
-            sessions: [{ ...session("t1::tab-1", ["/bin/zsh", "-ilc", "claude 'x'"], false), restored: true }],
+            sessions: opened
+              ? [session("t1::tab-1", ["claude 'go'"])]
+              : [{ ...session("t1::tab-1", ["/bin/zsh", "-ilc", "claude 'x'"], false), restored: true }],
           } as T
-        if (name === "pty.open") return { replay: "b2xk", alive: true, created: false, respawned: true } as T
+        if (name === "pty.open") {
+          opened = true
+          return { replay: "b2xk", alive: true, created: false, respawned: true } as T
+        }
         return {} as T
       },
     }
-    const result = await deliverHostedPrompt(rpc, { id: "t1", engineBin: "claude" }, "/wt/t1", "go", {
-      key: "t1::tab-1",
-      command: ["/bin/zsh", "-ilc", "claude 'go'"],
-    })
+    const result = await deliverHostedPrompt(
+      rpc,
+      { id: "t1", engineBin: "claude" },
+      "/wt/t1",
+      "go",
+      { key: "t1::tab-1", command: ["/bin/zsh", "-ilc", "claude 'go'"] },
+      { snapshot: psWith("claude") },
+    )
     expect(result).toMatchObject({ session: "t1::tab-1", started: true, delivered: true })
-    expect(calls.map((c) => c.name)).toEqual(["pty.list", "pty.open", "pty.detach"])
+    expect(calls.map((c) => c.name)).toEqual(["pty.list", "pty.open", "pty.list", "pty.detach"])
   })
 
   it("still first-starts the canonical engine when only DEAD sessions remain, cwd'd at the worktree", async () => {
     const calls: Array<{ name: string; payload: unknown }> = []
+    let opened = false
     const rpc = {
       request: async <T>(name: string, payload?: unknown): Promise<T> => {
         calls.push({ name, payload })
         if (name === "pty.list")
-          return { sessions: [session("t1::tab-1", ["/bin/zsh", "-ilc", "claude 'x'"], false)] } as T
-        if (name === "pty.open") return { replay: "", alive: true, created: true } as T
+          return {
+            sessions: [session("t1::tab-1", opened ? ["claude 'go'"] : ["/bin/zsh", "-ilc", "claude 'x'"], opened)],
+          } as T
+        if (name === "pty.open") {
+          opened = true
+          return { replay: "", alive: true, created: true } as T
+        }
         return {} as T
       },
     }
-    const result = await deliverHostedPrompt(rpc, { id: "t1", engineBin: "claude" }, "/wt/t1", "go", {
-      key: "t1::tab-1",
-      command: ["/bin/zsh", "-ilc", "claude 'go'"],
-    })
+    const result = await deliverHostedPrompt(
+      rpc,
+      { id: "t1", engineBin: "claude" },
+      "/wt/t1",
+      "go",
+      { key: "t1::tab-1", command: ["/bin/zsh", "-ilc", "claude 'go'"] },
+      { snapshot: psWith("claude") },
+    )
     // started:true is the "a NEW session was created" marker.
     expect(result).toMatchObject({ session: "t1::tab-1", started: true, delivered: true })
     const open = calls.find((c) => c.name === "pty.open")

--- a/packages/kobe/test/daemon/pty-exit-store.test.ts
+++ b/packages/kobe/test/daemon/pty-exit-store.test.ts
@@ -61,6 +61,31 @@ describe("pty exit store", () => {
     expect(records["t1::tab-2"]).toMatchObject({ code: null, signal: null })
   })
 
+  it("recovers the engine's exit code from the wrapper banner when the OS gave none", () => {
+    // A SIGKILLed session has no wait-status code, but the wrapper printed
+    // the engine's own — the record used to report null beside a tail that
+    // spelled the number out.
+    recordPtyExit(
+      endInfo({
+        exit: { code: null, signal: "SIGKILL", at: "2026-08-11T00:00:00.000Z" },
+        tail: "zsh: terminated  fakeengine hello\r\n  \u26a0 Engine exited (code 143). Check Settings.\r\n",
+      }),
+      path,
+    )
+    expect(readPtyExitRecords(path)["t1::tab-1"]).toMatchObject({ code: 143, signal: "SIGKILL", layer: "pty" })
+  })
+
+  it("never overrides a real wait-status code with the banner's", () => {
+    recordPtyExit(
+      endInfo({
+        exit: { code: 2, signal: null, at: "2026-08-11T00:00:00.000Z" },
+        tail: "  \u26a0 Engine exited (code 143). Check Settings.\r\n",
+      }),
+      path,
+    )
+    expect(readPtyExitRecords(path)["t1::tab-1"]?.code).toBe(2)
+  })
+
   it("newest record per key wins, and the file caps at the 50 newest", () => {
     recordPtyExit(endInfo({ exit: { code: 1, signal: null, at: "2026-08-11T00:00:00.000Z" } }), path)
     recordPtyExit(endInfo({ exit: { code: 137, signal: null, at: "2026-08-11T01:00:00.000Z" } }), path)

--- a/packages/kobe/test/orchestrator/index-sweep.test.ts
+++ b/packages/kobe/test/orchestrator/index-sweep.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Startup hygiene for the task-index directory. What matters here is as much
+ * what the sweep REFUSES to remove: it runs at daemon boot while other Rove
+ * processes may be mid-save, so a fresh staging file or a live holder's lock
+ * must survive it. Removing either would corrupt a write in flight.
+ */
+
+import { existsSync, mkdtempSync, rmSync, utimesSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { sweepIndexLeftovers } from "../../src/orchestrator/index/sweep.ts"
+
+let dir: string
+const at = (name: string) => join(dir, name)
+
+/** Backdate a file so the sweep sees it as a corpse rather than a live save. */
+function age(path: string, minutes: number): void {
+  const when = new Date(Date.now() - minutes * 60_000)
+  utimesSync(path, when, when)
+}
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "kobe-index-sweep-"))
+})
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true })
+})
+
+describe("sweepIndexLeftovers", () => {
+  it("removes an aged staging file and a lock whose holder is gone", () => {
+    const orphan = at("tasks.json.9832.01ABC.tmp")
+    writeFileSync(orphan, "x".repeat(1024))
+    age(orphan, 30)
+    writeFileSync(at("tasks.json.lock"), "999999:crashed")
+
+    const result = sweepIndexLeftovers(dir)
+
+    expect(result.tmp).toEqual([orphan])
+    expect(result.tmpBytes).toBe(1024)
+    expect(result.lock).toBe(true)
+    expect(existsSync(orphan)).toBe(false)
+    expect(existsSync(at("tasks.json.lock"))).toBe(false)
+  })
+
+  it("leaves a live holder's lock alone — another Rove is mid-save", () => {
+    writeFileSync(at("tasks.json.lock"), `${process.pid}:abc123`)
+    expect(sweepIndexLeftovers(dir).lock).toBe(false)
+    expect(existsSync(at("tasks.json.lock"))).toBe(true)
+  })
+
+  it("leaves a FRESH staging file alone — that write may still be running", () => {
+    const live = at("tasks.json.4242.01XYZ.tmp")
+    writeFileSync(live, "in flight")
+    const result = sweepIndexLeftovers(dir)
+    expect(result.tmp).toEqual([])
+    expect(existsSync(live)).toBe(true)
+  })
+
+  it("never touches the manifest itself, its backups, or unrelated files", () => {
+    for (const name of ["tasks.json", "tasks.json.old", "state.json", "daemon.log"]) {
+      writeFileSync(at(name), "keep")
+      age(at(name), 30)
+    }
+    sweepIndexLeftovers(dir)
+    for (const name of ["tasks.json", "tasks.json.old", "state.json", "daemon.log"]) {
+      expect(existsSync(at(name))).toBe(true)
+    }
+  })
+
+  it("reports nothing swept for a directory that does not exist", () => {
+    expect(sweepIndexLeftovers(join(dir, "absent"))).toEqual({ tmp: [], tmpBytes: 0, lock: false })
+  })
+})


### PR DESCRIPTION
Four items previous workers found, reproduced, and deliberately left out of scope
(`.scratch/loop-r13-api/api.md` A3 + B4, `.scratch/loop-r12/concurrency.md` C2 + C6).
No screenshots: none of this is screen-visible.

Isolated home for every live run: `.scratch/loop-r14-ak/home`, all twelve
`ROVE_`/`KOBE_` path vars inlined as separate assignments.

---

## A3 — `add` / `send --tab new` reported `engineReady: true` for a binary that does not exist

**PASS** — `add --command /nope/x` reports `engineReady: false` with a reason naming
the failed launch; `add` with a real engine still reports `engineReady: true`.

A hosted session stays alive after its engine exits (keepAlive `exec`s a login shell),
so `pty.open`'s `alive` is satisfied by a shell that printed `command not found`. The
argv-delivery path returned `engineReady: open.alive, delivered: true` off that flag.

The argv path now walks for the engine PROCESS before claiming anything —
`awaitEngineProcess`, the loop around the single `sessionHasEngine` implementation
#868 established, not a third path — with a 3s budget and a 150ms poll. A launch that
produces no engine trips the module's existing `started && !delivered` refusal, now
carrying `taskId`, `session`, `engineReady` and the session's own last line as `reason`
(it previously threw a bare message, losing the id of a task it had just created).

**BEFORE** (unfixed build, isolated home):
```
$ rove api add --repo $REPO --title ak-a3-bogus --command /nope/does-not-exist-engine --prompt work
{"taskId":"01M1P75EMD…","started":true,"engineReady":true,"session":"01M1P75EMD…::tab-1","delivered":true}
$ rove api send --task-id $T --tab new --command /nope/also-bogus --prompt second
{"ok":true,"session":"01M1P75EMD…::tab-2","started":true,"engineReady":true,"delivered":true}
$ rove api read-output --task-id $T --source terminal
  "zsh:2: no such file or directory: /nope/does-not-exist-engine"
  "  ⚠ Engine exited (code 127). Check Settings → Engines and fix the launch command."
```

**AFTER**:
```
$ rove api add --repo $REPO --title ak-a3-after2 --command /nope/does-not-exist-engine --prompt work
{"error":{"message":"failed to start hosted engine session for 01M1P7JS42…","code":"SESSION_FAILED",
 "taskId":"01M1P7JS42…","session":"01M1P7JS42…::tab-1","engineReady":false,
 "reason":"⚠ Engine exited (code 127). Check Settings → Engines and fix the launch command.",
 "hint":"the session was created but no engine ran in it — fix the task's launch command …",
 "nextCommandArgs":["api","read-output","--task-id","01M1P7JS42…","--source","terminal"]}}   exit=1
$ rove api send --task-id $TG --tab new --command /nope/also-bogus --prompt second
… same typed refusal on ::tab-2, exit=1

# healthy launches unchanged:
$ rove api add … --command <script that stays up> --prompt work
{"started":true,"engineReady":true,"delivered":true}                              exit=0
$ rove api add … --prompt "reply with the single word ok"      # real claude engine
{"vendor":"claude","started":true,"engineReady":true,"delivered":true}            2.28s total
```

**The one case that is not a failure**: a repo with `.rove/init.sh` runs it BEFORE the
engine, so during the install neither answer the probe could give is right — waiting
holds `add` open for the length of a `bun install`, and reporting failure rejects a
launch that is proceeding normally. The launch's own init marker distinguishes them, so
that case short-circuits to `engineReady: false, delivered: true` plus a reason,
without a wait. Verified against this repo (which has one):
```
{"started":true,"engineReady":false,"delivered":true,
 "reason":"repo init script is still running; the engine has not started yet"}     1.41s total
```

Unit guard: `test/cli/pty-delivery.test.ts` — "does not report engineReady/delivered from
a session that holds no engine". Mutation-verified: restoring `engineReady: open.alive`
fails 3 of 15 tests in that file.

---

## B4 — `exit.code` was null while the tail in the same payload said `Engine exited (code 143)`

**PASS** — a SIGKILLed session whose engine printed the banner reports
`code: 143, signal: "SIGKILL", layer: "pty"`; a clean exit still records nothing.

The parser (`engineExitCodeFromTail`) already existed and was wired to the engine layer
only. `recordPtyExit` now falls back to it when the wait status carries no code, and
`joinTaskTabs`'s `exit` object gains `layer` plus the same fallback (the live host's
in-memory exit is fresher but carries only a wait status, so `get-task` still reported
null while the host was up — fixing the store alone was not enough).

Repro: fake engine task → `SIGTERM` the engine (wrapper prints the 143 banner, drops to
its fallback shell) → `SIGKILL` the session.

**BEFORE** `rove api get-task`:
```json
{"id":"tab-1","alive":false,"exit":{"code":null,"signal":"SIGKILL",
  "tail":["…","  ⚠ Engine exited (code 143). Check Settings → Engines…"]}}
```
**AFTER**:
```json
{"id":"tab-1","alive":false,"exit":{"code":143,"signal":"SIGKILL","layer":"pty",
  "tail":["…","  ⚠ Engine exited (code 143). Check Settings → Engines…"]}}
```

Tests: `pty-exit-store.test.ts` (banner recovery + "never overrides a real wait-status
code"), `api-tab-snapshot.test.ts` (record's code taken for the same death, NOT borrowed
across a different `at`). All four mutation-verified.

Note for the reviewer: `recordPtyExit` runs in the **pty-host** process, which survives
`daemon restart` — the first AFTER run measured stale until the host itself was replaced.

---

## C2 — every crashed writer leaves a stale lockfile, and the takeover could delete a live holder's

**PASS** — `lockrace2.ts` at N=50 × 20 rounds: `overlapEvents` and `doubleOwner` both 0;
`lostupdate.ts` with `L_STALE=1` at N=50: `totalLost` 0 across 45 rounds.

`acquire` read the holder, judged the pid dead, then unlinked **unconditionally** — never
re-checking the file still held what it judged. It now removes only a byte-identical
match, through the same ownership check `release` already performs.

**Synchronously**, and that detail is the fix: the async `release` awaits between its read
and its unlink, and that await is a scheduling point a rival's entire takeover fits inside.
Measured, on the way through — the async verify alone still produced 2–5 double owners per
20 rounds. `acquireSync` gets the same `releaseSync` call.

| `lockrace2.ts`, N=50 × 20 rounds | overlapEvents | doubleOwner |
|---|---|---|
| BEFORE (4 runs) | 0, 2, 5, 2 | 9, 8, 12, 7 |
| async verify (4 runs) | 0, 2, 0, 1 | 2, 5, 3, 4 |
| AFTER — sync verify (4 runs) | 0, 0, 0, 0 | **0, 0, 0, 0** |

| `lostupdate.ts`, N=50 × 15 rounds × 3 runs | created | absent from disk | rounds losing data |
|---|---|---|---|
| BEFORE, stale lock present | 2250 | **29** | 22 / 45 |
| BEFORE, no stale lock | 2250 | 0 | 0 / 45 |
| AFTER, stale lock present | 2250 | **0** | 0 / 45 |
| AFTER, no stale lock | 2250 | 0 | 0 / 45 |

**Honesty caveat, carried over from the brief and re-confirmed here.** The measured loss is
**within one process** (many concurrent `acquire()` on one event loop). Rove creates one
`TaskIndexStore` per process and one store serialises its own saves, so this exact shape is
not reachable through today's callers; it matters because the multi-writer paths
(`withDaemonOrLocal` runs a local store whenever no daemon is up) are what two shells racing
`rove add` after a crash would hit. C7's cross-process negatives were re-run on the fixed
code and still hold: 8 rounds × 24 barrier-synchronised processes on one stale lock →
**0 overlap observations** (presence files, no clock comparison); 12 rounds × 14 processes
each doing a real `store.create()` → 168 reported, **0 lost**.

**No unit test for the race, deliberately.** It is a Bun-scheduling accident and does not
occur under vitest's node worker at all: with the unconditional unlink restored, N=64 × 6
rounds produced 4 bad rounds under `bun`, and **0 under node** at identical parameters. A
vitest test there would pass for the wrong reason, so the proof is the repro script. The
mechanism it depends on — `release`/`releaseSync` unlinking only a lock still ours — keeps
its existing test.

**The atomic write was not touched.** 20 fresh `kill -9` trials mid-save on a 30k-task,
11.8 MB manifest: `tasks.json` parsed with all 30000 tasks every time, as C7 found.

---

## C6 — a crash leaks a full copy of the manifest, and nothing sweeps it

**PASS** — after `kill -9` mid-save followed by a daemon start, no `tasks.json.*.tmp` and no
stale `tasks.json.lock` remain, and the surviving `tasks.json` still parses with the
pre-crash task count.

New `orchestrator/index/sweep.ts`, called once at daemon boot — not in `doSave`, which runs
inside the cross-process critical section.

**BEFORE** — 20 `kill -9` trials mid-save, 30k tasks each:
```json
{"trials":20,"trialsWithOrphanTmp":1,"orphanTmpKB":11512,"trialsWithStaleLock":20,"trialsWithBadJson":0}
```
**AFTER** — a real `rove daemon start` booted against each of those 20 crashed homes:
```json
{"homes":20,"withStaleLockAfterBoot":0,"withOrphanTmpAfterBoot":0,"withWrongTaskCount":0}
[rove] swept crash leftovers in …/kill/t2/.rove: 1 orphaned staging file(s) (11786577 bytes), stale task-index lockfile
```

What it refuses to remove matters as much: a lock naming a **live** pid, and a staging file
younger than five minutes (another Rove may be mid-save). Both are asserted in
`test/orchestrator/index-sweep.test.ts` and mutation-verified — dropping the age gate fails
the fresh-tmp case, dropping the pid check fails the live-lock case.

---

## Gates

`bun run lint` · `bun run typecheck` · `test:fast` 4473 passed (453 files) ·
`test:socket` 807 passed (100 files) · `bun test test/render` 474 pass / 0 fail ·
`file-size-check.sh` clean (largest touched: `handlers-tasks.ts` at 498) ·
`coverage-gate.mjs` no-op (no touched render-track source).

## Found while proving B4, NOT taken (out of scope)

When the pty host is gone, `get-task`/`collect` report `alive: null` and therefore
`exit: null` — `joinTaskTabs` only attaches an exit for `alive === false`, and a host
that cannot be asked makes every row's liveness unknown. So the durable record is
invisible through those two verbs at exactly the moment it exists for ("how did it die,
long after the host idle-exited", per the store's own docstring). Reproduced on the same
task used above, after the host went away:

```
$ rove api pty-list      → {"sessions":null}
$ rove api get-task …    → [{"id":"tab-1","alive":null,"exit":null}]
$ rove api collect --task-ids …  → [{"id":"tab-1","exit":null}]
$ rove api inspect …     → the record is right there, code 143, layer "pty"
```

Not fixed here: it is a different defect (the tri-state guard, not the exit record) and
belongs with the B3 family. Flagging it because it limits what B4 bought — the code and
layer are correct whenever the exit is shown at all, and `inspect` always shows them.

## Left undone / for the dispatcher

- Probing A3 against a repo with an init script created a nested Rove worktree under
  `.scratch/loop-r14-ak/home/.rove/worktrees/…`, registered in this repo's worktree list.
  It is gitignored and does not affect CI (`packages/kobe/vitest.config.ts` roots its
  include at the package), but it is mine to clean and I did not, having no standing
  authorization to delete. Say the word and it goes.
- Repro scripts and the isolated home live in `.scratch/loop-r14-ak/` (gitignored);
  `conc/kill/` holds ~20 × 11.8 MB crashed manifests from the kill trials.
