### PR TITLE
fix: the delete gate stops reporting "nothing here" without looking

### DIFF
--- a/.changeset/dirty-gate-sees-gitignored-work.md
+++ b/.changeset/dirty-gate-sees-gitignored-work.md
@@ -1,0 +1,31 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Deleting a task no longer destroys gitignored work without asking.
+
+The delete gate and the salvage snapshot both read `git status --porcelain`,
+which is blind to `.gitignore`d files — so a worktree whose only work was a
+`HANDOFF.md` or a `.scratch/` directory read as clean, deleted with no force
+and no confirmation, and wrote no salvage ref. Both now also ask
+`git status --ignored`, under the same 64 MB per-entry budget the snapshot
+already used: the delete refuses for exactly what a `--force` retry then
+rescues, and names the paths, because `git status` will not. A `node_modules/`
+is over that budget and still deletes with no ceremony. This also covers a
+nested worktree parked under a gitignored path, which was destroyed the same
+silent way.
+
+A salvage snapshot that could not capture everything now says so. `git add`
+records a submodule or nested worktree as a commit pointer rather than its
+files, so uncommitted work inside one was in neither the snapshot nor the
+commit that pointer named — while the audit line still told you to
+`git restore` from it. Those paths are now listed as `NOT captured`.
+
+Deleting a task whose worktree directory was already gone now actually
+deregisters it. The stale `.git/worktrees/` record can only be pruned from the
+owning repo, and the prune was looking for that repo by walking up from
+`~/.rove/worktrees/<key>` — a directory inside no repository — so it never
+ran. The delete reported `removed` while `git worktree list` still showed the
+entry as `prunable`, `git branch -D` failed forever with "used by worktree at
+<gone path>", and the worktrees page kept offering the ghost for adoption. The
+task's own repo is passed down now.

--- a/docs/WORKTREES.md
+++ b/docs/WORKTREES.md
@@ -141,6 +141,15 @@ The first confirmation can never silently turn into a force deletion. The
 second confirmation is the boundary that authorizes data loss. The branch is
 still retained, but uncommitted and untracked files are not part of it.
 
+Step 2 checks more than `git status --porcelain` reports. A gitignored
+`HANDOFF.md` or `.scratch/` shows in no status output, so the check also asks
+`git status --ignored` and refuses on any ignored entry under the 64 MB
+per-entry budget below — the same budget the snapshot uses, so the delete
+refuses for exactly what the forced retry then rescues. The refusal names
+those paths, because `git status` will not. An ignored entry OVER the budget
+(a `node_modules/`, a build directory) is not treated as work: it neither
+blocks the delete nor lands in the snapshot.
+
 ### Landing with `--delete-branch`
 
 `land --delete-branch` deletes the branch with `git branch -D`, which removes
@@ -182,6 +191,13 @@ build directory is far larger and is skipped, because a snapshot carrying one
 is too big to be useful. An ignored entry whose size cannot be read is
 skipped. So a gitignored `HANDOFF.md` or `.scratch/` is recoverable, and a
 gitignored 200 MB `dist/` is not.
+
+One thing a snapshot cannot hold: a submodule or a nested worktree. `git add`
+records those as a commit pointer rather than their files, so uncommitted work
+inside one is in neither the snapshot nor the commit that pointer names. Rove
+does not pretend otherwise — the audit line lists those paths as `NOT
+captured`, and the `git restore` commands below will not produce anything
+under them.
 
 List the snapshots, newest last:
 

