### PR TITLE
perf: stop every CLI command from loading the TUI, and coalesce pty snapshots at the renderer's frame period

### DIFF
--- a/.changeset/r15-as-cold-start-and-coalesce.md
+++ b/.changeset/r15-as-cold-start-and-coalesce.md
@@ -1,0 +1,24 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Stop every CLI command from loading the whole TUI before it can answer
+
+`src/cli/index.ts` already imported the heavy subcommands lazily, but the
+production build inlined every `await import()` into one 2.7MB file, so
+`rove --version` and each `rove api` verb evaluated the TUI, opentui and React
+first. The bundle is now code-split — `dist/cli/rove-run.js` is 347 bytes over
+141 chunks loaded on demand — taking `--version` from 174ms to 45ms and
+`rove api list` from 173ms to 46ms (medians of 7; the Bun startup floor is
+35ms). Launching the TUI is barely affected, since it does reach those modules.
+
+Splitting was blocked by `src/product.ts` being a re-export barrel, which makes
+Bun 1.3.14 emit two chunks for it and fail the build; it now rebinds its exports
+one at a time, with a comment saying why it must stay that way.
+
+Also match the terminal's snapshot coalescing to the renderer's frame period
+(16ms to 33ms). At 30fps a snapshot built more often than every 33ms is
+committed and laid out for a frame that is never drawn: a pane streaming
+200 lines/s built 49 snapshots a second and dropped ~40% of them, and now costs
+12.0% of a core instead of 14.7%. Output slower than ~30 lines a second, which
+is most engine output, is unchanged.

--- a/packages/kobe/scripts/build.ts
+++ b/packages/kobe/scripts/build.ts
@@ -33,6 +33,7 @@ import { chmod, cp, mkdir, rm } from "node:fs/promises"
 /** Both published bin names; each gets a launcher + the Bun bundle behind it. */
 const CLI_NAMES = ["kobe", "rove"] as const
 const OUT_FILES = CLI_NAMES.flatMap((name) => [`./dist/cli/${name}.js`, `./dist/cli/${name}-run.js`])
+const CLI_OUT_DIR = "./dist/cli"
 /** Canonical skill source (repo root) → its home in the tarball. */
 const SKILL_SRC_DIR = "../../.agents/skills/kobe"
 const SKILL_OUT_DIR = "./dist/skills/rove"
@@ -90,6 +91,13 @@ async function copySkill(): Promise<void> {
 }
 
 await buildWebUi()
