### PR TITLE
fix: an issue-update that half-lands, and a drawer save that reverts an agent (C1, C2)

### DIFF
--- a/.changeset/issue-update-atomic-and-drawer-field-patch.md
+++ b/.changeset/issue-update-atomic-and-drawer-field-patch.md
@@ -1,0 +1,17 @@
+---
+"@sma1lboy/rove": patch
+---
+
+`rove api issue-update` no longer half-applies. Title, body and the task link
+used to travel as two separate `issue.mutate` calls, so `--title X --task
+<bogus>` renamed the story and then failed the link — exit 1, a typed
+`TASK_NOT_FOUND`, and a hint telling you to retry a command that had already
+committed half its work. All three fields now ride one store write, and the
+task-existence check runs before the store takes its lock, so the error means
+what it says: nothing landed.
+
+The Kanban story drawer no longer reverts a field it never saw. It sent both
+the title and the body on every save, compared against the snapshot it opened
+with — so a person fixing a typo in the title silently overwrote a description
+an agent had rewritten while the drawer sat open. The save now carries only the
+fields that were actually edited.

--- a/docs/API.md
+++ b/docs/API.md
@@ -569,7 +569,8 @@ The daemon-owned issue store (backlog; see
 - `issue-set-status --repo PATH --id N --status S`: set an issue's status.
 - `issue-update --repo PATH --id N [--title T] [--body TEXT] [--task ID]`:
   edit title/body and/or link a task (kanban: In progress; `--task none`
-  unlinks).
+  unlinks). All three land in one store write, so a rejected `--task` leaves
+  the title and body unchanged — the error means nothing was applied.
 
 ## workitems
 

