### PR TITLE
A pane cannot say which task it is in, and goes blind when the daemon restarts (Group 2 + 3)

### DIFF
--- a/.changeset/plugin-pane-task-id-and-socket-close.md
+++ b/.changeset/plugin-pane-task-id-and-socket-close.md
@@ -1,0 +1,11 @@
+---
+"@sma1lboy/rove": patch
+---
+
+A plugin pane can now name the task it runs in, and a plugin knows when the daemon goes away.
+
+Panes get `ROVE_PLUGIN_TASK_ID` (both openers: `plugin pane open` and the ctrl+e picker), so a pane no longer has to guess its task by matching its cwd against `worktreePath` — a match that is ambiguous for project-main and directory tasks, which share one cwd. `plugin pane open` takes `--task <id>` and prints the same `{ok, clients, title, taskId}` JSON as `api pane-open`, so a caller can tell "no attached UI performed the split" (`clients: 0`) from "opened"; exit 0 alone never said that.
+
+The SDK gains `RoveSocket.onClose(handler)`, called once when the connection dies. A subscriber holds no pending request, so the old socket — which failed only pending requests — told it nothing at all when the daemon crashed, and a hosted pane's PTY outlives the daemon, so the pane kept drawing a frame that looked live. `RoveSocket.hello()` returns the RUNNING daemon's build version and channel list, which is the only way to tell "this host is too old for that channel" from "nothing has happened yet". `openPane()` takes a `taskId` and surfaces `clients`.
+
+PLUGIN-AUTHORING.md's "`command` is always argv: never a shell" now carries its pane exception — panes do run through the user's interactive login shell — and PLUGIN-SDK.md's pane example handles a lost connection instead of modelling the frozen board.

--- a/docs/PLUGIN-AUTHORING.md
+++ b/docs/PLUGIN-AUTHORING.md
@@ -202,8 +202,17 @@ any = ["ctrl-c to interrupt"]    # at least one must appear
 # bottom_lines = 12              # trailing non-empty lines examined (default 12)
 ```
 
-`command` is always argv: never a shell, no expansion (panes expand only
-`$ROVE_PLUGIN_ROOT`). Unknown event names are warnings (forward compat);
+`command` is argv, never a shell, for events, startup, shutdown and
+actions: no expansion, no pipes, no globs. **Panes are the exception** — a
+pane runs through the user's interactive login shell (`sh -ilc`, the same
+launch path as an engine tab), expands `$ROVE_PLUGIN_ROOT`, and therefore
+inherits the rc-file environment: your `command[0]` must resolve on the PATH
+the user's `.zshrc`/`.bashrc` builds, not the daemon's, and anything those
+files print (version-manager chatter, MOTDs, banners) reaches the terminal
+before your first draw. The pane kit's `start()` handles that for you — it
+enters the alternate screen and clears it, so rc output stays on the primary
+screen; a pane that does not use the kit should clear the screen itself
+before its first frame. Unknown event names are warnings (forward compat);
 invalid types/patterns are install-time errors.
 
 `first_message_delivery` says how the CLI takes a session's first message.
@@ -287,7 +296,7 @@ Every plugin command gets, on top of the user's environment:
 
 | Variable | Meaning |
 |---|---|
-| `ROVE_BIN_PATH` | exec this to call back into Rove — the absolute path of the running install when that is a runnable file (an npm install, a compiled binary), otherwise the bare `rove`/`kobe` name resolved on `PATH`, which is what a dev checkout run through `bun` falls back to |
+| `ROVE_BIN_PATH` | exec this to call back into Rove — the absolute path of the running install when that is a runnable file (an npm install, a compiled binary), otherwise the bare `rove`/`kobe` name resolved on `PATH`, which is what a dev checkout run through `bun` falls back to. In that fallback your callbacks run **a different build than the daemon that launched you**, so a verb or flag the daemon has can still fail as a usage error: compare `$ROVE_BIN_PATH --version` against the daemon's own `roveVersion` (see [Which host am I talking to](#which-host-am-i-talking-to)) before blaming your own arguments |
 | `ROVE_SOCKET_PATH` | daemon unix socket, for raw JSON requests |
 | `ROVE_HOME_DIR` | set when Rove runs against a non-default home (keep passing it through) |
 | `ROVE_PLUGIN_ID`, `ROVE_PLUGIN_ROOT` | who you are, where your files are |
@@ -297,7 +306,7 @@ Every plugin command gets, on top of the user's environment:
 | startup | `ROVE_PLUGIN_EVENT=startup` |
 | shutdown | `ROVE_PLUGIN_EVENT=shutdown` |
 | actions | `ROVE_PLUGIN_ACTION_ID`, `ROVE_PLUGIN_INVOKE_CWD` (where the user invoked, usually "the repo I mean") |
-| panes | `ROVE_PLUGIN_ENTRYPOINT_ID`; cwd is the task worktree |
+| panes | `ROVE_PLUGIN_ENTRYPOINT_ID`, `ROVE_PLUGIN_TASK_ID`; cwd is the task worktree. Panes get no `_TASK_TITLE` — read it with `"$ROVE_BIN_PATH" api get-task --task-id "$ROVE_PLUGIN_TASK_ID"` |
 
 Every `ROVE_*` variable above is also injected under its established `KOBE_*`
 alias. Existing plugins need no edits; when both are supplied, SDK readers
@@ -336,12 +345,36 @@ The high-value verbs live under `rove api`: machine-readable list via
 "$ROVE_BIN_PATH" plugin pane open you.example.board            # qualified-id form
 "$ROVE_BIN_PATH" plugin pane open --plugin you.example \
   --entrypoint board                                           # equivalent flag form
+"$ROVE_BIN_PATH" plugin pane open you.example.board --task ID  # a specific task, not the active one
 ```
