### PR TITLE
fix: help and the update page stop advertising what they cannot do

### DIFF
--- a/.changeset/help-advertises-dead-keys.md
+++ b/.changeset/help-advertises-dead-keys.md
@@ -1,0 +1,25 @@
+---
+"@sma1lboy/rove": patch
+---
+
+F1 stops advertising keys that do nothing, and the Update page stops offering a downgrade
+
+`HERE — only in <pane>` bypassed its own reachability test for rows with no
+chord of their own, so a live engine tab listed four diff-review keys with no
+diff on screen (pressing `j` typed a `j` into the engine) plus four composer
+keys belonging to the engine CLI, one of them a chord terminals cannot send.
+Those rows now go through the same reachability scan as everything else: the
+diff-review keys appear only while a diff is focused, the engine's composer
+keys are gone from Rove's help entirely, and the New Task mode chord is
+documented where it is true — on the dialog's own `MODE ctrl+[ ]` label.
+
+The Update page offered "Update now" and pre-selected it whether or not there
+was an update, so `enter` on a machine whose install was ahead of the published
+release ran the installer and downgraded it. With nothing newer it now says so,
+drops the action, and stops printing a backwards "changes from … to …" header
+over a "release notes are unavailable" line.
+
+The Files pane's Zen chip advertised `[~]`, a key bound to nothing; it now
+resolves through the live keymap like the Create-PR chip beside it (`[⌃ A Z]`,
+following a rebound prefix). F1's corner names the keys that scroll it — most
+of its content sits below the fold behind a one-cell scrollbar thumb.

--- a/packages/kobe/src/tui-react/component/help-dialog.tsx
+++ b/packages/kobe/src/tui-react/component/help-dialog.tsx
@@ -114,9 +114,19 @@ export function HelpDialog(props: {
             })}
           </text>
         </box>
-        <text fg={theme.textMuted} onMouseUp={close}>
-          {t("help.esc")}
-        </text>
+        {/* Corner, not a fourth header line: the fold this hint is about is
+            exactly what another header row would eat into. Always shown —
+            the keys work whether or not this particular list overflows, and
+            measuring the scrollbox needs post-layout state for a hint that
+            costs nothing when the content fits. */}
+        <box flexDirection="row" gap={2} flexShrink={0}>
+          <text fg={theme.textMuted} attributes={TextAttributes.DIM}>
+            {t("help.scrollKeys")}
+          </text>
+          <text fg={theme.textMuted} onMouseUp={close}>
+            {t("help.esc")}
+          </text>
+        </box>
       </box>
       {/* Long-content dialogs handle their own overflow: flexShrink={1}
           fits the dialog's maxHeight, the scrollbox owns the scrolling. */}

--- a/packages/kobe/src/tui-react/component/new-task-dialog/view-model.ts
+++ b/packages/kobe/src/tui-react/component/new-task-dialog/view-model.ts
@@ -267,6 +267,10 @@ export function useNewTaskViewModel(props: NewTaskDialogProps) {
           if (!completeFocusedField()) setField(advanceField)
         },
       },
+      // The dialog prints its own `MODE  ctrl+[ ]` label above the chips, so
+      // this chord has no KobeKeymap row: the dialog is modal, F1 cannot open
+      // over it, and the row it used to have could only ever render in panes
+      // where no New Task dialog was open.
       { key: "ctrl+]", cmd: () => switchToTab(nextDialogTab(tab)) },
       { key: "ctrl+[", cmd: () => switchToTab(prevDialogTab(tab)) },
       { key: "ctrl+e", cmd: () => cycleEngine(1) },

