### PR TITLE
After a reboot, a task's real conversations are reachable and named (B1, B2, B3)

### DIFF
--- a/.agents/skills/kobe/references/api-flags.md
+++ b/.agents/skills/kobe/references/api-flags.md
@@ -98,7 +98,7 @@ needs numbers, not when you want to know what a task is doing.
 
 <!-- generated:begin drive -->
 ```text
-send              --task-id --prompt|--prompt-file(REQ) --tab --command --plain
+send              --task-id --prompt|--prompt-file(REQ) --tab --command --respawn --plain
                   --allow-empty
 dispatch          --task-id(REQ) --prompt|--prompt-file(REQ) --tab
 deferred-list     --task-id

--- a/.changeset/frozen-tabs-reachable.md
+++ b/.changeset/frozen-tabs-reachable.md
@@ -1,0 +1,26 @@
+---
+"@sma1lboy/rove": patch
+---
+
+After a pty-host restart, a task's real conversations are reachable and named
+
+A reboot (or any pty-host restart) freezes every terminal tab: the session
+record keeps its command, cwd and scrollback, and the host lists it. Three
+verbs told a headless caller otherwise.
+
+- `send --tab tab-N` refused a frozen tab with `TAB_NOT_FOUND` and pointed at
+  `pty-list`, which lists that very tab. It now refuses with `TAB_RESTORED`
+  and a hint, and `send --respawn` revives the tab in place and delivers into
+  it — resuming its pinned conversation (`--resume <id>`) rather than
+  replaying the task's first prompt. The respawn is never implicit: a tab
+  with no pinned id would re-run its recorded launch command.
+- `send` with no `--tab` fell through to a never-started tab, spawned a blank
+  session and reported plain success while both real conversations sat
+  frozen. It now lists them as `frozenTabs` (`tab` + `sessionId`) whenever it
+  started a new session.
+- `get-task` / `collect` now return each engine tab's `sessionId` — the id
+  the engine's resume verb needs, persisted since engine tabs existed and
+  exposed nowhere. The canonical `send` path also records the id of a session
+  it just started, which the write-once snapshot seeding skipped: a tab
+  respawned after a restart was pinned to a new conversation while the
+  snapshot still named the previous one.

--- a/claude-plugin/skills/rove/references/api-flags.md
+++ b/claude-plugin/skills/rove/references/api-flags.md
@@ -98,7 +98,7 @@ needs numbers, not when you want to know what a task is doing.
 
 <!-- generated:begin drive -->
 ```text
-send              --task-id --prompt|--prompt-file(REQ) --tab --command --plain
+send              --task-id --prompt|--prompt-file(REQ) --tab --command --respawn --plain
                   --allow-empty
 dispatch          --task-id(REQ) --prompt|--prompt-file(REQ) --tab
 deferred-list     --task-id

--- a/docs/API.md
+++ b/docs/API.md
@@ -137,7 +137,12 @@ replacement in `nextCommandArgs`.
 - `get-task --task-id <id>`: one task's metadata; `.running` = any of its
   hosted engine tabs is live (not just the first); `.tabs` = the task's
   terminal tabs (`id`/`kind`/`title`/`vendor`/`liveVendor`/`lastTitle`/
-  `autoTitle` + per-tab `alive`): the discovery read for `send --tab tab-N`.
+  `autoTitle`/`sessionId` + per-tab `alive`): the discovery read for
+  `send --tab tab-N`. `sessionId` is the conversation the tab pinned — the
+  exact id `claude --resume <id>` (or the engine's own resume verb) reopens,
+  and the one `send --tab tab-N --respawn` brings back. Present on engine
+  tabs that recorded one, dead tabs included; absent for engines that mint
+  their own id late and for tabs that never spawned.
   `liveVendor` on a live tab is a fresh foreground process walk (which
   engine actually runs in the tab's shell right now. A hand-typed `claude`
   in a shell tab counts, a ctrl+C'd engine doesn't); dead tabs report the
@@ -346,7 +351,19 @@ branch included, live in the Rove agent skill. Prompts into existing sessions
   a tab-precise reply command (`--task-id <sender> --tab <sender's tab>`);
   `--plain` skips that prefix. `--tab new` spawns a fresh engine tab, while
   `--tab tab-N` targets that exact tab (`TAB_NOT_FOUND` if it is dead or
-  absent). `--command CMD` is valid only with `--tab new`: it pins that new
+  absent). A tab a **pty-host restart froze** is neither: it is listed by
+  `pty-list` with its scrollback and launch command intact, and it refuses
+  with `TAB_RESTORED` until you pass `--respawn`. `--respawn` (valid only
+  with `--tab tab-N`) revives that tab in place and then delivers, replying
+  `respawned: true`; a tab with a `sessionId` comes back on its own
+  conversation (`--resume <id>`), and a tab without one replays its recorded
+  launch command — which for claude carries the task's original first
+  prompt, so the flag is never implicit.
+  When `send` STARTS a new session (`started: true`) while the task has
+  freeze-restored engine tabs it did not use, the reply carries `frozenTabs`
+  — `{tab, sessionId}` for each — because otherwise "opened a blank agent
+  while your two real conversations are frozen" reports exactly like a
+  healthy first start, and `get-task` then says `running: true`. `--command CMD` is valid only with `--tab new`: it pins that new
   tab to that engine without changing the task's own. Using it with an
   existing tab is a `BAD_FLAG` error rather than a silent switch.
   Delivery needs a live engine in that tab: one that exited into the

--- a/docs/API.md
+++ b/docs/API.md
@@ -355,10 +355,12 @@ branch included, live in the Rove agent skill. Prompts into existing sessions
   `pty-list` with its scrollback and launch command intact, and it refuses
   with `TAB_RESTORED` until you pass `--respawn`. `--respawn` (valid only
   with `--tab tab-N`) revives that tab in place and then delivers, replying
-  `respawned: true`; a tab with a `sessionId` comes back on its own
-  conversation (`--resume <id>`), and a tab without one replays its recorded
-  launch command — which for claude carries the task's original first
-  prompt, so the flag is never implicit.
+  `respawned: true`. A tab with a `sessionId` comes back on its own
+  conversation (`--resume <id>`); a tab without one comes back on a fresh
+  conversation; a tab Rove holds no snapshot for replays its frozen launch
+  command, which for claude carries the task's original first prompt. That
+  last case is why the flag is never implicit. The prompt you send is always
+  pasted once the engine is up, never woven into the relaunch.
   When `send` STARTS a new session (`started: true`) while the task has
   freeze-restored engine tabs it did not use, the reply carries `frozenTabs`
   — `{tab, sessionId}` for each — because otherwise "opened a blank agent

--- a/docs/SESSIONS.md
+++ b/docs/SESSIONS.md
@@ -200,8 +200,8 @@ process, including a reboot.
 - Headlessly, a tab a host restart froze is revived by
   `rove api send --task-id <id> --tab tab-N --respawn --prompt "…"`. Without
   `--respawn` that tab refuses with `TAB_RESTORED` rather than being re-run
-  behind your back — reviving replays the tab's recorded launch command when
-  it pinned no conversation id. A `send` that starts a fresh session while
+  behind your back — reviving a tab Rove holds no snapshot for replays its
+  frozen launch command, first prompt and all. A `send` that starts a fresh session while
   such tabs exist lists them in `frozenTabs`, so an automation is told the
   message did not reach the conversation it thought it did.
 

--- a/docs/SESSIONS.md
+++ b/docs/SESSIONS.md
@@ -194,7 +194,16 @@ process, including a reboot.
   convenience, not an invariant — closing the last tab yourself leaves the task
   with none.)
 - To resume a conversation that is not represented by a tab, use the engine's