--- a/packages/kobe-daemon/src/daemon/handlers-issues.ts
+++ b/packages/kobe-daemon/src/daemon/handlers-issues.ts
@@ -16,17 +16,23 @@ export const ISSUE_HANDLERS: readonly DaemonRequestHandler[] = [
     name: "issue.mutate",
     async handle(payload, ctx) {
       const repoRoot = requireString(payload, "repoRoot")
-      // A `link` op names a task, and the store only type-checks `taskId` as a
-      // non-empty string — without this guard a typo'd id is accepted and the
-      // card sits in In progress pointing at nothing. The check lives HERE,
-      // rather than in the store: both the
+      // A `link` op — and an `update` carrying a `taskId` — names a task, and
+      // the store only type-checks `taskId` as a non-empty string; without
+      // this guard a typo'd id is accepted and the card sits in In progress
+      // pointing at nothing. The check lives HERE, rather than in the store:
+      // both the
       // CLI (`issue-update --task`) and the web link route funnel through this
       // one RPC, and the task index is on the handler context, so the issue
       // store keeps knowing nothing about tasks. The prose is the same one
       // every other handler throws, which `toApiError` maps to a typed
       // TASK_NOT_FOUND with the `api list` recovery command.
+      //
+      // It also runs BEFORE `issues.mutate` takes the store lock, which is
+      // what makes the CLI's title+link update all-or-nothing: a bad link
+      // rejects the whole op instead of landing the rename first.
       const op = payload.op
-      if (op && typeof op === "object" && (op as { type?: unknown }).type === "link") {
+      const opType = op && typeof op === "object" ? (op as { type?: unknown }).type : undefined
+      if (opType === "link" || opType === "update") {
         const taskId = (op as { taskId?: unknown }).taskId
         if (typeof taskId === "string" && taskId.length > 0 && !ctx.orch.getTask(taskId)) {
           throw new Error(`task not found: ${taskId}`)

--- a/packages/kobe-daemon/src/daemon/issues-store.ts
+++ b/packages/kobe-daemon/src/daemon/issues-store.ts
@@ -61,7 +61,7 @@ interface IssuesStoreFile {
 type IssueOp =
   | { type: "create"; title?: unknown; body?: unknown }
   | { type: "setStatus"; id?: unknown; status?: unknown }
-  | { type: "update"; id?: unknown; title?: unknown; body?: unknown }
+  | { type: "update"; id?: unknown; title?: unknown; body?: unknown; taskId?: unknown }
   | { type: "link"; id?: unknown; taskId?: unknown }
   | { type: "unlink"; id?: unknown }
   | { type: "delete"; id?: unknown }
@@ -307,10 +307,25 @@ export class IssuesStore {
           throw new Error("title must be a non-empty string")
         }
         if (typed.body !== undefined && typeof typed.body !== "string") throw new Error("body must be a string")
+        // The link rides the SAME locked write as title/body: a string links,
+        // `null` unlinks, absent leaves the link alone. `issue-update --title X
+        // --task <bogus>` was two RPCs, so the rename committed and only then
+        // did the link fail — a total-failure error for a half-applied command.
+        // Nothing in this branch reaches disk until the `writeStore` at the
+        // end of `mutate`, and the record it edits was parsed fresh from the
+        // file, so ANY throw here leaves the store byte-for-byte unchanged.
+        if (
+          typed.taskId !== undefined &&
+          typed.taskId !== null &&
+          (typeof typed.taskId !== "string" || typed.taskId.length === 0)
+        ) {
+          throw new Error("taskId must be a non-empty string or null")
+        }
         const issue = record.issues.find((i) => i.id === typed.id)
         if (!issue) throw new Error(`${ISSUE_NOT_FOUND_CODE}: no issue #${typed.id}`)
         if (typeof typed.title === "string") issue.title = typed.title
         if (typeof typed.body === "string") issue.body = typed.body
+        if (typed.taskId !== undefined) issue.taskId = typed.taskId === null ? undefined : (typed.taskId as string)
       } else if (typed.type === "link") {
         if (typeof typed.id !== "number") throw new Error("link requires a numeric id")
         if (typeof typed.taskId !== "string" || typed.taskId.length === 0) {

--- a/packages/kobe/src/cli/api/handlers-tasks.ts
+++ b/packages/kobe/src/cli/api/handlers-tasks.ts
@@ -33,17 +33,18 @@ export async function issueUpdate(ctx: VerbContext): Promise<unknown> {
   }
   const repoRoot = ctx.args.requireRepo("repo")
   const id = ctx.args.int("id")
-  let result: unknown
-  if (title !== undefined || body !== undefined) {
-    result = await simpleRpc(ctx, "issue.mutate", { repoRoot, op: { type: "update", id, title, body } })
-  }
-  if (task !== undefined) {
-    // `--task none` unlinks; anything else links. Linking IS the kanban move to
-    // In progress — the board column derives from the link, not a stored column.
-    const op = task === "none" ? { type: "unlink", id } : { type: "link", id, taskId: task }
-    result = await simpleRpc(ctx, "issue.mutate", { repoRoot, op })
-  }
-  return result
+  // ONE mutate, not two. Title/body and the link used to be separate RPCs, so
+  // `--title X --task <bogus>` committed the rename and THEN failed the link —
+  // the caller got exit 1, a typed TASK_NOT_FOUND and a hint saying "retry
+  // with a real id" for a command that had already half-run. The store applies
+  // all three fields under its one lock, and the daemon's task-existence check
+  // runs before that lock is taken, so a rejected link writes nothing.
+  //
+  // `--task none` unlinks (carried as `taskId: null`); anything else links.
+  // Linking IS the kanban move to In progress — the board column derives from
+  // the link, not a stored column.
+  const link = task === undefined ? {} : { taskId: task === "none" ? null : task }
+  return simpleRpc(ctx, "issue.mutate", { repoRoot, op: { type: "update", id, title, body, ...link } })
 }
 
 /**

--- a/packages/kobe/src/tui-react/component/kanban-page.tsx
+++ b/packages/kobe/src/tui-react/component/kanban-page.tsx
@@ -191,8 +191,17 @@ export function KanbanPage(props: {
       orchestrator: props.orchestrator,
     }).then(async (outcome) => {
       if (!outcome) return
-      const patch = { title: outcome.title, body: outcome.body }
-      if (patch.title !== issue.title || patch.body !== issue.body) {
+      // ONLY the fields the drawer actually changed. `issue` is the open-time
+      // snapshot the drawer seeded its drafts from, so a field still equal to
+      // it is one the user never touched — and writing it back would revert
+      // whatever another client (an agent on `rove api issue-update`) put
+      // there while the drawer sat open, silently, on a field the person
+      // saving never saw. The store leaves an absent field alone, so fixing a
+      // typo in the title now keeps a body rewritten underneath it.
+      const patch: { title?: string; body?: string } = {}
+      if (outcome.title !== issue.title) patch.title = outcome.title
+      if (outcome.body !== issue.body) patch.body = outcome.body
+      if (patch.title !== undefined || patch.body !== undefined) {
         await props.orchestrator
           ?.mutateIssue(board.repoRoot, { type: "update", id: issue.id, ...patch })
           .catch((err: unknown) => {

--- a/packages/kobe/test/cli/api-handlers-more.test.ts
+++ b/packages/kobe/test/cli/api-handlers-more.test.ts
@@ -366,9 +366,7 @@ describe("issue verbs", () => {
       client,
       runtime: stubRuntime(),
     })
-    expect(client.requests).toEqual([
-      { name: "issue.mutate", payload: { repoRoot: "/repo/x", op: { type: "link", id: 7, taskId: "01TASK" } } },
-    ])
+    expect(client.requests[0].payload).toMatchObject({ op: { type: "update", id: 7, taskId: "01TASK" } })
   })
 
   it("issue-update --task none unlinks", async () => {
@@ -377,18 +375,27 @@ describe("issue verbs", () => {
       client,
       runtime: stubRuntime(),
     })
-    expect(client.requests).toEqual([
-      { name: "issue.mutate", payload: { repoRoot: "/repo/x", op: { type: "unlink", id: 7 } } },
-    ])
+    expect(client.requests[0].payload).toMatchObject({ op: { type: "update", id: 7, taskId: null } })
   })
 
-  it("issue-update with title AND task sends update then link, in that order", async () => {
+  // The half-apply: title/body and the link used to be two RPCs, so a rejected
+  // link left the rename committed behind a total-failure error. One RPC is
+  // what makes the store's single lock cover the whole command.
+  it("issue-update with title AND task sends ONE mutate carrying both", async () => {
     const client = new FakeClient({ "issue.mutate": () => ({ issues: [] }) })
     await invokeVerb("issue-update", ["--repo", "/repo/x", "--id", "7", "--title", "Renamed", "--task", "01TASK"], {
       client,
       runtime: stubRuntime(),
     })
-    expect(client.requests.map((r) => (r.payload as { op: { type: string } }).op.type)).toEqual(["update", "link"])
+    expect(client.requests).toEqual([
+      {
+        name: "issue.mutate",
+        payload: {
+          repoRoot: "/repo/x",
+          op: { type: "update", id: 7, title: "Renamed", body: undefined, taskId: "01TASK" },
+        },
+      },
+    ])
   })
 })
 

--- a/packages/kobe/test/daemon/handlers-task-crud.test.ts
+++ b/packages/kobe/test/daemon/handlers-task-crud.test.ts
@@ -264,6 +264,23 @@ describe("daemon handler registry — tasks, issues, worktrees", () => {
       expect(rec.published).toEqual([])
     })
 
+    // The half-apply guard: `issue-update --title X --task <bogus>` is ONE
+    // `update` op now, so the same task check has to see the `taskId` it
+    // carries. Miss it and the store commits the rename under a lock the
+    // caller is then told nothing happened inside.
+    it("issue.mutate refuses an update whose taskId names no task, before writing the title", async () => {
+      const { ctx, rec } = fakeCtx({ getTask: () => undefined })
+      await expect(
+        dispatch(
+          "issue.mutate",
+          { repoRoot: "/repo", op: { type: "update", id: 1, title: "Renamed", taskId: "NOPE" } },
+          ctx,
+        ),
+      ).rejects.toThrow("task not found: NOPE")
+      expect(rec.issueCalls).toEqual([])
+      expect(rec.published).toEqual([])
+    })
+
     it("issue.mutate links to a task that exists", async () => {
       const { ctx, rec } = fakeCtx({ getTask: (id: string) => (id === "t1" ? TASK : undefined) })
       await expect(

--- a/packages/kobe/test/daemon/issues-store.test.ts
+++ b/packages/kobe/test/daemon/issues-store.test.ts
@@ -147,6 +147,51 @@ describe("IssuesStore", () => {
     expect(Object.values(after.repos)[0]?.repoRoot).toBe(canonicalRepo)
   })
 
+  // `update` carries the link so the CLI's `--title X --task Y` is ONE locked
+  // write. Split across two ops, a rejected link left the rename committed.
+  describe("update carrying a taskId", () => {
+    async function seeded(): Promise<{ repo: string; store: IssuesStore }> {
+      const repo = await makeRepo()
+      const home = await mkdtemp(join(tmpdir(), "kobe-issues-store-update-link-"))
+      cleanups.push(home)
+      const store = new IssuesStore(join(home, ".kobe", "issues.json"))
+      await store.mutate(repo, { type: "create", title: "Story", body: "B1" })
+      return { repo, store }
+    }
+
+    it("applies title, body and the link in one write", async () => {
+      const { repo, store } = await seeded()
+      await store.mutate(repo, { type: "update", id: 1, title: "Renamed", body: "B2", taskId: "task-abc" })
+      expect((await store.list(repo)).issues[0]).toMatchObject({ title: "Renamed", body: "B2", taskId: "task-abc" })
+    })
+
+    it("taskId null unlinks; absent leaves the link alone", async () => {
+      const { repo, store } = await seeded()
+      await store.mutate(repo, { type: "update", id: 1, taskId: "task-abc" })
+      await store.mutate(repo, { type: "update", id: 1, title: "Renamed" })
+      expect((await store.list(repo)).issues[0]).toMatchObject({ title: "Renamed", taskId: "task-abc" })
+      await store.mutate(repo, { type: "update", id: 1, taskId: null })
+      expect((await store.list(repo)).issues[0]?.taskId).toBeUndefined()
+    })
+
+    it("a rejected taskId writes nothing — the title does not half-land", async () => {
+      const { repo, store } = await seeded()
+      await expect(store.mutate(repo, { type: "update", id: 1, title: "Renamed", taskId: "" })).rejects.toThrow(
+        "taskId must be a non-empty string or null",
+      )
+      expect((await store.list(repo)).issues[0]).toMatchObject({ title: "Story", body: "B1" })
+    })
+
+    it("an update that omits body leaves a concurrently-written body alone", async () => {
+      const { repo, store } = await seeded()
+      // The C2 shape at the store layer: a title-only patch must not carry a
+      // stale body back over what another writer put there.
+      await store.mutate(repo, { type: "update", id: 1, body: "AGENT WROTE THIS" })
+      await store.mutate(repo, { type: "update", id: 1, title: "Typo fixed" })
+      expect((await store.list(repo)).issues[0]).toMatchObject({ title: "Typo fixed", body: "AGENT WROTE THIS" })
+    })
+  })
+
   describe("mirrorTaskDone", () => {
     async function linkedStore(): Promise<{ repo: string; store: IssuesStore }> {
       const repo = await makeRepo()


### PR DESCRIPTION
Batch C of loop R19 (`.scratch/loop-r19-issues/issues.md`). Both items are a write that reports one thing and does another. Batches A and B belong to other workers — `readStore`, `use-kanban-boards.ts` and `issueColumnKey` are untouched here.

---

## C1 — `issue-update` half-applied and reported total failure

**What changed.** `issueUpdate` fired two `issue.mutate` RPCs: one for title/body, one for the link. The first committed, the second failed, and the caller got only the failure — exit 1, a typed `TASK_NOT_FOUND`, and a hint saying *"retry with a real id"* for a command that had already renamed the story. Now the CLI sends **one** `update` op carrying `title`, `body` and `taskId` (`null` = unlink), the store applies all three under its existing lock, and the daemon's task-existence guard — extended to cover `update`, not just `link` — runs **before** that lock is taken.

**PASS criterion.** After the failing command, `issue-list` shows the original title and body, and the exit code is still 1 with the same typed error.

**Proof** — real verbs, source build (`dist/cli/rove.js`), isolated home, live daemon. `/tmp/loop-r19-be-caiman/c1-before.txt` and `c1-after.txt`:

```
BEFORE  {"id":1,"title":"first story","body":"B1"}
        $ rove api issue-update --id 1 --title "RENAMED BY HALF-APPLY" --body "B2" --task 01BOGUS…
        {"error":{"message":"task not found: 01BOGUS…","code":"TASK_NOT_FOUND",
                  "hint":"… list live tasks and retry with a real id"}}   exit=1
        {"id":1,"title":"RENAMED BY HALF-APPLY","body":"B2"}   ← landed anyway

AFTER   {"id":1,"title":"first story","body":"B1"}
        (same command, same typed error, exit=1)
        {"id":1,"title":"first story","body":"B1"}             ← nothing landed
```

Happy paths re-driven on the same build (`c1-after.txt`): `--title X --task <real>` links and renames in one call; `--task none` unlinks and keeps the title; `--body` alone leaves the title alone.

## C2 — the detail drawer reverted an agent's body edit made while it was open

**What changed.** `kanban-page.tsx` returned `{title, body}` on every drawer outcome and wrote both, comparing against the open-time snapshot — so a human fixing a typo in the title silently reverted a body another client rewrote while the drawer sat open. The save now builds the patch **field by field**: a field still equal to the open-time snapshot is one the user never touched, so it is omitted, and the store leaves it alone.

**PASS criterion.** Drawer open on issue #1; a separate `rove api issue-update --body "AGENT WROTE THIS"` process writes the body; the drawer user edits only the title and saves. The body must still read `AGENT WROTE THIS`.

**Proof** — real interleaving through the only ground-truth path (`/harness` browser → xterm.js → PTY sidecar → real OpenTUI), driven by one script run identically against both revisions. BEFORE was captured with `kanban-page.tsx` reverted to its `HEAD` state; the concurrent write is a genuinely separate `rove` process fired *while the drawer is open*, not two sequential calls.

```
                                                          BEFORE            AFTER
1. store before the drawer opens        title/body     Backlog fixture / Waiting to start.
2. drawer open on #1, seeded body                        true              true
3. store after the concurrent agent write               body = AGENT WROTE THIS (both)
4. store after the drawer title-only save
       title                                 Backlog fixture EDITED   Backlog fixture EDITED
       body                              »  Waiting to start.  «    »  AGENT WROTE THIS  «
5. reopened drawer shows the agent's body                false             true
6. reopened drawer shows the reverted body                true             false
```

Read off the OpenTUI **text buffer**, not the raster — `c2-before-buffer.txt` contains `Waiting to start.` and no `AGENT WROTE THIS`; `c2-after-buffer.txt` is the exact inverse. Screenshots of the same three beats are alongside.

Evidence (absolute paths):

| file | what |
|---|---|
| `/tmp/loop-r19-be-caiman/c1-before.txt` · `c1-after.txt` | C1 command transcripts against a live daemon |
| `/tmp/loop-r19-be-caiman/c2-before.txt` · `c2-after.txt` | the six-step interleaving log |
| `/tmp/loop-r19-be-caiman/c2-before-buffer.txt` · `c2-after-buffer.txt` | OpenTUI text buffer, drawer reopened on #1 |
| `/tmp/loop-r19-be-caiman/c2-{before,after}-{1-drawer-open,2-title-edited,3-reopened}.png` | harness screenshots |

---

## Mutation checks (the tests can fail)

- Handler guard reverted to `opType === "link"` → the new `handlers-task-crud` case fails.
- The store's `taskId` assignment deleted → both new `issues-store` link cases fail.
- **A second mutation at a different site did NOT fail**, and that is worth saying: moving the `taskId` validation *after* the title/body assignments keeps every test green. The store's all-or-nothing property does not come from validate-before-assign — every `mutate` parses the record fresh and nothing reaches disk until the single `writeStore` at the end, so any throw in the branch is already atomic. The code comment was corrected to name that mechanism instead of the one I had assumed.

## Not proved

Nothing in scope is unproved. C2's fix is TUI-only, so it has no unit test — the harness interleaving is the tightest proof available and it fails BEFORE / passes AFTER on the identical script.

## Gates

`bun run lint`, `bun run typecheck`, `bun run test:fast` (456 files / 4514 tests), `KOBE_INCLUDE_SOCKET=1 bun run test:socket` (100 files / 829 tests) — all green. Fixture daemon and its PTY host both stopped and verified gone (pid 36952 was the surviving `pty-host` the fixture cleanup left behind; killed and confirmed).
