### PR TITLE
fix: report the base a task actually came from, and the branch a delete promised to drop

### DIFF
--- a/.changeset/honest-base-ref-and-branch-delete.md
+++ b/.changeset/honest-base-ref-and-branch-delete.md
@@ -1,0 +1,46 @@
+---
+"@sma1lboy/rove": patch
+---
+
+`collect`'s ahead-count is measured against a base the task actually came from.
+
+The base was resolved by walking `origin/HEAD` → `origin/main` → `origin/master`
+→ `main` → `master` and taking the first ref that resolved, without asking
+whether that ref had anything to do with the branch. A repo with an abandoned
+orphan `main` beside a live `develop` reported `ahead: 5, behind: 1, diff: null`
+for a task holding one commit — and `ahead` is the number a fan-out coordinator
+picks winners on, where five looks like an attempt that did more work. The null
+diffstat was the only tell, and it is the field nobody reads. Each candidate is
+now checked for a common ancestor before it is accepted, and when none of them
+has one the base falls back to the branch the base checkout is actually on —
+what `land` has always merged into. A remote-less repo whose default branch is
+`trunk` reported every field null and now reports `trunk`, matching what
+`land --dry-run` answered on the same task all along.
+
+A base checkout with no commits yet is no longer reported as detached. `git
+rev-parse --abbrev-ref HEAD` exits 128 there and prints the literal string
+`HEAD` on stdout; the exit code was never read, so a repo sitting squarely on
+`main` was told to "check out a branch first" — advice the user was already
+following. `land` now asks `git symbolic-ref`, which names the branch of an
+unborn HEAD, and refuses with `UNBORN_BASE` naming the real condition. Reading
+the exit code also splits "git could not read this repo at all"
+(`UNREADABLE_BASE`) out of the detached answer it used to share. A genuinely
+detached base checkout still refuses with `DETACHED_HEAD`.
+
+`delete --delete-branch` on a task whose worktree directory was already gone
+kept the branch. The branch to delete was read out of the worktree, which by
+then did not exist, so the delete reported `removed` with the branch still in
+`git branch` — the same shape as the stale admin record fixed alongside it,
+where a verb reports success while doing nothing. The task's own branch is now
+passed down for that case.
+
+"Sync with base" no longer offers `git stash` as a way to clear a dirty
+worktree. It was the last recommendation of it left in the product, and the
+worktree it was talking about is a managed task worktree: the stash stack lives
+in the repo's common dir and is shared by every linked worktree, so a parallel
+task can pop or drop what was stashed there. It says commit, like every other
+surface already did.
+
+Internal: the two copies of the `git status --porcelain` path parser — landing's
+and syncing's, the second asserting it was the same shape as the first while
+being strictly more careful — are one function. — [@Sma1lboy](https://github.com/Sma1lboy)

--- a/docs/API.md
+++ b/docs/API.md
@@ -617,8 +617,9 @@ nothing to do), `skipped_missed`, `skipped_unavailable`, and
   destination, which is the thing "check the base checkout is on the branch
   you mean" asks you to check — and `ahead` is how many commits would land.
   When the land would be refused, `refusal` is one of `DETACHED_HEAD`,
-  `SAME_BRANCH`, `MAIN_CHECKOUT_DIRTY`, `MISSING_REF`, `EMPTY_BRANCH`,
-  `EMPTY_BRANCH_DIRTY_WORKTREE`, and `message` carries the same words the land
+  `UNREADABLE_BASE`, `UNBORN_BASE`, `SAME_BRANCH`, `MAIN_CHECKOUT_DIRTY`,
+  `MISSING_REF`, `EMPTY_BRANCH`, `EMPTY_BRANCH_DIRTY_WORKTREE`, and
+  `message` carries the same words the land
   itself would have failed with. A coordinator picking which sibling of a
   round to land should read this first — `ahead: 0` is the empty-merge that
   otherwise only surfaces at land time.

--- a/packages/kobe-daemon/src/daemon/contracts.ts
+++ b/packages/kobe-daemon/src/daemon/contracts.ts
@@ -164,6 +164,8 @@ export interface LandPreflightResult {
   readonly baseDirty?: boolean
   readonly refusal?:
     | "DETACHED_HEAD"
+    | "UNREADABLE_BASE"
+    | "UNBORN_BASE"
     | "SAME_BRANCH"
     | "MAIN_CHECKOUT_DIRTY"
     | "MISSING_REF"

--- a/packages/kobe/src/cli/api/branch-signals.ts
+++ b/packages/kobe/src/cli/api/branch-signals.ts
@@ -10,10 +10,9 @@
  * persisted on the task at create time, so a task cut from `release/2.x`
  * is measured against `release/2.x`, not against a guess. Records that
  * predate the field (or whose recorded ref does not resolve) fall back
- * to the re-resolution the worktrees page uses: `origin/HEAD` →
- * `origin/main` → `origin/master` → local `main`/`master`. All reads are
- * lock-free (`GIT_OPTIONAL_LOCKS=0`) and best-effort — a repo with no
- * resolvable base yields nulls, never an error.
+ * to {@link resolveBaseRef}. All reads are lock-free
+ * (`GIT_OPTIONAL_LOCKS=0`) and best-effort — a repo with no resolvable
+ * base yields nulls, never an error.
  */
 
 import { spawnSync } from "node:child_process"
@@ -51,14 +50,60 @@ function git(cwd: string, args: readonly string[]): string | null {
   }
 }
 
