### PR TITLE
Four places the engine contract could not say what a surface needed (B1, B2, C1, C2)

### DIFF
--- a/.changeset/codex-agent-turns.md
+++ b/.changeset/codex-agent-turns.md
@@ -1,0 +1,11 @@
+---
+"@sma1lboy/rove": patch
+---
+
+`rove api agent-turns` now reports Codex turns. Codex's rollout records
+`task_started`/`task_complete` with the turn id it assigns, plus the model and
+per-request token deltas, so a Codex task's turns now carry model, wall-clock,
+and tokens like Claude's. Its hook also reports session identity now — without
+that the daemon had a turn to record and no transcript to read it from. Engines
+with no turn reader still contribute nothing, and the verb says so rather than
+returning a confident empty page.

--- a/.changeset/plugin-first-message-delivery.md
+++ b/.changeset/plugin-first-message-delivery.md
@@ -1,0 +1,9 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Plugin engines can declare `first_message_delivery` in their manifest. A CLI
+whose first positional is a subcommand or a project directory died on its own
+first prompt under the `"argv"` default, and the key that fixes it existed on
+the registry but was unreachable from a manifest. An unknown value is now a
+manifest error instead of a silent fallback to the broken default.

--- a/docs/API.md
+++ b/docs/API.md
@@ -225,8 +225,10 @@ replacement in `nextCommandArgs`.
   `usage`), newest first, plus a `totals` roll-up (token sums, summed
   wall-clock, turn counts per model). Default window 7 days, 200 records.
   Records are produced by each engine's own adapter from that vendor's
-  transcript and stored by the daemon on `turn-complete`; engines without a
-  turn reader contribute nothing. Read-only.
+  transcript and stored by the daemon on `turn-complete`. Claude and codex
+  have a turn reader; every other engine has none, so a task on one yields an
+  empty page because nothing can read its turns, not because it did no work.
+  Read-only.
 - `pty-list` *(offline)*: hosted PTY sessions (key, alive, pid, command,
   live window title). `sessions: []` means a live PTY host with nothing
   running; `sessions: null` means there was no host to ask — "couldn't look",

--- a/docs/ENGINES.md
+++ b/docs/ENGINES.md
@@ -108,6 +108,15 @@ clobbering:
 This only ever fires for worktrees Rove itself created from a repo you already
 work in; your own directories are untouched.
 
+Contrib, plugin, and custom engines have no trust record Rove knows how to
+write, so whether a task worktree launches cleanly is up to the CLI. OpenCode
+does not gate at all (checked against 0.6.3 in an unseen directory, including
+with an empty config, so it needs nothing). Cursor Agent does gate — its
+`--trust` flag only applies to `--print`/headless runs, so an interactive
+task worktree stops at its trust prompt and you have to answer it once in the
+pane. The rest are unmeasured; if a task sits on a dialog at launch, that is
+what you are looking at.
+
 ### Custom launch commands
 
 Override any engine's launch command in Settings → Engines, or by hand in

--- a/docs/PLUGIN-AUTHORING.md
+++ b/docs/PLUGIN-AUTHORING.md
@@ -174,6 +174,7 @@ id = "aider"                     # VendorId; may not shadow a built-in (claude/c
 name = "Aider"                   # display name in the selector and Settings
 command = ["aider"]              # launch argv; argv[0] is the binary
 # process_names = ["aider-core"] # extra ps basenames (post-launch renames)
+# first_message_delivery = "paste"  # argv (default) | paste — see below
 
 [engines.identity]               # optional product identity for UI labels
 short_name = "Aider"             # falls back to `name`
@@ -192,6 +193,13 @@ any = ["ctrl-c to interrupt"]    # at least one must appear
 `command` is always argv: never a shell, no expansion (panes expand only
 `$ROVE_PLUGIN_ROOT`). Unknown event names are warnings (forward compat);
 invalid types/patterns are install-time errors.
+
+`first_message_delivery` says how the CLI takes a session's first message.
+The default `"argv"` appends the prompt as a positional argument. Declare
+`"paste"` when argv[1] means something else — a subcommand, or a project
+directory — or the launch dies on the prompt text instead of running it
+(`opencode "Run ls -la"` exits with `Failed to change directory to …`).
+With `"paste"` the message is typed into the running pane instead.
 
 The accepted platform tokens are exactly `macos`, `linux`, and `windows`.
 A top-level list applies to the whole plugin; `platforms` on an individual

--- a/packages/kobe-daemon/src/plugins/manifest-coerce.ts
+++ b/packages/kobe-daemon/src/plugins/manifest-coerce.ts
@@ -1,0 +1,69 @@
+/**
+ * TOML value coercion for the plugin manifest — the primitives, not the shape.
+ *
+ * The split from `manifest.ts`: THIS half turns an `unknown` parsed out of TOML
+ * into a typed value or throws a `rove-plugin.toml:`-prefixed diagnostic naming
+ * the offending field; `manifest.ts` owns what the manifest's fields ARE and in
+ * what combinations. Nothing here knows a single manifest key, which is what
+ * lets both halves grow without dragging the other along.
+ */
+
+export const PLUGIN_PLATFORMS = ["macos", "linux", "windows"] as const
+export type PluginPlatform = (typeof PLUGIN_PLATFORMS)[number]
+
+export class ManifestError extends Error {}
+
+export function fail(message: string): never {
+  throw new ManifestError(`rove-plugin.toml: ${message}`)
+}
+
+export function asString(value: unknown, field: string): string {
+  if (typeof value !== "string" || value.length === 0) fail(`\`${field}\` must be a non-empty string`)
+  return value
+}
+
+/**
+ * A setting's `default`, coerced to the string every value is stored as.
+ * TOML has real booleans and numbers and `type = "boolean"` invites writing
+ * `default = true`, which used to fail the whole manifest with "must be a
+ * non-empty string". `false` means "no default", matching the storage
+ * convention where a boolean is on iff its .env value is `"1"`.
+ */
+export function asSettingDefault(value: unknown, field: string): string | undefined {
+  if (value === undefined || value === false) return undefined
+  if (value === true) return "1"
+  if (typeof value === "number" && Number.isFinite(value)) return String(value)
+  return asString(value, field)
+}
+
+export function asCommand(value: unknown, field: string): string[] {
+  if (!Array.isArray(value) || value.length === 0 || !value.every((v) => typeof v === "string" && v.length > 0)) {
+    fail(`\`${field}\` must be a non-empty array of strings (argv form)`)
+  }
+  return value
+}
+
+export function asPlatforms(value: unknown, field: string): PluginPlatform[] | undefined {
+  if (value === undefined) return undefined
+  if (!Array.isArray(value) || !value.every((v) => (PLUGIN_PLATFORMS as readonly string[]).includes(v as string))) {
+    fail(`\`${field}\` must be an array drawn from ${PLUGIN_PLATFORMS.join(", ")}`)
+  }
+  return value as PluginPlatform[]
+}
+
+export function asTableArray(value: unknown, field: string): Record<string, unknown>[] {
+  if (value === undefined) return []
+  if (!Array.isArray(value) || !value.every((v) => typeof v === "object" && v !== null && !Array.isArray(v))) {
+    fail(`\`[[${field}]]\` must be an array of tables`)
+  }
+  return value as Record<string, unknown>[]
+}
+
+/** Non-empty array of strings, or undefined when the key is absent. */
+export function asStringArray(value: unknown, field: string): string[] | undefined {
+  if (value === undefined) return undefined
+  if (!Array.isArray(value) || !value.every((v) => typeof v === "string" && v.length > 0)) {
+    fail(`\`${field}\` must be a non-empty array of strings`)
+  }
+  return value as string[]
+}

--- a/packages/kobe-daemon/src/plugins/manifest.ts
+++ b/packages/kobe-daemon/src/plugins/manifest.ts
@@ -13,11 +13,21 @@ import { existsSync, readFileSync } from "node:fs"
 import { basename, join } from "node:path"
 import { PLUGIN_EVENT_NAMES, type PluginEventName } from "@sma1lboy/rove-plugin-sdk/contract"
 import { parse as parseToml } from "smol-toml"
