### PR TITLE
fix: give commit-tree a git identity in the daemon test fixtures

### DIFF
--- a/.changeset/publish-gate-commit-tree-identity.md
+++ b/.changeset/publish-gate-commit-tree-identity.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Fix the two `commit-tree` calls in the daemon test fixtures that never passed a git identity, which failed every release run on CI where no global `user.name` exists.

--- a/packages/kobe/test/daemon/behind-cache.test.ts
+++ b/packages/kobe/test/daemon/behind-cache.test.ts
@@ -65,7 +65,7 @@ describe("driftCached", () => {
     const first = counter(0)
     expect(await driftCached(repo, "main", first.compute)).toBe(0)
 
-    git("update-ref", "refs/heads/main", git("commit-tree", "HEAD^{tree}", "-p", "HEAD", "-m", "advance"))
+    git("update-ref", "refs/heads/main", git(...AUTHOR, "commit-tree", "HEAD^{tree}", "-p", "HEAD", "-m", "advance"))
 
     const second = counter(1)
     expect(await driftCached(repo, "main", second.compute)).toBe(1)

--- a/packages/kobe/test/daemon/worktree-probe.test.ts
+++ b/packages/kobe/test/daemon/worktree-probe.test.ts
@@ -90,7 +90,7 @@ describe("worktreeFingerprint", () => {
     git(repo, "checkout", "-q", "-b", "work")
     const before = worktreeFingerprint(repo)
     pause()
-    git(repo, "update-ref", "refs/heads/main", git(repo, "commit-tree", "HEAD^{tree}", "-p", "HEAD", "-m", "advance"))
+    git(repo, "update-ref", "refs/heads/main", git(repo, ...AUTHOR, "commit-tree", "HEAD^{tree}", "-p", "HEAD", "-m", "advance"))
     expect(worktreeFingerprint(repo)).not.toBe(before)
   })
 


### PR DESCRIPTION
Two tests fail on every release run, and have for 30 consecutive runs:

```
FAIL test/daemon/behind-cache.test.ts   > driftCached > recomputes when the BASE ref moves
FAIL test/daemon/worktree-probe.test.ts > worktreeFingerprint > moves when a default base ref moves…
fatal: empty ident name (for <runner@runnervmejwal…cloudapp.net>) not allowed
```

Both files define `const AUTHOR = ["-c", "user.email=t@t", "-c", "user.name=t"]` and pass it to
every `commit` call — but not to the `commit-tree` call that advances the base ref. `test/setup-env.ts`
sets `GIT_CONFIG_GLOBAL=/dev/null`, so the subprocess has no configured identity and git must guess.
macOS can derive a name from the OS, so it passes locally; the Linux runner can only build an email
from the hostname, leaving the name empty, so it fails.

### Evidence

At the git level, under a no-identity condition (`user.useConfigOnly=true` forces git to refuse to guess):

```
git -c user.useConfigOnly=true commit-tree "HEAD^{tree}" -p HEAD -m advance
  → fatal: Author identity unknown          exit=128
git -c user.useConfigOnly=true -c user.email=t@t -c user.name=t commit-tree …
  → 96ec199419264eb61c1c06a7d5a2278ab25fcbb2  exit=0
```

Locally both files still pass after the change: `Test Files 2 passed (2) / Tests 17 passed (17)`.

I could not reproduce the failure at the suite level on macOS — the condition needs git to be unable
to derive a name from anywhere, and forcing that with an empty `GIT_AUTHOR_NAME` also breaks the
`commit` calls that currently pass. The proof that this fixes CI is CI.