### PR TITLE
Two call sites ignore the home-directory override, and one of them writes (Batch 1 + 2)

### DIFF
--- a/.changeset/codex-max-effort-in-schema.md
+++ b/.changeset/codex-max-effort-in-schema.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+`max` is now listed everywhere the other five Codex effort levels are. The engine declares `none`/`low`/`medium`/`high`/`xhigh`/`max` and accepted all six at runtime, but `rove api schema`'s `set-effort` summary and `--level` description both stopped at `xhigh` — so an agent reading the schema to decide what to pass could never discover `max`. ENGINES.md and API.md carried the same short list.

--- a/.changeset/store-honours-home-dir-override.md
+++ b/.changeset/store-honours-home-dir-override.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+`rove export` and the daemon-down CLI fallback now honour `ROVE_HOME_DIR` / `KOBE_HOME_DIR`. `TaskIndexStore` resolved its home as `options.homeDir ?? homedir()` and never read the environment, so the two call sites that construct it with no options ignored the override: `rove export` in an isolated home printed the operator's real `~/.rove/tasks.json`, and with the daemon down `add` / `remove` / `adopt` / `rove <path>` wrote their task there instead. The env lookup moved into the constructor, so a call site that forgets to pass a home lands in the right one rather than the machine's.

--- a/docs/API.md
+++ b/docs/API.md
@@ -551,7 +551,8 @@ branch included, live in the Rove agent skill. Prompts into existing sessions
   removed `set-vendor`.
 - `set-effort --task-id ID --level LEVEL`: set a task's reasoning effort
   level (takes effect on the next session rebuild). Levels are declared by
-  the task's engine — codex accepts `none`, `low`, `medium`, `high`, `xhigh`;
+  the task's engine — codex accepts `none`, `low`, `medium`, `high`, `xhigh`,
+  `max`;
   claude declares none. A level the engine does not declare is rejected
   (`BAD_EFFORT`, naming the levels it does accept) rather than passed through,
   because the launch path drops an unknown level silently.

--- a/docs/ENGINES.md
+++ b/docs/ENGINES.md
@@ -71,7 +71,7 @@ it, so Rove assumes you meant it.
 
 ### Reasoning effort
 
-Codex accepts `none`, `low`, `medium`, `high`, `xhigh`, passed as
+Codex accepts `none`, `low`, `medium`, `high`, `xhigh`, `max`, passed as
 `-c model_reasoning_effort=<level>`. Other engines have no effort flag Rove
 can drive; a selected effort is ignored there rather than passed through.
 