--- a/packages/kobe-daemon/src/daemon/task-deletion-audit.ts
+++ b/packages/kobe-daemon/src/daemon/task-deletion-audit.ts
@@ -111,10 +111,19 @@ export function auditDeletionFailed(taskId: string, task: DaemonTask | undefined
  * lost work, so the commands ship with it. `repo` scopes them with `-C` when
  * known (a task carries its repo; a bare worktree path does not).
  */
-function recoveryText(ref: string, commit: string, repo?: string): string {
+function recoveryText(ref: string, commit: string, repo?: string, uncaptured: readonly string[] = []): string {
   const at = repo ? ` -C ${repo}` : ""
+  // A submodule or nested worktree is in the tree as a `160000` gitlink — a
+  // commit SHA, never the files — so `git restore --source` cannot produce
+  // anything under it. Naming those paths is the difference between advice
+  // that works and advice that fails silently on the one path the user cares
+  // about most.
+  const gap =
+    uncaptured.length > 0
+      ? ` NOT captured (submodule / nested worktree — the snapshot holds only a commit pointer): ${uncaptured.join(", ")}.`
+      : ""
   return (
-    `uncommitted work saved to ${ref} (${commit}). Recover with: ` +
+    `uncommitted work saved to ${ref} (${commit}).${gap} Recover with: ` +
     `git${at} show ${ref}  |  git${at} restore --source=${ref} -- <path>  |  ` +
     `list all: git${at} for-each-ref refs/rove/salvage`
   )
@@ -129,8 +138,14 @@ function recoveryText(ref: string, commit: string, repo?: string): string {
  * is exactly how this log reads. Finding the snapshot from a bare git ref
  * listing would instead require already knowing that it exists.
  */
-export function auditDeletionSalvaged(taskId: string, ref: string, commit: string, repo?: string): void {
-  logDaemonInfo(SUBSYSTEM, `salvaged task ${taskId} — ${recoveryText(ref, commit, repo)}`)
+export function auditDeletionSalvaged(
+  taskId: string,
+  ref: string,
+  commit: string,
+  repo?: string,
+  uncaptured: readonly string[] = [],
+): void {
+  logDaemonInfo(SUBSYSTEM, `salvaged task ${taskId} — ${recoveryText(ref, commit, repo, uncaptured)}`)
 }
 
 /**
@@ -139,8 +154,13 @@ export function auditDeletionSalvaged(taskId: string, ref: string, commit: strin
  * lines: this is the same class of loss, and a user searching `daemon.log`
  * for their vanished work should not have to know which UI destroyed it.
  */
-export function auditWorktreeSalvaged(worktreePath: string, ref: string, commit: string): void {
-  logDaemonInfo(SUBSYSTEM, `salvaged worktree ${worktreePath} — ${recoveryText(ref, commit)}`)
+export function auditWorktreeSalvaged(
+  worktreePath: string,
+  ref: string,
+  commit: string,
+  uncaptured: readonly string[] = [],
+): void {
+  logDaemonInfo(SUBSYSTEM, `salvaged worktree ${worktreePath} — ${recoveryText(ref, commit, undefined, uncaptured)}`)
 }
 
 /**

--- a/packages/kobe/src/cli/api/handlers-tasks.ts
+++ b/packages/kobe/src/cli/api/handlers-tasks.ts
@@ -466,14 +466,14 @@ function deleteRecoveryError(err: unknown, taskId: string): unknown {
   if (coded?.code !== DIRTY_WORKTREE_CODE) return err
   return new ApiError(coded.rest, DIRTY_WORKTREE_CODE, {
     taskId,
-    hint: "the worktree still holds uncommitted or untracked files — send the worker back to commit them, or pass --force to delete the task AND discard that work",
+    hint: "the worktree still holds work this delete would destroy — the message names it, and a gitignored path never shows in `git status`. Send the worker back to commit it, or pass --force to delete the task AND discard that work",
     nextCommandArgs: [
       "api",
       "send",
       "--task-id",
       taskId,
       "--prompt",
-      "your worktree has uncommitted changes and this task is being cleaned up — commit them yourself with a proper message, then report back",
+      "your worktree still holds work that this cleanup would destroy (it may be gitignored, so `git status` will not show it — check `git status --ignored`). Commit it yourself with a proper message, then report back",
     ],
   })
 }

--- a/packages/kobe/src/core/daemon-worktree-adapter.ts
+++ b/packages/kobe/src/core/daemon-worktree-adapter.ts
@@ -137,7 +137,7 @@ export async function removeWorktreeAdapter(
   await manager.remove(path, {
     force,
     onSalvage: (record) => {
-      if (record) auditWorktreeSalvaged(path, record.ref, record.commit)
+      if (record) auditWorktreeSalvaged(path, record.ref, record.commit, record.uncaptured)
     },
     // git deregistered the worktree but could not delete the directory. Not a
     // failure — the removal is as complete as git can make it and retrying is

--- a/packages/kobe/src/core/index.ts
+++ b/packages/kobe/src/core/index.ts
@@ -38,7 +38,7 @@ export async function createKobeCore(options: KobeCoreOptions = {}): Promise<Kob
     // deletion audit trail, which is where TROUBLESHOOTING already sends a
     // user asking "what happened to my task".
     onSalvage: (taskId, salvage) =>
-      auditDeletionSalvaged(String(taskId), salvage.ref, salvage.commit, store.get(taskId)?.repo),
+      auditDeletionSalvaged(String(taskId), salvage.ref, salvage.commit, store.get(taskId)?.repo, salvage.uncaptured),
     // The task IS deleted in this case, so nothing else will ever mention the
     // directory git could not unlink. Same log, same reason as the salvage
     // line: it is where a user is already told to look.

--- a/packages/kobe/src/orchestrator/core.ts
+++ b/packages/kobe/src/orchestrator/core.ts
@@ -50,7 +50,10 @@ export interface OrchestratorDeps {
    *  destroying it. The daemon binds this to its deletion audit log; a TUI-
    *  local orchestrator leaves it unset and the snapshot is still findable
    *  via `git for-each-ref refs/rove/salvage`. */
-  readonly onSalvage?: (taskId: TaskId, salvage: { readonly ref: string; readonly commit: string }) => void
+  readonly onSalvage?: (
+    taskId: TaskId,
+    salvage: { readonly ref: string; readonly commit: string; readonly uncaptured: readonly string[] },
+  ) => void
   /** Called when a deletion's `git worktree remove` deregistered the worktree
    *  but could not delete its directory. The deletion still completes; this is
    *  the only record of the leftover, so the daemon binds it to the same audit

--- a/packages/kobe/src/orchestrator/errors.ts
+++ b/packages/kobe/src/orchestrator/errors.ts
@@ -47,10 +47,22 @@ export const DIRTY_WORKTREE_CODE = "DIRTY_WORKTREE"
  * changes and `force` was not requested. The UI catches it (via
  * {@link DIRTY_WORKTREE_CODE}) and re-prompts for explicit force-delete
  * confirmation rather than silently destroying the work.
+ *
+ * `ignored` names the gitignored paths that triggered the refusal, when that
+ * is what did. `git status` cannot see those, so a user told only "uncommitted
+ * or untracked changes" would go looking with a command that reports nothing
+ * — the paths are the only way that refusal is actionable.
  */
 export class DirtyWorktreeError extends Error {
-  constructor(public readonly taskId: string) {
-    super(`${DIRTY_WORKTREE_CODE}: task ${taskId} worktree has uncommitted or untracked changes`)
+  constructor(
+    public readonly taskId: string,
+    public readonly ignored: readonly string[] = [],
+  ) {
+    const what =
+      ignored.length > 0
+        ? `gitignored work git status cannot see: ${ignored.join(", ")}`
+        : "uncommitted or untracked changes"
+    super(`${DIRTY_WORKTREE_CODE}: task ${taskId} worktree has ${what}`)
     this.name = "DirtyWorktreeError"
   }
 }

--- a/packages/kobe/src/orchestrator/task-deletion.ts
+++ b/packages/kobe/src/orchestrator/task-deletion.ts
@@ -51,12 +51,20 @@ export class TaskDeletionCoordinator {
     // doesn't apply — only the index entry goes away.
     if (task.worktreePath && !force && task.kind !== "dir") {
       let dirty = false
+      // Work `status --porcelain` cannot see. `.gitignore`d files survive a
+      // land and a sync, so they are not "dirty" — but they do NOT survive a
+      // worktree removal, and `HANDOFF.md` / `.scratch/**` / `.env*` are
+      // gitignored in this very repo. Gating on the porcelain alone let a
+      // worktree whose only work was a session's notes delete with no force,
+      // no confirm, and no salvage ref.
+      let ignored: readonly string[] = []
       try {
         dirty = await this.worktrees.isDirty(task.worktreePath)
+        if (!dirty) ignored = await this.worktrees.ignoredWork(task.worktreePath)
       } catch {
         // A missing/unreadable path is resolved by remove(), as before.
       }
-      if (dirty) throw new DirtyWorktreeError(task.id)
+      if (dirty || ignored.length > 0) throw new DirtyWorktreeError(task.id, ignored)
     }
 
     await this.store.update(task.id, {
@@ -95,6 +103,12 @@ export class TaskDeletionCoordinator {
         await this.worktrees.remove(task.worktreePath, {
           force: task.deletion.force,
           deleteBranch: task.deletion.deleteBranch === true,
+          // The owning repo, for the case where the worktree DIRECTORY is
+          // already gone: its stale admin record can only be pruned from
+          // here, and with the directory missing nothing on disk still points
+          // back at the repo. A task has always known this; it just never
+          // passed it down, so the prune silently never ran.
+          repo: task.repo,
           // `force` was frozen at prepare() time and this runs on a later
           // tick — possibly in a later daemon process (`resume()` replays a
           // queued deletion after a restart), so the worktree may have gone

--- a/packages/kobe/src/orchestrator/worktree/branch-anchor.ts
+++ b/packages/kobe/src/orchestrator/worktree/branch-anchor.ts
@@ -66,7 +66,9 @@ export async function anchorBranchTip(
 
     const ref = salvageRef(branch, now)
     if ((await git(["update-ref", ref, tip])).exitCode !== 0) return null
-    return { ref, commit: tip }
+    // Always complete: an anchor points at a commit that already exists, so
+    // there is no staging step that could drop a path.
+    return { ref, commit: tip, uncaptured: [] }
   } catch {
     return null
   }

--- a/packages/kobe/src/orchestrator/worktree/manager-remove.ts
+++ b/packages/kobe/src/orchestrator/worktree/manager-remove.ts
@@ -53,6 +53,17 @@ export interface WorktreeResidue {
 export interface RemoveOpts {
   readonly force?: boolean
   readonly deleteBranch?: boolean
+  /**
+   * The repo that owns this worktree, when the caller knows it.
+   *
+   * Only load-bearing for a worktree whose DIRECTORY IS ALREADY GONE: the
+   * stale `.git/worktrees/<name>` admin record can only be pruned from the
+   * owning repo, and with the directory missing there is nothing left to
+   * discover it from — `~/.rove/worktrees/<key>` is inside no repository at
+   * all. A task carries `task.repo`; a bare worktree path does not, and that
+   * caller keeps the (best-effort) discovery fallback.
+   */
+  readonly repo?: string
   /** Notified with the snapshot a force-removal took (null = nothing to
    *  save, or the snapshot could not be written). */
   readonly onSalvage?: (record: SalvageRecord | null) => void
@@ -73,6 +84,8 @@ export interface RemoveDeps {
   currentBranch(worktreePath: string): Promise<string | null>
   /** Whether the worktree has uncommitted or untracked changes. */
   isDirty(worktreePath: string): Promise<boolean>
+  /** The gitignored paths a removal would destroy — work `isDirty` is blind to. */
+  ignoredWork(worktreePath: string): Promise<readonly string[]>
   /** Deps for the opt-in post-removal branch delete. */
   branchDeps(): BranchDeps
 }
@@ -174,15 +187,22 @@ export async function removeWorktree(deps: RemoveDeps, worktreePath: string, opt
   const force = opts?.force === true
 
   if (!(await exec.exists(worktreePath))) {
-    // Best-effort metadata prune — the directory may be gone but a stale
-    // entry can survive in `.git/worktrees/`. `git worktree remove` will
-    // refuse, so we use prune.
+    // The directory is gone but a stale entry survives in `.git/worktrees/`,
+    // and only a prune IN THE OWNING REPO clears it. `git worktree remove`
+    // refuses a missing path, so prune is the whole of the removal here — skip
+    // it and the delete reports `removed` while git still lists the worktree
+    // as `prunable`, `git branch -D` fails forever with "used by worktree at
+    // <gone path>", and `discover-adoptable` keeps offering the ghost.
     //
-    // Probed from the PARENT: git runs with `cwd` set to the path, and a
-    // spawn into a directory this branch just proved is missing returns
-    // exit -1 (`exec-host.ts`), so probing the path itself always answered
-    // null and this prune never ran.
-    const goneRepo = await deps.findRepoFor(exec, path.dirname(worktreePath))
+    // The caller's `repo` is preferred because discovery CANNOT find it: git
+    // runs with `cwd` set to the path, and a spawn into a directory this
+    // branch just proved is missing returns exit -1 (`exec-host.ts`), so the
+    // probe walks up from the PARENT instead — and `~/.rove/worktrees/<key>`
+    // is in no repository, so it answers null and the prune never runs. Where
+    // that parent does happen to sit inside some unrelated repo it answers the
+    // wrong one, which is worse. The fallback stays for callers holding only a
+    // path (the worktrees page), which is where it can still work.
+    const goneRepo = opts?.repo ?? (await deps.findRepoFor(exec, path.dirname(worktreePath)))
     if (goneRepo) await deps.runGit(exec, ["worktree", "prune"], { cwd: goneRepo, allowFail: true })
     return
   }
@@ -270,10 +290,20 @@ export async function removeWorktree(deps: RemoveDeps, worktreePath: string, opt
     const salvaged = await salvageWorktree({ runGit: (e, a, o) => deps.runGit(e, a, o) }, exec, worktreePath)
     opts?.onSalvage?.(salvaged)
   } else {
-    const dirty = await deps.isDirty(worktreePath)
-    if (dirty) {
+    if (await deps.isDirty(worktreePath)) {
       throw new Error(
         `remove(): refusing to remove dirty worktree at ${worktreePath} (pass { force: true } to override)`,
+      )
+    }
+    // `status --porcelain` is blind to `.gitignore`d entries, so a worktree
+    // whose only work is `HANDOFF.md` or `.scratch/` reads clean and the
+    // removal above would destroy it with no salvage snapshot (the force path
+    // is the only one that takes one). Same rule as the snapshot, so the
+    // refusal names exactly what a `--force` retry would rescue.
+    const ignored = await deps.ignoredWork(worktreePath).catch(() => [])
+    if (ignored.length > 0) {
+      throw new Error(
+        `remove(): refusing to remove worktree at ${worktreePath} — it holds gitignored work git status cannot see: ${ignored.join(", ")} (pass { force: true } to override)`,
       )
     }
   }

--- a/packages/kobe/src/orchestrator/worktree/manager.ts
+++ b/packages/kobe/src/orchestrator/worktree/manager.ts
@@ -49,6 +49,7 @@ import {
 } from "./manager-list.ts"
 import { type RemoveOpts, removeWorktree } from "./manager-remove.ts"
 import { canonicalize, remoteWorktreePathFor, requireAbsolute, worktreePathFor } from "./paths.ts"
+import { smallIgnoredPaths } from "./salvage-ignored.ts"
 import { type SalvageRecord, salvageWorktree } from "./salvage.ts"
 import { parseWorktreeListPorcelain } from "./worktree-list.ts"
 
@@ -211,6 +212,7 @@ export class GitWorktreeManager implements WorktreeManager {
         findRepoFor: (exec, p) => this.findRepoFor(exec, p),
         currentBranch: (p) => this.currentBranch(p),
         isDirty: (p) => this.isDirty(p),
+        ignoredWork: (p) => this.ignoredWork(p),
         branchDeps: () => this.branchDeps(),
       },
       worktreePath,
@@ -338,6 +340,27 @@ export class GitWorktreeManager implements WorktreeManager {
       readOnly: true,
     })
     return out.stdout.length > 0
+  }
+
+  /**
+   * The gitignored paths in `worktreePath` that a delete would destroy — the
+   * work {@link isDirty} cannot see.
+   *
+   * A SEPARATE question from `isDirty`, deliberately, because the two have
+   * different answers and different consequences. `.gitignore`d files survive
+   * a land and a sync; they do not survive a worktree removal, and
+   * `HANDOFF.md` / `.scratch/**` / `.env*` are gitignored in this very repo.
+   * Folding this into `isDirty` would make every worktree holding a `.env`
+   * read dirty to the sidebar and to `land`'s preflight, which is a different
+   * (and wrong) claim.
+   *
+   * Same rule as the salvage snapshot ({@link smallIgnoredPaths}), so the gate
+   * refuses for exactly what the `--force` retry would then rescue: a
+   * multi-gigabyte `node_modules/` is over the size ceiling, so it neither
+   * blocks the delete nor bloats the snapshot.
+   */
+  async ignoredWork(worktreePath: string): Promise<readonly string[]> {
+    return smallIgnoredPaths(this.execAt(worktreePath), worktreePath)
   }
 
   /**

--- a/packages/kobe/src/orchestrator/worktree/salvage-ignored.ts
+++ b/packages/kobe/src/orchestrator/worktree/salvage-ignored.ts
@@ -21,6 +21,7 @@
  */
 
 import type { ExecHost } from "../../exec/exec-host.ts"
+import { READ_ONLY_GIT_ENV } from "../../lib/git-env.ts"
 
 /**
  * Per-entry size ceiling, in kilobytes. 64 MB: comfortably above any plausible
@@ -61,7 +62,13 @@ export function parseDuKb(stdout: string): Map<string, number> {
  */
 export async function smallIgnoredPaths(exec: ExecHost, worktreePath: string): Promise<string[]> {
   try {
-    const status = await exec.run(["git", "status", "--porcelain", "-z", "--ignored"], { cwd: worktreePath })
+    // Lock-free, like every other status probe (`lib/git-env.ts`): this now
+    // runs on the ORDINARY delete path, not just the force one, so it must not
+    // compete with an engine's `git commit` for `.git/index.lock`.
+    const status = await exec.run(["git", "status", "--porcelain", "-z", "--ignored"], {
+      cwd: worktreePath,
+      env: READ_ONLY_GIT_ENV,
+    })
     if (status.exitCode !== 0) return []
     const paths = parseIgnoredPaths(status.stdout)
     if (paths.length === 0) return []

--- a/packages/kobe/src/orchestrator/worktree/salvage.ts
+++ b/packages/kobe/src/orchestrator/worktree/salvage.ts
@@ -44,6 +44,27 @@ export interface SalvageDeps {
 export interface SalvageRecord {
   readonly ref: string
   readonly commit: string
+  /**
+   * Paths the snapshot could NOT capture: submodules and nested worktrees.
+   * `git add` stages those as a `160000` gitlink — a commit SHA, never the
+   * files — so uncommitted work inside one is in neither the snapshot tree nor
+   * the commit that SHA names, while the ref itself reports success. Empty for
+   * an ordinary snapshot; non-empty is the caller's cue to say so, because the
+   * recovery commands do not work for these paths.
+   */
+  readonly uncaptured: readonly string[]
+}
+
+/** The `160000` (gitlink) entries of `tree` — submodules and nested worktrees,
+ *  recorded as a commit SHA rather than their contents. */
+async function gitlinkPaths(git: (args: readonly string[]) => Promise<GitRunResult>, tree: string): Promise<string[]> {
+  const out = await git(["ls-tree", "-r", tree])
+  if (out.exitCode !== 0) return []
+  return out.stdout
+    .split("\n")
+    .filter((line) => line.startsWith("160000 "))
+    .map((line) => line.slice(line.indexOf("\t") + 1))
+    .filter((p) => p.length > 0)
 }
 
 /** `refs/rove/salvage/<branch>-<utc-stamp>` — a ref name git accepts, keyed by
@@ -77,10 +98,19 @@ export async function salvageWorktree(
 ): Promise<SalvageRecord | null> {
   const git = (args: readonly string[]) => deps.runGit(exec, args, { cwd: worktreePath, allowFail: true })
   try {
-    // Nothing uncommitted (tracked or untracked) → nothing a force-remove
-    // could destroy that HEAD doesn't already hold.
+    // Nothing uncommitted (tracked, untracked, OR salvageable-ignored) →
+    // nothing a force-remove could destroy that HEAD doesn't already hold.
+    //
+    // `--porcelain` alone CANNOT answer that: it is blind to `.gitignore`d
+    // entries, and `HANDOFF.md` / `.scratch/**` — the two places AGENTS.md
+    // tells agents to keep cross-session reasoning — are gitignored in this
+    // very repo. Returning here on an empty porcelain made the `add -f` pass
+    // below (the whole point of `salvage-ignored.ts`) unreachable for exactly
+    // the worktrees it exists for.
     const status = await git(["status", "--porcelain"])
-    if (status.exitCode !== 0 || status.stdout.trim().length === 0) return null
+    if (status.exitCode !== 0) return null
+    const ignored = await smallIgnoredPaths(exec, worktreePath)
+    if (status.stdout.trim().length === 0 && ignored.length === 0) return null
 
     // A throwaway index INSIDE the worktree's own git dir, so staging never
     // touches the real index and the file dies with the worktree either way.
@@ -95,7 +125,6 @@ export async function salvageWorktree(
       // build output. `-f` is what overrides `.gitignore`; without it the
       // first pass silently dropped them. Best-effort — a failure here leaves
       // the tracked+untracked snapshot the first pass already staged.
-      const ignored = await smallIgnoredPaths(exec, worktreePath)
       if (ignored.length > 0) await withIndex(["add", "-f", "--", ...ignored])
       const tree = (await withIndex(["write-tree"])).stdout.trim()
       if (!tree) return null
@@ -112,7 +141,11 @@ export async function salvageWorktree(
 
       const ref = salvageRef(branch && branch !== "HEAD" ? branch : null, now)
       if ((await git(["update-ref", ref, commit])).exitCode !== 0) return null
-      return { ref, commit }
+      // Read back what the tree actually holds. A submodule or nested worktree
+      // staged as a `160000` gitlink is a promise the recovery commands cannot
+      // keep, so the record says which paths it missed rather than letting the
+      // ref imply it caught everything.
+      return { ref, commit, uncaptured: await gitlinkPaths(git, tree) }
     } finally {
       // The index file lives in `.git/worktrees/<name>/`, which the removal
       // prunes anyway; clearing it keeps a failed salvage from leaving debris

--- a/packages/kobe/src/tui/i18n/messages/worktrees.ts
+++ b/packages/kobe/src/tui/i18n/messages/worktrees.ts
@@ -44,7 +44,7 @@ export const en = {
         calls `salvageWorktree` before `git worktree remove --force`), and
         overstating the danger pushes people to cancel a safe operation. */
     forceBody:
-      '"{branch}" has uncommitted or untracked work. Force delete removes the worktree, but the work is snapshotted first to a salvage ref — list them with `git for-each-ref refs/rove/salvage`. Force delete anyway?',
+      '"{branch}" has uncommitted, untracked, or gitignored work. Force delete removes the worktree, but the work is snapshotted first to a salvage ref — list them with `git for-each-ref refs/rove/salvage`. Force delete anyway?',
     failed: "Failed to delete worktree: {error}",
     residue:
       "Git deregistered the worktree, but couldn't delete {path} ({reason}). Rove is done with it — retrying won't help; delete the directory by hand if you want the space.",
@@ -114,7 +114,7 @@ export const zh: typeof en = {
     confirmBody: '确定删除 "{branch}" 对应的 worktree？工作目录会被移除，分支本身会保留。',
     forceTitle: "强制删除 worktree？",
     forceBody:
-      '"{branch}" 存在未提交或未跟踪的改动。强制删除会移除 worktree，但这些改动会先被快照到一个 salvage ref——用 `git for-each-ref refs/rove/salvage` 可以列出它们。仍要强制删除吗？',
+      '"{branch}" 存在未提交、未跟踪或被 gitignore 的改动。强制删除会移除 worktree，但这些改动会先被快照到一个 salvage ref——用 `git for-each-ref refs/rove/salvage` 可以列出它们。仍要强制删除吗？',
     failed: "删除 worktree 失败：{error}",
     residue:
       "Git 已注销该 worktree，但没能删掉 {path}（{reason}）。Rove 这边已经处理完了——重试没有用；想要回磁盘空间请手动删除该目录。",

--- a/packages/kobe/test/cli/api-handlers-delete.test.ts
+++ b/packages/kobe/test/cli/api-handlers-delete.test.ts
@@ -181,7 +181,7 @@ describe("task delete handler", () => {
         "--task-id",
         "t1",
         "--prompt",
-        "your worktree has uncommitted changes and this task is being cleaned up — commit them yourself with a proper message, then report back",
+        "your worktree still holds work that this cleanup would destroy (it may be gitignored, so `git status` will not show it — check `git status --ignored`). Commit it yourself with a proper message, then report back",
       ])
       expect(err.data?.hint).toMatch(/--force/)
     }

--- a/packages/kobe/test/orchestrator/salvage-ignored.test.ts
+++ b/packages/kobe/test/orchestrator/salvage-ignored.test.ts
@@ -112,3 +112,61 @@ test("parseDuKb keeps paths that contain spaces intact", () => {
   expect(sizes.get("node_modules/")).toBe(1403144)
   expect(sizes.get("sp ace/")).toBe(8)
 })
+
+/**
+ * The case the size budget was written for, and the one the gate above it
+ * could not see: a worktree whose ONLY work is gitignored.
+ *
+ * `git status --porcelain` — the command both the delete gate and salvage's
+ * own early-return read — reports nothing here, so the removal took the clean
+ * path: no force, no confirm, and salvage returned before the `add -f` pass
+ * ever ran. The files were gone with no ref anywhere.
+ */
+test("an ignored-only worktree is refused without force, and force salvages the work", async () => {
+  const wt = path.join(tmpRoot, "ignored-only")
+  git(repo, "worktree", "add", "-q", wt, "-b", "ignored-only")
+
+  fs.writeFileSync(path.join(wt, "HANDOFF.md"), "a whole session of reasoning\n")
+  fs.mkdirSync(path.join(wt, ".scratch"), { recursive: true })
+  fs.writeFileSync(path.join(wt, ".scratch", "notes.md"), "design notes\n")
+
+  // The premise: to `git status` this worktree is spotlessly clean.
+  expect(git(wt, "status", "--porcelain")).toBe("")
+
+  const manager = new GitWorktreeManager()
+  await expect(manager.remove(wt)).rejects.toThrow(/gitignored work/)
+  // Refusing is only worth anything if the files are still there afterwards.
+  expect(fs.existsSync(path.join(wt, "HANDOFF.md"))).toBe(true)
+  expect(fs.existsSync(path.join(wt, ".scratch", "notes.md"))).toBe(true)
+
+  let salvaged: { ref: string } | null = null
+  await manager.remove(wt, {
+    force: true,
+    onSalvage: (record) => {
+      salvaged = record
+    },
+  })
+
+  expect(fs.existsSync(wt)).toBe(false)
+  const ref = (salvaged as unknown as { ref: string } | null)?.ref
+  expect(ref).toBeTruthy()
+  expect(git(repo, "show", `${ref}:HANDOFF.md`)).toBe("a whole session of reasoning\n")
+  expect(git(repo, "show", `${ref}:.scratch/notes.md`)).toBe("design notes\n")
+})
+
+/**
+ * The other side of the budget. The gate must refuse for exactly what the
+ * force retry would rescue — otherwise a worktree holding nothing but a
+ * dependency tree becomes undeletable without `--force`, which is ceremony
+ * around no work at all.
+ */
+test("an ignored tree over the size budget still deletes with no force", async () => {
+  const wt = path.join(tmpRoot, "bulk-only")
+  git(repo, "worktree", "add", "-q", wt, "-b", "bulk-only")
+  fs.mkdirSync(path.join(wt, "node_modules", "pkg"), { recursive: true })
+  fs.writeFileSync(path.join(wt, "node_modules", "pkg", "bundle.js"), Buffer.alloc(70 * 1024 * 1024))
+
+  expect(git(wt, "status", "--porcelain")).toBe("")
+  await new GitWorktreeManager().remove(wt)
+  expect(fs.existsSync(wt)).toBe(false)
+})

--- a/packages/kobe/test/orchestrator/worktree-remove-partial.test.ts
+++ b/packages/kobe/test/orchestrator/worktree-remove-partial.test.ts
@@ -295,3 +295,40 @@ describe("remove() when the worktree is nested inside its own repo", () => {
     expect(existsSync(wt)).toBe(true)
   })
 })
+
+/**
+ * `remove()` when the worktree DIRECTORY is already gone (a user deleted it,
+ * or a tool did).
+ *
+ * The removal here is nothing but a `git worktree prune` in the owning repo —
+ * and that prune never ran. The repo was re-discovered by walking up from
+ * `path.dirname(worktreePath)`, which for a real Rove worktree is
+ * `~/.rove/worktrees/<key>`: inside no repository at all. So `remove()`
+ * returned `removed` while git still listed the entry as `prunable`, `git
+ * branch -D` failed forever with "used by worktree at <gone path>", and
+ * `discover-adoptable` kept offering the ghost. The owning repo was known the
+ * whole time — a task carries `task.repo`; it was simply never passed down.
+ */
+describe("remove() when the directory is already gone", () => {
+  it("prunes the stale admin record using the repo the caller passed", async () => {
+    const wt = join(managedRoot, "vanished")
+    execSync(`git worktree add -q ${JSON.stringify(wt)} -b vanish`, { cwd: repo, env: gitEnv })
+    rmSync(wt, { recursive: true, force: true })
+
+    // The premise: nothing on disk can lead git back to the owning repo.
+    expect(
+      execSync("git rev-parse --git-common-dir 2>&1 || true", {
+        cwd: join(managedRoot),
+        env: gitEnv,
+        encoding: "utf8",
+        shell: "/bin/sh",
+      }),
+    ).toContain("not a git repository")
+
+    await manager.remove(wt, { repo })
+
+    expect(registered(wt)).toBe(false)
+    // The user-visible consequence: the branch is usable again.
+    execSync("git branch -D vanish", { cwd: repo, env: gitEnv })
+  })
+})

--- a/packages/kobe/test/orchestrator/worktree-salvage.test.ts
+++ b/packages/kobe/test/orchestrator/worktree-salvage.test.ts
@@ -137,3 +137,45 @@ test("an unforced removal of a clean worktree takes no snapshot", async () => {
 
   expect(called).toBe(false)
 })
+
+/**
+ * A snapshot that reports success while holding a POINTER instead of the work.
+ *
+ * `git add -A` stages a submodule (and a nested worktree) as a `160000`
+ * gitlink — its commit SHA, never its file contents. The ref was written, the
+ * audit line told the user to `git restore --source=<ref>`, and the file was
+ * in neither the tree nor the SHA the gitlink names. Silence about that is the
+ * failure; the record has to say which paths it could not take.
+ */
+test("a submodule's uncommitted work is reported as uncaptured, not silently missed", async () => {
+  const child = path.join(tmpRoot, "child")
+  fs.mkdirSync(child)
+  git(child, "init", "-q", ".")
+  git(child, "config", "user.email", "test@example.com")
+  git(child, "config", "user.name", "Test")
+  fs.writeFileSync(path.join(child, "c.txt"), "child\n")
+  git(child, "add", "-A")
+  git(child, "commit", "-qm", "child init")
+
+  git(repo, "-c", "protocol.file.allow=always", "submodule", "add", "-q", child, "vendor/child")
+  git(repo, "commit", "-qm", "add submodule")
+
+  const wt = path.join(tmpRoot, "sub")
+  git(repo, "worktree", "add", "-q", wt, "-b", "sub")
+  git(wt, "-c", "protocol.file.allow=always", "submodule", "update", "-q", "--init")
+  fs.writeFileSync(path.join(wt, "vendor", "child", "subwork.txt"), "SUBWORK\n")
+
+  let salvaged: { ref: string; uncaptured: readonly string[] } | null = null
+  await new GitWorktreeManager().remove(wt, {
+    force: true,
+    onSalvage: (record) => {
+      salvaged = record as typeof salvaged
+    },
+  })
+
+  const record = salvaged as unknown as { ref: string; uncaptured: readonly string[] } | null
+  expect(record?.ref).toBeTruthy()
+  // The snapshot genuinely cannot hold it — the point is that it says so.
+  expect(git(repo, "ls-tree", "-r", "--name-only", record?.ref as string)).not.toContain("subwork.txt")
+  expect(record?.uncaptured).toEqual(["vendor/child"])
+})


### PR DESCRIPTION
Task AO — Batch A (A1, A2, A3) and B. C1/C2/D deliberately left for another worker.

Every item was reproduced against a real repo built and then damaged, under an isolated
daemon whose `ROVE_/KOBE_ {HOME_DIR, DAEMON_SOCKET_PATH, DAEMON_PID_PATH, PTY_SOCKET_PATH,
PTY_PID_PATH, DAEMON_WEB_PORT}` were each assigned inline (never `env $VAR`). Fixtures live
under `.scratch/loop-r15-ao/` only; nothing was run against `/Users/jacksonc/i/kobe` or
anything under `/Users/jacksonc/.rove/worktrees/`.

---

## A1 — a worktree whose only work is gitignored deleted with no gate, no confirm, no salvage

**PASS criterion:** the no-force delete is refused with `DIRTY_WORKTREE` naming `HANDOFF.md`
and `.scratch/`, and the `--force` retry writes a `refs/rove/salvage/…` whose `ls-tree` lists
both files. Plus: a `node_modules/`-sized ignored entry is still skipped.

**Root cause.** Both checkpoints read `git status --porcelain`, which is blind to
`.gitignore`d entries — `task-deletion.ts:52` (the delete gate) and `salvage.ts:82` (salvage's
early return). The comment above that early return — *"Nothing uncommitted (tracked or
untracked) → nothing a force-remove could destroy"* — is false for ignored files, and
`smallIgnoredPaths` ten lines below it proves the author knew. `salvage-ignored.ts` was
correct code made unreachable by the check above it.

**Fix.** A new `GitWorktreeManager.ignoredWork()` runs the same `smallIgnoredPaths` rule the
snapshot uses, and both delete gates consult it. `isDirty` is deliberately NOT changed:
gitignored files survive a land and a sync, so folding them in would make every worktree
holding a `.env` read dirty to the sidebar and to `land`'s preflight — a different and wrong
claim. Salvage no longer returns early when the porcelain is empty but ignored work exists.

Because gate and snapshot share one rule, the delete refuses for **exactly** what a `--force`
retry then rescues.

**Proof — BEFORE (unfixed):**
```
--- git status --porcelain:
(end)
--- git status --porcelain --ignored:
!! .scratch/
!! HANDOFF.md
--- delete WITHOUT --force:
{"taskId":"01M1PBQQHXH6ZCM0EY2G938X43","queued":true,"status":"removed"}
--- dir: ls: .../ignsalv-7ab8516af77e/flounder: No such file or directory
--- salvage refs: (empty)
```

**AFTER:**
```
--- delete WITHOUT --force:
{"error":{"message":"task 01M1PC18ERMYDB32C6TPSYNKPQ worktree has gitignored work git status
 cannot see: .scratch/, HANDOFF.md","code":"DIRTY_WORKTREE", …}}
--- dir still there?  HANDOFF.md  README.md
--- delete WITH --force: {"status":"removed"}
--- salvage refs: refs/rove/salvage/ign-20260904T140921Z
--- ls-tree:  .gitignore  .scratch/notes.md  HANDOFF.md  README.md
```

**Size-ceiling regression (both directions, measured):**
- 80 MB `node_modules/` as the ONLY ignored entry → `delete` **succeeds** with no force, no
  ceremony. (`du -sk` = 81920 kb vs the 65536 kb ceiling.)
- 80 MB `node_modules/` + 4 kb `.scratch/` → forced snapshot contains `.scratch/notes.md` and
  **not** `node_modules/`.

Note on cost: the gate adds one `git status --porcelain -z --ignored` plus one `du -sk` per
top-level ignored entry to the non-force delete path. On a repo whose ignored tree is a
1.4 GB `node_modules/`, `du -sk` walks it — the same walk salvage already paid on the force
path. I did not cap it; if it proves slow in practice the number to change is
`MAX_IGNORED_ENTRY_KB`'s measurement strategy, not the rule.

---

## A2 — salvage reported success while the snapshot held a gitlink

**PASS criterion:** either the snapshot contains `vendor/child/subwork.txt`, or the
`SalvageRecord` carries an explicit incompleteness signal the audit line surfaces, naming
`vendor/child`. Silence is the failure.

**Fix.** Took option (b) — the snapshot genuinely cannot hold a submodule's working tree.
After `write-tree`, the tree is read back and its `160000` entries land in a new
`SalvageRecord.uncaptured`, which `recoveryText` renders before the recovery commands.

**Proof — AFTER (daemon.log):**
```
salvaged task 01M1PC1ZNT8C3RVCTQER3MAFPW — uncommitted work saved to
refs/rove/salvage/sub-task-20260904T140943Z (d80705d…). NOT captured (submodule / nested
worktree — the snapshot holds only a commit pointer): vendor/child. Recover with: …
```
BEFORE, the same run produced the ref and the `git restore` advice with no mention of
`vendor/child`; `git ls-tree -r <ref>` showed `160000 commit … vendor/child` and
`subwork.txt in snapshot: 0`.

---

## A3 — a nested worktree under a gitignored path destroyed the same way

**PASS criterion:** the no-force delete is refused, naming `.scratch/nested`; the control
(non-ignored `.scratch/`) stays green.

**No separate probe was needed** — and that is the finding. `git status --porcelain --ignored`
in the parent reports `!! .scratch/`, so A1's gate covers this shape too. I verified that
rather than assuming it. No nested-worktree special case was added, so no new ceremony
exists; the size budget gives the right answer on its own.

**Proof — BEFORE:** `{"status":"removed"}`, nested dir gone, `nested-precious.txt` destroyed,
salvage refs empty.
**AFTER:** refused with `gitignored work git status cannot see: .scratch/`, and
`cat .scratch/nested/nested-precious.txt` → `NESTED-PRECIOUS-UNCOMMITTED`.

---

## B — `removed` reported for a branch left permanently wedged

**PASS criterion:** after `delete --wait` reports success, `git worktree list` shows only the
main checkout, `git branch -D vanish2` succeeds, and `discover-adoptable` returns `[]`.

**Root cause.** `manager-remove.ts:176` ran git discovery from `path.dirname(worktreePath)` —
`~/.rove/worktrees/<key>`, which is inside no repository — so `findRepoFor` returned null and
the prune never ran. The owning repo was sitting in `task.repo` the whole time and was never
passed down.

**Fix.** `RemoveOpts.repo`, preferred over discovery in the missing-directory branch, threaded
from `TaskDeletionCoordinator.finish`. The discovery fallback stays for callers holding only a
path (the worktrees page), which is where it can still work. Ordering is unaffected: the
directory is already gone in this branch, so the prune touches admin records only.

**Proof — BEFORE:**
```
--- rev-parse from parent of worktree: fatal: not a git repository
--- delete: {"status":"removed"}
--- worktree list: …/gone2  2f26d4c [main]
                   /private/tmp/…/goat  05c91bb [vanish2] prunable
--- branch -D vanish2: error: cannot delete branch 'vanish2' used by worktree at …/goat
--- discover-adoptable: {"worktrees":[{…"dirty":null,"kobeManaged":true}],"unreadable":[]}
```
**AFTER:**
```
--- delete: {"status":"removed"}
--- worktree list: …/gone2  c4dea42 [main]        ← only the main checkout
--- branch -D vanish2: Deleted branch vanish2 (was b2178fb).
--- discover-adoptable: {"worktrees":[],"unreadable":[]}
```

---

## Screenshots — the TUI half of A1

The two-stage force confirm `docs/WORKTREES.md` calls "the boundary that authorizes data
loss" never fired for an ignored-only worktree. Captured through the only ground-truth path
(`/harness` browser → xterm.js → PTY sidecar → real OpenTUI), same key sequence both times,
on two separate fixtures with their own port bases:

- **BEFORE** (source reverted to pre-fix, rebuilt, fresh fixture on base 5883):
  `/Users/jacksonc/.rove/worktrees/kobe-0aff3858ab76/gemsbok/.scratch/loop-r15-ao/shots/before.png`
  One confirm and the task is gone — sidebar reads *"No active tasks — create one above."*
  On disk: worktree unlinked, `git for-each-ref refs/rove/salvage` empty.
- **AFTER** (base 5873):
  `/Users/jacksonc/.rove/worktrees/kobe-0aff3858ab76/gemsbok/.scratch/loop-r15-ao/shots/after.png`
  The second dialog fires: *"Visual Fixture" has uncommitted changes — "visual-fixture" has
  uncommitted, untracked, or gitignored work…* The task is still in the sidebar and
  `HANDOFF.md` still reads `A WHOLE SESSION OF REASONING`.

Both PNGs are attached as a comment on this PR. They live under `.scratch/`, which is
gitignored — i.e. in exactly the directory this bug destroys, which is why they could not be
committed to the branch.

---

## Tests

Four regression tests, all real git, no mocks. Each was mutation-verified — the fix reverted
at one site, exactly one test goes red:

| Mutation | Red test |
|---|---|
| drop the `ignoredWork` gate in `manager-remove.ts` | `an ignored-only worktree is refused without force…` |
| restore salvage's empty-porcelain early return | same test (the salvage half) |
| make `uncaptured` always `[]` | `a submodule's uncommitted work is reported as uncaptured…` |
| re-discover the repo from `dirname` | `prunes the stale admin record using the repo the caller passed` |

`an ignored tree over the size budget still deletes with no force` guards the other direction.

**Gates:** repo-root `bun run lint` clean · `bun run typecheck` clean · vitest **4495 passed** ·
`bun test test/render` **474 passed** · `KOBE_INCLUDE_SOCKET=1 test:socket` **807 passed** ·
`bun run check-i18n` — 834 keys × 2 locales in sync.

The full suite caught one thing I had gotten wrong: `smallIgnoredPaths` runs `git status`
through `exec.run` directly, bypassing `runGit`'s `READ_ONLY_GIT_ENV`. Harmless while it only
ran on the force path; now that it runs on every ordinary delete, it would contend with an
engine's `git commit` for `.git/index.lock`. `git-readonly-env.test.ts` failed and named it.
Fixed by passing `READ_ONLY_GIT_ENV` explicitly.

One test expectation was updated deliberately: `api-handlers-delete.test.ts` pinned the exact
recovery prompt, which now has to cover a path `git status` will not show.

## Copy and docs

- `DirtyWorktreeError` names the ignored paths — a user told only "uncommitted or untracked
  changes" would go looking with a command that reports nothing.
- The force-confirm body now reads "uncommitted, untracked, or gitignored work", both locales,
  `check-i18n` green.
- `docs/WORKTREES.md`: step 2 of the two-stage flow documents the `--ignored` check and the
  shared budget; the salvage section documents the submodule / nested-worktree gap.

## Not done / out of scope

- **C1, C2, D** left for another worker, as instructed.
- `deleteBranch: true` on a task whose directory is already gone still leaks the branch: the
  branch name is read via `currentBranch(worktreePath)`, which needs the directory. Same class
  of defect as B (a verb reporting success while doing nothing), but a different symptom, no
  repro in the brief, and it needs another field threaded — flagging rather than widening.
- No new or moved keybinding chords.
