### PR TITLE
perf: window the file tree, and name the Terminal's second commit per pty frame

### DIFF
--- a/.changeset/r14-am-render-costs.md
+++ b/.changeset/r14-am-render-costs.md
@@ -1,0 +1,11 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Window the file tree so a large worktree stops laying out every row
+
+Expanding a directory with thousands of files made every cursor move lay out
+the whole list. The file tree body now mounts only the rows the viewport can
+show, padded above and below so the scrollbar and cursor-follow still see the
+full list: on a 5000-file worktree that takes an opentui frame from 17.5ms to
+0.6ms and first paint from 155ms to 88ms.

--- a/packages/kobe/src/tui-react/panes/filetree/FileTree.tsx
+++ b/packages/kobe/src/tui-react/panes/filetree/FileTree.tsx
@@ -59,8 +59,8 @@ import { useTheme } from "../../context/theme"
 import { useT } from "../../i18n"
 import { useBindings } from "../../lib/keymap"
 import { useLatest } from "../../lib/use-latest"
-import { FileTreeHeaderView } from "./header-view"
 import { FileTreeBodyView } from "./body-view"
+import { FileTreeHeaderView } from "./header-view"
 
 /** Public props. */
 export type FileTreeProps = {

--- a/packages/kobe/src/tui-react/panes/filetree/FileTree.tsx
+++ b/packages/kobe/src/tui-react/panes/filetree/FileTree.tsx
@@ -19,10 +19,9 @@
  */
 
 import { errorMessage } from "@/lib/error-message"
-import type { ScrollBoxRenderable } from "@opentui/core"
 import { useTerminalDimensions } from "@opentui/react"
 import { readRoveEnv } from "@sma1lboy/kobe-daemon/compat-env"
-import { useCallback, useEffect, useMemo, useReducer, useRef, useState } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import {
   type GitScope,
   type StatusEntry,
@@ -39,7 +38,6 @@ import {
   computePathBudget,
   computeStatWidths,
   expandOrDescendAction,
-  followScrollTop,
   gitErrorIsRetryable,
   summarizeGitError,
   toggleDir,

--- a/packages/kobe/src/tui-react/panes/filetree/FileTree.tsx
+++ b/packages/kobe/src/tui-react/panes/filetree/FileTree.tsx
@@ -22,7 +22,7 @@ import { errorMessage } from "@/lib/error-message"
 import type { ScrollBoxRenderable } from "@opentui/core"
 import { useTerminalDimensions } from "@opentui/react"
 import { readRoveEnv } from "@sma1lboy/kobe-daemon/compat-env"
-import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { useCallback, useEffect, useMemo, useReducer, useRef, useState } from "react"
 import {
   type GitScope,
   type StatusEntry,
@@ -60,7 +60,7 @@ import { useT } from "../../i18n"
 import { useBindings } from "../../lib/keymap"
 import { useLatest } from "../../lib/use-latest"
 import { FileTreeHeaderView } from "./header-view"
-import { FileTreeRowView } from "./row-view"
+import { FileTreeBodyView } from "./body-view"
 
 /** Public props. */
 export type FileTreeProps = {
@@ -405,15 +405,6 @@ export function FileTree(props: FileTreeProps) {
     }),
   }))
 
-  // ---------- viewport follow ----------
-  const scrollRef = useRef<ScrollBoxRenderable | null>(null)
-  useEffect(() => {
-    const scroll = scrollRef.current
-    if (!scroll || rows.length === 0) return
-    const y = followScrollTop(scroll.scrollTop, scroll.viewport.height, cursorIndex)
-    if (y != null) scroll.scrollTo({ x: 0, y })
-  }, [cursorIndex, rows])
-
   // ---------- render ----------
   const loaded = (tab === "all" && allFiles != null) || (tab === "changes" && changes != null)
   return (
@@ -432,50 +423,17 @@ export function FileTree(props: FileTreeProps) {
         }
       />
 
-      {/* Body: scrollable list. Track + thumb both transparent → invisible
-         by default but still scrollable. */}
-      <scrollbox
-        ref={(r: ScrollBoxRenderable | null) => {
-          scrollRef.current = r
-        }}
-        flexGrow={1}
-        verticalScrollbarOptions={{ trackOptions: { foregroundColor: "transparent" } }}
-      >
-        {props.worktreePath == null ? (
-          <box paddingTop={1} paddingLeft={1}>
-            <text fg={theme.textMuted}>{t("files.empty.noTask")}</text>
-          </box>
-        ) : error != null ? (
-          <box paddingTop={1} paddingLeft={1} flexDirection="column" gap={0}>
-            <text fg={theme.error} wrapMode="word">
-              {summarizeGitError(error, t)}
-            </text>
-            {gitErrorIsRetryable(error) ? (
-              <text fg={theme.textMuted} wrapMode="word">
-                {t("files.error.retryHint")}
-              </text>
-            ) : null}
-          </box>
-        ) : rows.length === 0 && loaded ? (
-          <box paddingTop={1} paddingLeft={1}>
-            <text fg={theme.textMuted}>{tab === "all" ? t("files.empty.noFiles") : t("files.empty.noChanges")}</text>
-          </box>
-        ) : rows.length > 0 ? (
-          <box flexShrink={0} gap={0} paddingRight={1}>
-            {rows.map((row, index) => (
-              <FileTreeRowView
-                key={`${row.kind}:${row.path}`}
-                row={row}
-                index={index}
-                cursor={index === cursorIndex}
-                statWidths={statWidths}
-                pathBudget={pathBudget}
-                onActivate={handleRowActivate}
-              />
-            ))}
-          </box>
-        ) : null}
-      </scrollbox>
+      <FileTreeBodyView
+        rows={rows}
+        cursorIndex={cursorIndex}
+        statWidths={statWidths}
+        pathBudget={pathBudget}
+        onActivate={handleRowActivate}
+        worktreePath={props.worktreePath}
+        error={error}
+        loaded={loaded}
+        tab={tab}
+      />
 
       {/* Footer hint — shown only when a worktree is loaded so the
          "no task" placeholder stays clean. First use shows the fuller

--- a/packages/kobe/src/tui-react/panes/filetree/body-view.tsx
+++ b/packages/kobe/src/tui-react/panes/filetree/body-view.tsx
@@ -71,7 +71,6 @@ export function FileTreeBodyView(props: {
       // React detach and reattach on every render, and each pair costs an extra
       // commit of the whole pane.
       ref={setScrollEl}
-     
       flexGrow={1}
       verticalScrollbarOptions={{ trackOptions: { foregroundColor: "transparent" } }}
     >

--- a/packages/kobe/src/tui-react/panes/filetree/body-view.tsx
+++ b/packages/kobe/src/tui-react/panes/filetree/body-view.tsx
@@ -1,0 +1,121 @@
+/** @jsxImportSource @opentui/react */
+/**
+ * The file tree's scrolling body: the one scrollbox, its four states (no
+ * worktree / git error / empty / rows), and the viewport windowing that keeps
+ * a large tree cheap to draw.
+ *
+ * Split out of `FileTree.tsx` along the seam that file already names in its
+ * siblings (`header-view`, `row-view`): everything above owns the pane's
+ * state, git reads and keys; everything here owns the list and where it is
+ * scrolled to. Cursor position comes in as a prop — deciding which row the
+ * cursor is on stays with the pane, only following it with the viewport lives
+ * here.
+ */
+
+import type { ScrollBoxRenderable } from "@opentui/core"
+import { useEffect, useState } from "react"
+import type { StatWidths } from "../../../tui/panes/filetree/pane-core"
+import { followScrollTop, gitErrorIsRetryable, summarizeGitError } from "../../../tui/panes/filetree/pane-core"
+import type { Row } from "../../../tui/panes/filetree/rows"
+import { useTheme } from "../../context/theme"
+import { useT } from "../../i18n"
+import { FileTreeRowView } from "./row-view"
+import { useRowWindow } from "./use-row-window"
+
+export function FileTreeBodyView(props: {
+  readonly rows: readonly Row[]
+  readonly cursorIndex: number
+  readonly statWidths: StatWidths
+  readonly pathBudget: number
+  readonly onActivate: (row: Row, index: number) => void
+  /** `null` renders the "no task" placeholder instead of a list. */
+  readonly worktreePath: string | null
+  readonly error: string | null
+  /** The active tab's git read has landed — tells an empty list from a pending one. */
+  readonly loaded: boolean
+  readonly tab: "all" | "changes"
+}) {
+  const { theme } = useTheme()
+  const t = useT()
+  const { rows, cursorIndex } = props
+
+  // The scrollbox is held as STATE, not a ref: `useRowWindow` subscribes to
+  // its scrollbar, so it has to re-run when the element itself changes.
+  const [scrollEl, setScrollEl] = useState<ScrollBoxRenderable | null>(null)
+  // Only the rows the viewport can show are mounted; the rest are two spacer
+  // boxes that hold the content's height. See `use-row-window.ts` for why
+  // opentui's own culling does not already cover this.
+  const rowWindow = useRowWindow({ scrollEl, rowCount: rows.length })
+
+  // Follow the cursor, then re-read the position immediately: a jump longer
+  // than one viewport would otherwise leave the window that is no longer on
+  // screen mounted, and the pane blank until something else asks for a redraw.
+  //
+  // Keyed on `rows.length`, NOT on `rows`: that array has a fresh identity
+  // every render, and an effect that both re-runs every render and sets state
+  // is a render loop. Following only ever depends on where the cursor is and
+  // how tall the list is.
+  const rowCount = rows.length
+  const sample = rowWindow.sample
+  useEffect(() => {
+    if (!scrollEl || rowCount === 0) return
+    const y = followScrollTop(scrollEl.scrollTop, scrollEl.viewport.height, cursorIndex)
+    if (y != null) scrollEl.scrollTo({ x: 0, y })
+    sample()
+  }, [cursorIndex, rowCount, scrollEl, sample])
+
+  return (
+    // Track + thumb both transparent → invisible by default but still scrollable.
+    <scrollbox
+      // Stable setter, not an inline arrow: a fresh ref-callback identity makes
+      // React detach and reattach on every render, and each pair costs an extra
+      // commit of the whole pane.
+      ref={setScrollEl}
+     
+      flexGrow={1}
+      verticalScrollbarOptions={{ trackOptions: { foregroundColor: "transparent" } }}
+    >
+      {props.worktreePath == null ? (
+        <box paddingTop={1} paddingLeft={1}>
+          <text fg={theme.textMuted}>{t("files.empty.noTask")}</text>
+        </box>
+      ) : props.error != null ? (
+        <box paddingTop={1} paddingLeft={1} flexDirection="column" gap={0}>
+          <text fg={theme.error} wrapMode="word">
+            {summarizeGitError(props.error, t)}
+          </text>
+          {gitErrorIsRetryable(props.error) ? (
+            <text fg={theme.textMuted} wrapMode="word">
+              {t("files.error.retryHint")}
+            </text>
+          ) : null}
+        </box>
+      ) : rows.length === 0 && props.loaded ? (
+        <box paddingTop={1} paddingLeft={1}>
+          <text fg={theme.textMuted}>
+            {props.tab === "all" ? t("files.empty.noFiles") : t("files.empty.noChanges")}
+          </text>
+        </box>
+      ) : rows.length > 0 ? (
+        <box flexShrink={0} gap={0} paddingRight={1}>
+          {rowWindow.start > 0 ? <box flexShrink={0} height={rowWindow.start} /> : null}
+          {rows.slice(rowWindow.start, rowWindow.end).map((row, offset) => {
+            const index = rowWindow.start + offset
+            return (
+              <FileTreeRowView
+                key={`${row.kind}:${row.path}`}
+                row={row}
+                index={index}
+                cursor={index === cursorIndex}
+                statWidths={props.statWidths}
+                pathBudget={props.pathBudget}
+                onActivate={props.onActivate}
+              />
+            )
+          })}
+          {rows.length > rowWindow.end ? <box flexShrink={0} height={rows.length - rowWindow.end} /> : null}
+        </box>
+      ) : null}
+    </scrollbox>
+  )
+}

--- a/packages/kobe/src/tui-react/panes/filetree/row-window-range.ts
+++ b/packages/kobe/src/tui-react/panes/filetree/row-window-range.ts
@@ -1,0 +1,32 @@
+/**
+ * The pure half of file-tree row windowing: which row indices must be mounted
+ * for a viewport of `height` rows scrolled to `top`.
+ *
+ * Its own module, with no `@opentui/*` import, so the ONE property that makes
+ * windowing safe can be tested on the vitest track: the returned range always
+ * COVERS every row the viewport can show. A window that is merely too small
+ * makes the timing probe faster in exactly the same way a correct one does —
+ * coverage is what tells a speedup from silently dropped rows.
+ */
+
+/** Rows kept above and below the viewport so a one-line scroll never shows a gap. */
+const OVERSCAN = 16
+
+/** Rows rendered before the first layout has given the viewport a height. */
+export const PRE_LAYOUT_ROWS = 64
+
+export function rowWindowRange(top: number, height: number, rowCount: number): { start: number; end: number } {
+  if (rowCount <= 0) return { start: 0, end: 0 }
+  // Pre-layout: a bounded prefix, never nothing — an empty window here would
+  // paint a blank pane that only a later scroll could repair.
+  if (height <= 0) return { start: 0, end: Math.min(rowCount, PRE_LAYOUT_ROWS) }
+  const end = Math.min(rowCount, Math.ceil(top + height) + OVERSCAN)
+  // `start` is clamped INSIDE the list, not just at 0. A `top` past the end —
+  // which is what a list shrinking under a scrolled viewport looks like (tab
+  // switch, a directory collapsing, a git refresh dropping files) — otherwise
+  // gives start > end: an empty window AND a negative bottom-spacer height,
+  // i.e. a blank pane. `end - 1` keeps at least one row mounted whenever the
+  // list has one.
+  const start = Math.max(0, Math.min(Math.floor(top) - OVERSCAN, end - 1))
+  return { start, end }
+}

--- a/packages/kobe/src/tui-react/panes/filetree/use-row-window.ts
+++ b/packages/kobe/src/tui-react/panes/filetree/use-row-window.ts
@@ -1,0 +1,95 @@
+/**
+ * Windows a flat list of ONE-CELL rows down to the scrollbox viewport plus a
+ * small overscan.
+ *
+ * Its own file rather than more of `FileTree.tsx` because it is a different
+ * job from the tree: everything here reads the scrollbox's imperative layout
+ * state and turns it into a row range, and nothing here knows what a row is.
+ *
+ * Why it exists at all: opentui lays out every renderable under the scrollbox
+ * on every frame, whether or not the viewport can show it. `viewportCulling`
+ * (on by default) only skips the PAINT of off-screen children, and only for
+ * DIRECT children of the scrollbox content — a wrapper box holding the rows
+ * hides them from it entirely. Memoizing the rows removes the React half and
+ * leaves the layout: measured on this pane against one 5000-file directory,
+ * a `j` keystroke cost 24ms of wall time, 19.6ms of it opentui frame time,
+ * with every row mounted.
+ *
+ * The two spacer boxes the caller pads with keep the content's total height
+ * equal to `rowCount`, so the scrollbar thumb, `scrollTop`, and the pane's own
+ * cursor-follow arithmetic all still see the whole list.
+ *
+ * ROW HEIGHT IS ASSUMED TO BE 1. That holds for every FileTree row (each is a
+ * single `flexDirection="row"` box of `wrapMode="none"` text). A list with
+ * taller or variable rows cannot use this hook — the sidebar tree, whose
+ * project headers carry a pad row, is exactly that case.
+ *
+ * Measurement rides the renderer's frame event rather than a callback on the
+ * scrollbox, because the two events that would announce a change are both
+ * unavailable: the scrollbox installs its own `onSizeChange` on the viewport
+ * (passing one through `viewportOptions` REPLACES the bar recalculation), and
+ * the scrollbar's own change event fires only once a position actually moves,
+ * never for the first layout. Reading two numbers per drawn frame is cheaper
+ * than either workaround, and it means a scroll from any source — wheel, drag,
+ * keys, `scrollTo` — lands the same way. State is only set when a number
+ * really changed, so an idle pane re-renders nothing.
+ */
+
+import type { ScrollBoxRenderable } from "@opentui/core"
+import { useRenderer } from "@opentui/react"
+import { useCallback, useEffect, useState } from "react"
+
+/** Rows kept above and below the viewport so a one-line scroll never shows a gap. */
+const OVERSCAN = 16
+
+/** Rows rendered before the first layout has given the viewport a height. */
+const PRE_LAYOUT_ROWS = 64
+
+export interface RowWindow {
+  /** First row index to render. */
+  readonly start: number
+  /** One past the last row index to render. */
+  readonly end: number
+  /**
+   * Re-read the scroll position now. The caller MUST call this straight after
+   * moving the scroll itself: a jump of more than one viewport leaves the old
+   * window entirely off screen, and waiting for the next drawn frame to notice
+   * shows a blank pane — or leaves it blank for good, when that scroll was the
+   * last thing asking for a redraw.
+   */
+  readonly sample: () => void
+}
+
+export function useRowWindow(opts: {
+  /** The scrollbox element, as state — the hook re-reads when it changes. */
+  readonly scrollEl: ScrollBoxRenderable | null
+  readonly rowCount: number
+}): RowWindow {
+  const { scrollEl, rowCount } = opts
+  const renderer = useRenderer()
+  const [view, setView] = useState<{ top: number; height: number }>({ top: 0, height: 0 })
+
+  const sample = useCallback((): void => {
+    if (!scrollEl || scrollEl.isDestroyed) return
+    const top = scrollEl.scrollTop
+    const height = scrollEl.viewport.height
+    // Set-on-change only: this runs once per drawn frame and once per render of
+    // the owning pane, and an unconditional update from either would loop.
+    setView((cur) => (cur.top === top && cur.height === height ? cur : { top, height }))
+  }, [scrollEl])
+
+  useEffect(() => {
+    if (!renderer) return
+    sample()
+    renderer.on("frame", sample)
+    return () => {
+      renderer.off("frame", sample)
+    }
+  }, [renderer, sample])
+
+  if (rowCount === 0) return { start: 0, end: 0, sample }
+  if (view.height <= 0) return { start: 0, end: Math.min(rowCount, PRE_LAYOUT_ROWS), sample }
+  const start = Math.max(0, Math.floor(view.top) - OVERSCAN)
+  const end = Math.min(rowCount, Math.ceil(view.top + view.height) + OVERSCAN)
+  return { start, end: Math.max(start, end), sample }
+}

--- a/packages/kobe/src/tui-react/panes/filetree/use-row-window.ts
+++ b/packages/kobe/src/tui-react/panes/filetree/use-row-window.ts
@@ -38,12 +38,7 @@
 import type { ScrollBoxRenderable } from "@opentui/core"
 import { useRenderer } from "@opentui/react"
 import { useCallback, useEffect, useState } from "react"
-
-/** Rows kept above and below the viewport so a one-line scroll never shows a gap. */
-const OVERSCAN = 16
-
-/** Rows rendered before the first layout has given the viewport a height. */
-const PRE_LAYOUT_ROWS = 64
+import { rowWindowRange } from "./row-window-range"
 
 export interface RowWindow {
   /** First row index to render. */
@@ -87,9 +82,6 @@ export function useRowWindow(opts: {
     }
   }, [renderer, sample])
 
-  if (rowCount === 0) return { start: 0, end: 0, sample }
-  if (view.height <= 0) return { start: 0, end: Math.min(rowCount, PRE_LAYOUT_ROWS), sample }
-  const start = Math.max(0, Math.floor(view.top) - OVERSCAN)
-  const end = Math.min(rowCount, Math.ceil(view.top + view.height) + OVERSCAN)
-  return { start, end: Math.max(start, end), sample }
+  const { start, end } = rowWindowRange(view.top, view.height, rowCount)
+  return { start, end, sample }
 }

--- a/packages/kobe/src/tui-react/panes/terminal/Terminal.tsx
+++ b/packages/kobe/src/tui-react/panes/terminal/Terminal.tsx
@@ -408,6 +408,9 @@ export function Terminal(props: TerminalProps) {
         </box>
       ) : null}
 
+      {/* The inline arrow is load-bearing, not an oversight: it re-attaches on
+          every render, which is what re-runs the geometry measurement until
+          Yoga has laid the box out. See `use-terminal-geometry.ts`. */}
       <box ref={(r: BoxRenderable | null) => setBodyEl(r)} onSizeChange={bumpGeomTick} flexGrow={1} overflow="hidden">
         {/* Body */}
         {pty ? (
@@ -425,7 +428,14 @@ export function Terminal(props: TerminalProps) {
             fg={theme.text}
             wrapMode="none"
             selectable={false}
-            ref={(r: TextRenderable | null) => setSnapshotTextEl(r)}
+            // The stable state setter, NOT an inline arrow. A fresh ref-callback
+            // identity makes React detach (`setState(null)`) and reattach
+            // (`setState(el)`) on every render; here that re-ran the paint
+            // effect's imperative content push a second time per PTY frame.
+            // The body box below deliberately keeps its inline arrow — see
+            // `use-terminal-geometry.ts`, whose first measurement depends on
+            // exactly that re-attach.
+            ref={setSnapshotTextEl}
           />
         ) : (
           <box paddingLeft={1} paddingTop={1} flexDirection="column" gap={0}>

--- a/packages/kobe/src/tui-react/panes/terminal/Terminal.tsx
+++ b/packages/kobe/src/tui-react/panes/terminal/Terminal.tsx
@@ -411,7 +411,7 @@ export function Terminal(props: TerminalProps) {
       {/* The inline arrow is load-bearing, not an oversight: it re-attaches on
           every render, which is what re-runs the geometry measurement until
           Yoga has laid the box out. See `use-terminal-geometry.ts`. */}
-      <box ref={setBodyEl} onSizeChange={bumpGeomTick} flexGrow={1} overflow="hidden">
+      <box ref={(r: BoxRenderable | null) => setBodyEl(r)} onSizeChange={bumpGeomTick} flexGrow={1} overflow="hidden">
         {/* Body */}
         {pty ? (
           // One multi-line `<text>` for the whole snapshot (rows flattened

--- a/packages/kobe/src/tui-react/panes/terminal/Terminal.tsx
+++ b/packages/kobe/src/tui-react/panes/terminal/Terminal.tsx
@@ -428,14 +428,7 @@ export function Terminal(props: TerminalProps) {
             fg={theme.text}
             wrapMode="none"
             selectable={false}
-            // The stable state setter, NOT an inline arrow. A fresh ref-callback
-            // identity makes React detach (`setState(null)`) and reattach
-            // (`setState(el)`) on every render; here that re-ran the paint
-            // effect's imperative content push a second time per PTY frame.
-            // The body box below deliberately keeps its inline arrow — see
-            // `use-terminal-geometry.ts`, whose first measurement depends on
-            // exactly that re-attach.
-            ref={setSnapshotTextEl}
+            ref={(r: TextRenderable | null) => setSnapshotTextEl(r)}
           />
         ) : (
           <box paddingLeft={1} paddingTop={1} flexDirection="column" gap={0}>

--- a/packages/kobe/src/tui-react/panes/terminal/Terminal.tsx
+++ b/packages/kobe/src/tui-react/panes/terminal/Terminal.tsx
@@ -411,7 +411,7 @@ export function Terminal(props: TerminalProps) {
       {/* The inline arrow is load-bearing, not an oversight: it re-attaches on
           every render, which is what re-runs the geometry measurement until
           Yoga has laid the box out. See `use-terminal-geometry.ts`. */}
-      <box ref={(r: BoxRenderable | null) => setBodyEl(r)} onSizeChange={bumpGeomTick} flexGrow={1} overflow="hidden">
+      <box ref={setBodyEl} onSizeChange={bumpGeomTick} flexGrow={1} overflow="hidden">
         {/* Body */}
         {pty ? (
           // One multi-line `<text>` for the whole snapshot (rows flattened

--- a/packages/kobe/src/tui-react/panes/terminal/use-terminal-geometry.ts
+++ b/packages/kobe/src/tui-react/panes/terminal/use-terminal-geometry.ts
@@ -16,6 +16,17 @@
  * `bodyEl` MUST be React state (not a plain ref) — the measurement effect
  * needs to re-run the instant the box ref is attached, and a plain `useRef`
  * would silently skip that first measurement.
+ *
+ * The caller's ref callback for that box MUST also be an inline arrow rather
+ * than the stable `setBodyEl`. A fresh callback identity makes React detach
+ * and reattach on every render, and that re-attach is what re-runs this
+ * measurement after Yoga's first pass: when the ref first attaches the box
+ * still reports 0x0, and `onSizeChange` arrives from the renderer's own loop,
+ * after the mount has already settled. Stabilise that ref and a pane can
+ * settle with no geometry and therefore no PTY at all — measured as three
+ * Terminal render tests losing their PTY. A replacement that re-measures on
+ * the renderer's frame event, on a 0ms or 16ms timer, or via one forced
+ * post-mount render all land too late for the same reason.
  */
 
 import type { BoxRenderable } from "@opentui/core"

--- a/packages/kobe/src/tui-react/panes/terminal/use-terminal-paint.ts
+++ b/packages/kobe/src/tui-react/panes/terminal/use-terminal-paint.ts
@@ -13,6 +13,7 @@
 import type { TextRenderable } from "@opentui/core"
 import { StyledText } from "@opentui/core"
 import { useEffect, useMemo, useState } from "react"
+import { profileSpan, profileTick } from "../../../tui/lib/render-profile"
 import type { TerminalRow } from "../../../tui/panes/terminal/pty"
 import { rowsToStyledText } from "../../../tui/panes/terminal/sgr-to-text-chunk"
 import {
@@ -22,7 +23,6 @@ import {
   sealRowEndAttributes,
 } from "../../../tui/panes/terminal/terminal-render"
 import { type SelectionRange, overlaySelection } from "../../../tui/panes/terminal/terminal-selection"
-import { profileSpan, profileTick } from "../../../tui/lib/render-profile"
 
 export interface UseTerminalPaintOpts {
   readonly visibleRows: readonly TerminalRow[]
@@ -42,17 +42,21 @@ export interface UseTerminalPaintOpts {
 export function useTerminalPaint(opts: UseTerminalPaintOpts): (el: TextRenderable | null) => void {
   const { visibleRows, firstRow, cols, selection, paintMatches, cursor, focused, colors } = opts
 
-  const cursorRows = useMemo(() => profileSpan("overlay", () => {
-    const withSelection = overlaySelection(visibleRows, selection, firstRow, cols)
-    // Search hits paint OVER the selection: the two can coexist (a highlight
-    // survives until the next click), and the hit is what you are steering.
-    const withMatches = paintMatches(withSelection, firstRow, cols)
-    // While a selection is active, the synthetic cursor cell is hidden
-    // (tmux copy-mode behavior): cursor and selection share the same
-    // inverse styling, so a cursor sitting just past the selection read
-    // as the highlight overrunning by one blinking cell.
-    return overlayCursor(withMatches, focused && !selection ? cursor : null, colors)
-  }), [visibleRows, selection, firstRow, cols, paintMatches, cursor, focused, colors])
+  const cursorRows = useMemo(
+    () =>
+      profileSpan("overlay", () => {
+        const withSelection = overlaySelection(visibleRows, selection, firstRow, cols)
+        // Search hits paint OVER the selection: the two can coexist (a highlight
+        // survives until the next click), and the hit is what you are steering.
+        const withMatches = paintMatches(withSelection, firstRow, cols)
+        // While a selection is active, the synthetic cursor cell is hidden
+        // (tmux copy-mode behavior): cursor and selection share the same
+        // inverse styling, so a cursor sitting just past the selection read
+        // as the highlight overrunning by one blinking cell.
+        return overlayCursor(withMatches, focused && !selection ? cursor : null, colors)
+      }),
+    [visibleRows, selection, firstRow, cols, paintMatches, cursor, focused, colors],
+  )
 
   // Flatten every visible row into ONE `StyledText`. A single element (not
   // per-row `<text>`s) is what makes the cursor positioning math work: the

--- a/packages/kobe/src/tui-react/panes/terminal/use-terminal-paint.ts
+++ b/packages/kobe/src/tui-react/panes/terminal/use-terminal-paint.ts
@@ -22,6 +22,7 @@ import {
   sealRowEndAttributes,
 } from "../../../tui/panes/terminal/terminal-render"
 import { type SelectionRange, overlaySelection } from "../../../tui/panes/terminal/terminal-selection"
+import { profileSpan, profileTick } from "../../../tui/lib/render-profile"
 
 export interface UseTerminalPaintOpts {
   readonly visibleRows: readonly TerminalRow[]
@@ -41,7 +42,7 @@ export interface UseTerminalPaintOpts {
 export function useTerminalPaint(opts: UseTerminalPaintOpts): (el: TextRenderable | null) => void {
   const { visibleRows, firstRow, cols, selection, paintMatches, cursor, focused, colors } = opts
 
-  const cursorRows = useMemo(() => {
+  const cursorRows = useMemo(() => profileSpan("overlay", () => {
     const withSelection = overlaySelection(visibleRows, selection, firstRow, cols)
     // Search hits paint OVER the selection: the two can coexist (a highlight
     // survives until the next click), and the hit is what you are steering.
@@ -51,7 +52,7 @@ export function useTerminalPaint(opts: UseTerminalPaintOpts): (el: TextRenderabl
     // inverse styling, so a cursor sitting just past the selection read
     // as the highlight overrunning by one blinking cell.
     return overlayCursor(withMatches, focused && !selection ? cursor : null, colors)
-  }, [visibleRows, selection, firstRow, cols, paintMatches, cursor, focused, colors])
+  }), [visibleRows, selection, firstRow, cols, paintMatches, cursor, focused, colors])
 
   // Flatten every visible row into ONE `StyledText`. A single element (not
   // per-row `<text>`s) is what makes the cursor positioning math work: the
@@ -62,11 +63,15 @@ export function useTerminalPaint(opts: UseTerminalPaintOpts): (el: TextRenderabl
   // so a wrapped underlined URL underlines everything below it. Its doc
   // comment has the full mechanism; drop this call once opentui resets per
   // row.
-  const styledSnapshot = useMemo(() => {
-    const resolved = resolveInverseAttributes(cursorRows, colors.foreground, colors.background)
-    const sealed = sealRowEndAttributes(resolved, cols, colors.foreground, colors.background)
-    return new StyledText(rowsToStyledText(sealed))
-  }, [cursorRows, cols, colors])
+  const styledSnapshot = useMemo(
+    () =>
+      profileSpan("styled", () => {
+        const resolved = resolveInverseAttributes(cursorRows, colors.foreground, colors.background)
+        const sealed = sealRowEndAttributes(resolved, cols, colors.foreground, colors.background)
+        return new StyledText(rowsToStyledText(sealed))
+      }),
+    [cursorRows, cols, colors],
+  )
 
   // Imperative content push — opentui 0.4 won't accept StyledText as a
   // JSX child or through the content prop (stringifies it).
@@ -76,7 +81,10 @@ export function useTerminalPaint(opts: UseTerminalPaintOpts): (el: TextRenderabl
     // <text> unmounts, but its null ref lands a render AFTER this effect
     // re-runs with the stale element — writing to it throws "TextBuffer is
     // destroyed" into the error boundary.
-    if (snapshotTextEl && !snapshotTextEl.isDestroyed) snapshotTextEl.content = styledSnapshot
+    if (snapshotTextEl && !snapshotTextEl.isDestroyed) {
+      profileTick("push")
+      snapshotTextEl.content = styledSnapshot
+    }
   }, [snapshotTextEl, styledSnapshot])
 
   return setSnapshotTextEl

--- a/packages/kobe/src/tui/lib/render-profile.ts
+++ b/packages/kobe/src/tui/lib/render-profile.ts
@@ -1,0 +1,66 @@
+/**
+ * Env-gated counters + timers for the terminal streaming path.
+ *
+ * `ROVE_RENDER_PROFILE=<path>` turns it on and names a file to append JSON
+ * lines to, one per second. Off (the default) every call is a single boolean
+ * test — the whole point is to be able to leave it in a hot path.
+ *
+ * It writes to a FILE and never to stdout: stdout belongs to the renderer, and
+ * a stray line there corrupts the frame it is trying to measure.
+ *
+ * What it answers: how many times per second each stage of "PTY bytes → drawn
+ * frame" actually runs, and how long each takes. The stages are counted
+ * separately from the renderer's own frame rate precisely so the two can be
+ * compared — producing snapshots faster than they are drawn is invisible in
+ * any single-stage measurement.
+ */
+
+const target = process.env.ROVE_RENDER_PROFILE
+export const renderProfileOn = Boolean(target)
+
+const counts = new Map<string, number>()
+const totals = new Map<string, number>()
+let started = 0
+
+function flush(): void {
+  if (counts.size === 0) return
+  const row: Record<string, number> = { sec: Math.round((Date.now() - started) / 1000) }
+  for (const [k, n] of counts) {
+    row[`${k}_n`] = n
+    const ms = totals.get(k)
+    if (ms !== undefined) row[`${k}_ms`] = +ms.toFixed(3)
+  }
+  counts.clear()
+  totals.clear()
+  try {
+    // Late require: nothing here may load in a process that has the profile off.
+    require("node:fs").appendFileSync(target as string, `${JSON.stringify(row)}\n`)
+  } catch {
+    /* profiling must never take the TUI down */
+  }
+}
+
+if (renderProfileOn) {
+  started = Date.now()
+  const timer = setInterval(flush, 1000)
+  // Never hold the process open just to report on it.
+  ;(timer as unknown as { unref?: () => void }).unref?.()
+}
+
+/** Count one occurrence of `stage`. */
+export function profileTick(stage: string): void {
+  if (!renderProfileOn) return
+  counts.set(stage, (counts.get(stage) ?? 0) + 1)
+}
+
+/** Run `fn`, counting it and accumulating its wall time under `stage`. */
+export function profileSpan<T>(stage: string, fn: () => T): T {
+  if (!renderProfileOn) return fn()
+  const t0 = performance.now()
+  try {
+    return fn()
+  } finally {
+    counts.set(stage, (counts.get(stage) ?? 0) + 1)
+    totals.set(stage, (totals.get(stage) ?? 0) + (performance.now() - t0))
+  }
+}

--- a/packages/kobe/src/tui/panes/terminal/pty-xterm-base.ts
+++ b/packages/kobe/src/tui/panes/terminal/pty-xterm-base.ts
@@ -4,6 +4,7 @@
 import { Unicode11Addon } from "@xterm/addon-unicode11"
 import { Terminal as XtermHeadless } from "@xterm/headless"
 import { persistedScrollbackRows } from "../../../state/scrollback"
+import { profileSpan, profileTick } from "../../lib/render-profile"
 import { type TerminalInputModes, encodeMouseButton, encodeWheel } from "./keys-pure"
 import { PtyListeners } from "./pty-listeners"
 import {
@@ -17,7 +18,6 @@ import {
 } from "./pty-types"
 import { XtermSnapshotEngine } from "./pty-xterm-snapshot"
 import { XtermRefreshTracker, wireXtermChannels, wireXtermDefaultColorQueries } from "./xterm-refresh"
-import { profileSpan, profileTick } from "../../lib/render-profile"
 
 export abstract class XtermTaskPty implements TaskPtyLike {
   readonly taskId: string

--- a/packages/kobe/src/tui/panes/terminal/pty-xterm-base.ts
+++ b/packages/kobe/src/tui/panes/terminal/pty-xterm-base.ts
@@ -17,6 +17,7 @@ import {
 } from "./pty-types"
 import { XtermSnapshotEngine } from "./pty-xterm-snapshot"
 import { XtermRefreshTracker, wireXtermChannels, wireXtermDefaultColorQueries } from "./xterm-refresh"
+import { profileSpan, profileTick } from "../../lib/render-profile"
 
 export abstract class XtermTaskPty implements TaskPtyLike {
   readonly taskId: string
@@ -349,6 +350,7 @@ export abstract class XtermTaskPty implements TaskPtyLike {
   private feedInternal(data: string | Uint8Array, muteReplies: boolean): void {
     if (this._killed) return
     if (muteReplies) this.muteReplies = true
+    profileTick("feed")
     this.term.write(data, () => {
       if (muteReplies) this.muteReplies = false
       if (!this.refreshTracker.supported) this.refreshTracker.markAll()
@@ -373,14 +375,16 @@ export abstract class XtermTaskPty implements TaskPtyLike {
 
   private refreshSnapshot(): void {
     if (this._killed) return
-    const result = this.snapshotEngine.refresh(
-      this.term,
-      this.rows,
-      this.scrollbackRows,
-      this.refreshTracker,
-      this.snapshot,
-      this.cursor,
-      this.snapshotWindow,
+    const result = profileSpan("refresh", () =>
+      this.snapshotEngine.refresh(
+        this.term,
+        this.rows,
+        this.scrollbackRows,
+        this.refreshTracker,
+        this.snapshot,
+        this.cursor,
+        this.snapshotWindow,
+      ),
     )
     if (result === null) {
       // Don't snapshot a half-painted frame. Self-reschedule rather than
@@ -397,6 +401,7 @@ export abstract class XtermTaskPty implements TaskPtyLike {
   }
 
   private publishSnapshot(): void {
+    profileTick("publish")
     this.listeners.publishData(this.snapshot, this.cursor, this.snapshotWindow)
   }
 

--- a/packages/kobe/test/tui/row-window.test.ts
+++ b/packages/kobe/test/tui/row-window.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "vitest"
+import { rowWindowRange } from "../../src/tui-react/panes/filetree/row-window-range"
+
+/**
+ * The one property that makes windowing safe: the mounted range covers every
+ * row the viewport can show. A window that is simply too small still makes
+ * the timing probe faster — this is the check that tells that apart from a
+ * real speedup, so it is exhaustive rather than a few sampled cases.
+ */
+describe("rowWindowRange covers the viewport", () => {
+  test("every (top, height, rowCount) mounts every visible row", () => {
+    for (const rowCount of [0, 1, 2, 45, 100, 2000, 5000]) {
+      for (const height of [0, 1, 7, 45, 120]) {
+        for (const top of [0, 0.5, 1, 13, 44.25, 999, 4999, 6000]) {
+          const { start, end } = rowWindowRange(top, height, rowCount)
+          expect(start).toBeGreaterThanOrEqual(0)
+          expect(end).toBeGreaterThanOrEqual(start)
+          expect(end).toBeLessThanOrEqual(rowCount)
+          if (rowCount === 0 || height <= 0) continue
+          // Rows the viewport actually paints, clamped to the list.
+          const firstVisible = Math.max(0, Math.min(Math.floor(top), rowCount - 1))
+          const lastVisible = Math.max(0, Math.min(Math.ceil(top + height) - 1, rowCount - 1))
+          for (let row = firstVisible; row <= lastVisible; row++) {
+            expect(
+              row >= start && row < end,
+              `row ${row} visible at top=${top} height=${height} count=${rowCount} but window is [${start},${end})`,
+            ).toBe(true)
+          }
+        }
+      }
+    }
+  })
+
+  test("the last row is reachable when scrolled to the bottom", () => {
+    for (const rowCount of [46, 100, 2000, 5000]) {
+      const height = 45
+      const { start, end } = rowWindowRange(rowCount - height, height, rowCount)
+      expect(end).toBe(rowCount)
+      expect(start).toBeLessThanOrEqual(rowCount - height)
+    }
+  })
+
+  test("windows a big list down to near the viewport, not to the whole list", () => {
+    // The speedup itself: 5000 rows must not mount 5000 renderables.
+    const { start, end } = rowWindowRange(2500, 45, 5000)
+    expect(end - start).toBeLessThan(120)
+  })
+
+  test("before first layout it mounts a bounded prefix, never nothing", () => {
+    const { start, end } = rowWindowRange(0, 0, 5000)
+    expect(start).toBe(0)
+    expect(end).toBeGreaterThan(0)
+    expect(end).toBeLessThanOrEqual(64)
+  })
+})


### PR DESCRIPTION
Task AM of the R14 render round: R14-1, R14-2, R14-3, R14-5 (R14-4 left out).

Two of the four close as **measurements that refute their own brief's guess**,
so read the findings before the diff.

---

## R14-5 — `sealRowEndAttributes` is NOT stale. Keep it. ✅ closed

The brief allowed either deletion (if opentui had fixed the leak) or "a note
recording the reproduction that proves the workaround is still load-bearing".
It is the second.

Probe drives a **real `CliRenderer` with a captured stdout** and diffs the ANSI
it actually emits, seal on vs off. Row 0 = 20 underlined cells filling all
columns; row 1 = 20 plain cells.

| run | cells of row 1 emitted with underline still open |
| --- | --- |
| synthetic positive control | 3 (detector proven to fire) |
| **without seal** | **20 / 20 — LEAK** |
| with seal (production) | 0 / 20 |

The emitted bytes without seal — no `24`, no `0` between the rows:

```
\e[1;1H \e[38;2;0;0;0m \e[49m \e[4m UUUUUUUUUUUUUUUUUUUU
\e[2;1H \e[38;2;0;0;0m \e[49m pppppppppppppppppppp   <- drawn with \e[4m still open
```

`term-paint.ts` at 200×50 therefore stays at **0.160ms** total (seal =
0.1225ms = 77% of it). Reproduced the explorer's number; not reducing it.

**Two ways this nearly reported the opposite.** The first detector split SGR
params on `;` and read any `0` as a reset — in `\e[38;2;0;0;0m` those are the
RGB triplet, so a real leak came back `leak: false`, i.e. "stale, delete it".
An earlier run also reported clean off a **zero-byte** capture
(`bufferedOutput:"memory"` swallows the stream). A positive control and reading
the raw bytes caught both. `captureSpans()` cannot be used here at all: it
reads per-cell buffer attributes, and this bug is in the writer.

---

## R14-2 — mechanism attributed; the brief's hypothesis is wrong; fix withheld

Baseline reproduced: 60 pty frames → **120 React commits**.

The brief said "`setSnapshot` + `setCursor` are not landing in the same commit".
They are. The counters:

```
onDataCalls: 61          <- the pty publishes ONCE per frame
phaseCounts: { mount: 1, update: 61, "nested-update": 66 }
```

`nested-update` is React's phase for a state update **during the commit phase**.
The second commit is a ref callback, not an unbatched setState: the Terminal's
body `<box>` used an inline arrow `ref={(r) => setBodyEl(r)}`, so every render
handed React a fresh identity → detach + reattach during commit → a second full
commit of the whole Terminal subtree.

Stabilising that ref takes 120 → **60** commits and nested-updates 66 → **2**.

**That fix is not safe and I am not shipping it.** The re-attach is load-bearing
for `use-terminal-geometry.ts`: at first attach the box still reports 0×0, and
`onSizeChange` arrives after mount has settled. Full `test/render`, same machine:

| tree | pass | fail |
| --- | --- | --- |
| `origin/main` baseline | 474 | **0** |
| + stable body ref | 471 | **3** |

The three are two kitty-input tests and the multi-line-paste test — panes that
settle with no geometry and therefore no PTY. **All three pass when run alone**,
so the isolated run is the one that lies; only the `origin/main` baseline could
separate "my regression" from the known path-shape false failures in a
`~/.rove/worktrees` checkout.

So R14-2 becomes a named problem for the next round — give geometry a first
measurement that does not ride ref-callback identity — instead of a 66-commit
mystery. The `use-terminal-geometry.ts` header now records that a renderer
frame event, a 0ms/16ms timer, and one forced post-mount render all land too
late, so the next attempt does not re-walk those three.

---

## R14-3 — file tree body windowed; the invariant test caught a real bug in it

`FileTree.tsx`'s body (one scrollbox, its four states, and the cursor-follow
effect) moves to `body-view.tsx`, which mounts only the rows the viewport can
show plus a 16-row overscan and pads with two spacer boxes so the scrollbar,
`scrollTop` and cursor-follow arithmetic still see the whole list.

`useRowWindow` measures on the renderer's frame event, not a scrollbox
callback: the scrollbox installs its own `onSizeChange` on the viewport
(passing one through `viewportOptions` REPLACES the bar recalculation), and the
scrollbar's change event never fires for the first layout. State is only set
when a number actually changed, so an idle pane re-renders nothing.

**The correctness proof is separate from the timing, and it failed first.**
`rowWindowRange` is split into its own `@opentui`-free module so the covering
invariant runs on the vitest track, exhaustively over top × height × rowCount:
*every row the viewport can show is mounted.*

It caught a real bug in the first implementation. `end: Math.max(start, end)`
could push `end` **above** `rowCount` when `top` is past the end of the list —
for a 1-row list at `top=44.25` the window was `[28, 28)`: zero rows mounted
and a bottom spacer of height `1 - 28 = -27`. A blank pane, reachable whenever
a list shrinks under a scrolled viewport (tab switch, a directory collapsing, a
git refresh dropping files). `start` is now clamped inside the list.

That is the failure the brief warned about — it would have made every timing
number look better while showing nothing.

### Numbers, real component, 5000-file worktree

`probes/filetree.test.tsx` (the REAL `FileTree`, not the synthetic list),
`origin/main` vs this branch on the same machine and fixture:

| | mount to first rows | opentui ms/frame | wall ms per `j` |
| --- | --- | --- | --- |
| before (`origin/main`) | 155ms | **17.524** | 22.367 |
| after | **88ms** | **0.602** | 18.271 |

**29× on frame cost; mount 155 → 88ms** (brief's gate: ≤120ms). Windowing
confirmed engaged, not merely fast: instrumented, the pane mounts **61-65 rows
out of 5001**.

**Read the wall column with care — it is the misleading one.** It barely moves
(22.4 → 18.3) because `pressKey` + `await frame()` is bounded by the renderer's
target FPS, not by what the frame costs. It is also not comparable to the
explorer's synthetic `totalPerFrame_ms`, which is a sum of two stats rather
than wall time. Taken alone it would have read as "windowing did almost
nothing" while frame cost fell 29×.

For reference the synthetic ceiling reproduces exactly as the explorer
reported — `rows.test.tsx` at `ROWCOUNT=5000`: 35.197ms → 0.853ms.

---

## R14-1 — instrumentation, and what it actually found

`src/tui/lib/render-profile.ts`: env-gated (`ROVE_RENDER_PROFILE=<path>`)
counters and timers wired at six stages of "PTY bytes → drawn frame" —
`feed`, `refresh`, `publish`, `overlay`, `styled`, `push`. Off, every call is
one boolean test. It appends JSON lines to a **file**, never stdout, because
stdout belongs to the renderer and a stray line there corrupts the frame it is
trying to measure.

**What it found: the Terminal subtree commits twice per pty frame**, so two
rows of the explorer's accounted table are costed at half their true rate —
"React commit 0.8%" and "opentui layout+paint 0.9%" are each ~2×. That is
roughly **2 of the ~9 unaccounted points**, and it is a re-costing of rows
already in the table rather than a new row.

**A second candidate was measured and REFUTED — mine.** I believed the
snapshot `<text>`'s inline arrow ref made the imperative content push run
twice per frame, and had written that into a code comment before measuring
it. The profiler says otherwise: `push_n` tracks `styled_n` one-for-one with
the inline ref (53/53, 54/54, 55/55) and equally without it. One push per pty
frame either way. The change had no measured effect, so it is **not in this
PR** and the comment asserting it is gone.

Sample output, 50 lines/s (`ROVE_RENDER_PROFILE=/tmp/p.jsonl`):

```
{"sec":1,"overlay_n":53,"overlay_ms":0.198,"styled_n":53,"styled_ms":6.923,"push_n":49}
{"sec":2,"overlay_n":54,"overlay_ms":0.220,"styled_n":54,"styled_ms":6.150,"push_n":54}
{"sec":3,"overlay_n":55,"overlay_ms":0.156,"styled_n":55,"styled_ms":5.346,"push_n":55}
```

`styled` (resolve + seal + `rowsToStyledText`) is ~35× `overlay` — independent
corroboration of R14-5's split from a different probe. `feed`/`refresh`/
`publish` are absent here only because this probe drives the scripted pty
registry, so `pty-xterm-base.ts` is not on the path.

**The gap is not closed, and I am not claiming a CPU number.** I did not get
`probes/cpu.ts` running end-to-end against a live fixture, so there is no
measured 13.7% → X%. The commit counts and per-stage numbers above are real and
re-measurable with the probes named; the CPU claim is not made.

The explorer's own two candidates remain the best untested leads, and nothing
here refutes them:
1. `pty-xterm-base.ts` coalesces at `setTimeout(…, 16)` = 62.5Hz against a
   renderer at `targetFps` 30 — up to half of every snapshot+paint pass is
   produced for a frame that is never drawn.
2. `refresh` walks viewport + full scrollback (1050 rows at the default
   1000-row scrollback) on every refresh.

Note for whoever takes them: `probes/cpu.ts` hardcoded the explorer's own
checkout path, so a worker running it from a worktree measures the operator's
fixture or dies on a missing `env.json` while believing it is isolated.
