### PR TITLE
fix: teach the foreground walk about contrib and plugin engines

### DIFF
--- a/.changeset/contrib-engine-foreground-walk.md
+++ b/.changeset/contrib-engine-foreground-walk.md
@@ -1,0 +1,15 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Fix contrib and plugin engines reading as "no engine is running". The
+process-tree walk that answers "which engine is live in this tab" only ever
+asked about the four built-ins, so a working Gemini CLI, OpenCode, Cursor
+Agent, Grok, Droid, Amp, or plugin engine got the *confirmed-absent* answer
+rather than an unrecognised one. Five surfaces acted on it: the daemon wrote a
+positive `rest` observation over a working engine every walk tick (and never
+recorded its death), the TUI attached no turn detector so the contrib screen
+manifests were never evaluated, a live engine tab was relabelled `shell N` with
+its title discarded, and `rove api get-task`'s `.tabs[].liveVendor` reported
+`null`. The walk now asks about every engine id the registry can name without
+reading state.

--- a/docs/design/engine-internals.md
+++ b/docs/design/engine-internals.md
@@ -159,9 +159,20 @@ merged hook-wins (`src/tui/workspace/turn-state-merge.ts`):
    covers hook-less or untrusted sessions of hook-capable engines.
 3. **Quiescence/mtime fallback** — for engines with no markers (copilot) the
    daemon watches the latest transcript mtime; a session that goes quiet
-   reads as done. Custom engines resolve to an empty history reader, so their
-   badge stays dark. Rove labels the gap honestly rather than guessing state
-   from screen scraping.
+   reads as done.
+4. **Screen manifests** — a declarative last resort for engines with no
+   transcript at all: the poll classifies the captured screen against the
+   engine's own `screenManifest` rules (`src/engine/screen-state.ts`). This
+   is what badges the contrib catalog and plugin engines, and it is the
+   *whole* reason contrib is a category — a catalog entry is a name, a
+   launch command, and these rules. An engine with no manifest and no
+   history reader (a genuinely custom one, registered with only a launch
+   command) has nothing to read either way, and its badge stays dark. Rove
+   labels *that* gap honestly rather than guessing.
+
+Which engine gets which tier is decided by the tab's LIVE process identity,
+not its recorded vendor (`engine/foreground.ts`) — so that walk must be able
+to name every engine that can badge, contrib and plugin ids included.
 
 Because hook delivery can lapse (daemon restart, dropped event), a ~10-minute
 watchdog caps how long a stale "working" badge survives without confirmation.

--- a/packages/kobe/src/engine/foreground.ts
+++ b/packages/kobe/src/engine/foreground.ts
@@ -18,8 +18,8 @@
  */
 
 import { basename } from "node:path"