+import {
+  ManifestError,
+  PLUGIN_PLATFORMS,
+  type PluginPlatform,
+  asCommand,
+  asPlatforms,
+  asSettingDefault,
+  asString,
+  asStringArray,
+  asTableArray,
+  fail,
+} from "./manifest-coerce.ts"
 import { settingKeyRejection } from "./setting-keys.ts"
 
-export type PluginPlatform = "macos" | "linux" | "windows"
-
-export const PLUGIN_PLATFORMS: readonly PluginPlatform[] = ["macos", "linux", "windows"]
+export { PLUGIN_PLATFORMS, type PluginPlatform }
 
 /** The event catalog lives in the published SDK's contract module — ONE
  *  source shared by the daemon and external plugin authors (catalog docs:
@@ -215,12 +225,6 @@ export function supportsPlatform(
   return platform !== undefined && declared.includes(platform)
 }
 
-class ManifestError extends Error {}
-
-function fail(message: string): never {
-  throw new ManifestError(`rove-plugin.toml: ${message}`)
-}
-
 /** Parse manifest text while preserving the source filename in diagnostics.
  * Direct callers default to the canonical filename; file readers pass the
  * actual basename so legacy manifests remain debuggable. */
@@ -233,48 +237,6 @@ export function parsePluginManifest(text: string, filename: string = PLUGIN_MANI
     }
     throw err
   }
-}
-
-function asString(value: unknown, field: string): string {
-  if (typeof value !== "string" || value.length === 0) fail(`\`${field}\` must be a non-empty string`)
-  return value
-}
-
-/**
- * A setting's `default`, coerced to the string every value is stored as.
- * TOML has real booleans and numbers and `type = "boolean"` invites writing
- * `default = true`, which used to fail the whole manifest with "must be a
- * non-empty string". `false` means "no default", matching the storage
- * convention where a boolean is on iff its .env value is `"1"`.
- */
-function asSettingDefault(value: unknown, field: string): string | undefined {
-  if (value === undefined || value === false) return undefined
-  if (value === true) return "1"
-  if (typeof value === "number" && Number.isFinite(value)) return String(value)
-  return asString(value, field)
-}
-
-function asCommand(value: unknown, field: string): string[] {
-  if (!Array.isArray(value) || value.length === 0 || !value.every((v) => typeof v === "string" && v.length > 0)) {
-    fail(`\`${field}\` must be a non-empty array of strings (argv form)`)
-  }
-  return value
-}
-
-function asPlatforms(value: unknown, field: string): PluginPlatform[] | undefined {
-  if (value === undefined) return undefined
-  if (!Array.isArray(value) || !value.every((v) => (PLUGIN_PLATFORMS as readonly string[]).includes(v as string))) {
-    fail(`\`${field}\` must be an array drawn from ${PLUGIN_PLATFORMS.join(", ")}`)
-  }
-  return value as PluginPlatform[]
-}
-
-function asTableArray(value: unknown, field: string): Record<string, unknown>[] {
-  if (value === undefined) return []
-  if (!Array.isArray(value) || !value.every((v) => typeof v === "object" && v !== null && !Array.isArray(v))) {
-    fail(`\`[[${field}]]\` must be an array of tables`)
-  }
-  return value as Record<string, unknown>[]
 }
 
 /**
@@ -422,14 +384,7 @@ function parseCanonicalPluginManifest(text: string): ParsedPluginManifest {
       if (state !== "working" && state !== "blocked" && state !== "idle") {
         fail(`engines[${i}].rules[${j}].state must be working | blocked | idle`)
       }
-      const strings = (value: unknown, field: string): string[] | undefined => {
-        if (value === undefined) return undefined
-        if (!Array.isArray(value) || !value.every((v) => typeof v === "string" && v.length > 0)) {
-          fail(`\`${field}\` must be a non-empty array of strings`)
-        }
-        return value as string[]
-      }
-      const lineRegex = strings(r.line_regex, `engines[${i}].rules[${j}].line_regex`)
+      const lineRegex = asStringArray(r.line_regex, `engines[${i}].rules[${j}].line_regex`)
       for (const re of lineRegex ?? []) {
         try {
           new RegExp(re)
@@ -437,8 +392,8 @@ function parseCanonicalPluginManifest(text: string): ParsedPluginManifest {
           fail(`engines[${i}].rules[${j}].line_regex \`${re}\` is not a valid regex`)
         }
       }
-      const all = strings(r.all, `engines[${i}].rules[${j}].all`)
-      const any = strings(r.any, `engines[${i}].rules[${j}].any`)
+      const all = asStringArray(r.all, `engines[${i}].rules[${j}].all`)
+      const any = asStringArray(r.any, `engines[${i}].rules[${j}].any`)
       if (!all && !any && !lineRegex) fail(`engines[${i}].rules[${j}] needs at least one of all/any/line_regex`)
       return {
         state: state as "working" | "blocked" | "idle",

--- a/packages/kobe-daemon/src/plugins/manifest.ts
+++ b/packages/kobe-daemon/src/plugins/manifest.ts
@@ -109,6 +109,15 @@ export interface PluginEngine {
   readonly identity?: {
     readonly shortName?: string
   }
+  /**
+   * How this CLI takes a session's FIRST message. Default `"argv"` appends the
+   * prompt as a positional, which is right for most CLIs and fatal for the ones
+   * whose positional slot means something else — a subcommand, or a project
+   * directory. Such an engine declares `"paste"` and the first message is typed
+   * into the running pane instead. Without this key the author's only fix is to
+   * not use the feature.
+   */
+  readonly firstMessageDelivery?: "argv" | "paste"
 }
 
 export interface PluginManifest {
@@ -453,6 +462,14 @@ function parseCanonicalPluginManifest(text: string): ParsedPluginManifest {
         ...(shortName !== undefined ? { shortName } : {}),
       }
     }
+    let firstMessageDelivery: PluginEngine["firstMessageDelivery"]
+    if (t.first_message_delivery !== undefined) {
+      const raw = asString(t.first_message_delivery, `engines[${i}].first_message_delivery`)
+      // A typo here would otherwise fall back to "argv" and kill the launch on
+      // the engine's own first prompt — the exact failure the key exists to fix.
+      if (raw !== "argv" && raw !== "paste") fail(`engines[${i}].first_message_delivery must be argv | paste`)
+      firstMessageDelivery = raw
+    }
     return {
       id: engineId,
       name: asString(t.name, `engines[${i}].name`),
@@ -462,6 +479,7 @@ function parseCanonicalPluginManifest(text: string): ParsedPluginManifest {
         : { processNames: asCommand(t.process_names, `engines[${i}].process_names`) }),
       rules,
       ...(identity ? { identity } : {}),
+      ...(firstMessageDelivery ? { firstMessageDelivery } : {}),
     }
   })
   const engineSeen = new Set<string>()

--- a/packages/kobe/src/cli/api/handlers-agent-turns.ts
+++ b/packages/kobe/src/cli/api/handlers-agent-turns.ts
@@ -8,6 +8,7 @@
  */
 
 import type { AgentTurnRecord } from "@sma1lboy/kobe-daemon/daemon/contracts"
+import { vendorsWithTurnReader } from "../../engine/registry.ts"
 import { daemonOf } from "./handler-helpers.ts"
 import type { VerbContext, VerbSpec } from "./types.ts"
 