--- a/packages/kobe/src/cli/api/handlers-engines.ts
+++ b/packages/kobe/src/cli/api/handlers-engines.ts
@@ -141,7 +141,7 @@ export const SET_EFFORT_VERB: VerbSpec = {
   name: "set-effort",
   group: "edit",
   summary:
-    "Set a task's reasoning effort level (takes effect on the next session rebuild). Rejected when the task's engine declares no levels, or does not declare THIS one — the error names the levels it does accept. Codex accepts none/low/medium/high/xhigh; claude has none.",
+    "Set a task's reasoning effort level (takes effect on the next session rebuild). Rejected when the task's engine declares no levels, or does not declare THIS one — the error names the levels it does accept. Codex accepts none/low/medium/high/xhigh/max; claude has none.",
   flags: [
     F.taskId(),
     // Deliberately not an enum: levels are declared PER ENGINE (registry
@@ -153,7 +153,7 @@ export const SET_EFFORT_VERB: VerbSpec = {
       type: "string",
       required: true,
       placeholder: "LEVEL",
-      description: "Effort level the task's engine declares (codex: none, low, medium, high, xhigh).",
+      description: "Effort level the task's engine declares (codex: none, low, medium, high, xhigh, max).",
     },
   ],
   handler: setEffort,

--- a/packages/kobe/src/orchestrator/index/store.ts
+++ b/packages/kobe/src/orchestrator/index/store.ts
@@ -12,6 +12,7 @@
 import { mkdir, open, rename, unlink, writeFile } from "node:fs/promises"
 import { homedir } from "node:os"
 import { dirname, join } from "node:path"
+import { readRoveHomeDirEnv } from "@sma1lboy/kobe-daemon/compat-env"
 import { LEGACY_KOBE_STATE_DIR_BASENAME, ROVE_STATE_DIR_BASENAME } from "../../product.ts"
 import type { Task, TaskId, TaskIndex, TaskStatus } from "../../types/task.ts"
 import { DEFAULT_TASK_VENDOR, toTaskId } from "../../types/task.ts"
@@ -20,7 +21,15 @@ import { acquireWithRetry, mergeTasksWithDisk, readDiskIndex, recoverIndexFromDi
 import { ulid } from "./ulid.ts"
 
 export interface TaskIndexStoreOptions {
-  /** Override the user's home dir. Tests use this to write into tmp. */
+  /**
+   * Override the user's home dir. Tests use this to write into tmp.
+   *
+   * Omitting it does NOT mean the OS home: the constructor falls back to
+   * `ROVE_HOME_DIR`/`KOBE_HOME_DIR` first. That default is load-bearing —
+   * every isolation recipe in this repo is those variables, and the CLI's
+   * daemon-down write fallback (`openLocalOrchestrator`) constructs this
+   * store with no options at all.
+   */
   readonly homeDir?: string
 }
 
@@ -57,7 +66,7 @@ export class TaskIndexStore {
   private readonly removedIds = new Map<string, string>()
 
   constructor(options: TaskIndexStoreOptions = {}) {
-    this.homeDir = options.homeDir ?? homedir()
+    this.homeDir = options.homeDir ?? readRoveHomeDirEnv() ?? homedir()
     this.roveDir = join(this.homeDir, ROVE_STATE_DIR_BASENAME)
     this.path = join(this.roveDir, "tasks.json")
     this.legacyPath = join(this.homeDir, LEGACY_KOBE_STATE_DIR_BASENAME, "tasks.json")

--- a/packages/kobe/src/types/task.ts
+++ b/packages/kobe/src/types/task.ts
@@ -215,7 +215,7 @@ export interface Task {
   readonly prStatus?: TaskPRStatus
   /**
    * Reasoning/effort level for the task's engine, when the vendor supports
-   * one (codex: `none`/`low`/`medium`/`high`/`xhigh`). Optional + additive:
+   * one (codex: `none`/`low`/`medium`/`high`/`xhigh`/`max`). Optional + additive:
    * missing records load unchanged, and a vendor with no effort levels
    * (claude today) leaves it undefined. The launch path maps it to the
    * vendor-correct flag (see `interactive-command.ts`).

--- a/packages/kobe/test/orchestrator/store-home-resolution.test.ts
+++ b/packages/kobe/test/orchestrator/store-home-resolution.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Which HOME a `new TaskIndexStore()` with no options resolves to.
+ *
+ * The seam against `store-legacy-layout.test.ts` is one level up: that file
+ * fixes which FILE inside a home answers, this one fixes which HOME. It exists
+ * because the failure is silent and lands on the wrong machine's data — the
+ * CLI's daemon-down write fallback (`openLocalOrchestrator`) and `rove export`
+ * both construct this store with no options, so a constructor that skipped the
+ * env wrote an isolated environment's tasks into the operator's real
+ * `~/.rove/tasks.json` and reported success.
+ */
+
+import { join } from "node:path"
+import { afterEach, describe, expect, it } from "vitest"
+import { TaskIndexStore } from "../../src/orchestrator/index/store.ts"
+
+const saved = { rove: process.env.ROVE_HOME_DIR, kobe: process.env.KOBE_HOME_DIR }
+
+afterEach(() => {
+  for (const [key, value] of [
+    ["ROVE_HOME_DIR", saved.rove],
+    ["KOBE_HOME_DIR", saved.kobe],
+  ] as const) {
+    if (value === undefined) Reflect.deleteProperty(process.env, key)
+    else process.env[key] = value
+  }
+})
+
+describe("home resolution with no explicit homeDir", () => {
+  it("uses ROVE_HOME_DIR", () => {
+    process.env.ROVE_HOME_DIR = "/tmp/rove-home-resolution/rove"
+    expect(new TaskIndexStore().filePath).toBe(join("/tmp/rove-home-resolution/rove", ".rove", "tasks.json"))
+  })
+
+  it("falls back to the legacy KOBE_HOME_DIR", () => {
+    Reflect.deleteProperty(process.env, "ROVE_HOME_DIR")
+    process.env.KOBE_HOME_DIR = "/tmp/rove-home-resolution/kobe"
+    expect(new TaskIndexStore().filePath).toBe(join("/tmp/rove-home-resolution/kobe", ".rove", "tasks.json"))
+  })
+
+  it("still lets an explicit homeDir win over both", () => {
+    process.env.ROVE_HOME_DIR = "/tmp/rove-home-resolution/rove"
+    process.env.KOBE_HOME_DIR = "/tmp/rove-home-resolution/kobe"
+    const store = new TaskIndexStore({ homeDir: "/tmp/rove-home-resolution/explicit" })
+    expect(store.filePath).toBe(join("/tmp/rove-home-resolution/explicit", ".rove", "tasks.json"))
+  })
+})

--- a/packages/kobe/test/render/engine-picker-dialog.test.tsx
+++ b/packages/kobe/test/render/engine-picker-dialog.test.tsx
@@ -110,7 +110,7 @@ describe("EnginePickerDialogView", () => {
     const p = mount("codex")
     const { frame, mockInput } = await p
     await frame()
-    // choices are [engine default, none, low, medium, high, xhigh]
+    // choices are [engine default, none, low, medium, high, xhigh, max]
     for (let i = 0; i < 5; i++) act(() => mockInput.pressArrow("right"))
     act(() => mockInput.pressEnter())
     await frame()


### PR DESCRIPTION
Two call sites ignored `ROVE_HOME_DIR`/`KOBE_HOME_DIR` and one of them wrote; and `max` was missing from every place the CLI *tells* you what Codex accepts.

Evidence files (raw command output, outside `.scratch/`):
`/tmp/loop-r19-bf-kestrel/batch1-before.txt`, `batch1-after.txt`, `batch1-write-pair.txt`, `batch2-schema.txt`, `batch2-runtime.txt`, `mutation.txt`.

---

## Item 1 — the task store never read the home-dir override

`TaskIndexStore`'s constructor was `options.homeDir ?? homedir()`. The env was consulted by every *caller* that remembered to (`core/index.ts:32` does it correctly), and the two that didn't were:

| call site | what it does |
|---|---|
| `cli/export-cmd.ts:142` | reads — `rove export` |
| `cli/orchestrator-bridge.ts:21` | **writes** — the daemon-down fallback for `add` / `remove` / `adopt` / `rove <path>` |

The fix puts the lookup in the constructor (`options.homeDir ?? readRoveHomeDirEnv() ?? homedir()`), the same pattern already in `core/index.ts` and `plugins/plugin-paths.ts`. Both call sites are corrected without touching either, and a future one that forgets to pass a home lands in the right place rather than the machine's.

**PASS criterion:** in an isolated home, `rove export --json` returns *that home's* tasks; and with the daemon down a write verb writes into that home, not into `homedir()`.

### Proof — read path (`batch1-before.txt` → `batch1-after.txt`)

Isolated home seeded with 2 sentinel tasks; run from source in this worktree; all of `ROVE_/KOBE_ {HOME_DIR, DAEMON_SOCKET_PATH, DAEMON_PID_PATH, PTY_SOCKET_PATH, PTY_PID_PATH, DAEMON_WEB_PORT}` inlined as separate assignments; private port base 7027.

```
                          BEFORE            AFTER
rove config --path        isolated home     isolated home     (control — override works)
rove api list             2 (sentinels)     2 (sentinels)
rove export --json        18 ← real ~       2 (sentinels)
```

The 18 were the operator's real tasks, including this very task's row.

### Proof — write path (`batch1-write-pair.txt`)

Never pointed at the operator's store. Instead `HOME` was set to a **disposable directory I created**, so the buggy `homedir()` fallback resolves into my own throwaway dir. Positive control first — `HOME=… bun -e 'homedir()'` returns the fake path, unset returns `/Users/jacksonc` — so the probe demonstrably responds.

Matched pair, identical fresh repo, `HOME` wiped before each run, daemon down, only `store.ts` swapped between them:

```
BEFORE  src: this.homeDir = options.homeDir ?? homedir()
        $ROVE_HOME_DIR/.rove/tasks.json : 2  (unchanged — the two sentinels)
        $HOME/.rove/tasks.json          : LEAKED, 1 — "fake-repo-2"

AFTER   src: this.homeDir = options.homeDir ?? readRoveHomeDirEnv() ?? homedir()
        $ROVE_HOME_DIR/.rove/tasks.json : 3  (sentinels + "fake-repo-2")
        $HOME/.rove/tasks.json          : (absent)
```

### Regression test

`test/orchestrator/store-home-resolution.test.ts` — 3 cases: `ROVE_HOME_DIR` wins, legacy `KOBE_HOME_DIR` answers when it doesn't, an explicit `homeDir` still beats both. Mutation-verified (`mutation.txt`): with the constructor reverted to `?? homedir()`, **2 of 3 fail**; with the fix, 3/3 pass.

### Operator's real store was not touched

`~/.rove/tasks.json` mtime moved 3× during this work. Each move traces to a **different** task's lifecycle, not mine:

| mtime | traces to |
|---|---|
| `1788546172` | `01M1PSJ4MS2NP0JPTN2EYF0T0V` "loop-r19 BE" updatedAt `18:22:52.620Z` |
| `1788546281` | same task **removed** (18 → 17 tasks) |
| `1788546310` | `01M1PTNQ0V9GR75SDDMNX0S4RH` "loop-r19 BG" created, updatedAt `18:25:10.028Z` |

This task's own row stayed frozen at `18:22:35.891Z` throughout, and no `fake-repo`/`SENTINEL` row ever appeared in it.

---

## Item 2 — `max` was missing from four places, two of them code

The registry declares six levels (`engine/builtin-engines.ts:117`) and the handler validates against it, so `max` has always worked. What was wrong was every place that *enumerates* them for a reader.

Fixed: `cli/api/handlers-engines.ts:144` (schema summary), `:156` (`--level` description), `docs/ENGINES.md:74`, `docs/API.md:554`. A sweep of every `xhigh` mention outside `node_modules`/`refs` found two more of the same defect — `types/task.ts:218` and a stale comment in `test/render/engine-picker-dialog.test.tsx` — fixed too. `ENGINES.md:22` was already right, which is what made the page contradict itself. CHANGELOG entries left alone as history.

**PASS criterion:** `rove api schema` offers `max`, and the runtime accepts it.

### Proof (`batch2-schema.txt`, `batch2-runtime.txt`)

```
BEFORE  summary tail : Codex accepts none/low/medium/high/xhigh; claude has none.
        --level desc : … (codex: none, low, medium, high, xhigh).
        schema offers "max": False

AFTER   summary tail : Codex accepts none/low/medium/high/xhigh/max; claude has none.
        --level desc : … (codex: none, low, medium, high, xhigh, max).
        schema offers "max": True
```

Runtime, isolated home, isolated daemon, against a codex task:

```
$ rove api set-effort --task-id … --level max
{"ok":true,"taskId":"01ISOLATEDBBBBBBBBBBBBBBBB","engine":"codex","effort":"max"}

$ rove api get-task …
{'vendor': 'codex', 'modelEffort': 'max'}        ← persisted

$ rove api set-effort … --level bogus
… "levels":["none","low","medium","high","xhigh","max"]   ← the error path always knew
```

---

## Gates

```
bun run lint          1452 files, no fixes applied
bun run typecheck     4 packages, exit 0
test:fast             457 files / 4520 tests passed
test:socket           100 files / 824 tests passed
test/render/engine-picker-dialog.test.tsx   10 pass / 0 fail
check-i18n            903 keys × 2 locales in sync
changeset:check       ok
```

## No screenshots, and why

Neither item touches a TUI surface. Item 1 is `rove export` and the daemon-down CLI write path; item 2 is two strings in `rove api schema` plus docs. The engine picker dialog already reads `effortLevels` from the registry, so it has been offering `max` all along and renders identically before and after — a `/harness` pair would be two identical frames. The ground truth for a CLI change is the CLI output, which is captured in full above and in the named evidence files.

## Not proved

- Nothing. Both PASS criteria were met at runtime; the write path was proved conclusively in a disposable `HOME` rather than argued from code.