-/** `origin/HEAD` → `origin/main` → `origin/master` → `main` → `master`. */
+/**
+ * Whether `ref` and HEAD have a common ancestor. A ref that resolves is not
+ * yet a base: two branches can both exist and share no history at all (an
+ * abandoned orphan `main` beside a live `develop` is the shape that produced
+ * this check). Measuring against one of those yields a fabricated ahead/behind
+ * pair and a null diffstat — `git diff <unrelated>...HEAD` fails outright, and
+ * that null was the only tell the numbers beside it were nonsense.
+ */
+function sharesHistory(worktreePath: string, ref: string): boolean {
+  return git(worktreePath, ["merge-base", ref, "HEAD"]) !== null
+}
+
+/**
+ * The branch the BASE CHECKOUT is on — the same question `land` asks before it
+ * merges ({@link landPreflight} reads it from the base repo), reached here
+ * from the worktree alone. `git worktree list --porcelain` names the main
+ * working tree in its first record, so one read answers both "which checkout
+ * is the base" and "what branch is it on". Null when that record has no branch
+ * (a detached base checkout) or the read fails.
+ */
+function baseCheckoutBranch(worktreePath: string): string | null {
+  const out = git(worktreePath, ["worktree", "list", "--porcelain"])
+  if (!out) return null
+  const first = out.split("\n\n", 1)[0] ?? ""
+  const line = first.split("\n").find((l) => l.startsWith("branch "))
+  if (!line) return null
+  const branch = line
+    .slice("branch ".length)
+    .trim()
+    .replace(/^refs\/heads\//, "")
+  return branch || null
+}
+
+/**
+ * The base to measure a task branch against when the task record names none:
+ * `origin/HEAD` → `origin/main` → `origin/master` → `main` → `master`, taking
+ * the first candidate that BOTH resolves and shares history with HEAD, then
+ * falling back to the base checkout's own branch.
+ *
+ * The history check and the fallback are one fix for one failure: a repo whose
+ * real base is `develop` or `trunk` gets either an unrelated ladder hit (a
+ * stale `main` nobody has touched in a year) or nothing at all, and `collect`
+ * then reports an ahead-count a fan-out coordinator picks winners on. Asking
+ * the base checkout is not a sixth guess — it is what `land` already merges
+ * into, so the two verbs now answer about the same branch.
+ */
 export function resolveBaseRef(worktreePath: string): string | null {
   const head = git(worktreePath, ["symbolic-ref", "--short", "refs/remotes/origin/HEAD"])
-  if (head) return head
-  for (const guess of ["origin/main", "origin/master", "main", "master"]) {
-    if (git(worktreePath, ["rev-parse", "--verify", "--quiet", guess]) !== null) return guess
+  for (const guess of [...(head ? [head] : []), "origin/main", "origin/master", "main", "master"]) {
+    if (git(worktreePath, ["rev-parse", "--verify", "--quiet", guess]) === null) continue
+    if (sharesHistory(worktreePath, guess)) return guess
   }
-  return null
+  const base = baseCheckoutBranch(worktreePath)
+  return base && sharesHistory(worktreePath, base) ? base : null
 }
 
 /**

--- a/packages/kobe/src/cli/api/verbs-lifecycle.ts
+++ b/packages/kobe/src/cli/api/verbs-lifecycle.ts
@@ -36,7 +36,7 @@ export const LIFECYCLE_VERBS: readonly VerbSpec[] = [
         name: "dry-run",
         type: "bool",
         description:
-          "Report whether the land would proceed, and write nothing. Returns { branch, landedOn, ahead?, baseDirty?, refusal?, dirtyFiles?, baseDir } — `landedOn` is the base checkout's CURRENT branch (the merge destination), `ahead` the commits that would land, and `refusal` one of DETACHED_HEAD, SAME_BRANCH, MAIN_CHECKOUT_DIRTY, MISSING_REF, EMPTY_BRANCH, EMPTY_BRANCH_DIRTY_WORKTREE when the land would be refused. Ignores --strategy/--delete-branch/--remove-worktree.",
+          "Report whether the land would proceed, and write nothing. Returns { branch, landedOn, ahead?, baseDirty?, refusal?, dirtyFiles?, baseDir } — `landedOn` is the base checkout's CURRENT branch (the merge destination), `ahead` the commits that would land, and `refusal` one of DETACHED_HEAD, UNREADABLE_BASE, UNBORN_BASE, SAME_BRANCH, MAIN_CHECKOUT_DIRTY, MISSING_REF, EMPTY_BRANCH, EMPTY_BRANCH_DIRTY_WORKTREE when the land would be refused. Ignores --strategy/--delete-branch/--remove-worktree.",
       },
       {
         name: "strategy",

--- a/packages/kobe/src/orchestrator/dirty-paths.ts
+++ b/packages/kobe/src/orchestrator/dirty-paths.ts
@@ -1,0 +1,29 @@
+/**
+ * One parse of `git status --porcelain` into the paths a refusal names.
+ *
+ * Landing and syncing both refuse on a dirty tree and both list the offending
+ * files, so both had to strip the two-character `XY` status and its separating
+ * space off every line — and they did it twice, with `sync-base.ts` asserting
+ * "same shape as landing's `porcelainPaths`" while being strictly more careful:
+ * it required a line long enough to HAVE a path and dropped empties afterwards,
+ * where landing's `slice(3)` on a short line yielded `""` and rendered it to
+ * the user as a filename. Real `git status --porcelain` always emits
+ * `XY <path>` (≥4 chars), so the two agreed on every input git actually
+ * produces — which is exactly why the drift survived: the comment was right in
+ * practice and wrong in the letter. The careful version is the one kept.
+ *
+ * Deliberately NOT `lib/git-parsers.ts`'s `parsePorcelainRows`, which unquotes
+ * C-escaped paths and resolves `R  old -> new` to the new path. That is the
+ * better parser and these call sites should probably use it, but adopting it
+ * changes the user-visible file lists on the `SYNC_WORKTREE_DIRTY` and
+ * `EmptyBranchDirtyWorktreeError` paths — its own change, with its own tests.
+ */
+
+/** Paths from `git status --porcelain` output, with the `XY ` prefix stripped. */
+export function parseDirtyPaths(stdout: string): string[] {
+  return stdout
+    .split("\n")
+    .filter((line) => line.length > 3)
+    .map((line) => line.slice(3).trim())
+    .filter((line) => line.length > 0)
+}

--- a/packages/kobe/src/orchestrator/land-preflight.ts
+++ b/packages/kobe/src/orchestrator/land-preflight.ts
@@ -21,6 +21,7 @@
 import type { ExecHost } from "../exec/exec-host.ts"
 import { READ_ONLY_GIT_ENV } from "../lib/git-env.ts"
 import type { Task } from "../types/task.ts"
+import { parseDirtyPaths } from "./dirty-paths.ts"
 import { EmptyBranchDirtyWorktreeError, EmptyBranchError, MainCheckoutDirtyError, MissingRefError } from "./errors.ts"
 import { type WorktreeExecDeps, defaultExecDeps } from "./worktree/exec-deps.ts"
 import { GitWorktreeManager } from "./worktree/manager.ts"
@@ -33,6 +34,8 @@ import { GitWorktreeManager } from "./worktree/manager.ts"
  */
 export type LandRefusal =
   | "DETACHED_HEAD"
+  | "UNREADABLE_BASE"
+  | "UNBORN_BASE"
   | "SAME_BRANCH"
   | "MAIN_CHECKOUT_DIRTY"
   | "MISSING_REF"
@@ -99,14 +102,6 @@ export async function isDirty(exec: ExecHost, dir: string): Promise<boolean> {
   return (await landGit(exec, dir, ["status", "--porcelain"], { readOnly: true })).stdout.trim().length > 0
 }
 
-/** Uncommitted/untracked paths from `git status --porcelain` output (strip the XY prefix). */
-export function porcelainPaths(stdout: string): string[] {
-  return stdout
-    .split("\n")
-    .filter((l) => l.length > 0)
-    .map((l) => l.slice(3).trim())
-}
-
 /**
  * Probe whether `task`'s branch can land, without touching anything.
  *
@@ -133,10 +128,24 @@ export async function landPreflight(task: Task, deps: WorktreeExecDeps = default
   if (!branch) throw new Error(`landPreflight: task ${task.id} has no branch to land (never materialised)`)
   const { exec, dir } = baseRepoCtx(task.repo, deps)
 
-  const headOut = await landGit(exec, dir, ["rev-parse", "--abbrev-ref", "HEAD"], { readOnly: true })
+  // `symbolic-ref --short HEAD`, not `rev-parse --abbrev-ref HEAD`: on a base
+  // checkout with NO COMMITS the latter exits 128 and prints the literal
+  // string `HEAD` on stdout, so reading its output as data reported a repo
+  // sitting squarely on `main` as detached, with advice ("check out a branch
+  // first") the user was already following. `symbolic-ref` names the branch of
+  // an unborn HEAD and fails only when HEAD genuinely is not a branch.
+  //
+  // And the EXIT CODE decides, so "git could not read this repo at all" stops
+  // sharing an answer with "the base checkout is detached": on failure, a HEAD
+  // that still resolves to a commit is a real detach; one that does not means
+  // the base dir is not a readable repo, which is a different thing to tell a
+  // user. Structural, not a match on git's message text.
+  const headOut = await landGit(exec, dir, ["symbolic-ref", "--short", "HEAD"], { readOnly: true })
   const landedOn = headOut.stdout.trim()
-  if (!landedOn || landedOn === "HEAD") {
-    return refuse({ branch, landedOn: "", baseDir: dir }, "DETACHED_HEAD")
+  if (headOut.exitCode !== 0 || !landedOn) {
+    const headCommit = await landGit(exec, dir, ["rev-parse", "--verify", "--quiet", "HEAD"], { readOnly: true })
+    const detached = headCommit.exitCode === 0 && headCommit.stdout.trim().length > 0
+    return refuse({ branch, landedOn: "", baseDir: dir }, detached ? "DETACHED_HEAD" : "UNREADABLE_BASE")
   }
   if (landedOn === branch) {
     return refuse({ branch, landedOn, baseDir: dir }, "SAME_BRANCH")
@@ -151,6 +160,15 @@ export async function landPreflight(task: Task, deps: WorktreeExecDeps = default
   // fallback. Collapsing the two is what made a renamed branch look like a
   // merge conflict.
   if (aheadOut.exitCode !== 0) {
+    // WHICH ref failed to resolve. An unborn base branch (`landedOn` is a real
+    // branch name that has no commit yet) is not a task branch renamed out
+    // from under us, and `MissingRefError`'s advice — re-point the task —
+    // cannot fix it. Probed only here, in a path that already failed, so the
+    // ordinary land pays nothing for the distinction.
+    const baseHead = await landGit(exec, dir, ["rev-parse", "--verify", "--quiet", "HEAD"], { readOnly: true })
+    if (baseHead.exitCode !== 0 || !baseHead.stdout.trim()) {
+      return refuse({ branch, landedOn, baseDirty, baseDir: dir }, "UNBORN_BASE")
+    }
     return refuse({ branch, landedOn, baseDirty, baseDir: dir }, baseDirty ? "MAIN_CHECKOUT_DIRTY" : "MISSING_REF")
   }
   const parsed = Number.parseInt(aheadOut.stdout.trim(), 10)
@@ -177,7 +195,7 @@ export async function landPreflight(task: Task, deps: WorktreeExecDeps = default
     }
     if (dirty) {
       const wtExec = deps.execForPath(worktreePath)
-      const files = porcelainPaths(
+      const files = parseDirtyPaths(
         (await landGit(wtExec, worktreePath, ["status", "--porcelain"], { readOnly: true })).stdout,
       )
       return refuse({ ...base, dirtyFiles: files }, "EMPTY_BRANCH_DIRTY_WORKTREE")
@@ -196,6 +214,12 @@ export function landRefusalError(task: Task, pf: LandPreflight & { readonly refu
   switch (pf.refusal) {
     case "DETACHED_HEAD":
       return new Error(`landTask: base checkout at ${pf.baseDir} is in detached-HEAD state; check out a branch first`)
+    case "UNREADABLE_BASE":
+      return new Error(`landTask: could not read HEAD of the base checkout at ${pf.baseDir} — is it still a git repo?`)
+    case "UNBORN_BASE":
+      return new Error(
+        `landTask: base checkout at ${pf.baseDir} is on '${pf.landedOn}' but has no commits yet, so there is nothing to merge '${pf.branch}' into; make the first commit there (or \`git merge --ff-only ${pf.branch}\`) and land again`,
+      )
     case "SAME_BRANCH":
       return new Error(`landTask: base checkout is already on '${pf.branch}' — nothing to land onto`)
     case "MAIN_CHECKOUT_DIRTY":

--- a/packages/kobe/src/orchestrator/sync-base.ts
+++ b/packages/kobe/src/orchestrator/sync-base.ts
@@ -24,6 +24,7 @@
 
 import { readOnlyGitProcessEnv } from "../lib/git-env.ts"
 import { spawnCapture } from "../lib/poll-scheduling.ts"
+import { parseDirtyPaths } from "./dirty-paths.ts"
 
 /** `git merge` can stall on a hook or a huge tree; kill it rather than hang. */
 export const SYNC_TIMEOUT_MS = 60_000
@@ -58,18 +59,6 @@ export function parseConflictedPaths(stdout: string): string[] {
 }
 
 /**
- * Paths from `git status --porcelain=v1`, with the two-character XY status and
- * its separating space stripped. Same shape as landing's `porcelainPaths`.
- */
-function parseDirtyPaths(stdout: string): string[] {
-  return stdout
-    .split("\n")
-    .filter((line) => line.length > 3)
-    .map((line) => line.slice(3).trim())
-    .filter((line) => line.length > 0)
-}
-
-/**
  * Merge `baseRef` into the worktree's current branch. Throws with a
  * `SYNC_CONFLICT: a, b, c` / `SYNC_WORKTREE_DIRTY: a, b, c` message on the two
  * outcomes a human can act on, and git's own stderr on anything else.
@@ -90,9 +79,12 @@ export async function syncWorktreeWithBase(
   const status = await git(worktreePath, ["status", "--porcelain=v1"], signal)
   if (status.status !== 0) throw new Error("git status failed")
   const dirty = parseDirtyPaths(status.stdout)
-  // Name them, the way SYNC_CONFLICT names its files: "commit or stash the
-  // worktree's changes" is not actionable when the change is one untracked
-  // file the user does not know is there.
+  // Name them, the way SYNC_CONFLICT names its files: "commit the worktree's
+  // changes" is not actionable when the change is one untracked file the user
+  // does not know is there. And it says COMMIT, not stash: this worktree is a
+  // managed task worktree, and the stash stack lives in the repo's common dir
+  // — shared by every linked worktree, so a parallel task can pop or drop what
+  // was stashed here (`docs/ORCHESTRATION.md`, `orchestrator/errors.ts`).
   if (dirty.length > 0) throw new Error(`${SYNC_DIRTY}: ${dirty.join(", ")}`)
 
   const before = await git(worktreePath, ["rev-parse", "HEAD"], signal)

--- a/packages/kobe/src/orchestrator/task-deletion.ts
+++ b/packages/kobe/src/orchestrator/task-deletion.ts
@@ -109,6 +109,10 @@ export class TaskDeletionCoordinator {
           // back at the repo. A task has always known this; it just never
           // passed it down, so the prune silently never ran.
           repo: task.repo,
+          // The branch to drop, for the same missing-directory case: it is
+          // normally read out of the worktree, which by then does not exist,
+          // so `deleteBranch` deleted nothing and said it had.
+          branch: task.branch,
           // `force` was frozen at prepare() time and this runs on a later
           // tick — possibly in a later daemon process (`resume()` replays a
           // queued deletion after a restart), so the worktree may have gone

--- a/packages/kobe/src/orchestrator/worktree/manager-remove.ts
+++ b/packages/kobe/src/orchestrator/worktree/manager-remove.ts
@@ -64,6 +64,17 @@ export interface RemoveOpts {
    * caller keeps the (best-effort) discovery fallback.
    */
   readonly repo?: string
+  /**
+   * The branch this worktree has checked out, when the caller knows it.
+   *
+   * Same reason as {@link repo}, for the same missing-directory case: the
+   * branch to delete is normally read out of the worktree with
+   * `currentBranch(worktreePath)`, and that needs the directory. With it gone
+   * the read returns null and `deleteBranch: true` silently deletes nothing —
+   * the verb reports success and the branch the user asked to drop is still
+   * there. A task carries `task.branch`; a bare worktree path does not.
+   */
+  readonly branch?: string
   /** Notified with the snapshot a force-removal took (null = nothing to
    *  save, or the snapshot could not be written). */
   readonly onSalvage?: (record: SalvageRecord | null) => void
@@ -203,7 +214,18 @@ export async function removeWorktree(deps: RemoveDeps, worktreePath: string, opt
     // wrong one, which is worse. The fallback stays for callers holding only a
     // path (the worktrees page), which is where it can still work.
     const goneRepo = opts?.repo ?? (await deps.findRepoFor(exec, path.dirname(worktreePath)))
-    if (goneRepo) await deps.runGit(exec, ["worktree", "prune"], { cwd: goneRepo, allowFail: true })
+    if (goneRepo) {
+      await deps.runGit(exec, ["worktree", "prune"], { cwd: goneRepo, allowFail: true })
+      // An opt-in branch delete still has to happen here. `currentBranch`
+      // cannot answer for a directory that is gone, so this is the one path
+      // where the branch has to arrive from the caller — and the prune above
+      // is what makes it deletable at all (git refuses a branch it still
+      // believes a worktree has checked out). Best-effort, like every other
+      // branch delete: it runs after the removal is otherwise complete.
+      if (opts?.deleteBranch === true && opts.branch) {
+        await deleteBranchAnchored(deps.branchDeps(), exec, goneRepo, opts.branch, { force })
+      }
+    }
     return
   }
 
@@ -281,7 +303,12 @@ export async function removeWorktree(deps: RemoveDeps, worktreePath: string, opt
 
   // Capture the branch BEFORE removal (once the worktree is gone we can't
   // read its HEAD) so an opt-in `deleteBranch` can clean it up after.
-  const branch = opts?.deleteBranch ? await deps.currentBranch(worktreePath).catch(() => null) : null
+  // The caller's `branch` is the fallback, not the primary: the worktree's own
+  // HEAD is the truth while the directory is readable (a caller's record can be
+  // stale), and `task.branch` is what is left when it is not.
+  const branch = opts?.deleteBranch
+    ? ((await deps.currentBranch(worktreePath).catch(() => null)) ?? opts.branch ?? null)
+    : null
 
   if (force) {
     // The last moment at which the doomed files still exist. The dirty check

--- a/packages/kobe/src/tui/i18n/messages/tasks.ts
+++ b/packages/kobe/src/tui/i18n/messages/tasks.ts
@@ -80,7 +80,7 @@ export const en = {
     done: "Merged {base} into this worktree",
     alreadyCurrent: "Already up to date with {base}",
     conflict: "Merge conflict — resolve then commit: {files}",
-    dirty: "Commit or stash the worktree's changes first, then sync: {files}",
+    dirty: "Commit the worktree's changes first, then sync: {files}",
     failed: "Sync failed: {error}",
   },
   /** Change-engine picker dialog (the menu route of `v`). */
@@ -271,7 +271,7 @@ export const zh: typeof en = {
     done: "已把 {base} 合并进该工作树",
     alreadyCurrent: "已经和 {base} 同步",
     conflict: "合并冲突——解决后提交：{files}",
-    dirty: "请先提交或暂存工作树里的改动，再同步：{files}",
+    dirty: "请先提交工作树里的改动，再同步：{files}",
     failed: "同步失败：{error}",
   },
   changeEngine: {

--- a/packages/kobe/test/cli/branch-signals.test.ts
+++ b/packages/kobe/test/cli/branch-signals.test.ts
@@ -8,7 +8,7 @@
 import { execFileSync } from "node:child_process"
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
-import { join } from "node:path"
+import { basename, join } from "node:path"
 import { afterEach, describe, expect, it } from "vitest"
 import { parseShortstat, readBranchSignals, resolveBaseRef } from "../../src/cli/api/branch-signals.ts"
 
@@ -68,6 +68,71 @@ describe("readBranchSignals", () => {
     expect(readBranchSignals(dir)).toEqual({ baseRef: null, ahead: null, behind: null, diff: null })
     expect(readBranchSignals("")).toEqual({ baseRef: null, ahead: null, behind: null, diff: null })
     expect(resolveBaseRef(dir)).toBeNull()
+  })
+})
+
+describe("a ladder hit that shares no history with the branch", () => {
+  /**
+   * The shape that made `collect` report `ahead: 5, behind: 1, diff: null` for
+   * a task holding ONE commit: an abandoned orphan `main` sitting beside the
+   * repo's real base, `develop`. Both branches resolve; they have no merge
+   * base at all, so every number measured against `main` is fabricated and the
+   * null diffstat is the only tell — the one field a fan-out coordinator
+   * reading `ahead` does not look at.
+   */
+  function makeOrphanMainRepo(): { repo: string; worktree: string } {
+    const repo = mkdtempSync(join(tmpdir(), "kobe-branch-signals-orphan-"))
+    cleanups.push(repo)
+    git(repo, "init", "-q", "-b", "develop")
+    writeFileSync(join(repo, "a.txt"), "one\n")
+    git(repo, "add", "a.txt")
+    git(repo, "commit", "-q", "-m", "develop base")
+    // An orphan `main`: no shared history with `develop` by construction.
+    git(repo, "checkout", "-q", "--orphan", "main")
+    git(repo, "rm", "-rqf", ".")
+    writeFileSync(join(repo, "OLD.md"), "old\n")
+    git(repo, "add", "-A")
+    git(repo, "commit", "-q", "-m", "abandoned main")
+    git(repo, "checkout", "-q", "develop")
+    // A linked worktree, so the base checkout stays on `develop` — the layout
+    // every managed task has, and the one `git worktree list` can answer for.
+    const worktree = join(repo, "..", `${basename(repo)}-wt`)
+    cleanups.push(worktree)
+    git(repo, "worktree", "add", "-q", "-b", "task", worktree)
+    writeFileSync(join(worktree, "one.txt"), "one\n")
+    git(worktree, "add", "-A")
+    git(worktree, "commit", "-q", "-m", "the ONE commit")
+    return { repo, worktree }
+  }
+
+  it("skips it and measures against the base checkout's real branch", () => {
+    const { worktree } = makeOrphanMainRepo()
+    const signals = readBranchSignals(worktree)
+    expect(signals.baseRef).toBe("develop")
+    expect(signals.ahead).toBe(1)
+    expect(signals.behind).toBe(0)
+    expect(signals.diff).toEqual({ files: 1, insertions: 1, deletions: 0 })
+  })
+
+  it("finds a default branch the ladder never names (`trunk`, no remote)", () => {
+    const repo = mkdtempSync(join(tmpdir(), "kobe-branch-signals-trunk-"))
+    cleanups.push(repo)
+    git(repo, "init", "-q", "-b", "trunk")
+    writeFileSync(join(repo, "a.txt"), "one\n")
+    git(repo, "add", "a.txt")
+    git(repo, "commit", "-q", "-m", "trunk base")
+    const worktree = join(repo, "..", `${basename(repo)}-wt`)
+    cleanups.push(worktree)
+    git(repo, "worktree", "add", "-q", "-b", "task", worktree)
+    writeFileSync(join(worktree, "t.txt"), "t\n")
+    git(worktree, "add", "-A")
+    git(worktree, "commit", "-q", "-m", "task work")
+    const signals = readBranchSignals(worktree)
+    // Was all-null: `main`/`master` do not exist and there is no remote, so
+    // the ladder ran out — while `land --dry-run` on the same task answered
+    // `landedOn: "trunk", ahead: 1` from the base checkout all along.
+    expect(signals.baseRef).toBe("trunk")
+    expect(signals.ahead).toBe(1)
   })
 })
 

--- a/packages/kobe/test/orchestrator/git-readonly-env.test.ts
+++ b/packages/kobe/test/orchestrator/git-readonly-env.test.ts
@@ -130,7 +130,10 @@ describe("landTask — READ_ONLY_GIT_ENV on probes", () => {
   it("pre-merge probes run lock-free; the merge itself does not", async () => {
     let headReads = 0
     const { exec, runs } = fakeExec((argv) => {
-      if (argv.includes("--abbrev-ref")) return { stdout: "main\n", stderr: "", exitCode: 0 }
+      // The base checkout's branch — `symbolic-ref`, which is what the
+      // preflight asks now that `rev-parse --abbrev-ref` was found to answer
+      // `HEAD` (exit 128) on a base checkout with no commits.
+      if (argv.includes("symbolic-ref")) return { stdout: "main\n", stderr: "", exitCode: 0 }
       if (argv.includes("status")) return ok
       if (argv.includes("rev-list")) return { stdout: "1\n", stderr: "", exitCode: 0 }
       if (argv.includes("merge")) return ok

--- a/packages/kobe/test/orchestrator/land-commit-failure.test.ts
+++ b/packages/kobe/test/orchestrator/land-commit-failure.test.ts
@@ -161,7 +161,7 @@ describe("a git commit that fails mid-land", () => {
         const args = argv.slice(1)
         calls.push([...args])
         const joined = args.join(" ")
-        if (joined.startsWith("rev-parse --abbrev-ref")) return ok("main")
+        if (joined.startsWith("symbolic-ref --short")) return ok("main")
         if (joined.startsWith("status --porcelain")) return ok("")
         if (joined.startsWith("rev-list --count")) return ok("1") // "has work"
         if (joined.startsWith("merge --squash")) return ok("")

--- a/packages/kobe/test/orchestrator/land-preflight.test.ts
+++ b/packages/kobe/test/orchestrator/land-preflight.test.ts
@@ -95,6 +95,36 @@ describe("landPreflight", () => {
     expect(pf.landedOn).toBe("")
   })
 
+  test("an UNBORN base checkout is not detached — it says it has no commits yet", async () => {
+    // `git rev-parse --abbrev-ref HEAD` exits 128 here and prints the literal
+    // string `HEAD` on stdout. Reading that output as data told a user sitting
+    // squarely on `main` to "check out a branch first".
+    const empty = path.join(tmpRoot, "empty")
+    fs.mkdirSync(empty)
+    git(["init", "-b", "main"], empty)
+    git(["config", "user.email", "t@t.t"], empty)
+    git(["config", "user.name", "t"], empty)
+    const wt = path.join(tmpRoot, "empty-wt")
+    git(["worktree", "add", "-b", "feat", wt], empty)
+    fs.writeFileSync(path.join(wt, "a.txt"), "work\n")
+    git(["add", "."], wt)
+    git(["commit", "-m", "work"], wt)
+
+    const pf = await landPreflight(task({ repo: empty, worktreePath: wt }))
+    expect(pf.refusal).toBe("UNBORN_BASE")
+    // The branch it IS on gets named, which the detached refusal cannot do.
+    expect(pf.landedOn).toBe("main")
+    expect(pf.message).toContain("no commits yet")
+  })
+
+  test("a base dir git cannot read at all is not reported as detached either", async () => {
+    branchOneAhead()
+    const notARepo = path.join(tmpRoot, "plain")
+    fs.mkdirSync(notARepo)
+    const pf = await landPreflight(task({ repo: notARepo }))
+    expect(pf.refusal).toBe("UNREADABLE_BASE")
+  })
+
   test("base already on the task's branch refuses with SAME_BRANCH", async () => {
     branchOneAhead()
     git(["checkout", "feat"], repo)

--- a/packages/kobe/test/orchestrator/worktree-remove-partial.test.ts
+++ b/packages/kobe/test/orchestrator/worktree-remove-partial.test.ts
@@ -331,4 +331,30 @@ describe("remove() when the directory is already gone", () => {
     // The user-visible consequence: the branch is usable again.
     execSync("git branch -D vanish", { cwd: repo, env: gitEnv })
   })
+
+  it("still deletes the branch the caller asked to drop", async () => {
+    // The branch to delete is normally read out of the worktree, and that
+    // read needs the directory. With it gone `currentBranch` answered null,
+    // so `deleteBranch: true` deleted nothing and `delete --delete-branch`
+    // reported `removed` with the branch still sitting in `git branch`.
+    const wt = join(managedRoot, "vanished-br")
+    execSync(`git worktree add -q ${JSON.stringify(wt)} -b vanish-br`, { cwd: repo, env: gitEnv })
+    rmSync(wt, { recursive: true, force: true })
+
+    await manager.remove(wt, { repo, deleteBranch: true, branch: "vanish-br", force: true })
+
+    const branches = execSync("git branch --format='%(refname:short)'", { cwd: repo, env: gitEnv, encoding: "utf8" })
+    expect(branches.split("\n")).not.toContain("vanish-br")
+  })
+
+  it("without deleteBranch the branch survives, as it does everywhere else", async () => {
+    const wt = join(managedRoot, "vanished-keep")
+    execSync(`git worktree add -q ${JSON.stringify(wt)} -b keep-br`, { cwd: repo, env: gitEnv })
+    rmSync(wt, { recursive: true, force: true })
+
+    await manager.remove(wt, { repo, branch: "keep-br" })
+
+    const branches = execSync("git branch --format='%(refname:short)'", { cwd: repo, env: gitEnv, encoding: "utf8" })
+    expect(branches.split("\n")).toContain("keep-br")
+  })
 })


### PR DESCRIPTION
loop-r15 AQ. Five items, one subject: a git fact reported without being checked.

Every repro was run against a **real repo built and then damaged** — no git mocks.
Runner: `.scratch/loop-r15-aq/rv` (repo source, isolated home
`/private/tmp/rove-loop-r15-aq/home`, all six `ROVE_`/`KOBE_` vars assigned
inline). Fixtures: `.scratch/loop-r15-aq/repos/*` via `mkrepo.sh`.

Evidence (paths that survive this task's deletion):
`/private/tmp/rove-loop-r15-aq/evidence/EVIDENCE.md` + the PNGs beside it.

---

## C1 — `collect`'s ahead-count was measured against a branch sharing no history

**PASS:** the 1-commit task reports `ahead: 1`, `behind: 0`, a non-null `diff` —
matching the `--base-branch develop` control exactly; and a remote-less `trunk`
repo reports `baseRef: "trunk"`, not null.

`resolveBaseRef` walked `origin/HEAD → origin/main → origin/master → main →
master` and took the first ref that **resolved**, never asking whether it had
anything to do with the branch. Fixture `repos/stalemain`: an abandoned orphan
`main` beside the real base `develop`.

```
ground truth   git rev-list --count develop..HEAD  ->  1

BEFORE  {"baseRef":"main","ahead":5,"behind":1,"diff":null}
AFTER   {"baseRef":"develop","ahead":1,"behind":0,"diff":{"files":1,"insertions":1,"deletions":0}}
```

`ahead` is the number a fan-out coordinator picks winners on, and 5 reads as an
attempt that did more work. `diff: null` was the only tell — `git diff
main...HEAD` fails outright with no merge base — and it is the field nobody
reads.

Second case, `repos/trunkrepo` (default branch `trunk`, no remote):

```
BEFORE  {"baseRef":null,"ahead":null,"behind":null,"diff":null}
AFTER   {"baseRef":"trunk","ahead":1,"behind":0,"diff":{"files":1,"insertions":1,"deletions":0}}
control land --dry-run on the SAME task, unchanged: {"landedOn":"trunk","ahead":1}
```

Each candidate is now rejected unless `git merge-base <ref> HEAD` succeeds, and
when none survives the base falls back to the branch the base checkout is
actually on — read via `git worktree list --porcelain`, which is the same
question `landPreflight` asks. No third ladder was invented; `collect` and
`land` now answer about the same branch.

## C2 — an unborn base checkout reported itself detached

**PASS:** the refusal names the real condition; the detached control stays
`DETACHED_HEAD`.

`headOut.exitCode` was never read. On a repo with no commits, `git rev-parse
--abbrev-ref HEAD` exits **128** and prints the literal string `HEAD` on stdout,
so that string was parsed as a branch name.

```
base checkout's actual state (fixture repos/empty):
  git symbolic-ref --short HEAD   -> 'main'   exit 0
  git branch --show-current       -> 'main'   exit 0
  git rev-parse --abbrev-ref HEAD -> 'HEAD'   exit 128   (fatal on stderr)

BEFORE  refusal DETACHED_HEAD  landedOn ""
        "base checkout ... is in detached-HEAD state; check out a branch first"
AFTER   refusal UNBORN_BASE    landedOn "main"
        "base checkout ... is on 'main' but has no commits yet, so there is
         nothing to merge 'unborn-test' into; make the first commit there
         (or `git merge --ff-only unborn-test`) and land again"
```

Reading the exit code also splits `UNREADABLE_BASE` ("git could not read HEAD of
the base checkout — is it still a git repo?") out of the answer it used to share
with a real detach. Both controls green: a genuinely detached base checkout
(`repos/det`) still refuses `DETACHED_HEAD` with `landedOn: ""`, and an ordinary
repo still lands unrefused.

Two new refusal strings are mirrored into `kobe-daemon/contracts.ts`,
`verbs-lifecycle.ts` and `docs/API.md`.

## deleteBranch leak on a missing directory (folded in)

**PASS:** after `delete --force --delete-branch --wait`, the branch is gone from
`git branch`.

`currentBranch(worktreePath)` needs the directory. With it gone the read returned
null, so `deleteBranch: true` deleted nothing and the verb reported `removed`.
Threaded the way `RemoveOpts.repo` was in #874.

BEFORE was captured by checking out b12d31af1's `manager-remove.ts` +
`task-deletion.ts` into place and restarting the isolated daemon — one variable,
nothing else changed.

```
BEFORE (repos/brBEFORE)   {"queued":true,"status":"removed"}
                          git branch ->   brbefore-task      <- LEAKED
                                        * main
AFTER  (repos/brAFTER)    {"queued":true,"status":"removed"}
                          git branch -> * main               <- gone
                          git worktree list -> only the main checkout
```

**Found while reproducing, and deliberately not changed:** `--delete-branch`
*without* `--force` is `git branch -d`, which refuses an unmerged branch and
swallows the failure. That is identical on the directory-present path and is
pre-existing behavior, so it is not part of this change — but it is why my first
repro looked like it reproduced on both sides.

## D — the last `git stash` recommendation in the product

**PASS:** `grep -rn stash packages/kobe/src packages/kobe-daemon/src docs/`
returns only warnings *against* stashing plus `salvage.ts:12`'s explanation of
why `git stash create` is unusable. `check-i18n` green (834 keys × 2 locales).

`tasks.ts:83` (en) and `:274` (zh) told the user to stash inside a **managed task
worktree** — the one place every other surface forbids it, because the stash
stack lives in the repo's common dir and is shared by every linked worktree. Both
locales changed together; `sync-base.ts`'s comment quoting the same phrase went
with it.

Harness screenshots (`/harness` → xterm.js → PTY sidecar → real OpenTUI, port
base 5873, fixture task materialised with `ensure-worktree` then dirtied):

| | toast on the `SYNC_WORKTREE_DIRTY` outcome |
|---|---|
| BEFORE | `? Commit or stash the worktree's changes…` |
| AFTER | `? Commit the worktree's changes first, t…` |

`/private/tmp/rove-loop-r15-aq/evidence/before-sync-dirty.png` and
`after-sync-dirty.png` (plus `01-menu.png`, the row menu the action is reached
from). The toast truncates at the right pane's width in both — the differing
prefix is the whole change. The BEFORE frame has engine-pane redraw noise from
the fixture PTY replaying after the restart; the toast itself is clean.

## Batch E1 — two porcelain parsers, one claiming to be the other

**PASS:** `grep -n "porcelainPaths\|parseDirtyPaths" packages/kobe/src` → one
definition, two call sites.

The drift was real and the comment was wrong: `sync-base.ts` said "same shape as
landing's `porcelainPaths`" while filtering `length > 3` and dropping empties,
where landing's `slice(3)` on a short line yielded `""` and rendered it to the
user as a filename. As the brief noted, real `git status --porcelain` always
emits `XY <path>`, so this is a consolidation, not a bug fix — the careful
version survives, in `orchestrator/dirty-paths.ts`. Rename entries and quoted
paths are still unhandled in both, deliberately left alone (that changes
user-visible output on two error paths and wants its own change).

---

## Not fixed, and why

`core/base-ref-cache.ts` is the daemon's **separate** async/memoised copy of the
same ladder, feeding the sidebar's `↓N` drift chip. It has the same latent bug.
I did not change it: it reads ref *files* to avoid spawning on the 2-second tick
(its header documents 19 worktrees paying 75 processes per 5 minutes), so a
merge-base check there is a different change with a different cost, and its
surface is a UI chip that needs its own screenshots. Flagging rather than
half-doing it.

## Gates

```
repo-root bun run lint              clean (1441 files)
packages/kobe bun run typecheck     clean
packages/kobe bun run check-i18n    834 keys × 2 locales in sync
bun run test:fast                   453 files / 4499 tests passed
KOBE_INCLUDE_SOCKET=1 test:socket   100 files / 807 tests passed
```

Two pre-existing tests stubbed `rev-parse --abbrev-ref`; both now stub
`symbolic-ref`, which is what the preflight asks.

**Mutation-checked** — each new test proven load-bearing by restoring the old
code and watching it go red:

- `branch-signals`: old ladder back → `expected 'main' to be 'develop'`,
  `expected null to be 'trunk'`
- `land-preflight`: old `rev-parse` probe back → `expected 'DETACHED_HEAD' to be
  'UNBORN_BASE'`, `… to be 'UNREADABLE_BASE'`
- `worktree-remove-partial`: branch delete removed from the missing-dir path →
  `expected [ … ] to not include 'vanish-br'`

## Isolation

Real `~/.rove/tasks.json` mtime moved 1788532479 → 1788533223. Traced rather
than assumed, as instructed: the only `loop-r15-aq` strings in the real store are
this task's own briefing text and the branch name `set-branch` wrote, and the
14:47:03 write matches this task's own row `01M1PDFKT0BD6P8KRNG96448EJ`
(`worktreePath` = this worktree). No fixture path and no fixture task is in the
real store. Nothing was written outside `.scratch/loop-r15-aq/`,
`.scratch/opentui-visual-5873/` and `/private/tmp/rove-loop-r15-aq/`.