+
+`plugin pane open` prints JSON: `{"ok":true,"clients":N,"pane":…,"taskId":…,"title":…}`.
+Branch on `clients`, not the exit code — the open is a broadcast, and `0`
+means no attached UI performed the split. Without `--task` the host uses the
+active task and fails when there is none, so an event hook should pass its
+own `$ROVE_PLUGIN_TASK_ID`.
 
 **Socket (advanced):** newline-delimited JSON frames on `ROVE_SOCKET_PATH`
 (`{"type":"request","id":"1","name":"task.list","payload":{}}`); request
 names and payloads in `packages/kobe-daemon/src/daemon/protocol.ts`. Prefer
 the CLI unless you need push channels.
+
+### Which host am I talking to
+
+The `hello` request answers it, and it is the only thing that can: your SDK
+version describes what YOU were built against, not what the running daemon
+knows. Send `{"type":"request","id":"1","name":"hello","payload":{}}` (the
+SDK wraps it as `RoveSocket.hello()`) and read back:
+
+- `kobeVersion` — the daemon's build version. The SDK also surfaces it as
+  `roveVersion`; the wire field keeps its original spelling.
+- `capabilities` — the broadcast channels **this** daemon has. A channel name
+  it does not know is dropped from a `subscribe` filter silently, so this is
+  how you tell "the host is too old for that channel" from "nothing has
+  happened yet".
+- `protocolVersion` / `minProtocolVersion` — the wire range it accepts.
+- `homeDir` — its state root. A different home means you reached a foreign
+  daemon (a sandbox one on the production socket path).
 
 ## Interaction surfaces
 

--- a/docs/PLUGIN-SDK.md
+++ b/docs/PLUGIN-SDK.md
@@ -85,7 +85,7 @@ channels.
 | `notify` | `(title, body?, opts?) => Promise<RoveRunResult>` | `rove api notify`; toast in every attached UI. |
 | `dispatch` | `(taskId, prompt, opts?) => Promise<RoveRunResult>` | `rove api dispatch`; text into a live session. |
 | `listTasks` | `<T>(opts?) => Promise<T>` | `rove api list`; all tasks as daemon-serialized JSON. |
