### PR TITLE
fix: the diff pane stops contradicting the Changes list next to it

### DIFF
--- a/.changeset/diff-pane-stops-contradicting-the-list.md
+++ b/.changeset/diff-pane-stops-contradicting-the-list.md
@@ -1,0 +1,25 @@
+---
+"@sma1lboy/rove": patch
+---
+
+The Changes tab's diff no longer contradicts the list sitting next to it.
+
+An attempt that committed all its work in a repo with no remote showed
+`no changes — clean worktree` beside a sidebar row reading `↑1`: no base ref
+resolved, so Branch scope was unreachable and `b` was a silent no-op. The base
+now falls back to a local `main` or `master`, and when nothing resolves at all
+the scope line names that as the reason.
+
+A renamed file's diff shows the rename and the same `+1 −1` as its own row,
+rather than the whole file as sixty added lines — restricting the pathspec to
+the new path had unpaired the rename. A changed binary and a mode-only change
+each state what changed instead of rendering a blank pane, in the single-file
+view and in a combined diff's sections. A `git diff` that fails now shows git's
+own error with `r` to retry, instead of being reported as the file's current
+content or as `no changes in src/`.
+
+A diff taller than the pane no longer paints over the pane's own header and
+footer, so a 6000-line diff still names its file and says `q` closes it, and
+`0 notes · 0 unsent` no longer arrives as `06notesn· 06unsent`. A combined
+diff labels a non-ASCII path as `src/notes 中文.md` rather than printing both
+C-quoted sides as raw octal escapes.

--- a/docs/TUI.md
+++ b/docs/TUI.md
@@ -210,6 +210,12 @@ is clean and Rove can resolve a base branch, it automatically switches to the
 whole branch-versus-base view so committed agent work does not disappear. Press
 `b` to choose the scope manually; the header always names the active scope.
 
+The base is the task's PR base when it has one, then `origin/HEAD`,
+`origin/main`, or `origin/master`, then a local `main` or `master` — so a repo
+with no remote still gets a branch view instead of an empty pane beside a
+sidebar row reporting commits. When none of those resolve, the scope line names
+that as the reason rather than leaving `b` as a silent no-op.
+
 **Combined diffs.** `d` on a **directory** row opens everything under it as one
 diff in one tab, and the Changes tab's `[D] diff everything` chip does the same
 for the whole worktree — reviewing a twelve-file attempt is one keypress and one
@@ -217,6 +223,14 @@ tab instead of twelve of each. A combined diff is **read-only**: a review note
 anchors to a single path, so a diff spanning files carries none, and its footer
 says so. Per-file notes are unchanged. A directory with nothing changed in the
 active scope says so rather than opening blank.
+
+**What a diff states instead of drawing nothing.** A renamed file's diff shows
+the rename and the same `+N −M` as its list row, not the whole file as added. A
+changed binary and a mode-only change each state what changed — in the
+single-file view and in a combined diff's section — because a patch git wrote
+entirely in its preamble has no hunks to draw. If git itself refuses (a pruned
+remote, a renamed base branch), the pane shows git's own error and `r` retries;
+a failed read is never reported as an absence of changes.
 
 Open a text file with `enter`. Rove uses the configured terminal editor; for a
 changed file it requests that editor's diff mode when Vim or Neovim is

