### PR TITLE
doctor --report stops littering your repo, and get-task's engineAlive gets documented (Batches 3-5)

### DIFF
--- a/.changeset/doctor-report-lands-in-home.md
+++ b/.changeset/doctor-report-lands-in-home.md
@@ -1,0 +1,30 @@
+---
+"@sma1lboy/rove": patch
+---
+
+`rove doctor --report` stops dropping a bug bundle into your repo, and `get-task` documents the field that tells an engine from its shell
+
+The report bundle now lands at `~/.rove/rove-doctor-report.txt`, beside the
+`daemon.log` and `pty.log` it quotes and under the same `ROVE_HOME_DIR`
+override. It used to be written into `process.cwd()`, which is where the
+instruction "run `rove doctor --report` and attach the file" sends people: run
+it inside a checkout and it left `rove-doctor-report.txt` untracked, matched by
+no `.gitignore`, one reflexive `git add -A` from committing recent daemon logs
+and environment. A fixed home path is also the same path every time, which is
+what makes the printed location worth reading out over chat.
+
+`docs/API.md` now names `engineAlive` in the `get-task` tab shape. Every tab
+already carried it and the page never listed it, while spending a paragraph one
+section down warning readers that a session outlives its engine — `alive: true,
+engineAlive: false` is that hazard's per-tab answer, and an automation reading
+the docs fell back to `collect` or its own `ps` walk for something one read had
+already returned. Documented with the same three-valued rule `.running` gets:
+`null` means nothing could look, never "no engine".
+
+`docs/API.md` also explains why `api add --repo` accepts a `.scratch/` or
+`$TMPDIR` checkout that `rove add` refuses: the eligibility gate governs what
+may become a PROJECT, so `add --repo` still runs it and merely skips minting the
+project row rather than failing the call.
+
+`CONTEXT.md` stops describing `rove web` and a daemon "browser transport", both
+removed in #855. The surviving sidecar is the harness one.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -44,15 +44,20 @@ the screen and respawn the recorded command on first attach. Explicit
 `pty.kill`, tab close, task archive/delete, terminal reset, or `rove reset`
 tears down the corresponding hosted session and frozen record.
 
-**Browser PTY sidecar** — the Node process started by `rove web`. It owns only
-browser-created terminal children and is separate from the standalone PTY Host.
+**Harness PTY sidecar** — the Node process `packages/kobe-harness` starts
+(`pty-server.mjs`, with its own bearer-token gate in `pty-auth.mjs`) to back
+the `/harness` capture page. It owns only browser-created terminal children
+and is separate from the standalone PTY Host. It is what survived #855, which
+deleted the browser dashboard, the daemon's HTTP/SSE transport, and the
+`rove web` command that used to start a sidecar.
 
 **PTY Registry** — the Workspace Host's client-side attachment manager. It
 maps tab keys to hosted sessions and reference-counts local consumers; it does
 not own child lifetime.
 
 **Daemon** — the long-lived control plane for the Task index, Worktree
-operations, settings, issues, activity channels, and browser transport. It does
+operations, settings, issues, and activity channels, reached over its unix
+socket and nothing else — #855 removed its HTTP/SSE transport too. It does
 not own or kill Hosted PTY children.
 
 **Orchestrator** — framework-free Task/Worktree state owned by the Daemon.

--- a/docs/API.md
+++ b/docs/API.md
@@ -137,7 +137,7 @@ replacement in `nextCommandArgs`.
 - `get-task --task-id <id>`: one task's metadata; `.running` = any of its
   hosted engine tabs is live (not just the first); `.tabs` = the task's
   terminal tabs (`id`/`kind`/`title`/`vendor`/`liveVendor`/`lastTitle`/
-  `autoTitle`/`sessionId` + per-tab `alive`): the discovery read for
+  `autoTitle`/`sessionId` + per-tab `alive`/`engineAlive`): the discovery read for
   `send --tab tab-N`. `sessionId` is the conversation the tab pinned — the
   exact id `claude --resume <id>` (or the engine's own resume verb) reopens,
   and the one `send --tab tab-N --respawn` brings back. Present on engine
@@ -147,6 +147,17 @@ replacement in `nextCommandArgs`.
   engine actually runs in the tab's shell right now. A hand-typed `claude`
   in a shell tab counts, a ctrl+C'd engine doesn't); dead tabs report the
   last recorded value.