-| `openPane` | `(qualifiedPaneId, opts?) => Promise<RoveRunResult>` | `rove plugin pane open`; opens one of your `[[panes]]`. |
+| `openPane` | `(qualifiedPaneId, opts?) => Promise<RoveRunResult & { clients?: number }>` | `rove plugin pane open`; opens one of your `[[panes]]`. `opts.taskId` picks the task (pass an event's `ctx.taskId`); without it the host uses the active task and fails when there is none. Check `clients` — `0` means no attached UI performed the split. |
 | `promptUser` | `(title, opts?) => Promise<string \| null>` | `rove api prompt`; host input dialog. Returns `null` on cancel, timeout, no attached TUI, or non-zero exit. |
 
 Combined example:
@@ -132,6 +132,8 @@ gives you live broadcast channels that the CLI cannot push.
 | `connect` | `(opts?) => Promise<void>` | Connect to `ROVE_SOCKET_PATH`. |
 | `request` | `<T>(name, payload?) => Promise<T>` | One request → response; rejects on daemon error frames. |
 | `subscribe` | `(handler, channels?) => Promise<void>` | Subscribe to channels (`role: "pane"`); omit channels for all. |
+| `hello` | `() => Promise<DaemonInfo>` | Ask the RUNNING daemon its build version and channel list. |
+| `onClose` | `(handler) => void` | Called once when the connection dies (restart, crash, error). Not called for your own `close()`. |
 | `close` | `() => void` | End the socket. |
 
 SDK consumers must always subscribe with `role: "pane"`. The SDK enforces this
@@ -148,41 +150,107 @@ the shape your target Rove version actually emits. The channel names are the
 `ui.prompt`.
 
 A name the daemon does not know is dropped from the filter, not rejected: the
-subscribe succeeds and that channel simply never arrives. So an SDK older than
-the Rove it talks to fails silently — check the SDK version before assuming a
-channel is dead.
-
-Your handler also receives `daemon.stopping` at daemon shutdown — not a
-channel, always delivered regardless of the filter.
+subscribe succeeds and that channel simply never arrives. So a channel can be
+dead for two reasons that look identical, and `DAEMON_CHANNELS` cannot tell
+them apart — it is the list YOUR SDK was built against, not the list the host
+has. Ask the host with `hello()`:
 
 ```ts
-import { Pane, RoveSocket } from "@sma1lboy/rove-plugin-sdk"
+const info = await daemon.hello()
+if (!info.capabilities.includes("usage.snapshot")) {
+  console.error(`Rove ${info.roveVersion} has no usage.snapshot channel`)
+}
+```
 
+`DaemonInfo` carries `roveVersion` / `kobeVersion` (the same build version
+under both spellings; the wire field is `kobeVersion`), `capabilities`,
+`protocolVersion` / `minProtocolVersion`, `daemonPid`, and `homeDir` — a
+`homeDir` that is not yours means you reached a foreign daemon. It is also
+the way to check `$ROVE_BIN_PATH --version` against the host: in a dev
+checkout those are different builds.
+
+### Surviving a daemon restart
+
+Your handler receives `daemon.stopping` at a graceful daemon shutdown — not a
+channel, always delivered regardless of the filter — and **that is the last
+thing it ever receives**. There is no reconnect: after it, the socket is
+dead. A crash is worse, because the daemon sends nothing at all.
+
+This matters most in a pane, because a hosted pane's PTY **survives a daemon
+restart by design**. Your process stays alive and keeps drawing its last
+frame, so a board that has stopped receiving anything is visually
+indistinguishable from a live one. Register `onClose` and either reconnect or
+say so on screen:
+
+```ts
+function connect(): void {
+  const daemon = new RoveSocket()
+  daemon.onClose(() => {
+    live = false
+    frame() // draw a "host gone — reconnecting" line, not a stale board
+    setTimeout(connect, 1000)
+  })
+  daemon
+    .connect()
+    .then(() => daemon.subscribe(onEvent, ["task.snapshot"]))
+    .then(() => {
+      live = true
+      frame()
+    })
+    .catch(() => {}) // onClose already scheduled the retry
+}
+```
+
+```ts
+import { Pane, pluginContext, RoveSocket } from "@sma1lboy/rove-plugin-sdk"
+
+const ctx = pluginContext()
 const pane = new Pane()
-const daemon = new RoveSocket()
-await daemon.connect()
 
 let tasks: any[] = []
+let live = false
 function frame() {
   pane.draw([
-    "MY BOARD",
-    "",
+    `MY BOARD — ${ctx.taskTitle ?? "no task"}`,
+    live ? "" : "  host unreachable — reconnecting",
     ...tasks.map((t) => `  ${t.status.padEnd(8)} ${t.title}`),
   ])
 }
 
-await daemon.subscribe((name, payload) => {
-  if (name === "task.snapshot") {
-    tasks = (payload as any).tasks ?? []
+function connect() {
+  const daemon = new RoveSocket()
+  // Without this the pane goes silently blind on a daemon restart: its PTY
+  // outlives the daemon, so it keeps drawing the frame above forever.
+  daemon.onClose(() => {
+    live = false
     frame()
-  }
-}, ["task.snapshot"])
+    setTimeout(connect, 1000)
+  })
+  daemon
+    .connect()
+    .then(() =>
+      daemon.subscribe((name, payload) => {
+        if (name !== "task.snapshot") return
+        tasks = (payload as any).tasks ?? []
+        live = true
+        frame()
+      }, ["task.snapshot"]),
+    )
+    .catch(() => {}) // onClose scheduled the retry
+}
 
 pane.start()
 pane.onKey((k) => { if (k.name === "q") pane.exit(0) })
 pane.onResize(frame)
 frame()
+connect()
 ```
+
+`pluginContext()` gives a pane the `taskId` it opened in, and its cwd is that
+task's worktree — do not try to identify the task by matching cwd against
+`worktreePath`, which is ambiguous for the task kinds that reuse an existing
+checkout. Panes get no `taskTitle`; fetch it with
+`roveJson(["api", "get-task", "--task-id", ctx.taskId!])`.
 
 ## Pane kit
 
@@ -211,6 +279,11 @@ mind or the embedded terminal will ghost-wrap:
    double-width characters.
 3. **Redraw the whole frame on every update.** The screen is not scrollback;
    paint every row you want visible.
+
+`Pane.start()` enters the alternate screen and clears it, which is what keeps
+these rules workable: a pane runs through the user's interactive login shell,
+so anything their rc files print lands in the terminal before your first
+frame. Clear the screen yourself if you draw without the kit.
 
 ```ts
 import { Pane } from "@sma1lboy/rove-plugin-sdk"
@@ -241,7 +314,7 @@ for the event catalog and channel list, so host and SDK cannot drift.
 | Export | Kind | Meaning |
 |---|---|---|
 | `PLUGIN_EVENT_NAMES` | `readonly string[]` | Every event a plugin can subscribe to. |
-| `DAEMON_CHANNELS` | `readonly string[]` | Every broadcast channel on the socket. |
+| `DAEMON_CHANNELS` | `readonly string[]` | Every broadcast channel this SDK knows. For what the RUNNING daemon has, call `hello()`. |
 | `PluginEventName` | type | Union of event names. |
 | `PluginEventEnvelope` | type | The `ROVE_PLUGIN_EVENT_JSON` envelope. |
 | `PluginEventTask` | type | Task block embedded in envelopes that map to a task. |

--- a/packages/kobe-daemon/src/plugins/pane-command.ts
+++ b/packages/kobe-daemon/src/plugins/pane-command.ts
@@ -24,6 +24,11 @@ export interface PaneLaunchOpts {
   readonly homeDir?: string
   readonly socketPath: string
   readonly binPath: string
+  /** The task the pane opens in, injected as `ROVE_PLUGIN_TASK_ID`. Without
+   *  it a pane can only guess its task by matching its cwd against
+   *  `worktreePath`, which is ambiguous for the two task kinds that reuse an
+   *  existing checkout (project-main, directory) and share one cwd. */
+  readonly taskId?: string
 }
 
 /** POSIX single-quote for embedding in a login-shell `-ilc` script. */
@@ -44,7 +49,10 @@ export function buildPaneArgv(
     binPath: opts.binPath,
     pluginId,
     pluginRoot,
-    extra: { ROVE_PLUGIN_ENTRYPOINT_ID: pane.id },
+    extra: {
+      ROVE_PLUGIN_ENTRYPOINT_ID: pane.id,
+      ...(opts.taskId ? { ROVE_PLUGIN_TASK_ID: opts.taskId } : {}),
+    },
   })
   const pairs = Object.entries(env).filter(([k]) => k.startsWith("ROVE_") || k.startsWith("KOBE_")) as [
     string,

--- a/packages/kobe-plugin-sdk/src/cli.ts
+++ b/packages/kobe-plugin-sdk/src/cli.ts
@@ -82,9 +82,28 @@ export function listTasks<T = unknown>(opts?: RoveRunOptions): Promise<T> {
   return roveJson<T>(["api", "list"], opts)
 }
 
-/** Open one of this plugin's own `[[panes]]` (qualified id: `you.plugin.pane`). */
-export function openPane(qualifiedPaneId: string, opts?: RoveRunOptions): Promise<RoveRunResult> {
-  return rove(["plugin", "pane", "open", qualifiedPaneId], opts)
+/**
+ * Open one of this plugin's own `[[panes]]` (qualified id: `you.plugin.pane`).
+ * Pass `taskId` from an event hook's `ctx.taskId`; without it the host falls
+ * back to the active task and fails when there is none.
+ *
+ * Resolves the `{ ok, clients, title, taskId }` JSON the verb prints — check
+ * `clients`, not the exit code: 0 means the open was broadcast but no
+ * attached UI performed the split.
+ */
+export async function openPane(
+  qualifiedPaneId: string,
+  opts: RoveRunOptions & { taskId?: string } = {},
+): Promise<RoveRunResult & { clients?: number }> {
+  const { taskId, ...run } = opts
+  const args = ["plugin", "pane", "open", qualifiedPaneId, ...(taskId ? ["--task", taskId] : [])]
+  const res = await rove(args, run)
+  try {
+    const parsed = JSON.parse(res.stdout) as { clients?: number }
+    return { ...res, ...(typeof parsed.clients === "number" ? { clients: parsed.clients } : {}) }
+  } catch {
+    return res // older host: the verb printed prose, so `clients` is unknowable
+  }
 }
 
 /**

--- a/packages/kobe-plugin-sdk/src/index.ts
+++ b/packages/kobe-plugin-sdk/src/index.ts
@@ -15,7 +15,13 @@ export {
   type KobeRunOptions,
   type KobeRunResult,
 } from "./cli.ts"
-export { RoveSocket, KobeSocket, type RoveSocketOptions, type KobeSocketOptions } from "./socket.ts"
+export {
+  RoveSocket,
+  KobeSocket,
+  type DaemonInfo,
+  type RoveSocketOptions,
+  type KobeSocketOptions,
+} from "./socket.ts"
 export { Pane, parseKeys, type Key, type PaneOptions } from "./pane.ts"
 export {
   PLUGIN_EVENT_NAMES,

--- a/packages/kobe-plugin-sdk/src/socket.ts
+++ b/packages/kobe-plugin-sdk/src/socket.ts
@@ -17,12 +17,33 @@ export type KobeSocketOptions = RoveSocketOptions
 
 type Pending = { resolve: (payload: unknown) => void; reject: (err: Error) => void }
 
+/** What the daemon answers `hello` with — the runtime compatibility check. */
+export interface DaemonInfo {
+  /** Wire-format version range the daemon speaks. */
+  readonly protocolVersion: number
+  readonly minProtocolVersion: number
+  /** The daemon's BUILD version. Both spellings carry the same value; the
+   *  wire field is `kobeVersion`. */
+  readonly roveVersion: string
+  readonly kobeVersion: string
+  /** The channel names THIS daemon broadcasts — the answer to "does the host
+   *  I'm talking to know this channel", which `DAEMON_CHANNELS` (what YOUR
+   *  SDK was built against) cannot give. */
+  readonly capabilities: readonly string[]
+  readonly daemonPid?: number
+  /** The daemon's state root; a plugin whose own home differs is talking to a
+   *  foreign daemon. */
+  readonly homeDir?: string
+}
+
 export class RoveSocket {
   private sock: Socket | null = null
   private buffer = ""
   private nextId = 1
   private readonly pending = new Map<string, Pending>()
   private eventHandler: ((name: string, payload: unknown) => void) | null = null
+  private closeHandler: ((err: Error) => void) | null = null
+  private closeNotified = false
 
   /** Connect; resolves once the socket is up (before any `hello`). */
   connect(opts: RoveSocketOptions = {}): Promise<void> {
@@ -63,7 +84,40 @@ export class RoveSocket {
     await this.request("subscribe", { role: "pane", ...(channels ? { channels } : {}) })
   }
 
+  /**
+   * Ask the running daemon what it is: build version and the channel list it
+   * actually broadcasts. This is the only runtime compatibility check —
+   * your own SDK version cannot tell you what the HOST knows, and an
+   * unknown channel name is dropped from a `subscribe` filter silently.
+   */
+  async hello(): Promise<DaemonInfo> {
+    const raw = await this.request<Record<string, unknown>>("hello", {})
+    const version = typeof raw.kobeVersion === "string" ? raw.kobeVersion : ""
+    return {
+      protocolVersion: Number(raw.protocolVersion ?? 0),
+      minProtocolVersion: Number(raw.minProtocolVersion ?? 0),
+      roveVersion: version,
+      kobeVersion: version,
+      capabilities: Array.isArray(raw.capabilities) ? (raw.capabilities as string[]) : [],
+      ...(typeof raw.daemonPid === "number" ? { daemonPid: raw.daemonPid } : {}),
+      ...(typeof raw.homeDir === "string" ? { homeDir: raw.homeDir } : {}),
+    }
+  }
+
+  /**
+   * Called once when the connection dies — a daemon restart, a crash, a
+   * socket error. Without it a subscriber goes silently blind: the daemon's
+   * `daemon.stopping` only covers a GRACEFUL stop, and a hosted pane's PTY
+   * outlives the daemon, so the pane keeps drawing its last frame and looks
+   * live. Reconnect from here (`new RoveSocket()` + connect + subscribe) or
+   * tell the user the host is gone. Not called for your own `close()`.
+   */
+  onClose(handler: (err: Error) => void): void {
+    this.closeHandler = handler
+  }
+
   close(): void {
+    this.closeNotified = true // deliberate teardown is not a lost connection
     this.sock?.end()
     this.sock = null
   }
@@ -97,6 +151,11 @@ export class RoveSocket {
   private failAll(err: Error): void {
     for (const waiter of this.pending.values()) waiter.reject(err)
     this.pending.clear()
+    // Pending requests were the ONLY thing this used to fail. A subscriber
+    // has no pending request, so it heard nothing and stayed blind forever.
+    if (this.closeNotified) return
+    this.closeNotified = true
+    this.closeHandler?.(err)
   }
 }
 

--- a/packages/kobe-plugin-sdk/test/socket.test.ts
+++ b/packages/kobe-plugin-sdk/test/socket.test.ts
@@ -64,3 +64,56 @@ describe("RoveSocket", () => {
     client.close()
   })
 })
+
+describe("RoveSocket.onClose", () => {
+  it("tells a subscriber the connection died, even with no request pending", async () => {
+    const sockets: Socket[] = []
+    const path = fakeDaemon((frame, sock) => {
+      sockets.push(sock)
+      sock.write(`${JSON.stringify({ type: "response", id: frame.id, payload: {} })}\n`)
+    })
+    const client = new RoveSocket()
+    const closes: string[] = []
+    client.onClose((err) => closes.push(err.message))
+    await client.connect({ socketPath: path })
+    // A subscriber holds no pending request — the pre-onClose socket failed
+    // only those, so a daemon crash reached the plugin as total silence.
+    await client.subscribe(() => {})
+    sockets[0]?.destroy()
+    await new Promise((r) => setTimeout(r, 50))
+    expect(closes).toHaveLength(1)
+  })
+
+  it("stays quiet for the plugin's own close()", async () => {
+    const path = fakeDaemon(() => {})
+    const client = new RoveSocket()
+    let fired = false
+    client.onClose(() => {
+      fired = true
+    })
+    await client.connect({ socketPath: path })
+    client.close()
+    await new Promise((r) => setTimeout(r, 50))
+    expect(fired).toBe(false)
+  })
+})
+
+describe("RoveSocket.hello", () => {
+  it("reports the RUNNING daemon's build and channel list under both spellings", async () => {
+    const path = fakeDaemon((frame, sock) => {
+      const payload =
+        frame.name === "hello"
+          ? { protocolVersion: 4, minProtocolVersion: 2, kobeVersion: "0.9.142", capabilities: ["task.snapshot"] }
+          : {}
+      sock.write(`${JSON.stringify({ type: "response", id: frame.id, payload })}\n`)
+    })
+    const client = new RoveSocket()
+    await client.connect({ socketPath: path })
+    const info = await client.hello()
+    expect(info.roveVersion).toBe("0.9.142")
+    expect(info.kobeVersion).toBe("0.9.142")
+    expect(info.capabilities).toEqual(["task.snapshot"])
+    expect(info.protocolVersion).toBe(4)
+    client.close()
+  })
+})

--- a/packages/kobe/src/cli/plugin-cmd.ts
+++ b/packages/kobe/src/cli/plugin-cmd.ts
@@ -55,7 +55,8 @@ function printUsage(out: NodeJS.WriteStream): void {
       "  log <id> [-n <count>]                                 tail the plugin's command-run log",
       "  action list [--plugin <id>]                           declared actions",
       "  action invoke <plugin-id.action-id>                   run an action now",
-      "  pane open --plugin <id> --entrypoint <pane-id>        open a plugin pane as a terminal tab",
+      "  pane open <plugin-id.pane-id> [--task <task-id>]      open a plugin pane as a terminal tab (JSON:",
+      "                                                        clients — 0 = no attached UI performed the split)",
       "",
       "Marketplace: https://github.com/topics/rove-plugin (legacy kobe-plugin is included)",
       "",
@@ -217,25 +218,31 @@ async function openPane(pluginId: string, entrypoint: string, taskFlag: string |
   if (!pane) throw new PluginCliError(`no pane \`${entrypoint}\` in \`${pluginId}\`; declare it under [[panes]]`)
   assertPlatformSupported(`${pluginId}.${pane.id}`, pane, loaded.manifest)
 