-import { BUILTIN_VENDORS, type VendorId } from "../types/vendor"
-import { engineEntry } from "./registry"
+import type { VendorId } from "../types/vendor"
+import { engineEntry, identifiableEngineIds } from "./registry"
 
 /** One line of `ps -A -o pid=,ppid=,args=`. */
 export type ProcRow = {
@@ -65,6 +65,12 @@ function executableNameFromArgv(argv: readonly string[]): string | null {
  * counts — scanning arguments is what made the title heuristic wrong
  * (`cc-switch start claude …` is cc-switch, not claude; its claude CHILD
  * is what identifies, and the tree walk finds that one).
+ *
+ * Asks about every id the registry can name state-free
+ * ({@link identifiableEngineIds}), not just the built-ins: a running
+ * OpenCode answering `null` here is not "no engine", it is this function
+ * not having been asked about OpenCode — and every consumer of the walk
+ * reads that `null` as a POSITIVE no-engine verdict.
  */
 export function vendorFromArgv(commandLine: string): VendorId | null {
   const name = executableNameFromArgv(commandLine.trim().split(/\s+/))
@@ -72,7 +78,7 @@ export function vendorFromArgv(commandLine: string): VendorId | null {
   // defaultCommand[0] is the launch binary; processNames covers engines
   // that rewrite their process title post-launch (kimi → `kimi-co`).
   return (
-    BUILTIN_VENDORS.find((v) => {
+    identifiableEngineIds().find((v) => {
       const entry = engineEntry(v)
       return entry.defaultCommand[0] === name || entry.processNames?.includes(name) === true
     }) ?? null

--- a/packages/kobe/src/engine/registry.ts
+++ b/packages/kobe/src/engine/registry.ts
@@ -27,7 +27,7 @@
  */
 
 import type { EngineCapabilities, EngineIdentity, EngineQuotaUsage, EngineUsageSnapshot, Message } from "@/types/engine"
-import { type VendorId, isBuiltinVendor } from "@/types/vendor"
+import { BUILTIN_VENDORS, type VendorId, isBuiltinVendor } from "@/types/vendor"
 import type {
   ClaudeAccount,
   CodexAccount,
@@ -38,7 +38,7 @@ import type {
 } from "./account-detect.ts"
 import type { EngineTurnReader } from "./agent-turn.ts"
 import { BUILTIN_ENGINES } from "./builtin-engines.ts"
-import { contribEngineEntry, isContribEngine } from "./contrib-engines.ts"
+import { CONTRIB_ENGINE_IDS, contribEngineEntry, isContribEngine, pluginEngineIds } from "./contrib-engines.ts"
 import { EMPTY_HISTORY } from "./history-readers.ts"
 import { type EngineHookAdapter, NoopHookAdapter } from "./hook-adapter.ts"
 import type { EngineScreenManifest } from "./screen-state.ts"
@@ -272,6 +272,23 @@ export function engineEntry(vendor: VendorId): EngineRegistryEntry {
   // Shipped contrib engines (data-only long tail): the custom empty entry
   // overlaid with the catalog's identity + screen manifest.
   return isContribEngine(vendor) ? contribEngineEntry(vendor, custom) : custom
+}
+
+/**
+ * Every engine id whose launch binary this module can NAME without reading
+ * state: the built-ins, the shipped contrib catalog, and whatever plugins
+ * registered this run. That is the identifiable set — a truly custom id
+ * carries its binary in `engineCommand.<id>`, which lives in state this
+ * module deliberately never reads, so callers holding that state pass the
+ * launch argv in themselves (see `foreground.ts#engineProcessIn`'s
+ * `extraLaunch`).
+ *
+ * Recomputed per call rather than cached: `pluginEngineIds()` changes when
+ * plugins are enabled/disabled at runtime, and the array is small enough
+ * that a stale cache would cost more than it saves.
+ */
+export function identifiableEngineIds(): readonly VendorId[] {
+  return [...BUILTIN_VENDORS, ...CONTRIB_ENGINE_IDS, ...pluginEngineIds()]
 }
 
 /**

--- a/packages/kobe/test/engine/activity-observer.test.ts
+++ b/packages/kobe/test/engine/activity-observer.test.ts
@@ -16,6 +16,7 @@ import type {
   OrchestratorSignals,
   TaskEngineState,
 } from "../../src/client/remote-orchestrator-payloads"
+import { foregroundEngineIn, parsePsSnapshot } from "../../src/engine/foreground"
 import { engineTitleTurnHint } from "../../src/engine/registry"
 import { createStateCell } from "../../src/lib/external-store"
 import { tabRowActivity } from "../../src/tui/panes/sidebar/tree-core"
@@ -31,7 +32,7 @@ interface FakeSession {
   totalBytes: number
 }
 
-function world(opts: { silenceMs?: number; correctAfterMs?: number } = {}) {
+function world(opts: { silenceMs?: number; correctAfterMs?: number; walk?: (pid: number) => string | null } = {}) {
   const bus = new DaemonEventBus()
   const registry = new DaemonActivityRegistry(bus)
   const engineState = createStateCell<ReadonlyMap<string, TaskEngineState>>(new Map())
@@ -61,7 +62,7 @@ function world(opts: { silenceMs?: number; correctAfterMs?: number } = {}) {
       foregroundEngines: (pids) => {
         const out = new Map<number, { vendor: string; pid: number } | null>()
         for (const pid of pids) {
-          const vendor = state.engines.get(pid)
+          const vendor = opts.walk ? opts.walk(pid) : state.engines.get(pid)
           out.set(pid, vendor ? { vendor, pid: pid + 1 } : null)
         }
         return Promise.resolve(out)
@@ -238,6 +239,31 @@ describe("activity observer", () => {
     const replay = w.registry.currentNonIdle()
     expect(replay.some((p) => p.tabId === "tab-1" && p.state === "idle")).toBe(true)
     expect(replay.some((p) => p.tabId === "tab-9")).toBe(false)
+  })
+
+  /**
+   * The walk is the observer's ONLY engine-presence evidence, and `null`
+   * from it is a positive claim: `applyRest(track, "no engine in
+   * foreground")`. Its id set was built-ins only, so a working OpenCode
+   * got a `rest` observation written over it every walk tick — a WRONG
+   * signal, not a missing one. Driven through the real walk over a
+   * synthetic `ps`, because a hand-stubbed vendor cannot show the bug.
+   */
+  it("does not claim REST over a working contrib engine (real walk)", async () => {
+    const rows = parsePsSnapshot(`
+42 1 /bin/zsh -l
+43 42 /usr/local/bin/opencode
+`)
+    const w = world({ silenceMs: 90, walk: (pid) => foregroundEngineIn(rows, pid)?.vendor ?? null })
+    const session: FakeSession = { key: KEY, alive: true, pid: 42, title: "opencode", totalBytes: 100 }
+    w.state.sessions = [session]
+    // Output moving = the engine is working. Before the fix the walk said
+    // "no engine" and forced idle regardless of the bytes.
+    await wait(40)
+    session.totalBytes += 50
+    await waitFor(() => w.row("tab-1")?.state === "running")
+    // And the honest rest still lands once it goes quiet.
+    await waitFor(() => w.row("tab-1")?.state === "idle")
   })
 
   it("a tab-scoped idle never clears a rollup another tab owns", async () => {

--- a/packages/kobe/test/engine/foreground.test.ts
+++ b/packages/kobe/test/engine/foreground.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from "vitest"
+import { afterEach, describe, expect, it } from "vitest"
+import { clearPluginEngines, registerPluginEngine } from "../../src/engine/contrib-engines.ts"
 import {
   engineProcessIn,
   foregroundEngine,
@@ -175,5 +176,55 @@ describe("hasAncestor (env inherits, a pid chain doesn't)", () => {
   it("is false for an unknown pid, and terminates on a cyclic snapshot", () => {
     expect(hasAncestor(rows, 999, 10)).toBe(false)
     expect(hasAncestor(parsePsSnapshot("30 31 a\n31 30 b"), 30, 10)).toBe(false)
+  })
+})
+
+/**
+ * The walk's id set. `null` from this module is read by every consumer as
+ * "walked the shell, positively no engine" — so an id the loop never asks
+ * about is not a missing answer, it is a WRONG one: the daemon writes a
+ * `rest` observation over a working engine, the TUI attaches no turn
+ * detector, and the tab is relabelled "shell N".
+ */
+describe("vendorFromArgv covers every engine the registry can name state-free", () => {
+  afterEach(() => clearPluginEngines())
+
+  it("identifies a shipped contrib engine, not just the built-ins", () => {
+    expect(vendorFromArgv("/usr/local/bin/opencode")).toBe("opencode")
+    expect(vendorFromArgv("/opt/homebrew/bin/gemini --yolo")).toBe("gemini")
+    // Contrib entries whose binary name differs from their id.
+    expect(vendorFromArgv("cursor-agent")).toBe("cursor")
+  })
+
+  it("identifies a plugin-registered engine, and forgets it when the plugin unloads", () => {
+    registerPluginEngine("aider", { displayName: "Aider", defaultCommand: ["aider"], screenManifest: { rules: [] } })
+    expect(vendorFromArgv("/usr/local/bin/aider --model gpt-5")).toBe("aider")
+    clearPluginEngines()
+    expect(vendorFromArgv("/usr/local/bin/aider --model gpt-5")).toBeNull()
+  })
+
+  it("walks to a live contrib engine under a tab's shell", () => {
+    const rows = parsePsSnapshot(`
+100 1 /bin/zsh -l
+101 100 /usr/local/bin/opencode
+200 1 /bin/zsh -l
+`)
+    expect(foregroundEngineIn(rows, 100)?.vendor).toBe("opencode")
+    expect(foregroundEngineIn(rows, 100)?.pid).toBe(101)
+    // Still honestly null for a shell with no engine under it.
+    expect(foregroundEngineIn(rows, 200)).toBeNull()
+  })
+
+  it("a genuinely custom engine stays unnameable here — callers pass its launch argv", () => {
+    // `engineCommand.<id>` lives in state this module must not read, so the
+    // walk cannot name `my-agent`; the delivery gate's `extraLaunch` is how
+    // a caller holding that state asks about it.
+    const rows = parsePsSnapshot(`
+10 1 /bin/zsh -l
+11 10 /Users/me/bin/my-agent --serve
+`)
+    expect(foregroundEngineIn(rows, 10)).toBeNull()
+    expect(engineProcessIn(rows, 10)).toBe(false)
+    expect(engineProcessIn(rows, 10, "/Users/me/bin/my-agent")).toBe(true)
   })
 })

--- a/packages/kobe/test/tui/tab-title-stable.test.ts
+++ b/packages/kobe/test/tui/tab-title-stable.test.ts
@@ -15,6 +15,7 @@
  */
 
 import { describe, expect, it } from "vitest"
+import { foregroundEngineIn, parsePsSnapshot } from "../../src/engine/foreground"
 import { tabTitle, tabTitleStable } from "../../src/tui/workspace/terminal-tab-split"
 import type { TerminalTab } from "../../src/tui/workspace/terminal-tabs-core"
 
@@ -148,5 +149,30 @@ describe("tabTitleStable", () => {
     expect(tabTitleStable(bare, "codex", "codex")).toBe("codex 1")
     // A named thread is a name again, with no further signal needed.
     expect(tabTitleStable(tab, "codex", "codex", "⠹ rework the parser")).toBe("rework the parser 1")
+  })
+})
+
+/**
+ * The demotion branch (`liveVendor === null` on an engine tab → "shell N")
+ * is right: a ctrl+C'd tab must stop wearing its engine's name. It was only
+ * ever wrong because the probe LIED — the walk's id set was built-ins only,
+ * so a working OpenCode answered the confirmed-no-engine arm and its tab
+ * lost its title. Wired through the real walk, not a hand-passed `null`.
+ */
+describe("tabTitleStable over the real foreground walk", () => {
+  const rows = parsePsSnapshot(`
+100 1 /bin/zsh -l
+101 100 /usr/local/bin/opencode
+200 1 /bin/zsh -l
+`)
+  const probe = (pid: number) => foregroundEngineIn(rows, pid)?.vendor ?? null
+  const tab = engineTab({ vendor: "opencode", lastTitle: "Refactor the parser" })
+
+  it("a live contrib engine tab keeps its name instead of demoting to a shell", () => {
+    expect(tabTitleStable(tab, "opencode", probe(100))).toBe("Refactor the parser 1")
+  })
+
+  it("and a contrib tab whose engine really quit still demotes", () => {
+    expect(tabTitleStable(tab, "opencode", probe(200))).toBe("shell 1")
   })
 })

--- a/packages/kobe/test/tui/turn-target.test.ts
+++ b/packages/kobe/test/tui/turn-target.test.ts
@@ -10,6 +10,8 @@
  */
 
 import { describe, expect, it } from "vitest"
+import { foregroundEngineIn, parsePsSnapshot } from "../../src/engine/foreground"
+import { engineEntry } from "../../src/engine/registry"
 import type { TerminalTab } from "../../src/tui/workspace/terminal-tabs-core"
 import { targetFor } from "../../src/tui/workspace/turn-target"
 
@@ -39,5 +41,34 @@ describe("targetFor", () => {
   it("a shell tab attaches only on a live engine", () => {
     expect(targetFor("t", shellTab(), "claude", () => "claude")).toEqual({ vendor: "claude", key: "t::tab-2" })
     expect(targetFor("t", shellTab(), "claude", () => undefined)).toBeNull()
+  })
+})
+
+/**
+ * The composed path the TUI actually runs: process walk → `targetFor` →
+ * `engineEntry(...).screenManifest`. Contrib engines exist as a category
+ * *because* they ship hand-tuned screen manifests, and nothing evaluated
+ * them for a contrib task — the walk answered `null` (its id set was
+ * built-ins only), so `targetFor` detached and `use-turn-polls` never
+ * reached the manifest.
+ */
+describe("targetFor over the real foreground walk", () => {
+  const rows = parsePsSnapshot(`
+100 1 /bin/zsh -l
+101 100 /usr/local/bin/opencode
+200 1 /bin/zsh -l
+`)
+  const pids: Record<string, number> = { "t-oc::tab-1": 100, "t-oc::tab-2": 200 }
+  const vendorOf = (key: string) => foregroundEngineIn(rows, pids[key] ?? 0)?.vendor ?? null
+
+  it("attaches a detector to a live contrib engine, and reaches its screen manifest", () => {
+    const target = targetFor("t-oc", engineTab({ vendor: "opencode" }), "opencode", vendorOf)
+    expect(target).toEqual({ vendor: "opencode", key: "t-oc::tab-1" })
+    expect(engineEntry(target?.vendor ?? "").screenManifest?.rules.length).toBeGreaterThan(0)
+  })
+
+  it("still detaches for a contrib tab whose engine really did quit", () => {
+    const tab = engineTab({ id: "tab-2", vendor: "opencode" })
+    expect(targetFor("t-oc", tab, "opencode", vendorOf)).toBeNull()
   })
 })


### PR DESCRIPTION
# Task AU — one function did not know contrib engines exist

`vendorFromArgv` (`packages/kobe/src/engine/foreground.ts`) resolved its
candidates through the registry correctly but only ever iterated
`BUILTIN_VENDORS`. Every contrib id (`gemini`, `opencode`, `cursor`, `grok`,
`droid`, `amp`), every plugin engine, and every custom engine answered `null`
from the process walk — and every consumer reads that `null` as *"walked the
shell, positively no engine"*, not *"I wasn't asked about that one"*.

**The fix is one line plus its enumerator.** `registry.ts` gains
`identifiableEngineIds()` — built-ins + `CONTRIB_ENGINE_IDS` +
`pluginEngineIds()`, i.e. every id the registry can name *without reading
state* — and the walk asks about that set. No new import cycle, no state read,
so `foreground.ts`'s "must stay state-free" constraint survives.

## On the tri-state — deliberately unchanged

The brief asked me to consider whether `null` should become "don't know".
**I did not change it, and that is a decision, not an omission.**

After this fix `null` is honest for every engine Rove can *name*. What is left
outside is a genuinely custom id, whose binary lives only in
`engineCommand.<id>` — state this module must not read. Widening `null` to
"unknown" for *any* unrecognised running process would make a shell running
`vim` indistinguishable from a live engine, which is a worse lie than the one
being fixed. The existing escape hatch is the right one: a caller that holds
the launch command passes it as `engineProcessIn`'s `extraLaunch` — which is
exactly how prompt delivery already dodged this gap, and is **the path this PR
must not break**. That path is now pinned by a test
(`test/engine/foreground.test.ts`, "a genuinely custom engine stays unnameable
here"), which passes both with and without the fix on purpose.

## Per item

Every test below was **mutation-verified**: reverted to `BUILTIN_VENDORS` →
6 red; restored → 58 green. Re-run after the rebase onto `origin/main`
(`ab5b0dc2d`), not carried over from before it.

### A1 — the cause · `vendorFromArgv` covers every nameable engine
**PASS:** `foregroundEngineIn(rows, 100)?.vendor === "opencode"` for the
briefing's synthetic snapshot, and the same for a plugin engine registered via
`registerPluginEngine`.
**Proof** — `packages/kobe/.scratch/loop-r16-engines/fg.ts`, the briefing's own
repro:

```
BEFORE  opencode(contrib)  foregroundEngineIn = null       | engineProcessIn(no hint) = false
        claude(builtin)    foregroundEngineIn = "claude"   | engineProcessIn(no hint) = true
        gemini(contrib)    foregroundEngineIn = null       | engineProcessIn(no hint) = false

AFTER   opencode(contrib)  foregroundEngineIn = "opencode" | engineProcessIn(no hint) = true
        claude(builtin)    foregroundEngineIn = "claude"   | engineProcessIn(no hint) = true
        gemini(contrib)    foregroundEngineIn = "gemini"   | engineProcessIn(no hint) = true
```

Tests: `test/engine/foreground.test.ts` (+4 cases, incl. plugin
register/unload and the custom-engine gap).

### A2 — the daemon no longer claims REST over a working contrib engine
**PASS:** the observer, driven by the **real walk** over a synthetic `ps` with
a live `opencode`, is not forced to `rest` while output advances.
**Proof (unit):** `test/engine/activity-observer.test.ts`, "does not claim REST
over a working contrib engine (real walk)". The existing fake `foregroundEngines`
stub could not show this bug — a hand-stubbed vendor bypasses the defect — so
`world()` gained a `walk` hook that runs the production `foregroundEngineIn`.

**Proof (harness, BEFORE/AFTER):** `/harness` → xterm.js → PTY sidecar → real
OpenTUI, isolated fixture on port base **6811**, a real `opencode` v0.6.3 in a
hosted PTY, `KOBE_VISUAL_FRESH=1` rebuild between the two shots.

| | tab row |
|---|---|
| BEFORE `/Users/jacksonc/i/evidence/loop-r16-au/a2a4-before.png` | `○ Refactor the parser 1` |
| AFTER  `/Users/jacksonc/i/evidence/loop-r16-au/a2a4-after.png`  | `· Refactor the parser 1` |

Per `tree-rows.tsx:398-404`, `○` is *"the daemon holds a KNOWN-idle tombstone
for this tab"* and `·` (`NO_STATE_GLYPH`) is *"no daemon signal at all"*. So
BEFORE, the daemon asserted a positive idle state for the tab — written by
`applyRest(track, "no engine in foreground")` off the false premise that a live
OpenCode was absent. AFTER, the observer no longer short-circuits; with
opencode sitting quietly at its prompt and no title vocabulary yet, *no claim*
is the honest answer, and a real rest claim now has to come from the evidence
path (silence window / turn detector) that A3 restores.

### A3 — the contrib screen manifests are finally evaluated
**PASS:** `targetFor(...)` returns `{vendor:"opencode", key:"t-oc::tab-1"}` and
`engineEntry(target.vendor).screenManifest` is reachable.
**Proof** — `.scratch/loop-r16-engines/target.ts`:

```
BEFORE  opencode task -> null                                      claude task -> {"vendor":"claude",…}
AFTER   opencode task -> {"vendor":"opencode","key":"t-oc::tab-1"}  claude task -> {"vendor":"claude",…}
```

Promoted into `test/tui/turn-target.test.ts` as a vitest case that composes the
**real walk** with `targetFor` and asserts the manifest has rules — plus a
counterpart proving a contrib tab whose engine really quit still detaches.

### A4 — a live contrib engine tab keeps its name
**PASS:** an engine tab whose foreground process is `opencode` keeps its title
instead of demoting to `shell N`.
**Proof (unit):** `test/tui/tab-title-stable.test.ts` — wired through the real
walk, not a hand-passed `null`, with the "engine really quit still demotes"
counterpart so the branch is not simply inverted.

**Proof (live fixture):** measured on the **running harness fixture's own
inputs** — the host-session pid from `rove api inspect` plus a real `ps`
snapshot — against both builds, same session, same pid:

```
BEFORE  …::tab-1 pid 67630 alive true | walk = null       | sidebar label = "shell 1"
AFTER   …::tab-1 pid 67630 alive true | walk = "opencode" | sidebar label = "Refactor the parser 1"
```
(`/Users/jacksonc/i/evidence/loop-r16-au/a2a4-label-flip.txt`)

**What I could NOT prove, stated plainly:** this label flip does **not** appear
in the two screenshots. In the visual fixture the sidebar's *TUI-side* probe
(`live-engine.ts` → `resolve()`) returns `undefined` for the fixture's hosted
tab, so `tabTitleStable`'s `liveVendor === null` branch is never reached in
*either* build and both render `Refactor the parser 1`. I confirmed that is a
fixture property, not an inert fix, by holding the shot at `wait:30000` on the
unfixed build (`probe-longwait.png` — still no demotion) and then measuring the
same fixture's real inputs directly, above. The badge difference the screenshots
*do* capture comes from the **daemon's** walk, which does answer there — which
is why A2 is screenshot-visible and A4 is not.

### A5 — `.tabs[].liveVendor` reports the live contrib engine
**PASS:** `get-task` shows `liveVendor === "opencode"` while the engine runs.
**Proof:** a real `opencode` in a hosted PTY under a fully isolated home
(`ROVE_/KOBE_` HOME_DIR + DAEMON_SOCKET_PATH + DAEMON_PID_PATH + PTY_SOCKET_PATH
+ PTY_PID_PATH + DAEMON_WEB_PORT all inlined; web port 6712). **Same live
session, same daemon — only the CLI build differs**, because the walk for this
verb runs CLI-side in `cli/api/runtime.ts`:

```
BEFORE  { "id":"tab-1","kind":"engine","liveVendor": null,       "alive":true,"engineAlive":true }
AFTER   { "id":"tab-1","kind":"engine","liveVendor": "opencode", "alive":true,"engineAlive":true }
```

Note `engineAlive: true` in **both** — that is the `extraLaunch` dodge the brief
warned about, still working. `/Users/jacksonc/i/evidence/loop-r16-au/a5-liveVendor.txt`

`use-scratch-adopt.ts`'s `if (!liveEngines.get(key)) continue` reads the same
store, so scratch adoption stops being built-ins-only by the same change. I did
not exercise the adoption flow itself — flagging that as inferred, not proven.

### A6 — the docs
**I treated `docs/ENGINES.md` as the promise** and fixed
`docs/design/engine-internals.md`. Three reasons:

1. `ENGINES.md` is the **published, user-facing contract** (docs.rove.run);
   `engine-internals.md` is an internal design note.
2. The machinery `ENGINES.md` promises already **exists and is complete** —
   six hand-tuned manifests in `CONTRIB_ENGINES`, wired into
   `use-turn-polls.ts` via `entry.screenManifest`. The only missing link was
   `targetFor` never attaching (A3). The design doc describes the world before
   that work landed.
3. Its claim was already wrong about a **built-in**: "Rove labels the gap
   honestly rather than guessing state from screen scraping" contradicts
   copilot, which `ENGINES.md` lists as `✓ (screen-based)` and which ships a
   manifest today.

The paragraph is now a fourth detection tier (screen manifests, naming what
they badge) plus an honest floor: an engine with *no* manifest and *no* history
reader has nothing to read either way, and its badge stays dark.

## Gates

`bun run lint` · `bun run typecheck` · `test:fast` 4453/4453 ·
`test:socket` 807/807 · `bun test test/render` 475/475 — all green, rebased on
`ab5b0dc2d`.

## Notes

- No new or moved keybinding chords.
- No file crossed the 500-line cap: `foreground.ts` 207, `registry.ts` 400.
- **One unintended live engine launch.** The `opencode` sentinel I put on PATH
  was shadowed by the machine's real `opencode` (the engine launches under
  `zsh -ilc`, which re-sources `.zshrc` and rebuilds PATH). The real CLI came up
  and sat at its prompt; no prompt was ever delivered to it, so no turn ran.
  Everything else used sentinels, pure-function repros, and registry reads.
- Evidence lives **outside** the worktree at `/Users/jacksonc/i/evidence/loop-r16-au/`
  (`repro-before.txt`, `repro-after.txt`, `a5-liveVendor.txt`,
  `a2a4-label-flip.txt`, `a2a4-before.png`, `a2a4-after.png`, `probe-longwait.png`)
  so a merged task's worktree deletion cannot take it.
- Batches B and C untouched. `refs/`, `.github/workflows/*`,
  `core/base-ref-cache.ts`, `cli/api/branch-signals.ts` and the attention/inbox
  stores untouched.
