### PR TITLE
fix: close the i18n gate's reachability hole, and stop a Chinese label being cut with no ellipsis

### DIFF
--- a/.changeset/i18n-gate-reachability.md
+++ b/.changeset/i18n-gate-reachability.md
@@ -1,0 +1,39 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Close the hole the i18n gate's own comment described, and stop a Chinese label
+from being cut with no ellipsis.
+
+`check-i18n` validates PARITY — that `en` and `zh` agree with each other — so a
+key missing from BOTH locales passes it. `workspace.reopenSession` had no
+`keys.desc` entry in either, and because `tKeys()` falls back to the raw lookup
+key, the F1 help dialog printed the literal string `workspace.reopenSession` as
+that binding's description, in both languages. The binding's real English
+sentence has been sitting unused in the keymap table the whole time; the help
+dialog never reads it. Two keymap categories (`Diff review`, `Inbox`) had the
+same gap, unreached only by accident of which surfaces are wired today.
+
+`test/tui/i18n-key-resolution.test.ts` now covers what it previously carved out
+by name: every binding id must resolve in `keys.desc`, and every category header
+any surface can print — the help dialog's scope mapping, the prefix HUD's guide
+mapping, and the keymap's own `category` field — must resolve in `keys.category`.
+Deleting a `keys.desc` entry from both locales keeps `check-i18n` green and now
+fails this test, which is the shape of failure it exists to catch. The two
+category mappers moved to the framework-free `lib/help-groups.ts` so the guard
+can ask them directly instead of duplicating their literals.
+
+The prefix HUD's stroke echo fed a CELL budget into a code-point truncator, so a
+Chinese caption "fit" and Yoga then sheared it: `ctrl+a + 2 → 打开例行任务（`,
+ending on an opening full-width bracket with nothing to say the rest was
+dropped, where English got a clean `Open routine…`. Same mismatch in
+`truncateTitle`, whose budget every caller measures with `approxCellWidth`.
+
+The Routines schedule preview, its relative clocks, and the modals the Settings
+screen opens are no longer English-only inside a translated UI. Two
+`toLocale*` calls passed no locale at all and followed the OS rather than the UI
+setting — wrong in both directions — and the next-run date built its word order
+from an English weekday/month table; it now comes from `Intl` for the active
+locale, so zh reads `2026/8/3` rather than `8/3/2026`. The Work Items page's
+private copy of `relativeAge` (which rounded where every other age on screen
+floors) is gone in favour of the shared clock.

--- a/packages/kobe/src/tui-react/component/automations-format.ts
+++ b/packages/kobe/src/tui-react/component/automations-format.ts
@@ -7,17 +7,28 @@
  */
 
 import { relativeBuckets } from "../../lib/relative-time"
+import { intlLocale, t } from "../../tui/i18n"
 
 /** `in 5m` / `12m ago` / a date once it is more than a day out. `\u2014` when
- *  the timestamp is missing or unparsable — an absence, never a fake "now". */
+ *  the timestamp is missing or unparsable — an absence, never a fake "now".
+ *  The date falls back on `Intl` for the UI locale, not the machine's. */
 export function formatWhen(iso: string | undefined, now: number): string {
   if (!iso) return "—"
   const at = Date.parse(iso)
   if (!Number.isFinite(at)) return "—"
   const deltaMs = at - now
+  const ahead = deltaMs >= 0
   const { minutes, hours } = relativeBuckets(Math.abs(deltaMs))
-  if (minutes < 1) return deltaMs >= 0 ? "now" : "just now"
-  if (minutes < 60) return deltaMs >= 0 ? `in ${minutes}m` : `${minutes}m ago`
-  if (hours < 24) return deltaMs >= 0 ? `in ${hours}h` : `${hours}h ago`
-  return new Date(at).toLocaleDateString()
+  if (minutes < 1) return t(ahead ? "automations.when.now" : "automations.when.justNow")
+  if (minutes < 60) return t(ahead ? "automations.when.inMinutes" : "automations.when.minutesAgo", { n: minutes })
+  if (hours < 24) return t(ahead ? "automations.when.inHours" : "automations.when.hoursAgo", { n: hours })
+  return new Date(at).toLocaleDateString(intlLocale())
+}
+
+/** The daemon's run-status enum as display text; an unmapped status falls
+ *  through to its raw value so a new one is loud rather than blank. */
+export function formatRunStatus(status: string, translate: (key: string) => string): string {
+  const key = `automations.runStatus.${status}`
+  const label = translate(key)
+  return label === key ? status : label
 }

--- a/packages/kobe/src/tui-react/component/automations-runs.tsx
+++ b/packages/kobe/src/tui-react/component/automations-runs.tsx
@@ -17,7 +17,7 @@ import type { AutomationRun } from "@sma1lboy/kobe-daemon/daemon/contracts"
 import type { ReactNode } from "react"
 import { useTheme } from "../context/theme"
 import { useT } from "../i18n"