-  // Shared composition with the TUI's ctrl+e picker (plugins/pane-command.ts):
-  // one login-shell `-ilc` script, env contract riding an `env` prefix, cwd = worktree.
-  const argv = buildPaneArgv(loaded.entry.id, loaded.entry.root, pane, {
-    socketPath: defaultDaemonSocketPath(),
-    binPath: resolvePluginBinPath(),
-  })
-
   const { openDaemonSession, resolveActiveTaskId } = await import("./daemon-session.ts")
   const session = await openDaemonSession({ mode: "start" })
   try {
     const taskId = taskFlag ?? (await resolveActiveTaskId(session.client))
     if (!taskId) throw new PluginCliError("no active task; pass --task <id>")
-    await session.client.request("tab.open", {
+    // Resolve the task BEFORE composing argv: its id rides the env contract
+    // into the pane, so the pane can name the task it runs in instead of
+    // guessing from its cwd.
+    // Shared composition with the TUI's ctrl+e picker (plugins/pane-command.ts):
+    // one login-shell `-ilc` script, env contract riding an `env` prefix, cwd = worktree.
+    const argv = buildPaneArgv(loaded.entry.id, loaded.entry.root, pane, {
+      socketPath: defaultDaemonSocketPath(),
+      binPath: resolvePluginBinPath(),
+      taskId,
+    })
+    const reply = (await session.client.request("tab.open", {
       taskId,
       argv,
       title: pane.title,
       placement: pane.placement,
-    })
-    console.log(`opened pane ${pluginId}.${pane.id} in task ${taskId}`)
+    })) as Record<string, unknown> | undefined
+    // Same machine-readable shape as `api pane-open`: `clients` is the only
+    // way a caller can tell "nobody performed the split" from "opened" —
+    // exit 0 alone means the broadcast went out, not that a UI acted on it.
+    console.log(JSON.stringify({ ...reply, ok: true, pane: `${pluginId}.${pane.id}`, taskId, title: pane.title }))
   } finally {
     session.close()
   }

