### PR TITLE
fix: reject a cwd match that crosses a repository boundary

### DIFF
--- a/.changeset/cwd-match-repo-boundary.md
+++ b/.changeset/cwd-match-repo-boundary.md
@@ -1,0 +1,7 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Stop attributing another repository's engine session to a project. Engine activity hooks are global — they fire for every session on the machine — and the daemon mapped a hook's `cwd` to a task by pure longest-path-prefix, so a session in a *different* git repository nested under a tracked project (a vendored clone under `refs/`, a `.dev-sandbox` checkout, any repo under a `$HOME` scratch shell's directory task) lit that project's activity badge, filled its event feed, fired its plugin events, and billed its tokens in `rove api agent-turns` / `digest`.
+
+A cwd now only matches a task when no git repository boundary sits between the task's worktree and the cwd. Plain subdirectories of the task's own repo still match, and a nested repo that is itself a Rove task still gets its own sessions.

--- a/packages/kobe-daemon/src/daemon/cwd-task.ts
+++ b/packages/kobe-daemon/src/daemon/cwd-task.ts
@@ -13,11 +13,20 @@
  * `main` task's worktreePath can be the repo root itself, so the more specific
  * (longer) worktree must win.
  *
+ * A prefix match alone is NOT enough: the hooks are global, so a session in a
+ * DIFFERENT repository nested under a tracked project's root (a vendored
+ * clone under `refs/`, a `.dev-sandbox` checkout, any repo under a `$HOME`
+ * scratch shell's directory task) prefix-matches that project and would be
+ * billed its badge, its events, its plugin dispatch and its tokens. So a
+ * candidate is rejected when a repository boundary sits between the task's
+ * worktree and the cwd — see {@link crossesRepoBoundary}.
+ *
  * cwds that match no task (an unrelated repo, a project root with no main task)
  * return undefined → the event is dropped.
  */
 
 import { createHash } from "node:crypto"
+import { existsSync } from "node:fs"
 import { homedir } from "node:os"
 import path from "node:path"
 import { LEGACY_KOBE_STATE_DIR_BASENAME, ROVE_STATE_DIR_BASENAME, readRoveHomeDirEnv } from "../compat-env.ts"
@@ -79,21 +88,51 @@ function isAncestorOrSelf(wt: string, cwd: string): boolean {
 }
 
 /**
+ * True when some directory strictly below `wt`, down to and including `cwd`,
+ * is a git repository root of its own — i.e. walking up from the engine's cwd
+ * to the task's worktree crosses out of one repository into another.
+ *
+ * `.git` is tested with a bare existence check because both spellings mean the
+ * same thing here: a directory for a normal clone, a file for a submodule or a
+ * linked worktree. Either way `git rev-parse --show-toplevel` in `cwd` would
+ * answer something other than the task's worktree, so the engine is not
+ * working on that task's code.
+ *
+ * `wt` itself is deliberately never tested — a task's own worktree IS a repo
+ * root (or a linked worktree with a `.git` file), and testing it would reject
+ * every legitimate match.
+ */
+function crossesRepoBoundary(wt: string, cwd: string): boolean {
+  for (let dir = cwd; dir.length > wt.length; dir = path.dirname(dir)) {
+    if (existsSync(path.join(dir, ".git"))) return true
+  }
+  return false
+}
+
+/**
  * Return the id of the task whose worktree contains `cwd`, preferring the
- * longest (most specific) worktree path, or undefined if none match.
+ * longest (most specific) worktree path, or undefined if none match or the
+ * best match is in a different repository than `cwd`.
+ *
+ * Only the winner is boundary-checked: a boundary below the longest candidate
+ * is below every shorter one too, so if the most specific match crosses, so
+ * does every alternative.
  */
 export function matchTaskByCwd(tasks: ReadonlyArray<CwdMatchTask>, cwd: string): string | undefined {
   const target = normalize(cwd)
   let bestId: string | undefined
+  let bestWt = ""
   let bestLen = -1
   for (const t of tasks) {
     if (!t.worktreePath) continue
     const wt = normalize(t.worktreePath)
     if (isAncestorOrSelf(wt, target) && wt.length > bestLen) {
       bestLen = wt.length
+      bestWt = wt
       bestId = t.id
     }
   }
+  if (bestId && crossesRepoBoundary(bestWt, target)) return undefined
   return bestId
 }
 

--- a/packages/kobe/test/daemon/cwd-task.test.ts
+++ b/packages/kobe/test/daemon/cwd-task.test.ts
@@ -1,3 +1,5 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
 import path from "node:path"
 import { findAdoptableWorktree, matchTaskByCwd, matchTaskByWorktreePath } from "@sma1lboy/kobe-daemon/daemon/cwd-task"
 import { afterEach, beforeEach, describe, expect, it } from "vitest"
@@ -67,6 +69,66 @@ describe("matchTaskByCwd", () => {
   it("tolerates a trailing slash on either side", () => {
     expect(matchTaskByCwd([{ id: "z", worktreePath: "/repo/wt/" }], "/repo/wt")).toBe("z")
     expect(matchTaskByCwd([{ id: "z", worktreePath: "/repo/wt" }], "/repo/wt/")).toBe("z")
+  })
+})
+
+// The engine hooks are global, so a cwd under a tracked worktree can belong to
+// a DIFFERENT repository — a vendored clone under `refs/`, a `.dev-sandbox`
+// checkout, any repo under a `$HOME` scratch shell's directory task. Real
+// directories, because the boundary is decided by a `.git` on disk.
+describe("matchTaskByCwd across a repository boundary", () => {
+  let root: string
+
+  beforeEach(() => {
+    root = mkdtempSync(path.join(tmpdir(), "rove-cwd-task-"))
+    // A tracked project, its own plain subdir, and a nested UNRELATED repo.
+    mkdirSync(path.join(root, "alpha", ".git"), { recursive: true })
+    mkdirSync(path.join(root, "alpha", "src", "deep"), { recursive: true })
+    mkdirSync(path.join(root, "alpha", "refs", "vendorlib", ".git"), { recursive: true })
+    // A repo and a plain directory under a `$HOME`-style directory task.
+    mkdirSync(path.join(root, "gamma", ".git"), { recursive: true })
+    mkdirSync(path.join(root, "notes"), { recursive: true })
+  })
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true })
+  })
+
+  it("drops a cwd in a nested repo of its own", () => {
+    const tasks = [{ id: "alpha", worktreePath: path.join(root, "alpha") }]
+    expect(matchTaskByCwd(tasks, path.join(root, "alpha", "refs", "vendorlib"))).toBeUndefined()
+    expect(matchTaskByCwd(tasks, path.join(root, "alpha", "refs", "vendorlib", "sub"))).toBeUndefined()
+  })
+
+  it("still matches a plain subdirectory of the same repo", () => {
+    const tasks = [{ id: "alpha", worktreePath: path.join(root, "alpha") }]
+    expect(matchTaskByCwd(tasks, path.join(root, "alpha", "src", "deep"))).toBe("alpha")
+    expect(matchTaskByCwd(tasks, path.join(root, "alpha"))).toBe("alpha")
+  })
+
+  it("does not make a directory task the owner of every repo beneath it", () => {
+    const tasks = [{ id: "scratch", worktreePath: root }]
+    expect(matchTaskByCwd(tasks, path.join(root, "gamma"))).toBeUndefined()
+    expect(matchTaskByCwd(tasks, path.join(root, "alpha", "src", "deep"))).toBeUndefined()
+    // A plain directory under it crosses nothing and still belongs to the task.
+    expect(matchTaskByCwd(tasks, path.join(root, "notes"))).toBe("scratch")
+  })
+
+  it("matches a nested repo that is a task in its own right", () => {
+    // The nested repo IS tracked: the longer worktree wins and no boundary
+    // sits below it, so its own sessions keep landing on it.
+    const tasks = [
+      { id: "alpha", worktreePath: path.join(root, "alpha") },
+      { id: "vendor", worktreePath: path.join(root, "alpha", "refs", "vendorlib") },
+    ]
+    expect(matchTaskByCwd(tasks, path.join(root, "alpha", "refs", "vendorlib", "sub"))).toBe("vendor")
+  })
+
+  it("treats a `.git` FILE (submodule / linked worktree) as a boundary too", () => {
+    mkdirSync(path.join(root, "alpha", "vendored"), { recursive: true })
+    writeFileSync(path.join(root, "alpha", "vendored", ".git"), "gitdir: ../../elsewhere\n")
+    const tasks = [{ id: "alpha", worktreePath: path.join(root, "alpha") }]
+    expect(matchTaskByCwd(tasks, path.join(root, "alpha", "vendored"))).toBeUndefined()
   })
 })
 


