### PR TITLE
The store warns you about a story, then deletes it; the board hides a backlog that exists (A1–A2, B1–B2)

### DIFF
--- a/.changeset/store-keeps-what-it-warns-about.md
+++ b/.changeset/store-keeps-what-it-warns-about.md
@@ -1,0 +1,38 @@
+---
+"@sma1lboy/rove": patch
+---
+
+The issue store keeps the story it warns you about, and the Kanban board stops
+losing a backlog when the task that made it ends
+
+`skipped` used to document a recovery window one mutation wide. A read that met
+an entry whose `id` was not a number dropped it, counted it honestly, and logged
+the repo — then the next write re-emitted only what it had parsed, so one
+unrelated `issue-set-status` on a different story erased the unreadable one from
+disk. Reads still skip; writes now carry those raw entries through untouched, so
+the warning describes something you can still go and fix.
+
+The same read met a record whose `issues` was an object and reported `skipped:
+0` — the one value the field documents as "you have it all" — after dropping
+every story in it. It now counts them, and a write aimed at that repo refuses
+with `ISSUE_STORE_UNREADABLE`, naming the file and the repo, instead of
+persisting the emptiness on the next `issue-create`. A write to a sibling repo
+in the same file round-trips the unreadable record whole. A syntactically broken
+store keeps failing loudly and leaving the file byte-for-byte intact; its error
+now names the path.
+
+The Kanban board derived its project sections from live tasks, so the ordinary
+end of the loop — land the work, delete the task — took the whole backlog off
+screen and left the page saying "No projects yet — create a task first", with
+the stories still on disk. A story filed with `issue-create --repo <path>` into
+a repo that never had a task was invisible from the moment it was filed. Sections
+now come from every repo that can have a backlog: the ones the issue store holds
+a record for (a new `issue.repos` read), your saved projects, and the repos of
+live tasks. The empty-state line now says how to get a project instead of naming
+tasks as the only route.
+
+An issue whose own status is `doing` lands in In progress. The board bucketed it
+with `open`, so the documented `open → doing → done` step moved no card, and the
+story drawer's "project" placement — which writes exactly that status and links
+no task — left the card in Backlog while its engine ran. The link is still the
+other way in, and is still what `--task none` reverses.

--- a/docs/HARNESS.md
+++ b/docs/HARNESS.md
@@ -206,7 +206,8 @@ only its beats. `--encode-only` re-encodes the take already on disk.
   transcript, and so the framing, to differ every run. Seeding is idempotent:
   a re-shoot reuses the sessions it already paid quota for.
 - **The kanban capture is the exception: no engine, fully deterministic.** A
-  card reaches In progress by being LINKED to a task, so `hero-issues.ts`
+  card reaches In progress by being LINKED to a task or by its own `doing`
+  status; the take is about the link, so `hero-issues.ts`
   seeds the board off the fixture's idle tasks, and `hero-kanban.ts` fires a
   real `rove api issue-update --task` mid-take to move a card on camera. It
   files a story and creates a task, so it is NOT idempotent — re-shoot from