-import { formatWhen } from "./automations-format"
+import { formatRunStatus, formatWhen } from "./automations-format"
 
 /** Run-status → how it should read at a glance. The four "didn't run" reasons
  *  are deliberately distinct: `skipped_precheck` is healthy (nothing to do),
@@ -154,7 +154,7 @@ export function RunHistory(props: { runs: readonly AutomationRun[]; now: number 
         runs.slice(0, 5).map((run) => {
           return (
             <text key={run.id} fg={runToneColor(run.status, theme)}>
-              {`${triggerGlyph(run.trigger)} #${run.runNumber} ${run.status}${run.error ? ` \u2014 ${run.error}` : ""}  ${formatWhen(run.at, props.now)}`}
+              {`${triggerGlyph(run.trigger)} #${run.runNumber} ${formatRunStatus(run.status, t)}${run.error ? ` \u2014 ${run.error}` : ""}  ${formatWhen(run.at, props.now)}`}
             </text>
           )
         })

--- a/packages/kobe/src/tui-react/component/help-dialog.tsx
+++ b/packages/kobe/src/tui-react/component/help-dialog.tsx
@@ -15,7 +15,12 @@
 import { type ScrollBoxRenderable, TextAttributes } from "@opentui/core"
 import { useMemo, useRef } from "react"
 import { formatChord } from "../../tui/lib/chord-glyphs"
-import { type HelpGrammarSection, type HelpSurface, grammarHelpSections } from "../../tui/lib/help-groups"
+import {
+  type HelpGrammarSection,
+  type HelpSurface,
+  grammarHelpSections,
+  scopeCategory,
+} from "../../tui/lib/help-groups"
 import { currentPrefixConfiguration } from "../../tui/lib/keymap-dispatch"
 import type { BindingReachability } from "../../tui/lib/keymap-reachability"
 import { KobeKeymap, useKeymapVersion } from "../context/keybindings"
@@ -23,15 +28,6 @@ import { useTheme } from "../context/theme"
 import { tKeys, useT } from "../i18n"
 import { currentBindingReachability, useBindings } from "../lib/keymap"
 import { type DialogContext, useDialog, useDialogPaddingX } from "../ui/dialog"
-
-function scopeCategory(scope: HelpGrammarSection["scope"]): string {
-  if (!scope) return "Global"
-  if (scope === "sidebar") return "Sidebar"
-  if (scope === "workspace") return "Workspace"
-  if (scope === "files") return "Files"
-  if (scope === "terminal") return "Terminal"
-  return "Dialog"
-}
 
 function displayCap(cap: string): string {
   return cap

--- a/packages/kobe/src/tui-react/component/prefix-hud.tsx
+++ b/packages/kobe/src/tui-react/component/prefix-hud.tsx
@@ -12,12 +12,13 @@
 
 import { useTerminalDimensions } from "@opentui/react"
 import { useEffect, useState } from "react"
-import { displayWidth } from "../../lib/display-width"
+import { charWidth, displayWidth } from "../../lib/display-width"
 import { KobeKeymap, findBinding } from "../../tui/context/keybindings"
+import { guideCategory } from "../../tui/lib/help-groups"
 import { currentPrefixConfiguration } from "../../tui/lib/keymap-dispatch"
 import { PREFIX_GUIDE_DELAY_MS, PREFIX_HUD_TTL_MS, prefixHudClock, prefixHudState } from "../../tui/lib/prefix-hud"
 import { DIRECT_GUIDE_PREFIX_ACTION_ID } from "../../tui/lib/shortcut-reveal"
-import { truncateEnd } from "../../tui/lib/truncate"
+import { truncateEndCells } from "../../tui/lib/truncate"
 import { useTheme } from "../context/theme"
 import { tKeys, useT } from "../i18n"
 import { invokeArmedPrefixActionFromCurrentStack } from "../lib/keymap"
@@ -47,16 +48,6 @@ function actionLabel(action: string, translate: ReturnType<typeof useT>): string
 
 type GuideAction = { action: string; strokes: string[] }
 type GuideGroup = { category: string; actions: GuideAction[] }
-
-function guideCategory(action: string): string {
-  if (["kanban.open", "automations.open", "workItems.open"].includes(action)) return "Views"
-  if (action.startsWith("focus.")) return "Navigation"
-  if (action.startsWith("inbox.") || action.startsWith("attention.")) return "Attention"
-  if (action.startsWith("chat.tab.") || action.startsWith("chat.session.")) return "Sessions"
-  if (action.startsWith("chat.fork.") || action.startsWith("task.")) return "Tasks"
-  if (action.startsWith("settings.") || action === "workspace.zenToggle") return "Tools"
-  return findBinding(action)?.category ?? "Global"
-}
 
 /** Keep catalogue order while collapsing aliases such as p / shift+p. */
 function groupPrefixGuideOptions(options: readonly { stroke: string; action: string }[]): GuideGroup[] {
@@ -274,11 +265,20 @@ export function PrefixHud(props: { left: number; width: number }) {
       {fresh.map((entry) => (
         <box key={entry.id} paddingLeft={1} paddingRight={1} backgroundColor={theme.backgroundDialog}>
           <text fg={theme.textMuted} wrapMode="none">
-            {truncateEnd(
+            {/*
+              `width` is a CELL budget, so it must be spent by the cell-aware
+              truncator: the code-point twin reads a Chinese label as fitting,
+              returns it whole, and `wrapMode="none"` hands Yoga a hard cut with
+              no ellipsis — 「打开例行任务（定时任务）」 clipped to 「打开例行任务（」,
+              which reads as a complete label ending in a dangling bracket.
+              Same reasoning as the height math above.
+            */}
+            {truncateEndCells(
               `${entry.prefixKey ? `${entry.prefixKey} + ` : ""}${entry.stroke} ${
                 entry.action ? `→ ${actionLabel(entry.action, t)}` : "∅"
               }`,
               width - 2,
+              charWidth,
             )}
           </text>
         </box>

--- a/packages/kobe/src/tui-react/component/settings-dialog/actions.ts
+++ b/packages/kobe/src/tui-react/component/settings-dialog/actions.ts
@@ -11,6 +11,7 @@ import {
   removeTasksFileForReset,
 } from "../../../tui/component/settings-dialog/actions-core"
 import type { KVContext } from "../../context/kv"
+import { t } from "../../i18n"
 import type { DialogContext } from "../../ui/dialog"
 import { DialogConfirm } from "../../ui/dialog-confirm"
 
@@ -28,8 +29,8 @@ export async function confirmResetState(
 ): Promise<void> {
   const ok = await DialogConfirm.show(
     dialog,
-    "Reset UI state?",
-    "Wipes ~/.config/rove/state.json and ~/.rove/tasks.json, then quits Rove — relaunch for a fresh start with an empty working session list. Worktrees on disk and engine session history are NOT touched.",
+    t("settings.reset.title"),
+    t("settings.reset.body"),
     "cancel",
     undefined,
     { danger: true },
@@ -38,7 +39,7 @@ export async function confirmResetState(
   kv.clear()
   removeTasksFileForReset()
   destroyRendererSafely(renderer, "reset")
-  process.stderr.write("Rove: UI state reset. Relaunch Rove to start fresh.\n")
+  process.stderr.write(`${t("settings.reset.done")}\n`)
   process.exit(0)
 }
 
@@ -52,14 +53,9 @@ export async function confirmRestartDaemon(
   renderer: DestroyableRenderer | null | undefined,
 ): Promise<void> {
   if (!hasRestartableDaemon(orchestrator)) return
-  const ok = await DialogConfirm.show(
-    dialog,
-    "Restart backend?",
-    "Quits this Rove window. Relaunch to (re)spawn the daemon. Any other attached windows keep their connection. In v0.6 the daemon's RPC surface shrank to task CRUD + subscribe, so a graceful daemon.stop RPC is no longer plumbed through the client — quit + relaunch is the path.",
-    "cancel",
-  )
+  const ok = await DialogConfirm.show(dialog, t("settings.restart.title"), t("settings.restart.body"), "cancel")
   if (ok !== true) return
   destroyRendererSafely(renderer, "daemon restart")
-  process.stderr.write("Rove: window closed. Relaunch Rove to start fresh.\n")
+  process.stderr.write(`${t("settings.restart.done")}\n`)
   process.exit(0)
 }

--- a/packages/kobe/src/tui-react/component/settings-dialog/deferred-flush-feedback.ts
+++ b/packages/kobe/src/tui-react/component/settings-dialog/deferred-flush-feedback.ts
@@ -1,6 +1,7 @@
 import { errorMessage } from "@/lib/error-message"
 import { logClientError } from "@sma1lboy/kobe-daemon/client/client-log"
 import type { RemoteOrchestrator } from "../../../client/remote-orchestrator"
+import { t } from "../../i18n"
 import type { DialogContext } from "../../ui/dialog"
 import { DialogConfirm } from "../../ui/dialog-confirm"
 
@@ -16,8 +17,8 @@ export async function flushDeferredPromptsWithFeedback(
     logClientError("settings", `deferred prompt flush failed: ${message}`)
     await DialogConfirm.show(
       dialog,
-      "Deferred prompts were not flushed",
-      `${message}. Restart or update the daemon, then retry.`,
+      t("settings.deferredFlush.failedTitle"),
+      t("settings.deferredFlush.failedBody", { message }),
       "cancel",
     )
   }

--- a/packages/kobe/src/tui-react/component/settings-dialog/use-engine-settings.ts
+++ b/packages/kobe/src/tui-react/component/settings-dialog/use-engine-settings.ts
@@ -24,6 +24,7 @@ import { getGlobalDefaultVendor, setGlobalDefaultVendor } from "../../../state/v
 import { DEFAULT_TASK_VENDOR, type VendorId } from "../../../types/task"
 import { ALL_VENDORS, isBuiltinVendor } from "../../../types/vendor"
 import type { KVContext } from "../../context/kv"
+import { t } from "../../i18n"
 import type { DialogContext } from "../../ui/dialog"
 import { RenameTaskDialog } from "../rename-task-dialog"
 
@@ -138,9 +139,9 @@ export function useEngineSettings(
 
   async function editEngine(vendor: VendorId): Promise<void> {
     const next = await RenameTaskDialog.show(dialog, engineCommandText(vendor), {
-      dialogTitle: `${engineName(vendor)} launch command`,
-      fieldLabel: "COMMAND",
-      submitLabel: "save",
+      dialogTitle: t("settings.engines.launchCommandTitle", { name: engineName(vendor) }),
+      fieldLabel: t("settings.field.command"),
+      submitLabel: t("settings.action.save"),
       allowEmpty: true, // blank clears the override → built-in default
     })
     if (next === undefined) return
@@ -148,9 +149,9 @@ export function useEngineSettings(
   }
   async function renameEngine(vendor: VendorId): Promise<void> {
     const next = await RenameTaskDialog.show(dialog, engineName(vendor), {
-      dialogTitle: `${engineName(vendor)} display name (blank = default)`,
-      fieldLabel: "NAME",
-      submitLabel: "save",
+      dialogTitle: t("settings.engines.displayNameTitle", { name: engineName(vendor) }),
+      fieldLabel: t("settings.field.name"),
+      submitLabel: t("settings.action.save"),
       allowEmpty: true, // blank clears the name override → default label
     })
     if (next === undefined) return
@@ -176,19 +177,19 @@ export function useEngineSettings(
   // name and register a new custom engine. Reuses RenameTaskDialog per field.
   async function addEngineFlow(): Promise<void> {
     const idRaw = await RenameTaskDialog.show(dialog, "", {
-      dialogTitle: "Add engine",
-      fieldLabel: "ID",
-      submitLabel: "next",
-      placeholder: "lowercase slug, e.g. aider",
+      dialogTitle: t("settings.engines.addTitle"),
+      fieldLabel: t("settings.field.id"),
+      submitLabel: t("settings.action.next"),
+      placeholder: t("settings.engines.idPlaceholder"),
     })
     if (idRaw === undefined) return
     const id = idRaw.trim().toLowerCase()
     if (!id || isBuiltinVendor(id) || customEngines().includes(id)) return // no blank / shadow / dup
     const command = await RenameTaskDialog.show(dialog, "", {
-      dialogTitle: `Add engine · ${id}`,
-      fieldLabel: "COMMAND",
-      submitLabel: "next",
-      placeholder: "e.g. aider --model sonnet",
+      dialogTitle: t("settings.engines.addStepTitle", { id }),
+      fieldLabel: t("settings.field.command"),
+      submitLabel: t("settings.action.next"),
+      placeholder: t("settings.engines.commandPlaceholder"),
     })
     if (command === undefined) return
     // Declared ONCE, here: a custom engine is a named PRESET, and its
@@ -197,16 +198,16 @@ export function useEngineSettings(
     // protocol — the engine still launches, it just gets no transcript
     // reader, trust pre-answer, or engine-specific delivery.
     const protocol = await RenameTaskDialog.show(dialog, "", {
-      dialogTitle: `Add engine · ${id} — protocol (blank = none)`,
-      fieldLabel: "PROTOCOL",
-      submitLabel: "next",
+      dialogTitle: t("settings.engines.addProtocolTitle", { id }),
+      fieldLabel: t("settings.field.protocol"),
+      submitLabel: t("settings.action.next"),
       allowEmpty: true,
       placeholder: ENGINE_PROTOCOLS.join(" / "),
     })
     const name = await RenameTaskDialog.show(dialog, id, {
-      dialogTitle: `Add engine · ${id}`,
-      fieldLabel: "NAME",
-      submitLabel: "add",
+      dialogTitle: t("settings.engines.addStepTitle", { id }),
+      fieldLabel: t("settings.field.name"),
+      submitLabel: t("settings.action.add"),
       allowEmpty: true, // blank = humanized id
     })
     kv.set("customEngineIds", [...customEngines(), id])

--- a/packages/kobe/src/tui-react/component/settings-dialog/use-section-data.ts
+++ b/packages/kobe/src/tui-react/component/settings-dialog/use-section-data.ts
@@ -110,7 +110,7 @@ export function usePluginSettings(section: SectionId, dialog: DialogContext): Pl
         // The label is plugin-owned copy, like an action title — shown raw.
         dialogTitle: setting.label,
         fieldLabel: key,
-        submitLabel: "save",
+        submitLabel: t("settings.action.save"),
         allowEmpty: true,
         placeholder: setting.type === "secret" && setting.value !== "" ? "••••••••" : setting.defaultValue,
       })

--- a/packages/kobe/src/tui-react/component/settings-dialog/use-settings-prefs.ts
+++ b/packages/kobe/src/tui-react/component/settings-dialog/use-settings-prefs.ts
@@ -170,9 +170,12 @@ export function useSettingsPrefs(kv: KVContext, dialog: DialogContext, onCompose
   }
   async function editEditorCustom(): Promise<void> {
     const next = await RenameTaskDialog.show(dialog, editorCustomCommand(), {
-      dialogTitle: "Custom editor command (use {file} for the path)",
-      fieldLabel: "COMMAND",
-      submitLabel: "save",
+      // No params on purpose: the `{file}` in this title is a command
+      // placeholder the user types, not an i18n slot. `interpolate` leaves
+      // the template untouched when no params are passed.
+      dialogTitle: t("settings.general.editorCustomTitle"),
+      fieldLabel: t("settings.field.command"),
+      submitLabel: t("settings.action.save"),
       allowEmpty: true,
     })
     if (next === undefined) return
@@ -192,7 +195,7 @@ export function useSettingsPrefs(kv: KVContext, dialog: DialogContext, onCompose
     const next = await RenameTaskDialog.show(dialog, String(scrollbackRows()), {
       dialogTitle: t("settings.general.scrollbackTitle"),
       fieldLabel: t("settings.general.scrollbackField"),
-      submitLabel: "save",
+      submitLabel: t("settings.action.save"),
       placeholder: String(DEFAULT_SCROLLBACK_ROWS),
     })
     if (next === undefined) return
@@ -245,7 +248,7 @@ export function useSettingsPrefs(kv: KVContext, dialog: DialogContext, onCompose
     const next = await RenameTaskDialog.show(dialog, worktreeCustomPath(), {
       dialogTitle: t("settings.general.worktreeBaseTitle"),
       fieldLabel: t("settings.general.worktreeBaseField"),
-      submitLabel: "save",
+      submitLabel: t("settings.action.save"),
       placeholder: `${PROJECT_DIR_TOKEN}/../worktrees`,
       allowEmpty: true,
     })
@@ -256,8 +259,8 @@ export function useSettingsPrefs(kv: KVContext, dialog: DialogContext, onCompose
       if (!hasProjectDirToken(raw)) {
         await DialogConfirm.show(
           dialog,
-          "Can't use that worktree location",
-          `${PROJECT_DIR_TOKEN} only expands as the leading path segment (e.g. ${PROJECT_DIR_TOKEN}/../kobe-worktrees). Keeping the previous setting.`,
+          t("settings.general.worktreeBaseInvalidTitle"),
+          t("settings.general.worktreeBaseTokenBody", { token: PROJECT_DIR_TOKEN }),
           "cancel",
         )
         return
@@ -270,8 +273,8 @@ export function useSettingsPrefs(kv: KVContext, dialog: DialogContext, onCompose
       } catch (err) {
         await DialogConfirm.show(
           dialog,
-          "Can't use that worktree location",
-          `${resolved} isn't usable (${errorMessage(err)}). Keeping the previous setting — pick a writable directory.`,
+          t("settings.general.worktreeBaseInvalidTitle"),
+          t("settings.general.worktreeBaseUnusableBody", { path: resolved, error: errorMessage(err) }),
           "cancel",
         )
         return

--- a/packages/kobe/src/tui-react/component/work-items-page.tsx
+++ b/packages/kobe/src/tui-react/component/work-items-page.tsx
@@ -19,6 +19,7 @@ import type { WorkItem } from "@sma1lboy/kobe-daemon/daemon/work-items"
 import { type ReactNode, useEffect, useState } from "react"
 import type { RemoteOrchestrator } from "../../client/remote-orchestrator"
 import { errorMessage } from "../../lib/error-message"
+import { relativeAge as sharedRelativeAge } from "../../lib/relative-time"
 import { clampCursor } from "../../tui/component/new-task-dialog/state"
 import { sidebarProjectLabel } from "../../tui/panes/sidebar/groups"
 import type { Task } from "../../types/task"
@@ -59,14 +60,13 @@ function errorHint(error: string, t: ReturnType<typeof useT>): string {
   }
 }
 
+/** ISO shell over the product's one relative clock. The local copy this
+ *  replaces ROUNDED where every other age on screen floors, so the same
+ *  instant read `2h` here and `1h` two panes over. */
 function relativeAge(iso: string, now: number): string {
   const at = Date.parse(iso)
   if (!Number.isFinite(at)) return ""
-  const mins = Math.round((now - at) / 60_000)
-  if (mins < 60) return `${Math.max(mins, 0)}m`
-  const hours = Math.round(mins / 60)
-  if (hours < 24) return `${hours}h`
-  return `${Math.round(hours / 24)}d`
+  return sharedRelativeAge(at, now)
 }
 
 export function WorkItemsPage(props: {

--- a/packages/kobe/src/tui-react/workspace/inbox-item-view.ts
+++ b/packages/kobe/src/tui-react/workspace/inbox-item-view.ts
@@ -11,6 +11,7 @@
  */
 
 import { relativeCountdown } from "@/lib/relative-time"
+import { intlLocale } from "@/tui/i18n"
 import type { Task } from "@/types/task"
 import type { RGBA } from "@opentui/core"
 import type { AttentionInboxItem } from "@sma1lboy/kobe-daemon/daemon/contracts"
@@ -80,7 +81,9 @@ export function quotaResumeNote(
   const at = Date.parse(raw)
   if (!Number.isFinite(at)) return null
   return t("workspace.inbox.resumesAt", {
-    time: new Date(at).toLocaleTimeString(undefined, { hour: "numeric", minute: "2-digit" }),
+    // The UI locale, not the machine's: the sentence around this clock is
+    // translated, so an OS-locale clock inside it is a seam the user sees.
+    time: new Date(at).toLocaleTimeString(intlLocale(), { hour: "numeric", minute: "2-digit" }),
   })
 }
 

--- a/packages/kobe/src/tui/component/automation-composer.ts
+++ b/packages/kobe/src/tui/component/automation-composer.ts
@@ -9,6 +9,7 @@
  * rather than letting the daemon reject a typo after the fact.
  */
 
+import { intlLocale, t } from "@/tui/i18n"
 import { isValidCron, nextCronAfter } from "@sma1lboy/kobe-daemon/daemon/cron"
 import { relativeBuckets } from "../../lib/relative-time"
 
@@ -88,18 +89,21 @@ export function previewSchedule(expression: string, nowMs: number): SchedulePrev
 
 function formatRelative(deltaMs: number): string {
   const { minutes, hours, days } = relativeBuckets(deltaMs)
-  if (minutes < 60) return `in ${Math.max(1, minutes)}m`
-  if (hours < 24) return `in ${hours}h`
-  return `in ${days}d`
+  if (minutes < 60) return t("automations.when.inMinutes", { n: Math.max(1, minutes) })
+  if (hours < 24) return t("automations.when.inHours", { n: hours })
+  return t("automations.when.inDays", { n: days })
 }
-
-const WEEKDAYS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"] as const
-const MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"] as const
 
 /**
  * Local wall-clock, at the coarsest useful precision: `09:00` when it fires
- * today, `Mon 09:00` within the week, `Mon Aug 3, 09:00` beyond it. The date
+ * today, `Mon 09:00` within the week, `Mon, Aug 3, 09:00` beyond it. The date
  * is what disambiguates a schedule; repeating today's is noise.
+ *
+ * The calendar words and their ORDER come from `Intl` for the UI locale, not
+ * from an English table plus a hand-built template: zh reads `8月3日周一`,
+ * not `周一 8月 3`, and every locale added later gets its own order for free.
+ * The 24-hour clock is built by hand on purpose — it is the same instant in
+ * every locale, and `Intl`'s en-US default would turn it into `9:00 AM`.
  */
 function formatAbsolute(atMs: number, nowMs: number): string {
   const at = new Date(atMs)
@@ -108,7 +112,10 @@ function formatAbsolute(atMs: number, nowMs: number): string {
   const sameDay =
     at.getFullYear() === now.getFullYear() && at.getMonth() === now.getMonth() && at.getDate() === now.getDate()
   if (sameDay) return time
-  const weekday = WEEKDAYS[at.getDay()] ?? ""
-  if (atMs - nowMs < 6 * 24 * 60 * 60 * 1000) return `${weekday} ${time}`
-  return `${weekday} ${MONTHS[at.getMonth()] ?? ""} ${at.getDate()}, ${time}`
+  const withinWeek = atMs - nowMs < 6 * 24 * 60 * 60 * 1000
+  const date = at.toLocaleDateString(
+    intlLocale(),
+    withinWeek ? { weekday: "short" } : { weekday: "short", month: "short", day: "numeric" },
+  )
+  return withinWeek ? `${date} ${time}` : t("automations.when.dateTime", { date, time })
 }

--- a/packages/kobe/src/tui/component/cron-segments.ts
+++ b/packages/kobe/src/tui/component/cron-segments.ts
@@ -13,6 +13,8 @@
  * so the reachable set is small and each rung means something on its own.
  */
 
+import { t } from "@/tui/i18n"
+
 /** Which of the five cron fields a segment is. Index = position. */
 export const CRON_SEGMENTS = ["minute", "hour", "dayOfMonth", "month", "dayOfWeek"] as const
 export type CronSegment = (typeof CRON_SEGMENTS)[number]
@@ -37,16 +39,10 @@ const DOW_LADDER = ["*", "MON-FRI", "SAT,SUN", "MON", "TUE", "WED", "THU", "FRI"
 
 // Plural weekday names keyed by cron abbreviation. English weekday names
 // don't derive mechanically from their three-letter forms — "TUE" + "days"
-// is "Tuedays" — so each one is spelled out.
-const DOW_NAMES: Record<string, string> = {
-  MON: "Mondays",
-  TUE: "Tuesdays",
-  WED: "Wednesdays",
-  THU: "Thursdays",
-  FRI: "Fridays",
-  SAT: "Saturdays",
-  SUN: "Sundays",
-}
+// is "Tuedays" — so each one is spelled out, per locale, in the catalog.
+/** The weekday codes `describeCron` names, and the catalog keys under
+ *  `automations.schedule.dow.*` that must exist for each. */
+export const DOW_CODES = ["MON", "TUE", "WED", "THU", "FRI", "SAT", "SUN"] as const
 
 function range(from: number, to: number): string[] {
   const out: string[] = []
@@ -105,36 +101,47 @@ export function describeCron(expression: string): string | null {
   if (month !== "*" || dom !== "*") return null
   if (minute === undefined || hour === undefined || dow === undefined) return null
 
-  const at = describeTimeOfDay(minute, hour)
-  if (!at) return null
+  const timeOfDay = describeTimeOfDay(minute, hour)
+  if (!timeOfDay) return null
+  const { at, bare } = timeOfDay
   // An "every N" phrase already says it recurs — prefixing it with "every
   // day" produces the double qualifier "every day every 15m". Only a
   // specific clock time needs the day qualifier.
   // An "every N" phrase already says it recurs — prefixing it with "every
   // day" gives the double qualifier "every day every 15m". Every other
   // phrase (a clock time, an hourly minute) still takes the qualifier.
-  if (dow === "*") return at.startsWith("every ") ? at : `every day ${at}`
-  if (dow === "MON-FRI") return `weekdays ${at}`
-  if (dow === "SAT,SUN") return `weekends ${at}`
-  const named = DOW_NAMES[dow.toUpperCase()]
-  if (named) return `${named} ${at}`
+  if (dow === "*") return bare ? at : t("automations.schedule.everyDay", { at })
+  if (dow === "MON-FRI") return t("automations.schedule.weekdays", { at })
+  if (dow === "SAT,SUN") return t("automations.schedule.weekends", { at })
+  const code = DOW_CODES.find((candidate) => candidate === dow.toUpperCase())
+  if (code) return t("automations.schedule.onWeekday", { weekday: t(`automations.schedule.dow.${code}`), at })
   return null
 }
 
-function describeTimeOfDay(minute: string, hour: string): string | null {
+/**
+ * `at` is the phrase; `bare` marks the ones that ALREADY say they recur
+ * ("every 15m"), which must not take a day qualifier on top — "every day
+ * every 15m". English could detect that from an "every " prefix; a
+ * translated phrase cannot, so the shape is reported instead of sniffed.
+ */
+function describeTimeOfDay(minute: string, hour: string): { at: string; bare: boolean } | null {
   if (hour === "*") {
-    if (minute === "*") return "every minute"
-    if (minute.startsWith("*/")) return `every ${minute.slice(2)}m`
+    if (minute === "*") return { at: t("automations.schedule.everyMinute"), bare: true }
+    if (minute.startsWith("*/"))
+      return { at: t("automations.schedule.everyMinutes", { n: minute.slice(2) }), bare: true }
     // Only a single clock minute names a real fire time. A list or range
     // (`15,45`, `10-20`) is not one instant — `:15,45` would assert a time
     // the schedule never has, so stay silent and let the raw cron plus the
     // next-run preview carry the truth.
-    if (/^\d+$/.test(minute)) return `hourly at :${minute.padStart(2, "0")}`
+    if (/^\d+$/.test(minute))
+      return { at: t("automations.schedule.hourlyAt", { minute: minute.padStart(2, "0") }), bare: false }
     return null
   }
-  if (hour.startsWith("*/") && minute === "0") return `every ${hour.slice(2)}h`
+  if (hour.startsWith("*/") && minute === "0")
+    return { at: t("automations.schedule.everyHours", { n: hour.slice(2) }), bare: true }
   if (/^\d+$/.test(hour) && /^\d+$/.test(minute)) {
-    return `at ${hour.padStart(2, "0")}:${minute.padStart(2, "0")}`
+    const time = `${hour.padStart(2, "0")}:${minute.padStart(2, "0")}`
+    return { at: t("automations.schedule.atClock", { time }), bare: false }
   }
   return null
 }

--- a/packages/kobe/src/tui/i18n/catalog.ts
+++ b/packages/kobe/src/tui/i18n/catalog.ts
@@ -88,10 +88,17 @@ const zh: Messages = {
   doctor: doctorZh,
 }
 
-/** Registered locales, in display order. */
+/**
+ * Registered locales, in display order. `intl` is the BCP-47 tag handed to
+ * `Intl`/`toLocale*` — a UI language is a catalog id, and the two are not
+ * interchangeable. Calling `toLocaleDateString()` with no argument formats in
+ * the OS locale instead, which is wrong in BOTH directions: a zh UI on an
+ * `en-US` machine printed `8/3/2026`, an en UI on a `zh-CN` machine printed
+ * `2026/8/3`, and neither followed the setting the user actually changed.
+ */
 export const LOCALES = [
-  { id: "en", label: "English" },
-  { id: "zh", label: "中文" },
+  { id: "en", label: "English", intl: "en-US" },
+  { id: "zh", label: "中文", intl: "zh-CN" },
 ] as const
 
 export type LocaleId = (typeof LOCALES)[number]["id"]

--- a/packages/kobe/src/tui/i18n/index.ts
+++ b/packages/kobe/src/tui/i18n/index.ts
@@ -33,6 +33,15 @@ export function currentLang(): LocaleId {
   return langState.get()
 }
 
+/**
+ * The BCP-47 tag for the active UI language — the argument every `Intl` /
+ * `toLocale*` call needs so a date or clock follows the UI setting rather
+ * than the machine's.
+ */
+export function intlLocale(): string {
+  return LOCALES.find((locale) => locale.id === langState.get())?.intl ?? "en-US"
+}
+
 /** Read-only process locale state for UI adapters. */
 export function localeState(): ReadableState<LocaleId> {
   return langState

--- a/packages/kobe/src/tui/i18n/messages/automations.ts
+++ b/packages/kobe/src/tui/i18n/messages/automations.ts
@@ -28,6 +28,61 @@ export const en = {
     dayOfWeek: "weekday",
   },
 
+  /**
+   * The schedule preview — the one line that answers "when does this fire".
+   * `describeCron` names the recurrence, `when.*` the next occurrence. Word
+   * order is part of the translation, so each phrase is ONE key with slots
+   * rather than fragments the caller concatenates.
+   */
+  schedule: {
+    everyDay: "every day {at}",
+    weekdays: "weekdays {at}",
+    weekends: "weekends {at}",
+    onWeekday: "{weekday} {at}",
+    everyMinute: "every minute",
+    everyMinutes: "every {n}m",
+    everyHours: "every {n}h",
+    hourlyAt: "hourly at :{minute}",
+    atClock: "at {time}",
+    /** Recurring weekday phrase — English pluralises, Chinese prefixes. */
+    dow: {
+      MON: "Mondays",
+      TUE: "Tuesdays",
+      WED: "Wednesdays",
+      THU: "Thursdays",
+      FRI: "Fridays",
+      SAT: "Saturdays",
+      SUN: "Sundays",
+    },
+  },
+  /** Next-run and last-run clocks. `{n}` is already a coarse bucket. */
+  when: {
+    inMinutes: "in {n}m",
+    inHours: "in {n}h",
+    inDays: "in {n}d",
+    minutesAgo: "{n}m ago",
+    hoursAgo: "{n}h ago",
+    now: "now",
+    justNow: "just now",
+    /** `{date}` is `Intl`-formatted for the UI locale, so it carries its own
+     *  word order; only the comma before the clock is ours. */
+    dateTime: "{date}, {time}",
+  },
+  /**
+   * The daemon's `AutomationRunStatus` enum, so a run row is not half English
+   * in a Chinese page. `run.error` beside it stays untranslated on purpose —
+   * it is a machine message the user searches for and pastes into an issue,
+   * and a translated copy of it matches nothing.
+   */
+  runStatus: {
+    dispatched: "dispatched",
+    revived: "revived",
+    deferred: "deferred",
+    skipped_precheck: "skipped (precheck)",
+    skipped_missed: "skipped (missed)",
+    skipped_unavailable: "skipped (unavailable)",
+    dispatch_failed: "dispatch failed",
+  },
   cronNever: "valid, but never fires",
   missing: {
     name: "Give it a name.",
@@ -92,6 +147,45 @@ export const zh: typeof en = {
     dayOfWeek: "星期",
   },
 
+  schedule: {
+    everyDay: "每天{at}",
+    weekdays: "工作日{at}",
+    weekends: "周末{at}",
+    onWeekday: "{weekday}{at}",
+    everyMinute: "每分钟",
+    everyMinutes: "每 {n} 分钟",
+    everyHours: "每 {n} 小时",
+    hourlyAt: "每小时的 :{minute}",
+    atClock: "{time}",
+    dow: {
+      MON: "每周一",
+      TUE: "每周二",
+      WED: "每周三",
+      THU: "每周四",
+      FRI: "每周五",
+      SAT: "每周六",
+      SUN: "每周日",
+    },
+  },
+  when: {
+    inMinutes: "{n} 分钟后",
+    inHours: "{n} 小时后",
+    inDays: "{n} 天后",
+    minutesAgo: "{n} 分钟前",
+    hoursAgo: "{n} 小时前",
+    now: "即将",
+    justNow: "刚刚",
+    dateTime: "{date} {time}",
+  },
+  runStatus: {
+    dispatched: "已派发",
+    revived: "已重启会话",
+    deferred: "已排队待放行",
+    skipped_precheck: "已跳过（预检）",
+    skipped_missed: "已跳过（错过时间）",
+    skipped_unavailable: "已跳过（不可用）",
+    dispatch_failed: "派发失败",
+  },
   cronNever: "语法合法，但永远不会触发",
   missing: {
     name: "起个名字。",

--- a/packages/kobe/src/tui/i18n/messages/keys.ts
+++ b/packages/kobe/src/tui/i18n/messages/keys.ts
@@ -18,6 +18,8 @@ export const en = {
     Sessions: "Sessions",
     Attention: "Attention",
     Tools: "Tools",
+    "Diff review": "Diff review",
+    Inbox: "Inbox",
   },
   desc: {
     "help.open": "Show keybindings help",
@@ -75,6 +77,7 @@ export const en = {
     "workspace.split.focus-next": "Focus next split",
     "workspace.split.close": "Close active split (tab when unsplit)",
     "workspace.split.rename": "Rename active split (tab when unsplit)",
+    "workspace.reopenSession": "Reopen a session in a task whose tabs are all closed",
     "files.nav": "Move cursor up/down",
     "files.hierarchy": "Collapse / expand tree level",
     "files.open": "Open file in configured editor (diff when supported)",
@@ -122,6 +125,8 @@ export const zh: typeof en = {
     Sessions: "会话",
     Attention: "提醒",
     Tools: "工具",
+    "Diff review": "差异审阅",
+    Inbox: "收件箱",
   },
   desc: {
     "help.open": "显示快捷键帮助",
@@ -179,6 +184,7 @@ export const zh: typeof en = {
     "workspace.split.focus-next": "聚焦下一个分屏",
     "workspace.split.close": "关闭当前分屏（未分屏时关闭标签页）",
     "workspace.split.rename": "重命名当前分屏（未分屏时重命名标签页）",
+    "workspace.reopenSession": "在标签页全部关闭的任务中重新打开会话",
     "files.nav": "上下移动光标",
     "files.hierarchy": "折叠 / 展开树层级",
     "files.open": "在已配置的编辑器中打开文件（支持时显示 diff）",

--- a/packages/kobe/src/tui/i18n/messages/settings.ts
+++ b/packages/kobe/src/tui/i18n/messages/settings.ts
@@ -76,6 +76,13 @@ export const en = {
     worktreeCustomUnset: "(unset — enter to edit)",
     worktreeBaseTitle: "Custom worktree location (blank = default; $project_dir = project root)",
     worktreeBaseField: "PATH",
+    editorCustomTitle: "Custom editor command (use {file} for the path)",
+    worktreeBaseInvalidTitle: "Can't use that worktree location",
+    /** `{token}` is the literal `$project_dir`, not a translatable word. */
+    worktreeBaseTokenBody:
+      "{token} only expands as the leading path segment (e.g. {token}/../kobe-worktrees). Keeping the previous setting.",
+    worktreeBaseUnusableBody:
+      "{path} isn't usable ({error}). Keeping the previous setting — pick a writable directory.",
     terminal: "Terminal",
     terminalHint: "Applies to terminals opened after the change.",
     scrollbackRow: "scrollback: {rows} rows",
@@ -92,11 +99,51 @@ export const en = {
       always: "always",
     },
   },
+  /**
+   * Copy for the modals the Settings screen opens — `DialogConfirm` bodies
+   * and the field labels / submit captions of the `RenameTaskDialog` it
+   * reuses per field. These sit INSIDE a translated dialog, so leaving them
+   * as literals produced a Chinese screen with an English modal on top.
+   */
+  field: {
+    command: "COMMAND",
+    name: "NAME",
+    id: "ID",
+    protocol: "PROTOCOL",
+  },
+  action: {
+    save: "save",
+    next: "next",
+    add: "add",
+  },
+  reset: {
+    title: "Reset UI state?",
+    body: "Wipes ~/.config/rove/state.json and ~/.rove/tasks.json, then quits Rove — relaunch for a fresh start with an empty working session list. Worktrees on disk and engine session history are NOT touched.",
+    /** Printed to stderr AFTER the TUI is torn down — the user reads it in
+     *  their shell, so it is UI copy despite not going through a pane. */
+    done: "Rove: UI state reset. Relaunch Rove to start fresh.",
+  },
+  restart: {
+    title: "Restart backend?",
+    body: "Quits this Rove window. Relaunch to (re)spawn the daemon. Any other attached windows keep their connection. In v0.6 the daemon's RPC surface shrank to task CRUD + subscribe, so a graceful daemon.stop RPC is no longer plumbed through the client — quit + relaunch is the path.",
+    done: "Rove: window closed. Relaunch Rove to start fresh.",
+  },
+  deferredFlush: {
+    failedTitle: "Deferred prompts were not flushed",
+    failedBody: "{message}. Restart or update the daemon, then retry.",
+  },
   engines: {
     title: "Engines",
     hint: "Every engine Rove can launch, with what detection found under each one: where its binary is, and for the engines with an account detector whether you are logged in. [x] = offered when picking an engine for a task; (●) = the global default (per-project picks, e.g. Ctrl+Shift+T, override it) — click either, or use the keys below. Override a launch command when the binary isn't on PATH or to pass default flags. space on/off · enter edit command · r rename · x reset/remove · d set default.",
     customTag: "  (custom)",
     addEngine: "+ Add engine",
+    launchCommandTitle: "{name} launch command",
+    displayNameTitle: "{name} display name (blank = default)",
+    addTitle: "Add engine",
+    addStepTitle: "Add engine · {id}",
+    addProtocolTitle: "Add engine · {id} — protocol (blank = none)",
+    idPlaceholder: "lowercase slug, e.g. aider",
+    commandPlaceholder: "e.g. aider --model sonnet",
   },
   accounts: {
     checking: "Checking…",
@@ -260,6 +307,10 @@ export const zh: typeof en = {
     worktreeCustomUnset: "(未设置 — enter 编辑)",
     worktreeBaseTitle: "自定义工作树位置（留空 = 默认；$project_dir = 项目根目录）",
     worktreeBaseField: "路径",
+    editorCustomTitle: "自定义编辑器命令（用 {file} 代表文件路径）",
+    worktreeBaseInvalidTitle: "无法使用该工作树位置",
+    worktreeBaseTokenBody: "{token} 只能作为路径的第一段展开（如 {token}/../kobe-worktrees）。保留原设置。",
+    worktreeBaseUnusableBody: "{path} 不可用（{error}）。保留原设置 —— 请选择一个可写目录。",
     terminal: "终端",
     terminalHint: "对修改后新打开的终端生效。",
     scrollbackRow: "回滚行数: {rows} 行",
@@ -275,11 +326,43 @@ export const zh: typeof en = {
       always: "始终显示",
     },
   },
+  field: {
+    command: "命令",
+    name: "名称",
+    id: "标识",
+    protocol: "协议",
+  },
+  action: {
+    save: "保存",
+    next: "下一步",
+    add: "添加",
+  },
+  reset: {
+    title: "重置界面状态？",
+    body: "将清除 ~/.config/rove/state.json 和 ~/.rove/tasks.json 并退出 Rove —— 重新启动后会是一个干净的开始，工作会话列表为空。磁盘上的工作树和引擎会话历史不受影响。",
+    done: "Rove：界面状态已重置。重新启动 Rove 即可从头开始。",
+  },
+  restart: {
+    title: "重启后端？",
+    body: "会退出当前 Rove 窗口。重新启动即可（重新）拉起 daemon。其他已连接的窗口不受影响。v0.6 起 daemon 的 RPC 只保留了任务增删改查和订阅，客户端不再接出优雅的 daemon.stop，所以退出再启动就是这条路径。",
+    done: "Rove：窗口已关闭。重新启动 Rove 即可从头开始。",
+  },
+  deferredFlush: {
+    failedTitle: "排队的提示词未能放行",
+    failedBody: "{message}。请重启或升级 daemon 后重试。",
+  },
   engines: {
     title: "引擎",
     hint: "Rove 能启动的所有引擎，每个下面跟着本地探测到的情况：二进制在哪，以及对有账户探测器的引擎是否已登录。[x] = 为任务选引擎时会列出它；(●) = 全局默认引擎（各项目自己的选择会覆盖它，如 Ctrl+Shift+T）——两者都可直接点，也可用下面的按键。二进制不在 PATH 上、或要传默认参数时，覆盖它的启动命令。space 开/关 · enter 编辑命令 · r 重命名 · x 重置/移除 · d 设为默认。",
     customTag: "  (自定义)",
     addEngine: "+ 添加引擎",
+    launchCommandTitle: "{name} 的启动命令",
+    displayNameTitle: "{name} 的显示名称（留空 = 默认）",
+    addTitle: "添加引擎",
+    addStepTitle: "添加引擎 · {id}",
+    addProtocolTitle: "添加引擎 · {id} —— 协议（留空 = 无）",
+    idPlaceholder: "小写短名，如 aider",
+    commandPlaceholder: "如 aider --model sonnet",
   },
   accounts: {
     checking: "检查中…",

--- a/packages/kobe/src/tui/lib/help-groups.ts
+++ b/packages/kobe/src/tui/lib/help-groups.ts
@@ -4,6 +4,11 @@
  * help dialog share. `groupBindings` stays generic over the `category`
  * field; the cap helpers read the real keymap via `findBinding` (itself
  * framework-free and vitest-safe — tests import both directly).
+ *
+ * The two category mappers live here rather than in their rendering
+ * components for the same reason: which header a binding prints under is the
+ * only thing that says which `keys.category` entries the catalog must carry,
+ * and a CI guard cannot import an opentui component to ask.
  */
 
 import type { KobeBinding, KobeBindingScope } from "../context/keybindings"
@@ -142,4 +147,33 @@ export function grammarHelpSections(
   if (prefix.length) sections.push({ kind: "prefix", rows: prefix })
   for (const [scope, rows] of other) sections.push({ kind: "other", scope, rows })
   return sections
+}
+
+/**
+ * The category header the F1 help dialog prints a section under. The dialog
+ * groups by SCOPE, not by the binding's own `category` field.
+ */
+export function scopeCategory(scope: HelpGrammarSection["scope"]): string {
+  if (!scope) return "Global"
+  if (scope === "sidebar") return "Sidebar"
+  if (scope === "workspace") return "Workspace"
+  if (scope === "files") return "Files"
+  if (scope === "terminal") return "Terminal"
+  return "Dialog"
+}
+
+/**
+ * The category header the prefix HUD's guide groups an action under. Mostly
+ * a synthetic set of its own (`Views` / `Sessions` / `Tasks` / …) that has no
+ * counterpart in `KobeKeymap.category`, falling through to the binding's own
+ * category — and then to `Global` — only for actions no rule claims.
+ */
+export function guideCategory(action: string): string {
+  if (["kanban.open", "automations.open", "workItems.open"].includes(action)) return "Views"
+  if (action.startsWith("focus.")) return "Navigation"
+  if (action.startsWith("inbox.") || action.startsWith("attention.")) return "Attention"
+  if (action.startsWith("chat.tab.") || action.startsWith("chat.session.")) return "Sessions"
+  if (action.startsWith("chat.fork.") || action.startsWith("task.")) return "Tasks"
+  if (action.startsWith("settings.") || action === "workspace.zenToggle") return "Tools"
+  return findBinding(action)?.category ?? "Global"
 }

--- a/packages/kobe/src/tui/panes/sidebar/labels.ts
+++ b/packages/kobe/src/tui/panes/sidebar/labels.ts
@@ -1,12 +1,18 @@
-import { truncateEnd } from "../../lib/truncate"
+import { approxCharCells } from "../../../lib/display-width"
+import { truncateEndCells } from "../../lib/truncate"
 
 /**
  * Truncate a task title to a cell budget with a trailing ellipsis. Keeps the
  * prefix unconditionally because a title's front carries the most meaning.
- * Thin alias over the shared {@link truncateEnd} owner.
+ * Thin alias over the shared {@link truncateEndCells} owner.
+ *
+ * Cell-aware, and `approxCharCells` specifically: every caller sizes `max`
+ * from `approxCellWidth` (the sidebar hover/context-menu layout), and a budget
+ * measured one way must be spent the same way or a CJK label overdraws the box
+ * it was measured for.
  */
 export function truncateTitle(title: string, max: number): string {
-  return truncateEnd(title, max)
+  return truncateEndCells(title, max, approxCharCells)
 }
 
 /**

--- a/packages/kobe/test/render/failure-toast.test.tsx
+++ b/packages/kobe/test/render/failure-toast.test.tsx
@@ -313,7 +313,13 @@ test("work-items: list rows render with number, labels, and age", async () => {
   expect(text).toContain("#42")
   expect(text).toContain("Fix the thing")
   expect(text).toContain("octocat · bug · p2")
-  expect(text).toContain("0m")
+  // The age column, by SHAPE not by literal: the fixture stamps `updatedAt`
+  // at module load, so the exact value depends on how long the file took to
+  // reach this test. It used to read `0m` because the page carried its own
+  // rounding copy of `relativeAge` with no seconds step; on the shared clock
+  // a freshly-stamped row reads `3s`, and both are the same assertion —
+  // "a row prints an age".
+  expect(text).toMatch(/\b\d+[smhd]\b/)
 })
 
 test("work-items: a failed list names the fix inline", async () => {

--- a/packages/kobe/test/render/which-key-help.test.tsx
+++ b/packages/kobe/test/render/which-key-help.test.tsx
@@ -1,10 +1,11 @@
 /** @jsxImportSource @opentui/react */
 /** Real-render coverage for the prefix guide and its F1 reference view. */
 
-import { afterEach, describe, expect, it } from "bun:test"
+import { afterEach, beforeEach, describe, expect, it } from "bun:test"
 import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
+import { displayWidth } from "../../src/lib/display-width"
 import { HelpDialog } from "../../src/tui-react/component/help-dialog"
 import { PrefixHud } from "../../src/tui-react/component/prefix-hud"
 import { ShortcutRevealProvider } from "../../src/tui-react/component/shortcut-reveal"
@@ -14,6 +15,7 @@ import { useDialog } from "../../src/tui-react/ui/dialog"
 import { useWorkspaceKeybindings } from "../../src/tui-react/workspace/host-keybindings"
 import type { HostPagesState } from "../../src/tui-react/workspace/host-pages"
 import { bindByIds } from "../../src/tui/context/keybindings"
+import { currentLang, setLocaleLang } from "../../src/tui/i18n"
 import { CTRL_HOLD_THRESHOLD_MS } from "../../src/tui/lib/ctrl-hold"
 import {
   PREFIX_GUIDE_DELAY_MS,
@@ -333,5 +335,51 @@ describe("which-key prefix guide", () => {
     const bottomBorderRow = rows.findIndex((row) => row.includes("╰"))
     expect(bottomBorderRow).toBeGreaterThan(overflowRow)
     expect(bottomBorderRow).toBeLessThan(height)
+  })
+})
+
+describe("the resolved-action feed against a CELL budget", () => {
+  /**
+   * Rove defaults to Simplified Chinese, so a wide label is the ordinary case
+   * for this row. The HUD's `width` is CELLS; a code-point truncator reads
+   * `ctrl+a + 2 → 打开例行任务（定时任务）` as 25 points against a 26 budget,
+   * returns it whole, and `wrapMode="none"` lets Yoga hard-cut it — the user
+   * gets a label ending in a dangling 「（」 with no ellipsis to say anything
+   * was dropped. The English twin clips cleanly at the same width, which is
+   * why an ASCII-only assertion cannot catch this.
+   */
+  const HUD_WIDTH = 28 // 26 cells of text between the 1-cell paddings
+
+  let restore = currentLang()
+  beforeEach(() => {
+    restore = currentLang()
+    act(() => resetPrefixHud())
+  })
+  afterEach(() => {
+    setLocaleLang(restore)
+    act(() => resetPrefixHud())
+  })
+
+  async function feedRow(lang: "en" | "zh"): Promise<string> {
+    setLocaleLang(lang)
+    prefixHudPush({ prefixKey: "ctrl+a", stroke: "2", action: "automations.open", at: Date.now() })
+    const { frame } = await renderComponent(<PrefixHud left={1} width={HUD_WIDTH} />, { width: 80, height: 24 })
+    const row = (await frame()).split("\n").find((line) => line.includes("ctrl+a + 2"))
+    if (row === undefined) throw new Error("no HUD row rendered")
+    return row
+  }
+
+  it("clips a Chinese label with an ellipsis inside its cell budget", async () => {
+    const row = await feedRow("zh")
+    expect(row).toContain("打开例行任务…")
+    // The tail the code-point truncator kept, and Yoga then sheared off.
+    expect(row).not.toContain("定时任务）")
+    expect(displayWidth(row.trim())).toBeLessThanOrEqual(HUD_WIDTH - 2)
+  })
+
+  it("still clips the English label the same way", async () => {
+    const row = await feedRow("en")
+    expect(row).toContain("Open routine…")
+    expect(displayWidth(row.trim())).toBeLessThanOrEqual(HUD_WIDTH - 2)
   })
 })

--- a/packages/kobe/test/tui-react/automations-format.test.ts
+++ b/packages/kobe/test/tui-react/automations-format.test.ts
@@ -1,0 +1,64 @@
+/**
+ * The Routines page's clocks, in both locales.
+ *
+ * These three formatters produced the last English text on an otherwise
+ * translated page — `in 5m`, a raw `skipped_precheck`, and a `toLocaleDateString()`
+ * with NO locale argument, which follows the machine rather than the UI
+ * setting and is therefore wrong in both directions: a zh UI on an `en-US`
+ * box printed `8/3/2026`, an en UI on a `zh-CN` box printed `2026/8/3`.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "vitest"
+import { formatRunStatus, formatWhen } from "../../src/tui-react/component/automations-format"
+import { currentLang, setLocaleLang, t } from "../../src/tui/i18n"
+
+const NOW = new Date(2026, 6, 31, 10, 0, 0).getTime()
+const iso = (deltaMs: number): string => new Date(NOW + deltaMs).toISOString()
+const ASCII_LETTER = /[A-Za-z]/
+
+describe("formatWhen", () => {
+  let restore = currentLang()
+  beforeEach(() => {
+    restore = currentLang()
+  })
+  afterEach(() => setLocaleLang(restore))
+
+  test("English keeps its current phrasing", () => {
+    setLocaleLang("en")
+    expect(formatWhen(iso(5 * 60_000), NOW)).toBe("in 5m")
+    expect(formatWhen(iso(-12 * 60_000), NOW)).toBe("12m ago")
+    expect(formatWhen(iso(3 * 3_600_000), NOW)).toBe("in 3h")
+    expect(formatWhen(iso(-3 * 3_600_000), NOW)).toBe("3h ago")
+  })
+
+  test("Chinese carries no English, including the >24h date fallback", () => {
+    setLocaleLang("zh")
+    for (const delta of [0, 5 * 60_000, -12 * 60_000, 3 * 3_600_000, -3 * 3_600_000]) {
+      expect(formatWhen(iso(delta), NOW), String(delta)).not.toMatch(ASCII_LETTER)
+    }
+    // The fallback formats through Intl for the UI locale; zh-CN puts the
+    // year first, which an OS-locale `en-US` box would never produce.
+    expect(formatWhen(iso(3 * 24 * 3_600_000), NOW)).toBe("2026/8/3")
+  })
+
+  test("an absent or unparsable timestamp is an absence, never a fake now", () => {
+    expect(formatWhen(undefined, NOW)).toBe("—")
+    expect(formatWhen("not-a-date", NOW)).toBe("—")
+  })
+})
+
+describe("formatRunStatus", () => {
+  test("maps the daemon enum through the catalog", () => {
+    setLocaleLang("en")
+    expect(formatRunStatus("skipped_precheck", t)).toBe("skipped (precheck)")
+    setLocaleLang("zh")
+    expect(formatRunStatus("skipped_precheck", t)).toBe("已跳过（预检）")
+    setLocaleLang("en")
+  })
+
+  test("an unmapped status falls through to its raw value, loudly", () => {
+    // A status the daemon adds and the catalog has not caught up with must
+    // still print something the reader can search for — never a blank cell.
+    expect(formatRunStatus("invented_status", t)).toBe("invented_status")
+  })
+})

--- a/packages/kobe/test/tui/automation-composer.test.ts
+++ b/packages/kobe/test/tui/automation-composer.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "vitest"
+import { afterEach, beforeEach, describe, expect, test } from "vitest"
 import {
   COMPOSER_FIELDS,
   type ComposerDraft,
@@ -7,6 +7,8 @@ import {
   nextComposerField,
   previewSchedule,
 } from "../../src/tui/component/automation-composer"
+import { describeCron } from "../../src/tui/component/cron-segments"
+import { currentLang, setLocaleLang } from "../../src/tui/i18n"
 
 const FULL: ComposerDraft = {
   name: "weekday audit",
@@ -113,5 +115,55 @@ describe("previewSchedule", () => {
     const at = new Date(preview.nextRunMs)
     expect(at.getHours()).toBe(9)
     expect(preview.nextRunMs).toBeGreaterThan(NOW)
+  })
+})
+
+/**
+ * The schedule preview is the ONE line that answers "when does this fire",
+ * and it was the last fully-English line in an otherwise Chinese composer:
+ * `weekdays at 09:00 · in 2d · Mon 09:00`. The assertion is on ASCII LETTERS
+ * rather than on exact wording — the wording is a translation call, "no
+ * English left in it" is the contract.
+ */
+describe("the schedule preview under a non-English locale", () => {
+  const ASCII_LETTER = /[A-Za-z]/
+
+  let restore = currentLang()
+  beforeEach(() => {
+    restore = currentLang()
+    setLocaleLang("zh")
+  })
+  afterEach(() => setLocaleLang(restore))
+
+  test("the recurrence phrase carries no English", () => {
+    expect(describeCron("0 9 * * MON-FRI")).toBe("工作日09:00")
+    for (const cron of [
+      "0 9 * * MON-FRI",
+      "0 9 * * SAT,SUN",
+      "30 6 * * *",
+      "*/15 * * * *",
+      "0 */6 * * *",
+      "0 9 * * TUE",
+    ]) {
+      expect(describeCron(cron), cron).not.toMatch(ASCII_LETTER)
+    }
+  })
+
+  test("the next-run clock and date carry no English", () => {
+    const preview = previewSchedule("0 9 * * MON-FRI", NOW)
+    if (preview.kind !== "ok") throw new Error("expected a schedule")
+    expect(preview.relative).not.toMatch(ASCII_LETTER)
+    expect(preview.absolute).not.toMatch(ASCII_LETTER)
+    // The whole line, as the composer assembles it.
+    expect(`${describeCron("0 9 * * MON-FRI")} · ${preview.relative} · ${preview.absolute}`).not.toMatch(ASCII_LETTER)
+  })
+
+  test("a date beyond the week follows the locale's own order, not an English template", () => {
+    const preview = previewSchedule("0 0 1 2 *", NOW)
+    if (preview.kind !== "ok") throw new Error("expected a schedule")
+    // zh-CN puts the month first and the weekday last; the old WEEKDAYS /
+    // MONTHS tables could only ever emit `Mon Feb 1, 00:00`.
+    expect(preview.absolute).toContain("2月1日")
+    expect(preview.absolute).not.toMatch(ASCII_LETTER)
   })
 })

--- a/packages/kobe/test/tui/i18n-key-resolution.test.ts
+++ b/packages/kobe/test/tui/i18n-key-resolution.test.ts
@@ -14,23 +14,37 @@
  *   - literal `t("…")` / `t('…')` calls,
  *   - `labelKey: "…"` table entries, whose `t(row.labelKey)` call site has no
  *     literal of its own, and
- *   - the two enumerable dynamic `t()` template families
- *     (`settings.sections.<id>` and `settings.general.accent<Slot>`), checked
- *     against their runtime value sets so a new section / accent slot can't
- *     ship a key with no catalog entry.
+ *   - the enumerable dynamic `t()` template families
+ *     (`settings.sections.<id>`, `settings.general.accent<Slot>`,
+ *     `automations.schedule.dow.<CODE>`, `automations.runStatus.<status>`),
+ *     checked against their runtime value sets so a new section, accent slot,
+ *     weekday, or daemon run status can't ship a key with no catalog entry.
  *
- * Out of scope (no static key to check): `tKeys("category"|"desc", id)` is only
- * ever called with a dynamic keybinding id, so its coverage rides on the
- * keybinding catalog rather than this scan.
+ * `tKeys("category"|"desc", id)` has no static key to scan — it is only ever
+ * called with a dynamic keybinding id — so it gets its own reachability tests
+ * at the bottom of this file, driven from the keymap and the two category
+ * mappers instead of from source text. Without them the same silent failure
+ * reappears one layer over: `workspace.reopenSession` had no `keys.desc`
+ * entry in EITHER locale, so parity passed while the F1 help dialog printed
+ * the literal binding id as that row's description.
+ *
+ * Those two tests check `en` only, and that is not a gap: `zh: typeof en` in
+ * `messages/keys.ts` makes a locale missing a key a TYPE error, and the
+ * parity test covers it at runtime as well.
  */
 
 import { readFileSync, readdirSync } from "node:fs"
 import { join } from "node:path"
 import { fileURLToPath } from "node:url"
+import type { AutomationRunStatus } from "@sma1lboy/kobe-daemon/daemon/contracts"
 import { describe, expect, test } from "vitest"
+import { DOW_CODES } from "../../src/tui/component/cron-segments"
 import { SECTIONS } from "../../src/tui/component/settings-dialog/model"
+import { KobeKeymap } from "../../src/tui/context/keybindings"
+import type { KobeBindingScope } from "../../src/tui/context/keybindings"
 import { en } from "../../src/tui/i18n/catalog"
 import { UI_PREFS_FOCUS_ACCENT_SLOTS } from "../../src/tui/lib/apply-ui-prefs"
+import { guideCategory, scopeCategory } from "../../src/tui/lib/help-groups"
 
 const SRC_ROOT = fileURLToPath(new URL("../../src", import.meta.url))
 
@@ -101,6 +115,23 @@ function collectLiteralKeys(): Map<string, string[]> {
 
 const capitalize = (s: string): string => s.charAt(0).toUpperCase() + s.slice(1)
 
+/**
+ * The daemon's run-status union as a runtime list. Written as an exhaustive
+ * `Record` on purpose: adding a status to `AutomationRunStatus` without
+ * listing it here is a TYPE error, so the catalog check below cannot quietly
+ * stop covering the full enum.
+ */
+const RUN_STATUS_KEYS: Record<AutomationRunStatus, true> = {
+  dispatched: true,
+  revived: true,
+  deferred: true,
+  skipped_precheck: true,
+  skipped_missed: true,
+  skipped_unavailable: true,
+  dispatch_failed: true,
+}
+const AUTOMATION_RUN_STATUSES = Object.keys(RUN_STATUS_KEYS)
+
 describe("i18n key resolution", () => {
   test('every literal t("…") key resolves in the English catalog', () => {
     const keyToFiles = collectLiteralKeys()
@@ -120,11 +151,72 @@ describe("i18n key resolution", () => {
     expect(unresolved).toEqual([])
   })
 
+  // `automations.schedule.dow.${code}` in component/cron-segments.ts.
+  test("every cron weekday code has a catalog phrase", () => {
+    const unresolved = DOW_CODES.map((code) => `automations.schedule.dow.${code}`).filter((key) => !VALID_KEYS.has(key))
+    expect(unresolved).toEqual([])
+  })
+
+  // `automations.runStatus.${status}` in component/automations-format.ts.
+  // Driven from the daemon's own union so a status added there cannot reach
+  // the Routines page with no catalog entry — `formatRunStatus` would then
+  // print the raw `skipped_unavailable` into a Chinese row.
+  test("every daemon run status has a catalog label", () => {
+    const unresolved = AUTOMATION_RUN_STATUSES.map((status) => `automations.runStatus.${status}`).filter(
+      (key) => !VALID_KEYS.has(key),
+    )
+    expect(unresolved).toEqual([])
+  })
+
   // `settings.general.accent${Slot}` in settings-dialog/sections.tsx.
   test("every focus-accent slot has a catalog label", () => {
     const unresolved = UI_PREFS_FOCUS_ACCENT_SLOTS.map((slot) => `settings.general.accent${capitalize(slot)}`).filter(
       (key) => !VALID_KEYS.has(key),
     )
     expect(unresolved).toEqual([])
+  })
+})
+
+/**
+ * Every scope a section can carry, plus the `undefined` the help dialog
+ * passes for an unscoped section. Typed as the real union so adding a scope
+ * to `KobeBindingScope` fails to compile here until it is listed.
+ */
+const HELP_SCOPES: readonly (KobeBindingScope | undefined)[] = [
+  undefined,
+  "global",
+  "sidebar",
+  "workspace",
+  "files",
+  "inbox",
+  "terminal",
+]
+
+describe("keybinding catalog reachability", () => {
+  test("every binding id has a keys.desc entry", () => {
+    expect(KobeKeymap.length).toBeGreaterThan(0)
+    const missing = KobeKeymap.map((binding) => binding.id)
+      .filter((id) => !(id in en.keys.desc))
+      .sort()
+
+    // tKeys() falls back to the raw key, which for this group IS the binding
+    // id — so a miss here renders `workspace.reopenSession` to the user where
+    // a sentence belongs. The binding's own English `description:` field is
+    // never displayed; the catalog is the only source the help dialog reads.
+    expect(missing).toEqual([])
+  })
+
+  test("every category header a surface can print has a keys.category entry", () => {
+    // Three sources, because three different rules pick the header: the help
+    // dialog groups by SCOPE, the prefix HUD's guide by its own synthetic
+    // mapping, and that mapping falls through to the binding's own category.
+    const reachable = new Set<string>([
+      ...HELP_SCOPES.map(scopeCategory),
+      ...KobeKeymap.map((binding) => guideCategory(binding.id)),
+      ...KobeKeymap.map((binding) => binding.category),
+    ])
+    const missing = [...reachable].filter((category) => !(category in en.keys.category)).sort()
+
+    expect(missing).toEqual([])
   })
 })

--- a/packages/kobe/test/tui/sidebar-label.test.ts
+++ b/packages/kobe/test/tui/sidebar-label.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest"
 
+import { approxCellWidth } from "../../src/lib/display-width"
 import { spacedTitle, truncateTitle } from "../../src/tui/panes/sidebar/labels"
 
 describe("sidebar row labels", () => {
@@ -13,5 +14,20 @@ describe("sidebar row labels", () => {
 
   it("does not bake spacing into plain title truncation", () => {
     expect(truncateTitle("delta_project", 6)).toBe("delta…")
+  })
+
+  /**
+   * `max` is a CELL budget — every caller sizes it with `approxCellWidth` —
+   * so a wide title must be spent in the same unit it was measured in. A
+   * code-point truncator reads these 6 glyphs as fitting a 6 budget and
+   * returns all 12 cells of them, drawing through the box that was sized
+   * for 6.
+   */
+  it("spends a CJK title against cells, not code points", () => {
+    const title = "终端渲染说明"
+    expect([...title].length).toBe(6)
+    expect(approxCellWidth(title)).toBe(12)
+    expect(approxCellWidth(truncateTitle(title, 6))).toBeLessThanOrEqual(6)
+    expect(truncateTitle(title, 6)).toBe("终端…")
   })
 })


### PR DESCRIPTION
Three batches from `.scratch/loop-r18-i18n/i18n.md`, in the explorer's order (3 → 1 → 2). One theme: **`check-i18n` validates PARITY, so a key missing from BOTH locales passes it** — and everything below is either that hole or a string that never became a key at all.

Every screen-visible claim is measured off the **terminal text buffer** through `/harness` → xterm.js → PTY → real OpenTUI, same chord, same fixture, only `state.json.locale` changed. BEFORE frames were captured on base code (`d542d1a30`, `git checkout <base> -- packages/kobe/src` + rebuild, then restored); AFTER on the built branch. Port base 7311, isolated home under `.scratch/opentui-visual-7311/`, fixture and its PTY host both torn down and verified gone.

Evidence (absolute paths, outside `.scratch/`): `/tmp/loop-r18-ba/`

---

## Batch 3 — a cell budget spent by a code-point truncator

`prefix-hud.tsx` fed `width - 2` (CELLS) into `truncateEnd` (CODE POINTS). A Chinese caption is 25 points against a 26 budget, so it "fit", came back whole, and `wrapMode="none"` let Yoga shear it — landing right after an **opening** full-width bracket, with no ellipsis to say anything was dropped.

**PASS criterion:** the zh HUD line ends in `…` and fits the same cell budget English does; English is unchanged.

```
BEFORE  zh   ctrl+a + 2 → 打开例行任务（      ← hard cut, no ellipsis
AFTER   zh   ctrl+a + 2 → 打开例行任务…
BEFORE  en   ctrl+a + 2 → Open routine…      ← control, unchanged
AFTER   en   ctrl+a + 2 → Open routine…
```

`/tmp/loop-r18-ba/{before,after}-hud-zh.png` · `{before,after}-hud-zh.txt` · `{before,after}-hud-en.txt`

Fixed at the same time: `truncateTitle`, whose `max` every caller measures with `approxCellWidth` while it spent it in code points. That is the context-menu call site from 3.2 — one function, both callers, not a per-caller patch. Its doc already claimed "cell budget"; now it is one.

Regression tests: `test/render/which-key-help.test.tsx` renders the real `PrefixHud` at width 28 in zh and asserts the row contains `打开例行任务…`, does **not** contain `定时任务）`, and stays inside the budget. **Mutation-verified** — reverting only the call site to `truncateEnd`:

```
Expected to contain: "打开例行任务…"
Received: "  ctrl+a + 2 → 打开例行任务（   …"     ← byte-identical to the harness BEFORE
```

## Batch 1 — a test that documented its own gap, delegating to a guard that did not exist

`workspace.reopenSession` had no `keys.desc` entry in **either** locale. `tKeys()` falls back to the raw lookup key — which for this group is the binding id — so the F1 help dialog printed the literal string `workspace.reopenSession` as that row's description. The correct English sentence has been sitting unread at `keybindings-chat.ts:146` the whole time; the dialog never reads the binding's `description` field. `Diff review` and `Inbox` had the same gap in `keys.category`.

**PASS criterion:** no binding id or category header renders raw, and deleting a `keys.desc` entry from both locales — which keeps `check-i18n` green — fails CI.

```
BEFORE zh  ⏎   workspace.reopenSession                       (⏎)
AFTER  zh  ⏎   在标签页全部关闭的任务中重新打开会话            (⏎)
```
`/tmp/loop-r18-ba/{before,after}-help-zh.png` · `{before,after}-help-zh.txt`. Grep for `reopenSession` across the AFTER dialog: **0 occurrences**.

`test/tui/i18n-key-resolution.test.ts` now covers what its own module doc previously carved out by name (paragraph deleted). Two tests, driven from the keymap and the two category mappers rather than from source text: every binding id resolves in `keys.desc`; every category header any surface can print resolves in `keys.category` — unioning the help dialog's scope mapping, the prefix HUD's guide mapping, and the keymap's own `category` field, as the brief specified.

**Mutation-verified at two independent sites**, each showing the exact shape the guard exists for:

| mutation | `check-i18n` | new guard |
|---|---|---|
| delete `keys.desc["sidebar.rename"]` from **both** locales | `OK — 842 keys × 2 locales in sync` | `expected [ 'sidebar.rename' ] to deeply equal []` |
| delete `keys.category["Diff review"]` from **both** locales | `OK — 842 keys × 2 locales in sync` | `expected [ 'Diff review' ] to deeply equal []` |

To make that possible, `scopeCategory` (help-dialog.tsx) and `guideCategory` (prefix-hud.tsx) moved to the framework-free `lib/help-groups.ts` — a vitest guard cannot import an opentui component to ask which header a binding prints under, and duplicating their literals into the test would guard the copy rather than the code.

## Batch 2 — ~30 un-catalogued strings, fixed at the mechanism in each owner

Not a re-translation pass: each owner got the machinery it was missing, and the wording followed.

**The Routines schedule preview** — the one line answering "when does this fire", and the last fully-English line in a Chinese composer.

```
BEFORE  weekdays at 09:00 · in 2d · Mon 09:00
AFTER   工作日09:00 · 2 天后 · 周一 09:00
```
`/tmp/loop-r18-ba/{before,after}-composer-zh.png` · `{before,after}-composer-zh.txt` (the BEFORE frame carries both this line and Batch 3's clipped HUD).

- `describeCron` / `describeTimeOfDay` read their phrases from the catalog. `describeTimeOfDay` now **reports** whether its phrase is already self-recurring instead of sniffing an `"every "` prefix — English could detect that, a translated phrase cannot, and without it zh would read "每天每 15 分钟".
- `formatRelative` / `formatWhen` likewise.
- `formatAbsolute` takes its calendar words **and their order** from `Intl` for the active locale, deleting the `WEEKDAYS`/`MONTHS` tables. zh reads `2026/8/3`, not `8/3/2026`; the explorer's "give zh its own template" is unnecessary once the platform owns word order. The 24-hour clock is still built by hand — same instant everywhere, and `Intl`'s en-US default would turn it into `9:00 AM`.

**Two `toLocale*` calls passed no locale at all**, following the OS instead of the UI setting — wrong in both directions. `intlLocale()` in `tui/i18n` is now the single owner of the BCP-47 tag, carried on `LOCALES` beside each catalog id.

**The daemon's run-status enum** is mapped through the catalog; an unmapped status falls through to its raw value so a new one is loud, not blank. `run.error` stays untranslated deliberately — it is a machine message the user searches for and pastes into an issue, and a translated copy matches nothing. (Written down here because the next reader will ask.)

**The Settings dialog's modals** — `Reset UI state?`, `Restart backend?`, `Add engine`, `Can't use that worktree location`, the `COMMAND`/`NAME`/`ID`/`PROTOCOL` field labels and `save`/`next`/`add` captions, and the two lines printed to stderr *after* Rove exits.

**The duplicate `relativeAge`** in `work-items-page.tsx` is gone in favour of the shared clock. This one changed real behavior and one test caught it: the local copy **rounded** where `src/lib/relative-time.ts` documents that every step must floor, and it had no seconds step, so a freshly-stamped row read `0m` where every other age on screen reads `3s`. `test/render/failure-toast.test.tsx` asserted that `0m`; it now asserts the age by shape (`/\b\d+[smhd]\b/`), since the fixture stamps `updatedAt` at module load and the literal depended on how long the file took to run.

Tests: `test/tui/automation-composer.test.ts` asserts the whole assembled zh preview line matches no `[A-Za-z]` (the explorer's stated criterion) and that a beyond-the-week date contains `2月1日`; `test/tui-react/automations-format.test.ts` covers `formatWhen` in both locales including the `>24h` Intl fallback, plus `formatRunStatus`'s fall-through. The resolution gate was extended to the two new enumerable dynamic key families (`automations.schedule.dow.<CODE>`, `automations.runStatus.<status>`), the latter driven from the daemon's union via an exhaustive `Record`, so adding a status there without a catalog entry is a **type** error.

---

## Gates

| gate | result |
|---|---|
| `bun run lint` (repo root) | clean, 1449 files |
| `bun run typecheck` | clean |
| `bun run test:fast` | 455 files, **4509 passed** |
| `bun test test/render` | 108 files, **479 passed** |
| `KOBE_INCLUDE_SOCKET=1 bun run test:socket` | 100 files, **819 passed** |
| `bun run check-i18n` | `900 keys × 2 locales in sync` (was 840) |

Rebased on `origin/main` @ `e91042fb6` (0.9.139); lint / typecheck / check-i18n / test:fast / render all re-run green after the rebase.

## Not done / notes

- **No new or moved chords.** Nothing in these batches needed one.
- **Batch 4 was read and acted on in exactly one place:** the explorer's correction that the broken-surrogate class is closed at the helper level is why Batch 3 is a call-site unit fix and not a helper rewrite. The catalog width audit was not re-derived.
- `describeTimeOfDay`'s return type changed from `string | null` to `{ at, bare } | null`. It is module-private; the 18 existing English assertions in `test/tui/cron-segments.test.ts` all still pass unchanged, which is the behavior-preserving proof.
- **Wording is a first pass.** The zh strings are mine and read correctly, but the mechanism is the deliverable — every one of them is now a catalog key that can be edited without touching code.
