### PR TITLE
A cap that calls itself generous deletes the overflow, and a 30s poll that is really 169s

### DIFF
--- a/.changeset/freeze-restore-budget.md
+++ b/.changeset/freeze-restore-budget.md
@@ -1,0 +1,27 @@
+---
+"@sma1lboy/rove": patch
+---
+
+A pty-host boot no longer deletes the scrollback it decided not to restore
+
+`loadFrozenSessions` kept the 64 newest frozen sessions and `rmSync`'d the rest.
+The cap's comment called 64 "several times any realistic number of open terminal
+tabs"; a machine measured while writing this held 108 records / 69MB, and every
+record past 64 was from the previous day's work — so the next host boot would
+have permanently deleted 44 tabs' scrollback. The count grows with tab churn
+over a host's lifetime, not with how many tasks you have: one long-lived task
+cycling `tab-60`, `tab-63`, `tab-68` gets there on its own.
+
+The cap is now a restore budget in bytes (`FREEZE_RESTORE_MAX_BYTES`, 64MB),
+and a record past it is left on disk rather than deleted. It is also applied
+*before* reading, off each file's mtime, which is what the old comment claimed
+("bounds the boot read at ~32MB") and did not do — the 64-record cap ran after
+every file had already been read, so a 400-record directory read 262MB to keep
+32MB of it. Measured on seeded directories at the same mean record size: 108
+records deleted 44 and now deletes 0; 200 deleted 136 and now deletes 0; 400
+deleted 336 and now deletes 0. Load time was 10/17/33/82ms across those four
+sizes and is now flat at ~13ms.
+
+Only the 14-day TTL deletes now, and it reaches records the budget never reads,
+so the directory is still bounded. A boot that defers or expires anything says
+so in `pty.log` — a store that quietly loses scrollback was the actual harm.

--- a/.changeset/pr-poller-concurrency.md
+++ b/.changeset/pr-poller-concurrency.md
@@ -1,0 +1,20 @@
+---
+"@sma1lboy/rove": patch
+---
+
+The PR-status poller's 30s interval is now the rate you actually get
+
+One pass awaited each `gh pr list` in turn, and the ticker drops any tick
+arriving while a pass is still running — so the real per-task refresh was
+`max(30s, N × gh_latency)` while `DEFAULT_PR_STATUS_POLL_MS` and the module doc
+both said 30s. A pass now runs up to `PR_POLL_CONCURRENCY` (8) calls at once.
+Measured through the real `spawn` path with a counting shim at 800ms per call:
+18 tasks 15.2s → 2.6s, 50 tasks 42.1s → 5.9s, 200 tasks 169.5s → 21.5s, with
+peak concurrency going from 1 to 8 and the same number of `gh` children spawned.
+At 50 tasks the effective refresh was 42s and is now the documented 30s.
+
+This matters past a stale chip: `prStatus` is the only CI truth Rove holds, and
+an unattended worker asks it whether its own PR is green. The tick, the jitter,
+and the per-task backoffs are unchanged — only the pass was serial, and `gh`
+waits on the network rather than the CPU, so serialising it was never buying
+back the subprocess budget its comment claimed.

--- a/docs/SESSIONS.md
+++ b/docs/SESSIONS.md
@@ -13,7 +13,7 @@ instead.
 | Quit the TUI | ✓ | ✓ | ✓ | ✓ |
 | Drop your SSH connection | ✓ | ✓ | ✓ | ✓ |
 | `rove daemon restart` | ✓ | ✓ | ✓ | ✓ |
-| Reboot, or the PTY host dies | — command relaunched on attach | ✓ restored, for the 64 newest records under 14 days old | ✓ | ✓ |
+| Reboot, or the PTY host dies | — command relaunched on attach | ✓ restored, newest first, up to 64MB of scrollback | ✓ | ✓ |
 | Close a tab | — that tab only | — that tab's ring is dropped | ✓ | ✓ |
 | Delete a managed/directory Task | — all of that Task's tabs | — those rings are dropped | task record removed; worktree removed unless it's a directory Task (branch stays; a force-delete salvages uncommitted work under `refs/rove/salvage/`) | ✓ |
 | Press F5 | — active terminal is replaced | — old ring is dropped | ✓ | ✓ |
@@ -81,11 +81,14 @@ flowchart TB
   per few seconds while streaming, immediately on exit, and in full at
   shutdown. A host that comes back up (after a crash, a reboot, an idle-exit)
   thaws each surviving record into a dead *restored* session: reattaching