--- a/packages/kobe/src/tui-react/component/update-page.tsx
+++ b/packages/kobe/src/tui-react/component/update-page.tsx
@@ -56,14 +56,28 @@ export function UpdatePage(props: { onClose: () => void }) {
   const [checked, setChecked] = useState(false)
   const [releaseNotes, setReleaseNotes] = useState<ReleaseNotesRangeItem[]>([])
   const [loadingNotes, setLoadingNotes] = useState(true)
-  const [selected, setSelected] = useState<ActionId>("update")
+  /**
+   * Starts on "close", NOT "update": until the registry answers there is no
+   * known newer release, and `enter` on a pre-selected "Update now" ran the
+   * installer regardless — a DOWNGRADE whenever `latest < current` (a stale
+   * npm dist-tag, a locally built newer install). `load()` promotes the
+   * selection to "update" only once `hasUpdate` is true.
+   */
+  const [selected, setSelected] = useState<ActionId>("close")
   const [status, setStatus] = useState<string | null>(null)
 
   const latest = info?.latest ?? CURRENT_VERSION
   const latestUnknown = checked && info === null
+  const hasUpdate = info?.hasUpdate === true
+  /** The registry answered, and it answered "nothing newer". */
+  const upToDate = checked && info !== null && !hasUpdate
   const releaseUrl = releaseNotes[0]?.url ?? releasePageUrl(latest)
   const actions: ReadonlyArray<{ id: ActionId; key: string; label: string; detail: string }> = [
-    { id: "update", key: "U", label: t("update.actions.updateNow"), detail: UPDATE_COMMAND },
+    // Offered only when there IS one. `hasUpdate` used to pick a text colour
+    // and nothing else, so the action stayed on screen either way.
+    ...(hasUpdate
+      ? [{ id: "update" as const, key: "U", label: t("update.actions.updateNow"), detail: UPDATE_COMMAND }]
+      : []),
     {
       id: "release",
       key: "R",
@@ -87,8 +101,14 @@ export function UpdatePage(props: { onClose: () => void }) {
     const next = await checkLatestVersion({ force: true })
     setInfo(next)
     setChecked(true)
-    const latestVersion = next?.latest ?? CURRENT_VERSION
-    const fetched = await fetchReleaseNotesRange({ current: CURRENT_VERSION, latest: latestVersion })
+    if (next?.hasUpdate) setSelected("update")
+    // Only a FORWARD range has notes. Asking for current→latest when latest
+    // is older answered [] and the page printed "Release notes are
+    // unavailable" under a backwards "changes from v0.9.138 to v0.9.110"
+    // header — an empty range dressed as a failed fetch.
+    const fetched = next?.hasUpdate
+      ? await fetchReleaseNotesRange({ current: CURRENT_VERSION, latest: next.latest })
+      : []
     setReleaseNotes(fetched)
     setLoadingNotes(false)
   }
@@ -97,7 +117,7 @@ export function UpdatePage(props: { onClose: () => void }) {
     const ids = actions.map((a) => a.id)
     const index = ids.indexOf(selected)
     const next = (index + delta + ids.length) % ids.length
-    setSelected(ids[next] ?? "update")
+    setSelected(ids[next] ?? "close")
   }
 
   function activate(id: ActionId = selected): void {
@@ -105,6 +125,9 @@ export function UpdatePage(props: { onClose: () => void }) {
       props.onClose()
       return
     }
+    // `u` stays bound so the key is never a silent no-op mystery, but with no
+    // newer release there is nothing to run.
+    if (id === "update" && !hasUpdate) return
     if (id === "release") {
       setStatus(openWithSystemViewer(releaseUrl) ? t("update.statusReleaseOpened") : t("update.statusReleaseError"))
       return
@@ -167,11 +190,21 @@ export function UpdatePage(props: { onClose: () => void }) {
             {t("update.latestUnknown")}
           </text>
         ) : (
-          <text fg={info?.hasUpdate ? theme.warning : theme.success} attributes={TextAttributes.BOLD} wrapMode="none">
+          <text fg={hasUpdate ? theme.warning : theme.success} attributes={TextAttributes.BOLD} wrapMode="none">
             v{latest}
           </text>
         )}
       </box>
+
+      {/* Green-vs-amber on the version number was the ONLY thing that ever
+          said "nothing to install". A colour is not a sentence. */}
+      {upToDate ? (
+        <box flexShrink={0} paddingTop={1}>
+          <text fg={theme.success} wrapMode="word">
+            {t("update.upToDate")}
+          </text>
+        </box>
+      ) : null}
 
       <box flexDirection="column" flexShrink={0} paddingTop={1} gap={0}>
         {actions.map((action) => (
@@ -211,11 +244,13 @@ export function UpdatePage(props: { onClose: () => void }) {
         </text>
       ) : null}
 
-      <box flexShrink={0} paddingTop={1}>
-        <text fg={theme.textMuted} attributes={TextAttributes.DIM} wrapMode="none">
-          {t("update.changesSectionHeader", { from: CURRENT_VERSION, to: latest })}
-        </text>
-      </box>
+      {hasUpdate ? (
+        <box flexShrink={0} paddingTop={1}>
+          <text fg={theme.textMuted} attributes={TextAttributes.DIM} wrapMode="none">
+            {t("update.changesSectionHeader", { from: CURRENT_VERSION, to: latest })}
+          </text>
+        </box>
+      ) : null}
       <scrollbox
         flexGrow={1}
         flexShrink={1}
@@ -226,7 +261,9 @@ export function UpdatePage(props: { onClose: () => void }) {
       >
         <box flexDirection="column" paddingRight={1} paddingBottom={1} gap={0}>
           {loadingNotes ? <text fg={theme.textMuted}>{t("update.loadingNotes")}</text> : null}
-          {!loadingNotes && releaseNotes.length === 0 ? (
+          {/* Only a real fetch can fail. With nothing newer to fetch, this
+              line was reporting a failure that never happened. */}
+          {!loadingNotes && hasUpdate && releaseNotes.length === 0 ? (
             <text fg={theme.textMuted} wrapMode="word">
               {t("update.notesUnavailable")}
             </text>

--- a/packages/kobe/src/tui-react/ops/preview-review.tsx
+++ b/packages/kobe/src/tui-react/ops/preview-review.tsx
@@ -175,14 +175,18 @@ export function useDiffReview(args: {
   useBindings(() => ({
     enabled: enabled && args.focused,
     bindings: [
-      { key: "j", cmd: () => moveCursor(1) },
-      { key: "down", cmd: () => moveCursor(1) },
-      { key: "k", cmd: () => moveCursor(-1) },
-      { key: "up", cmd: () => moveCursor(-1) },
-      { key: "v", cmd: () => setAnchor((a) => (a == null ? cursor : null)) },
-      { key: "c", cmd: () => void promptNote() },
+      // The `id`s mirror the doc-only `diff.review.*` rows in KobeKeymap. The
+      // chords stay literal here (FIXED_BINDING_IDS rejects overrides for
+      // them) — the id is what puts the rows in the reachability scan, so F1
+      // lists them only while a diff with rows is actually focused.
+      { key: "j", id: "diff.review.cursor", cmd: () => moveCursor(1) },
+      { key: "down", id: "diff.review.cursor", cmd: () => moveCursor(1) },
+      { key: "k", id: "diff.review.cursor", cmd: () => moveCursor(-1) },
+      { key: "up", id: "diff.review.cursor", cmd: () => moveCursor(-1) },
+      { key: "v", id: "diff.review.range", cmd: () => setAnchor((a) => (a == null ? cursor : null)) },
+      { key: "c", id: "diff.review.note", cmd: () => void promptNote() },
       { key: "x", cmd: () => dropNoteAtCursor() },
-      { key: "s", cmd: () => sendAll() },
+      { key: "s", id: "diff.review.send", cmd: () => sendAll() },
     ],
   }))
 

--- a/packages/kobe/src/tui-react/panes/filetree/header-view.tsx
+++ b/packages/kobe/src/tui-react/panes/filetree/header-view.tsx
@@ -7,6 +7,7 @@
  */
 
 import { TextAttributes } from "@opentui/core"
+import { findBinding } from "../../../tui/context/keybindings"
 import { formatChord } from "../../../tui/lib/chord-glyphs"
 import { currentPrefixConfiguration } from "../../../tui/lib/keymap-dispatch"
 import type { GitScope } from "../../../tui/panes/filetree/git"
@@ -42,6 +43,11 @@ export function FileTreeHeaderView(props: FileTreeHeaderProps) {
   // disabled: the chip stays clickable, just without a chord label.
   const prefixKey = currentPrefixConfiguration().key
   const createPRChord = prefixKey ? `[${formatChord(prefixKey)} P]` : null
+  // Zen is prefix-only too, so its cap comes from the same live pair. It used
+  // to be the string literal `[~]`, and `~` is bound to nothing anywhere in
+  // Rove — the chip taught a dead key while `prefix+z` was the real one.
+  const zenStroke = findBinding("workspace.zenToggle")?.prefixKeys?.[0]
+  const zenChord = prefixKey && zenStroke ? `[${formatChord(prefixKey)} ${zenStroke.toUpperCase()}]` : null
   return (
     <>
       {/* Action row — sits above the All / Changes tabs so it's reachable
@@ -84,9 +90,11 @@ export function FileTreeHeaderView(props: FileTreeHeaderProps) {
                 props.onZenToggle?.()
               }}
             >
-              <text fg={theme.accent} attributes={TextAttributes.BOLD} wrapMode="none">
-                [~]
-              </text>
+              {zenChord ? (
+                <text fg={theme.accent} attributes={TextAttributes.BOLD} wrapMode="none">
+                  {zenChord}
+                </text>
+              ) : null}
               <text fg={theme.text} wrapMode="none">
                 {t("files.actions.zen")}
               </text>

--- a/packages/kobe/src/tui/context/keybindings-chat.ts
+++ b/packages/kobe/src/tui/context/keybindings-chat.ts
@@ -4,53 +4,13 @@ import type { KobeBinding } from "./keybindings-table.ts"
 
 export const CHAT_BINDINGS: readonly KobeBinding[] = [
   // ─── Workspace ────────────────────────────────────────────────────────
-  {
-    // Composer textarea handles enter via its own onKeyDown. This row
-    // exists only for help-dialog visibility; no chord is registered
-    // here.
-    id: "chat.send",
-    scope: "workspace",
-    keys: [],
-    category: "Workspace",
-    description: "Send message (composer)",
-    hint: { keys: "enter" },
-  },
-  {
-    // Composer textarea inserts a literal newline on shift+enter (kitty/
-    // CSI-u terminals) and ctrl+J everywhere else; no chord is registered
-    // here. Surfaced in Help (F1) so the user doesn't have to memorize
-    // it after we stripped the inline footer hint from the composer.
-    id: "chat.newline",
-    scope: "workspace",
-    keys: [],
-    category: "Workspace",
-    description: "Newline in composer",
-    hint: { keys: "shift+enter" },
-  },
-  {
-    // Shift+tab inside the composer cycles the per-task permission mode
-    // (default ↔ plan); the chord is registered in
-    // Composer's onKeyDown, not here. Doc-only entry so Help (F1)
-    // advertises the binding to a focused user.
-    id: "chat.cycle-mode",
-    scope: "workspace",
-    keys: [],
-    category: "Workspace",
-    description: "Cycle permission mode (composer)",
-    hint: { keys: "shift+tab" },
-  },
-  {
-    // Ctrl+enter mid-stream interrupts the in-flight subprocess and
-    // dispatches the new buffer immediately. Plain enter while
-    // streaming queues instead. Chord is registered in Composer's
-    // onKeyDown; this entry is doc-only.
-    id: "chat.steer",
-    scope: "workspace",
-    keys: [],
-    category: "Workspace",
-    description: "Steer (interrupt + send) — mid-stream only",
-    hint: { keys: "ctrl+enter" },
-  },
+  // The workspace is a PTY running the engine CLI — Rove has no composer of
+  // its own, so `chat.send` / `chat.newline` / `chat.cycle-mode` / `chat.steer`
+  // (and `chat.interrupt`, formerly in keybindings-table.ts) are gone. They
+  // hard-coded ONE vendor's composer keymap into Rove's help and rendered in
+  // every workspace and terminal pane; `shift+enter` in particular is a chord
+  // terminals cannot deliver without kitty-protocol setup Rove keeps off.
+  // Engine-owned UI data belongs to the engine adapter (AGENTS.md).
   {
     id: "chat.tab.new",
     scope: "workspace",

--- a/packages/kobe/src/tui/context/keybindings-table.ts
+++ b/packages/kobe/src/tui/context/keybindings-table.ts
@@ -329,18 +329,6 @@ export const KobeKeymap: readonly KobeBinding[] = [
     category: "Navigation",
     description: "Toggle zen mode (hide the files column)",
   },
-  {
-    // Doc-only: the chord is registered inline in Chat.tsx (gated on
-    // focused + streaming + no dialog). ESC does NOT "detach" focus back to
-    // the sidebar — that would pull focus out from under the user mid-edit.
-    // Use `ctrl+q` (`focus.sidebar`) for the explicit detach;
-    // ESC in chat is reserved for interrupting the current turn.
-    id: "chat.interrupt",
-    scope: "workspace",
-    keys: [],
-    category: "Workspace",
-    description: "Interrupt current turn (esc while streaming)",
-  },
   // ─── Sidebar + Tasks pane ─────────────────────────────────────────────
   // The rows below this header live in keybindings-sidebar.ts — a long
   // literal cut at its scope headers, not a responsibility boundary. Order
@@ -436,30 +424,12 @@ export const KobeKeymap: readonly KobeBinding[] = [
   // Those aren't user-configurable shortcuts — they're terminal-pane
   // behavior that has to forward whatever the user types to the shell.
 
-  // ─── Dialog (informational) ───────────────────────────────────────────
-  {
-    // Dialogs (DialogProvider, DialogConfirm, etc.) own their own escape
-    // binding higher on the binding stack. We list this here for the
-    // help dialog only — there's no global ESC handler anymore: ESC is
-    // owned by DialogProvider (when a dialog is open) and Chat.tsx (when
-    // chat is focused + streaming). Idle ESC is a no-op.
-    id: "dialog.cancel",
-    scope: "global",
-    keys: [],
-    category: "Dialog",
-    description: "Close the top dialog (esc)",
-  },
-  {
-    // New-task dialog sub-tab cycling. Chord is registered inside the
-    // dialog's own useBindings (so it wins over the workspace
-    // `chat.tab.cycle-*` bindings, which are gated off while a dialog
-    // is on the stack). This entry is doc-only — help dialog and any
-    // future settings UI render it from here.
-    id: "dialog.newtask.tab.cycle",
-    scope: "global",
-    keys: [],
-    category: "Dialog",
-    description: "Switch New Task tab (Existing / New Repo)",
-    hint: { keys: "ctrl+[/]" },
-  },
+  // ─── Dialog ───────────────────────────────────────────────────────────
+  // No rows. Every dialog owns its own chrome and prints its own chords —
+  // `esc` in the corner, `MODE  ctrl+[ ]` above the new-task chips — and
+  // dialogs are modal, so F1 cannot open over one anyway. The two rows that
+  // used to live here (`dialog.cancel`, `dialog.newtask.tab.cycle`) could
+  // only ever render where they were false: `dialog.cancel` had no `hint`
+  // and rendered nowhere at all, and the new-task chord showed in the
+  // sidebar, workspace and terminal — i.e. whenever the dialog was closed.
 ] as const

--- a/packages/kobe/src/tui/i18n/messages/help.ts
+++ b/packages/kobe/src/tui/i18n/messages/help.ts
@@ -8,6 +8,10 @@ export const en = {
   title: "Rove — keybindings",
   /** Close / cancel hint */
   esc: "esc",
+  /** Corner hint next to `esc`. The list is a scrollbox and routinely runs
+   *  two thirds below the fold behind a one-cell scrollbar thumb, with
+   *  nothing on screen naming the keys that move it. */
+  scrollKeys: "↑↓ ⇞⇟ scroll",
   commandLayer: "{prefix} — more Rove commands",
   escCancel: "esc cancel",
   directLayer: "Hold ctrl — Rove shortcuts",
@@ -27,6 +31,7 @@ export const en = {
 export const zh: typeof en = {
   title: "Rove — 快捷键",
   esc: "esc",
+  scrollKeys: "↑↓ ⇞⇟ 滚动",
   commandLayer: "{prefix} — 更多 Rove 命令",
   escCancel: "esc 取消",
   directLayer: "按住 ctrl — Rove 快捷键",

--- a/packages/kobe/src/tui/i18n/messages/update.ts
+++ b/packages/kobe/src/tui/i18n/messages/update.ts
@@ -12,6 +12,11 @@ export const en = {
   /** The registry check failed (offline, npm down, timeout). Must stay
    *  distinct from "you are up to date". */
   latestUnknown: "unknown — could not reach the registry",
+  /** The registry answered and nothing is newer. Distinct from
+   *  `latestUnknown`: this one is a checked fact, not a failed lookup. Worded
+   *  for BOTH cases it covers — the installed build can equal the published
+   *  release or be ahead of it (a local build, a lagging dist-tag). */
+  upToDate: "No newer release — nothing to install.",
   releaseUrlUnavailable: "release URL unavailable",
   statusReleaseOpened: "Opened release page in your browser.",
   statusReleaseError: "Could not open release URL.",
@@ -60,6 +65,7 @@ export const zh: typeof en = {
   current: "当前",
   latest: "最新",
   latestUnknown: "未知 —— 无法连接到 registry",
+  upToDate: "没有更新的版本 —— 无需安装。",
   releaseUrlUnavailable: "发布链接不可用",
   statusReleaseOpened: "已在浏览器中打开发布说明页面。",
   statusReleaseError: "无法打开发布链接。",

--- a/packages/kobe/src/tui/lib/help-groups.ts
+++ b/packages/kobe/src/tui/lib/help-groups.ts
@@ -78,8 +78,13 @@ export type HelpGrammarSection = {
 
 function directCap(row: KobeBinding): string | null {
   if (row.keys.length > 0) return row.hint?.keys ?? row.keys[0] ?? null
-  // Documentation-only rows (composer and diff keys) still describe a
-  // direct, surface-owned gesture through their friendly hint.
+  // Documentation-only rows (the diff-review keys, the new-task tab cycler)
+  // still describe a direct, surface-owned gesture through their friendly
+  // hint. They carry no `keys`, so they are never dispatched from the table —
+  // the owning component registers the raw chord and tags it with this row's
+  // id, which is what puts them in the reachability scan alongside every
+  // other row. A doc-only row whose owner is not mounted is unreachable and
+  // must not be advertised.
   return row.prefixKeys?.length ? null : (row.hint?.keys ?? null)
 }
 
@@ -117,8 +122,7 @@ export function grammarHelpSections(
     const prefixAvailable = reachability ? reachability.prefix.has(binding.id) : staticallyAvailable
     if (cap) {
       const row = { binding, primary: cap, aliases: binding.keys.filter((key) => key !== cap) }
-      const docOnlyHere = binding.keys.length === 0 && !binding.prefixKeys?.length && staticallyAvailable
-      if ((directAvailable && (staticallyAvailable || binding.presentation === "onePress")) || docOnlyHere) {
+      if (directAvailable && (staticallyAvailable || binding.presentation === "onePress")) {
         if (binding.presentation === "onePress") direct.push(row)
         else here.push(row)
       } else if (!staticallyAvailable && binding.scope !== "global") {

--- a/packages/kobe/test/tui-react/help-groups.test.ts
+++ b/packages/kobe/test/tui-react/help-groups.test.ts
@@ -44,12 +44,17 @@ describe("grammarHelpSections", () => {
     { id: "modified-local", scope: "sidebar", keys: ["ctrl+p"], category: "Sidebar", description: "Filter" },
     { id: "more", scope: "global", keys: [], prefixKeys: ["f"], category: "Global", description: "Fork" },
     { id: "file", scope: "files", keys: ["o"], category: "Files", description: "Open" },
+    // Doc-only: no `keys`, no `prefixKeys`, advertised through `hint` alone.
+    // The owning component registers the raw chord and tags it with this id.
+    { id: "doc-only", scope: "sidebar", keys: [], category: "Sidebar", description: "Review", hint: { keys: "v" } },
   ]
 
   it("teaches focused, one-press, and prefix gestures before other panes", () => {
     const sections = grammarHelpSections(rows, "sidebar", "ctrl+a")
     expect(sections.map((section) => section.kind)).toEqual(["here", "direct", "prefix", "other"])
-    expect(sections[0]?.rows.map((row) => row.binding.id)).toEqual(["local", "modified-local"])
+    // No reachability snapshot (the standalone help page): every row that
+    // statically matches the surface is listed, doc-only rows included.
+    expect(sections[0]?.rows.map((row) => row.binding.id)).toEqual(["local", "modified-local", "doc-only"])
     expect(sections[1]?.rows.map((row) => row.binding.id)).toEqual(["help"])
     expect(sections[2]?.rows[0]?.primary).toBe("ctrl+a + f")
     expect(sections[3]?.scope).toBe("files")
@@ -71,5 +76,29 @@ describe("grammarHelpSections", () => {
     expect(sections.find((section) => section.kind === "prefix")?.rows.map((row) => row.binding.id)).toEqual(["more"])
     expect(sections.flatMap((section) => section.rows).some((row) => row.binding.id === "modified-local")).toBe(false)
     expect(sections.some((section) => section.kind === "other" && section.scope === "sidebar")).toBe(false)
+  })
+
+  /**
+   * A doc-only row used to bypass the reachability test entirely (`||
+   * docOnlyHere`), so a matching `scope` alone put it in HERE. That advertised
+   * four diff-review keys in every workspace and terminal pane with no diff on
+   * screen — pressing `j` typed a `j` into the engine instead.
+   */
+  it("keeps an unreachable doc-only row out of HERE and lists it once its owner registers", () => {
+    const hidden = grammarHelpSections(rows, "sidebar", "ctrl+a", {
+      direct: new Set(["help", "local"]),
+      prefix: new Set(),
+      inputPassthrough: false,
+    })
+    expect(hidden.flatMap((section) => section.rows).some((row) => row.binding.id === "doc-only")).toBe(false)
+
+    const shown = grammarHelpSections(rows, "sidebar", "ctrl+a", {
+      direct: new Set(["help", "local", "doc-only"]),
+      prefix: new Set(),
+      inputPassthrough: false,
+    })
+    const here = shown.find((section) => section.kind === "here")
+    expect(here?.rows.map((row) => row.binding.id)).toEqual(["local", "doc-only"])
+    expect(here?.rows.find((row) => row.binding.id === "doc-only")?.primary).toBe("v")
   })
 })


### PR DESCRIPTION
Batch A + Batch B of `.scratch/loop-r18-discover/discover.md`. C and D untouched.

Every BEFORE/AFTER below is the **xterm text buffer** read through
`/harness` → xterm.js → PTY sidecar → real OpenTUI, on an isolated fixture
(`KOBE_VISUAL_PORT_BASE=6247`, home `.scratch/opentui-visual-6247/`), with the
discover run's `buf.ts` probe. PNGs sit next to each `.txt`.

Evidence: `/Users/jacksonc/.rove/evidence/loop-r18-bb/`

---

## Batch A — `HERE` advertised rows nothing had registered

**Root cause.** `grammarHelpSections` OR'd `docOnlyHere` in **after** the whole
reachability test (`help-groups.ts:120-121`), so any row with `keys: []` and a
`hint` landed in `HERE` whenever its `scope` statically matched the focused
pane. Doc-only rows can never be in `reachability.direct` because nothing tags
the raw chord their owner registers — so instead of teaching reachability about
them, the code stepped around it.

**Fix.** The bypass is deleted. The four `diff.review.*` rows are now tagged
onto the raw bindings `preview-review.tsx` already registers (`{ key: "j", id:
"diff.review.cursor", … }`) — the chords stay literal, `FIXED_BINDING_IDS`
still rejects overrides for them; the `id` only puts them in the reachability
scan. The rows whose surface documents its own chords leave the table.

### PASS criteria and proof

**1. Live engine tab: no diff-review row, no composer row.**
`enter wait:3000 f1` — `before/after: A-terminal-{before,after}.{txt,png}`

BEFORE, first eight rows of `HERE — only in Terminal`:
```
 ⏎        Send message (composer)
 ⇧ ⏎      Newline in composer
 ⇧ tab    Cycle permission mode (composer)
 ⌃ ⏎      Steer (interrupt + send) — mid-stream only
 j/k      Move the line cursor over the diff
 v        Toggle range anchor at the cursor
 c        Add a review note at the cursor
 s        Send all unsent review notes to the engine
 ⌃ ⇞      Scroll scrollback up
 ⌃ ⇟      Scroll scrollback down
 ⌃ [/]    Switch New Task tab (Existing / New Repo)
```
AFTER, the whole section:
```
 ⌃ ⇞      Scroll scrollback up
 ⌃ ⇟      Scroll scrollback down
```

**2. Last tab closed: none of them either.**
`enter wait:2500 ctrl+w wait:1500 f1` — `A-empty-{before,after}.{txt,png}`
BEFORE had a nine-row `HERE — only in Workspace` (four composer, four
diff-review, the New Task chord). AFTER has **no `HERE` section at all**.

**3. Positive control — a real diff DOES list them.**
`… ] j d …  ctrl+q right f1` on a worktree with a modified README —
`A-diff-after.{txt,png}`:
```
HERE — only in Workspace
 j/k      Move the line cursor over the diff
 v        Toggle range anchor at the cursor
 c        Add a review note at the cursor
 s        Send all unsent review notes to the engine
```

**4. `⌃ [/] Switch New Task tab` appears only where it is true.** Gone from
the sidebar (`B3-sidebar-f1-after.txt`), the workspace (`A-empty-after.txt`)
and the terminal (`A-terminal-after.txt`).

I first tagged the dialog's `ctrl+[` / `ctrl+]` registration with the id, then
measured that **the New Task dialog is modal and F1 cannot open over it**
(`esc ctrl+a n f1` renders the dialog, not the help) — so the row could never
render anywhere it was true. The dialog already prints `MODE  ctrl+[ ]` above
its three chips, live and in the right place, so the row is deleted instead.
That also disposes of the stale "(Existing / New Repo)" text naming 2 of 3
modes without my touching the i18n catalogue (see *Not done*).

**5. `chat.interrupt` leaves the table**, together with `chat.send`,
`chat.newline`, `chat.cycle-mode`, `chat.steer` and `dialog.cancel`.
There is no `Chat.tsx` and no `Composer.tsx` in the repo — the workspace is a
PTY running the engine CLI, so those five rows hard-coded **one vendor's**
composer keymap into Rove's neutral help (AGENTS.md § Engine-owned UI data),
and `⇧ ⏎` is the shift+named-key case terminals cannot deliver at all.
`chat.interrupt` and `dialog.cancel` had no `hint`, so `directCap()` returned
`null` and they rendered in no surface whatsoever.

**Regression test + mutation check.** `test/tui-react/help-groups.test.ts`
gains one case: a doc-only row stays out of `HERE` when reachability does not
carry its id, and appears with its hint cap once it does. Restoring the `||
docOnlyHere` line turns it red:
```
× keeps an unreachable doc-only row out of HERE and lists it once its owner registers
  → expected true to be false
× uses the live stack snapshot to hide inactive submode bindings
  → expected [ 'local', 'doc-only' ] to deeply equal [ 'local' ]
```

---

## Batch B

### B1 — the Zen chip taught a dead key

`[~]` was a bare string literal; `~` is bound to nothing in src, test or docs.

**PASS: the cap resolves through the live keymap, and pressing what it prints
toggles zen.** `B1-tilde-before.txt`, `B1-zen-after.txt`, `B1-zen-rebound.txt`

| | chip | files pane after pressing it |
|---|---|---|
| BEFORE, press `~` | `[~] Zen` | still there (`grep -c 'All  Changes'` → **1**) |
| AFTER, press `⌃ A Z` | `[⌃ A Z] Zen` | gone (**0**) |

**A rebound prefix changes it.** With `prefix: {key: ctrl+g}` in the fixture's
`keybindings.yaml`, `ctrl+g z` exits zen and the header reads:
```
[⌃ G Z] Zen
[⌃ G P] Ask agent to create PR
```
— the cap now comes from the same live pair (`currentPrefixConfiguration()` +
the row's `prefixKeys[0]`) as the Create-PR chip beside it.

### B2 — the update page's default action could downgrade you

`useState<ActionId>("update")` pre-selected "Update now"; the `actions` array
was a flat literal with no `hasUpdate` condition; `hasUpdate` only picked a
colour. The fixture reproduces the inverse case with no stubbing.

**PASS (a) with `latest <= current`.** `esc u` — `B2-update-{before,after}.{txt,png}`

BEFORE (`[U]` is the highlighted row — see PNG):
```
  current  v0.9.138  latest  v0.9.110
   [U]  Update now     curl -fsSL https://raw.githubusercontent.com/.../update.sh | sh
   [R]  Open release   https://github.com/Sma1lboy/rove/releases/tag/v0.9.110
   [Q]  Close          return to the workspace
  ── changes from v0.9.138 to v0.9.110 ──
  Release notes are unavailable. Use Open release to view the GitHub release page.
```
AFTER (`[Q] Close` is the highlighted row):
```
  current  v0.9.138  latest  v0.9.110
  No newer release — nothing to install.
   [R]  Open release   https://github.com/Sma1lboy/rove/releases/tag/v0.9.110
   [Q]  Close          return to the workspace
```
Said in words; the action is gone, not merely deselected; the backwards header
is suppressed; and "Release notes are unavailable" no longer reports a failure
that never happened (the fetch is skipped, not failed).

**PASS (b) with `latest > current`: byte-identical to today.**
`KOBE_FAKE_UPDATE=0.9.200`, BEFORE captured by checking out the two unmodified
files, rebuilding, and re-running the same probe —
`B2-hasupdate-{before,after}.{txt,png}`:
```
$ diff B2-hasupdate-before.txt B2-hasupdate-after.txt
IDENTICAL — has-update branch unchanged
```
`[U] Update now` is present and pre-selected in both (PNG highlight).

### B3 — F1 scrolls and nothing said so

Corner now reads `↑↓ ⇞⇟ scroll  esc` in every F1 capture above.

Always shown rather than gated on measured overflow: the keys work either way,
and measuring the scrollbox needs post-layout state for a hint that costs one
corner slot when the content fits. It is a corner and not a fourth header line
precisely because a header line would eat into the fold it is about.

---

## NEEDS OWNER SIGN-OFF — surfaced, not implemented

- The `[D] diff everything` chip's `shift+D` keycap, while `docs/TUI.md`
  describes that chip as the **chordless** path.
- Any new chord for the six right-click-only verbs (`Set status`, `Copy branch
  name`, `Copy path`, `Run again`, `Field notes`, `Sync with base`).
- Whether `⌃ A + k` / `⌃ A + u` should render in F1 and the command guide with
  no "proposed" marker, while `docs/KEYBINDINGS.md` marks both proposed.

**No chord was added or moved in this PR.** The only key behaviour change is
that `u` on the Update page is a no-op when there is nothing to install.

## Not done, and why

- **`diff.review.drop` (`x`) and `diff.review.reload` (`r`).** The diff footer
  names all six keys; `KobeKeymap` has rows for only four, so F1's Diff-review
  section lists 4 of 6. Adding the two rows needs two `desc` entries in
  `src/tui/i18n/messages/keys.ts` — without them F1 would render the raw id,
  which is exactly the `workspace.reopenSession` defect another worker owns
  right now. Left for whoever lands that file.
- **Orphaned `desc` entries.** The six deleted rows leave six unused entries in
  `keys.ts` (`chat.send`, `chat.newline`, `chat.cycle-mode`, `chat.steer`,
  `chat.interrupt`, `dialog.cancel`, `dialog.newtask.tab.cycle`). `check-i18n`
  passes (it compares locales to each other, not to the keymap) and all 4497
  vitest + 477 render tests pass. I left them so this PR never touches
  `keys.ts`. They should be swept when the catalogue-parity guard lands.
- **i18n files I did touch:** only `messages/update.ts` (one new `upToDate`
  key) and `messages/help.ts` (one new `scrollKeys` key) — neither is `keys.ts`
  or `tKeys`, and B2/B3 cannot be done correctly without user-facing strings.

## Gates

`bun run lint` (repo root) · `bun run typecheck` · `bun run check-i18n`
(842 keys × 2 locales) · `bun run test:fast` **4497 passed / 454 files** ·
`bun test test/render` **477 pass, 0 fail**.

## Housekeeping

Fixture daemon and PTY host both stopped, found by the socket/log they held,
not by argv. Ports 6247-6250 free; nothing left under
`.scratch/opentui-visual-6247`. Other worktrees' `pty-host` processes untouched.