--- a/packages/kobe/src/tui-react/workspace/TerminalTabs.tsx
+++ b/packages/kobe/src/tui-react/workspace/TerminalTabs.tsx
@@ -354,6 +354,7 @@ export function TerminalTabs(props: TerminalTabsProps): ReactNode {
     state,
     active,
     vendor: props.vendor,
+    taskId: props.taskId,
     worktree: props.worktree,
     liveTitles,
     update,

--- a/packages/kobe/src/tui-react/workspace/use-tab-dialogs.ts
+++ b/packages/kobe/src/tui-react/workspace/use-tab-dialogs.ts
@@ -65,6 +65,9 @@ export function useTabDialogs(deps: {
   state: TabsState
   active: TerminalTab
   vendor: VendorId
+  /** The task these tabs belong to — rides into a plugin pane's env as
+   *  `ROVE_PLUGIN_TASK_ID` so the pane can name its own task. */
+  taskId: string
   worktree: string
   liveTitles: ReadonlyMap<string, string>
   update: (next: TabsState) => void
@@ -175,7 +178,11 @@ export function useTabDialogs(deps: {
       // offered in the default combo (the dialog filters otherwise).
       let panes: PaneLaunch[] = []
       try {
-        panes = listPaneLaunches({ socketPath: defaultDaemonSocketPath(), binPath: activeCliName() })
+        panes = listPaneLaunches({
+          socketPath: defaultDaemonSocketPath(),
+          binPath: activeCliName(),
+          taskId: deps.taskId,
+        })
       } catch {
         /* registry unreadable → engines only */
       }

--- a/packages/kobe/test/cli/plugin-cmd.test.ts
+++ b/packages/kobe/test/cli/plugin-cmd.test.ts
@@ -126,7 +126,7 @@ describe("plugin command workflow", () => {
     await runPluginSubcommand(["link", root])
 
     const client = {
-      request: vi.fn().mockResolvedValue(undefined),
+      request: vi.fn().mockResolvedValue({ clients: 0 }),
     }
     sessionMocks.openDaemonSession.mockResolvedValue({ client, close: vi.fn() })
     sessionMocks.resolveActiveTaskId.mockResolvedValue("task-42")
@@ -146,6 +146,19 @@ describe("plugin command workflow", () => {
         placement: "split",
       }),
     )
-    expect(output.join("\n")).toContain("opened pane example.logs in task task-42")
+    // The resolved task rides the env contract into the pane, so the pane can
+    // name its own task instead of guessing from its cwd.
+    const script = (client.request.mock.calls.find(([name]) => name === "tab.open")?.[1] as { argv: string[] })
+      .argv[2] as string
+    expect(script).toContain("'ROVE_PLUGIN_TASK_ID=task-42'")
+    // Machine-readable like `api pane-open`: `clients` 0 means the broadcast
+    // went out but no attached UI performed the split — exit 0 cannot say that.
+    expect(JSON.parse(output.join("\n"))).toMatchObject({
+      ok: true,
+      clients: 0,
+      pane: "example.logs",
+      taskId: "task-42",
+      title: "Logs",
+    })
   })
 })

--- a/packages/kobe/test/plugins/pane-command.test.ts
+++ b/packages/kobe/test/plugins/pane-command.test.ts
@@ -47,6 +47,17 @@ describe("buildPaneArgv", () => {
       expect(script).toContain(frag)
     }
   })
+
+  it("injects the task id so a pane can name its own task", () => {
+    const pane = { id: "b", title: "B", placement: "split" as const, command: ["run"] }
+    const script = buildPaneArgv("p.id", "/plug/root", pane, { ...OPTS, taskId: "01TASK" })[2] as string
+    for (const frag of ["'ROVE_PLUGIN_TASK_ID=01TASK'", "'KOBE_PLUGIN_TASK_ID=01TASK'"]) {
+      expect(script).toContain(frag)
+    }
+    // No task resolved (an opener that never had one) → no empty var to
+    // read as "task id is the empty string".
+    expect(buildPaneArgv("p.id", "/plug/root", pane, OPTS)[2] as string).not.toContain("PLUGIN_TASK_ID")
+  })
 })
 
 describe("listPaneLaunches", () => {

--- a/packages/kobe/test/render/new-chat-flow.test.tsx
+++ b/packages/kobe/test/render/new-chat-flow.test.tsx
@@ -117,6 +117,7 @@ function Driver(props: { state: TabsState; captured: Captured }) {
     state: props.state,
     active: props.state.tabs[0]!,
     vendor: "claude",
+    taskId: "task-under-test",
     worktree,
     liveTitles: new Map(),
     update: (next) => props.captured.updates.push(next),


### PR DESCRIPTION
Loop r20 plugin exploration, **Group 3** (panes are second-class citizens of the documented contract) plus **Group 2** (a plugin cannot see the host it is talking to). Groups 1 and 4 landed separately in #894; nothing here touches `plugins/runtime.ts`'s hook execution or the registry poll.

Every claim below was measured from an author's seat: a real plugin (`bi.probe` / `bi.board`) linked into an isolated from-source daemon (0.9.142), plus the `/harness` → xterm.js → PTY sidecar → real OpenTUI path for the screen-visible ones. Evidence lives at **`/Users/jacksonc/rove-evidence/loop-r20-bi/`** (probe plugins, raw terminal buffers, screenshots).

---

## 1. A pane can name the task it is in (3.1)

**PASS:** a pane prints its resolved task id where it printed `(none)`.

`buildPaneArgv` injected only `ROVE_PLUGIN_ENTRYPOINT_ID`, and `plugin pane open --task <id>` resolved a task id one frame before composing argv and then threw it away. The only workaround left — matching `cwd` against `worktreePath` over `task.snapshot` — cannot be correct for project-main and directory tasks, which reuse an existing checkout and share one cwd.

Both openers now resolve the task first and pass `taskId` into `buildPaneArgv`, which injects `ROVE_PLUGIN_TASK_ID` (+ its `KOBE_` alias). No `_TASK_TITLE`: the TUI picker has no title to give, and a half-present variable is the same defect in a new place — the doc points at `api get-task --task-id "$ROVE_PLUGIN_TASK_ID"` instead.

**Proof** — the login-shell script the host hands a TUI, tapped off the daemon's `tab.open` channel (`{before,after}-pane-argv.txt`):

```
BEFORE:  (no PLUGIN_TASK_* variable in the env prefix at all)
AFTER:   ROVE_PLUGIN_TASK_ID=01M1PWXAXTSNGYA1SFEPC5SFW1
         KOBE_PLUGIN_TASK_ID=01M1PWXAXTSNGYA1SFEPC5SFW1
```

Running that exact argv under a real PTY and reading the pane's own text buffer (`{before,after}-pane-raw.txt`):

```
BEFORE:  BI BOARD   taskId=(none)                       daemon=connected  tasks=2
AFTER:   BI BOARD   taskId=01M1PWXAXTSNGYA1SFEPC5SFW1   daemon=connected  tasks=2
```

## 2. A pane is told when the daemon dies — including under `kill -9` (3.2)

**PASS:** a subscriber receives something actionable when the daemon goes away, on both paths.

`RoveSocket`'s close handler failed *pending requests only*. A subscriber holds no pending request, so it heard nothing — and because the hosted PTY survives a daemon restart by design, the pane kept drawing its last frame and looked live. `onClose(handler)` now fires once from `failAll`, and is deliberately silent for the plugin's own `close()`.

**Proof — real daemon, real `kill -9`** (not a mocked close event; the whole finding is that the real one is never delivered). `{before,after}-socket-{graceful,kill9}.txt`:

```
BEFORE  kill -9:   … event task.snapshot            ← last line, forever; probe still alive
AFTER   kill -9:   … event task.snapshot
                   … CLOSE-SIGNAL: daemon socket closed

BEFORE  graceful:  … event daemon.stopping          ← last line, forever
AFTER   graceful:  … event daemon.stopping
                   … CLOSE-SIGNAL: daemon socket closed
```

**Harness BEFORE/AFTER** (`/harness` → xterm → PTY → real OpenTUI, fixture on port base 7727; identical key sequence, fixture daemon `kill -9`'d ~10s before each capture):

| | |
|---|---|
| `BEFORE-daemon-killed.png` | `task: (none)` · `host: connected` — the frozen board, still claiming a host that is dead |
| `AFTER-daemon-killed.png` | `task: 01M1PXKAHH2WNA2KC9NCH7FDZG` · `host: UNREACHABLE — reconnecting` |

`after-1-board-live.png` is the same board before the kill, rendering the live task list.

*(The probe board latches on loss rather than reconnecting, so the captured frame is stable; the documented recipe reconnects.)*

## 3. `openPane()` can target a task and reports what actually happened (3.4)

**PASS:** JSON carrying `clients`, and `openPane()` accepts a task id.

`plugin pane open` printed prose and exited 0 whether or not any UI performed the split; its sibling `api pane-open` returns `clients` for exactly that reason. Copied the sibling.

```
BEFORE:  opened pane bi.probe.board in task 01M1PWXAXTSNGYA1SFEPC5SFW1
AFTER:   {"ok":true,"clients":2,"pane":"bi.probe.board","taskId":"01M1PWXAXTSNGYA1SFEPC5SFW1","title":"BI Board"}
```

SDK `openPane(id, { taskId })` appends `--task` and surfaces `clients` (falling back gracefully on an older host that still prints prose).

## 4. A plugin can ask which host it is talking to (2.1, 2.2)

**PASS:** the answer has one obvious spelling and both pages name it.

`hello` already returned `kobeVersion` + `capabilities` — the running daemon's real channel list — callable from a plugin today and documented on neither page, while PLUGIN-SDK.md told authors to "check the SDK version", which cannot answer the question. Added `RoveSocket.hello(): DaemonInfo`, which surfaces the build version under both `roveVersion` and `kobeVersion` (the wire field keeps its spelling) alongside `capabilities` / `protocolVersion` / `homeDir`.

**Proof** — from inside a plugin action against the from-source daemon (`after-hello.txt`):

```
$ ./r.sh plugin action invoke bi.probe.info
{"version":"0.9.142","caps":19}
```

0.9.142 is the *daemon*, not the 0.9.105 on `PATH` — which is 2.2's point, now stated in the `ROVE_BIN_PATH` row: in a dev checkout your callbacks run a different build than the daemon that launched you, and comparing `$ROVE_BIN_PATH --version` against `hello`'s version is how you notice.

I did **not** re-derive the SDK-vs-daemon channel drift; the report measured zero and this is about discoverability.

## 5. "`command` is always argv: never a shell" (3.3)

**I treated the BEHAVIOUR as the promise and fixed the doc.** The login shell is a deliberate choice cross-referenced to `session-launch.ts`, and silently changing how existing panes launch would break every pane whose `command[0]` resolves only on the user's rc-file PATH. The sentence now carries its pane exception and names the three consequences (rc-file PATH, `command[0]` resolution, rc output arriving before your first draw).

On the drawing hazard: `Pane.start()` already enters the alternate screen and clears it, so rc chatter stays on the primary screen. That is now stated in the Pane-kit section, together with "clear the screen yourself if you draw without the kit" — the honest shape, rather than implying panes are unprotected.

---

## Tests

Four mutations, each caught by exactly one test:

| Mutation | Test that failed |
|---|---|
| drop the task-var injection in `buildPaneArgv` | `pane-command > injects the task id…` |
| revert `failAll` to pending-only (the original bug) | `onClose > tells a subscriber the connection died…` |
| drop the deliberate-close guard | `onClose > stays quiet for the plugin's own close()` |
| `hello()` drops the `roveVersion` alias | `hello > reports the RUNNING daemon's build…` |

Gates: repo-root `bun run lint`, `bun run typecheck`, `test:fast` (457 files / 4521 tests), `bun test test/render` (479), `KOBE_INCLUDE_SOCKET=1 test:socket` (100 files / 829) — all green.

coverage-exemption: packages/kobe/src/tui-react/workspace/TerminalTabs.tsx — one line (`taskId: props.taskId` into the dialogs hook). The file reads 33.8% because it cannot be mounted under the render harness (baseline, unchanged by this PR); the behavior it enables is proven by the harness screenshots above.
coverage-exemption: packages/kobe/src/tui-react/workspace/use-tab-dialogs.ts — reads 0% on the VITEST track because vitest never imports it; it is exercised by the render track (`test/render/new-chat-flow.test.tsx`, updated here). Its react dependency is type-only, so `isRenderTrackOnly` classifies it into the wrong track.

## Not proven

Nothing in scope is unproven. Two notes on the setup, both artifacts of this checkout rather than of Rove:

- The harness probe connects through a short symlink to the daemon socket: this worktree's fixture home makes the socket path 109 bytes, past the 104-byte `sun_path` limit. Product behavior is unaffected — the CLI-path proofs used the real path directly.
- Fixture daemon and PTY host were both stopped after capture; `lsof` over my socket paths shows no leftovers.