+  `alive` and `engineAlive` answer different questions and a fleet reader
+  needs both: `alive` is the tab's hosted PTY SESSION, `engineAlive` is
+  whether an ENGINE PROCESS is running inside that session's tree. keepAlive
+  `exec`s a login shell where an engine exits, so `alive: true,
+  engineAlive: false` is a tab holding a bare zsh prompt — the per-tab form
+  of the session-outlives-its-engine hazard described under `collect`'s
+  `.running` below, and the field that settles it in one read instead of a
+  `collect` hop or your own `ps` walk. Both are three-valued: `null` means
+  nothing walked the tab (a `ps` that failed, a pty host that could not be
+  asked), which is "couldn't look" and never a verdict. **Never read `null`
+  as `false`** — the same rule `.running` states, for the same reason.
   A dead tab whose session ended abnormally also carries `exit`
   (`code`/`signal`/`at`); clean exits stay `exit: null`. A live PTY session
   the persisted snapshot does not list still gets a row, marked
@@ -321,6 +332,16 @@ replacement in `nextCommandArgs`.
 
   `--command` picks the engine (an id from `engine-list`, or a full command
   line). Omitted, the repo's default engine is used.
+
+  `--repo` accepts paths `rove add` refuses — a checkout under `.scratch/`,
+  `.dev-sandbox/` or `$TMPDIR` gets a task here and gets
+  `cannot be a project — inside a sandbox or scratch directory` there. The
+  two verbs ask different questions: `rove add` registers a PROJECT, and the
+  eligibility gate exists to stop throwaway checkouts becoming permanent
+  sidebar rows. `add --repo` creates a TASK, and the same gate still runs —
+  it just skips minting the project row and the `savedRepos` entry instead
+  of failing the call. So the task appears under a header derived from its
+  own repo, and disappears with it.
 
 A create issued from inside a Rove engine tab records
 the caller as the new task's `dispatcher` (`{taskId, tabId}` from

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -89,13 +89,16 @@ rove api inspect --task-id <task-id> --pretty
 PTY sessions, persisted tab snapshots, and durable abnormal-exit records, so
 it is the best first attachment for a badge, label, or engine-crash report.
 `rove doctor --report` writes a bundle containing the same diagnosis plus
-recent logs and environment details.
+recent logs and environment details. It lands at
+`~/.rove/rove-doctor-report.txt` — beside the logs it quotes, and the same
+path wherever you ran the command from, so it never drops an untracked file
+into the repo you were debugging.
 
 The raw logs live under the active Rove home (normally your OS home):
 
 | Path | Contains |
 |---|---|
-| `~/.rove/daemon.log` | daemon startup, crashes, RPC and web-transport failures, task-deletion audit |
+| `~/.rove/daemon.log` | daemon startup, crashes, RPC failures, task-deletion audit |
 | `~/.rove/pty.log` | Hosted PTY startup and session-host failures |
 | `~/.rove/client.log` | TUI/pane connection, disconnect, and reconnect diagnostics |
 

--- a/packages/kobe/src/cli/doctor-report.ts
+++ b/packages/kobe/src/cli/doctor-report.ts
@@ -16,8 +16,8 @@
  * unit-testable without touching disk.
  */
 