-  replays the old screen and respawns the command in place. Two limits prune
-  the rest at boot rather than thawing them: a record untouched for **14 days**
-  is deleted, and only the **64 most recently updated** survive — past that,
-  the oldest go. Closing a tab, deleting a task, or `rove reset` deletes the
-  record too. An intentional end is never resurrected.
+  replays the old screen and respawns the command in place. A boot restores
+  newest first up to **64MB** of scrollback and stops there; the records past
+  that budget are left on disk untouched, so a directory bigger than one boot
+  wants to read never loses anything. What actually deletes is age: a record
+  untouched for **14 days** goes, which is what keeps the directory bounded.
+  Closing a tab, deleting a task, or `rove reset` deletes the record too. An
+  intentional end is never resurrected. Each boot writes what it restored,
+  deferred, and expired to `pty.log`.
 
 ## Detaching and reattaching
 

--- a/packages/kobe-daemon/src/daemon/pr-status-collector.ts
+++ b/packages/kobe-daemon/src/daemon/pr-status-collector.ts
@@ -52,9 +52,9 @@
  * auth/network blip never clobbers a known chip. A non-zero exit is ALWAYS an
  * `error` — "no PR" only comes from the structural empty-array success path,
  * never from a guessed stderr pattern, so a `gh` failure cannot silently
- * masquerade as "no PR". Best-effort + sequential (gentle on the
- * subprocess budget); a per-task failure is logged, never fatal, never blocks
- * the other tasks in the pass.
+ * masquerade as "no PR". Best-effort, at most
+ * {@link PR_POLL_CONCURRENCY} `gh` calls in flight; a per-task failure is
+ * logged, never fatal, never blocks the other tasks in the pass.
  */
 
 import { spawn } from "node:child_process"
@@ -113,6 +113,23 @@ export const NO_REMOTE_BACKOFF_MS = 30 * 60_000
 export const PR_POLL_JITTER_RATIO = 0.2
 /** Kill a `gh pr list` that hangs past this (network stall). */
 export const PR_VIEW_TIMEOUT_MS = 10_000
