### PR TITLE
A mode set at creation, with nothing that ever repairs it (A1–A2, B1–B2)

### DIFF
--- a/.changeset/owner-only-state-tree.md
+++ b/.changeset/owner-only-state-tree.md
@@ -1,0 +1,38 @@
+---
+"@sma1lboy/rove": patch
+---
+
+The state directory and the plugin tree are repaired to owner-only on every
+start, not just when they are created
+
+`<home>/.rove` was created by a bare `mkdir` and landed at 0755 under the
+default umask, and the daemon socket inside it bound at `srwxr-xr-x` because
+`listen()` applies the umask too. Nothing else gates that socket — connections
+are accepted with no peer-credential check — so on a shared machine the
+directory mode was the entire ACL, and reaching the socket means `add` (launch
+an engine) and `send` (text into a live session). Both the daemon and the PTY
+host now create that directory 0700 and chmod it again on every boot, and both
+sockets are chmod'd 0600 after the bind.
+
+The "again on every boot" half is the one that matters. `mkdirSync` and
+`writeFileSync` apply their `mode` only when they create the path, so a home
+that predates the mode arguments kept 0755 forever — the population a
+creation-time fix cannot reach is exactly the exposed one.
+
+The same defect had the plugin tree world-readable.
+`docs/PLUGIN-AUTHORING.md` tells authors to keep API keys in the config `.env`
+and states that the `.env`, the state directory and `log.jsonl` are owner-only;
+that was true for a fresh install and false for every older one, because
+`writePluginSettings` rewrites the `.env` in place and an in-place write never
+changes a mode. Every registered plugin's config, state, `.env`, `log.jsonl`
+and the registry are now repaired at daemon start and after each settings save,
+so the documented sentence holds on installs that already exist.
+
+Two comments in the web-token chain described mechanisms that are gone.
+`pty-auth.mjs` credited the daemon with minting the token file it fails closed
+without — no daemon path does; `kobe-harness/dev.ts` is the only minter, which
+matters to anyone adding a launcher. The harness token header was written
+around a `<meta name="rove-web-token">` injector that #855 deleted along with
+the daemon-hosted web transport, and presented the only channel that still
+works, `VITE_ROVE_WEB_TOKEN`, as a narrow fallback. Both now say what the code
+does.

--- a/packages/kobe-daemon/src/daemon/owner-only.ts
+++ b/packages/kobe-daemon/src/daemon/owner-only.ts
@@ -1,0 +1,64 @@
+/**
+ * Owner-only modes for the state tree, applied as a REPAIR pass rather than
+ * only at creation.
+ *
+ * `mkdirSync`/`writeFileSync`'s `mode` option binds at `O_CREAT` and is a
+ * silent no-op for a path that already exists. Every install therefore splits
+ * into two populations, and only one of them is fixed by getting the creation
+ * mode right: a home created before the mode argument landed keeps 0755/0644
+ * forever, which is precisely the population that is exposed. So each of these
+ * helpers chmods unconditionally, on every start, and not just when it creates
+ * the path.
+ *
+ * This matters most for `<home>/.rove` itself. `server.ts` accepts every
+ * connection on the daemon socket with no peer-credential check — a defensible
+ * design, but only because the containing directory is supposed to be owner-
+ * only. Reaching that socket means `add` (launch an engine — arbitrary
+ * execution as the owner) and `send` (text into a live session). The directory
+ * mode IS the access-control mechanism, so nothing else in the daemon may
+ * assume it without setting it.
+ *
+ * Best-effort throughout: a chmod that fails (foreign owner, read-only mount,
+ * a home on a filesystem with no unix modes) must never keep the daemon from
+ * booting. A loose mode is worse than a tight one; neither is worse than a
+ * daemon that will not start.
+ */
+
+import { chmod, mkdir } from "node:fs/promises"
+
+/** Directories a local user other than the owner has no business entering. */
+export const OWNER_ONLY_DIR_MODE = 0o700
+/** Files that are credentials, or that name the owner's repos and sessions. */
+export const OWNER_ONLY_FILE_MODE = 0o600
+
+/** chmod that swallows every failure — see the module header on why. */
+async function tighten(path: string, mode: number): Promise<void> {
+  try {
+    await chmod(path, mode)
+  } catch {
+    /* absent, not ours, or a filesystem without modes */
+  }
+}
+
+/** Re-`chmod` an existing directory to 0700. Safe on an absent path. */
+export function tightenDirPermissions(dir: string): Promise<void> {
+  return tighten(dir, OWNER_ONLY_DIR_MODE)
+}
+
+/** Re-`chmod` an existing file to 0600. Safe on an absent path. */
+export function tightenFilePermissions(file: string): Promise<void> {
+  return tighten(file, OWNER_ONLY_FILE_MODE)
+}
+
+/**
+ * `mkdir -p` a state directory AND tighten it.
+ *
+ * Both halves are required: the `mode` creates a fresh tree correctly, the
+ * chmod repairs a tree that already exists. Intermediate parents get the
+ * caller's umask, which is deliberate — `<home>` is the user's own directory
+ * and not ours to narrow.
+ */
+export async function ensureOwnerOnlyDir(dir: string): Promise<void> {
+  await mkdir(dir, { recursive: true, mode: OWNER_ONLY_DIR_MODE })
+  await tightenDirPermissions(dir)
+}