@@ -74,8 +75,10 @@ async function agentTurns(ctx: VerbContext): Promise<unknown> {
 export const AGENT_TURNS_VERB: VerbSpec = {
   name: "agent-turns",
   group: "read",
-  summary:
-    "Per-turn agent telemetry: one record per completed engine turn (task/tab/vendor/model/timings/tokens), newest first, plus totals. Engine-produced, daemon-stored; read-only. Claude and codex report turns — a task on any other engine yields an empty page because that engine has no turn reader, not because it did no work.",
+  // The reporting engines are READ OFF THE REGISTRY, never written here: a
+  // literal pair would put vendor strings in a neutral layer and would go stale
+  // the moment a third adapter lands.
+  summary: `Per-turn agent telemetry: one record per completed engine turn (task/tab/vendor/model/timings/tokens), newest first, plus totals. Engine-produced, daemon-stored; read-only. Engines that report turns: ${vendorsWithTurnReader().join(", ")} — a task on any other engine yields an empty page because that engine has no turn reader, not because it did no work.`,
   flags: [
     { name: "task-id", type: "string", placeholder: "ID", description: "Only this task's turns." },
     {

--- a/packages/kobe/src/cli/api/handlers-agent-turns.ts
+++ b/packages/kobe/src/cli/api/handlers-agent-turns.ts
@@ -75,7 +75,7 @@ export const AGENT_TURNS_VERB: VerbSpec = {
   name: "agent-turns",
   group: "read",
   summary:
-    "Per-turn agent telemetry: one record per completed engine turn (task/tab/vendor/model/timings/tokens), newest first, plus totals. Engine-produced, daemon-stored; read-only.",
+    "Per-turn agent telemetry: one record per completed engine turn (task/tab/vendor/model/timings/tokens), newest first, plus totals. Engine-produced, daemon-stored; read-only. Claude and codex report turns — a task on any other engine yields an empty page because that engine has no turn reader, not because it did no work.",
   flags: [
     { name: "task-id", type: "string", placeholder: "ID", description: "Only this task's turns." },
     {

--- a/packages/kobe/src/engine/builtin-engines.ts
+++ b/packages/kobe/src/engine/builtin-engines.ts
@@ -37,6 +37,7 @@ import { fetchCodexQuotaUsage } from "./codex-local/quota.ts"
 import { CODEX_SCREEN_MANIFEST } from "./codex-local/screen.ts"
 import { codexSessionIdFromTitle } from "./codex-local/terminal-title.ts"
 import { trustCodexWorktree } from "./codex-local/trust.ts"
+import { readCodexTurns } from "./codex-local/turns.ts"
 import { COPILOT_SCREEN_MANIFEST } from "./copilot-local/screen.ts"
 import { trustCopilotWorktree } from "./copilot-local/trust.ts"
 import {
@@ -123,6 +124,7 @@ export const BUILTIN_ENGINES: Record<"claude" | "codex" | "copilot" | "kimi", En
     capabilities: codexCapabilities,
     identity: codexIdentity,
     trustWorktree: trustCodexWorktree,
+    readTurns: readCodexTurns,
     screenManifest: CODEX_SCREEN_MANIFEST,
     // Codex's default is activity + project-name, which makes every tab in
     // one repo say "rove". Keep its native activity state, but ask Codex to

--- a/packages/kobe/src/engine/codex-local/hook-adapter.ts
+++ b/packages/kobe/src/engine/codex-local/hook-adapter.ts
@@ -30,6 +30,7 @@
 
 import { homedir } from "node:os"
 import { join } from "node:path"
+import type { EngineSessionRef } from "../hook-adapter.ts"
 import type { EngineActivityDetail, EngineActivityKind } from "../hook-events.ts"
 import { JsonHookAdapter } from "../json-hook-adapter.ts"
 import type { HookEventSpec } from "../json-hooks.ts"
@@ -92,5 +93,23 @@ export class CodexHookAdapter extends JsonHookAdapter {
       return { compact: { trigger: payload.trigger === "manual" ? "manual" : "auto" } }
     }
     return undefined
+  }
+
+  /** Codex spells session identity exactly as Claude does. Its `Stop` payload
+   *  schema (read off codex-cli 0.153.2's binary) REQUIRES both `session_id`
+   *  and `transcript_path`, and `transcript_path` is the rollout JSONL — the
+   *  same file `codexHistoryReader.transcriptPath` resolves. Without this
+   *  override the daemon records a codex turn with no transcript to read, so
+   *  {@link import("./turns.ts").readCodexTurns} is never reached and
+   *  `rove api agent-turns` answers an empty page for a codex task.
+   *  `transcript_path` is nullable in the schema, hence the string guard. */
+  override sessionFromPayload(payload: Record<string, unknown>): EngineSessionRef | undefined {
+    if (typeof payload.session_id !== "string" || !payload.session_id) return undefined
+    return {
+      sessionId: payload.session_id,
+      ...(typeof payload.transcript_path === "string" && payload.transcript_path
+        ? { transcriptPath: payload.transcript_path }
+        : {}),
+    }
   }
 }

--- a/packages/kobe/src/engine/codex-local/turns.ts
+++ b/packages/kobe/src/engine/codex-local/turns.ts
@@ -1,0 +1,171 @@
+/**
+ * Codex's {@link EngineTurnReader} — per-turn telemetry lifted out of a
+ * rollout JSONL.
+ *
+ * Codex records turn boundaries EXPLICITLY, so this needs none of the
+ * inference Claude's reader does: `event_msg/task_started` opens a turn and
+ * carries the `turn_id` codex assigns it, `event_msg/task_complete` closes the
+ * same id, and `turn_context` names the model that ran it. That `turn_id` is
+ * the vendor-stable dedupe key {@link AgentTurn.id} asks for — the same turn
+ * yields the same id on every re-read, with no "last assistant message"
+ * heuristic. A turn with no `task_complete` is still running (or was
+ * interrupted) and is not emitted: the verb promises COMPLETED turns.
+ *
+ * Usage is summed from `token_count.last_token_usage`, which is the delta for
+ * ONE model request — a turn holding a tool loop writes several. The sibling
+ * `total_token_usage` is session-cumulative, so summing THAT would charge every
+ * turn for the whole session up to it. Summing the per-request deltas inside a
+ * turn reproduces the cumulative delta exactly (verified against a 5-turn
+ * rollout from codex-cli 0.149.1: turn 1's seven deltas sum to 217178, the
+ * cumulative total standing at its `task_complete`). `token_count` carries no
+ * `turn_id`, so it attributes to the turn that is currently open.
+ *
+ * Pure (string in, records out) so it unit-tests without a filesystem; the
+ * bounded file read lives in the reader wrapper below.
+ */
+
+import type { AgentTurn } from "../agent-turn.ts"
+import { isJsonlLineWithinBound, readTextFileBounded } from "../file-bounds.ts"
+import { codexUsageToSnapshot } from "./usage.ts"
+
+function isObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v)
+}
+
+function num(v: unknown): number {
+  return typeof v === "number" && Number.isFinite(v) ? v : 0
+}
+
+interface Draft {
+  turnId: string
+  startedAt: number
+  model?: string
+  contextWindow?: number
+  /** Running sum of this turn's per-request `last_token_usage` fields. */
+  input: number
+  cachedInput: number
+  output: number
+  sawUsage: boolean
+}
+
+/**
+ * Parse a Codex rollout into completed turns, oldest-first.
+ * `fallbackSessionId` names the session when the rollout has no `session_meta`
+ * header (a file opened mid-stream). Exported for unit tests; production
+ * callers use {@link readCodexTurns}.
+ */
+export function parseCodexTurns(raw: string, fallbackSessionId = ""): AgentTurn[] {
+  const out: AgentTurn[] = []
+  const drafts = new Map<string, Draft>()
+  let sessionId = fallbackSessionId
+  let openTurnId = ""
+
+  for (const line of raw.split("\n")) {
+    const trimmed = line.trim()
+    if (!trimmed || !isJsonlLineWithinBound(trimmed)) continue
+    let record: unknown
+    try {
+      record = JSON.parse(trimmed)
+    } catch {
+      continue
+    }
+    if (!isObject(record)) continue
+    const payload = isObject(record.payload) ? record.payload : undefined
+    if (!payload) continue
+    const at = typeof record.timestamp === "string" ? Date.parse(record.timestamp) : Number.NaN
+
+    if (record.type === "session_meta") {
+      const id = payload.session_id ?? payload.id
+      if (typeof id === "string" && id) sessionId = id
+      continue
+    }
+
+    // `turn_context` is the only record naming the model, and it may land
+    // before or after its `task_started` — key it by turn_id, never by "open".
+    if (record.type === "turn_context") {
+      const turnId = typeof payload.turn_id === "string" ? payload.turn_id : ""
+      const model = typeof payload.model === "string" ? payload.model : ""
+      if (!turnId || !model) continue
+      const draft = drafts.get(turnId)
+      if (draft) draft.model = model
+      else drafts.set(turnId, { ...emptyDraft(turnId, Number.NaN), model })
+      continue
+    }
+
+    if (record.type !== "event_msg") continue
+
+    if (payload.type === "task_started") {
+      const turnId = typeof payload.turn_id === "string" ? payload.turn_id : ""
+      if (!turnId) continue
+      const existing = drafts.get(turnId)
+      // `started_at` is epoch SECONDS; the record's own ISO timestamp is the
+      // millisecond-precision answer `AgentTurn` asks for, so prefer it.
+      const startedAt = Number.isFinite(at) ? at : num(payload.started_at) * 1000
+      drafts.set(turnId, { ...emptyDraft(turnId, startedAt), ...(existing?.model ? { model: existing.model } : {}) })
+      if (typeof payload.model_context_window === "number") {
+        const d = drafts.get(turnId)
+        if (d) d.contextWindow = payload.model_context_window
+      }
+      openTurnId = turnId
+      continue
+    }
+
+    if (payload.type === "token_count") {
+      const draft = drafts.get(openTurnId)
+      if (!draft) continue
+      const info = isObject(payload.info) ? payload.info : undefined
+      const last = info && isObject(info.last_token_usage) ? info.last_token_usage : undefined
+      if (!last) continue
+      draft.input += num(last.input_tokens)
+      draft.cachedInput += num(last.cached_input_tokens)
+      draft.output += num(last.output_tokens)
+      draft.sawUsage = true
+      if (draft.contextWindow === undefined && typeof info?.model_context_window === "number") {
+        draft.contextWindow = info.model_context_window
+      }
+      continue
+    }
+
+    if (payload.type !== "task_complete") continue
+    const turnId = typeof payload.turn_id === "string" ? payload.turn_id : ""
+    const draft = turnId ? drafts.get(turnId) : undefined
+    // A `task_complete` with no opener is a rollout we started reading
+    // mid-turn — there is no start time to attribute, so skip it rather than
+    // emit a turn stamped with a guess.
+    if (!draft || !Number.isFinite(draft.startedAt)) continue
+    drafts.delete(turnId)
+    if (openTurnId === turnId) openTurnId = ""
+    const endedAt = Number.isFinite(at) ? at : num(payload.completed_at) * 1000
+    const usage = draft.sawUsage
+      ? codexUsageToSnapshot(
+          { input_tokens: draft.input, cached_input_tokens: draft.cachedInput, output_tokens: draft.output },
+          draft.contextWindow !== undefined ? { contextWindowTokens: draft.contextWindow } : {},
+        )
+      : undefined
+    out.push({
+      id: draft.turnId,
+      sessionId,
+      ...(draft.model ? { model: draft.model } : {}),
+      startedAt: draft.startedAt,
+      endedAt,
+      ...(usage ? { usage } : {}),
+    })
+  }
+  return out
+}
+
+function emptyDraft(turnId: string, startedAt: number): Draft {
+  return { turnId, startedAt, input: 0, cachedInput: 0, output: 0, sawUsage: false }
+}
+
+/** Codex's {@link import("../agent-turn.ts").EngineTurnReader}: bounded file
+ *  read + {@link parseCodexTurns}. Never throws — an unreadable rollout
+ *  yields no turns. */
+export async function readCodexTurns(transcriptPath: string): Promise<readonly AgentTurn[]> {
+  try {
+    const raw = await readTextFileBounded(transcriptPath)
+    return parseCodexTurns(raw)
+  } catch {
+    return []
+  }
+}

--- a/packages/kobe/src/engine/codex-local/turns.ts
+++ b/packages/kobe/src/engine/codex-local/turns.ts
@@ -97,15 +97,17 @@ export function parseCodexTurns(raw: string, fallbackSessionId = ""): AgentTurn[
     if (payload.type === "task_started") {
       const turnId = typeof payload.turn_id === "string" ? payload.turn_id : ""
       if (!turnId) continue
-      const existing = drafts.get(turnId)
+      // A `turn_context` that landed first carries the only model name there
+      // is — keep it rather than resetting the draft over it.
+      const model = drafts.get(turnId)?.model
       // `started_at` is epoch SECONDS; the record's own ISO timestamp is the
       // millisecond-precision answer `AgentTurn` asks for, so prefer it.
       const startedAt = Number.isFinite(at) ? at : num(payload.started_at) * 1000
-      drafts.set(turnId, { ...emptyDraft(turnId, startedAt), ...(existing?.model ? { model: existing.model } : {}) })
-      if (typeof payload.model_context_window === "number") {
-        const d = drafts.get(turnId)
-        if (d) d.contextWindow = payload.model_context_window
-      }
+      drafts.set(turnId, {
+        ...emptyDraft(turnId, startedAt),
+        ...(model ? { model } : {}),
+        ...(typeof payload.model_context_window === "number" ? { contextWindow: payload.model_context_window } : {}),
+      })
       openTurnId = turnId
       continue
     }

--- a/packages/kobe/src/engine/json-hook-adapter.ts
+++ b/packages/kobe/src/engine/json-hook-adapter.ts
@@ -87,9 +87,8 @@ export abstract class JsonHookAdapter implements EngineHookAdapter {
     return undefined
   }
 
-  /** Default: no session identity in the payload. Claude overrides (its
-   *  hooks pipe `session_id`/`transcript_path`); codex session extraction is
-   *  a documented follow-up. */
+  /** Default: no session identity in the payload. Claude and codex both
+   *  override — their hooks pipe `session_id`/`transcript_path`. */
   sessionFromPayload(_payload: Record<string, unknown>): EngineSessionRef | undefined {
     return undefined
   }

--- a/packages/kobe/src/engine/kimi-local/hook-adapter.ts
+++ b/packages/kobe/src/engine/kimi-local/hook-adapter.ts
@@ -183,9 +183,19 @@ export class KimiHookAdapter implements EngineHookAdapter {
 
   /** Kimi's stdin payload spells tool fields `tool_name`; the permission
    *  event is always a permission (Kimi has no elicitation notification).
-   *  `turn-failed` classifies the StopFailure — without it every Kimi
-   *  failure reduces to `error`, Kimi can never reach `rate_limited`, and
-   *  auto-resume is never armed when Kimi hits its 5-hour limit. */
+   *  `turn-failed` classifies the StopFailure — without it every Kimi failure
+   *  reduces to `error` and Kimi can never reach `rate_limited`, so the user
+   *  sees a generic error instead of "waiting on the 5-hour window".
+   *
+   *  The BADGE is all this buys, and that is not an oversight. Auto-resume
+   *  (`daemon/quota-resume.ts`) arms off a reset TIMESTAMP, which it gets from
+   *  the vendor's live usage API via `quotaUsage`. Kimi ships no such API, and
+   *  this payload carries only `error_type`/`error_message` — no reset time on
+   *  either path. The only remaining move would be guessing a reset for a
+   *  ROLLING 5-hour window whose start nobody recorded, and a resume that
+   *  fires early spends a turn to fail again. So: classify for the badge,
+   *  arm nothing. Pinned by "arms nothing for an engine with no quota probe"
+   *  in `test/daemon/quota-resume.test.ts`. */
   activityDetailFromPayload(
     kind: EngineActivityKind,
     payload: Record<string, unknown>,

--- a/packages/kobe/src/engine/plugin-engines.ts
+++ b/packages/kobe/src/engine/plugin-engines.ts
@@ -43,6 +43,7 @@ export function loadPluginEngines(homeDir?: string): readonly string[] {
             ...(engine.processNames ? { processNames: engine.processNames } : {}),
             screenManifest: { rules: engine.rules },
             identity,
+            ...(engine.firstMessageDelivery ? { firstMessageDelivery: engine.firstMessageDelivery } : {}),
           })
           if (ok) {
             registered.push(engine.id)

--- a/packages/kobe/src/engine/registry.ts
+++ b/packages/kobe/src/engine/registry.ts
@@ -381,3 +381,17 @@ export function vendorsWithQuotaProbe(): readonly VendorId[] {
     .filter((entry) => entry.quotaUsage)
     .map((entry) => entry.vendor)
 }
+
+/**
+ * Built-in vendors that ship a per-turn reader. `agent-turns` names these in
+ * its own summary so an empty page can say WHY it is empty — an engine with no
+ * reader contributes nothing, which is a different fact from a task that did no
+ * work. Derived rather than written down: a hard-coded pair in the CLI layer
+ * would be a vendor string in neutral code AND would go stale the moment a
+ * third adapter lands.
+ */
+export function vendorsWithTurnReader(): readonly VendorId[] {
+  return Object.values(BUILTIN_ENGINES)
+    .filter((entry) => entry.readTurns)
+    .map((entry) => entry.vendor)
+}

--- a/packages/kobe/src/engine/trust-worktree.ts
+++ b/packages/kobe/src/engine/trust-worktree.ts
@@ -1,14 +1,39 @@
 /**
- * Worktree pre-trust at spawn time. A Rove-created worktree is
- * a directory the engine has never seen, and every vendor gates that behind
- * a first-run trust dialog a hosted session cannot answer — nobody is at the
- * pane to press a key, so the launch stalls on the dialog instead of starting
- * the turn. (Kimi's is the loudest failure: whether a stray Enter accepts or
- * EXITS the process depends on which option that kimi version defaults to.)
- * The vendor-specific
- * store writes live behind the registry's `trustWorktree` hook; THIS wrapper
- * owns the call policy every spawn path shares: best-effort, never blocks a
- * launch (a failed write just leaves the dialog in the user's way).
+ * Worktree pre-trust at spawn time. A Rove-created worktree is a directory the
+ * engine has never seen, and each of the four BUILT-INS gates that behind a
+ * first-run trust dialog a hosted session cannot answer — nobody is at the pane
+ * to press a key, so the launch stalls on the dialog instead of starting the
+ * turn. (Kimi's is the loudest failure: whether a stray Enter accepts or EXITS
+ * the process depends on which option that kimi version defaults to.) The
+ * vendor-specific store writes live behind the registry's `trustWorktree` hook;
+ * THIS wrapper owns the call policy every spawn path shares: best-effort, never
+ * blocks a launch (a failed write just leaves the dialog in the user's way).
+ *
+ * "Every vendor" is what this said before, and it is not true — measured
+ * 2026-09-04, launching each installed CLI under a PTY in a fresh git
+ * directory and reading the first screen without sending a key:
+ *
+ *   - opencode 0.6.3 does NOT gate. It lands on its composer (`enter send`)
+ *     both with the user's real config and with an EMPTY `HOME`, where every
+ *     directory is unseen and a per-directory gate would have to fire. It has
+ *     no trust flag in `--help` either. So a contrib engine getting
+ *     `undefined` here is not automatically a stalled launch.
+ *   - cursor-agent DOES gate: its own `--help` carries `--trust  Trust the
+ *     current workspace without prompting`, and scopes that flag to
+ *     `--print`/headless — which is exactly the escape hatch Rove's
+ *     interactive launch cannot use. It is a shipped contrib engine with no
+ *     `trustWorktree`, so this gap is real, just not universal. (Not observed
+ *     live: the cursor-agent on the probe machine stops at its login wall,
+ *     which the CURSOR screen manifest already reports as `blocked`.)
+ *   - gemini / grok / droid / amp: UNVERIFIED — not installed on the machine
+ *     this was measured on. Do not assume either way.
+ *
+ * A note for whoever closes the cursor gap: the obvious shape — a declarative
+ * `trustRecord: { file, jsonPath, value }` a manifest could express — does not
+ * cover what is already here. Three built-ins do merge one key into one config
+ * file, but kimi writes a whole FILE PER WORKSPACE whose NAME is
+ * `wd_<lowercased basename>_<sha256(realpath)[:12]>` (see `kimi-local/trust.ts`).
+ * A record format that cannot express kimi cannot replace this hook.
  */
 
 import type { VendorId } from "../types/vendor.ts"

--- a/packages/kobe/test/daemon/agent-turns.test.ts
+++ b/packages/kobe/test/daemon/agent-turns.test.ts
@@ -1,8 +1,9 @@
 /** Durable per-turn telemetry: store persistence + the hook-driven ingest. */
 
-import { mkdtemp, rm, stat } from "node:fs/promises"
+import { mkdtemp, rm, stat, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
+import { daemonRuntime } from "@/core/daemon-runtime"
 import { ingestAgentTurns } from "@sma1lboy/kobe-daemon/daemon/agent-turns-ingest"
 import { AgentTurnsStore } from "@sma1lboy/kobe-daemon/daemon/agent-turns-store"
 import type { AgentTurn, AgentTurnRecord, DaemonOrchestrator } from "@sma1lboy/kobe-daemon/daemon/contracts"
@@ -166,5 +167,79 @@ describe("ingestAgentTurns", () => {
     const { runtime, orch, asked } = deps()
     await ingestAgentTurns(store, runtime, orch, { taskId: "task-1", transcriptPath: "/t.jsonl" })
     expect(asked[0].vendor).toBe("claude")
+  })
+
+  // The whole join, with NO stubbed reader: real runtime adapter -> real
+  // registry lookup -> the vendor's own parser. This is what tells an
+  // `agent-turns` page that is honestly empty apart from one that is empty
+  // because the engine has no reader — with codex's `readTurns` unregistered
+  // this records 0 and the assertions below fail.
+  it("records codex turns through the real runtime adapter", async () => {
+    const { store } = await createStore()
+    const rollout = join(dir as string, "rollout.jsonl")
+    const turnId = "01a060d6-dd1a-7621-889f-d9da35a4699e"
+    await writeFile(
+      rollout,
+      [
+        { timestamp: "2026-09-02T06:38:09.182Z", type: "session_meta", payload: { session_id: "sess-cx" } },
+        {
+          timestamp: "2026-09-02T06:38:09.182Z",
+          type: "event_msg",
+          payload: { type: "task_started", turn_id: turnId, model_context_window: 258400 },
+        },
+        {
+          timestamp: "2026-09-02T06:38:09.398Z",
+          type: "turn_context",
+          payload: { turn_id: turnId, model: "gpt-5.6-luna" },
+        },
+        {
+          timestamp: "2026-09-02T06:38:16.153Z",
+          type: "event_msg",
+          payload: {
+            type: "token_count",
+            info: {
+              total_token_usage: { input_tokens: 19292, cached_input_tokens: 8960, output_tokens: 276 },
+              last_token_usage: { input_tokens: 19292, cached_input_tokens: 8960, output_tokens: 276 },
+            },
+          },
+        },
+        {
+          timestamp: "2026-09-02T06:39:02.616Z",
+          type: "event_msg",
+          payload: { type: "task_complete", turn_id: turnId },
+        },
+      ]
+        .map((r) => JSON.stringify(r))
+        .join("\n"),
+    )
+    const orch = { getTask: () => ({ repo: "/repo", vendor: "codex" }) } as unknown as DaemonOrchestrator
+
+    const result = await ingestAgentTurns(store, daemonRuntime, orch, {
+      taskId: "task-cx",
+      vendor: "codex",
+      transcriptPath: rollout,
+    })
+
+    expect(result.recorded).toBe(1)
+    expect(store.list()).toEqual([
+      {
+        id: turnId,
+        // Read off the rollout's `session_meta`, so the record names the codex
+        // session it came from and not just the Rove task.
+        sessionId: "sess-cx",
+        taskId: "task-cx",
+        vendor: "codex",
+        model: "gpt-5.6-luna",
+        repo: "/repo",
+        startedAt: Date.parse("2026-09-02T06:38:09.182Z"),
+        endedAt: Date.parse("2026-09-02T06:39:02.616Z"),
+        usage: {
+          input_tokens: 10332,
+          output_tokens: 276,
+          cache_read_input_tokens: 8960,
+          context_window_tokens: 258400,
+        },
+      },
+    ])
   })
 })

--- a/packages/kobe/test/daemon/quota-resume.test.ts
+++ b/packages/kobe/test/daemon/quota-resume.test.ts
@@ -9,6 +9,8 @@ import {
 } from "../../../kobe-daemon/src/daemon/quota-resume.ts"
 import type { QuotaUsageCache } from "../../../kobe-daemon/src/daemon/quota-usage-cache.ts"
 import type { DaemonRuntimeAdapter } from "../../../kobe-daemon/src/daemon/runtime.ts"
+import { daemonRuntime } from "../../src/core/daemon-runtime.ts"
+import { vendorsWithQuotaProbe } from "../../src/engine/registry.ts"
 
 const NOW = Date.parse("2026-07-27T12:00:00.000Z")
 const PAST = new Date(NOW - 1000).toISOString()
@@ -119,6 +121,32 @@ describe("scheduleQuotaResume", () => {
     await scheduleQuotaResume(orch, RUNTIME, fakeCache(null), "t1", () => NOW)
     await scheduleQuotaResume(orch, RUNTIME, fakeCache({ windows: [], capturedAt: NOW }), "t1", () => NOW)
     expect(orch.setQuotaResume).not.toHaveBeenCalled()
+  })
+
+  // Kimi's hook adapter classifies its 429s as `rate_limit` — that is what
+  // makes the sticky `rate_limited` badge light up, and it is the whole of what
+  // the classification buys. Arming a resume needs a RESET TIMESTAMP, and kimi
+  // publishes one nowhere: it ships no quota API, so no `quotaUsage` probe, and
+  // its `turn-failed` payload carries only `error_type`/`error_message`. The
+  // only way to arm one would be to guess a reset for a 5-hour ROLLING window
+  // whose start nobody recorded, and a resume that fires at the wrong time
+  // spends a turn to fail again. So this asserts the honest behavior rather
+  // than a wish: a kimi rate-limit arms nothing.
+  it("arms nothing for an engine with no quota probe (kimi), badge only", async () => {
+    const orch = fakeOrch([task("t1", { vendor: "kimi" })])
+    // The REAL adapter, not a stub — the point is what the registry answers.
+    const runtime = { defaultTaskVendor: "claude" } as unknown as DaemonRuntimeAdapter
+    const cache = {
+      get: vi.fn(async (vendor: string) => (await daemonRuntime.quotaUsage(vendor as never)) ?? null),
+    } as unknown as QuotaUsageCache & { get: ReturnType<typeof vi.fn> }
+
+    await scheduleQuotaResume(orch, runtime, cache, "t1", () => NOW)
+
+    expect(cache.get).toHaveBeenCalledWith("kimi", 0)
+    expect(orch.setQuotaResume).not.toHaveBeenCalled()
+    // The reason, stated where a future reader will look: kimi is absent from
+    // the probe list, so there is nothing to ask when the limit lands.
+    expect(vendorsWithQuotaProbe()).toEqual(["claude", "codex"])
   })
 
   it("ignores unknown and deleting tasks", async () => {

--- a/packages/kobe/test/engine/codex-hook-adapter.test.ts
+++ b/packages/kobe/test/engine/codex-hook-adapter.test.ts
@@ -19,6 +19,29 @@ vi.mock("../../src/cli/invocation.ts", () => ({
 describe("CodexHookAdapter", () => {
   const adapter = new CodexHookAdapter()
 
+  // Field names + nullability taken from the `stop.command.input` JSON schema
+  // embedded in codex-cli 0.153.2's binary, which REQUIRES both keys. Without
+  // this the daemon records a turn-complete carrying no transcript, so codex's
+  // turn reader is never reached and `agent-turns` stays empty.
+  it("extracts session identity from a Stop payload", () => {
+    expect(
+      adapter.sessionFromPayload({
+        hook_event_name: "Stop",
+        session_id: "01a060d6-aae5-7c90-91c0-d5f81da8f343",
+        transcript_path: "/Users/x/.codex/sessions/2026/09/01/rollout-x.jsonl",
+        model: "gpt-5.6-luna",
+      }),
+    ).toEqual({
+      sessionId: "01a060d6-aae5-7c90-91c0-d5f81da8f343",
+      transcriptPath: "/Users/x/.codex/sessions/2026/09/01/rollout-x.jsonl",
+    })
+  })
+
+  it("tolerates the schema's nullable transcript_path and an absent session", () => {
+    expect(adapter.sessionFromPayload({ session_id: "s1", transcript_path: null })).toEqual({ sessionId: "s1" })
+    expect(adapter.sessionFromPayload({ transcript_path: "/t.jsonl" })).toBeUndefined()
+  })
+
   it("declares itself a wired hook engine writing ~/.codex/hooks.json", () => {
     expect(adapter.vendor).toBe("codex")
     expect(adapter.supportsHooks()).toBe(true)

--- a/packages/kobe/test/engine/codex-turns.test.ts
+++ b/packages/kobe/test/engine/codex-turns.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Per-turn telemetry extraction from a Codex rollout.
+ *
+ * Record shapes are copied from a real `~/.codex/sessions/**.jsonl` written by
+ * codex-cli 0.149.1 (prose payloads — base instructions, the assistant's reply,
+ * rate limits — dropped; every field this reader touches is verbatim).
+ */
+
+import { parseCodexTurns } from "@/engine/codex-local/turns"
+import { describe, expect, test } from "vitest"
+
+const SID = "01a060d6-aae5-7c90-91c0-d5f81da8f343"
+const T1 = "01a060d6-dd1a-7621-889f-d9da35a4699e"
+const T2 = "01a060d7-dd1a-7621-889f-d9da35a4699e"
+
+function line(record: Record<string, unknown>): string {
+  return JSON.stringify(record)
+}
+
+const meta = line({ timestamp: "2026-09-02T06:38:09.182Z", type: "session_meta", payload: { session_id: SID } })
+
+function started(ts: string, turnId: string): string {
+  return line({
+    timestamp: ts,
+    type: "event_msg",
+    payload: { type: "task_started", turn_id: turnId, started_at: 1788331089, model_context_window: 258400 },
+  })
+}
+
+function context(ts: string, turnId: string, model = "gpt-5.6-luna"): string {
+  return line({ timestamp: ts, type: "turn_context", payload: { turn_id: turnId, model } })
+}
+
+/** One model request inside a turn. `total` is session-cumulative, `last` is
+ *  this request's delta — the reader must use `last`. */
+function tokenCount(ts: string, last: [number, number, number], total: [number, number, number]): string {
+  const usage = ([i, c, o]: [number, number, number]) => ({
+    input_tokens: i,
+    cached_input_tokens: c,
+    output_tokens: o,
+  })
+  return line({
+    timestamp: ts,
+    type: "event_msg",
+    payload: {
+      type: "token_count",
+      info: { total_token_usage: usage(total), last_token_usage: usage(last), model_context_window: 258400 },
+    },
+  })
+}
+
+function completed(ts: string, turnId: string): string {
+  return line({
+    timestamp: ts,
+    type: "event_msg",
+    payload: { type: "task_complete", turn_id: turnId, completed_at: 1788331142, duration_ms: 53436 },
+  })
+}
+
+/** Two turns, the first holding a two-request tool loop. */
+const ROLLOUT = [
+  meta,
+  started("2026-09-02T06:38:09.182Z", T1),
+  context("2026-09-02T06:38:09.398Z", T1),
+  tokenCount("2026-09-02T06:38:16.153Z", [19292, 8960, 276], [19292, 8960, 276]),
+  tokenCount("2026-09-02T06:38:40.000Z", [28295, 9000, 246], [47587, 17960, 522]),
+  completed("2026-09-02T06:39:02.616Z", T1),
+  started("2026-09-02T06:39:18.843Z", T2),
+  context("2026-09-02T06:39:19.000Z", T2),
+  tokenCount("2026-09-02T06:39:40.000Z", [37995, 10000, 70], [85582, 27960, 592]),
+  completed("2026-09-02T06:40:24.755Z", T2),
+].join("\n")
+
+describe("parseCodexTurns", () => {
+  test("emits one record per completed turn, with model, span, and summed usage", () => {
+    const turns = parseCodexTurns(ROLLOUT)
+    expect(turns).toHaveLength(2)
+    expect(turns[0]).toEqual({
+      id: T1,
+      sessionId: SID,
+      model: "gpt-5.6-luna",
+      startedAt: Date.parse("2026-09-02T06:38:09.182Z"),
+      endedAt: Date.parse("2026-09-02T06:39:02.616Z"),
+      usage: {
+        // The turn's two requests: input 19292+28295 = 47587 total, of which
+        // 8960+9000 = 17960 was cached, so 29627 was billed as fresh input.
+        input_tokens: 29627,
+        output_tokens: 522,
+        cache_read_input_tokens: 17960,
+        context_window_tokens: 258400,
+      },
+    })
+    expect(turns[1]?.id).toBe(T2)
+    expect(turns[1]?.usage?.output_tokens).toBe(70)
+  })
+
+  test("charges a turn only its own requests, not the session running total", () => {
+    // The regression this guards: `total_token_usage` sits in the same record
+    // and is cumulative, so reading it would bill turn 2 for turn 1 as well.
+    const turns = parseCodexTurns(ROLLOUT)
+    expect(turns[1]?.usage?.input_tokens).toBe(37995 - 10000)
+    expect(turns[1]?.usage?.cache_read_input_tokens).toBe(10000)
+  })
+
+  test("turn ids are stable across re-reads — the dedupe key AgentTurn requires", () => {
+    // The hook fires on every Stop and the rollout is re-read from the top, so
+    // an unstable id would re-record every past turn on each read.
+    expect(parseCodexTurns(ROLLOUT).map((t) => t.id)).toEqual(parseCodexTurns(ROLLOUT).map((t) => t.id))
+    expect(parseCodexTurns(ROLLOUT).map((t) => t.id)).toEqual([T1, T2])
+  })
+
+  test("a turn still running is not emitted until its task_complete lands", () => {
+    const open = ROLLOUT.split("\n").slice(0, -1).join("\n")
+    expect(parseCodexTurns(open).map((t) => t.id)).toEqual([T1])
+    expect(parseCodexTurns(ROLLOUT).map((t) => t.id)).toEqual([T1, T2])
+  })
+
+  test("a task_complete with no opener (file read mid-turn) is skipped", () => {
+    const orphan = [meta, completed("2026-09-02T06:39:02.616Z", T1)].join("\n")
+    expect(parseCodexTurns(orphan)).toEqual([])
+  })
+
+  test("a turn with no token_count carries no usage rather than zeros", () => {
+    const noUsage = [meta, started("2026-09-02T06:38:09.182Z", T1), completed("2026-09-02T06:39:02.616Z", T1)].join(
+      "\n",
+    )
+    expect(parseCodexTurns(noUsage)[0]?.usage).toBeUndefined()
+  })
+
+  test("garbage lines and an absent session_meta do not throw", () => {
+    const messy = ["not json", "", "{}", started("2026-09-02T06:38:09.182Z", T1), completed("x", T1)].join("\n")
+    expect(() => parseCodexTurns(messy, "fallback-sid")).not.toThrow()
+    expect(parseCodexTurns(messy, "fallback-sid")[0]?.sessionId).toBe("fallback-sid")
+  })
+})

--- a/packages/kobe/test/engine/plugin-engines-load.test.ts
+++ b/packages/kobe/test/engine/plugin-engines-load.test.ts
@@ -100,4 +100,20 @@ describe("loadPluginEngines", () => {
     homeWith([])
     expect(loadPluginEngines()).toEqual([])
   })
+
+  // A subcommand- or directory-positional CLI dies on its own first prompt
+  // under the "argv" default. The manifest key is the author's only fix, so it
+  // has to survive all three hops: TOML parse -> ContribEngineSpec -> registry.
+  it("carries first_message_delivery from the manifest to the registry entry", () => {
+    const paste = MANIFEST.replace('command = ["aider"]', 'command = ["aider"]\nfirst_message_delivery = "paste"')
+    homeWith([{ id: "acme.engines", root: pluginRoot(paste) }])
+    expect(loadPluginEngines()).toEqual(["aider"])
+    expect(engineEntry("aider").firstMessageDelivery).toBe("paste")
+  })
+
+  it("omitting first_message_delivery leaves the registry's argv default", () => {
+    homeWith([{ id: "acme.engines", root: pluginRoot(MANIFEST) }])
+    expect(loadPluginEngines()).toEqual(["aider"])
+    expect(engineEntry("aider").firstMessageDelivery).toBeUndefined()
+  })
 })

--- a/packages/kobe/test/engine/plugin-engines.test.ts
+++ b/packages/kobe/test/engine/plugin-engines.test.ts
@@ -67,6 +67,22 @@ describe("plugin manifest [[engines]]", () => {
     expect(() => parsePluginManifest(bad)).toThrow(/needs at least one of/)
   })
 
+  it("parses first_message_delivery", () => {
+    const paste = MANIFEST.replace(
+      'command = ["aider", "--no-auto-commits"]',
+      'command = ["aider"]\nfirst_message_delivery = "paste"',
+    )
+    expect(parsePluginManifest(paste).manifest.engines[0]?.firstMessageDelivery).toBe("paste")
+    expect(parsePluginManifest(MANIFEST).manifest.engines[0]?.firstMessageDelivery).toBeUndefined()
+  })
+
+  it("rejects an unknown first_message_delivery rather than falling back to argv", () => {
+    // Silently defaulting would leave the author with the launch failure the
+    // key exists to fix, and no error pointing at the typo.
+    const bad = MANIFEST.replace('name = "Aider"', 'name = "Aider"\nfirst_message_delivery = "stdin"')
+    expect(() => parsePluginManifest(bad)).toThrow(/first_message_delivery must be argv \| paste/)
+  })
+
   it("rejects invalid line_regex", () => {
     const bad = `${MANIFEST}\n[[engines.rules]]\nstate = "working"\nline_regex = ["("]\n`
     expect(() => parsePluginManifest(bad)).toThrow(/not a valid regex/)

--- a/packages/kobe/test/engine/registry.test.ts
+++ b/packages/kobe/test/engine/registry.test.ts
@@ -20,6 +20,7 @@ import {
   getCapabilities,
   supportsStructuredHistory,
   vendorsWithQuotaProbe,
+  vendorsWithTurnReader,
 } from "../../src/engine/registry.ts"
 
 /** A DetectDeps with every binary found and no files/env, overridable per test. */
@@ -150,6 +151,21 @@ describe("vendorsWithQuotaProbe", () => {
 
   it("omits engines with no probe rather than listing them as silent failures", () => {
     expect(vendorsWithQuotaProbe()).not.toContain("copilot")
+  })
+})
+
+describe("vendorsWithTurnReader", () => {
+  it("lists every engine that can report per-turn telemetry", () => {
+    // `agent-turns` builds its own summary from this, so an empty page can say
+    // WHY it is empty. Hard-coding the pair in the CLI layer would put vendor
+    // strings in neutral code and go stale on the third adapter.
+    const vendors = vendorsWithTurnReader()
+    expect([...vendors].sort()).toEqual(["claude", "codex"])
+    for (const vendor of vendors) expect(engineEntry(vendor).readTurns).toBeDefined()
+  })
+
+  it("omits engines with no reader rather than implying they report nothing", () => {
+    expect(vendorsWithTurnReader()).not.toContain("kimi")
   })
 })
 


### PR DESCRIPTION
Task AV — four places the engine contract could not say what a surface needed.
Batch A is another worker's; `engine/foreground.ts`, `activity-observer.ts` and
`targetFor` are untouched here.

Evidence lives outside this worktree so it survives deletion:
**`/Users/jacksonc/rove-evidence/loop-r16-av/`**

---

## B2 — verify before building. It half-survived.

**PASS:** point each installed contrib CLI at a directory it has never seen and
observe whether it gates. If none do, the brief is void and `trust-worktree.ts`'s
"every vendor" gets narrowed.

**Method.** A PTY probe (`trust-probe.mjs`) launches the CLI in a fresh `git init`
dir, captures the first screen, then SIGKILLs. **Nothing was ever written to any
child's stdin** — no Enter, no keys, no accidental accept or upgrade. The only
things I sent any vendor CLI were `opencode --help` and `cursor-agent --help`.

**Positive control first** (a probe that reports "no dialog" is worthless until it
is shown to render one): `claude` under an empty `HOME` renders its blocking
theme-picker with the `❯` cursor. The probe sees modal gates.

| CLI | Result |
|---|---|
| opencode 0.6.3 | **Does not gate.** Lands on its composer (`enter send`) with the real config *and* with an empty `HOME`, where every directory is unseen and a per-directory gate would have to fire. No trust flag in `--help`. |
| cursor-agent 2026.04.17 | **Does gate.** Its own `--help`: `--trust  Trust the current workspace without prompting (only works with --print/headless mode)`. The flag documents the prompt and scopes the bypass to exactly the mode Rove's interactive launch is not. Not seen live — this machine's cursor-agent stops at its login wall (already reported `blocked` by the CURSOR manifest). |
| gemini / grok / droid / amp | **Unverified** — not installed here. No claim made. |

**Verdict: partly void.** "Every vendor" is false, so it is narrowed. The gap is
real for a shipped contrib engine, so it is recorded rather than dropped.

**I did not build the fix, and the brief's proposed shape is why.** A declarative
`trustRecord: { file, jsonPath, value }` cannot replace this hook: three built-ins
do merge one key into one file, but **kimi writes a file per workspace whose NAME
is `wd_<lowercased basename>_<sha256(realpath)[:12]>`**. A record format that
cannot express kimi is not a replacement. Building a speculative one for a store
I cannot even observe (cursor-agent is not logged in here) would have been
unprovable. Narrowed the doc, named the gap, left the hook.

📎 `b2-trust-probe-results.txt`

---

## B1 — a manifest key that existed on one side only

**PASS:** a manifest declaring `first_message_delivery = "paste"` parses, survives
`loadPluginEngines`, and `engineEntry(id).firstMessageDelivery === "paste"`.

`ContribEngineSpec` carries the field and `contribEngineEntry` honors it, but the
manifest parser never read such a key and `plugin-engines.ts` dropped it — so an
author wrapping a subcommand- or directory-positional CLI got a launch that dies
on its own first prompt and no way to say so. Parsed, forwarded, documented. An
unknown value is now a manifest error rather than a silent fall back to the argv
default that caused the failure.

**Proof — two mutation sites, each killing exactly its own test:**

| Mutation | Result |
|---|---|
| drop the forwarding in `plugin-engines.ts` | `× carries first_message_delivery from the manifest to the registry entry` (1 failed, 5 passed) |
| drop the enum check in `manifest.ts` | `× rejects an unknown first_message_delivery rather than falling back to argv` (1 failed, 22 passed) |

---

## C1 — a confident empty page

**PASS (as stated in the brief):** `rove api agent-turns` on a Codex task returns
records matching what the task actually did, and the test distinguishes an
honestly-empty page from one empty because nobody wrote the reader.

Codex turns out to be *easier* than claude, not harder: the rollout records
boundaries explicitly — `task_started` / `task_complete` carry the `turn_id` codex
itself assigns (a vendor-stable `AgentTurn.id`, no "last assistant message"
heuristic) and `turn_context` names the model.

**One thing the brief got wrong, flagged rather than widened silently:** it is not
only an adapter file. Codex's hook adapter never overrode `sessionFromPayload`
(the base class even said "codex session extraction is a documented follow-up"),
so no `transcriptPath` ever reached the daemon and a perfect reader would have
been dead code. Fixed in the same adapter — no contract change. Field names come
from the `stop.command.input` JSON schema embedded in codex-cli 0.153.2's binary,
which **requires** `session_id` and `transcript_path`.

**Usage:** summed from `token_count.last_token_usage` (the per-request delta; a
turn with a tool loop writes several). The sibling `total_token_usage` is
session-cumulative — reading it would charge every turn for the whole session
before it.

### End-to-end BEFORE / AFTER — real production path

Identical Stop-hook payload and rollout fixture through `rove hook turn-complete`
(so `sessionFromPayload` is exercised), against two isolated daemons on private
homes and ports.

**BEFORE** — `origin/main` 6b3a616e3, freshly built; bundle verified to contain
zero occurrences of `parseCodexTurns`/`task_complete`:
```json
"totals": { "turns": 0, ... },  "turns": []
```
**AFTER** — this branch:
```json
"totals": { "turns": 5, "inputTokens": 57402, "outputTokens": 5749,
            "cacheReadTokens": 1230848, "durationMs": 211496,
            "byModel": { "gpt-5.6-luna": 5 } }
```

📎 `c1-BEFORE-agent-turns.json` · `c1-AFTER-agent-turns.json`

### Reconciled against the vendor's own numbers

Run over a real 5-turn rollout, every turn checks out against codex's cumulative
totals and its own `duration_ms`:

```
id=01a060d6-dd1a model=gpt-5.6-luna dur=53434ms in=32602 cached=184576 out=1437
id=01a060d7-ed36 model=gpt-5.6-luna dur=65912ms in=11019 cached=383488 out=1386
id=01a060da-3dfc model=gpt-5.6-luna dur=71334ms in=10589 cached=430592 out=2445
id=01a060db-9d35 model=gpt-5.6-luna dur=7213ms  in=1864  cached=91648  out=148
id=01a060dc-ace0 model=gpt-5.6-luna dur=13603ms in=1328  cached=140544 out=333
```
Turn 1: `in+cached` = 217178 = the cumulative `total_input` standing at its
`task_complete`; `out` = 1437 = the cumulative `total_output` there. Turns 2-5
each equal the cumulative delta across their span, and turns 2-5's durations are
bit-exact against codex's own `duration_ms`.

📎 `c1-real-rollout.txt`

**The test that tells the two empties apart** — `records codex turns through the
real runtime adapter` drives `ingestAgentTurns` with **no stubbed reader**: real
`daemonRuntime` → real registry lookup → the vendor's parser. Mutation: remove
`readTurns: readCodexTurns` → `× ... expect(result.recorded).toBe(1)`. That is
precisely the "empty because nobody implemented the reader" state.
Second mutation site: swap `last_token_usage` for `total_token_usage` → 2 red.

The verb's summary and `docs/API.md` now name which engines report turns, so an
empty page for any other engine says why instead of implying no work happened.

---

## C2 — a classification that arms nothing

**PASS:** decide honestly whether this is a gap to fill or a comment promising
what the design never intended, and say which.

**Conclusion: the comment, not the code.** Arming requires a reset *timestamp*.
`scheduleQuotaResume` gets one from the vendor's live usage API via `quotaUsage`;
only claude and codex declare one. Kimi ships no such API, and its `turn-failed`
payload carries only `error_type` / `error_message` — **no reset time on either
path**. The only remaining move would be guessing a reset for a *rolling* 5-hour
window whose start nobody recorded, and quota-resume's own doc says a resume that
fires wrong burns a turn redoing work. So there is nothing to build here that
would be honest.

The classification still earns its place — it is what lights the sticky
`rate_limited` badge, which is real user-visible value. Only the auto-resume
claim was false; the comment now says what it buys and why a resume cannot
follow.

Rather than the brief's suggested currently-red test (a red test cannot land, and
would assert a wish), the test pins the **honest** behavior with its own positive
control: it asserts `cache.get` **was** called with `"kimi"` — proving it got past
the guards and actually asked — and that nothing was armed, plus
`vendorsWithQuotaProbe() === ["claude", "codex"]` as the stated reason. Mutation
(arm unconditionally) → 2 red, so it is not vacuous.

---

## Two refactors, both prompted by the work

**The vendor names came back out.** My first pass wrote "Claude and codex report
turns" into the `agent-turns` verb summary — vendor strings in a neutral layer,
which is the exact smell this batch exists to remove, and stale on the third
adapter. `vendorsWithTurnReader()` now joins `vendorsWithQuotaProbe()` as a
registry accessor and the summary reads off it:

```
$ rove api agent-turns --help
... Engines that report turns: claude, codex — a task on any other engine
yields an empty page because that engine has no turn reader, not because it
did no work.
```

## One refactor the cap asked for

B1's +13 lines pushed `packages/kobe-daemon/src/plugins/manifest.ts` to 511
(cap ~500), so it is split rather than exempted. **The seam:**
`manifest-coerce.ts` turns an `unknown` parsed out of TOML into a typed value
or fails with a field-named diagnostic, and knows no manifest key;
`manifest.ts` keeps what the fields ARE and in what combinations. While there,
the engine rules' local copy of the string-array coercer folds into the shared
one. No behavior change — 466 lines now, whole suite green either side.

## Gates

`bun run lint` clean · `bun run typecheck` clean · **4475 vitest passed (451
files)** · **814 socket passed (100 files)** — all on the rebased tree.

## Not proven

- **No harness screenshots.** Nothing here renders in the TUI: B1 is a plugin
  manifest key, B2 is documentation, C1 is a CLI/API surface (its evidence is the
  `agent-turns` BEFORE/AFTER above), C2 is a comment plus a test. Saying so
  rather than attaching an unrelated picture.
- **No live Codex turn was spent.** The end-to-end run replays a real Stop payload
  over a real rollout, which exercises every hop; what it does not exercise is
  codex *itself* invoking the hook. Codex also will not run a non-managed hook
  until the user trusts it via `/hooks`, so that hop needs a human either way.
- **cursor-agent's trust dialog was inferred from its own `--help`, not seen** —
  this machine's install stops at its login wall.
- **gemini / grok / droid / amp were not probed** — not installed here.

## New keybindings

None.