+
+/**
+ * How many `gh pr list` calls one pass may have in flight.
+ *
+ * A pass used to await each task in turn, and `startTicker` drops any tick
+ * arriving while one is still running — so the real per-task refresh was
+ * `max(tickMs, N × gh_latency)`, not the {@link DEFAULT_PR_STATUS_POLL_MS}
+ * this module documents. Measured at 800ms per call, one pass took 42s at 50
+ * tasks and 170s at 200, all of it one child at a time.
+ *
+ * 8 keeps 200 tasks inside a single tick while staying far below any
+ * fd/process ceiling. `gh` waits on the network rather than the CPU, so
+ * serialising it was never buying back a real constraint; the per-task
+ * backoffs in `nextPoll` are what actually bound how often it runs, and they
+ * are untouched.
+ */
+export const PR_POLL_CONCURRENCY = 8
 
 /**
  * The outcome of one `gh pr list --head <branch>`:
@@ -307,7 +324,6 @@ export async function runPrStatusPass(orch: DaemonOrchestrator, opts: PrStatusPa
     failureCapMs: PR_FAILURE_CAP_MS,
     jitterRatio: PR_POLL_JITTER_RATIO,
   }
-  const changed: string[] = []
   const tasks = orch.listTasks()
   // Drop entries for tasks that are GONE, not merely ineligible. The delete
   // below only fires for ids still in `listTasks()`, so a deleted task's entry
@@ -316,6 +332,10 @@ export async function runPrStatusPass(orch: DaemonOrchestrator, opts: PrStatusPa
   for (const id of opts.schedule.keys()) {
     if (!live.has(id)) opts.schedule.delete(id)
   }
+  // Selection is synchronous and happens against ONE `opts.now`, before any
+  // `gh` runs — so which tasks are due does not depend on how long the pass
+  // takes, the way it would if the filter were interleaved with the awaits.
+  const due: Array<{ task: Task; prevFailures: number }> = []
   for (const task of tasks) {
     if (!isPrPollable(task)) {
       opts.schedule.delete(task.id) // forget backoff for now-ineligible tasks
@@ -323,7 +343,11 @@ export async function runPrStatusPass(orch: DaemonOrchestrator, opts: PrStatusPa
     }
     const entry = opts.schedule.get(task.id)
     if (entry && opts.now < entry.nextAllowedAt) continue
-    const prevFailures = entry?.failures ?? 0
+    due.push({ task, prevFailures: entry?.failures ?? 0 })
+  }
+
+  /** One task's poll. Returns its id when the persisted status changed. */
+  const pollOne = async (task: Task, prevFailures: number): Promise<string | undefined> => {
     try {
       const result = await opts.run(task.worktreePath, task.branch)
       if (result.kind === "error") {
@@ -336,20 +360,20 @@ export async function runPrStatusPass(orch: DaemonOrchestrator, opts: PrStatusPa
           `gh pr list failed (${result.error}) for task ${task.id} [${task.branch}] — keeping last PR status, backing off`,
         )
         // The log alone left the chip claiming a fact nobody was refreshing.
-        if (await setPrStaleMarker(orch, task.id, result.error)) changed.push(task.id)
+        const marked = await setPrStaleMarker(orch, task.id, result.error)
         opts.schedule.set(
           task.id,
           opts.runtime.prStatus.nextPoll({ kind: "error", error: result.error }, prevFailures, opts.now, cfg, rand),
         )
-        continue
+        return marked ? task.id : undefined
       }
       if (result.kind === "empty") {
         // gh ran and there is genuinely no PR yet. Keep the last value; back off
         // (a branch rarely sprouts a PR between ticks). `gh` reaching the
         // provider is what clears the stale marker, not the answer it gave.
-        if (await setPrStaleMarker(orch, task.id, undefined)) changed.push(task.id)
+        const marked = await setPrStaleMarker(orch, task.id, undefined)
         opts.schedule.set(task.id, opts.runtime.prStatus.nextPoll({ kind: "empty" }, prevFailures, opts.now, cfg, rand))
-        continue
+        return marked ? task.id : undefined
       }
       const next = opts.runtime.prStatus.mapView(result.view, opts.at)
       // Re-read under the live store (the task may have been deleted
@@ -357,15 +381,16 @@ export async function runPrStatusPass(orch: DaemonOrchestrator, opts: PrStatusPa
       const current = orch.getTask(task.id)
       if (!current) {
         opts.schedule.delete(task.id)
-        continue
+        return undefined
       }
       // `sameStatus` ignores `lastError`, so an otherwise-identical status
       // would leave a stale marker on a chip that just polled cleanly. `next`
       // never carries one, so writing it IS the clear.
       const wasStale = current.prStatus?.lastError !== undefined
+      let changedId: string | undefined
       if (wasStale || !opts.runtime.prStatus.sameStatus(current.prStatus, next ?? undefined)) {
         await orch.setPRStatus(task.id, next)
-        changed.push(task.id)
+        changedId = task.id
       }
       // A merged/closed PR is done — poll it rarely; an open one tracks checks.
       const settled = next?.lifecycle === "merged" || next?.lifecycle === "closed"
@@ -373,18 +398,32 @@ export async function runPrStatusPass(orch: DaemonOrchestrator, opts: PrStatusPa
         task.id,
         opts.runtime.prStatus.nextPoll({ kind: "pr", settled }, prevFailures, opts.now, cfg, rand),
       )
+      return changedId
     } catch (err) {
       // The injected runner threw (the real one never does). Treat as a
       // transient error so it backs off rather than hammering.
       logDaemonError("pr-status-poller", err)
-      if (await setPrStaleMarker(orch, task.id, "network").catch(() => false)) changed.push(task.id)
+      const marked = await setPrStaleMarker(orch, task.id, "network").catch(() => false)
       opts.schedule.set(
         task.id,
         opts.runtime.prStatus.nextPoll({ kind: "error", error: "network" }, prevFailures, opts.now, cfg, rand),
       )
+      return marked ? task.id : undefined
     }
   }
-  return changed
+
+  // Fixed-size worker pool over `due`. Results land in their task's own slot,
+  // so the returned ids stay in task order however the polls interleave.
+  const slots = new Array<string | undefined>(due.length)
+  let cursor = 0
+  const worker = async (): Promise<void> => {
+    for (let i = cursor++; i < due.length; i = cursor++) {
+      const item = due[i]
+      if (item) slots[i] = await pollOne(item.task, item.prevFailures)
+    }
+  }
+  await Promise.all(Array.from({ length: Math.min(PR_POLL_CONCURRENCY, due.length) }, worker))
+  return slots.filter((id): id is string => id !== undefined)
 }
 
 /**

--- a/packages/kobe-daemon/src/daemon/pty-freeze-store.ts
+++ b/packages/kobe-daemon/src/daemon/pty-freeze-store.ts
@@ -27,7 +27,7 @@
  * contract); a bare SIGTERM / crash / reboot leaves it for the next host.
  */
 
-import { chmodSync, mkdirSync, readFileSync, readdirSync, renameSync, rmSync, writeFileSync } from "node:fs"
+import { chmodSync, mkdirSync, readFileSync, readdirSync, renameSync, rmSync, statSync, writeFileSync } from "node:fs"
 import { join } from "node:path"
 import { StringDecoder } from "node:string_decoder"
 import { defaultPtyFreezeDir } from "./paths.ts"