--- a/packages/kobe/src/tui-react/ops/preview-review.tsx
+++ b/packages/kobe/src/tui-react/ops/preview-review.tsx
@@ -185,8 +185,18 @@ export function useDiffReview(args: {
 
   /* --------- footer --------- */
   const unsent = unsentComments(comments).length
+  // Opaque background: the row is mostly spaces, and a diff drawn behind it
+  // showed through them — `0 notes · 0 unsent` arrived as `06notesn· 06unsent`
+  // with the diff's next line bleeding through every gap.
   const footer = enabled ? (
-    <box flexDirection="row" justifyContent="space-between" paddingLeft={1} paddingRight={1} flexShrink={0}>
+    <box
+      flexDirection="row"
+      justifyContent="space-between"
+      paddingLeft={1}
+      paddingRight={1}
+      flexShrink={0}
+      backgroundColor={theme.background}
+    >
       <text fg={unsent > 0 ? theme.warning : theme.textMuted} wrapMode="none">
         {t("ops.preview.review.count", { total: comments.length, unsent })}
       </text>

--- a/packages/kobe/src/tui-react/ops/preview.tsx
+++ b/packages/kobe/src/tui-react/ops/preview.tsx
@@ -17,9 +17,11 @@ import { formatBytes } from "../../lib/format-bytes"
 import { openWithSystemViewer } from "../../lib/open-external"
 import type { DiffReviewApi } from "../../tui/ops/diff-comments"
 import {
+  type PatchNote,
   type PreviewData,
   filetypeOf,
   isCombinedPathspec,
+  isImagePath,
   loadPreviewData,
   unifiedDiffFiles,
 } from "../../tui/ops/preview-core"
@@ -82,7 +84,11 @@ export function PreviewScreen(props: OpsPreviewArgs) {
 
   // System-open (`o`) only makes sense for a LOCAL worktree — the file the
   // OS viewer would open doesn't exist on this machine for a remote one.
-  const canSystemOpen = data?.kind === "binary" && !execHostForWorktreePath(props.worktree).isRemote
+  // A changed binary gets the same hand-off as an unchanged one: the diff is
+  // unreadable in a terminal either way, and the viewer is the way out.
+  const canSystemOpen =
+    (data?.kind === "binary" || (data?.kind === "patch-note" && data.note.kind === "binary")) &&
+    !execHostForWorktreePath(props.worktree).isRemote
 
   // Review overlay (line-anchored notes) — inert unless the host supplied
   // `review` AND the preview is a diff. Owns its own (PROPOSED) chords.
@@ -97,6 +103,14 @@ export function PreviewScreen(props: OpsPreviewArgs) {
     focused: props.focused ?? true,
     diffRef,
   })
+
+  // One vocabulary for a hunk-less patch, shared by the single-file card and
+  // a combined diff's sections — the two used to disagree by rendering
+  // nothing in different shapes.
+  const noteLabel = (note: PatchNote, path: string): string =>
+    note.kind === "mode"
+      ? t("ops.preview.modeChanged", { from: note.from, to: note.to })
+      : t(isImagePath(path) ? "ops.preview.imageChanged" : "ops.preview.binaryChanged")
 
   const onClose = props.onClose ?? (() => process.exit(0))
   useBindings(() => ({
@@ -124,7 +138,17 @@ export function PreviewScreen(props: OpsPreviewArgs) {
 
   return (
     <box flexDirection="column" flexGrow={1} backgroundColor={theme.background}>
-      <box flexDirection="row" gap={1} paddingLeft={1} paddingRight={1}>
+      {/* Opaque background + flexShrink={0}: a diff taller than the pane used
+         to paint straight over this row, so a 6000-line file opened with
+         nothing on screen naming it or saying `q` closes it. */}
+      <box
+        flexDirection="row"
+        gap={1}
+        paddingLeft={1}
+        paddingRight={1}
+        flexShrink={0}
+        backgroundColor={theme.background}
+      >
         <text fg={theme.accent}>{pathspecLabel}</text>
         <text fg={theme.textMuted}>
           {data?.kind === "diff"
@@ -133,14 +157,45 @@ export function PreviewScreen(props: OpsPreviewArgs) {
               : t("ops.preview.diffVsHead")
             : data?.kind === "binary"
               ? t(data.image ? "ops.preview.image" : "ops.preview.binary")
-              : t("ops.preview.file")}
+              : data?.kind === "patch-note"
+                ? noteLabel(data.note, props.relPath)
+                : data?.kind === "error"
+                  ? t("ops.preview.gitFailed")
+                  : t("ops.preview.file")}
         </text>
+        {data?.kind === "diff" && data.origPath != null ? (
+          <text fg={theme.textMuted}>{t("ops.preview.renamedFrom", { origPath: data.origPath })}</text>
+        ) : null}
         <text fg={theme.textMuted}>{t("ops.preview.closeHint")}</text>
         {combined ? <text fg={theme.textMuted}>{t("ops.preview.notesPerFile")}</text> : null}
       </box>
-      <box flexGrow={1}>
+      {/* Clipped: `<diff>` has no intrinsic height and draws every row it
+         has, so without this it overdraws the chrome on both sides of it. */}
+      <box flexGrow={1} overflow="hidden">
         {data == null ? (
           <text fg={theme.textMuted}>{t("ops.preview.loading")}</text>
+        ) : data.kind === "error" ? (
+          // git refused. The Files pane next door already renders its own git
+          // failures rather than swallowing them; this used to be the one
+          // surface that turned a refusal into "no changes".
+          <box flexDirection="column" paddingLeft={1} paddingTop={1} gap={1}>
+            <text fg={theme.error} wrapMode="word">
+              {data.message}
+            </text>
+            <text fg={theme.textMuted}>{t("ops.preview.retryHint")}</text>
+          </box>
+        ) : data.kind === "patch-note" ? (
+          // Same card shape as the image/binary placeholder — a real change
+          // git stated in the preamble, which `<diff>` draws no rows for.
+          <box flexDirection="column" paddingLeft={1} paddingTop={1} gap={1}>
+            <text fg={theme.text}>
+              {noteLabel(data.note, props.relPath)}
+              {/* Size belongs to a binary, whose bytes are the only thing
+                 that changed; on a mode flip it is noise. */}
+              {data.note.kind === "binary" && data.sizeBytes != null ? ` · ${formatBytes(data.sizeBytes)}` : ""}
+            </text>
+            {canSystemOpen ? <text fg={theme.textMuted}>{t("ops.preview.openHint")}</text> : null}
+          </box>
         ) : data.kind === "empty" ? (
           <box paddingLeft={1} paddingTop={1}>
             <text fg={theme.textMuted}>{t("ops.preview.noChanges", { pathspec: pathspecLabel })}</text>
@@ -173,16 +228,25 @@ export function PreviewScreen(props: OpsPreviewArgs) {
                 <text fg={theme.accent} attributes={TextAttributes.BOLD} wrapMode="none">
                   {file.path}
                 </text>
-                <box height={file.lines} flexShrink={0}>
-                  <diff
-                    diff={file.text}
-                    view="unified"
-                    wrapMode="none"
-                    filetype={filetypeOf(file.path)}
-                    syntaxStyle={style}
-                    showLineNumbers={true}
-                  />
-                </box>
+                {file.note ? (
+                  // `lines` counts hunk rows, so a patch with none got
+                  // height={0} — a bare filename over empty space. Three of
+                  // eight sections of a real commit rendered that way.
+                  <text fg={theme.textMuted} wrapMode="none">
+                    {`  ${noteLabel(file.note, file.path)}`}
+                  </text>
+                ) : (
+                  <box height={file.lines} flexShrink={0}>
+                    <diff
+                      diff={file.text}
+                      view="unified"
+                      wrapMode="none"
+                      filetype={filetypeOf(file.path)}
+                      syntaxStyle={style}
+                      showLineNumbers={true}
+                    />
+                  </box>
+                )}
               </box>
             ))}
           </scrollbox>

--- a/packages/kobe/src/tui-react/panes/filetree/header-view.tsx
+++ b/packages/kobe/src/tui-react/panes/filetree/header-view.tsx
@@ -142,11 +142,16 @@ export function FileTreeHeaderView(props: FileTreeHeaderProps) {
          when a base resolved, the `b` toggle affordance. */}
       {props.tab === "changes" ? (
         <box flexDirection="column" paddingBottom={1} flexShrink={0} gap={0}>
-          <text fg={theme.textMuted} wrapMode="none">
+          {/* Wraps: the no-base reason does not fit a narrow pane on one
+             line, and a truncated reason is no better than no reason. */}
+          <text fg={theme.textMuted} wrapMode="word">
             {props.scope === "branch" && props.base != null
               ? t("files.scope.branch", { base: props.base })
               : t("files.scope.working")}
-            {props.base != null ? `  ${t("files.scope.toggleHint")}` : ""}
+            {/* No base means Branch scope cannot be entered at all, so `b` is
+               a no-op. Saying why beats a bare scope line next to a sidebar
+               row reporting commits the pane cannot show. */}
+            {props.base != null ? `  ${t("files.scope.toggleHint")}` : `  ${t("files.scope.noBase")}`}
           </text>
           <text fg={theme.textMuted} wrapMode="none">
             {t("files.legend.changes")}

--- a/packages/kobe/src/tui/i18n/messages/files.ts
+++ b/packages/kobe/src/tui/i18n/messages/files.ts
@@ -23,6 +23,9 @@ export const en = {
     working: "scope: working tree",
     branch: "scope: vs {base}",
     toggleHint: "b to toggle",
+    /** Stated in place of the toggle hint when no base ref resolved: Branch
+     *  scope is unreachable, and a silent `b` reads as a broken key. */
+    noBase: "no base ref for branch scope (no origin/HEAD, main or master)",
   },
   empty: {
     noTask: "(no task — press n to create)",
@@ -69,6 +72,7 @@ export const zh: typeof en = {
     working: "范围：工作区改动",
     branch: "范围：对比 {base}",
     toggleHint: "按 b 切换",
+    noBase: "分支范围没有基准 ref（没有 origin/HEAD、main 或 master）",
   },
   empty: {
     noTask: "（暂无任务 — 按 n 创建）",

--- a/packages/kobe/src/tui/i18n/messages/ops.ts
+++ b/packages/kobe/src/tui/i18n/messages/ops.ts
@@ -20,6 +20,18 @@ export const en = {
     /** A directory / whole-worktree diff git produced no hunks for. A single
      *  file falls back to its content; a pathspec has none to fall back to. */
     noChanges: "no changes in {pathspec}",
+    /** A rename's header: the side the file came from, which its own diff
+     *  now shows paired instead of as a whole-file add. */
+    renamedFrom: "renamed from {origPath}",
+    /** A real patch git expressed entirely in its preamble. Blank is not an
+     *  answer here — it cannot be told apart from "nothing changed". */
+    binaryChanged: "binary file changed",
+    imageChanged: "image changed",
+    modeChanged: "mode changed · {from} → {to}",
+    /** git refused. Carries git's own stderr rather than presenting the
+     *  absent diff as an absence of changes. */
+    gitFailed: "could not read the diff",
+    retryHint: "r to retry",
     /** Footer on a combined diff: review notes anchor to ONE path, so a diff
      *  spanning files carries none. Stated so the absence reads as a rule. */
     notesPerFile: "notes are per-file — open a single file's diff to add them",
@@ -49,6 +61,12 @@ export const zh: typeof en = {
     openHint: "o 用系统查看器打开",
     allFiles: "全部文件",
     noChanges: "{pathspec} 没有改动",
+    renamedFrom: "重命名自 {origPath}",
+    binaryChanged: "二进制文件已改动",
+    imageChanged: "图片已改动",
+    modeChanged: "权限位已改动 · {from} → {to}",
+    gitFailed: "读取 diff 失败",
+    retryHint: "按 r 重试",
     notesPerFile: "备注按单文件锚定——要加备注请打开单个文件的 diff",
     review: {
       noteDialogTitle: "评审备注 — {location}",

--- a/packages/kobe/src/tui/ops/preview-core.ts
+++ b/packages/kobe/src/tui/ops/preview-core.ts
@@ -5,6 +5,7 @@
  * SyntaxStyle builder lives in `./preview-syntax`), no framework.
  */
 
+import { unquoteGitPath } from "@/lib/git-parsers"
 import { readWorktreeFile, runWorktreeGit, worktreeFileSize } from "@/worktree/content"
 
 /** Map a file extension to an opentui tree-sitter grammar name. */
@@ -29,11 +30,30 @@ export function filetypeOf(relPath: string): string | undefined {
   }
 }
 
+/**
+ * What a patch that git expressed entirely in its PREAMBLE changed: a binary
+ * whose bytes differ, or a file whose mode flipped. Both are real, non-empty
+ * patches with no hunks — and `<diff>` draws hunk rows and nothing else, so
+ * without this they render as a blank pane, which is indistinguishable from
+ * "nothing changed": the one thing the patch proves false.
+ */
+export type PatchNote =
+  | { readonly kind: "binary" }
+  | { readonly kind: "mode"; readonly from: string; readonly to: string }
+
 export type PreviewData =
-  /** `diff` renders opentui `<diff>` (unified vs HEAD); `code` a plain `<code>` view. */
-  | { readonly kind: "diff" | "code"; readonly text: string }
+  /** Unified diff → opentui `<diff>`. `origPath` is set when the patch is a
+   *  rename, so the header can name the side the file came from. */
+  | { readonly kind: "diff"; readonly text: string; readonly origPath?: string }
+  /** The file's own content → a plain `<code>` view. */
+  | { readonly kind: "code"; readonly text: string }
   /** Image/binary placeholder card — the TUI can't render these as text. */
   | { readonly kind: "binary"; readonly image: boolean; readonly sizeBytes: number | null }
+  /** A non-empty patch with no hunks — see {@link PatchNote}. */
+  | { readonly kind: "patch-note"; readonly note: PatchNote; readonly sizeBytes: number | null }
+  /** git itself refused. Carries git's stderr so the pane can name the
+   *  failure instead of presenting an absent diff as an absence of changes. */
+  | { readonly kind: "error"; readonly message: string }
   /**
    * A COMBINED diff (a directory, or the whole worktree) that git produced no
    * hunks for. A single file falls back to its own content here, which is the
@@ -55,7 +75,7 @@ export function isCombinedPathspec(relPath: string): boolean {
 
 /** One file's slice of a multi-file unified diff. */
 export interface UnifiedDiffFile {
-  /** The new-side path from the `diff --git` header, for the section label. */
+  /** The new-side path from the patch, decoded, for the section label. */
   readonly path: string
   /** That file's complete patch, parseable on its own. */
   readonly text: string
@@ -63,6 +83,63 @@ export interface UnifiedDiffFile {
    *  the count of context/added/removed lines. The view needs it because a
    *  `<diff>` inside a scroll container has no intrinsic height. */
   readonly lines: number
+  /** Set when the patch has no hunks: what it changed, so the section states
+   *  it instead of rendering a label over zero rows. */
+  readonly note?: PatchNote
+}
+
+/**
+ * Classify a patch git expressed entirely in its preamble. Returns `null`
+ * when the patch has hunks and should render as an ordinary diff.
+ */
+export function hunklessPatchNote(patch: string): PatchNote | null {
+  if (/^@@/m.test(patch)) return null
+  let binary = false
+  let from: string | undefined
+  let to: string | undefined
+  for (const line of patch.split("\n")) {
+    if (line.startsWith("old mode ")) from = line.slice("old mode ".length).trim()
+    else if (line.startsWith("new mode ")) to = line.slice("new mode ".length).trim()
+    else if (line.startsWith("Binary files ") || line.startsWith("GIT binary patch")) binary = true
+  }
+  if (binary) return { kind: "binary" }
+  if (from != null && to != null) return { kind: "mode", from, to }
+  return null
+}
+
+/** Decode one `--- ` / `+++ ` side into its path. `null` for `/dev/null`. */
+function sidePath(field: string): string | null {
+  // git appends a TAB after the path when it needed quoting or holds a space.
+  // The tab always follows the closing quote, so cutting at it is safe.
+  const raw = field.replace(/\t[\s\S]*$/, "")
+  if (raw === "/dev/null") return null
+  const path = unquoteGitPath(raw)
+  return path.startsWith("a/") || path.startsWith("b/") ? path.slice(2) : path
+}
+
+/**
+ * The b-side path of a `diff --git a/X b/Y` header.
+ *
+ * git C-quotes a path holding any non-ASCII byte, so a Chinese filename's
+ * header reads `diff --git "a/…" "b/…"` — there is no ` b/` in it to split
+ * on, which is what left the label showing raw octal escapes and both sides
+ * at once. Spaces, by contrast, are NOT quoted, so an unquoted header is
+ * genuinely ambiguous by scanning; the split whose two sides name the same
+ * file resolves it for everything except a rename.
+ */
+function headerPath(header: string): string {
+  // A quoted a-side: `unquoteGitPath` decodes exactly the first field and
+  // stops at its closing quote. The two sides agree except on a rename, and
+  // a header is only consulted for patches that have no `+++` line at all —
+  // binary and mode-only, neither of which can be a rename.
+  if (header.startsWith('"')) return sidePath(unquoteGitPath(header)) ?? header
+  for (let i = header.indexOf(" b/"); i >= 0; i = header.indexOf(" b/", i + 1)) {
+    const a = sidePath(header.slice(0, i))
+    const b = sidePath(header.slice(i + 1))
+    if (a != null && a === b) return b
+  }
+  const last = header.lastIndexOf(" b/")
+  return (last >= 0 ? sidePath(header.slice(last + 1)) : null) ?? header
 }
 
 /**
@@ -76,24 +153,30 @@ export interface UnifiedDiffFile {
  */
 export function unifiedDiffFiles(text: string): UnifiedDiffFile[] {
   const files: UnifiedDiffFile[] = []
-  let current: { path: string; lines: string[]; rows: number } | null = null
+  let current: { path: string; lines: string[]; rows: number; plus?: string; minus?: string } | null = null
   const push = () => {
-    if (current) files.push({ path: current.path, text: `${current.lines.join("\n")}\n`, lines: current.rows })
+    if (!current) return
+    const patch = `${current.lines.join("\n")}\n`
+    // Prefer the `+++`/`---` lines: one field to end-of-line, so they carry a
+    // path with a space unambiguously where the `diff --git` header cannot.
+    // A deletion's `+++` is `/dev/null`, so its own `---` side is the label.
+    const path = current.plus ?? current.minus ?? current.path
+    const note = hunklessPatchNote(patch)
+    files.push({ path, text: patch, lines: current.rows, ...(note ? { note } : {}) })
   }
   for (const line of text.split("\n")) {
     if (line.startsWith("diff --git ")) {
       push()
-      // `diff --git a/x b/x` — take the b-side, which is the path after a
-      // rename and identical otherwise.
-      const b = line.slice("diff --git ".length).split(" b/").slice(1).join(" b/")
-      current = { path: b || line.slice("diff --git ".length), lines: [line], rows: 0 }
+      current = { path: headerPath(line.slice("diff --git ".length)), lines: [line], rows: 0 }
       continue
     }
     if (!current) continue
     current.lines.push(line)
+    if (line.startsWith("+++ ")) current.plus = sidePath(line.slice(4)) ?? undefined
+    else if (line.startsWith("--- ")) current.minus = sidePath(line.slice(4)) ?? undefined
     // Hunk bodies only: `@@` headers and the `---`/`+++`/`index` preamble are
     // not rendered as rows.
-    if (/^[ +-]/.test(line) && !line.startsWith("+++ ") && !line.startsWith("--- ")) current.rows += 1
+    else if (/^[ +-]/.test(line)) current.rows += 1
   }
   push()
   return files
@@ -109,6 +192,43 @@ export function isImagePath(relPath: string): boolean {
 /** Null byte in the head of a utf8-decoded read = not renderable text. */
 export function looksBinaryText(text: string): boolean {
   return text.slice(0, 8192).includes("\u0000")
+}
+
+/**
+ * Re-run a single file's diff with BOTH sides of a rename in the pathspec.
+ *
+ * Restricting `git diff` to the new path alone removes the old path from the
+ * comparison, so git cannot pair the two and reports the whole file as added
+ * — 60 solid green lines where the row beside it correctly says `+1 −1`, and
+ * where the combined diff of the same commit shows the one-line change. The
+ * pairing survives only in an UNRESTRICTED `--name-status`, which is where
+ * the old path comes from.
+ *
+ * Returns `null` when this is not an unpaired rename — every ordinary add
+ * pays one metadata-only git call and takes this exit.
+ */
+async function pairRename(
+  worktree: string,
+  spec: string,
+  relPath: string,
+): Promise<{ text: string; origPath: string } | null> {
+  // `-z` keeps the fields NUL-separated and the paths raw, so a non-ASCII or
+  // spaced path needs no unquoting here.
+  const listed = await runWorktreeGit(worktree, ["diff", spec, "--name-status", "--find-renames", "-z"])
+  if (listed.status !== 0) return null
+  const fields = listed.stdout.split("\u0000")
+  for (let i = 0; i < fields.length; i += 1) {
+    const code = fields[i]
+    if (code == null || !/^[RC]\d*$/.test(code)) continue
+    const orig = fields[i + 1]
+    const neu = fields[i + 2]
+    i += 2
+    if (orig == null || neu !== relPath) continue
+    const paired = await runWorktreeGit(worktree, ["diff", spec, "--", relPath, orig])
+    if (paired.status !== 0 || paired.stdout.trim().length === 0) return null
+    return { text: paired.stdout, origPath: orig }
+  }
+  return null
 }
 
 /**
@@ -128,6 +248,11 @@ export function looksBinaryText(text: string): boolean {
  * which `<diff>` already renders. Only the EMPTY case differs — reading "the
  * file" back does not mean anything for a directory, so it reports `empty`
  * instead of rendering a blank code view.
+ *
+ * A git that REFUSES the BASE is never one of those outcomes. A bad base — a
+ * pruned remote, a renamed base branch — used to collapse into an empty diff
+ * and then be presented as the file's current content or as `no changes in
+ * src/`, both of which state as fact something git never said.
  */
 export async function loadPreviewData(
   worktree: string,
@@ -139,8 +264,28 @@ export async function loadPreviewData(
   }
   const spec = range ? `${range.base}...HEAD` : "HEAD"
   const res = await runWorktreeGit(worktree, ["diff", spec, "--", relPath])
+  // A refused diff is only a FAILURE when a base was asked for. Without one,
+  // git declining means there is nothing to diff against — an unborn HEAD, or
+  // a file outside any repo — and the file's own content is the honest answer,
+  // which is what the standalone `rove ops --preview <file>` relies on.
+  if (res.status !== 0 && range) {
+    const stderr = (res.stderr ?? "").trim()
+    return { kind: "error", message: stderr || `git diff ${spec} exited with code ${res.status ?? -1}` }
+  }
   const diff = res.status === 0 ? res.stdout : ""
-  if (diff.trim().length > 0) return { kind: "diff", text: diff }
+  if (diff.trim().length > 0) {
+    if (!isCombinedPathspec(relPath)) {
+      // A rename unpaired by the restricted pathspec arrives as a whole-file
+      // add, so `new file mode` is the cheap gate on the recovery below.
+      if (/^new file mode /m.test(diff)) {
+        const paired = await pairRename(worktree, spec, relPath)
+        if (paired) return { kind: "diff", text: paired.text, origPath: paired.origPath }
+      }
+      const note = hunklessPatchNote(diff)
+      if (note) return { kind: "patch-note", note, sizeBytes: await worktreeFileSize(worktree, relPath) }
+    }
+    return { kind: "diff", text: diff }
+  }
   if (isCombinedPathspec(relPath)) return { kind: "empty" }
   const text = (await readWorktreeFile(worktree, relPath)) ?? ""
   if (looksBinaryText(text)) {

--- a/packages/kobe/src/tui/panes/filetree/git.ts
+++ b/packages/kobe/src/tui/panes/filetree/git.ts
@@ -244,8 +244,15 @@ export function attachUntrackedChildren(entries: StatusEntry[], others: readonly
  * ref off `task.prStatus`, the only place kobe persists a base). Otherwise
  * asks git for the repo's default branch — `origin/HEAD`, falling back to
  * `origin/main` / `origin/master` — mirroring `daemon-worktree-adapter`'s
- * `defaultRef`. Returns `null` when none resolves (no remote / detached),
- * and the caller stays in working scope.
+ * `defaultRef`, then to a LOCAL `main` / `master` for a repo that has no
+ * remote at all. Returns `null` only when nothing resolves (orphan branch, or
+ * a repo whose default branch is the one checked out here), and the caller
+ * stays in working scope and says so.
+ *
+ * The local fallback is what keeps a remoteless repo's Branch scope reachable.
+ * Without it an attempt that committed all its work showed `no changes —
+ * clean worktree` beside a sidebar row reading `↑1`: the diff existed, the
+ * base to compare it against did not, and `b` was a silent no-op.
  */
 export async function resolveBase(
   worktreePath: string,
@@ -267,7 +274,25 @@ export async function resolveBase(
       // rev-parse --verify exits non-zero when the ref is absent; try next.
     }
   }
+  const head = await revParse("HEAD", worktreePath, signal)
+  for (const guess of ["main", "master"]) {
+    const sha = await revParse(guess, worktreePath, signal)
+    // Skip a local default that IS this worktree's HEAD: `main...HEAD` is
+    // empty by construction there, and offering it would just move the empty
+    // pane behind a toggle instead of saying there is nothing to compare to.
+    if (sha != null && sha !== head) return guess
+  }
   return null
+}
+
+/** `git rev-parse --verify <ref>`, or `null` when the ref does not resolve. */
+async function revParse(ref: string, worktreePath: string, signal?: AbortSignal): Promise<string | null> {
+  try {
+    const out = (await runGit(["rev-parse", "--verify", "--quiet", ref], worktreePath, signal)).trim()
+    return out.length > 0 ? out : null
+  } catch {
+    return null
+  }
 }
 
 /**

--- a/packages/kobe/test/tui-react/ops-preview-core.test.ts
+++ b/packages/kobe/test/tui-react/ops-preview-core.test.ts
@@ -13,6 +13,7 @@ import { join } from "node:path"
 import { describe, expect, test } from "vitest"
 import {
   filetypeOf,
+  hunklessPatchNote,
   isCombinedPathspec,
   isImagePath,
   loadPreviewData,
@@ -175,4 +176,238 @@ describe("binary detection helpers", () => {
     expect(looksBinaryText("hello\u0000world")).toBe(true)
     expect(looksBinaryText("plain text\n")).toBe(false)
   })
+})
+
+/**
+ * A patch git expressed entirely in its preamble. `<diff>` draws hunk rows
+ * and nothing else, so these used to render as a blank pane — an answer that
+ * cannot be told apart from "nothing changed", which is the one thing the
+ * patch proves false.
+ */
+describe("hunklessPatchNote", () => {
+  test("a changed binary is classified, not collapsed into emptiness", () => {
+    const patch = [
+      "diff --git a/assets/bundle.zip b/assets/bundle.zip",
+      "index eda69c0..8dd93b0 100644",
+      "Binary files a/assets/bundle.zip and b/assets/bundle.zip differ",
+      "",
+    ].join("\n")
+    expect(hunklessPatchNote(patch)).toEqual({ kind: "binary" })
+  })
+
+  test("a mode-only change names both modes", () => {
+    const patch = ["diff --git a/src/run.sh b/src/run.sh", "old mode 100644", "new mode 100755", ""].join("\n")
+    expect(hunklessPatchNote(patch)).toEqual({ kind: "mode", from: "100644", to: "100755" })
+  })
+
+  test("a patch with hunks is not a note — it renders as a diff", () => {
+    expect(hunklessPatchNote(TWO_FILE_SAMPLE)).toBeNull()
+  })
+
+  // A file can change its mode AND its content in one commit. Reading the
+  // preamble alone would hide the hunks behind a `mode changed` card.
+  test("a mode change that also has hunks stays a diff", () => {
+    const patch = [
+      "diff --git a/src/run.sh b/src/run.sh",
+      "old mode 100644",
+      "new mode 100755",
+      "index 1234567..89abcde",
+      "--- a/src/run.sh",
+      "+++ b/src/run.sh",
+      "@@ -1,2 +1,2 @@",
+      " #!/bin/sh",
+      "-echo hi",
+      "+echo bye",
+      "",
+    ].join("\n")
+    expect(hunklessPatchNote(patch)).toBeNull()
+  })
+})
+
+const TWO_FILE_SAMPLE = [
+  "diff --git a/a.ts b/a.ts",
+  "--- a/a.ts",
+  "+++ b/a.ts",
+  "@@ -1 +1 @@",
+  "-old",
+  "+new",
+  "",
+].join("\n")
+
+describe("unifiedDiffFiles labels and hunk-less sections", () => {
+  // git C-quotes any non-ASCII path, so the header has no ` b/` to split on
+  // and the label used to show raw octal escapes and BOTH sides at once.
+  test("a C-quoted non-ASCII path is decoded to the b-side alone", () => {
+    const patch = [
+      'diff --git "a/src/notes \\344\\270\\255\\346\\226\\207.md" "b/src/notes \\344\\270\\255\\346\\226\\207.md"',
+      "index 9c59e24..ea18402 100644",
+      '--- "a/src/notes \\344\\270\\255\\346\\226\\207.md"\t',
+      '+++ "b/src/notes \\344\\270\\255\\346\\226\\207.md"\t',
+      "@@ -1 +1,2 @@",
+      " first",
+      "+second",
+      "",
+    ].join("\n")
+    expect(unifiedDiffFiles(patch).map((f) => f.path)).toEqual(["src/notes 中文.md"])
+  })
+
+  // git does NOT quote spaces, so the header alone is ambiguous; the `+++`
+  // line is one field to end-of-line and settles it.
+  test("a path containing a space keeps its space", () => {
+    const patch = [
+      "diff --git a/src/a b.txt b/src/a b.txt",
+      "index 587be6b..b77b4eb 100644",
+      "--- a/src/a b.txt\t",
+      "+++ b/src/a b.txt\t",
+      "@@ -1 +1,2 @@",
+      " x",
+      "+y",
+      "",
+    ].join("\n")
+    expect(unifiedDiffFiles(patch).map((f) => f.path)).toEqual(["src/a b.txt"])
+  })
+
+  test("a deletion is labelled by its own path, not /dev/null", () => {
+    const patch = [
+      "diff --git a/src/obsolete.txt b/src/obsolete.txt",
+      "deleted file mode 100644",
+      "--- a/src/obsolete.txt",
+      "+++ /dev/null",
+      "@@ -1 +0,0 @@",
+      "-delete me",
+      "",
+    ].join("\n")
+    expect(unifiedDiffFiles(patch).map((f) => f.path)).toEqual(["src/obsolete.txt"])
+  })
+
+  test("a rename's section is labelled by the NEW path", () => {
+    const patch = [
+      "diff --git a/src/legacy.txt b/src/renamed-core.txt",
+      "similarity index 94%",
+      "rename from src/legacy.txt",
+      "rename to src/renamed-core.txt",
+      "--- a/src/legacy.txt",
+      "+++ b/src/renamed-core.txt",
+      "@@ -1 +1 @@",
+      "-line 5",
+      "+line 5 RENAMED",
+      "",
+    ].join("\n")
+    expect(unifiedDiffFiles(patch).map((f) => f.path)).toEqual(["src/renamed-core.txt"])
+  })
+
+  // A section whose patch has no hunks got `height={0}` — a bare filename
+  // over empty space. It must carry what changed instead.
+  test("hunk-less sections carry a note so no section renders over zero rows", () => {
+    const patch = [
+      "diff --git a/assets/bundle.zip b/assets/bundle.zip",
+      "index eda69c0..8dd93b0 100644",
+      "Binary files a/assets/bundle.zip and b/assets/bundle.zip differ",
+      "diff --git a/src/run.sh b/src/run.sh",
+      "old mode 100644",
+      "new mode 100755",
+      "",
+    ].join("\n")
+    const files = unifiedDiffFiles(patch)
+    expect(files.map((f) => f.path)).toEqual(["assets/bundle.zip", "src/run.sh"])
+    expect(files.map((f) => f.lines)).toEqual([0, 0])
+    expect(files[0]?.note).toEqual({ kind: "binary" })
+    expect(files[1]?.note).toEqual({ kind: "mode", from: "100644", to: "100755" })
+  })
+})
+
+/** Real repos, because every one of these is a claim about what git emits. */
+describe("loadPreviewData — failures and hunk-less patches are never 'no changes'", () => {
+  function commit(repo: string, message: string): void {
+    execFileSync("git", ["add", "-A"], { cwd: repo })
+    execFileSync("git", ["-c", "user.email=t@t", "-c", "user.name=t", "commit", "-q", "-m", message], { cwd: repo })
+  }
+
+  // Restricting the pathspec to the new path alone unpairs the rename, so git
+  // reports every line as added: 60 green lines where the list row beside it
+  // says `+1 −1` and the combined diff shows one changed line.
+  test("a renamed file's diff shows the rename, not the whole file as added", async () => {
+    const repo = makeRepo()
+    const sixty = (edited: boolean): string =>
+      `${Array.from({ length: 60 }, (_, i) => (edited && i === 4 ? "line 5 EDITED" : `line ${i + 1}`)).join("\n")}\n`
+    writeFileSync(join(repo, "legacy.txt"), sixty(false))
+    commit(repo, "base")
+    execFileSync("git", ["mv", "legacy.txt", "renamed.txt"], { cwd: repo })
+    writeFileSync(join(repo, "renamed.txt"), sixty(true))
+    commit(repo, "rename")
+
+    const data = await loadPreviewData(repo, "renamed.txt", { base: "HEAD~1" })
+    if (data.kind !== "diff") throw new Error(`expected diff, got ${data.kind}`)
+    expect(data.text).toContain("rename from legacy.txt")
+    expect(data.text).toContain("rename to renamed.txt")
+    expect(data.origPath).toBe("legacy.txt")
+    // The patch's own counts now match the list row: one line each way.
+    const added = data.text.split("\n").filter((l) => l.startsWith("+") && !l.startsWith("+++")).length
+    const removed = data.text.split("\n").filter((l) => l.startsWith("-") && !l.startsWith("---")).length
+    expect([added, removed]).toEqual([1, 1])
+  })
+
+  test("an ordinary added file is still a plain add, not mislabelled a rename", async () => {
+    const repo = makeRepo()
+    writeFileSync(join(repo, "fresh.ts"), "export const fresh = 1\n")
+    commit(repo, "add")
+    const data = await loadPreviewData(repo, "fresh.ts", { base: "HEAD~1" })
+    if (data.kind !== "diff") throw new Error(`expected diff, got ${data.kind}`)
+    expect(data.text).toContain("new file mode")
+    expect(data.origPath).toBeUndefined()
+  })
+
+  test("a changed binary renders a stated card, never a blank pane", async () => {
+    const repo = makeRepo()
+    writeFileSync(join(repo, "bundle.zip"), Buffer.from([0x50, 0x4b, 0x03, 0x04, 0x00, 0x01]))
+    commit(repo, "base")
+    writeFileSync(join(repo, "bundle.zip"), Buffer.from([0x50, 0x4b, 0x03, 0x04, 0x00, 0x02, 0x03]))
+    commit(repo, "change")
+    const data = await loadPreviewData(repo, "bundle.zip", { base: "HEAD~1" })
+    if (data.kind !== "patch-note") throw new Error(`expected patch-note, got ${data.kind}`)
+    expect(data.note).toEqual({ kind: "binary" })
+    expect(data.sizeBytes).toBe(7)
+  })
+
+  test("a mode-only change names both modes instead of rendering nothing", async () => {
+    const repo = makeRepo()
+    writeFileSync(join(repo, "run.sh"), "#!/bin/sh\necho hi\n")
+    commit(repo, "base")
+    execFileSync("chmod", ["+x", join(repo, "run.sh")])
+    commit(repo, "chmod")
+    const data = await loadPreviewData(repo, "run.sh", { base: "HEAD~1" })
+    if (data.kind !== "patch-note") throw new Error(`expected patch-note, got ${data.kind}`)
+    expect(data.note).toEqual({ kind: "mode", from: "100644", to: "100755" })
+  })
+
+  // `status === 0 ? stdout : ""` collapsed "git refused" into "the diff was
+  // empty", and the fallbacks then presented that as a fact: a single file
+  // came back as its own CURRENT CONTENT, a directory as `no changes in src/`.
+  test("an unresolvable base is an error carrying git's own stderr — for a file", async () => {
+    const repo = makeRepo()
+    const data = await loadPreviewData(repo, "a.ts", { base: "origin/gone" })
+    if (data.kind !== "error") throw new Error(`expected error, got ${data.kind}`)
+    expect(data.message).toMatch(/origin\/gone/)
+    // The old behaviour: the file's own content rendered as a plain `file`.
+    expect(data.message).not.toContain("export const a = 1")
+  })
+
+  test("an unresolvable base is an error — for a directory, not 'no changes'", async () => {
+    const repo = makeRepo()
+    const data = await loadPreviewData(repo, ".", { base: "origin/gone" })
+    if (data.kind !== "error") throw new Error(`expected error, got ${data.kind}`)
+    expect(data.message).toMatch(/origin\/gone/)
+  })
+})
+
+// The counterpart to the two bad-base cases above: with NO base asked for,
+// git declining means there is nothing to diff against, and the file's own
+// content is the honest answer — the standalone `rove ops --preview <file>`
+// is pointed at directories that are not repos at all.
+test("a preview outside any git repo still shows the file, not a git error", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "kobe-preview-norepo-"))
+  writeFileSync(join(dir, "note.txt"), "FIRST CONTENT\n")
+  const data = await loadPreviewData(dir, "note.txt")
+  if (data.kind !== "code") throw new Error(`expected code, got ${data.kind}`)
+  expect(data.text).toContain("FIRST CONTENT")
 })

--- a/packages/kobe/test/tui/filetree-git.test.ts
+++ b/packages/kobe/test/tui/filetree-git.test.ts
@@ -328,4 +328,31 @@ describe("resolveBase", () => {
     runGit.mockImplementation(async () => fail("detached, no remote"))
     expect(await resolveBase("/repo")).toBeNull()
   })
+
+  // A repo with no remote used to resolve no base at all, which made Branch
+  // scope unreachable: an attempt that had committed everything showed
+  // `no changes — clean worktree` beside a sidebar row reading `↑1`.
+  test("falls back to a LOCAL default branch when the repo has no remote", async () => {
+    runGit.mockImplementation(async (_cwd, args) => {
+      if (args.includes("symbolic-ref")) return fail("no origin/HEAD")
+      if (args.includes("origin/main") || args.includes("origin/master")) return fail("no such ref")
+      if (args.includes("HEAD")) return ok("aaaaaaa\n")
+      if (args.includes("main")) return ok("bbbbbbb\n")
+      return fail("nope")
+    })
+    expect(await resolveBase("/repo")).toBe("main")
+  })
+
+  // `main...HEAD` is empty by construction when `main` IS this HEAD, so
+  // offering it would move the empty pane behind a toggle rather than say
+  // there is nothing to compare against.
+  test("skips a local default branch that is this worktree's own HEAD", async () => {
+    runGit.mockImplementation(async (_cwd, args) => {
+      if (args.includes("symbolic-ref")) return fail("no origin/HEAD")
+      if (args.includes("origin/main") || args.includes("origin/master")) return fail("no such ref")
+      if (args.includes("HEAD") || args.includes("main")) return ok("samesha\n")
+      return fail("nope")
+    })
+    expect(await resolveBase("/repo")).toBeNull()
+  })
 })


### PR DESCRIPTION
# The diff pane contradicts the list sitting next to it

Six items from `loop-r14-review` — GROUP 1 (all four) and GROUP 2. The Changes
list was already right; the diff behind it disagreed with it. Each item below
names its PASS criterion and the proof.

Fixture: three genuinely diverged sibling tasks on one repo, one carrying every
hard case (rename, delete, add, non-image binary, image, mode-only change,
symlink, non-ASCII filename, 6000-line file, 60-line file), driven through
`/harness` → xterm.js → PTY sidecar → real OpenTUI on a private port base 6811.
Where the claim is about characters, the assertion reads the terminal **text
buffer**, not pixels. Screenshots are under
`/Users/jacksonc/.rove/worktrees/kobe-0aff3858ab76/jay/.scratch/loop-r14-al/shots/`
(`.txt` beside each `.png` is that frame's buffer dump).

---

## 1.1 — an attempt that committed everything showed "no changes"

The repo had no remote, so `resolveBase` returned `null`: Branch scope was
unreachable, the auto-fallback could not fire, `b` was a silent no-op, and the
scope line printed nothing where the hint goes. `resolveBase` now falls back to
a local `main`/`master` (skipping one that IS this worktree's HEAD, where
`main...HEAD` is empty by construction), and when nothing resolves the scope
line names that as the reason.

**PASS** — with a remoteless repo and a `↑1` clean-worktree task, the Changes
tab either shows the branch diff or states in the scope line why it cannot;
`(no changes — clean worktree)` never appears for a task the sidebar reports as
ahead.

| | |
|---|---|
| BEFORE | `before-11-attempt-b-empty` — sidebar `attempt-b ↑1`, pane `(no changes — clean worktree)`, no toggle hint |
| AFTER | `after-11-attempt-b-empty` — sidebar `attempt-b ↑1`, pane `scope: vs main` + `A src/normalise.js +1 −0` / `M src/parser.js +1 −1` |
| AFTER (nothing resolves) | `after-11-nobase-stated` — `scope: working tree  no base ref for branch scope (no origin/HEAD, main or master)` |

Tests: `resolveBase` falls back to a local default; skips one equal to HEAD.

## 1.2 — a renamed file's diff showed the whole file as added

Restricting the pathspec to the new path removes the old path from the
comparison, so git cannot pair the rename and emits `new file mode` plus every
line. `loadPreviewData` now recovers the pairing from an unrestricted
`--name-status --find-renames -z` and re-runs with both paths. Gated on
`new file mode`, so an ordinary add pays one metadata-only git call.

**PASS** — `d` on an `R` row produces a patch containing `rename from` /
`rename to` with the same `+N −M` as its list row.

| | |
|---|---|
| BEFORE | `before-12-rename` — 60 solid green lines (` 1 + line 1` …) beside a row reading `R …renamed-core.txt +1 −1` |
| AFTER | `after-12-rename` — header `src/renamed-core.txt diff vs origin/main renamed from src/legacy.txt`, body `5 - line 5` / `5 + line 5 RENAMED-AND-EDITED` |

## 1.3 — a changed binary and a mode-only change rendered a blank pane

Both are real, non-empty patches; git wrote them entirely in the preamble
(`Binary files … differ`, `old mode` / `new mode`) and `<diff>` draws only hunk
rows. New `hunklessPatchNote` classifies them and the preview renders a card in
the shape the image card already had, system-viewer hand-off included.

**PASS** — no pathspec whose diff is non-empty renders an empty pane.

| | |
|---|---|
| BEFORE | `before-13-binary` / `before-13-mode` — header, then nothing |
| AFTER | `after-13-binary` → `binary file changed · 43 B` + `o open in system viewer`; `after-13-mode` → `mode changed · 100644 → 100755` |

## 1.4 — a failed `git diff` was reported as "no changes"

`status === 0 ? stdout : ""` collapsed "git refused" into "the diff was empty",
and the fallbacks then presented that as fact. A non-zero exit **with a base
asked for** now returns an error kind carrying git's stderr, rendered with `r`
to retry.

Scoped deliberately to the base case: with no base, git declining means there is
nothing to diff against (unborn HEAD, or a file outside any repo) and the file's
content is the honest answer — which the standalone `rove ops --preview <file>`
relies on. The render test `r re-reads the file the diff tab is showing` caught
the first, over-broad version of this fix; a unit test now pins the boundary.

**PASS** — with an unresolvable base the preview names the failure and offers
`r`; it never renders the file's content in place of a diff, and never says
`no changes in <pathspec>`.

| | |
|---|---|
| BEFORE | `before-14-badbase` — pane `no changes in all files` while the Files pane one column over reads `fatal: ambiguous argument 'origin/trunk...HEAD'` |
| AFTER | `after-14-badbase` — pane `could not read the diff` / `fatal: bad revision 'origin/trunk...HEAD'` / `r to retry` |

## 2.1 — a tall diff overdrew the pane's own header and footer

`<diff>` has no intrinsic height and drew every row it had, over the chrome on
both sides. The content box is now `overflow="hidden"` and the header/footer
carry an opaque background.

**PASS** — a 6000-line diff shows its header; a 60-line diff's footer reads
exactly `0 notes · 0 unsent`, asserted on bytes.

| | |
|---|---|
| BEFORE | `before-21-bigfile` — top line is `1 + export const k0 = 0`; nothing names the file or says `q` closes it |
| AFTER | `after-21-bigfile` — `src/zz-generated.ts diff vs origin/main · q to close` |

Footer, on the same 60-row diff with **only** the 2.1 paint change reverted, so
the A/B isolates it:

```
before  '06notesw·40 unsent'   30 36 6e 6f 74 65 73 77 c2 b7 34 30 20 75 6e 73 65 6e 74
after   '0 notes · 0 unsent'   30 20 6e 6f 74 65 73 20 c2 b7 20 30 20 75 6e 73 65 6e 74
```

(`before-21-footer` / `after-21-footer`.)

## 2.2 — a combined diff labelled a non-ASCII path with raw octal escapes

git C-quotes any non-ASCII path, so the header reads `diff --git "a/…" "b/…"`
and there is no ` b/` to split on. Labels now come from the `+++ b/<path>` line
(one field to end-of-line, trailing TAB trimmed, C-quoting decoded), falling
back to `---` for a deletion and to a quoting-aware header parse for a
hunk-less patch. Since git does **not** quote spaces, the header fallback picks
the split whose two sides name the same file.

**PASS** — a combined diff over `src/notes 中文.md` labels it `src/notes 中文.md`.

| | |
|---|---|
| BEFORE | `before-2223-combined` — `"a/src/notes \344\270\255\346\226\207.md" "b/src/notes \344\270\255\346\226\207.md"` |
| AFTER | `after-2223-combined` — `src/notes 中文.md`; no octal escapes anywhere in the frame |

Tests cover a C-quoted path, a path containing a space, a deletion, and a
rename (label = new path).

## 2.3 — in a combined diff, hunk-less files were a bare filename over empty space

`lines` counts hunk rows and the view used it as the section's explicit height,
so a patch with none got `height={0}`. `UnifiedDiffFile` now carries the same
`PatchNote` 1.3 introduced and the section renders one line of text — one
vocabulary, not a second one.

**PASS** — no section renders as a label over zero rows; every file git listed
is accounted for by visible text.

| | |
|---|---|
| BEFORE | `before-2223-combined` — `assets/bundle.zip`, `assets/icon.png`, `src/run.sh` each a label and nothing else |
| AFTER | `after-2223-combined` — `binary file changed`, `image changed`, `mode changed · 100644 → 100755`; all 10 files' labels present |

---

## Gates

```
repo-root bun run lint    clean (1440 files)
bun run typecheck         clean
bun run check-i18n        834 keys × 2 locales in sync
bun run test:fast         4491 passed
bun test test/render      474 passed, 0 fail
bun run test:socket       805 passed
```

Mutation-verified in two rounds at different sites (collapse the git-refusal
back into an empty diff; drop the rename pairing; drop the hunk-less
classification; restore the naive ` b/` split; drop the `note` from
`UnifiedDiffFile`; lose `origPath`; stop trimming git's trailing TAB; stop
skipping a local default equal to HEAD; drop the `@@` guard). Every mutation is
caught. The `@@`-guard mutation survived round 1, which exposed a real gap — a
file changing both mode and content would have had its hunks hidden behind a
`mode changed` card — and that case is now tested.

## Notes

- `docs/TUI.md` updated in the same PR: the base-resolution order and what a
  diff states instead of drawing nothing.
- No keybinding was added or moved.
- Not proven: the package-level `bun run lint` (as opposed to the repo-root one
  CI gates on) flags a pre-existing format issue in
  `packages/kobe/test/daemon/worktree-probe.test.ts`, a file outside this diff
  and untouched here.
- GROUP 3 belongs to another worker. No side-by-side comparison view was built
  — the review deliberately left that as a design question for the owner.