### PR DESCRIPTION
## A cwd is not a repo

`matchTaskByCwd` mapped a hook's `cwd` to the task whose `worktreePath` is the longest path-prefix of it, and never asked whether the two are in the **same repository**. Engine activity hooks are global — they fire for every session on the machine — so a session in a *different* git repo nested under a tracked project was folded into that project.

Past the badge, the same guessed `taskId` drives `engineEvents`, the `engine.lifecycle` broadcast, `plugins.handleEngineReport`, `maybeAutoStart`, and `ingestAgentTurnsBestEffort` — so `rove api agent-turns` and `digest` billed another repository's tokens to this project.

### The fix

One guard in the shared matcher, where all of those consumers route through: the winning candidate is rejected when a `.git` (directory *or* file — submodule / linked worktree) sits in any directory strictly below the task's worktree, down to and including the cwd. Only the winner is checked: a boundary below the longest candidate is below every shorter one too.

The worktree itself is never tested (it *is* a repo root), so plain subdirectories of the task's own repo still match, and a nested repo that is a Rove task in its own right keeps its own sessions.

This is one change for all three items of Batch A — A2 (`$HOME` scratch shells / parent-directory `dir` tasks) and A3 (`.dev-sandbox` / `.scratch` checkouts) are the same rule seen from two other angles: both are repos under a coarser task's directory, so the boundary check drops them.