-  own picker (e.g. claude-code's `/resume`) inside a fresh engine tab.
+  own picker (e.g. claude-code's `/resume`) inside a fresh engine tab. When
+  the conversation IS a tab, you do not have to hunt for the id: `rove api
+  get-task --task-id <id>` prints each engine tab's `sessionId`.
+- Headlessly, a tab a host restart froze is revived by
+  `rove api send --task-id <id> --tab tab-N --respawn --prompt "…"`. Without
+  `--respawn` that tab refuses with `TAB_RESTORED` rather than being re-run
+  behind your back — reviving replays the tab's recorded launch command when
+  it pinned no conversation id. A `send` that starts a fresh session while
+  such tabs exist lists them in `frozenTabs`, so an automation is told the
+  message did not reach the conversation it thought it did.
 
 ## Not supported
 

--- a/packages/kobe/src/cli/api/exact-tab-delivery.ts
+++ b/packages/kobe/src/cli/api/exact-tab-delivery.ts
@@ -1,0 +1,185 @@
+/**
+ * `send --tab tab-N`: delivery into ONE addressed terminal tab.
+ *
+ * Split from `pty-delivery.ts`, which owns the CANONICAL path — find the
+ * task's engine session, or create it when the task has none. This side
+ * never searches and never spawns a second engine: the caller named a tab,
+ * so the only questions are whether that tab can take a prompt and, when a
+ * pty-host restart froze it, whether the caller asked for it to be revived.
+ *
+ * Shared reporting helpers (`outcomeFields`, the engine-start probe budget,
+ * the composer-busy deferral) stay in `pty-delivery.ts` and are imported
+ * here, so both paths keep spelling an outcome the same way.
+ */
+
+import type { PtyOpenResult } from "@sma1lboy/kobe-daemon/daemon/protocol"
+import type { PtySessionInfo } from "@sma1lboy/kobe-daemon/daemon/pty-host"
+import type { PsSnapshot } from "../../engine/foreground.ts"
+import {
+  ComposerBusyError,
+  type PromptWriteOutcome,
+  awaitEngineProcess,
+  hostedSessionFailureLine,
+} from "../../engine/hosted-session.ts"
+import { sessionHasEngine } from "../../engine/session-engine-presence.ts"
+import type { EngineSessionLaunch } from "../../engine/session-launch.ts"
+import { readPersistedTerminalDefaultColors } from "../../tui/lib/terminal-colors.ts"
+import type { VendorId } from "../../types/vendor.ts"
+import {
+  ENGINE_NOT_OBSERVED_REASON,
+  ENGINE_START_POLL_MS,
+  ENGINE_START_PROBE_MS,
+  type PtyHostRpc,
+  deferOrThrow,
+  deliverToKey,
+  outcomeFields,
+  resolveComposerManifest,
+} from "./pty-delivery.ts"
+import { ApiError, type DeliveredPrompt, type PromptDeferralSink } from "./types.ts"
+
+/**
+ * Deliver into ONE exact tab (`send --tab tab-N`) — no fallback, no spawn.
+ * The addressed tab must exist and be alive; anything else is a typed error
+ * so a script targeting "the second tab" never silently lands in the first.
+ */
+export async function deliverToExactTab(
+  rpc: PtyHostRpc,
+  taskId: string,
+  tabId: string,
+  cwd: string,
+  prompt: string,
+  opts?: {
+    readonly engineBin?: string
+    readonly snapshot?: PsSnapshot
+    readonly vendor?: VendorId
+    readonly defer?: PromptDeferralSink
+    /** Caller consent to revive a freeze-restored tab (`send --respawn`),
+     *  plus the resume launch to bring it back with. `null` from the factory
+     *  = the snapshot has no engine tab by this id, so the host replays the
+     *  frozen command instead. */
+    readonly respawn?: () => EngineSessionLaunch | null
+  },
+): Promise<DeliveredPrompt> {
+  const key = `${taskId}::${tabId}`
+  const { sessions = [] } = await rpc.request<{ sessions?: PtySessionInfo[] }>("pty.list", {})
+  const session = sessions.find((s) => s.key === key)
+  let respawned = false
+  if (!session?.alive) {
+    // A FREEZE-RESTORED tab is not an absent one: the host is listing it, its
+    // command/cwd/scrollback survived, and `pty.open` respawns it in place.
+    // Saying TAB_NOT_FOUND here sent the caller to `pty-list`, which lists
+    // the very tab it just refused — and left every task's real conversation
+    // headlessly unreachable after a reboot.
+    if (session?.restored === true) {
+      if (!opts?.respawn) throw restoredTabError(taskId, tabId, prompt)
+      const launch = opts.respawn()
+      // A size-less open: the host keeps the frozen geometry, and the
+      // caller's command (when it has one) wins over the frozen launch.
+      const open = await rpc.request<PtyOpenResult>("pty.open", {
+        key,
+        cwd,
+        ...(launch ? { command: launch.command } : {}),
+        defaultColors: readPersistedTerminalDefaultColors(),
+      })
+      respawned = open.respawned === true || open.alive === true
+      if (!respawned) {
+        throw new ApiError(`tab ${tabId} on task ${taskId} could not be respawned`, "SESSION_FAILED", {
+          hint: "the frozen record is still on disk; open the task in the TUI to see the session's own output",
+          nextCommandArgs: ["api", "read-output", "--task-id", taskId, "--tab", tabId, "--source", "terminal"],
+        })
+      }
+      // The prompt is PASTED, never woven into the respawn argv — an engine
+      // resumed by id must not replay the task's first prompt. So the engine
+      // has to be up before the write; `engineReady: false` below is the
+      // honest answer when it never appeared.
+      const enginePid = await awaitEngineProcess(rpc, key, opts.engineBin, {
+        timeoutMs: ENGINE_START_PROBE_MS,
+        intervalMs: ENGINE_START_POLL_MS,
+        snapshot: opts.snapshot,
+      })
+      if (enginePid === null) {
+        return {
+          session: key,
+          pane: key,
+          started: false,
+          respawned: true,
+          engineReady: false,
+          delivered: false,
+          reason: (await hostedSessionFailureLine(rpc, key)) ?? ENGINE_NOT_OBSERVED_REASON,
+        }
+      }
+      const outcome = await deliverRespawned(rpc, key, prompt, opts, taskId, tabId)
+      return outcome
+    }
+    throw new ApiError(
+      `tab ${tabId} has no live session on task ${taskId} — see \`rove api pty-list\` for alive tabs`,
+      "TAB_NOT_FOUND",
+    )
+  }
+  // Same foreground gate as the canonical path: an addressed tab whose
+  // engine exited (or that always was a shell tab) must not have the prompt
+  // pasted into its shell. ANY running engine passes — the addressed tab's
+  // engine need not match the task's vendor (cross-vendor send).
+  if (!(await sessionHasEngine(session.pid, opts?.engineBin, opts?.snapshot))) {
+    throw new ApiError(
+      `tab ${tabId} on task ${taskId} has no live engine process — it is a plain shell right now`,
+      "ENGINE_NOT_RUNNING",
+      {
+        hint: "spawn a fresh engine tab for this prompt with --tab new, or pick an engine tab from pty-list",
+        nextCommandArgs: ["api", "pty-list"],
+      },
+    )
+  }
+  // No pty.detach — see deliverHostedPrompt's existing-key path.
+  const deliveryOpts = { screenManifest: resolveComposerManifest(opts?.vendor) }
+  let outcome: PromptWriteOutcome | null
+  try {
+    outcome = await deliverToKey(rpc, key, prompt, deliveryOpts)
+  } catch (err) {
+    if (err instanceof ComposerBusyError) return deferOrThrow(err, opts?.defer, taskId, tabId, prompt)
+    throw err
+  }
+  return { session: key, pane: key, started: false, ...outcomeFields(outcome) }
+}
+
+/**
+ * Write into a tab this call just respawned. Same gate/deferral contract as
+ * the alive path, with `respawned: true` so the caller can tell "reopened
+ * your frozen conversation" from "delivered into a session already running".
+ */
+async function deliverRespawned(
+  rpc: PtyHostRpc,
+  key: string,
+  prompt: string,
+  opts: { readonly vendor?: VendorId; readonly defer?: PromptDeferralSink },
+  taskId: string,
+  tabId: string,
+): Promise<DeliveredPrompt> {
+  let outcome: PromptWriteOutcome | null
+  try {
+    outcome = await deliverToKey(rpc, key, prompt, { screenManifest: resolveComposerManifest(opts.vendor) })
+  } catch (err) {
+    if (err instanceof ComposerBusyError) return deferOrThrow(err, opts.defer, taskId, tabId, prompt)
+    throw err
+  }
+  return { session: key, pane: key, started: false, respawned: true, ...outcomeFields(outcome) }
+}
+
+/**
+ * The refusal a restored tab gets without `--respawn`. Distinct code, and it
+ * names the missing STEP rather than pointing back at the listing that shows
+ * the tab: reviving re-runs the tab's recorded launch, which for a tab with
+ * no pinned conversation id replays the task's original first prompt.
+ */
+function restoredTabError(taskId: string, tabId: string, prompt: string): ApiError {
+  return new ApiError(
+    `tab ${tabId} on task ${taskId} is a freeze-restored session — its pty host restarted, so the tab exists with its scrollback but nothing is running in it`,
+    "TAB_RESTORED",
+    {
+      taskId,
+      tabId,
+      hint: "revive it with --respawn (resumes the tab's pinned conversation when it has one — `get-task` shows `sessionId`; a tab without one replays its recorded launch command)",
+      nextCommandArgs: ["api", "send", "--task-id", taskId, "--tab", tabId, "--respawn", "--prompt", prompt],
+    },
+  )
+}

--- a/packages/kobe/src/cli/api/exact-tab-delivery.ts
+++ b/packages/kobe/src/cli/api/exact-tab-delivery.ts
@@ -38,9 +38,11 @@ import {
 import { ApiError, type DeliveredPrompt, type PromptDeferralSink } from "./types.ts"
 
 /**
- * Deliver into ONE exact tab (`send --tab tab-N`) — no fallback, no spawn.
- * The addressed tab must exist and be alive; anything else is a typed error
- * so a script targeting "the second tab" never silently lands in the first.
+ * Deliver into ONE exact tab (`send --tab tab-N`) — no fallback, no search.
+ * The addressed tab must be able to take the prompt; anything else is a typed
+ * error so a script targeting "the second tab" never silently lands in the
+ * first. The one tab this may START is the addressed one itself, and only
+ * when it is freeze-restored AND the caller passed `opts.respawn`.
  */
 export async function deliverToExactTab(
   rpc: PtyHostRpc,
@@ -63,7 +65,6 @@ export async function deliverToExactTab(
   const key = `${taskId}::${tabId}`
   const { sessions = [] } = await rpc.request<{ sessions?: PtySessionInfo[] }>("pty.list", {})
   const session = sessions.find((s) => s.key === key)
-  let respawned = false
   if (!session?.alive) {
     // A FREEZE-RESTORED tab is not an absent one: the host is listing it, its
     // command/cwd/scrollback survived, and `pty.open` respawns it in place.
@@ -81,8 +82,7 @@ export async function deliverToExactTab(
         ...(launch ? { command: launch.command } : {}),
         defaultColors: readPersistedTerminalDefaultColors(),
       })
-      respawned = open.respawned === true || open.alive === true
-      if (!respawned) {
+      if (open.respawned !== true && open.alive !== true) {
         throw new ApiError(`tab ${tabId} on task ${taskId} could not be respawned`, "SESSION_FAILED", {
           hint: "the frozen record is still on disk; open the task in the TUI to see the session's own output",
           nextCommandArgs: ["api", "read-output", "--task-id", taskId, "--tab", tabId, "--source", "terminal"],
@@ -108,8 +108,7 @@ export async function deliverToExactTab(
           reason: (await hostedSessionFailureLine(rpc, key)) ?? ENGINE_NOT_OBSERVED_REASON,
         }
       }
-      const outcome = await deliverRespawned(rpc, key, prompt, opts, taskId, tabId)
-      return outcome
+      return await deliverRespawned(rpc, key, prompt, opts, taskId, tabId)
     }
     throw new ApiError(
       `tab ${tabId} has no live session on task ${taskId} — see \`rove api pty-list\` for alive tabs`,

--- a/packages/kobe/src/cli/api/handlers-lifecycle.ts
+++ b/packages/kobe/src/cli/api/handlers-lifecycle.ts
@@ -1,0 +1,205 @@
+/**
+ * Verb handlers for the `lifecycle` group: `delete`, `land`, `adopt`.
+ *
+ * Split from `handlers-tasks.ts`, which owns reads and prompt delivery.
+ * These three END a task — worktree teardown, branch merge, taking over an
+ * existing checkout — so each carries a recovery story for a teardown that
+ * got half-way (a dirty worktree, a branch with unmerged commits), which is
+ * a different failure mode from "the prompt did not land".
+ */
+
+import { errorMessage } from "@/lib/error-message"
+import type { SerializedTask } from "@sma1lboy/kobe-daemon/daemon/protocol"
+import { resolveCommandProtocol } from "../../engine/engine-presets.ts"
+import { DIRTY_WORKTREE_CODE, EMPTY_BRANCH_DIRTY_WORKTREE_CODE } from "../../orchestrator/errors.ts"
+import type { DaemonRpc } from "../daemon-session.ts"
+import { verifiedSelfSession } from "./dispatcher.ts"
+import { daemonOf } from "./handler-helpers.ts"
+import { ApiError, type VerbContext, splitDaemonCode } from "./types.ts"
+
+/** How long `delete --wait` follows a deletion before reporting `pending`.
+ *  A worktree teardown is filesystem-bound; this is generous headroom, not a
+ *  deadline the deletion itself respects. */
+const DELETE_WAIT_TIMEOUT_MS = 60_000
+const DELETE_POLL_INTERVAL_MS = 250
+
+export async function deleteTask(ctx: VerbContext): Promise<unknown> {
+  const daemon = daemonOf(ctx)
+  const taskId = ctx.args.require("task-id")
+  const force = ctx.args.bool("force") ?? false
+  // Branch deletion is opt-in (same flag as `land`): delete drops the
+  // worktree + task entry, git keeps the branch as the durable record.
+  const deleteBranch = ctx.args.bool("delete-branch") ?? false
+  // Deleting somebody else's task destroys their worktree and every tab in
+  // it, so the daemon's audit line has to name WHO asked. Same verified
+  // identity `send`/`add` use, never the bare env: unverifiable
+  // stays unattributed rather than blaming a stranger's session.
+  const self = await verifiedSelfSession()
+  let res: { taskId: string; queued: boolean }
+  try {
+    res = (await daemon.request("task.delete", {
+      taskId,
+      force,
+      deleteBranch,
+      ...(self ? { requestedByTaskId: self.taskId, requestedByTabId: self.tabId } : {}),
+    })) as { taskId: string; queued: boolean }
+  } catch (err) {
+    throw deleteRecoveryError(err, taskId)
+  }
+  // The daemon's task.delete removes the worktree + index entry but never the
+  // hosted session. Without this, a scripted delete
+  // orphans the `kobe-<id>` session + its engine — invisible to every kobe UI
+  // since the task is gone from tasks.json. Mirror the TUI's finishDeletedTaskFlow
+  // and kill it here, after the delete RPC succeeds.
+  await ctx.runtime.tearDownSession(taskId)
+  if (!res.queued) return { ...res, status: "not_found" as const }
+  // Removal runs in the background, so the default reply can only say the work
+  // was scheduled. A caller that needs the OUTCOME (a cleanup script deciding
+  // whether to retry, an agent tearing down its own fan-out) asks for it.
+  if (!ctx.args.bool("wait")) return { ...res, status: "queued" as const }
+  return { ...res, ...(await awaitDeletion(daemon, taskId)) }
+}
+
+/**
+ * Poll the task index until the deletion resolves. The index IS the record —
+ * `finish()` removes the row on success and stamps `deletion.phase = "error"`
+ * with the git failure on it — so this reads the outcome rather than tracking
+ * a second copy of it. Previously that error reached `daemon.log` and nowhere
+ * else, which is how a failed removal came back looking like a successful one.
+ */
+async function awaitDeletion(
+  daemon: DaemonRpc,
+  taskId: string,
+): Promise<{ status: "removed" | "failed" | "pending"; error?: string }> {
+  const deadline = Date.now() + DELETE_WAIT_TIMEOUT_MS
+  for (;;) {
+    const { tasks } = await daemon.request<{ tasks: SerializedTask[] }>("task.list")
+    const task = tasks.find((t) => t.id === taskId)
+    if (!task) return { status: "removed" }
+    const deletion = task.deletion
+    if (deletion?.phase === "error") {
+      return { status: "failed", error: deletion.error ?? "worktree removal failed" }
+    }
+    // A worktree teardown is filesystem-bound and can take tens of seconds, so
+    // running out of patience is not the same as failing: `pending` says the
+    // deletion is still owned by the daemon and the caller should look again,
+    // never that it was refused.
+    if (Date.now() >= deadline) return { status: "pending" }
+    await new Promise((resolve) => setTimeout(resolve, DELETE_POLL_INTERVAL_MS))
+  }
+}
+
+export async function land(ctx: VerbContext): Promise<unknown> {
+  const daemon = daemonOf(ctx)
+  const taskId = ctx.args.require("task-id")
+  // `--dry-run` returns the same probe the land itself runs first, and writes
+  // nothing: the destination branch, how many commits would land, whether the
+  // base is dirty, and the refusal if there is one. A coordinator deciding
+  // WHICH sibling to land needs this before it picks; a human needs it because
+  // the destination is the base checkout's current branch, which nothing else
+  // tells them until the success toast.
+  if (ctx.args.bool("dry-run") === true) {
+    const res = await daemon.request<{ result: unknown }>("task.landPreflight", { taskId })
+    return res.result
+  }
+  const strategy = ctx.args.str("strategy") === "squash" ? "squash" : "merge"
+  let res: { result: unknown }
+  try {
+    res = await daemon.request<{ result: unknown }>("task.land", {
+      taskId,
+      strategy,
+      deleteBranch: ctx.args.bool("delete-branch") ?? false,
+      // Left UNDEFINED when the flag is absent so the orchestrator's default
+      // (remove it) applies; only an explicit `--remove-worktree=false` keeps
+      // the worktree. Coercing undefined to false here would pin the CLI to
+      // an opt-in it does not have.
+      removeWorktree: ctx.args.bool("remove-worktree"),
+      // Sent on EVERY land: the daemon refuses to remove the worktree the
+      // caller is running from, and it can only know where that is if we tell
+      // it. Removal is the default, so an agent landing its own task would
+      // otherwise delete its own cwd.
+      callerCwd: process.cwd(),
+    })
+  } catch (err) {
+    throw landRecoveryError(err, taskId)
+  }
+  return { ok: true, taskId, ...(res.result as object) }
+}
+
+/**
+ * Give EMPTY_BRANCH_DIRTY_WORKTREE an executable recovery path (the
+ * self-healing `hint` + `nextCommandArgs` convention, same shape as
+ * TASK_NOT_FOUND): the worker WROTE its work but never committed it, so the
+ * recovery is a `send` back to THAT worker telling it to commit its own work
+ * with its own message — never an auto-commit here, the commit message
+ * belongs to whoever did the work. The branch name rides the daemon's error
+ * message (only the message survives the RPC wire), so it is lifted back out
+ * for the prompt. The clean-worktree variant (EMPTY_BRANCH) deliberately
+ * gets NO recovery path: "worker reported success but delivered nothing" is
+ * a signal a human must look at, not something to auto-retry.
+ */
+function landRecoveryError(err: unknown, taskId: string): unknown {
+  const message = errorMessage(err)
+  if (!message.includes(EMPTY_BRANCH_DIRTY_WORKTREE_CODE)) return err
+  const branch = /EMPTY_BRANCH_DIRTY_WORKTREE: '([^']+)'/.exec(message)?.[1] ?? "your task branch"
+  return new ApiError(splitDaemonCode(message)?.rest ?? message, EMPTY_BRANCH_DIRTY_WORKTREE_CODE, {
+    hint: "the worker wrote files but never committed them — send it back to commit its own work, then land again",
+    nextCommandArgs: [
+      "api",
+      "send",
+      "--task-id",
+      taskId,
+      "--prompt",
+      `your work is uncommitted on ${branch} — commit it yourself with a proper message, then report back`,
+    ],
+  })
+}
+
+/**
+ * Give `delete`'s dirty-worktree refusal the same executable recovery `land`
+ * gets. This is the refusal an unattended cleanup loop hits most, and the
+ * recovery is deliberately NOT `--force`: uncommitted files in a task
+ * worktree are somebody's unlanded work, so the first move is to send the
+ * worker back to commit it, exactly as EMPTY_BRANCH_DIRTY_WORKTREE does.
+ * Discarding the work stays a decision a caller has to make in words.
+ *
+ * The generic boundary ({@link splitDaemonCode} in `toApiError`) already
+ * lifts `DIRTY_WORKTREE` into `code` on its own; this adds only the two
+ * self-healing fields, which need the task id the boundary does not have.
+ */
+function deleteRecoveryError(err: unknown, taskId: string): unknown {
+  const message = errorMessage(err)
+  const coded = splitDaemonCode(message)
+  if (coded?.code !== DIRTY_WORKTREE_CODE) return err
+  return new ApiError(coded.rest, DIRTY_WORKTREE_CODE, {
+    taskId,
+    hint: "the worktree still holds work this delete would destroy — the message names it, and a gitignored path never shows in `git status`. Send the worker back to commit it, or pass --force to delete the task AND discard that work",
+    nextCommandArgs: [
+      "api",
+      "send",
+      "--task-id",
+      taskId,
+      "--prompt",
+      "your worktree still holds work that this cleanup would destroy (it may be gitignored, so `git status` will not show it — check `git status --ignored`). Commit it yourself with a proper message, then report back",
+    ],
+  })
+}
+
+export async function adopt(ctx: VerbContext): Promise<unknown> {
+  const daemon = daemonOf(ctx)
+  const { args } = ctx
+  const input: Record<string, string> = {
+    repo: args.requireRepo("repo"),
+    worktreePath: args.requirePath("worktree"),
+  }
+  const branch = args.str("branch")
+  if (branch) input.branch = branch
+  const command = args.str("command")
+  if (command) {
+    input.command = command
+    input.vendor = resolveCommandProtocol(command)
+  }
+  const title = args.str("title")
+  if (title) input.title = title
+  return daemon.request<{ task: SerializedTask }>("worktree.adopt", input)
+}

--- a/packages/kobe/src/cli/api/handlers-tasks.ts
+++ b/packages/kobe/src/cli/api/handlers-tasks.ts
@@ -1,8 +1,13 @@
 /**
- * Verb handlers for task CRUD + prompt delivery + issue-update — the
- * `read` / `create` / `drive` / `edit` / `lifecycle` / `worktree` groups
- * that aren't a one-line `simpleRpc` inline in the {@link VERBS} table.
- * Split out of `api-cmd.ts` (see that file's header).
+ * Verb handlers for task reads, prompt delivery and issue-update — the
+ * `read` / `drive` / `edit` groups that aren't a one-line `simpleRpc` inline
+ * in the {@link VERBS} table. Split out of `api-cmd.ts` (see that file's
+ * header).
+ *
+ * The `lifecycle` group (delete / land / adopt) lives in
+ * `handlers-lifecycle.ts`: those verbs END a task and each owns a recovery
+ * story for a half-finished teardown, which is a different failure mode from
+ * "the prompt did not land" and moves on a different schedule.
  */
 
 import { errorMessage } from "@/lib/error-message"
@@ -18,12 +23,6 @@ import { daemonOf, simpleRpc } from "./handler-helpers.ts"
 import { resolveActiveTaskId } from "./runtime.ts"
 import { taskEngineArgv } from "./tab-snapshot.ts"
 import { ApiError, type VerbContext, type VerbSpec, helpStep, splitDaemonCode } from "./types.ts"
-
-/** How long `delete --wait` follows a deletion before reporting `pending`.
- *  A worktree teardown is filesystem-bound; this is generous headroom, not a
- *  deadline the deletion itself respects. */
-const DELETE_WAIT_TIMEOUT_MS = 60_000
-const DELETE_POLL_INTERVAL_MS = 250
 
 export async function issueUpdate(ctx: VerbContext): Promise<unknown> {
   const title = ctx.args.str("title")
@@ -157,6 +156,18 @@ export async function send(ctx: VerbContext): Promise<unknown> {
       helpStep("send"),
     )
   }
+  const respawn = ctx.args.bool("respawn")
+  // Reviving is an exact-tab act: the canonical path already respawns a
+  // restored tab-1 on its own (it is the tab it would create), and `--tab
+  // new` spawns by definition. Refuse rather than accept a flag that would
+  // do nothing — a caller asking to revive tab-2 must not get a silent no-op.
+  if (respawn && (tab === undefined || tab === "new")) {
+    throw new ApiError(
+      `--respawn addresses one frozen tab; pass --tab tab-N (got --tab ${tab ?? "<canonical>"})`,
+      "BAD_FLAG",
+      helpStep("send"),
+    )
+  }
   // Protocol resolution happens HERE, in the CLI, because the preset
   // registry lives in kobe's state.json — the same tier-(a) read `add` does.
   const tabVendor = tabCommand ? resolveCommandProtocol(tabCommand) : undefined
@@ -204,6 +215,7 @@ export async function send(ctx: VerbContext): Promise<unknown> {
       tab,
       tabVendor,
       tabCommand,
+      respawn,
     },
     text,
   )
@@ -232,6 +244,15 @@ export async function send(ctx: VerbContext): Promise<unknown> {
     // The deferred outcome is a SUCCESS, not an error — say so explicitly so a
     // scripted sender does not read `deferred` as a failure and retry.
     ...(delivered.deferred ? { deferred: delivered.deferred } : {}),
+    // This call reopened a frozen tab rather than delivering into a session
+    // that was already running (`send --tab tab-N --respawn`).
+    ...(delivered.respawned ? { respawned: true } : {}),
+    // The conversations this call did NOT reach. Only present when a NEW
+    // session was started, which is the branch where `started/delivered:
+    // true` plus `running: true` reads as "your message reached the agent"
+    // while the task's real conversations sit frozen. See
+    // `DeliveredPrompt.frozenTabs`.
+    ...(delivered.frozenTabs?.length ? { frozenTabs: delivered.frozenTabs } : {}),
   }
 }
 
@@ -314,185 +335,4 @@ export async function setActive(ctx: VerbContext): Promise<unknown> {
   const taskId = none ? null : ctx.args.require("task-id")
   await daemon.request("task.setActive", { taskId })
   return { ok: true, activeTaskId: taskId }
-}
-
-export async function deleteTask(ctx: VerbContext): Promise<unknown> {
-  const daemon = daemonOf(ctx)
-  const taskId = ctx.args.require("task-id")
-  const force = ctx.args.bool("force") ?? false
-  // Branch deletion is opt-in (same flag as `land`): delete drops the
-  // worktree + task entry, git keeps the branch as the durable record.
-  const deleteBranch = ctx.args.bool("delete-branch") ?? false
-  // Deleting somebody else's task destroys their worktree and every tab in
-  // it, so the daemon's audit line has to name WHO asked. Same verified
-  // identity `send`/`add` use, never the bare env: unverifiable
-  // stays unattributed rather than blaming a stranger's session.
-  const self = await verifiedSelfSession()
-  let res: { taskId: string; queued: boolean }
-  try {
-    res = (await daemon.request("task.delete", {
-      taskId,
-      force,
-      deleteBranch,
-      ...(self ? { requestedByTaskId: self.taskId, requestedByTabId: self.tabId } : {}),
-    })) as { taskId: string; queued: boolean }
-  } catch (err) {
-    throw deleteRecoveryError(err, taskId)
-  }
-  // The daemon's task.delete removes the worktree + index entry but never the
-  // hosted session. Without this, a scripted delete
-  // orphans the `kobe-<id>` session + its engine — invisible to every kobe UI
-  // since the task is gone from tasks.json. Mirror the TUI's finishDeletedTaskFlow
-  // and kill it here, after the delete RPC succeeds.
-  await ctx.runtime.tearDownSession(taskId)
-  if (!res.queued) return { ...res, status: "not_found" as const }
-  // Removal runs in the background, so the default reply can only say the work
-  // was scheduled. A caller that needs the OUTCOME (a cleanup script deciding
-  // whether to retry, an agent tearing down its own fan-out) asks for it.
-  if (!ctx.args.bool("wait")) return { ...res, status: "queued" as const }
-  return { ...res, ...(await awaitDeletion(daemon, taskId)) }
-}
-
-/**
- * Poll the task index until the deletion resolves. The index IS the record —
- * `finish()` removes the row on success and stamps `deletion.phase = "error"`
- * with the git failure on it — so this reads the outcome rather than tracking
- * a second copy of it. Previously that error reached `daemon.log` and nowhere
- * else, which is how a failed removal came back looking like a successful one.
- */
-async function awaitDeletion(
-  daemon: DaemonRpc,
-  taskId: string,
-): Promise<{ status: "removed" | "failed" | "pending"; error?: string }> {
-  const deadline = Date.now() + DELETE_WAIT_TIMEOUT_MS
-  for (;;) {
-    const { tasks } = await daemon.request<{ tasks: SerializedTask[] }>("task.list")
-    const task = tasks.find((t) => t.id === taskId)
-    if (!task) return { status: "removed" }
-    const deletion = task.deletion
-    if (deletion?.phase === "error") {
-      return { status: "failed", error: deletion.error ?? "worktree removal failed" }
-    }
-    // A worktree teardown is filesystem-bound and can take tens of seconds, so
-    // running out of patience is not the same as failing: `pending` says the
-    // deletion is still owned by the daemon and the caller should look again,
-    // never that it was refused.
-    if (Date.now() >= deadline) return { status: "pending" }
-    await new Promise((resolve) => setTimeout(resolve, DELETE_POLL_INTERVAL_MS))
-  }
-}
-
-export async function land(ctx: VerbContext): Promise<unknown> {
-  const daemon = daemonOf(ctx)
-  const taskId = ctx.args.require("task-id")
-  // `--dry-run` returns the same probe the land itself runs first, and writes
-  // nothing: the destination branch, how many commits would land, whether the
-  // base is dirty, and the refusal if there is one. A coordinator deciding
-  // WHICH sibling to land needs this before it picks; a human needs it because
-  // the destination is the base checkout's current branch, which nothing else
-  // tells them until the success toast.
-  if (ctx.args.bool("dry-run") === true) {
-    const res = await daemon.request<{ result: unknown }>("task.landPreflight", { taskId })
-    return res.result
-  }
-  const strategy = ctx.args.str("strategy") === "squash" ? "squash" : "merge"
-  let res: { result: unknown }
-  try {
-    res = await daemon.request<{ result: unknown }>("task.land", {
-      taskId,
-      strategy,
-      deleteBranch: ctx.args.bool("delete-branch") ?? false,
-      // Left UNDEFINED when the flag is absent so the orchestrator's default
-      // (remove it) applies; only an explicit `--remove-worktree=false` keeps
-      // the worktree. Coercing undefined to false here would pin the CLI to
-      // an opt-in it does not have.
-      removeWorktree: ctx.args.bool("remove-worktree"),
-      // Sent on EVERY land: the daemon refuses to remove the worktree the
-      // caller is running from, and it can only know where that is if we tell
-      // it. Removal is the default, so an agent landing its own task would
-      // otherwise delete its own cwd.
-      callerCwd: process.cwd(),
-    })
-  } catch (err) {
-    throw landRecoveryError(err, taskId)
-  }
-  return { ok: true, taskId, ...(res.result as object) }
-}
-
-/**
- * Give EMPTY_BRANCH_DIRTY_WORKTREE an executable recovery path (the
- * self-healing `hint` + `nextCommandArgs` convention, same shape as
- * TASK_NOT_FOUND): the worker WROTE its work but never committed it, so the
- * recovery is a `send` back to THAT worker telling it to commit its own work
- * with its own message — never an auto-commit here, the commit message
- * belongs to whoever did the work. The branch name rides the daemon's error
- * message (only the message survives the RPC wire), so it is lifted back out
- * for the prompt. The clean-worktree variant (EMPTY_BRANCH) deliberately
- * gets NO recovery path: "worker reported success but delivered nothing" is
- * a signal a human must look at, not something to auto-retry.
- */
-function landRecoveryError(err: unknown, taskId: string): unknown {
-  const message = errorMessage(err)
-  if (!message.includes(EMPTY_BRANCH_DIRTY_WORKTREE_CODE)) return err
-  const branch = /EMPTY_BRANCH_DIRTY_WORKTREE: '([^']+)'/.exec(message)?.[1] ?? "your task branch"
-  return new ApiError(splitDaemonCode(message)?.rest ?? message, EMPTY_BRANCH_DIRTY_WORKTREE_CODE, {
-    hint: "the worker wrote files but never committed them — send it back to commit its own work, then land again",
-    nextCommandArgs: [
-      "api",
-      "send",
-      "--task-id",
-      taskId,
-      "--prompt",
-      `your work is uncommitted on ${branch} — commit it yourself with a proper message, then report back`,
-    ],
-  })
-}
-
-/**
- * Give `delete`'s dirty-worktree refusal the same executable recovery `land`
- * gets. This is the refusal an unattended cleanup loop hits most, and the
- * recovery is deliberately NOT `--force`: uncommitted files in a task
- * worktree are somebody's unlanded work, so the first move is to send the
- * worker back to commit it, exactly as EMPTY_BRANCH_DIRTY_WORKTREE does.
- * Discarding the work stays a decision a caller has to make in words.
- *
- * The generic boundary ({@link splitDaemonCode} in `toApiError`) already
- * lifts `DIRTY_WORKTREE` into `code` on its own; this adds only the two
- * self-healing fields, which need the task id the boundary does not have.
- */
-function deleteRecoveryError(err: unknown, taskId: string): unknown {
-  const message = errorMessage(err)
-  const coded = splitDaemonCode(message)
-  if (coded?.code !== DIRTY_WORKTREE_CODE) return err
-  return new ApiError(coded.rest, DIRTY_WORKTREE_CODE, {
-    taskId,
-    hint: "the worktree still holds work this delete would destroy — the message names it, and a gitignored path never shows in `git status`. Send the worker back to commit it, or pass --force to delete the task AND discard that work",
-    nextCommandArgs: [
-      "api",
-      "send",
-      "--task-id",
-      taskId,
-      "--prompt",
-      "your worktree still holds work that this cleanup would destroy (it may be gitignored, so `git status` will not show it — check `git status --ignored`). Commit it yourself with a proper message, then report back",
-    ],
-  })
-}
-
-export async function adopt(ctx: VerbContext): Promise<unknown> {
-  const daemon = daemonOf(ctx)
-  const { args } = ctx
-  const input: Record<string, string> = {
-    repo: args.requireRepo("repo"),
-    worktreePath: args.requirePath("worktree"),
-  }
-  const branch = args.str("branch")
-  if (branch) input.branch = branch
-  const command = args.str("command")
-  if (command) {
-    input.command = command
-    input.vendor = resolveCommandProtocol(command)
-  }
-  const title = args.str("title")
-  if (title) input.title = title
-  return daemon.request<{ task: SerializedTask }>("worktree.adopt", input)
 }

--- a/packages/kobe/src/cli/api/pty-delivery.ts
+++ b/packages/kobe/src/cli/api/pty-delivery.ts
@@ -41,6 +41,7 @@ import { sessionHasEngine } from "../../engine/session-engine-presence.ts"
 import type { EngineSessionLaunch } from "../../engine/session-launch.ts"
 import { readPersistedTerminalDefaultColors } from "../../tui/lib/terminal-colors.ts"
 import type { VendorId } from "../../types/vendor.ts"
+import { restoredTabsOf } from "./tab-respawn.ts"
 import { ApiError, type DeliveredPrompt, type PromptDeferralSink } from "./types.ts"
 
 // `sessionHasEngine` is the foreground gate for delivery into an existing
@@ -103,9 +104,9 @@ const writePrompt = writeHostedPromptIfClear
  * `engineReady: false` with the session's own output as the reason rather
  * than a claim nobody checked.
  */
-const ENGINE_START_PROBE_MS = 3_000
-const ENGINE_START_POLL_MS = 150
-const ENGINE_NOT_OBSERVED_REASON = `no engine process appeared in the session within ${ENGINE_START_PROBE_MS}ms`
+export const ENGINE_START_PROBE_MS = 3_000
+export const ENGINE_START_POLL_MS = 150
+export const ENGINE_NOT_OBSERVED_REASON = `no engine process appeared in the session within ${ENGINE_START_PROBE_MS}ms`
 
 /**
  * Turn an observed write into the API's outcome fields. One place so every
@@ -113,7 +114,7 @@ const ENGINE_NOT_OBSERVED_REASON = `no engine process appeared in the session wi
  * its own optimistic defaults — which is how `delivered: true` came to mean
  * "we called write()" on one path and "we checked" on another.
  */
-function outcomeFields(outcome: PromptWriteOutcome | null): {
+export function outcomeFields(outcome: PromptWriteOutcome | null): {
   engineReady: boolean
   delivered: boolean
   bytes?: number
@@ -208,6 +209,12 @@ export async function deliverHostedPrompt(
     }
   }
 
+  // Everything below SPAWNS. Name the conversations a pty-host restart froze
+  // and this call is about to pass over: without it "started a blank session
+  // while your real work sits frozen" is byte-identical to a healthy first
+  // start. See {@link DeliveredPrompt.frozenTabs}.
+  const frozen = restoredTabsOf(sessions, target.id, launch.key)
+  const disclose = frozen.length > 0 ? { frozenTabs: frozen } : {}
   const staleCanonical = sessions.find((session) => session.key === launch.key && !session.alive)
   // A FREEZE-RESTORED corpse is not killed: `pty.open` respawns it in place
   // (pre-restart scrollback kept), so the launch below both revives the tab
@@ -232,6 +239,7 @@ export async function deliverHostedPrompt(
         started: open.created !== false || open.respawned === true,
         engineReady: false,
         delivered: false,
+        ...disclose,
       }
     }
     // Paste-delivery vendor (kimi — issue #25): the launch spawned the bare
@@ -256,6 +264,7 @@ export async function deliverHostedPrompt(
         pane: launch.key,
         started: open.created !== false || open.respawned === true,
         ...outcomeFields(outcome),
+        ...disclose,
       }
     }
     // Another API process may win the create race after our pty.list. Its
@@ -274,7 +283,7 @@ export async function deliverHostedPrompt(
         if (err instanceof ComposerBusyError) return deferOrThrow(err, opts?.defer, target.id, tabId, prompt)
         throw err
       }
-      return { session: launch.key, pane: launch.key, started, ...outcomeFields(outcome) }
+      return { session: launch.key, pane: launch.key, started, ...outcomeFields(outcome), ...disclose }
     }
     // OUR launch carried the prompt in its argv, so no paste happened here.
     // The engine reads the prompt from its own command line — a delivery this