@@ -178,13 +178,36 @@ function parseRecord(raw: string): FrozenPtySession | null {
 export const FREEZE_TTL_MS = 14 * 24 * 60 * 60 * 1000
 
 /**
- * Hard ceiling on restored sessions, newest first. The TTL handles the
- * ordinary case; this bounds the pathological one (a burst of tasks inside
- * the window). 64 is several times any realistic number of open terminal
- * tabs, and at the 512KB scrollback cap it bounds the boot read at ~32MB
- * rather than the unbounded read that made a 54MB directory possible.
+ * How much frozen scrollback ONE boot reads back, newest first.
+ *
+ * This is a restore budget, not a retention policy: a record past it is left
+ * on disk untouched, not deleted. The two jobs used to be one 64-record cap
+ * that did neither well — it was applied AFTER reading every file (so it
+ * bounded nothing) and it `rmSync`'d the overflow (so a directory that had
+ * merely outgrown a guess lost real scrollback). A measured install carried
+ * 108 records / 69MB against that "several times any realistic number" cap,
+ * and every record past 64 was from the previous day's work.
+ *
+ * Bytes rather than records because bytes are what both costs actually track:
+ * the boot read, and the rings the host then holds in memory for the whole
+ * session. 64MB is ~128 sessions at the 512KB ring cap and ~100 at the 640KB
+ * mean record that install showed.
  */
-export const FREEZE_MAX_RECORDS = 64
+export const FREEZE_RESTORE_MAX_BYTES = 64 * 1024 * 1024
+
+/** What one {@link loadFrozenSessions} did — `pty-server` logs it, so a boot
+ *  that dropped or deferred someone's scrollback says so in `daemon.log`
+ *  instead of doing it silently. */
+export interface FreezeLoadSummary {
+  readonly restored: number
+  readonly bytesRead: number
+  /** Past {@link FREEZE_RESTORE_MAX_BYTES}: not read, not deleted, still on disk. */
+  readonly deferred: number
+  /** Past {@link FREEZE_TTL_MS}: deleted. */
+  readonly expired: number
+  /** Present but unparseable — left alone for a human to look at. */
+  readonly unreadable: number
+}
 
 /** Newest-first by `updatedAt`; unparseable stamps sort oldest. */
 function updatedAtMs(record: FrozenPtySession): number {
@@ -193,38 +216,76 @@ function updatedAtMs(record: FrozenPtySession): number {
 }
 
 /**
- * Every restorable record in `dir`; missing/corrupt entries read as none.
+ * Every restorable record in `dir` that fits the restore budget; missing or
+ * corrupt entries read as none.
  *
- * Pruned on the way out — expired (older than {@link FREEZE_TTL_MS}) and
- * over-cap records are DELETED, not merely skipped. Without this the
- * directory only ever grows: `pty.sweep` reaches only a RUNNING host, so a
- * task deleted while the host was down leaves its record behind forever,
- * and every subsequent boot pays the full read AND thaws the dead task's
- * session back into the live table.
+ * Ordering comes from each file's mtime, taken from `statSync` — deciding
+ * what to read by a field INSIDE the records would mean reading all of them
+ * first, which is the unbounded read this budget exists to stop. A record is
+ * rewritten wholesale on every freeze, so its mtime and its `updatedAt` are
+ * stamped at the same moment; the parsed `updatedAt` still governs the TTL
+ * for everything actually read, so a record whose mtime drifted newer than
+ * its contents (a copy, a restore-from-backup) is still expired correctly.
+ *
+ * Only the TTL deletes. That is what bounds the directory — `pty.sweep`
+ * reaches only a RUNNING host, so a task deleted while the host was down
+ * leaves its record behind, and two weeks is the backstop. Deferring a record
+ * for being over budget must never delete it: the budget is a statement about
+ * this boot's memory, and the user may still want that scrollback.
  */
-export function loadFrozenSessions(dir = defaultPtyFreezeDir(), now = Date.now()): FrozenPtySession[] {
+export function loadFrozenSessions(
+  dir = defaultPtyFreezeDir(),
+  now = Date.now(),
+  report?: (summary: FreezeLoadSummary) => void,
+): FrozenPtySession[] {
   let names: string[]
   try {
     names = readdirSync(dir)
   } catch {
     return []
   }
-  const kept: Array<{ name: string; record: FrozenPtySession }> = []
-  const stale: string[] = []
+  const entries: Array<{ name: string; size: number; mtimeMs: number }> = []
   for (const name of names) {
     if (!name.endsWith(".json")) continue
+    try {
+      const st = statSync(join(dir, name))
+      entries.push({ name, size: st.size, mtimeMs: st.mtimeMs })
+    } catch {
+      // Vanished between readdir and stat — nothing to restore or delete.
+    }
+  }
+  entries.sort((a, b) => b.mtimeMs - a.mtimeMs)
+
+  const kept: FrozenPtySession[] = []
+  const stale: string[] = []
+  let bytesRead = 0
+  let deferred = 0
+  let unreadable = 0
+  for (const entry of entries) {
+    // mtime can only run at or ahead of the record's own stamp, so an
+    // mtime-expired file is expired for certain — safe to drop unread.
+    if (now - entry.mtimeMs > FREEZE_TTL_MS) {
+      stale.push(entry.name)
+      continue
+    }
+    if (bytesRead + entry.size > FREEZE_RESTORE_MAX_BYTES && kept.length > 0) {
+      deferred++
+      continue
+    }
     let record: FrozenPtySession | null = null
     try {
-      record = parseRecord(readFileSync(join(dir, name), "utf8"))
+      record = parseRecord(readFileSync(join(dir, entry.name), "utf8"))
     } catch {
       // One unreadable file must not cost the rest.
     }
-    if (!record) continue
-    if (now - updatedAtMs(record) > FREEZE_TTL_MS) stale.push(name)
-    else kept.push({ name, record })
+    bytesRead += entry.size
+    if (!record) {
+      unreadable++
+      continue
+    }
+    if (now - updatedAtMs(record) > FREEZE_TTL_MS) stale.push(entry.name)
+    else kept.push(record)
   }
-  kept.sort((a, b) => updatedAtMs(b.record) - updatedAtMs(a.record))
-  for (const over of kept.splice(FREEZE_MAX_RECORDS)) stale.push(over.name)
   for (const name of stale) {
     try {
       rmSync(join(dir, name), { force: true })
@@ -232,7 +293,9 @@ export function loadFrozenSessions(dir = defaultPtyFreezeDir(), now = Date.now()
       /* best-effort: a record we couldn't delete is simply skipped this boot */
     }
   }
-  return kept.map((entry) => entry.record)
+  kept.sort((a, b) => updatedAtMs(b) - updatedAtMs(a))
+  report?.({ restored: kept.length, bytesRead, deferred, expired: stale.length, unreadable })
+  return kept
 }
 
 /** Owner-only. See {@link tightenExistingPermissions} for why the mode

--- a/packages/kobe-daemon/src/daemon/pty-server.ts
+++ b/packages/kobe-daemon/src/daemon/pty-server.ts
@@ -239,8 +239,9 @@ export async function startPtyHostServer(options: PtyHostServerOptions = {}): Pr
       // the directory holds is the one thing a user cannot otherwise see, and
       // `expired` is a deletion — silence there is how a store quietly loses
       // scrollback nobody knew was at risk.
-      const notes = [`restored ${s.restored} (${(s.bytesRead / 1e6).toFixed(0)}MB)`]
-      if (s.deferred > 0) notes.push(`${s.deferred} left unread past the ${FREEZE_RESTORE_MAX_BYTES / 1e6}MB budget`)
+      const mib = (bytes: number): string => `${Math.round(bytes / (1024 * 1024))}MB`
+      const notes = [`restored ${s.restored} (${mib(s.bytesRead)})`]
+      if (s.deferred > 0) notes.push(`${s.deferred} left unread past the ${mib(FREEZE_RESTORE_MAX_BYTES)} budget`)
       if (s.expired > 0) notes.push(`${s.expired} deleted past the ${FREEZE_TTL_MS / 86_400_000}-day TTL`)
       if (s.unreadable > 0) notes.push(`${s.unreadable} unreadable`)
       log("freeze", notes.join(", "))

--- a/packages/kobe-daemon/src/daemon/pty-server.ts
+++ b/packages/kobe-daemon/src/daemon/pty-server.ts
@@ -44,7 +44,13 @@ import { DAEMON_PROTOCOL_VERSION, type DaemonFrame, frameToLine } from "./protoc
 import { migrateLegacyPtyHostData } from "./pty-data-migration.ts"
 import type { PtyDriver } from "./pty-driver.ts"
 import { recordPtyExit } from "./pty-exit-store.ts"
-import { clearFrozenSessions, fileFreezeSink, loadFrozenSessions } from "./pty-freeze-store.ts"
+import {
+  FREEZE_RESTORE_MAX_BYTES,
+  FREEZE_TTL_MS,
+  clearFrozenSessions,
+  fileFreezeSink,
+  loadFrozenSessions,
+} from "./pty-freeze-store.ts"
 import { PtyHost } from "./pty-host.ts"
 import { parseTerminalDefaultColors } from "./terminal-colors.ts"
 
@@ -227,7 +233,19 @@ export async function startPtyHostServer(options: PtyHostServerOptions = {}): Pr
     driver: options.driver,
     log,
   })
-  ptys.restoreFrozen(loadFrozenSessions(freezeDir))
+  ptys.restoreFrozen(
+    loadFrozenSessions(freezeDir, Date.now(), (s) => {
+      // Say what the boot did with the store. Restoring fewer sessions than
+      // the directory holds is the one thing a user cannot otherwise see, and
+      // `expired` is a deletion — silence there is how a store quietly loses
+      // scrollback nobody knew was at risk.
+      const notes = [`restored ${s.restored} (${(s.bytesRead / 1e6).toFixed(0)}MB)`]
+      if (s.deferred > 0) notes.push(`${s.deferred} left unread past the ${FREEZE_RESTORE_MAX_BYTES / 1e6}MB budget`)
+      if (s.expired > 0) notes.push(`${s.expired} deleted past the ${FREEZE_TTL_MS / 86_400_000}-day TTL`)
+      if (s.unreadable > 0) notes.push(`${s.unreadable} unreadable`)
+      log("freeze", notes.join(", "))
+    }),
+  )
 
   // A Windows named pipe lives in the `\\.\pipe` namespace, not the
   // filesystem — there is no parent directory to create.

--- a/packages/kobe/test/daemon/pty-freeze-store.test.ts
+++ b/packages/kobe/test/daemon/pty-freeze-store.test.ts
@@ -6,12 +6,13 @@
  * ring cap on thaw, and the reset semantics (clear = starts fresh).
  */
 
-import { chmodSync, mkdirSync, mkdtempSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs"
+import { chmodSync, mkdirSync, mkdtempSync, readdirSync, rmSync, statSync, utimesSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import {
-  FREEZE_MAX_RECORDS,
+  FREEZE_RESTORE_MAX_BYTES,
   FREEZE_TTL_MS,
+  type FreezeLoadSummary,
   type FreezeableSession,
   type FrozenPtySession,
   clearFrozenSessions,
@@ -180,12 +181,20 @@ describe("existing-permission remediation", () => {
   })
 })
 
-describe("pruning stale + over-cap records", () => {
+describe("pruning stale + over-budget records", () => {
   const DAY = 24 * 60 * 60 * 1000
 
-  function writeRecord(key: string, updatedAt: string): void {
-    fileFreezeSink(dir).save({ ...freezeSession(fakeSession({ key })), updatedAt })
+  function writeRecord(key: string, updatedAt: string, ringBytes = 0): void {
+    const chunks = ringBytes > 0 ? [Buffer.alloc(ringBytes, 0x61)] : undefined
+    fileFreezeSink(dir).save({ ...freezeSession(fakeSession({ key, ...(chunks ? { chunks } : {}) })), updatedAt })
+    // Ordering is decided by mtime (see `loadFrozenSessions`), so pin it
+    // rather than relying on write order resolving at ms granularity.
+    const at = Date.parse(updatedAt) / 1000
+    utimesSync(join(dir, `${encodeURIComponent(key)}.json`), at, at)
   }
+
+  /** Two of these overflow FREEZE_RESTORE_MAX_BYTES; one does not. */
+  const HALF_BUDGET_RING = Math.ceil(((FREEZE_RESTORE_MAX_BYTES / 2 + 2 * 1024 * 1024) * 3) / 4)
 
   it("deletes records past the TTL instead of thawing them", () => {
     const now = Date.parse("2026-08-30T00:00:00.000Z")
@@ -201,20 +210,54 @@ describe("pruning stale + over-cap records", () => {
     expect(readdirSync(dir).filter((n) => n.endsWith(".json"))).toHaveLength(1)
   })
 
-  it("keeps the newest FREEZE_MAX_RECORDS and deletes the rest", () => {
+  it("restores newest-first up to the byte budget and LEAVES the rest on disk", () => {
     const now = Date.parse("2026-08-30T00:00:00.000Z")
-    const total = FREEZE_MAX_RECORDS + 5
-    for (let i = 0; i < total; i++) {
-      // i=0 newest, ascending index = older.
-      writeRecord(`t${i}::tab-1`, new Date(now - i * 60_000).toISOString())
-    }
+    writeRecord("newer::tab-1", new Date(now - 60_000).toISOString(), HALF_BUDGET_RING)
+    writeRecord("older::tab-1", new Date(now - 120_000).toISOString(), HALF_BUDGET_RING)
 
     const loaded = loadFrozenSessions(dir, now)
 
-    expect(loaded).toHaveLength(FREEZE_MAX_RECORDS)
-    expect(loaded[0]?.key).toBe("t0::tab-1")
-    expect(loaded.map((r) => r.key)).not.toContain(`t${total - 1}::tab-1`)
-    expect(readdirSync(dir).filter((n) => n.endsWith(".json"))).toHaveLength(FREEZE_MAX_RECORDS)
+    expect(loaded.map((r) => r.key)).toEqual(["newer::tab-1"])
+    // The point of the whole change: over-budget is DEFERRED, never deleted.
+    // A directory that outgrew a guess used to lose the overflow permanently.
+    expect(readdirSync(dir).filter((n) => n.endsWith(".json"))).toHaveLength(2)
+  })
+
+  it("still restores a lone record larger than the whole budget", () => {
+    const now = Date.parse("2026-08-30T00:00:00.000Z")
+    writeRecord("huge::tab-1", new Date(now - 60_000).toISOString(), FREEZE_RESTORE_MAX_BYTES)
+
+    expect(loadFrozenSessions(dir, now).map((r) => r.key)).toEqual(["huge::tab-1"])
+  })
+
+  it("expires a record the budget never reads, so the TTL still bounds the directory", () => {
+    const now = Date.parse("2026-08-30T00:00:00.000Z")
+    writeRecord("newer::tab-1", new Date(now - 60_000).toISOString(), HALF_BUDGET_RING)
+    // Past the budget AND past the TTL. Only a check that runs BEFORE the read
+    // can reach it — a budget that merely stopped reading would strand it
+    // forever, and the directory would grow without bound again.
+    writeRecord("ancient::tab-1", new Date(now - 30 * DAY).toISOString(), HALF_BUDGET_RING)
+
+    const loaded = loadFrozenSessions(dir, now)
+
+    expect(loaded.map((r) => r.key)).toEqual(["newer::tab-1"])
+    expect(readdirSync(dir).filter((n) => n.endsWith(".json"))).toEqual(["newer%3A%3Atab-1.json"])
+  })
+
+  it("reports what the boot did with the store", () => {
+    const now = Date.parse("2026-08-30T00:00:00.000Z")
+    writeRecord("newer::tab-1", new Date(now - 60_000).toISOString(), HALF_BUDGET_RING)
+    writeRecord("older::tab-1", new Date(now - 120_000).toISOString(), HALF_BUDGET_RING)
+    writeRecord("ancient::tab-1", new Date(now - 30 * DAY).toISOString())
+
+    let summary: FreezeLoadSummary | undefined
+    loadFrozenSessions(dir, now, (s) => {
+      summary = s
+    })
+
+    // Deferring and deleting are different outcomes and the log must say which.
+    expect(summary).toMatchObject({ restored: 1, deferred: 1, expired: 1, unreadable: 0 })
+    expect(summary?.bytesRead).toBeLessThanOrEqual(FREEZE_RESTORE_MAX_BYTES)
   })
 
   it("keeps a record right at the TTL edge", () => {


### PR DESCRIPTION
Two daemon costs that each broke a promise their own comment made. Both were
measured before and after at three or four fleet sizes, through the real code
path — a real `pty-host` process for one, real `spawn`ed children counted by a
PATH shim for the other. No screenshots: neither item has a UI surface, and
nothing rendered changes.

Re-runnable probes live in `.scratch/loop-r20-bj/`; raw output is in
`/tmp/loop-r20-bj-evidence/`.

---

## 1. The freeze store deletes scrollback it merely decided not to restore

`pty-freeze-store.ts:187` capped restores at 64 records and `rmSync`'d the
overflow. The comment justifying 64 made two claims, both false:

- *"several times any realistic number of open terminal tabs"* — the machine
  this was written on held **108 records / 69MB** (110 / 70M by the end of the
  session; it is still growing). Everything past position 64 was dated
  **Sep 3 22:43** — the previous day's work. It grows with tab churn over a
  host's lifetime, not with task count; one task there holds `tab-60`,
  `tab-63`, `tab-68`.
- *"bounds the boot read at ~32MB"* — the cap ran **after** `readFileSync` on
  every record, so the read was unbounded in file count.

**Change.** The cap is now `FREEZE_RESTORE_MAX_BYTES` (64MB), applied *before*
any read by sorting on `statSync` mtime, and a record past the budget is left
on disk rather than deleted. Only the 14-day TTL deletes, and it now reaches
records the budget never reads (mtime can only run at or ahead of a record's
own stamp, so an mtime-expired file is expired for certain) — so the directory
is still bounded. The boot reports what it restored, deferred and expired.

Bytes rather than records because bytes are what both costs actually track: the
boot read, and the rings the host then holds in memory all session.

### PASS criterion
With a directory larger than the budget, the number of records **deleted** is 0,
and the load stops scaling with directory size.

### Proof — seeded directories at the operator's mean record size (640KB)
`bun .scratch/loop-r20-bj/freeze-probe.ts`

| records | on disk | load ms before → after | restored before → after | **deleted before → after** |
|---|---|---|---|---|
| 64  | 42 MB  | 10 → 10 | 64 → 64  | 0 → 0 |
| 108 | 71 MB  | 17 → 13 | 64 → 102 | **44 → 0** |
| 200 | 131 MB | 33 → 12 | 64 → 102 | **136 → 0** |
| 400 | 262 MB | 82 → 12 | 64 → 102 | **336 → 0** |

Load time went from scaling 10→82ms with directory size to flat ~12ms: that is
the ordering fix, externally visible. Restored count rose 64 → 102 because the
budget is spent on bytes rather than on a record count guessed against a
different ring size.

### Proof — a real `pty-host` process, seeded with 120 records / 75MB
`.scratch/loop-r20-bj/live-boot.sh` (isolated home, port base 8123, run from
source; BEFORE captured by `git checkout <base> -- <the two files>`)

```
== before ==                                    == after ==
seeded : 120 records,  75M                      seeded : 120 records,  75M
(no freeze line at all)                         [pty-host freeze] restored 102 (64MB), 18 left unread past the 64MB budget
after  : 64 records,  40M                       after  : 120 records,  75M
```

**56 records destroyed by one boot, silently → 0 destroyed, and it says what it
did.** Full output: `/tmp/loop-r20-bj-evidence/live-boot-{before,after}.txt`.

---

## 2. The PR poller's documented 30s is not the rate you get

`pr-status-collector.ts:319` awaited each `gh pr list` in turn, and
`ticker.ts` drops any tick landing while a pass runs — so the real per-task
refresh was `max(30s, N × gh_latency)` while `DEFAULT_PR_STATUS_POLL_MS` and the
module doc both said 30s. This is the loop's recurring defect in a performance
costume: a documented interval that is not the real one, with nothing telling
you which you are getting.

**Change.** A fixed pool of `PR_POLL_CONCURRENCY` (8). Task selection is now a
synchronous pre-pass against one `opts.now`, so which tasks are due no longer
depends on how long the pass takes. Results land in per-task slots, so the
returned changed-ids stay in task order however the polls interleave. The tick,
the jitter, and the per-task backoffs are untouched.

### PASS criterion
Pass duration at N=200 under 30s (within one tick), down from 160s+.

### Proof — real `spawn`ed children through a counting PATH shim
`bun .scratch/loop-r20-bj/pr-pass-probe.ts` (real `makeGhPrViewRunner`, shim
`gh` at 800ms; concurrency computed from wall-clock epoch-ms start/end pairs the
shim writes, since `hrtime` is not comparable across processes)

| tasks | pass before → after | peak concurrency | real `gh` children | effective refresh before → after |
|---|---|---|---|---|
| 18  | 15.2s → **2.6s**  | 1 → 8 | 18 → 18   | 30s → 30s |
| 50  | 42.1s → **6.0s**  | 1 → 8 | 50 → 50   | 42s → **30s** |
| 200 | 169.5s → **21.5s** | 1 → 8 | 200 → 200 | 169s → **30s** |

Same number of children spawned; only the overlap changed. At 200 tasks the
pass now fits inside one tick, so the documented interval is the real one at
every size measured.

---

## Tests

`test/daemon/pty-freeze-store.test.ts` replaces the old cap test with four:
over-budget records are deferred not deleted; a lone record larger than the
whole budget still restores; a record the budget never reads still expires (the
pin on the pre-read TTL check — a budget that merely stopped reading would
strand it and let the directory grow unbounded again); and the summary reports
restored/deferred/expired separately.

Mutation-verified at two different sites, re-run after the rebase:

| mutation | result |
|---|---|
| over-budget records pushed to `stale` again (the old harm) | 2 failed / 13 passed |
| pre-read mtime TTL check deleted | 1 failed / 14 passed |

## Gates (post-rebase onto `3ef2066`)

- root `bun run lint` — clean; `bun run typecheck` — 4/4 clean
- `bun run test:fast` — 458 files, **4527 passed**
- `KOBE_INCLUDE_SOCKET=1 bun run test:socket` — 100 files, **834 passed**
- `bun test test/render` — 108 files, **479 passed**

## Not proved

- The 64MB budget is an argued number, not a measured optimum. It is bounded
  below by "restore more than the 64-record cap did on a real directory" and
  above by host RSS; I did not measure where restore latency or host memory
  actually starts to hurt, so a later round may want to move it.
- Concurrency 8 was verified to fit 200 tasks in one tick at 800ms latency. I
  did not test it against a real rate-limited `github.com` — the shim never
  leaves the machine, deliberately.

## Boundaries respected

Left alone as instructed: the scrollback-write-volume and `git status` walk
briefs, `core/base-ref-cache.ts`, `plugins/runtime.ts`, the issue store,
`refs/`, `.github/workflows/*`. The operator's `~/.rove` was read only — its
`pty-sessions` directory still holds every record it did before. My isolated
daemon and pty-host both idle-exited; verified no process holds a socket under
`.scratch/loop-r20-bj`.