**Considered and not done:** extending `handlers-engine-report.ts`'s `if (explicitId)` inbox guard to the token and plugin paths. That deletes working telemetry for the legitimate case (a user running `claude` in a task's own worktree from an external terminal) instead of fixing the wrong answer. Making the guess *correct* fixes every consumer, the guarded inbox included. `project-eligibility.ts` is untouched.

### PASS criterion

The nested-unrelated-repo hook no longer attributes; the same-repo subdirectory still does; the token path is checked separately from the badge path.

### Proof — isolated fixture, four scenarios

Isolated daemon (`ROVE_/KOBE_ HOME_DIR + DAEMON_SOCKET_PATH + DAEMON_PID_PATH + PTY_SOCKET_PATH + PTY_PID_PATH + DAEMON_WEB_PORT` all inlined, port base 6817), fixture repos in `/tmp/rove-r17-aw-fx`. `badge` reads the daemon activity registry via `rove api inspect`, `tokens` reads the agent-turns store via `rove api agent-turns` — two separate consumers, same run.

**BEFORE** (`/tmp/rove-r17-aw-evidence/before-repro.txt`):

```
A1 case    (nested unrelated repo)  cwd=/private/tmp/rove-r17-aw-fx/alpha/refs/vendorlib
    badge : ATTRIBUTED to alpha main task
    tokens: turns=1 input=1000 [('msg_a1case', 'alpha main task')]
A1 control (same-repo subdir)       cwd=/private/tmp/rove-r17-aw-fx/alpha/src/deep
    badge : ATTRIBUTED to alpha main task
    tokens: turns=2 input=2000 [('msg_a1case', 'alpha main task'), ('msg_a1ctl', 'alpha main task')]
A2 case    (repo under dir task)    cwd=/private/tmp/rove-r17-aw-fx/gamma
    badge : ATTRIBUTED to scratch-shell dir task
    tokens: turns=3 input=3000 [..., ('msg_a2case', 'scratch-shell dir task')]
A2 control (plain dir under it)     cwd=/private/tmp/rove-r17-aw-fx/notes
    badge : ATTRIBUTED to scratch-shell dir task
    tokens: turns=4 input=4000 [..., ('msg_a2ctl', 'scratch-shell dir task')]
```