--- a/packages/kobe-daemon/src/daemon/owner-only.ts
+++ b/packages/kobe-daemon/src/daemon/owner-only.ts
@@ -25,6 +25,8 @@
  */
 
 import { chmod, mkdir } from "node:fs/promises"
+import { join } from "node:path"
+import { ROVE_STATE_DIR_BASENAME } from "../compat-env.ts"
 
 /** Directories a local user other than the owner has no business entering. */
 export const OWNER_ONLY_DIR_MODE = 0o700
@@ -61,4 +63,19 @@ export function tightenFilePermissions(file: string): Promise<void> {
 export async function ensureOwnerOnlyDir(dir: string): Promise<void> {
   await mkdir(dir, { recursive: true, mode: OWNER_ONLY_DIR_MODE })
   await tightenDirPermissions(dir)
+}
+
+/**
+ * The one directory this module exists for: `<home>/.rove`.
+ *
+ * Keyed on the HOME rather than on `dirname(socketPath)`, which is the obvious
+ * spelling and the wrong one. A socket path is overridable
+ * (`ROVE_DAEMON_SOCKET_PATH`) and, for a home nested deeply enough to overrun
+ * `sun_path`, `fitSocketPath` moves it to `$TMPDIR` on its own — so tightening
+ * the socket's parent would narrow whatever directory the user pointed at,
+ * including a shared `/tmp`. Nothing else in the tree wants that, and a socket
+ * that lands outside the state dir is protected by its own 0600 mode instead.
+ */
+export function ensureOwnerOnlyStateDir(homeDir: string): Promise<void> {
+  return ensureOwnerOnlyDir(join(homeDir, ROVE_STATE_DIR_BASENAME))
 }

--- a/packages/kobe-daemon/src/daemon/pty-server.ts
+++ b/packages/kobe-daemon/src/daemon/pty-server.ts
@@ -23,7 +23,7 @@
  */
 
 import { readFileSync } from "node:fs"
-import { unlink, writeFile } from "node:fs/promises"
+import { mkdir, unlink, writeFile } from "node:fs/promises"
 import { type Server, type Socket, createServer } from "node:net"
 import { dirname } from "node:path"
 import { StringDecoder } from "node:string_decoder"
@@ -31,7 +31,7 @@ import { ClientWriter } from "./client-writer.ts"
 import { linkLegacyRuntimePath } from "./compat-link.ts"
 import { logDaemonError } from "./crash-log.ts"
 import { objectPayload, requireString } from "./handler-validators.ts"
-import { ensureOwnerOnlyDir } from "./owner-only.ts"
+import { ensureOwnerOnlyStateDir } from "./owner-only.ts"
 import {
   defaultPtyFreezeDir,
   defaultPtyHostPidPath,
@@ -237,8 +237,9 @@ export async function startPtyHostServer(options: PtyHostServerOptions = {}): Pr
   // 0700 on creation AND on every boot — same reasoning as the daemon's, and
   // the same directory: this host spawns shells for whoever reaches its
   // socket, so the directory mode is the gate (see owner-only.ts).
-  if (!pipeSocket) await ensureOwnerOnlyDir(dirname(socketPath))
-  await ensureOwnerOnlyDir(dirname(pidPath))
+  await ensureOwnerOnlyStateDir(resolveDaemonHomeDir())
+  if (!pipeSocket) await mkdir(dirname(socketPath), { recursive: true })
+  await mkdir(dirname(pidPath), { recursive: true })
   // Never unlink before listen: an already-running host keeps its socket
   // alive after unlink, so a second host could bind the same pathname,
   // overwrite the pidfile, and strand the first host's live sessions.

--- a/packages/kobe-daemon/src/daemon/pty-server.ts
+++ b/packages/kobe-daemon/src/daemon/pty-server.ts
@@ -23,7 +23,7 @@
  */
 
 import { readFileSync } from "node:fs"
-import { mkdir, unlink, writeFile } from "node:fs/promises"
+import { unlink, writeFile } from "node:fs/promises"
 import { type Server, type Socket, createServer } from "node:net"
 import { dirname } from "node:path"
 import { StringDecoder } from "node:string_decoder"
@@ -31,6 +31,7 @@ import { ClientWriter } from "./client-writer.ts"
 import { linkLegacyRuntimePath } from "./compat-link.ts"
 import { logDaemonError } from "./crash-log.ts"
 import { objectPayload, requireString } from "./handler-validators.ts"
+import { ensureOwnerOnlyDir } from "./owner-only.ts"
 import {
   defaultPtyFreezeDir,
   defaultPtyHostPidPath,
@@ -46,6 +47,7 @@ import type { PtyDriver } from "./pty-driver.ts"
 import { recordPtyExit } from "./pty-exit-store.ts"
 import { clearFrozenSessions, fileFreezeSink, loadFrozenSessions } from "./pty-freeze-store.ts"
 import { PtyHost } from "./pty-host.ts"
+import { listenOnUnixSocket } from "./socket-guard.ts"
 import { parseTerminalDefaultColors } from "./terminal-colors.ts"
 
 /**
@@ -232,8 +234,11 @@ export async function startPtyHostServer(options: PtyHostServerOptions = {}): Pr
   // A Windows named pipe lives in the `\\.\pipe` namespace, not the
   // filesystem — there is no parent directory to create.
   const pipeSocket = isWindowsPipePath(socketPath)
-  if (!pipeSocket) await mkdir(dirname(socketPath), { recursive: true })
-  await mkdir(dirname(pidPath), { recursive: true })
+  // 0700 on creation AND on every boot — same reasoning as the daemon's, and
+  // the same directory: this host spawns shells for whoever reaches its
+  // socket, so the directory mode is the gate (see owner-only.ts).
+  if (!pipeSocket) await ensureOwnerOnlyDir(dirname(socketPath))
+  await ensureOwnerOnlyDir(dirname(pidPath))
   // Never unlink before listen: an already-running host keeps its socket
   // alive after unlink, so a second host could bind the same pathname,
   // overwrite the pidfile, and strand the first host's live sessions.
@@ -423,10 +428,10 @@ export async function startPtyHostServer(options: PtyHostServerOptions = {}): Pr
     }
   }
 
-  await new Promise<void>((resolve, reject) => {
-    server.once("error", reject)
-    server.listen(socketPath, () => resolve())
-  })
+  // Shared with the daemon's bind (socket-guard.ts) so both sockets get the
+  // same post-listen chmod — `listen()` applies the umask, so an unchmod'd
+  // node lands world-connectable.
+  await listenOnUnixSocket(server, socketPath)
   await writeFile(pidPath, `${process.pid}\n`, "utf8")
   // Same reason as the daemon's: a pre-rename TUI that can't see this host
   // starts a SECOND one, and the engine tabs split across the pair.

--- a/packages/kobe-daemon/src/daemon/server.ts
+++ b/packages/kobe-daemon/src/daemon/server.ts
@@ -4,7 +4,7 @@
  * surface: hello / daemon.status / daemon.stop + handlers.ts + subscribe.
  */
 
-import { unlink, writeFile } from "node:fs/promises"
+import { mkdir, unlink, writeFile } from "node:fs/promises"
 import { type Server, createServer } from "node:net"
 import { dirname } from "node:path"
 import { StringDecoder } from "node:string_decoder"
@@ -31,7 +31,7 @@ import { assertHomeUnclaimed, claimHome, releaseHomeClaim } from "./home-owner.t
 import { IssuesStore, defaultIssuesStorePath } from "./issues-store.ts"
 import { DaemonLifetime, FIRST_GUI_GRACE_MS, resolveIdleGraceMs } from "./lifetime.ts"
 import { NotesStore, defaultNotesStorePath } from "./notes-store.ts"
-import { ensureOwnerOnlyDir } from "./owner-only.ts"
+import { ensureOwnerOnlyStateDir } from "./owner-only.ts"
 import {
   defaultDaemonPidPath,
   defaultDaemonSocketPath,
@@ -161,8 +161,9 @@ export async function startDaemonServer(orch: DaemonOrchestrator, options: Daemo
   // credential check, so this directory's mode is the entire ACL, and an
   // install that predates the mode argument is exactly the one that is
   // exposed (see owner-only.ts).
-  await ensureOwnerOnlyDir(dirname(socketPath))
-  await ensureOwnerOnlyDir(dirname(pidPath))
+  await ensureOwnerOnlyStateDir(homeDir)
+  await mkdir(dirname(socketPath), { recursive: true })
+  await mkdir(dirname(pidPath), { recursive: true })
   // Same repair for the plugin tree, whose `.env` is where PLUGIN-AUTHORING
   // tells authors to keep API keys.
   tightenInstalledPluginPermissions(options.homeDir)

--- a/packages/kobe-daemon/src/daemon/server.ts
+++ b/packages/kobe-daemon/src/daemon/server.ts
@@ -4,12 +4,13 @@
  * surface: hello / daemon.status / daemon.stop + handlers.ts + subscribe.
  */
 
-import { mkdir, unlink, writeFile } from "node:fs/promises"
+import { unlink, writeFile } from "node:fs/promises"
 import { type Server, createServer } from "node:net"
 import { dirname } from "node:path"
 import { StringDecoder } from "node:string_decoder"
 import { probeDaemonSocket } from "../client/daemon-process.ts"
 import { ptyHostHasLiveSessions, sweepPtyHostSessions } from "../client/pty-process.ts"
+import { tightenInstalledPluginPermissions } from "../plugins/permissions.ts"
 import { maybeStartPluginHost } from "../plugins/runtime.ts"
 import { type ClientState, broadcast, drainClientBuffer, writeFrame } from "./client-connection.ts"
 import { ClientWriter } from "./client-writer.ts"
@@ -30,6 +31,7 @@ import { assertHomeUnclaimed, claimHome, releaseHomeClaim } from "./home-owner.t
 import { IssuesStore, defaultIssuesStorePath } from "./issues-store.ts"
 import { DaemonLifetime, FIRST_GUI_GRACE_MS, resolveIdleGraceMs } from "./lifetime.ts"
 import { NotesStore, defaultNotesStorePath } from "./notes-store.ts"
+import { ensureOwnerOnlyDir } from "./owner-only.ts"
 import {
   defaultDaemonPidPath,
   defaultDaemonSocketPath,
@@ -155,8 +157,15 @@ export async function startDaemonServer(orch: DaemonOrchestrator, options: Daemo
     engineEvents,
   } = await initDaemonStores(orch, runtime, bus, options.homeDir)
 
-  await mkdir(dirname(socketPath), { recursive: true })
-  await mkdir(dirname(pidPath), { recursive: true })
+  // 0700 on creation AND on every boot: the socket below has no peer-
+  // credential check, so this directory's mode is the entire ACL, and an
+  // install that predates the mode argument is exactly the one that is
+  // exposed (see owner-only.ts).
+  await ensureOwnerOnlyDir(dirname(socketPath))
+  await ensureOwnerOnlyDir(dirname(pidPath))
+  // Same repair for the plugin tree, whose `.env` is where PLUGIN-AUTHORING
+  // tells authors to keep API keys.
+  tightenInstalledPluginPermissions(options.homeDir)
   // Stale leftover only — a live owner was refused at the top of this boot.
   await unlink(socketPath).catch(() => {})
 

--- a/packages/kobe-daemon/src/daemon/socket-guard.ts
+++ b/packages/kobe-daemon/src/daemon/socket-guard.ts
@@ -26,6 +26,8 @@
 
 import { readFile, stat, unlink } from "node:fs/promises"
 import type { Server } from "node:net"
+import { OWNER_ONLY_FILE_MODE, tightenFilePermissions } from "./owner-only.ts"
+import { isWindowsPipePath } from "./paths.ts"
 
 /** How often a running daemon re-checks that it still owns its socket path. */
 export const DEFAULT_SOCKET_WATCH_MS = 5000
@@ -35,10 +37,22 @@ type EventedServer = Server & {
   removeListener(event: "error", listener: (err: Error) => void): void
 }
 
-/** Bind `server` to `socketPath`; resolves once listening, rejects on the
- *  first bind error (EADDRINUSE, path too long, …). */
-export function listenOnUnixSocket(server: Server, socketPath: string): Promise<void> {
-  return new Promise<void>((resolve, reject) => {
+/**
+ * Bind `server` to `socketPath`; resolves once listening, rejects on the
+ * first bind error (EADDRINUSE, path too long, …).
+ *
+ * The socket is chmod'd to 0600 after the bind, not before: `listen()` applies
+ * the process umask, so under the default 022 the node lands `srwxr-xr-x` and
+ * any local user can connect. The containing directory being 0700
+ * (`ensureOwnerOnlyDir`) already closes that, but the socket is the thing the
+ * whole no-peer-credential design leans on, so it says owner-only itself
+ * rather than borrowing the statement from its parent.
+ *
+ * A Windows named pipe has no filesystem node to chmod; its ACL comes from the
+ * pipe namespace instead.
+ */
+export async function listenOnUnixSocket(server: Server, socketPath: string): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
     const evented = server as EventedServer
     evented.once("error", reject)
     server.listen(socketPath, () => {
@@ -46,7 +60,12 @@ export function listenOnUnixSocket(server: Server, socketPath: string): Promise<
       resolve()
     })
   })
+  if (!isWindowsPipePath(socketPath)) await tightenFilePermissions(socketPath)
 }
+
+/** The mode a bound socket is left at — exported so a test can assert the
+ *  intent rather than restate the octal. */
+export const SOCKET_MODE = OWNER_ONLY_FILE_MODE
 
 export async function readPidFile(pidPath: string): Promise<number | null> {
   try {

--- a/packages/kobe-daemon/src/plugins/permissions.ts
+++ b/packages/kobe-daemon/src/plugins/permissions.ts
@@ -1,0 +1,71 @@
+/**
+ * Owner-only repair for the installed-plugin tree.
+ *
+ * `docs/PLUGIN-AUTHORING.md` invites authors to keep API keys in the config
+ * `.env` and states flatly that the `.env`, the state directory and
+ * `log.jsonl` "are all owner-only (0600/0700)". The install path does create
+ * them that way — but `mkdirSync`/`writeFileSync`'s `mode` binds only at
+ * creation, and `writePluginSettings` rewrites an existing `.env` in place. So
+ * a plugin installed before those mode arguments landed keeps 0755/0644 for
+ * the life of the install, and rewriting its settings never corrects it. The
+ * documented sentence was true for new installs and false for every old one.
+ *
+ * The remedy is the same shape the two sibling credential stores already use
+ * (`web-token.ts`'s `tightenTokenPermissions`, and `pty-freeze-store.ts`'s
+ * chmod-every-record loop): repair on the way past, not only on creation.
+ *
+ * Sync because every caller is — the daemon's boot sequence runs this once,
+ * and `writePluginSettings` is a synchronous store. Best-effort throughout: a
+ * plugin whose tree cannot be chmod'd must not keep the daemon from booting or
+ * a settings edit from saving.
+ */
+
+import { chmodSync } from "node:fs"
+import { OWNER_ONLY_DIR_MODE, OWNER_ONLY_FILE_MODE } from "../daemon/owner-only.ts"
+import {
+  pluginConfigDir,
+  pluginDataDir,
+  pluginLogPath,
+  pluginRegistryPath,
+  pluginStateDir,
+  pluginsRootDir,
+} from "./plugin-paths.ts"
+import { loadPluginRegistry } from "./registry.ts"
+
+function tighten(path: string, mode: number): void {
+  try {
+    chmodSync(path, mode)
+  } catch {
+    /* absent, not ours, or a filesystem without modes */
+  }
+}
+
+/**
+ * Repair one plugin's config/state/log modes.
+ *
+ * The parent directories are included, not just the `.env`: a 0600 file inside
+ * a 0755 directory still leaks its name and mtime, and the state directory the
+ * docs name is a directory, so the promise is only kept if both halves are.
+ */
+export function tightenPluginPermissions(id: string, homeDir?: string): void {
+  tighten(pluginDataDir(id, homeDir), OWNER_ONLY_DIR_MODE)
+  tighten(pluginConfigDir(id, homeDir), OWNER_ONLY_DIR_MODE)
+  tighten(pluginStateDir(id, homeDir), OWNER_ONLY_DIR_MODE)
+  tighten(`${pluginConfigDir(id, homeDir)}/.env`, OWNER_ONLY_FILE_MODE)
+  tighten(pluginLogPath(id, homeDir), OWNER_ONLY_FILE_MODE)
+}
+
+/**
+ * Repair every registered plugin. Called once per daemon boot, which is the
+ * moment that covers an install predating the mode arguments — the population
+ * a creation-time fix cannot reach.
+ */
+export function tightenInstalledPluginPermissions(homeDir?: string): void {
+  tighten(pluginsRootDir(homeDir), OWNER_ONLY_DIR_MODE)
+  // `savePluginRegistry` already writes this 0600, and for the same reason it
+  // names every installed plugin and its checkout path. A registry that
+  // predates that mode argument is still 0644, and rewriting it in place never
+  // corrects it.
+  tighten(pluginRegistryPath(homeDir), OWNER_ONLY_FILE_MODE)
+  for (const entry of loadPluginRegistry(homeDir).plugins) tightenPluginPermissions(entry.id, homeDir)
+}

--- a/packages/kobe-daemon/src/plugins/settings-env.ts
+++ b/packages/kobe-daemon/src/plugins/settings-env.ts
@@ -8,6 +8,7 @@
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs"
 import { join } from "node:path"
 import { type PluginManifest, qualifiedActionId, readPluginManifest } from "./manifest.ts"
+import { tightenPluginPermissions } from "./permissions.ts"
 import { pluginConfigDir } from "./plugin-paths.ts"
 import { loadPluginRegistry } from "./registry.ts"
 
@@ -74,9 +75,13 @@ export function writePluginSettings(pluginId: string, values: Record<string, str
   }
   while (next.length > 0 && next[next.length - 1] === "") next.pop()
   // 0700/0600: this .env is where PLUGIN-AUTHORING tells authors to keep API
-  // keys, so it must not be world-readable like the manifest beside it.
+  // keys, so it must not be world-readable like the manifest beside it. The
+  // `mode` arguments only cover a FRESH path — this is a rewrite-in-place, so
+  // an existing 0644 .env keeps 0644 through every save. Hence the repair
+  // afterwards, which is what actually closes an old install.
   mkdirSync(pluginConfigDir(pluginId, homeDir), { recursive: true, mode: 0o700 })
   writeFileSync(path, next.length > 0 ? `${next.join("\n")}\n` : "", { mode: 0o600 })
+  tightenPluginPermissions(pluginId, homeDir)
 }
 
 /**

--- a/packages/kobe-harness/pty-auth.mjs
+++ b/packages/kobe-harness/pty-auth.mjs
@@ -16,9 +16,14 @@
  * this file runs under node — node-pty does not work under bun — and the
  * daemon's path module is TypeScript.
  *
- * Fail closed: no readable token file means no request is served. That cannot
- * strand a working install, because the daemon mints the file before the
- * sidecar has anything to talk to.
+ * Fail closed: no readable token file means no request is served. The minter
+ * is `kobe-harness/dev.ts`, which calls `ensureWebToken` before it spawns this
+ * sidecar — NOT the daemon. Nothing under `kobe-daemon/` calls `ensureWebToken`
+ * at all (the daemon-hosted web transport that used to went away with #855), so
+ * a launcher that starts the sidecar without minting first gets a gate that
+ * refuses every request. That is the correct failure, but it looks like a bug:
+ * if you are adding a launcher, mint the token in it, and do not "fix" the
+ * fail-closed branch below for looking unreachable.
  */
 
 import { timingSafeEqual } from "node:crypto"

--- a/packages/kobe-harness/src/lib/web-token.ts
+++ b/packages/kobe-harness/src/lib/web-token.ts
@@ -1,28 +1,29 @@
 /**
  * The PTY sidecar's bearer token, as the browser sees it.
  *
- * The daemon rewrites a `<meta name="rove-web-token">` into index.html for a
- * request that ALREADY presented the token. It will not mint one for an
- * anonymous caller, because `/` is ungated (a browser cannot attach a header
- * to the subresources it fetches itself) and injecting there handed the
- * credential to any `curl`.
+ * `VITE_ROVE_WEB_TOKEN` is the live channel, and currently the only one: Vite
+ * serves the harness HTML, `dev.ts` mints the token and passes it in as that
+ * env var, and `withWebTokenQuery` puts it on the WebSocket URL. Without it the
+ * sidecar refuses the upgrade.
  *
- * So the meta tag only appears on the entry navigation. `sessionStorage`
- * carries it from there: a reload that arrives without the query would
- * otherwise have neither channel. Per-tab and per-origin, so it is scoped to
- * this browser profile — the local user who cannot read the 0600 token file
- * cannot read this either.
+ * The `<meta name="rove-web-token">` and `sessionStorage` branches below are
+ * HISTORICAL. They read a tag the daemon-hosted web transport used to rewrite
+ * into index.html for a request that had already presented the token — #855
+ * deleted that transport, and nothing injects the tag any more (grep
+ * `rove-web-token`: only this file and its tests). The `sessionStorage` pair
+ * existed to carry that tag across a reload arriving without the query. Both
+ * are unreachable in production; they are still exercised by
+ * `test/web-token.test.ts` against a synthetic DOM. Removing them is a
+ * deliberate deletion, not a cleanup to fold into an unrelated change — so
+ * they stay until someone decides that, and a reader debugging a missing token
+ * should look at `VITE_ROVE_WEB_TOKEN`, not for an injector.
  *
  * Read once, but LAZILY on first use rather than at import: this module is
  * pulled in by modules that unit tests import under node with no DOM, and a
  * module-load `document` read would throw there before any test body runs.
  * Cached after the first call — the served page carries one token for its
- * whole life, and rotating it means restarting the daemon, which means
+ * whole life, and rotating it means restarting the harness, which means
  * reloading anyway.
- *
- * Absent in `vite dev`, where Vite (not the daemon) serves the HTML and so
- * nothing injects the tag. `VITE_ROVE_WEB_TOKEN` covers that case; without
- * either, the sidecar refuses the WebSocket upgrade.
  */
 const STORAGE_KEY = "rove-web-token"
 

--- a/packages/kobe/test/daemon/paths.test.ts
+++ b/packages/kobe/test/daemon/paths.test.ts
@@ -44,6 +44,7 @@ import { migrateLegacyPtyHostData } from "@sma1lboy/kobe-daemon/daemon/pty-data-
 import { defaultUiPrefsStatePath } from "@sma1lboy/kobe-daemon/daemon/ui-prefs-watcher"
 import { pluginConfigDir, pluginRegistryPath, pluginStateDir } from "@sma1lboy/kobe-daemon/plugins/plugin-paths"
 import { afterEach, beforeEach, describe, expect, test } from "vitest"
+import { roveStateDir } from "../../src/env.ts"
 
 const PREV = {
   ROVE_HOME_DIR: process.env.ROVE_HOME_DIR,
@@ -178,12 +179,25 @@ describe("defaultDaemonLogPath", () => {
 })
 
 describe("ROVE_HOME_DIR compatibility state matrix", () => {
+  /**
+   * Every path a running install writes to, asserted as an exact string under
+   * an isolated home. This is the guard against a store that resolves its own
+   * path and lands outside the home — the failure mode that let `tasks.json`
+   * escape: a store whose path is not listed here is not covered by anything,
+   * because the escape is invisible until someone's sandbox run scribbles on
+   * their real `~/.rove`. ADD AN ENTRY when you add a persisted path.
+   *
+   * `taskIndex` reaches through the kobe package's `roveStateDir()` rather
+   * than a kobe-daemon `default*Path` — which is exactly why it was missing,
+   * and why it is spelled out here instead of left to the daemon-side group.
+   */
   test("every path is canonical once nothing legacy is live", () => {
     process.env.KOBE_HOME_DIR = "/tmp/legacy-home"
     process.env.ROVE_HOME_DIR = "/tmp/rove-home"
 
     expect({
       attention: defaultAttentionInboxPath(),
+      taskIndex: join(roveStateDir(), "tasks.json"),
       automations: defaultAutomationsPath(),
       clientLog: defaultClientLogPath(),
       daemonLog: defaultDaemonLogPath(),
@@ -202,6 +216,7 @@ describe("ROVE_HOME_DIR compatibility state matrix", () => {
       uiPrefs: defaultUiPrefsStatePath(),
     }).toEqual({
       attention: "/tmp/rove-home/.rove/attention-inbox.json",
+      taskIndex: "/tmp/rove-home/.rove/tasks.json",
       automations: "/tmp/rove-home/.rove/automations.json",
       clientLog: "/tmp/rove-home/.rove/client.log",
       daemonLog: "/tmp/rove-home/.rove/daemon.log",


### PR DESCRIPTION
Batch BL: A1, A2, B1, B2 from `.scratch/loop-r21-trust/trust.md`, plus C1.

A1 and A2 are the same defect twice — a mode set at creation with no
remediation pass — so they share one fix: `owner-only.ts`, a third caller of
the pattern `tightenTokenPermissions` and `pty-freeze-store.ts` already
establish. D1/D2 and C2–C4 are out of scope and untouched.

**Evidence is `stat` output, not screenshots.** The PASS criterion here is a
filesystem mode; a TUI screenshot cannot show one. Full transcripts are on the
operator's machine at `/tmp/r21bl-RXEKBK/{before,after,pty-before,pty-after}.txt`
and reproduced inline below. Every probe ran from source
(`bun ./src/cli/rove.ts`, PATH install is behind), against an isolated home,
with `env -u KOBE_DAEMON_SOCKET_PATH -u ROVE_DAEMON_SOCKET_PATH …` — without
that an agent in a Rove tab binds the operator's live daemon socket. Nothing
under the operator's real `~/.rove` was read or chmod'd.

---

## A1 — `<home>/.rove` was 0755 in production; the socket inside it was world-connectable

`server.ts` accepted every connection with no peer-credential check, which is
defensible only because the containing directory is supposed to be 0700.
Nothing in the product set that: the sole `chmod` to 0700 lived in
`ensureWebToken`, whose only caller is `kobe-harness/dev.ts`. In a real install
the directory came from a bare `mkdir` and landed 0755, and `listen()` applies
the umask so the socket bound `srwxr-xr-x`. Reaching that socket means `add`
(launch an engine — arbitrary execution as the owner) and `send` (text into a
live session).

**PASS:** after a fresh `daemon start` into an empty home, `<home>/.rove` is
`drwx------` and neither socket is group- or world-connectable.

| | BEFORE (`1d8d65f0`) | AFTER |
|---|---|---|
| `.rove` (fresh) | `drwxr-xr-x` | `drwx------` |
| `daemon.sock` | `srwxr-xr-x` | `srw-------` |
| `.rove` (pty host, pre-existing 0755) | `drwxr-xr-x` | `drwx------` |
| `pty.sock` | `srwxr-xr-x` | `srw-------` |

The PTY host needed its own run — the daemon probe never starts it. Its BEFORE
was captured by checking the base revision of `pty-server.ts` + `socket-guard.ts`
into the tree, probing, and restoring (`git diff HEAD` empty afterwards).

## A2 — plugin `.env` documented 0600, 0644 on every install that predates the fix

`docs/PLUGIN-AUTHORING.md:329` states flatly that the config `.env`, state
directory and `log.jsonl` "are all owner-only (0600/0700)". True for a fresh
install; false for every older one, because `writePluginSettings` rewrites the
`.env` in place and `writeFileSync`'s `mode` binds only at `O_CREAT`. Verified
directly: writing `{mode:0o600}` over an existing 0644 file leaves it 0644.

**PASS:** a plugin dir pre-created 0755 with a 0644 `.env` is at 0700/0600 after
the next start. This is the half that matters — every existing install is the
broken case.

Seeded `probe.plugin` at 0755/0644, then one `daemon start`:

```
--- modes BEFORE daemon start ---          --- AFTER daemon start (fixed) ---
drwxr-xr-x  .rove                          drwx------  .rove
drwxr-xr-x  plugins/probe.plugin/config    drwx------  plugins/probe.plugin/config
drwxr-xr-x  plugins/probe.plugin/state     drwx------  plugins/probe.plugin/state
-rw-r--r--  …/config/.env                  -rw-------  …/config/.env
-rw-r--r--  …/log.jsonl                    -rw-------  …/log.jsonl
```

On the unfixed code the AFTER column is byte-identical to the BEFORE column —
that transcript is `/tmp/r21bl-RXEKBK/before.txt`.

`plugins.json` is included: `savePluginRegistry` already intends 0600 for it and
an in-place rewrite never corrected an older one. My own first AFTER run left it
visibly 0644, which is how I found it.

**Scope check, done the way the explorer did it rather than padding the count:**
`tasks.json` is NOT in this fix. `TaskIndexStore` writes a fresh 0600 tmp file
and renames over the target, so the inode is replaced and the mode self-heals on
the next save. Only in-place writers are affected.

## B1 — `pty-auth.mjs` credited a daemon mint that has no caller

> Fail closed … because the daemon mints the file before the sidecar has
> anything to talk to.

Verified: `grep -rn ensureWebToken` returns the definition, `kobe-harness/dev.ts`,
and two comments. No daemon path calls it. The gate is correct; the stated reason
is not, and a wrong reason here is load-bearing — the next person to add a
launcher would ship one that silently serves nothing, or "fix" the fail-closed
branch for looking unreachable. The comment now names `dev.ts` and says so.

**Not making the daemon mint instead.** That was the explorer's alternative, and
its main draw was that `ensureWebToken` chmods `.rove` as a side effect — which
A1 now does directly, unconditionally, in both servers. Minting a credential
that no production reader consumes would add a secret for no consumer.

**PASS:** the comment names the actual minter. Re-run the grep in the comment.

## B2 — the harness token header described an injector deleted in #855

The header was written around a `<meta name="rove-web-token">` the daemon-hosted
web transport used to inject, and framed `VITE_ROVE_WEB_TOKEN` — the only channel
that still works — as a narrow `vite dev` fallback. `grep -rn rove-web-token`
hits only that file and its tests.

**PASS:** the header describes `VITE_ROVE_WEB_TOKEN` as the live channel and the
meta/`sessionStorage` path as historical. Taken as comment-only: the dead
branches still have passing tests against a synthetic DOM, and per the brief
their deletion needs owner consent. **Flagging for sign-off** — say the word and
the branches plus `test/web-token.test.ts`'s meta cases go in a follow-up.

## C1 — the home-isolation matrix did not cover the path that escaped

Already better than described: `test/daemon/paths.test.ts` asserts 17 persisted
paths as exact strings under an isolated home. But `tasks.json` — the
`TaskIndexStore` escape the explorer wanted covered — was not among them,
because it resolves through the kobe package's `roveStateDir()` rather than a
kobe-daemon `default*Path`. So the fix is the missing entry, not a new file.

**PASS (mutation-proven):** making `roveStateDir()` read `os.homedir()` directly
— the escape shape — turns the test red with exactly the escape signature:

```
-   "taskIndex": "/tmp/rove-home/.rove/tasks.json",
+   "taskIndex": "/Users/jacksonc/.rove/tasks.json",
      Tests  1 failed | 32 passed (33)
```

Reverted; 33/33 green. Header now says to add an entry when a persisted path is
added.

---

## Gates

- root `bun run lint` — clean, 1456 files
- `bun run typecheck` — clean
- `bun run test:fast` — 458 files, **4527 passed**
- `KOBE_INCLUDE_SOCKET=1 bun run test:socket` — 100 files, **831 passed**

## Notes

- `listenOnUnixSocket` (socket-guard.ts) gained the post-listen chmod and
  `pty-server.ts` now uses it instead of its own duplicate listen promise — one
  seam, both sockets, one fewer copy. Windows named pipes are skipped: no
  filesystem node to chmod.
- Every chmod is best-effort. A foreign owner or a read-only mount must not stop
  the daemon booting; a loose mode is bad, a daemon that will not start is worse.
- No new or moved keybindings.
- No file crossed 500 lines; `server.ts` and `pty-server.ts` each net a line or
  two shorter.
- Left alone as instructed: D1/D2, C2–C4, `pty-freeze-store.ts`,
  `pr-status-collector.ts`, `refs/`, `.github/workflows/*`.
- No leftover processes: both fixture daemons stopped, both probe PTY hosts
  self-exited via `KOBE_PTY_IDLE_EXIT_MS`, and an `lsof` sweep for my scratch
  paths came back empty. The five PTY hosts running on this machine all predate
  this session and belong to other checkouts; untouched.

---

## Follow-up in this PR: keying the tighten on the home, not the socket's parent

Self-caught while re-reading the diff. `dirname(socketPath)` is the obvious
spelling and the wrong one — `ROVE_DAEMON_SOCKET_PATH` is overridable, and for a
home nested deeply enough to overrun `sun_path`, `fitSocketPath` relocates the
socket to `$TMPDIR` by itself. Chmod'ing that parent would narrow whatever
directory the user pointed at, including a shared `/tmp` on a Linux box with
the default `TMPDIR`. `ensureOwnerOnlyStateDir(homeDir)` only ever touches
`<home>/.rove`; a socket that lands elsewhere carries its own 0600.

Re-proved on a deeply-nested home whose socket does fall back:

```
TMPDIR before: drwx------ /var/folders/.../T
TMPDIR after:  drwx------ /var/folders/.../T
state dir:     drwx------ …/deep/nested/home/.rove
socket:        srw------- /var/folders/.../T/kobe-c0821f93-daemon.sock
```

Being straight about that control: macOS `$TMPDIR` is per-user and already
0700, so before/after being equal does not by itself prove the chmod is gone —
the guarantee is structural (nothing now resolves a path from the socket's
parent). The case it protects is a Linux `TMPDIR=/tmp`, where the earlier
version would have attempted `chmod 0700 /tmp` and had it fail silently.

Gates re-run after the change: lint clean, 4527 vitest, 831 daemon.