--- a/docs/TUI.md
+++ b/docs/TUI.md
@@ -439,12 +439,16 @@ workspace. The chords stay live, so you can hop between pages directly.
 ![The Kanban board: Backlog, In progress and Done for one project, with the card cursor on an in-progress story](assets/kanban.png)
 
 The [issue store](CONCEPTS.md#the-issue-store) as a board, one project at a
-time (`tab` cycles projects). Four columns:
+time (`tab` cycles projects). A project gets a section if it can hold a
+backlog at all — the issue store has a record for it, you saved it as a
+project, or a live task runs in it — so deleting the task you finished leaves
+its stories on the board. Four columns:
 
-- **Backlog.** Open or doing, not linked to a task.
-- **In progress.** Linked to a task. The link *is* the column: agents move
-  cards with `rove api issue-update --task`, and in-progress cards show the
-  linked task's live engine activity.
+- **Backlog.** Status `open`, not linked to a task.
+- **In progress.** Status `doing`, or linked to a task. Either route works:
+  agents move cards with `rove api issue-update --task`, a session started
+  from the drawer sets `doing`, and in-progress cards show the linked task's
+  live engine activity when there is a task to read it from.
 - **Parked.** Status `hold`, linked or not; sits between In progress and
   Done.
 - **Done.** Status `done`.

--- a/packages/kobe-daemon/src/daemon/handlers-issues.ts
+++ b/packages/kobe-daemon/src/daemon/handlers-issues.ts
@@ -13,6 +13,12 @@ export const ISSUE_HANDLERS: readonly DaemonRequestHandler[] = [
     },
   },
   {
+    name: "issue.repos",
+    async handle(_payload, ctx) {
+      return { repos: await ctx.issues.repos() }
+    },
+  },
+  {
     name: "issue.mutate",
     async handle(payload, ctx) {
       const repoRoot = requireString(payload, "repoRoot")

--- a/packages/kobe-daemon/src/daemon/issues-store.ts
+++ b/packages/kobe-daemon/src/daemon/issues-store.ts
@@ -23,6 +23,14 @@ export const ISSUE_STATUSES: readonly IssueStatus[] = ["open", "doing", "hold", 
  */
 const ISSUE_NOT_FOUND_CODE = "ISSUE_NOT_FOUND"
 
+/**
+ * Same wire trick for "this repo's record is shaped in a way this read did not
+ * understand at all". Reads stay soft (the entries are counted into
+ * {@link RepoIssues.skipped}); WRITES refuse, because a whole-file write can
+ * only re-emit what it parsed, and everything it did not parse would be gone.
+ */
+const ISSUE_STORE_UNREADABLE_CODE = "ISSUE_STORE_UNREADABLE"
+
 export interface Issue {
   id: number
   title: string
@@ -51,6 +59,19 @@ interface RepoIssueRecord {
   repoRoot: string
   nextId: number
   issues: Issue[]
+  /**
+   * Raw `issues` entries {@link normalizeIssue} rejected, kept verbatim and
+   * re-emitted by {@link serializeRecord} on every write. A normalizing read
+   * feeding a whole-file write used to ERASE from disk what it merely could
+   * not list, so `skipped` documented a recovery window one mutation wide.
+   */
+  unusable: readonly unknown[]
+  /**
+   * The record's `issues` was not an array, so this read parsed NOTHING here.
+   * Holds the whole original record so a write triggered by a sibling repo
+   * round-trips it untouched; a write aimed at THIS repo refuses instead.
+   */
+  unreadable?: { readonly raw: unknown }
 }
 
 interface IssuesStoreFile {
@@ -146,6 +167,43 @@ async function resolveRepo(raw: unknown): Promise<{ repoRoot: string; repoKey: s
   }
 }
 
+/** How many stories a non-array `issues` is hiding — the values of a map-shaped
+ *  record, else the one value we cannot count into. Never `0`: `skipped: 0` is
+ *  the single value {@link RepoIssues.skipped} documents as "you have it all". */
+function unreadableCount(raw: unknown): number {
+  if (raw !== null && typeof raw === "object" && !Array.isArray(raw)) return Math.max(1, Object.keys(raw).length)
+  return 1
+}
+
+function readRecord(value: object): { record: RepoIssueRecord; dropped: number } {
+  const record = value as Partial<RepoIssueRecord> & { issues?: unknown }
+  const base = {
+    repoRoot: typeof record.repoRoot === "string" ? record.repoRoot : "",
+    nextId: typeof record.nextId === "number" ? record.nextId : 1,
+  }
+  if (record.issues !== undefined && !Array.isArray(record.issues)) {
+    // `entries = []` used to make `dropped` come out `0` here — the read had
+    // thrown away every story and reported the value that means it threw away
+    // none. Then the next write persisted the emptiness.
+    return {
+      record: { ...base, issues: [], unusable: [], unreadable: { raw: value } },
+      dropped: unreadableCount(record.issues),
+    }
+  }
+  const entries: readonly unknown[] = Array.isArray(record.issues) ? record.issues : []
+  const issues = entries.map(normalizeIssue).filter((issue): issue is Issue => issue !== null)
+  const unusable = entries.filter((entry) => normalizeIssue(entry) === null)
+  return {
+    record: {
+      repoRoot: base.repoRoot,
+      nextId: typeof record.nextId === "number" ? record.nextId : nextIdFallback(entries),
+      issues,
+      unusable,
+    },
+    dropped: unusable.length,
+  }
+}
+
 async function readStore(path: string): Promise<StoreRead> {
   try {
     const raw = JSON.parse(await readFile(path, "utf8")) as Partial<IssuesStoreFile>
@@ -154,38 +212,43 @@ async function readStore(path: string): Promise<StoreRead> {
     if (raw.repos && typeof raw.repos === "object") {
       for (const [key, value] of Object.entries(raw.repos)) {
         if (!value || typeof value !== "object") continue
-        const record = value as Partial<RepoIssueRecord>
-        const entries: readonly unknown[] = Array.isArray(record.issues) ? record.issues : []
-        const issues = entries.map(normalizeIssue).filter((issue): issue is Issue => issue !== null)
+        const { record, dropped } = readRecord(value)
         // Dropping silently is what made a filed story stop existing in every
         // read while still sitting in the file. Count it here so `list` can
         // say so, and log it so the daemon log names the repo.
-        const dropped = entries.length - issues.length
         if (dropped > 0) {
           skipped.set(key, dropped)
+          const why = record.unreadable ? '"issues" is not an array' : "id is not a number"
           logDaemonError(
             "issues-store-read",
-            new Error(
-              `${key}: dropped ${dropped} unreadable issue entr${dropped === 1 ? "y" : "ies"} (id is not a number)`,
-            ),
+            new Error(`${key}: dropped ${dropped} unreadable issue entr${dropped === 1 ? "y" : "ies"} (${why})`),
           )
         }
-        repos[key] = {
-          repoRoot: typeof record.repoRoot === "string" ? record.repoRoot : "",
-          nextId: typeof record.nextId === "number" ? record.nextId : nextIdFallback(entries),
-          issues,
-        }
+        repos[key] = record
       }
     }
     return { file: { version: 1, repos }, skipped }
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code === "ENOENT") return { file: emptyStore(), skipped: new Map() }
-    throw err
+    // A syntactically broken store already fails loudly and leaves the file
+    // intact — but the CLI envelope showed only the parser's complaint, which
+    // names neither the file nor the repo, so an agent could not say which
+    // store to open.
+    throw new Error(`${path}: ${err instanceof Error ? err.message : String(err)}`)
   }
 }
 
+/** File shape for one record: the issues this read understood, followed by the
+ *  raw entries it did not. An unreadable record round-trips whole. */
+function serializeRecord(record: RepoIssueRecord): unknown {
+  if (record.unreadable) return record.unreadable.raw
+  return { repoRoot: record.repoRoot, nextId: record.nextId, issues: [...record.issues, ...record.unusable] }
+}
+
 async function writeStore(path: string, store: IssuesStoreFile): Promise<void> {
-  await writeJsonAtomic(path, store)
+  const repos: Record<string, unknown> = {}
+  for (const [key, record] of Object.entries(store.repos)) repos[key] = serializeRecord(record)
+  await writeJsonAtomic(path, { version: store.version, repos })
 }
 
 function response(repoRoot: string, record: RepoIssueRecord | null, skipped = 0): RepoIssues {
@@ -206,11 +269,28 @@ export class IssuesStore {
     return serialized(this.path, async () => {
       const { file: store, skipped } = await readStore(this.path)
       const record = store.repos[repoKey] ?? null
-      if (record && record.repoRoot !== repoRoot) {
+      if (record && !record.unreadable && record.repoRoot !== repoRoot) {
         record.repoRoot = repoRoot
         await writeStore(this.path, store)
       }
       return response(repoRoot, record, skipped.get(repoKey) ?? 0)
+    })
+  }
+
+  /**
+   * Every repo root this store holds a record for. The board derived its
+   * sections from the TASK index, so landing the work and deleting the task —
+   * the ordinary end of the loop — took the whole backlog off screen, and a
+   * story filed with `issue-create --repo <path>` into a repo that never had a
+   * task was invisible from the moment it was filed. A repo the store knows
+   * about is a repo with a backlog; that is what a board section means.
+   */
+  async repos(): Promise<readonly string[]> {
+    return serialized(this.path, async () => {
+      const { file } = await readStore(this.path)
+      return Object.values(file.repos)
+        .map((record) => record.repoRoot)
+        .filter((root) => root.length > 0)
     })
   }
 
@@ -274,8 +354,18 @@ export class IssuesStore {
       const { file: store, skipped } = await readStore(this.path)
       let record = store.repos[repoKey]
       if (!record) {
-        record = { repoRoot, nextId: 1, issues: [] }
+        record = { repoRoot, nextId: 1, issues: [], unusable: [] }
         store.repos[repoKey] = record
+      }
+      if (record.unreadable) {
+        // Every write here is a whole-file write of what the read produced.
+        // This record produced nothing, so applying the op would replace the
+        // stories still in the file with just the op's result. Naming the file
+        // and the repo is the difference between a refusal an agent can act on
+        // and one it can only report.
+        throw new Error(
+          `${ISSUE_STORE_UNREADABLE_CODE}: ${repoRoot}'s record in ${this.path} has a non-array "issues" — refusing to write over stories this build cannot read`,
+        )
       }
       record.repoRoot = repoRoot
       const typed = op as IssueOp

--- a/packages/kobe-daemon/src/daemon/protocol.ts
+++ b/packages/kobe-daemon/src/daemon/protocol.ts
@@ -117,6 +117,9 @@ export type DaemonRequestName =
   | "task.ensureWorktree"
   | "task.setActive"
   | "issue.list"
+  // Repo roots the issue store holds a record for — a board section means
+  // "this repo has a backlog", which the task index cannot answer.
+  | "issue.repos"
   | "issue.mutate"
   | "worktree.discoverAdoptable"
   | "worktree.adopt"

--- a/packages/kobe/src/client/remote-orchestrator-writes.ts
+++ b/packages/kobe/src/client/remote-orchestrator-writes.ts
@@ -357,6 +357,15 @@ export async function listIssuesOp(client: KobeDaemonClient, repoRoot: string): 
   return client.request<RepoIssues>("issue.list", { repoRoot })
 }
 
+/** Repo roots the issue store holds a record for (`issue.repos`) — the kanban
+ *  page's board source. A repo with a backlog is a board section; deriving the
+ *  set from the task index instead made a landed-and-deleted task take its
+ *  whole backlog off screen. */
+export async function listIssueReposOp(client: KobeDaemonClient): Promise<readonly string[]> {
+  const res = await client.request<{ repos?: readonly string[] }>("issue.repos", {})
+  return res.repos ?? []
+}
+
 /** A repo's durable field notes, newest first (`note.list`) — the sidebar's
  *  project-row reader. Same wire shape `state/field-notes.ts` reads at launch,
  *  but through the daemon so the reader sees the whole live store (50), not

--- a/packages/kobe/src/client/remote-orchestrator.ts
+++ b/packages/kobe/src/client/remote-orchestrator.ts
@@ -437,6 +437,12 @@ export class RemoteOrchestrator {
     return writes.listIssuesOp(this.client, repoRoot)
   }
 
+  /** Repo roots the issue store knows (`issue.repos`) — the kanban page's
+   *  board source, see {@link writes.listIssueReposOp}. */
+  listIssueRepos(): Promise<readonly string[]> {
+    return writes.listIssueReposOp(this.client)
+  }
+
   /** One issue-store mutation (`issue.mutate`) — the kanban detail drawer's
    *  write path (link on start, setStatus for the project placement). */
   mutateIssue(repoRoot: string, op: unknown): Promise<RepoIssues> {

--- a/packages/kobe/src/state/issue-board.ts
+++ b/packages/kobe/src/state/issue-board.ts
@@ -6,10 +6,15 @@
  *   - Done        — terminal disposition (wins over a stale task link).
  *   - Parked      — parked disposition (`hold` / unknown): work stopped on
  *                   purpose, worktree preserved — linked or not.
- *   - In progress — the issue is linked to a task (`taskId` set = started).
- *   - Backlog     — everything else (open / doing / unlinked).
+ *   - In progress — the issue says so (`doing`) OR it is linked to a task
+ *                   (`taskId` set = started).
+ *   - Backlog     — everything else (open / unlinked).
  * `in_progress` is DERIVED from the link, not stored — `kobe api issue-update
- * --task <id>` is the "move card" gesture, `--task none` moves it back.
+ * --task <id>` is the "move card" gesture, `--task none` moves it back. The
+ * link is not the ONLY route in: `doing` is the issue's own lifecycle step
+ * (`docs/WORK-TRACKING.md`: open → doing → done) and reading it needs no task
+ * at all, which is what the board's `project` placement — a session that runs
+ * on the main checkout with no task to link — depends on to move its card.
  */
 
 import type { Issue } from "@sma1lboy/kobe-daemon/daemon/issues-store"
@@ -91,6 +96,10 @@ export function issueColumnKey(issue: Issue, taskExists?: (taskId: string) => bo
   if (disposition === "terminal") return "done"
   if (disposition === "parked") return "parked"
   if (issue.taskId !== undefined && issue.taskId !== "" && (taskExists?.(issue.taskId) ?? true)) return "in_progress"
+  // The issue's own "I picked this up". Unlinked `doing` used to be
+  // indistinguishable from `open`, so the documented open → doing step moved
+  // no card and an agent that followed it watched its story sit in Backlog.
+  if (issue.status === "doing") return "in_progress"
   return "backlog"
 }
 

--- a/packages/kobe/src/tui-react/component/use-kanban-boards.ts
+++ b/packages/kobe/src/tui-react/component/use-kanban-boards.ts
@@ -1,8 +1,16 @@
 /**
- * Kanban board loading — the data half of `kanban-page.tsx`: fetch every saved
- * repo's issue file, poll it while the page is open, and land the initial
- * project/card cursor. Rendering, key handling, and mutations stay in the
- * page.
+ * Kanban board loading — the data half of `kanban-page.tsx`: fetch the issue
+ * file of every repo that can have a backlog, poll it while the page is open,
+ * and land the initial project/card cursor. Rendering, key handling, and
+ * mutations stay in the page.
+ *
+ * "Can have a backlog" is three sources unioned, because no one of them is the
+ * whole set: the STORE's own repo keys (`issue.repos` — a story filed with
+ * `issue-create --repo <path>` reaches a repo that may have no task and no
+ * saved-project entry), the user's SAVED projects (an empty board you can file
+ * into), and the repos of LIVE tasks. Deriving the set from tasks alone was
+ * the bug: landing the work and deleting the task — the ordinary end of the
+ * loop — dropped every card, and the page then said "No projects yet".
  *
  * The seam is IO: this is the only part that talks to the orchestrator, so the
  * page's own logic never has to reason about a poll landing mid-interaction.
@@ -12,6 +20,8 @@ import type { RepoIssues } from "@sma1lboy/kobe-daemon/daemon/issues-store"
 import { useEffect, useState } from "react"
 import type { RemoteOrchestrator } from "../../client/remote-orchestrator"
 import { errorMessage } from "../../lib/error-message"
+import { isRemoteRepoKey } from "../../state/remote-repos"
+import { getSavedRepos } from "../../state/repos"
 
 /** Agent moves land within one poll; issue.list is a local JSON read, so
  *  polling while the page is open is cheap. */
@@ -63,43 +73,54 @@ export function useKanbanBoards(args: {
       setBoards([])
       return
     }
-    const repos = [...new Set(orchestrator.listTasks().map((task) => task.repo))]
-    void Promise.all(
-      repos.map((repo) =>
-        orchestrator.listIssues(repo).catch(
-          (err: unknown): KanbanBoardEntry => ({
-            // A rejected read still owns its section. `exists: false` here is
-            // NOT the empty-board case below — `readError` is what separates
-            // "no issue file yet" from "could not read the issue file".
-            repoRoot: repo,
-            exists: false,
-            nextId: 1,
-            issues: [],
-            skipped: 0,
-            readError: errorMessage(err),
-          }),
-        ),
-      ),
-    ).then((results) => {
-      if (disposed) return
-      // A repo whose issue file doesn't exist yet still gets a section —
-      // `exists: false` just means an empty board, not an error.
-      const next = [...results]
-      next.sort((a, b) => a.repoRoot.localeCompare(b.repoRoot))
-      setBoards(next)
-      // First load lands on the focus task's project (opened via `c` on a
-      // task row) or, without one, the project you opened kobe in — the
-      // active task's repo (loose realpath tolerance, like WorktreesPage).
-      const norm = (p: string): string => p.replace(/^\/private\//, "/").replace(/\/+$/, "")
-      const activeId = orchestrator.activeTaskSignal().get()
-      const targetRepo = focusTask?.repo ?? orchestrator.listTasks().find((task) => task.id === activeId)?.repo
-      const initialBoard = targetRepo ? next.find((board) => norm(board.repoRoot) === norm(targetRepo)) : undefined
-      setActiveRepo((prev) => prev ?? initialBoard?.repoRoot ?? null)
-      // …and the card cursor on the focus task's linked story, if any.
-      const focusId = focusTask?.id
-      const linked = focusId ? initialBoard?.issues.find((issue) => issue.taskId === focusId) : undefined
-      if (linked) setSelectedId((prev) => prev ?? linked.id)
-    })
+    const local = [...getSavedRepos(), ...orchestrator.listTasks().map((task) => task.repo)]
+    void orchestrator
+      .listIssueRepos()
+      // A daemon too old to know `issue.repos` leaves the board on the sources
+      // this process can see for itself, rather than rendering nothing.
+      .catch((): readonly string[] => [])
+      .then((stored) => {
+        // `ssh://` saved keys are remote projects; the issue store is keyed by
+        // git path and would reject each one as a visible read error.
+        const repos = [...new Set([...local, ...stored])].filter((repo) => repo && !isRemoteRepoKey(repo))
+        return Promise.all(
+          repos.map((repo) =>
+            orchestrator.listIssues(repo).catch(
+              (err: unknown): KanbanBoardEntry => ({
+                // A rejected read still owns its section. `exists: false` here
+                // is NOT the empty-board case below — `readError` is what
+                // separates "no issue file yet" from "could not read it".
+                repoRoot: repo,
+                exists: false,
+                nextId: 1,
+                issues: [],
+                skipped: 0,
+                readError: errorMessage(err),
+              }),
+            ),
+          ),
+        )
+      })
+      .then((results) => {
+        if (disposed) return
+        // A repo whose issue file doesn't exist yet still gets a section —
+        // `exists: false` just means an empty board, not an error.
+        const next = [...results]
+        next.sort((a, b) => a.repoRoot.localeCompare(b.repoRoot))
+        setBoards(next)
+        // First load lands on the focus task's project (opened via `c` on a
+        // task row) or, without one, the project you opened kobe in — the
+        // active task's repo (loose realpath tolerance, like WorktreesPage).
+        const norm = (p: string): string => p.replace(/^\/private\//, "/").replace(/\/+$/, "")
+        const activeId = orchestrator.activeTaskSignal().get()
+        const targetRepo = focusTask?.repo ?? orchestrator.listTasks().find((task) => task.id === activeId)?.repo
+        const initialBoard = targetRepo ? next.find((board) => norm(board.repoRoot) === norm(targetRepo)) : undefined
+        setActiveRepo((prev) => prev ?? initialBoard?.repoRoot ?? null)
+        // …and the card cursor on the focus task's linked story, if any.
+        const focusId = focusTask?.id
+        const linked = focusId ? initialBoard?.issues.find((issue) => issue.taskId === focusId) : undefined
+        if (linked) setSelectedId((prev) => prev ?? linked.id)
+      })
     const timer = setInterval(() => setReloadTick((tick) => tick + 1), POLL_MS)
     return () => {
       disposed = true

--- a/packages/kobe/src/tui/i18n/messages/kanban.ts
+++ b/packages/kobe/src/tui/i18n/messages/kanban.ts
@@ -8,8 +8,11 @@ export const en = {
   /** Footer/legend hint. */
   hint: "tab project · ←↓↑→ card · enter detail · n new · d delete · r refresh · esc close",
   loading: "Loading issues…",
-  /** No saved projects / no tasks to derive repos from. */
-  noRepos: "No projects yet — create a task first.",
+  /** Nothing to render a section for: no saved project, no live task, and no
+   *  repo in the issue store. It used to say "create a task first" while
+   *  deriving its sections from the task index alone, so a store full of
+   *  stories read as an empty one. */
+  noRepos: "No projects yet — add one with `rove add <path>`, or file a story with `rove api issue-create`.",
   /** A repo section with zero issues. */
   empty: "No issues — agents file them via `rove api issue-create`.",
   /** In place of the four columns when THIS project's issue read rejected.
@@ -114,7 +117,7 @@ export const zh: typeof en = {
   title: "看板",
   hint: "tab 切项目 · ←↓↑→ 选卡片 · enter 详情 · n 新建 · d 删除 · r 刷新 · esc 关闭",
   loading: "正在加载 issues…",
-  noRepos: "还没有项目——先创建一个任务。",
+  noRepos: "还没有项目——用 `rove add <路径>` 添加一个，或用 `rove api issue-create` 创建一个 story。",
   empty: "暂无 issue——agent 可通过 `rove api issue-create` 创建。",
   readFailed: "读取该项目的 story 失败：{error}",
   readFailedToast: "读取 {repo} 的 story 失败：{error}",

--- a/packages/kobe/test/daemon/handlers.test.ts
+++ b/packages/kobe/test/daemon/handlers.test.ts
@@ -59,6 +59,7 @@ describe("daemon handler registry", () => {
       "task.ensureWorktree",
       "task.setActive",
       "issue.list",
+      "issue.repos",
       "issue.mutate",
       "worktree.discoverAdoptable",
       "worktree.adopt",

--- a/packages/kobe/test/daemon/issues-store.test.ts
+++ b/packages/kobe/test/daemon/issues-store.test.ts
@@ -293,7 +293,10 @@ describe("IssuesStore", () => {
  * `exists: true` and no warning anywhere.
  */
 describe("IssuesStore corrupt-record honesty", () => {
-  async function seed(entry: Record<string, unknown>, nextId: unknown): Promise<{ store: IssuesStore; repo: string }> {
+  async function seed(
+    entry: Record<string, unknown>,
+    nextId: unknown,
+  ): Promise<{ store: IssuesStore; repo: string; storePath: string }> {
     const repo = await realpath(await makeRepo())
     const dir = await mkdtemp(join(tmpdir(), "kobe-issues-corrupt-"))
     cleanups.push(dir)
@@ -311,7 +314,7 @@ describe("IssuesStore corrupt-record honesty", () => {
     raw.repos[key]!.issues[0] = { ...raw.repos[key]!.issues[0], ...entry }
     raw.repos[key]!.nextId = nextId
     await writeFile(storePath, JSON.stringify(raw), "utf8")
-    return { store, repo }
+    return { store, repo, storePath }
   }
 
   it("counts an unreadable entry instead of reporting the survivors as the whole board", async () => {
@@ -342,6 +345,50 @@ describe("IssuesStore corrupt-record honesty", () => {
     const created = await store.mutate(repo, { type: "create", title: "collision probe" })
     expect(created.issues[0]?.id).toBe(3)
     expect(new Set(created.issues.map((issue) => issue.id)).size).toBe(created.issues.length)
+  })
+
+  it("keeps an unreadable entry on disk across an unrelated mutation", async () => {
+    // The warning used to document a recovery window one mutation wide: the
+    // read counted issue "2" into `skipped`, then the next whole-file write
+    // re-emitted only what it had parsed and the story was gone for good.
+    const { store, repo, storePath } = await seed({ id: "2" }, 3)
+    await store.mutate(repo, { type: "setStatus", id: 1, status: "done" })
+    const onDisk = JSON.parse(await readFile(storePath, "utf8")) as {
+      repos: Record<string, { issues: { id: unknown }[] }>
+    }
+    const ids = Object.values(onDisk.repos)[0]!.issues.map((issue) => issue.id)
+    expect(ids).toContain("2")
+    // …and the read still says so, rather than going quiet now that the write
+    // "cleaned up".
+    await expect(store.list(repo)).resolves.toMatchObject({ skipped: 1 })
+  })
+
+  it("refuses to write over a record whose `issues` is an object, and never calls it skipped: 0", async () => {
+    const repo = await realpath(await makeRepo())
+    const dir = await mkdtemp(join(tmpdir(), "kobe-issues-object-"))
+    cleanups.push(dir)
+    const storePath = join(dir, "issues.json")
+    const store = new IssuesStore(storePath)
+    await store.mutate(repo, { type: "create", title: "ship the thing" })
+    await store.mutate(repo, { type: "create", title: "second story" })
+    const raw = JSON.parse(await readFile(storePath, "utf8")) as {
+      repos: Record<string, { issues: unknown }>
+    }
+    const key = Object.keys(raw.repos)[0]!
+    const before = raw.repos[key]!.issues as { id: number }[]
+    // A map keyed by id — the shape a hand-edit or an older writer leaves.
+    raw.repos[key]!.issues = Object.fromEntries(before.map((issue) => [String(issue.id), issue]))
+    await writeFile(storePath, JSON.stringify(raw), "utf8")
+
+    // `skipped: 0` is the one value the field documents as "you have it all",
+    // and the object branch used to report exactly that after dropping both.
+    await expect(store.list(repo)).resolves.toMatchObject({ skipped: 2 })
+    // The next create used to persist the emptiness. Now it refuses by name.
+    await expect(store.mutate(repo, { type: "create", title: "would erase two" })).rejects.toThrow(
+      "ISSUE_STORE_UNREADABLE",
+    )
+    const after = JSON.parse(await readFile(storePath, "utf8")) as { repos: Record<string, { issues: unknown }> }
+    expect(after.repos[key]!.issues).toEqual(raw.repos[key]!.issues)
   })
 
   it("counts an unusable id toward the next allocation, so the fallback cannot reuse it", async () => {

--- a/packages/kobe/test/render/failure-toast.test.tsx
+++ b/packages/kobe/test/render/failure-toast.test.tsx
@@ -57,6 +57,7 @@ async function expectErrorToast(
 test("kanban: a failed issue delete shows an error toast, not just a log line", async () => {
   const orch = {
     listTasks: () => [{ repo: REPO }],
+    listIssueRepos: async () => [REPO],
     listIssues: async () => ({ repoRoot: REPO, exists: true, nextId: 9, issues: [issue(1)] }),
     activeTaskSignal: () => ({ get: () => null }),
     mutateIssue: async () => {
@@ -96,6 +97,7 @@ test("kanban: a failed issue delete shows an error toast, not just a log line", 
 test("kanban: a failed issue create shows an error toast", async () => {
   const orch = {
     listTasks: () => [{ repo: REPO }],
+    listIssueRepos: async () => [REPO],
     listIssues: async () => ({ repoRoot: REPO, exists: true, nextId: 9, issues: [issue(1)] }),
     activeTaskSignal: () => ({ get: () => null }),
     mutateIssue: async () => {

--- a/packages/kobe/test/render/host-pages.test.tsx
+++ b/packages/kobe/test/render/host-pages.test.tsx
@@ -61,6 +61,7 @@ function fakeOrchestrator(): RemoteOrchestrator {
     connectionStateSignal: () => ONLINE,
     listAutomations: async () => ({ automations: [], keepsDaemonAlive: false }),
     automationRuns: async () => ({ runs: [] }),
+    listIssueRepos: async () => ["/x/kobe"],
     listIssues: async () => ({ repoRoot: "/x/kobe", exists: true, nextId: 99, issues: [] }),
     listWorkItems: async () => ({ items: [] }),
     activeTaskSignal: () => ({ get: () => null }),

--- a/packages/kobe/test/render/kanban-columns.test.tsx
+++ b/packages/kobe/test/render/kanban-columns.test.tsx
@@ -34,6 +34,7 @@ function orchestrator(
 ) {
   return {
     listTasks: () => tasks,
+    listIssueRepos: async () => [REPO],
     listIssues: async () => ({ repoRoot: REPO, exists: true, nextId: 99, issues }),
     activeTaskSignal: () => ({ get: () => null }),
   } as never
@@ -225,6 +226,7 @@ test("r refetches the board", async () => {
   let fetches = 0
   const orch = {
     listTasks: () => [{ repo: REPO }],
+    listIssueRepos: async () => [REPO],
     listIssues: async () => {
       fetches += 1
       return { repoRoot: REPO, exists: true, nextId: 9, issues: [issue(1)] }

--- a/packages/kobe/test/render/rail-page-cursor-follow.test.tsx
+++ b/packages/kobe/test/render/rail-page-cursor-follow.test.tsx
@@ -126,6 +126,7 @@ function issue(id: number) {
 function boardOrchestrator() {
   return {
     listTasks: () => [{ id: "T1", repo: REPO }],
+    listIssueRepos: async () => [REPO],
     listIssues: async () => ({ repoRoot: REPO, exists: true, nextId: 9, issues: [issue(1), issue(2)] }),
     activeTaskSignal: () => ({ get: () => null }),
   } as never

--- a/packages/kobe/test/render/rail-pages-baseline.test.tsx
+++ b/packages/kobe/test/render/rail-pages-baseline.test.tsx
@@ -35,6 +35,7 @@ function fakeOrchestrator(): RemoteOrchestrator {
     listTasks: () => [SELECTED_TASK],
     listAutomations: async () => ({ automations: [], keepsDaemonAlive: false }),
     automationRuns: async () => ({ runs: [] }),
+    listIssueRepos: async () => ["/x/kobe"],
     listIssues: async () => ({ repoRoot: "/x/kobe", exists: true, nextId: 99, issues: [] }),
     listWorkItems: async () => ({ items: [] }),
     connectionStateSignal: () => ONLINE,

--- a/packages/kobe/test/render/silent-failure-toasts.test.tsx
+++ b/packages/kobe/test/render/silent-failure-toasts.test.tsx
@@ -38,6 +38,7 @@ function issue(id: number, over: Record<string, unknown> = {}) {
 test("kanban: a rejected detail-drawer edit shows an error toast, not the stale card", async () => {
   const orch = {
     listTasks: () => [{ repo: REPO }],
+    listIssueRepos: async () => [REPO],
     listIssues: async () => ({ repoRoot: REPO, exists: true, nextId: 9, issues: [issue(1)] }),
     activeTaskSignal: () => ({ get: () => null }),
     mutateIssue: async () => {
@@ -96,6 +97,7 @@ test("kanban: a rejected detail-drawer edit shows an error toast, not the stale 
 test("kanban: a project whose issue read rejects keeps its slot, says why, and toasts", async () => {
   const orch = {
     listTasks: () => [{ repo: REPO }, { repo: BROKEN }],
+    listIssueRepos: async () => [REPO, BROKEN],
     listIssues: async (repo: string) => {
       if (repo === BROKEN) throw new Error("JSON Parse error: Unterminated string")
       return { repoRoot: REPO, exists: true, nextId: 9, issues: [issue(1)], skipped: 0 }

--- a/packages/kobe/test/state/issue-board.test.ts
+++ b/packages/kobe/test/state/issue-board.test.ts
@@ -43,10 +43,21 @@ describe("issueColumnKey", () => {
     expect(issueColumnKey(issue({ id: 7, status: "doing", taskId: "01T" }))).toBe("in_progress")
   })
 
-  test("open / doing / empty-link are backlog", () => {
+  test("open / empty-link are backlog", () => {
     expect(issueColumnKey(issue({ id: 8 }))).toBe("backlog")
-    expect(issueColumnKey(issue({ id: 9, status: "doing" }))).toBe("backlog")
     expect(issueColumnKey(issue({ id: 10, taskId: "" }))).toBe("backlog")
+  })
+
+  // `doing` needs no task to mean what it says. Bucketing it with `open` made
+  // the documented open → doing step move no card, and left the drawer's
+  // `project` placement — which writes exactly this status and links nothing —
+  // running an engine behind a card still sitting in Backlog.
+  test("an unlinked `doing` issue is in progress on its own say-so", () => {
+    expect(issueColumnKey(issue({ id: 9, status: "doing" }))).toBe("in_progress")
+    expect(issueColumnKey(issue({ id: 11, status: "doing", taskId: "" }))).toBe("in_progress")
+    // …and a `doing` card whose task vanished stays there rather than falling
+    // back to Backlog: the link is gone, the issue's own status is not.
+    expect(issueColumnKey(issue({ id: 12, status: "doing", taskId: "01GONE" }), () => false)).toBe("in_progress")
   })
 
   // The defensive half of the link contract. The daemon unlinks an issue when


### PR DESCRIPTION
Batch A (A1, A2) and Batch B (B1, B2) of the issues exploration. Every item was
driven against a **source build in an isolated home**, not a mock; the harness
shots go through `/harness` → xterm.js → PTY sidecar → real OpenTUI.

Evidence lives outside `.scratch/`:
`/tmp/loop-r19-bd-nyala/` (repro transcripts + `shots/`).

---

## A1 — the warning documented a one-mutation recovery window

**PASS:** a partially valid store survives an unrelated mutation.

`readStore` dropped an entry whose `id` was not a number and counted it into
`skipped`; `mutate` then wrote the **normalized** store back, so any unrelated
write erased that story. Reads still skip. Writes now re-emit the raw entries
verbatim (`RepoIssueRecord.unusable` → `serializeRecord`).

Real verbs, isolated home, `issue-set-status` on a **different** story:

```
                              BEFORE (origin/main)        AFTER
on disk                       ids = ["2",1]               ids = ["2",1]
issue-list                    skipped = 1, listed [1]     skipped = 1, listed [1]
after issue-set-status --id 1 ids = [1]      ← destroyed  ids = [1,"2"]   ← kept
```

`/tmp/loop-r19-bd-nyala/repro-a-BEFORE.txt`, `repro-a-AFTER.txt`

## A2 — `skipped: 0` while dropping everything

**PASS:** an object-shaped `issues` refuses rather than reporting `skipped: 0`.

```
                       BEFORE (origin/main)                     AFTER
issue-list             skipped = 0, listed []                   skipped = 2, listed []
issue-create           succeeded — store now holds only #3      ISSUE_STORE_UNREADABLE
store after create     NO — stories lost                        byte-identical: YES
```

The refusal names the file and the repo, so an agent can act on it:

```
ISSUE_STORE_UNREADABLE: <repo>'s record in <home>/.rove/issues.json has a
non-array "issues" — refusing to write over stories this build cannot read
```

A write aimed at a **sibling** repo in the same file still succeeds and
round-trips the unreadable record whole.

**The loud path was left alone**, as the brief required: a syntactically corrupt
store still throws and leaves the file byte-for-byte intact. The only change
there is that the error now names the path — the parser's own message named
neither file nor repo.

## B1 — the board hid a backlog that exists

**PASS:** the board shows a saved repo's backlog with no task alive.

The module header said *"fetch every **saved** repo's issue file"*; line 66
derived from `listTasks()`. The code now matches the header, plus the two other
sources that can hold a backlog — union of: the **store's** own repo keys (new
`issue.repos` read), **saved** projects, and **live task** repos. Remote
(`ssh://`) saved keys are filtered out; a daemon too old to know `issue.repos`
degrades to the local sources rather than rendering nothing.

Scenario: 5 stories across 2 repos, **zero tasks** (the ordinary end of the
loop), plus one repo reachable only through `issue-create --repo` — never a
saved project, never a task.

| | |
|---|---|
| BEFORE | `/tmp/loop-r19-bd-nyala/shots/b1-before.png` — *"No projects yet — create a task first."* |
| AFTER | `/tmp/loop-r19-bd-nyala/shots/b1-after.png` — sidebar reads "No active tasks", board reads `fixture-repo 1/2` with all four cards |
| AFTER (2/2) | `/tmp/loop-r19-bd-nyala/shots/b1-after-orphan.png` — `orphan-repo 2/2`, the store-only repo, holding "Filed with no task" #1 |

The empty-state line no longer names tasks as the only route in (`kanban.ts`,
both locales; `check-i18n` green).

## B2 — `doing` was indistinguishable from `open`

**PASS:** `doing` lands in its own column.

`issueColumnKey` bucketed three of four documented statuses. An unlinked `doing`
now returns `in_progress` on the issue's own say-so — reading no task status, so
**the derived-`in_progress` design is untouched**: the task link is still a way
in and `--task none` still reverses it. This is what lets the drawer's `project`
placement (writes `doing`, links nothing) move its card instead of leaving it in
Backlog while its engine runs.

| | |
|---|---|
| BEFORE | `/tmp/loop-r19-bd-nyala/shots/b2-before.png` — #4 "Picked up, no task" in **Backlog (2)**, In progress (1) |
| AFTER | `/tmp/loop-r19-bd-nyala/shots/b2-after.png` — #4 in **In progress (2)**, Backlog (1) |

---

## Docs

`docs/TUI.md` described Backlog as "open or doing" and In progress as the task
link alone — both wrong after B1/B2. It now names `doing` as the second route in
and states the section rule (a project appears when it can hold a backlog, not
only when a task is alive). `docs/HARNESS.md`'s kanban-capture note said a card
reaches In progress by being linked, full stop; it now says the take is about
the link. `TUI.md` is already in `sync-docs.mjs` `SECTIONS`.

## Gates

- repo-root `bun run lint` — clean (1452 files)
- `bun run typecheck` — clean
- `bun run check-i18n` — 903 keys × 2 locales in sync
- `bun run test:fast` — 457 files, **4521 passed**
- `KOBE_INCLUDE_SOCKET=1 bun run test:socket` — 100 files, **831 passed**

Mutation-verified, one site each (both caught by exactly the intended test, no
other test moved):

| mutation | result |
|---|---|
| drop `...record.unusable` from the write | ✗ *keeps an unreadable entry on disk across an unrelated mutation* |
| disable the `record.unreadable` write refusal | ✗ *refuses to write over a record whose `issues` is an object…* |

## Not proven

- No new or moved keybinding chords.
- No file crossed the 500-line cap; `use-kanban-boards.ts` and `issues-store.ts`
  both grew but stayed under it, and neither gained a second job.
- Batch C untouched, as assigned.