**AFTER** (`/tmp/rove-r17-aw-evidence/after-repro.txt`):

```
A1 case    (nested unrelated repo)  cwd=/private/tmp/rove-r17-aw-fx/alpha/refs/vendorlib
    badge : not attributed
    tokens: turns=0 input=0 []
A1 control (same-repo subdir)       cwd=/private/tmp/rove-r17-aw-fx/alpha/src/deep
    badge : ATTRIBUTED to alpha main task
    tokens: turns=1 input=1000 [('msg_a1ctl', 'alpha main task')]
A2 case    (repo under dir task)    cwd=/private/tmp/rove-r17-aw-fx/gamma
    badge : not attributed
    tokens: turns=1 input=1000 [('msg_a1ctl', 'alpha main task')]
A2 control (plain dir under it)     cwd=/private/tmp/rove-r17-aw-fx/notes
    badge : ATTRIBUTED to scratch-shell dir task
    tokens: turns=2 input=2000 [('msg_a1ctl', ...), ('msg_a2ctl', 'scratch-shell dir task')]
```

Both cases drop, both controls survive, on both the badge path and the token path.

### Proof — harness screenshots (browser `/harness` → xterm.js → PTY sidecar → real OpenTUI)

Isolated visual fixture at port base 6827. A git repo was created at `<task worktree>/refs/vendorlib` and a `turn-start` hook fired from it in a loop while the shot was taken. Watch the `claude 1` row under `visual-fixture`.

| shot | code | hook cwd | `claude 1` row |
|---|---|---|---|
| `/tmp/rove-r17-aw-evidence/before-badge.png` | unfixed | nested unrelated repo | **orange activity bar + running glyph** |
| `/tmp/rove-r17-aw-evidence/baseline-nohook.png` | unfixed | *(no hook at all)* | idle, no bar |
| `/tmp/rove-r17-aw-evidence/after-badge.png` | fixed | nested unrelated repo | idle, no bar — matches the no-hook baseline |
| `/tmp/rove-r17-aw-evidence/after-badge-control.png` | fixed | same-repo subdir | **orange activity bar + running glyph** — legitimate matching preserved |

The same flip read out of the fixture daemon at capture time:

```
activity after restart:                          {}
activity after nested-repo hook (AFTER code):    {}
activity after same-repo subdir hook (control):  {"01M1PM1V36X1W44HQTZVCCWH8V": {"state":"running", ...}}
```

### Tests

5 cases added to `test/daemon/cwd-task.test.ts` against real temp directories (the boundary is a `.git` on disk): nested repo dropped, plain subdir kept, `dir`-task-owns-everything dropped while its plain subdir is kept, a nested repo that is itself a task still matched, and a `.git` *file* treated as a boundary.

Mutation-verified — with `cwd-task.ts` reverted, 3 of the 5 fail (the two "still matches" controls pass either way, as they must):

```
Tests  3 failed | 26 passed (29)     # fix reverted
Tests  29 passed (29)                # fix applied
```

### Gates

```
bun run lint       Checked 1438 files. No fixes applied.
bun run typecheck   4 packages, exit 0
test:fast          450 files / 4471 tests passed
test:socket        100 files /  817 tests passed
```

### Not proved

Nothing outstanding for Batch A. The A2 `dir`-task row was seeded into the isolated fixture's `tasks.json` by hand (the API has no verb to create one) — the operator's real daemon was never driven; the real `~/.rove/tasks.json` contains no fixture path.

### Left for the owner (not in this PR)

A3 notes in passing that `project-eligibility.ts` matches `.scratch` / `.dev-sandbox` by *segment anywhere in the path*, so a user's own repo at `~/work/.scratch/thing` is refused as a project too. That is an eligibility decision, explicitly out of scope here, and this fix does not depend on it: after the boundary check, such a checkout is simply not attributed to its enclosing project rather than misattributed to it.