+
+// Empty dist/cli before the CLI build, for the same reason copyWebUi() empties
+// dist/web-ui: splitting names chunks by content hash, so every build whose
+// sources changed leaves its predecessor's chunks behind and they ship in the
+// npm tarball forever. Everything in here is regenerated below.
+await rm(CLI_OUT_DIR, { recursive: true, force: true })
+await mkdir(CLI_OUT_DIR, { recursive: true })
 
 const result = await Bun.build({
   entrypoints: ["./src/cli/index.ts", "./src/cli/kobe.ts", "./src/cli/rove.ts"],

--- a/packages/kobe/scripts/build.ts
+++ b/packages/kobe/scripts/build.ts
@@ -97,6 +97,15 @@ const result = await Bun.build({
   root: "./src",
   target: "bun",
   conditions: ["browser"],
+  // Without this every `await import()` in src/cli is inlined into one 2.7MB
+  // file, so `rove --version` and every `rove api` verb evaluate the TUI,
+  // opentui and React before they can answer. The laziness is already written
+  // in src/cli/index.ts; splitting is what makes the build honour it.
+  // Chunks are named into `cli/` because package.json `files` ships
+  // `dist/cli`, not `dist` — a chunk emitted at the dist root is absent from
+  // the tarball and the published CLI dies on the first dynamic import.
+  splitting: true,
+  naming: { chunk: "cli/chunk-[hash].[ext]" },
   // Keep native/runtime-resolved packages external. @opentui/core loads
   // @opentui/core-${platform}-${arch} dynamically; bundling core moves
   // that dynamic import into dist/index.js, where Bun can no longer

--- a/packages/kobe/src/product.ts
+++ b/packages/kobe/src/product.ts
@@ -1,20 +1,18 @@
 /** Stable names used while the product moves from kobe to rove. */
-import {
-  LEGACY_KOBE_CONFIG_DIR_BASENAME,
-  LEGACY_KOBE_PRODUCT_NAME,
-  LEGACY_KOBE_STATE_DIR_BASENAME,
-  ROVE_CONFIG_DIR_BASENAME,
-  ROVE_PRODUCT_NAME,
-  ROVE_STATE_DIR_BASENAME,
-} from "@sma1lboy/kobe-daemon/compat-env"
+import * as compatEnv from "@sma1lboy/kobe-daemon/compat-env"
 
-export {
-  LEGACY_KOBE_CONFIG_DIR_BASENAME,
-  LEGACY_KOBE_PRODUCT_NAME,
-  LEGACY_KOBE_STATE_DIR_BASENAME,
-  ROVE_CONFIG_DIR_BASENAME,
-  ROVE_PRODUCT_NAME,
-  ROVE_STATE_DIR_BASENAME,
-}
+// Re-bound one at a time, deliberately, instead of the shorter
+// `import { X } from …; export { X }`. That barrel form makes Bun 1.3.14's
+// bundler emit two chunks for this module and fail the whole build with
+// "Multiple files share the same output path" the moment `splitting` is on
+// (scripts/build.ts) — and splitting is what keeps `rove --version` and the
+// `api` verbs from evaluating the TUI. Collapsing this back into a re-export
+// takes cold start from ~65ms to ~150ms via a red build, not a slow one.
+export const LEGACY_KOBE_CONFIG_DIR_BASENAME = compatEnv.LEGACY_KOBE_CONFIG_DIR_BASENAME
+export const LEGACY_KOBE_PRODUCT_NAME = compatEnv.LEGACY_KOBE_PRODUCT_NAME
+export const LEGACY_KOBE_STATE_DIR_BASENAME = compatEnv.LEGACY_KOBE_STATE_DIR_BASENAME
+export const ROVE_CONFIG_DIR_BASENAME = compatEnv.ROVE_CONFIG_DIR_BASENAME
+export const ROVE_PRODUCT_NAME = compatEnv.ROVE_PRODUCT_NAME
+export const ROVE_STATE_DIR_BASENAME = compatEnv.ROVE_STATE_DIR_BASENAME
 
 export type ProductCliName = typeof ROVE_PRODUCT_NAME | typeof LEGACY_KOBE_PRODUCT_NAME

--- a/packages/kobe/src/tui/panes/terminal/pty-xterm-base.ts
+++ b/packages/kobe/src/tui/panes/terminal/pty-xterm-base.ts
@@ -19,6 +19,25 @@ import {
 import { XtermSnapshotEngine } from "./pty-xterm-snapshot"
 import { XtermRefreshTracker, wireXtermChannels, wireXtermDefaultColorQueries } from "./xterm-refresh"
 
+/**
+ * How long a burst of PTY output is coalesced before one snapshot is built.
+ *
+ * This is the renderer's frame period, not a guess. `createCliRenderer` runs
+ * at `targetFps` 30 (src/tui/lib/host-render-options.ts sets no override, and
+ * `snapshot-coalesce.test.tsx` reads 30 off a live renderer), so a snapshot
+ * produced more often than every 33ms is built, published, committed through
+ * React and laid out by opentui for a frame that is then never drawn.
+ *
+ * It used to be 16ms — 62.5Hz against a 30Hz renderer. Measured on a pane
+ * streaming 200 lines/s at 200x50: 49 refreshes/s where the renderer drew 30,
+ * so ~40% of the whole snapshot→paint pass was discarded work.
+ *
+ * Raising it costs no visible latency: the extra snapshots were never on
+ * screen. It must not exceed the frame period either, or output visibly lags
+ * the renderer — hence the test that pins it to the live `targetFps`.
+ */
+export const SNAPSHOT_COALESCE_MS = 33
+
 export abstract class XtermTaskPty implements TaskPtyLike {
   readonly taskId: string
   readonly cwd: string
@@ -370,7 +389,7 @@ export abstract class XtermTaskPty implements TaskPtyLike {
     setTimeout(() => {
       this.refreshQueued = false
       this.refreshSnapshot()
-    }, 16)
+    }, SNAPSHOT_COALESCE_MS)
   }
 
   private refreshSnapshot(): void {

--- a/packages/kobe/test/render/snapshot-coalesce.test.tsx
+++ b/packages/kobe/test/render/snapshot-coalesce.test.tsx
@@ -1,0 +1,29 @@
+/**
+ * The PTY snapshot coalesce window must stay pinned to the renderer's frame
+ * period. Nothing else checks this: the constant and `targetFps` live in
+ * different layers, and drift between them is silent — too small and every
+ * extra snapshot is built, committed and laid out for a frame that is never
+ * drawn (the state this test was written to stop returning to); too large and
+ * terminal output visibly lags the renderer.
+ *
+ * `targetFps` is read off a LIVE renderer rather than asserted as a literal,
+ * so an opentui default change fails here instead of quietly re-inflating the
+ * streaming path.
+ */
+import { expect, test } from "bun:test"
+import { testRender } from "@opentui/react/test-utils"
+import { SNAPSHOT_COALESCE_MS } from "../../src/tui/panes/terminal/pty-xterm-base"
+
+test("snapshot coalesce window matches the renderer's frame period", async () => {
+  const t = await testRender(
+    <box>
+      <text>fps</text>
+    </box>,
+    { width: 20, height: 5 },
+  )
+  const targetFps = (t.renderer as unknown as { targetFps: number }).targetFps
+  expect(targetFps).toBeGreaterThan(0)
+  // Round, not equal: 1000/30 is 33.33 and the timer takes whole ms.
+  expect(SNAPSHOT_COALESCE_MS).toBe(Math.round(1000 / targetFps))
+  await (t as unknown as { destroy?: () => Promise<void> }).destroy?.()
+})


### PR DESCRIPTION
Task AS: R14-4 (cold start) and the remainder of R14-1 (the streaming
terminal's unaccounted CPU), picked up from #876.

Read the two "NOT met" sections before the numbers. One of the two fixes here
does nothing at the rate the brief measures, and neither of R14-1's PASS gates
is met — I am reporting that rather than dressing it up.

Evidence lives OUTSIDE `.scratch/` so it survives this worktree being deleted:
- `/Users/jacksonc/i/loop-r15-as/data/r14-4-coldstart.md`
- `/Users/jacksonc/i/loop-r15-as/data/r14-1-streaming.md`
- `/Users/jacksonc/i/loop-r15-as/probes/` (the fixed probes)
- `/Users/jacksonc/i/loop-r15-as/data/*.jsonl` (raw render-profile output)

No screenshots: neither change alters what is drawn, only when and how often.

---

## First, the landmine from #876 — fixed

> `probes/cpu.ts` hardcoded the explorer's own checkout path, so a worker
> running it from a worktree measures the operator's fixture or dies on a
> missing `env.json` while believing it is isolated.

`ptyrecv.ts` and `frames.ts` had the identical line, so this is fixed once at
the seam: `probes/fixture-root.ts` resolves the fixture from the probe's own
location, and **refuses to guess** — no `env.json`, no run, instead of falling
back to somebody else's checkout. Every number below comes from this worktree's
own fixture (port base 7411, 20 tasks, 200x50).

---

## R14-4 — cold start. PASS on `--version`, MISS on boot.

**PASS criterion:** `rove --version` median of 7 <= 90ms, and
`bootToFirstFrameMs` <= 150ms.

### Root cause, named

`Bun.build` without `splitting` **inlines every `await import()`** into one
file. `dist/cli/rove-run.js` was 2,756,587 bytes and all of it was evaluated
before `--version` could answer. The laziness in `src/cli/index.ts` and
`index-commands.ts` is real in source and was erased at build time — the
shipped bundle kept only `import("fs")`, `import("path")`, `import("ws")`,
none of them ours.

I measured the prize before engineering anything: a bundle containing only what
`--version` needs is 7,931 bytes and runs in 40ms, against 149ms for the real
one. Bun's own startup floor is 35ms.

### The blocker, and why `src/product.ts` changed

`splitting: true` failed the build outright:

```
error: Multiple files share the same output path ./chunk-<hash>.js
  from input src/product.ts
```

Splitting itself works in Bun 1.3.14 (positive control: a three-module toy
project splits fine), so it was our graph. `src/product.ts` was a pure
re-export barrel; rebinding through `import * as` + `export const` makes the
split build succeed. That is the entire blocker, and the file now carries a
comment saying so — collapsing it back into a barrel does not slow the build
down, it turns it red.

Chunks are named into `cli/` because `package.json` `files` ships `dist/cli`,
not `dist`; a chunk emitted at the dist root is absent from the tarball and the
published CLI dies on its first dynamic import.

### Numbers — median of 7, same machine, same session

| command | before | after |
| --- | --- | --- |
| `rove --version` | 174ms | **45ms** |
| `rove --help` | 170ms | 47ms |
| `rove api schema` | 175ms | 49ms |
| `rove api list` | 173ms | 46ms |
| `rove completions bash` | 168ms | 44ms |
| `rove statsu` (error path) | 169ms | 47ms |

`dist/cli/rove-run.js`: 2,756,587 -> **347 bytes**, rest in 138 chunks loaded
on demand. Gate was 90ms; `--version` is 45ms.

### Correctness, separated from the speedup

A split bundle either resolves its chunks or it does not, so this is checked
against a rebuilt pre-split `dist`, not against my memory of it. All 13 CLI
surfaces byte-identical, exit codes identical: `--version`, `--help`, `--skill`,
`statsu`, `api schema`, `api list`, `add/adopt/remove/repo/doctor/config --help`,
`completions bash`.

And because "works from `dist/`" is not "works when installed", `npm pack` +
extract + run from the tarball, on **both** launcher paths:

```
=== packed CLI, bun path ===
--version : rove 0.9.129     api schema: {"apiVersion":2,...
=== packed CLI, NODE launcher path (npm i -g / npx shape) ===
rove 0.9.129
=== timing from the packed tarball (median of 7) ===  48 ms
```
141 chunks present in the tarball, `rove-run.js` included.

### NOT met: `bootToFirstFrameMs`

Same fixture, `probes/cpu.ts`:

| | runs | |
| --- | --- | --- |
| before | 405 (cold), 190, 195 | ~192ms |
| after | 175, 178, 188 | ~178ms |

**~14ms. The <= 150ms gate is NOT met and I am not claiming it.** The reason is
structural: the TUI eventually reaches almost every module it defers, so
splitting only removes what the TUI never touches (`api-cmd`, `doctor`,
`plugin`, `export`). The win is real for every non-TUI invocation — which is
every `rove api` call an agent makes — and small for boot. Making boot itself
cheaper is a different job: the modules the first paint needs are genuinely
needed.

### One problem this change introduced, and fixed

Hashed chunk names accumulate: a rebuild whose sources changed left the previous
build's chunks in `dist/cli` (I hit 212 chunks where a clean build makes 138),
and they would ship in the tarball forever. `build.ts` empties `dist/cli` first
now — the same treatment `copyWebUi()` already applies to `dist/web-ui`, two
functions above, for exactly this reason. Verified: clean build 138, rebuild
after a source change 138.

---

## R14-1 remainder — one lead confirmed, one ruled out, gap NOT closed

**PASS criterion:** TUI CPU <= 9% at 50 lines/s (from 13.7%); *or*, failing
that, a six-stage breakdown summing to within 2 points of measured. **Neither
is met.** Details below.

### The renderer's frame period, read off a live renderer

`{"targetFps":30,"_targetFps":30,"frameMs":33.33}` — not taken on trust from
the brief.

### Lead 1: the 16ms coalesce — CONFIRMED, but only above ~30 pty frames/s

The 16ms timer is a **ceiling** (62.5Hz), not a rate. What actually happens
depends on how fast the pty delivers, which the brief's framing did not
separate:

| spam rate | pty feed/s | refresh/s (16ms) | renderer draws/s | wasted |
| --- | --- | --- | --- | --- |
| 50 lines/s | ~24 | ~24 | 30 | **none** — arrival is the limiter |
| 200 lines/s | ~50 | ~49 | 30 | ~40% |
| unthrottled | ~72 | ~37 | 30 | ~19% |

`SNAPSHOT_COALESCE_MS` 16 -> 33. Coalesce constant is the **only** delta
between these columns (same split `dist`, same fixture, same session):

| rate | metric | before (16ms) | after (33ms) |
| --- | --- | --- | --- |
| 200 lines/s | refresh/s | 49.0 49.2 49.3 48.7 | 23.9 24.8 24.8 23.4 |
| 200 lines/s | **TUI CPU** | 14.53 14.82 14.33 15.02 (med **14.68**) | 12.32 11.89 11.83 12.14 (med **12.02**) |
| 50 lines/s | refresh/s | 24.3 24.2 24.7 | 23.7 23.7 23.8 |
| 50 lines/s | **TUI CPU** | 11.52 11.77 11.46 (med **11.52**) | 11.59 11.28 11.52 (med **11.52**) |

**At the brief's headline rate this fix does nothing.** It is worth ~2.7 points
of a core only when an engine bursts — a build log, a test run, a large file
dump. It is still worth shipping (strictly less discarded work, no visible
latency: the extra snapshots were never drawn), but the <= 9% gate is not met
and I am not claiming it.

Guarded rather than merely commented: `test/render/snapshot-coalesce.test.tsx`
pins the constant to a **live** renderer's `targetFps`, so opentui changing its
default fails here instead of silently re-inflating the path. Mutation-tested in
both directions — 16 -> `Expected: 33 / Received: 16`, 50 -> fail, 33 -> pass. A
guard never shown to fire proves nothing.

### Lead 2: `refresh` walks viewport + full scrollback — RULED OUT as the missing points

It is real and it does scale as predicted. In the live TUI, `refresh_ms` climbs
`3.79 -> 3.79 -> 3.86 -> 7.04 -> 8.04 -> 8.66 -> 9.32` ms/s over the first
seconds as the 1000-row scrollback fills; `snap-bench` confirms
`snapshotRows: 1050`, `refresh_afterNewLine: 0.3674ms`.

**But the absolute size rules it out.** 0.33ms x ~24 frames/s = **0.80% of a
core**. Capping the snapshot to the viewport wins at most ~0.4 of the ~5.8
points that are missing, against real risk to scroll and search correctness.
Not done, deliberately — recorded here so the next round does not re-measure it.

### The six-stage breakdown — sums to 5.68% against 11.52% measured

50 lines/s, ~24.5 pty frames/s, 200x50, every stage measured on this machine:

| stage | probe | % of a core |
| --- | --- | --- |
| socket + JSON + base64 | `ptyrecv` EMULATE=0 | 1.67 |
| xterm emulator | `ptyrecv` EMULATE=1 (2.49) minus above | 0.82 |
| `XtermSnapshotEngine.refresh` | render-profile, live TUI | 0.80 |
| overlay + styled (paint pipeline) | render-profile, live TUI | 0.15 |
| React commit, Terminal subtree | `termreact` (0.424 ms/pty frame) | 1.04 |
| opentui layout+paint | `fullscreen` (0.397 ms/frame @30fps) | 1.20 |
| **accounted** | | **5.68** |
| **measured** | `cpu.ts` | **11.52** |

**~5.8 points still unattributed — the alternate PASS is not met either.** What
this does establish is where the cost is *not*: transport, emulator, refresh and
the paint pipeline are each bounded and small, and lead 2 is far too small to be
the answer. Both of the explorer's candidates are now closed as explanations for
the gap.

Left for whoever takes it, none of them measured by me: GC pressure from
allocating a 1050-row snapshot array ~24x/s; opentui laying out the **whole**
tree (sidebar, tab strip, status bar) per frame rather than the terminal's
10,000 cells that `fullscreen.test.tsx` isolates in a bare renderer; and the
renderer's own fixed per-frame cost at 30fps.

---

## Gates

| gate | result |
| --- | --- |
| repo-root `bun run lint` | clean, 1437 files |
| `bun run typecheck` | all 4 packages exit 0 |
| `bun test test/render` | **475 pass, 0 fail** (474 baseline + the new guard) |
| `bun run test:fast` (vitest) | **4503 pass, 0 fail**, 454 files |
| `KOBE_INCLUDE_SOCKET=1 bun run test:socket` | **807 pass, 0 fail**, 100 files |
| `npm pack` + run from tarball | both launcher paths OK, 141 chunks shipped |

Rebased onto `origin/main` (0.9.131) and rebuilt after; `--version` 50ms there.

## For the reviewer

- `build.ts` emptying `dist/cli` deletes generated output only, mirroring the
  existing `copyWebUi()` precedent in the same file. Say the word and I will
  drop it — it is separable from the split itself.
- No new or moved keybinding chords.
- No file crossed 500 lines: `pty-xterm-base.ts` 455 -> 473, `build.ts` 178 -> 191.