@@ -300,6 +309,7 @@ export async function deliverHostedPrompt(
         engineReady: false,
         delivered: true,
         reason: "repo init script is still running; the engine has not started yet",
+        ...disclose,
       }
     }
     // Otherwise walk for the process — the same `sessionHasEngine` the
@@ -318,6 +328,7 @@ export async function deliverHostedPrompt(
         engineReady: false,
         delivered: false,
         reason: (await hostedSessionFailureLine(rpc, launch.key)) ?? ENGINE_NOT_OBSERVED_REASON,
+        ...disclose,
       }
     }
     return {
@@ -326,66 +337,14 @@ export async function deliverHostedPrompt(
       started,
       engineReady: true,
       delivered: true,
+      ...disclose,
     }
   } finally {
     await rpc.request("pty.detach", { key: launch.key }).catch(() => {})
   }
 }
 
-/**
- * Deliver into ONE exact tab (`send --tab tab-N`) — no fallback, no spawn.
- * The addressed tab must exist and be alive; anything else is a typed error
- * so a script targeting "the second tab" never silently lands in the first.
- */
-export async function deliverToExactTab(
-  rpc: PtyHostRpc,
-  taskId: string,
-  tabId: string,
-  cwd: string,
-  prompt: string,
-  opts?: {
-    readonly engineBin?: string
-    readonly snapshot?: PsSnapshot
-    readonly vendor?: VendorId
-    readonly defer?: PromptDeferralSink
-  },
-): Promise<DeliveredPrompt> {
-  const key = `${taskId}::${tabId}`
-  const { sessions = [] } = await rpc.request<{ sessions?: PtySessionInfo[] }>("pty.list", {})
-  const session = sessions.find((s) => s.key === key)
-  if (!session?.alive) {
-    throw new ApiError(
-      `tab ${tabId} has no live session on task ${taskId} — see \`rove api pty-list\` for alive tabs`,
-      "TAB_NOT_FOUND",
-    )
-  }
-  // Same foreground gate as the canonical path: an addressed tab whose
-  // engine exited (or that always was a shell tab) must not have the prompt
-  // pasted into its shell. ANY running engine passes — the addressed tab's
-  // engine need not match the task's vendor (cross-vendor send).
-  if (!(await sessionHasEngine(session.pid, opts?.engineBin, opts?.snapshot))) {
-    throw new ApiError(
-      `tab ${tabId} on task ${taskId} has no live engine process — it is a plain shell right now`,
-      "ENGINE_NOT_RUNNING",
-      {
-        hint: "spawn a fresh engine tab for this prompt with --tab new, or pick an engine tab from pty-list",
-        nextCommandArgs: ["api", "pty-list"],
-      },
-    )
-  }
-  // No pty.detach — see deliverHostedPrompt's existing-key path.
-  const deliveryOpts = { screenManifest: resolveComposerManifest(opts?.vendor) }
-  let outcome: PromptWriteOutcome | null
-  try {
-    outcome = await deliverToKey(rpc, key, prompt, deliveryOpts)
-  } catch (err) {
-    if (err instanceof ComposerBusyError) return deferOrThrow(err, opts?.defer, taskId, tabId, prompt)
-    throw err
-  }
-  return { session: key, pane: key, started: false, ...outcomeFields(outcome) }
-}
-
-function resolveComposerManifest(vendor?: VendorId): EngineScreenManifest | undefined {
+export function resolveComposerManifest(vendor?: VendorId): EngineScreenManifest | undefined {
   return vendor ? engineEntry(vendor).screenManifest : undefined
 }
 
@@ -395,7 +354,7 @@ function resolveComposerManifest(vendor?: VendorId): EngineScreenManifest | unde
  * daemon accepts it; an occupied slot or failed handoff is an error. Without
  * a sink there is no queue, so surface the legacy typed error.
  */
-async function deferOrThrow(
+export async function deferOrThrow(
   error: ComposerBusyError,
   sink: PromptDeferralSink | undefined,
   taskId: string,

--- a/packages/kobe/src/cli/api/runtime.ts
+++ b/packages/kobe/src/cli/api/runtime.ts
@@ -17,9 +17,9 @@ import { type DaemonRpc, resolveActiveTaskId } from "../daemon-session.ts"
 // Kept for existing callers in this directory; new callers should import from
 // daemon-session.ts directly to keep the daemon/session boundary clean.
 export { resolveActiveTaskId }
+import { deliverToExactTab } from "./exact-tab-delivery.ts"
 import {
   deliverHostedPrompt,
-  deliverToExactTab,
   ensurePtyHost,
   killTaskSessions,
   listSessions,
@@ -27,6 +27,7 @@ import {
   openPtyHost,
   taskKeys,
 } from "./pty-delivery.ts"
+import { restoredTabLaunch } from "./tab-respawn.ts"
 import {
   type TaskSessionRow,
   closeTabsSnapshot,
@@ -75,10 +76,19 @@ async function deliverHosted(
         vendor: target.vendor,
         effort: target.modelEffort,
       })[0]
-      return await deliverToExactTab(host.rpc, target.id, target.tab, worktree, prompt, {
+      const tabId = target.tab
+      return await deliverToExactTab(host.rpc, target.id, tabId, worktree, prompt, {
         engineBin,
         vendor: target.vendor,
         defer,
+        // Only with explicit consent (`send --respawn`). The factory is lazy
+        // so the snapshot read happens only on the branch that needs it —
+        // reviving a tab a pty-host restart froze.
+        ...(target.respawn
+          ? {
+              respawn: () => restoredTabLaunch(target, tabId, worktree, process.env.SHELL?.trim() || "/bin/zsh"),
+            }
+          : {}),
       })
     }
     const newTab = target.tab === "new" ? mintCliTab(target.id, target.tabVendor, target.tabCommand) : undefined
@@ -147,10 +157,19 @@ async function deliverHosted(
     // in mintCliTab); see `tab-snapshot.ts`. When THIS delivery started the
     // session, record the pinned session id + spawned flag too, so a later
     // dead-reattach resumes the conversation (see engineTabArgv).
+    if (!newTab) publishCliTabSnapshot(target.id, result.started ? sessionId : undefined)
     if (result.started && sessionId) {
-      if (newTab) markCliTabSession(target.id, newTab, sessionId)
-      else publishCliTabSnapshot(target.id, sessionId)
-    } else if (!newTab) publishCliTabSnapshot(target.id)
+      // publishCliTabSnapshot is write-ONCE by contract (a mounted TUI owns
+      // tab state), so on a task that already has a snapshot it no-ops and
+      // the id never lands. That is not a missing field but a WRONG one: a
+      // canonical send after a host restart respawns tab-1 under a fresh
+      // pinned id while the snapshot still names the previous conversation,
+      // so `--resume` would reopen the wrong one. Recording the id of a
+      // session THIS process just started is not fighting the TUI — it is
+      // the same write `--tab new` already does.
+      const startedTab = newTab ?? result.session.split("::")[1]
+      if (startedTab) markCliTabSession(target.id, startedTab, sessionId)
+    }
     return result
   } catch (error) {
     if (error instanceof ApiError) throw error
@@ -324,8 +343,18 @@ export const defaultApiRuntime: ApiRuntime = {
       /* keep tabs readable without the records */
     }
     const snapshot = readTabsSnapshot(taskId)
+    // The pinned conversation id per tab — persisted since engine tabs
+    // existed, readable nowhere. It is the whole recovery for a dead engine
+    // tab (`claude --resume <id>`), and `send --tab N --respawn` names it in
+    // its refusal, so a caller must be able to read it back.
+    const sessionIds = new Map(
+      (snapshot?.tabs ?? []).map((t) => [t.id, (t as { sessionId?: string | null }).sessionId ?? undefined]),
+    )
     return {
-      tabs: joinTaskTabs(snapshot, taskId, listed, exits, liveVendors, engineAlive),
+      tabs: joinTaskTabs(snapshot, taskId, listed, exits, liveVendors, engineAlive).map((row) => {
+        const sessionId = sessionIds.get(row.id)
+        return sessionId ? { ...row, sessionId } : row
+      }),
       running: hostReachable ? hasLiveEngineTab(snapshot, taskId, sessions, engineAlive) : null,
     }
   },

--- a/packages/kobe/src/cli/api/tab-respawn.ts
+++ b/packages/kobe/src/cli/api/tab-respawn.ts
@@ -1,0 +1,112 @@
+/**
+ * Reviving a FREEZE-RESTORED terminal tab from the CLI.
+ *
+ * A pty-host restart (a reboot, a crash, `pty-host` killed) leaves every tab
+ * as a thawed corpse: the frozen record keeps its command, cwd, geometry and
+ * scrollback, and `pty.open` respawns the child in place. A TUI attach does
+ * that on its own (`docs/SESSIONS.md`, "Detaching and reattaching"); nothing
+ * headless could reach it, so after a reboot every task's real conversation
+ * was unreachable until a human opened the TUI.
+ *
+ * Separate from `pty-delivery.ts` because the two answer different
+ * questions. Delivery writes into a session that is already running; this
+ * module decides what argv brings a DEAD one back — which is engine
+ * knowledge (`engineTabArgv`'s resume verbs) plus the persisted tab
+ * snapshot, neither of which delivery reads.
+ *
+ * The respawn is never implicit: `send --tab tab-N` still refuses a restored
+ * tab unless the caller passes `--respawn`. Re-running a tab's recorded
+ * launch command is a side effect the caller has to ask for — for a tab with
+ * no pinned conversation id the frozen command is replayed verbatim, and for
+ * a claude tab that command carries the task's original first prompt as a
+ * positional argument.
+ */
+
+import type { PtySessionInfo } from "@sma1lboy/kobe-daemon/daemon/pty-host"
+import { engineLaunchArgv } from "../../engine/engine-presets.ts"
+import { type EngineSessionLaunch, buildEngineSessionLaunch } from "../../engine/session-launch.ts"
+import { type EngineTab, engineTabArgv } from "../../tui/workspace/terminal-tabs-core.ts"
+import type { VendorId } from "../../types/vendor.ts"
+import { readTabsSnapshot } from "./tab-snapshot.ts"
+
+/** One freeze-restored tab: the id a caller addresses it by, plus the
+ *  conversation id `--resume` would reopen (absent when none was pinned). */
+export interface RestoredTabRef {
+  readonly tab: string
+  readonly sessionId?: string
+}
+
+/**
+ * The task's freeze-restored (thawed, dead) tabs — the conversations a host
+ * restart froze, in the order the host lists them. `exceptKey` drops the tab
+ * the caller is about to use, so a disclosure names only the ones it passed
+ * over. Split leaves belong to their tab and never list on their own.
+ */
+export function restoredTabsOf(
+  sessions: readonly PtySessionInfo[],
+  taskId: string,
+  exceptKey?: string,
+): RestoredTabRef[] {
+  const prefix = `${taskId}::`
+  const ids: string[] = []
+  for (const s of sessions) {
+    if (s.alive || s.restored !== true || s.key === exceptKey || !s.key.startsWith(prefix)) continue
+    const tab = s.key.slice(prefix.length)
+    if (tab.includes("::")) continue
+    if (!ids.includes(tab)) ids.push(tab)
+  }
+  const tabs = readTabsSnapshot(taskId)?.tabs ?? []
+  return ids.map((tab) => {
+    const sessionId = (tabs.find((t) => t.id === tab) as EngineTab | undefined)?.sessionId
+    return sessionId ? { tab, sessionId } : { tab }
+  })
+}
+
+/** What `restoredTabLaunch` needs from the task to compose a tab's argv. */
+export interface RespawnTaskContext {
+  readonly id: string
+  readonly kind?: string
+  readonly repo?: string
+  readonly vendor?: VendorId
+  readonly command?: string
+  readonly modelEffort?: string
+}
+
+/**
+ * The launch that brings tab `tabId` back. Composed through the same
+ * {@link engineTabArgv} a TUI dead-reattach uses, so a tab with a pinned
+ * conversation comes back as `--resume <id>` (claude) / `-S <id>` (kimi) /
+ * `resume <id>` (codex) rather than replaying its original first prompt.
+ * `null` when the snapshot has no engine tab by that id — the caller then has
+ * no argv of its own and the host falls back to the frozen command.
+ */
+export function restoredTabLaunch(
+  task: RespawnTaskContext,
+  tabId: string,
+  worktreePath: string,
+  shell: string,
+): EngineSessionLaunch | null {
+  const tab = readTabsSnapshot(task.id)?.tabs.find((t) => t.id === tabId && t.kind === "engine") as
+    | EngineTab
+    | undefined
+  if (!tab) return null
+  const base = engineLaunchArgv({
+    command: tab.engineCommand ?? (tab.vendor ? undefined : task.command),
+    vendor: tab.vendor ?? task.vendor,
+    effort: task.modelEffort,
+  })
+  return buildEngineSessionLaunch({
+    task: { id: task.id, kind: (task.kind as "task") ?? "task", vendor: tab.vendor ?? task.vendor, repo: task.repo },
+    worktreePath,
+    shell,
+    // `live: false` is the fact that makes this a RESUME rather than a fresh
+    // pin: the tab spawned before, its PTY is gone, and its conversation is
+    // the one to reopen.
+    argv: engineTabArgv(tab, base, false, task.vendor),
+    // The prompt this send carries is PASTED after the engine is up, never
+    // woven into the launch — a resumed conversation must not replay the
+    // task's first prompt, which is exactly what an argv-carried one does.
+    promptIntent: { kind: "none" },
+    tabId,
+  })
+}

--- a/packages/kobe/src/cli/api/types.ts
+++ b/packages/kobe/src/cli/api/types.ts
@@ -8,6 +8,7 @@
 import type { VendorId } from "../../types/vendor.ts"
 import type { DaemonRpc } from "../daemon-session.ts"
 import type { VerbArgs } from "./flags.ts"
+import type { RestoredTabRef } from "./tab-respawn.ts"
 import type { TaskTabRow } from "./tab-snapshot.ts"
 
 export type Flags = Map<string, string>
@@ -180,6 +181,14 @@ export interface PromptTarget {
    * `PromptDeliveryIntent`'s `new-task` kind). `send` never sets it.
    */
   readonly newTask?: boolean
+  /**
+   * Consent to REVIVE a freeze-restored `--tab tab-N` (`send --respawn`).
+   * Without it an addressed tab a pty-host restart froze stays a typed
+   * refusal (`TAB_RESTORED`): respawning re-runs the tab's recorded launch,
+   * and for a tab with no pinned conversation id that command still carries
+   * the task's original first prompt. Never inferred — a caller asks.
+   */
+  readonly respawn?: boolean
 }
 
 export interface DeliveredPrompt {
@@ -223,6 +232,26 @@ export interface DeliveredPrompt {
    * the text. Absent when no write was attempted.
    */
   readonly promptEcho?: "confirmed" | "unconfirmed"
+  /**
+   * Freeze-restored (thawed, dead) engine tabs on this task that this call
+   * did NOT deliver into — the conversations a pty-host restart froze.
+   *
+   * Present only when a NEW session was started (`started: true`), which is
+   * the branch where the two outcomes are indistinguishable otherwise: a
+   * first start of a fresh task and "your two real conversations are frozen,
+   * so I opened a blank one" both report `started/engineReady/delivered:
+   * true`, and `get-task` then says `running: true` because the blank tab is
+   * alive. Each entry carries the tab id to address and the conversation id
+   * to resume it with, so the caller can act instead of guessing.
+   */
+  readonly frozenTabs?: readonly RestoredTabRef[]
+  /**
+   * This delivery RESPAWNED a freeze-restored tab before writing into it
+   * (`send --tab tab-N --respawn`). Distinct from {@link started}, which
+   * means a new session: a respawn reopens the SAME tab, keeping its
+   * scrollback, and resumes its pinned conversation when it has one.
+   */
+  readonly respawned?: true
   /**
    * Why nothing was confirmed — the session's own last line (its shell's
    * `no such file or directory`, or the wrapper's `Engine exited (code N)`
@@ -286,6 +315,19 @@ export interface PromptDeliveryOps {
   ): Promise<DeliveredPrompt>
 }
 
+/**
+ * A tab row plus the conversation id pinned on it (`TerminalTab.sessionId`)
+ * — the exact uuid `claude --resume` / `codex resume` needs. Rove has always
+ * persisted it per engine tab and exposed it on no read surface, so the
+ * documented recovery for a dead tab was to hunt for the id in the engine's
+ * own picker while it sat one field away in `state.json`.
+ *
+ * Declared here rather than on `TaskTabRow` itself only because the join
+ * happens in `runtime.ts`, where the snapshot is already in hand; folding
+ * the field into `joinTaskTabs` is the tidier home for it.
+ */
+export type TaskTabRowWithSession = TaskTabRow & { readonly sessionId?: string }
+
 // ── Runtime (the side-effect seam handlers run against) ─────────────────────
 
 /**
@@ -317,7 +359,7 @@ export interface ApiRuntime {
   taskTabs(
     taskId: string,
     engineArgv?: readonly string[],
-  ): Promise<{ tabs: readonly TaskTabRow[]; running: boolean | null }>
+  ): Promise<{ tabs: readonly TaskTabRowWithSession[]; running: boolean | null }>
   /** Close one exact Terminal Tab without a mounted TUI. */
   closeTerminalTab(taskId: string, tabId: string): Promise<{ kind: TaskTabRow["kind"]; wasAlive: boolean }>
   /** Deliver a prompt into a task's engine pane (building the session if needed). */

--- a/packages/kobe/src/cli/api/verbs-drive.ts
+++ b/packages/kobe/src/cli/api/verbs-drive.ts
@@ -39,6 +39,13 @@ export const DRIVE_VERBS: readonly VerbSpec[] = [
           "Engine launch command for a `--tab new` tab — the API twin of the TUI's ctrl+e pick. Lets one worktree run two agents on the same files (e.g. hand the stuck work to codex without leaving the branch). An engine id from `engine-list` or a full command line; pinned to that tab, so it survives restarts and a later set-command on the task. Only valid with --tab new.",
       },
       {
+        name: "respawn",
+        type: "bool",
+        required: false,
+        description:
+          "Revive a FREEZE-RESTORED --tab tab-N before delivering. After a pty-host restart (reboot, crash) a tab keeps its scrollback and launch command but nothing runs in it; without this flag such a tab is refused (TAB_RESTORED) rather than silently re-run. With it, the tab is respawned in place and resumes its pinned conversation when it has one (`get-task` shows each tab's sessionId) — a tab with none replays its recorded launch command, which for claude carries the task's original first prompt. Only valid with --tab tab-N.",
+      },
+      {
         name: "plain",
         type: "bool",
         required: false,

--- a/packages/kobe/src/cli/api/verbs-lifecycle.ts
+++ b/packages/kobe/src/cli/api/verbs-lifecycle.ts
@@ -10,7 +10,7 @@
 
 import { F } from "./flags.ts"
 import { simpleRpc } from "./handler-helpers.ts"
-import { deleteTask, land } from "./handlers-tasks.ts"
+import { deleteTask, land } from "./handlers-lifecycle.ts"
 import type { VerbSpec } from "./types.ts"
 
 export const LIFECYCLE_VERBS: readonly VerbSpec[] = [

--- a/packages/kobe/src/cli/api/verbs-worktree.ts
+++ b/packages/kobe/src/cli/api/verbs-worktree.ts
@@ -9,7 +9,7 @@
 
 import { F } from "./flags.ts"
 import { simpleRpc } from "./handler-helpers.ts"
-import { adopt } from "./handlers-tasks.ts"
+import { adopt } from "./handlers-lifecycle.ts"
 import type { VerbSpec } from "./types.ts"
 
 export const WORKTREE_VERBS: readonly VerbSpec[] = [

--- a/packages/kobe/test/cli/exact-tab-delivery.test.ts
+++ b/packages/kobe/test/cli/exact-tab-delivery.test.ts
@@ -1,0 +1,129 @@
+/**
+ * `exact-tab-delivery.ts` — `send --tab tab-N`, delivery into ONE addressed
+ * tab. Split from `pty-delivery.test.ts` along the same seam as the source:
+ * that file owns delivery through the canonical path (find the task's engine
+ * session, or create it); this one owns delivery when the caller named the
+ * tab, including the case where the tab is GONE — absent, a plain shell, or
+ * thawed-but-dead after a pty-host restart. The composer-busy gates on the
+ * same function live in `pty-delivery-gates.test.ts`.
+ */
+
+import type { PtySessionInfo } from "@sma1lboy/kobe-daemon/daemon/pty-host"
+import { describe, expect, it } from "vitest"
+import { deliverToExactTab } from "../../src/cli/api/exact-tab-delivery.ts"
+import type { ApiError } from "../../src/cli/api/types.ts"
+
+function session(key: string, command: string[], alive = true): PtySessionInfo {
+  return { key, alive, pid: alive ? 123 : null, command, title: "" }
+}
+
+/** A ps snapshot in which pid 123 (the session shell) hosts `child`. */
+function psWith(child: string): () => Promise<string> {
+  return async () => `123 1 -zsh\n456 123 ${child}\n`
+}
+
+/**
+ * A fake engine that has announced bracketed paste and echoes what it was
+ * written, the way a real composer redraws pasted text. Delivery waits for
+ * the announce before writing and confirms the prompt's tail on capture, so
+ * a silent fake would poll until its confirm budget expired.
+ */
+function echoingPeek(): { onWrite: (data: string) => void; peek: () => unknown } {
+  let buffer = ""
+  return {
+    onWrite: (data: string) => {
+      buffer += data
+    },
+    peek: () => ({
+      exists: true,
+      alive: true,
+      data: Buffer.from(`\x1b[?2004h${buffer}`).toString("base64"),
+      offset: 0,
+    }),
+  }
+}
+
+describe("deliverToExactTab", () => {
+  function rpcWith(sessions: PtySessionInfo[]) {
+    const calls: string[] = []
+    const engine = echoingPeek()
+    const rpc = {
+      request: async <T>(name: string, payload?: unknown): Promise<T> => {
+        calls.push(name)
+        if (name === "pty.list") return { sessions } as T
+        if (name === "pty.peek") return engine.peek() as T
+        if (name === "pty.write") engine.onWrite((payload as { data?: string }).data ?? "")
+        return {} as T
+      },
+    }
+    return { rpc, calls }
+  }
+
+  it("a DIFFERENT vendor's engine in the addressed tab still receives (cross-vendor send)", async () => {
+    const { rpc, calls } = rpcWith([session("t1::tab-2", ["codex"])])
+    const result = await deliverToExactTab(rpc, "t1", "tab-2", "/wt/t1", "go", {
+      engineBin: "claude", // task vendor is claude; tab runs codex
+      snapshot: psWith("codex"),
+    })
+    expect(result).toMatchObject({ session: "t1::tab-2", delivered: true })
+    expect(calls).toContain("pty.write")
+  })
+
+  it("refuses a tab that is a plain shell (ENGINE_NOT_RUNNING, not a paste)", async () => {
+    const { rpc, calls } = rpcWith([session("t1::tab-2", ["/bin/zsh"])])
+    const err = await deliverToExactTab(rpc, "t1", "tab-2", "/wt/t1", "go", {
+      snapshot: psWith("grep something"),
+    }).then(
+      () => null,
+      (e) => e,
+    )
+    expect((err as ApiError).code).toBe("ENGINE_NOT_RUNNING")
+    expect(calls).not.toContain("pty.write")
+  })
+
+  it("refuses a dead/absent tab (TAB_NOT_FOUND)", async () => {
+    const { rpc } = rpcWith([session("t1::tab-2", ["claude"], false)])
+    const err = await deliverToExactTab(rpc, "t1", "tab-2", "/wt/t1", "go").then(
+      () => null,
+      (e) => e,
+    )
+    expect((err as ApiError).code).toBe("TAB_NOT_FOUND")
+  })
+
+  // A pty-host restart leaves every tab thawed-but-dead. TAB_NOT_FOUND for
+  // one of those sent the caller to `pty-list`, which LISTS it — so the
+  // refusal has to be its own code, and reviving has to be reachable.
+  it("distinguishes a freeze-restored tab from an absent one (TAB_RESTORED, not TAB_NOT_FOUND)", async () => {
+    const { rpc, calls } = rpcWith([{ ...session("t1::tab-2", ["claude"], false), restored: true }])
+    const err = await deliverToExactTab(rpc, "t1", "tab-2", "/wt/t1", "go").then(
+      () => null,
+      (e) => e,
+    )
+    expect((err as ApiError).code).toBe("TAB_RESTORED")
+    // Refusal, not a silent revival: nothing was opened and nothing written.
+    expect(calls).not.toContain("pty.open")
+    expect(calls).not.toContain("pty.write")
+  })
+
+  it("respawns a freeze-restored tab and delivers into it when the caller opts in", async () => {
+    const restored = { ...session("t1::tab-2", ["claude"], false), restored: true }
+    const sessions: PtySessionInfo[] = [restored]
+    const { rpc, calls } = rpcWith(sessions)
+    const inner = rpc.request
+    rpc.request = async <T>(name: string, payload?: unknown): Promise<T> => {
+      const out = await inner<T>(name, payload)
+      // The host's respawn-in-place: the same key comes back alive.
+      if (name === "pty.open") sessions[0] = session("t1::tab-2", ["claude"])
+      return name === "pty.open" ? ({ alive: true, respawned: true } as T) : out
+    }
+    const result = await deliverToExactTab(rpc, "t1", "tab-2", "/wt/t1", "go", {
+      engineBin: "claude",
+      snapshot: psWith("claude"),
+      respawn: () => ({ key: "t1::tab-2", command: ["zsh", "-lc", "claude --resume abc"] }),
+    })
+    expect(calls).toContain("pty.open")
+    // `respawned`, never `started`: the SAME tab came back, scrollback and
+    // conversation intact — a new session would be a different claim.
+    expect(result).toMatchObject({ session: "t1::tab-2", delivered: true, respawned: true, started: false })
+  })
+})

--- a/packages/kobe/test/cli/pty-delivery-gates.test.ts
+++ b/packages/kobe/test/cli/pty-delivery-gates.test.ts
@@ -13,7 +13,7 @@
 
 import type { PtySessionInfo } from "@sma1lboy/kobe-daemon/daemon/pty-host"
 import { describe, expect, it } from "vitest"
-import { deliverToExactTab } from "../../src/cli/api/pty-delivery.ts"
+import { deliverToExactTab } from "../../src/cli/api/exact-tab-delivery.ts"
 import { ApiError } from "../../src/cli/api/types.ts"
 
 function session(key: string, command: string[], alive = true): PtySessionInfo {

--- a/packages/kobe/test/cli/pty-delivery.test.ts
+++ b/packages/kobe/test/cli/pty-delivery.test.ts
@@ -6,7 +6,8 @@
 
 import type { PtySessionInfo } from "@sma1lboy/kobe-daemon/daemon/pty-host"
 import { describe, expect, it } from "vitest"
-import { deliverHostedPrompt, deliverToExactTab, deliverToKey } from "../../src/cli/api/pty-delivery.ts"
+import { deliverToExactTab } from "../../src/cli/api/exact-tab-delivery.ts"
+import { deliverHostedPrompt, deliverToKey } from "../../src/cli/api/pty-delivery.ts"
 import { ApiError } from "../../src/cli/api/types.ts"
 
 function session(key: string, command: string[], alive = true): PtySessionInfo {
@@ -447,5 +448,76 @@ describe("deliverToExactTab", () => {
       (e) => e,
     )
     expect((err as ApiError).code).toBe("TAB_NOT_FOUND")
+  })
+
+  // A pty-host restart leaves every tab thawed-but-dead. TAB_NOT_FOUND for
+  // one of those sent the caller to `pty-list`, which LISTS it — so the
+  // refusal has to be its own code, and reviving has to be reachable.
+  it("distinguishes a freeze-restored tab from an absent one (TAB_RESTORED, not TAB_NOT_FOUND)", async () => {
+    const { rpc, calls } = rpcWith([{ ...session("t1::tab-2", ["claude"], false), restored: true }])
+    const err = await deliverToExactTab(rpc, "t1", "tab-2", "/wt/t1", "go").then(
+      () => null,
+      (e) => e,
+    )
+    expect((err as ApiError).code).toBe("TAB_RESTORED")
+    // Refusal, not a silent revival: nothing was opened and nothing written.
+    expect(calls).not.toContain("pty.open")
+    expect(calls).not.toContain("pty.write")
+  })
+
+  it("respawns a freeze-restored tab and delivers into it when the caller opts in", async () => {
+    const restored = { ...session("t1::tab-2", ["claude"], false), restored: true }
+    const sessions: PtySessionInfo[] = [restored]
+    const { rpc, calls } = rpcWith(sessions)
+    const inner = rpc.request
+    rpc.request = async <T>(name: string, payload?: unknown): Promise<T> => {
+      const out = await inner<T>(name, payload)
+      // The host's respawn-in-place: the same key comes back alive.
+      if (name === "pty.open") sessions[0] = session("t1::tab-2", ["claude"])
+      return name === "pty.open" ? ({ alive: true, respawned: true } as T) : out
+    }
+    const result = await deliverToExactTab(rpc, "t1", "tab-2", "/wt/t1", "go", {
+      engineBin: "claude",
+      snapshot: psWith("claude"),
+      respawn: () => ({ key: "t1::tab-2", command: ["zsh", "-lc", "claude --resume abc"] }),
+    })
+    expect(calls).toContain("pty.open")
+    // `respawned`, never `started`: the SAME tab came back, scrollback and
+    // conversation intact — a new session would be a different claim.
+    expect(result).toMatchObject({ session: "t1::tab-2", delivered: true, respawned: true, started: false })
+  })
+})
+
+describe("deliverHostedPrompt frozen-tab disclosure", () => {
+  it("names the freeze-restored tabs a fresh spawn passed over", async () => {
+    const sessions: PtySessionInfo[] = [
+      { ...session("t1::tab-2", ["claude"], false), restored: true },
+      { ...session("t1::tab-3", ["claude"], false), restored: true },
+    ]
+    const engine = echoingPeek()
+    const rpc = {
+      request: async <T>(name: string, payload?: unknown): Promise<T> => {
+        if (name === "pty.list") return { sessions } as T
+        if (name === "pty.peek") return engine.peek() as T
+        if (name === "pty.write") engine.onWrite((payload as { data?: string }).data ?? "")
+        if (name === "pty.open") {
+          sessions.push(session("t1::tab-1", ["claude"]))
+          return { alive: true, created: true } as T
+        }
+        return {} as T
+      },
+    }
+    const result = await deliverHostedPrompt(
+      rpc,
+      { id: "t1", engineBin: "claude" },
+      "/wt/t1",
+      "go",
+      { key: "t1::tab-1", command: ["zsh", "-lc", "claude 'go'"] },
+      { snapshot: psWith("claude") },
+    )
+    // Without this the reply is byte-identical to a healthy first start,
+    // while both real conversations sit frozen in the same host.
+    expect(result.started).toBe(true)
+    expect(result.frozenTabs?.map((t) => t.tab)).toEqual(["tab-2", "tab-3"])
   })
 })

--- a/packages/kobe/test/cli/pty-delivery.test.ts
+++ b/packages/kobe/test/cli/pty-delivery.test.ts
@@ -1,12 +1,12 @@
 /**
- * `pty-delivery.ts` — the bracketed paste that `kobe api` delivery routes
- * through. The engine-key resolver's own tests live in
- * `pty-engine-key.test.ts`.
+ * `pty-delivery.ts` — the CANONICAL delivery path: find the task's engine
+ * session or create it, and the bracketed paste `kobe api` routes through.
+ * The engine-key resolver's own tests live in `pty-engine-key.test.ts`;
+ * delivery into ONE addressed tab is `exact-tab-delivery.test.ts`.
  */
 
 import type { PtySessionInfo } from "@sma1lboy/kobe-daemon/daemon/pty-host"
 import { describe, expect, it } from "vitest"
-import { deliverToExactTab } from "../../src/cli/api/exact-tab-delivery.ts"
 import { deliverHostedPrompt, deliverToKey } from "../../src/cli/api/pty-delivery.ts"
 import { ApiError } from "../../src/cli/api/types.ts"
 
@@ -400,91 +400,6 @@ describe("deliverHostedPrompt", () => {
     )
     expect(err).toBeInstanceOf(ApiError)
     expect((err as ApiError).code).toBe("ENGINE_NOT_RUNNING")
-  })
-})
-
-describe("deliverToExactTab", () => {
-  function rpcWith(sessions: PtySessionInfo[]) {
-    const calls: string[] = []
-    const engine = echoingPeek()
-    const rpc = {
-      request: async <T>(name: string, payload?: unknown): Promise<T> => {
-        calls.push(name)
-        if (name === "pty.list") return { sessions } as T
-        if (name === "pty.peek") return engine.peek() as T
-        if (name === "pty.write") engine.onWrite((payload as { data?: string }).data ?? "")
-        return {} as T
-      },
-    }
-    return { rpc, calls }
-  }
-
-  it("a DIFFERENT vendor's engine in the addressed tab still receives (cross-vendor send)", async () => {
-    const { rpc, calls } = rpcWith([session("t1::tab-2", ["codex"])])
-    const result = await deliverToExactTab(rpc, "t1", "tab-2", "/wt/t1", "go", {
-      engineBin: "claude", // task vendor is claude; tab runs codex
-      snapshot: psWith("codex"),
-    })
-    expect(result).toMatchObject({ session: "t1::tab-2", delivered: true })
-    expect(calls).toContain("pty.write")
-  })
-
-  it("refuses a tab that is a plain shell (ENGINE_NOT_RUNNING, not a paste)", async () => {
-    const { rpc, calls } = rpcWith([session("t1::tab-2", ["/bin/zsh"])])
-    const err = await deliverToExactTab(rpc, "t1", "tab-2", "/wt/t1", "go", {
-      snapshot: psWith("grep something"),
-    }).then(
-      () => null,
-      (e) => e,
-    )
-    expect((err as ApiError).code).toBe("ENGINE_NOT_RUNNING")
-    expect(calls).not.toContain("pty.write")
-  })
-
-  it("refuses a dead/absent tab (TAB_NOT_FOUND)", async () => {
-    const { rpc } = rpcWith([session("t1::tab-2", ["claude"], false)])
-    const err = await deliverToExactTab(rpc, "t1", "tab-2", "/wt/t1", "go").then(
-      () => null,
-      (e) => e,
-    )
-    expect((err as ApiError).code).toBe("TAB_NOT_FOUND")
-  })
-
-  // A pty-host restart leaves every tab thawed-but-dead. TAB_NOT_FOUND for
-  // one of those sent the caller to `pty-list`, which LISTS it — so the
-  // refusal has to be its own code, and reviving has to be reachable.
-  it("distinguishes a freeze-restored tab from an absent one (TAB_RESTORED, not TAB_NOT_FOUND)", async () => {
-    const { rpc, calls } = rpcWith([{ ...session("t1::tab-2", ["claude"], false), restored: true }])
-    const err = await deliverToExactTab(rpc, "t1", "tab-2", "/wt/t1", "go").then(
-      () => null,
-      (e) => e,
-    )
-    expect((err as ApiError).code).toBe("TAB_RESTORED")
-    // Refusal, not a silent revival: nothing was opened and nothing written.
-    expect(calls).not.toContain("pty.open")
-    expect(calls).not.toContain("pty.write")
-  })
-
-  it("respawns a freeze-restored tab and delivers into it when the caller opts in", async () => {
-    const restored = { ...session("t1::tab-2", ["claude"], false), restored: true }
-    const sessions: PtySessionInfo[] = [restored]
-    const { rpc, calls } = rpcWith(sessions)
-    const inner = rpc.request
-    rpc.request = async <T>(name: string, payload?: unknown): Promise<T> => {
-      const out = await inner<T>(name, payload)
-      // The host's respawn-in-place: the same key comes back alive.
-      if (name === "pty.open") sessions[0] = session("t1::tab-2", ["claude"])
-      return name === "pty.open" ? ({ alive: true, respawned: true } as T) : out
-    }
-    const result = await deliverToExactTab(rpc, "t1", "tab-2", "/wt/t1", "go", {
-      engineBin: "claude",
-      snapshot: psWith("claude"),
-      respawn: () => ({ key: "t1::tab-2", command: ["zsh", "-lc", "claude --resume abc"] }),
-    })
-    expect(calls).toContain("pty.open")
-    // `respawned`, never `started`: the SAME tab came back, scrollback and
-    // conversation intact — a new session would be a different claim.
-    expect(result).toMatchObject({ session: "t1::tab-2", delivered: true, respawned: true, started: false })
   })
 })
 


### PR DESCRIPTION
Batch B of `loop-r17-resume` (B1, B2, B3). One theme: after a pty-host restart
(a reboot, a crash, the host killed) every terminal tab is thawed-but-dead —
the frozen record keeps its command, cwd, geometry and scrollback, and the host
lists it. Three verbs told a headless caller otherwise, so the practical state
was: **after a reboot, every task's real conversation is unreachable until a
human opens the TUI.**

Nothing here auto-adopts or auto-resumes anything. B2 and B3 are pure
disclosure; B1 makes the respawn a TUI attach already performs *askable*, and
refuses by default.

All three were reproduced and re-measured in an isolated fixture (its own
`ROVE_/KOBE_ HOME_DIR / DAEMON_SOCKET_PATH / DAEMON_PID_PATH / PTY_SOCKET_PATH
/ PTY_PID_PATH / DAEMON_WEB_PORT=7811`, run from source, not the 0.9.105 on
PATH). Evidence transcripts: `/tmp/loop-r17-az-evidence/`.

Isolation verified, not assumed: `grep -c "scratch/loop-r17-az/home"` and a
grep for both fixture task ids against the real `~/.rove/tasks.json` are both
0; the fixture daemon and pty host are stopped.

---

## B2 — `send` names the conversations it passed over

**PASS criterion.** With every real conversation frozen, a `send` that starts a
fresh session must disclose the frozen tabs it did not use.

**BEFORE** (`/tmp/loop-r17-az-evidence/before-b2-b3.txt`) — tab-1/2/3 all
freeze-restored:

```json
{"ok":true,"session":"…::tab-1","started":true,"engineReady":true,"delivered":true}
```

`get-task` then reported `running: true`, because the blank tab is alive.

**AFTER** (`/tmp/loop-r17-az-evidence/after-b2.txt`), same fixture, same state:

```json
{
  "ok": true, "session": "…::tab-1", "started": true, "engineReady": true, "delivered": true,
  "frozenTabs": [
    { "tab": "tab-2", "sessionId": "dbd0931c-af9b-44ae-9c81-abeac22ced88" },
    { "tab": "tab-3", "sessionId": "83a6c407-8f8e-4533-8828-f4035270b692" }
  ]
}
```

**One correction to the brief.** It says "*No field distinguishes the two
branches*". `started: true` already did — its docstring is "A NEW session was
created by this call (never 'delivered into one')", and it was in the measured
payload. What was genuinely absent is the *context*: a first start of a healthy
task and "I opened a blank agent because your two real conversations are
frozen" both report `started/engineReady/delivered: true`. `frozenTabs` is that
missing half, and it names the tabs and the ids to reach them with. No
behaviour change — the branch was already chosen, this reports which one.

## B1 — a frozen tab is reachable, and the refusal is actionable

**PASS criterion (option b + a).** `send --tab tab-N` against a restored tab
must not be `TAB_NOT_FOUND` pointing at a listing that shows the tab; and the
respawn a TUI attach performs must be reachable headlessly.

**BEFORE** (`before-b1.txt`) — host back up, `pty-list` listing tab-2:

```json
{"error":{"message":"tab tab-2 has no live session on task … — see `rove api pty-list` for alive tabs","code":"TAB_NOT_FOUND"}}
```

**AFTER, default** (`after-b1-refusal.txt`) — no flag, nothing opened:

```json
{"error":{
  "message":"tab tab-2 on task … is a freeze-restored session — its pty host restarted, so the tab exists with its scrollback but nothing is running in it",
  "code":"TAB_RESTORED",
  "hint":"revive it with --respawn (resumes the tab's pinned conversation when it has one — `get-task` shows `sessionId`; a tab without one replays its recorded launch command)",
  "nextCommandArgs":["api","send","--task-id","…","--tab","tab-2","--respawn","--prompt","wake tab2"]
}}
```

**AFTER, with consent** (`after-b1-respawn.txt`):

```json
{"ok":true,"session":"…::tab-2","started":false,"delivered":true,"promptEcho":"confirmed","respawned":true}
```

### Why the respawn is explicit, and why the first-prompt hazard is gone

The brief flagged that an implicit respawn re-runs the recorded command, which
for a claude tab replays the task's original first prompt as an argv argument.
Two answers, both in this PR:

**1. The replay is avoided, not accepted.** The respawn composes its argv
through the same `engineTabArgv` a TUI dead-reattach uses, so a tab that
spawned before and has a pinned id comes back on `--resume <id>` with the
prompt *pasted* after the engine is up. Proof from the tab's own ring — the
original spawn and the respawn, same conversation:

```
SENTINEL claude UP pid=71843 argv=[--session-id dbd0931c-af9b-44ae-9c81-abeac22ced88 second conversation]
SENTINEL claude UP pid=91305 argv=[--resume dbd0931c-af9b-44ae-9c81-abeac22ced88]
```

**2. It is still explicit.** A tab with *no* pinned conversation id (a
non-resumable engine, a tab that never spawned) has no resume argv, so the host
falls back to the frozen launch command — the replay. And even a clean resume
starts a process and spends engine quota the caller did not ask for; `send
--tab tab-N` has never spawned anything. So the default stays a refusal and
`--respawn` is the consent, with the hazard spelled out in both the flag help
and the error hint. **New CLI flag — flagging it explicitly per the contract**
(`--respawn` on `send`, valid only with `--tab tab-N`; using it with
`--tab new`/canonical is a `BAD_FLAG` rather than a silent no-op).

## B3 — the pinned resume id is readable, and recorded correctly

**PASS criterion.** `get-task` returns `sessionId` per engine tab including
dead ones; and a headlessly-started tab has its id persisted.

**BEFORE** (`before-b2-b3.txt`) — every row: `id / kind / title / vendor /
liveVendor / lastTitle / autoTitle / alive / engineAlive / exit`, no id.

**AFTER** (`after-b3-read.txt`), `get-task` and `collect` alike:

```
{"id": "tab-1", "alive": false, "engineAlive": false, "sessionId": "c47b02fc-…"}
{"id": "tab-2", "alive": false, "engineAlive": false, "sessionId": "dbd0931c-…"}
{"id": "tab-3", "alive": false, "engineAlive": false, "sessionId": "83a6c407-…"}
```

### The write path was worse than "null for agent-started work"

The brief predicted the field would be null for a CLI-started tab. Measured, it
is **wrong**, not absent. `publishCliTabSnapshot` is write-once — it no-ops
when the task already has a snapshot — so a canonical `send` that respawns
tab-1 after a restart pins a *new* conversation while the snapshot still names
the previous one:

BEFORE (`before-b3-write.txt`):

```
state.json  tab-1 sessionId = c47b02fc-09a2-4c36-a051-d8de2ee5b43b
live argv   --session-id 17aad766-3c77-4f90-8ec9-5b849162ab99 'revive me'
```

`--resume` off that field would have reopened the wrong conversation. AFTER
(`after-b3-write.txt`), the two agree:

```
state.json  tab-1 sessionId = f478c27b-b962-483a-acd6-32c1d1bbfe36
live argv   --session-id f478c27b-b962-483a-acd6-32c1d1bbfe36 'revive me'
```

Recording the id of a session *this process just started* is the same write
`--tab new` already does; it does not fight a mounted TUI for tab state.

---

## Tests

Three new cases in `test/cli/pty-delivery.test.ts`, chosen as the tightest
proof of the branches the fixture exercised once: the `TAB_RESTORED` refusal
(and that it opens/writes nothing), the opt-in respawn, and the `frozenTabs`
disclosure. Mutation-verified — `if (session?.restored === true)` → `if
(false)` and dropping `...disclose` from the success return fails exactly those
three and nothing else.

## Gates

- `bun run lint` — 0
- `bun run typecheck` — 0
- `bun run test:fast` — 451 files, 4489 tests, 0 fail
- `bun test test/render` — 108 files, 477 tests, 0 fail
- `KOBE_INCLUDE_SOCKET=1 bun run test:socket` — 100 files, 819 tests, 0 fail

## Notes for review

- **No harness screenshots.** These three items change API/CLI response shapes
  only; nothing renders differently in the TUI, so a `/harness` capture would
  show two identical frames. The verb transcripts above are the ground truth
  the task's own proof standard asks for ("PASS is the verb telling the
  truth"). Saying so rather than attaching a decorative pair.
- **`sessionId` is joined in `runtime.ts`, not in `joinTaskTabs`.** The tidier
  home is `TaskTabRow` itself, but `tab-snapshot.ts` is owned by the Batch A
  worker this round (A3 edits the same object literal). `runtime.ts` already
  holds the snapshot, so the join is three lines there and folding it into
  `joinTaskTabs` is a one-line follow-up once A lands. Noted in the type's
  docstring too.
- **Two files split** to stay under the 500-line cap, both along stated seams:
  `exact-tab-delivery.ts` (deliver into ONE addressed tab, including reviving
  it) out of `pty-delivery.ts` (find or create the task's engine session); and
  `handlers-lifecycle.ts` (delete / land / adopt — the verbs that END a task
  and each own a half-teardown recovery story) out of `handlers-tasks.ts`,
  mirroring the existing `verbs-lifecycle.ts` grouping.
- **Docs updated in the same PR** per AGENTS.md: `docs/API.md` (`get-task`
  `sessionId`, `send --respawn` / `TAB_RESTORED` / `frozenTabs`) and
  `docs/SESSIONS.md` ("Resuming a conversation" no longer sends the reader to
  claude's `/resume` picker for an id Rove can print). `api-flags.md`
  regenerated with `bun scripts/gen-skill-api-flags.ts`.
- **Not touched**, per the task's boundaries: `cwd-task.ts`,
  `handlers-engine-report.ts`, `tab-snapshot.ts`, the worktree manager,
  `refs/`, `.github/workflows/*`.