-import { readFileSync, writeFileSync } from "node:fs"
-import { join } from "node:path"
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs"
+import { dirname, join } from "node:path"
 import { defaultDaemonLogPath, defaultPtyHostLogPath } from "@sma1lboy/kobe-daemon/daemon/paths"
 
 /**
@@ -117,9 +117,24 @@ export function buildReportBundle(
   ].join("\n")
 }
 
-/** Write the bundle to `rove-doctor-report.txt` in the cwd; return its path. */
+/**
+ * Write the bundle next to the logs it quotes — `<home>/.rove/`, the
+ * directory `defaultDaemonLogPath()` already resolves, so the report cannot
+ * drift away from the `daemon.log` / `pty.log` it tails and it inherits the
+ * same `ROVE_HOME_DIR` override for free. Returns its path.
+ *
+ * It used to land in `process.cwd()`. The instruction we give users is "run
+ * `rove doctor --report` and attach the file", and they run it where the
+ * trouble is — inside their repo, which is where it landed, untracked and
+ * matched by no `.gitignore`. That is a bug bundle full of daemon logs and
+ * env one reflexive `git add -A` away from a commit. A fixed home-rooted
+ * path is also the same path every time, which is what makes the printed
+ * location worth reading out over chat.
+ */
 export function writeReportBundle(doctorLines: readonly string[]): string {
-  const path = join(process.cwd(), "rove-doctor-report.txt")
+  const dir = dirname(defaultDaemonLogPath())
+  mkdirSync(dir, { recursive: true })
+  const path = join(dir, "rove-doctor-report.txt")
   writeFileSync(
     path,
     buildReportBundle(doctorLines, {

--- a/packages/kobe/test/cli/doctor-cmd.test.ts
+++ b/packages/kobe/test/cli/doctor-cmd.test.ts
@@ -232,15 +232,21 @@ describe("runDoctorSubcommand", () => {
     expect(output()).toContain("the PTY host process is alive but its socket is unreachable (wedged)")
   })
 
-  it("--report writes a bundle file and points the user at it", async () => {
+  // The cwd is mocked to a DIFFERENT directory than the home on purpose: the
+  // bundle landing in the user's repo (untracked, gitignored nowhere, full of
+  // logs and env) is the regression, so "not in the cwd" is half the contract
+  // and asserting only the home path would pass with both writes happening.
+  it("--report writes the bundle under the Rove home, never the cwd", async () => {
     mocks.request.mockRejectedValue(new Error("not running"))
-    const cwdSpy = vi.spyOn(process, "cwd").mockReturnValue(home)
+    const cwd = mkdtempSync(join(tmpdir(), "rove-doctor-cwd-"))
+    const cwdSpy = vi.spyOn(process, "cwd").mockReturnValue(cwd)
 
     await runDoctorSubcommand(["--report"])
 
-    expect(output()).toContain("report written:")
-    expect(existsSync(join(home, "rove-doctor-report.txt"))).toBe(true)
-    const bundle = readFileSync(join(home, "rove-doctor-report.txt"), "utf8")
+    const reportPath = join(home, ".rove", "rove-doctor-report.txt")
+    expect(output()).toContain(`report written: ${reportPath}`)
+    expect(existsSync(join(cwd, "rove-doctor-report.txt"))).toBe(false)
+    const bundle = readFileSync(reportPath, "utf8")
     expect(bundle).toContain("# Rove doctor report")
     expect(bundle).toContain("## diagnosis")
     cwdSpy.mockRestore()


### PR DESCRIPTION
Batches 3, 4 and 5 of `.scratch/loop-r19-docs/docs.md`. Batches 1 and 2 belong to
another worker; `store.ts`, `export-cmd.ts`, `orchestrator-bridge.ts` and the
Codex effort levels are untouched.

**Everything below was run from source** (`bun packages/kobe/src/cli/rove.ts`,
reports `rove 0.9.141`) against an isolated home under
`.scratch/loop-r19-bg/home`, port base 7911. The `rove` on PATH is 0.9.105 and
was never used for a measurement. Wrapper: `.scratch/loop-r19-bg/r.sh`.

Evidence outside `.scratch/`, left in place:

| File | What it holds |
|---|---|
| `/Users/jacksonc/tmp-r19bg-evidence/batch3-before.txt` | live `get-task` tabs + the BEFORE grep |
| `/Users/jacksonc/tmp-r19bg-evidence/batch4-before.txt` | the report landing in a repo, `git status`, `check-ignore` |
| `/Users/jacksonc/tmp-r19bg-evidence/batch5a-before.txt` | `rove web` unknown, daemon has no HTTP server |
| `/Users/jacksonc/tmp-r19bg-evidence/batch5d-add-vs-api-add.txt` | `rove add` rejects, `api add --repo` accepts |
| `/Users/jacksonc/tmp-r19bg-evidence/after-all.txt` | every PASS criterion, after |
| `/Users/jacksonc/tmp-r19bg-evidence/not-done-cli-md-blocked.txt` | the two items I did not change, with their measurements |

No `/harness` screenshots: nothing here renders. Three of the four items are
prose in `docs/`, and the fourth changes where a CLI writes a text file — a
screenshot of a terminal would be a worse artifact than the pasted output, which
is what this task's own proof standard asks for.

---

## Batch 3 — `get-task` publishes `engineAlive`, the docs never named it

**PASS criterion.** `grep -n engineAlive docs/API.md` returns a line in the
`get-task` bullet that also spells out the `null` case.

**The claim** (`docs/API.md:139-140`, before): `.tabs` = `id`/`kind`/`title`/
`vendor`/`liveVendor`/`lastTitle`/`autoTitle`/`sessionId` **+ per-tab `alive`**.

**What actually comes back** — a task whose tab-2 outlived its engine, live from
this build:

```json
{ "id": "tab-2", "kind": "engine", "vendor": "generic", "liveVendor": null,
  "alive": true, "engineAlive": false, "exit": null }
```

**One correction to the brief.** `grep -rn engineAlive docs/` no longer returns
nothing — #886 landed today and the word now appears once, at `docs/API.md:229`,
inside `collect`'s `.exit`/`layer` prose. That makes the finding sharper rather
than weaker: the page *uses* `engineAlive` to explain a death record while never
declaring it as a field of the shape it enumerates four sections up. A reader
who greps for it lands in the middle of an explanation of something else.

**Doc or code? Doc.** The field is deliberate, three-valued, and documented in
source (`packages/kobe/src/cli/api/tab-snapshot.ts:58-63`). I treated the code
as the promise.

**After** — `docs/API.md:150-161`, carrying the same `null` rule `.running` gets:

```
$ grep -n "engineAlive" docs/API.md
140:  `autoTitle`/`sessionId` + per-tab `alive`/`engineAlive`): the discovery read for
150:  `alive` and `engineAlive` answer different questions and a fleet reader
151:  needs both: `alive` is the tab's hosted PTY SESSION, `engineAlive` is
154:  engineAlive: false` is a tab holding a bare zsh prompt — the per-tab form
229:    whose SESSION IS STILL ALIVE (`alive: true, engineAlive: false` — the
```

---

## Batch 4 — `doctor --report` dropped a bug bundle in your repo

**The three options, and which I took.** The brief asked for options plus the
one that is safe under every reading. I implemented **option 2** and did not
implement 1 or 3:

| | Option | Why not / why |
|---|---|---|
| 1 | Document that it lands in the CWD | Cheapest, keeps the hazard. The file is daemon logs + env, untracked and un-ignored, one `git add -A` from a commit. Documenting a footgun is not defusing it. |
| 2 | **Write it under `<home>/.rove/`** | **Taken.** Never a user's repo under any reading. Lands beside the `daemon.log`/`pty.log` it quotes, inherits `ROVE_HOME_DIR` for free, and is the same path every time — which is what makes the printed location worth reading out over chat. |
| 3 | Keep CWD, add the name to this repo's `.gitignore` | Fixes exactly one repo. Every other repo a user runs it in still gets the file. Rejected on its own, and made moot by 2. |

**BEFORE** (`batch4-before.txt`), run from inside a git repo:

```
report written: /Users/jacksonc/tmp-r19bg-probe/rove-doctor-report.txt

$ git status --short
?? rove-doctor-report.txt

$ git check-ignore -v rove-doctor-report.txt; echo exit=$?
exit=1                       # no match — not ignored
```

**AFTER**, same repo, same command:

```
report written: …/.scratch/loop-r19-bg/home/.rove/rove-doctor-report.txt

$ git status --short
                             # empty — PASS
```

The path is under the isolated home, so the move honours `ROVE_HOME_DIR`
(it reuses `dirname(defaultDaemonLogPath())` rather than adding new env
plumbing that could drift from the logs it bundles).

**Test, mutation-verified.** The existing test mocked `process.cwd()` to the
home directory, so it would have passed either way. It now mocks the cwd to a
*different* directory and asserts both halves — the bundle is at the home path,
and `<cwd>/rove-doctor-report.txt` does not exist:

```
=== MUTATION (writeReportBundle reverted to process.cwd()) ===
 FAIL  test/cli/doctor-cmd.test.ts > --report writes the bundle under the Rove home, never the cwd
   → expected 'Rove doctor\n  build:  v0.9.141 (darw…' to contain 'report written: /var/folders/dg/bl1p3…'
      Tests  1 failed | 11 passed (12)
=== RESTORED ===
      Tests  12 passed (12)
```

`docs/TROUBLESHOOTING.md:91` now states the location. `docs/CLI.md:305-306` says
`--report` "writes a bug bundle … and prints its path", which stays true
unchanged — no CLI.md edit was needed for this item.

---

## Batch 5a — `CONTEXT.md:47` described a command removed in 0.9.139

```
$ rove web
rove: unknown command 'web'

$ git grep -nE 'Bun\.serve|createServer|node:http' -- packages/kobe-daemon/src
packages/kobe-daemon/src/daemon/pty-server.ts:27:import { … createServer } from "node:net"
packages/kobe-daemon/src/daemon/server.ts:8:import { … createServer } from "node:net"
```

Only `node:net`. **Code is right; the sentence was stale.** The glossary entry
now describes what actually survived #855 — the harness sidecar
(`packages/kobe-harness/pty-server.mjs`, bearer-token gate in `pty-auth.mjs`) —
and names #855 so the next reader does not re-derive this.

**One line past what the brief named, same removal:** `CONTEXT.md:55` listed
"browser transport" among the daemon's responsibilities and
`docs/TROUBLESHOOTING.md:98` listed "web-transport failures" in `daemon.log`'s
contents. Both are the same deleted thing, both proven stale by the git grep
above, both fixed here. `docs/agents/domain.md:24` also mentions ADR-0003 but as
a worked example of writing a contradiction note — left alone.

---

## Batch 5d — `rove add` and `rove api add` disagree about scratch paths

```
$ rove add …/.scratch/loop-r19-bg/repo
rove add: "…" cannot be a project — inside a sandbox or scratch directory
exit=1

$ rove api add --repo …/.scratch/loop-r19-bg/repo --title scratchprobe
{"taskId":"01M1PTTVT0YX8ZA7DGZ4A6CY6C", …, "started":false}
exit=0
```

**It is intentional, and I found the mechanism rather than stopping at the
observation.** Reading the isolated home back afterwards:

```
$ savedRepos            -> ['/Users/jacksonc/tmp-r19bg-probe']
$ tasks.json
main | tmp-r19bg-probe | /Users/jacksonc/tmp-r19bg-probe
task | bgprobe          | /Users/jacksonc/tmp-r19bg-probe
task | scratchprobe     | …/.scratch/loop-r19-bg/repo
```

The scratch repo got a **task** and no `main` row and no `savedRepos` entry.
The gate governs what may become a PROJECT, and
`ensureIfEligible` (`orchestrator/main-task.ts:78`) returns `null` instead of
throwing — so `api add --repo` still runs the gate and merely skips minting the
permanent row. `rove add`, whose entire job is registering a project, has
nothing left to do and fails. **Code is right; both sides were undocumented.**
One paragraph added under `add` in `docs/API.md`.

---

## Not done — and why

**5c. `rove update`'s two help texts disagree.** Measured, unchanged:

```
$ rove --help | grep update
  update [version|channel|list]   Self-update rove, switch channel, or list versions
$ rove update --help | head -1
Usage: rove update [version|channel|list|dry-run]
$ grep -n 'update \[version' docs/CLI.md
101:  update [version|channel|list]   Self-update rove, switch channel, or list versions
```

The fix is `usage.ts:42` **plus** `docs/CLI.md:101`, because CLI.md's
`## All commands` block is byte-identical to `rove --help` and that byte-identity
is one of this task's measured negatives. This batch is under an explicit "do not
touch `CLI.md`" boundary, and shipping only the code half would knowingly break
the identity the negative certifies. So I left both. Two-line patch for whoever
gets the go-ahead: add `|dry-run` to `usage.ts:42` and to `docs/CLI.md:101`.

**5b. `CLI.md`'s env table — no defect. The report is wrong on this one.**
`docs/CLI.md:25` already documents both variables, in prose, in the bootstrap
section:

> `ROVE_BUN` names the Bun binary to use, `ROVE_NO_BUN_BOOTSTRAP=1` turns a
> missing Bun into a plain error instead of an install offer

and a third the table also omits, `ROVE_SKIP_BUN_CHECK=1`. The omission is
structural, not an oversight: the table's own preamble defines its scope as the
`ROVE_*`/`KOBE_*` alias pairs ("`ROVE_HOME_DIR` beats `KOBE_HOME_DIR` … and so
on for the whole table"), and none of the three bootstrap variables has a
`KOBE_*` alias —

```
$ grep -rn "KOBE_BUN|KOBE_NO_BUN_BOOTSTRAP|KOBE_SKIP_BUN_CHECK" packages/ bin/
(no matches)
```

They also cannot be runtime knobs: they are read by the launcher before a Bun
exists. Adding them to a table that promises an alias for every row would make
the page less true, not more. Recommend closing this one as measured-correct.

---

## Gates

```
$ bun run lint        # repo root
Checked 1451 files in 279ms. No fixes applied.

$ bun run typecheck
@sma1lboy/rove-plugin-sdk build: Exited with code 0
@sma1lboy/kobe-daemon typecheck: Exited with code 0
@sma1lboy/rove typecheck: Exited with code 0
@sma1lboy/rove-plugin-sdk typecheck: Exited with code 0

$ env -u ROVE_INVOKED_AS bun run test:fast      # packages/kobe
 Test Files  456 passed (456)
      Tests  4517 passed (4517)
```

No file crossed the 500-line cap; `doctor-report.ts` is 148 lines.

## Cleanup

Isolated daemon **and** PTY host stopped, checked by the socket they hold rather
than by argv. Scratch git repo left at `/Users/jacksonc/tmp-r19bg-probe` for
anyone re-running this; delete when done.
