### PR TITLE
0.2 TB a day to keep 512 KB of scrollback, and 18 git forks per idle worktree

### DIFF
--- a/.changeset/pty-freeze-write-volume.md
+++ b/.changeset/pty-freeze-write-volume.md
@@ -1,0 +1,11 @@
+---
+"@sma1lboy/rove": patch
+---
+
+A working terminal no longer rewrites its whole scrollback to disk every five seconds
+
+Each hosted PTY session keeps a 512KB ring of scrollback, and persisting it re-encodes and rewrites the entire ring — about 683KB of base64 — however few bytes actually moved. Engines repaint their status line at least once a second while a turn runs, so every session with an agent working in it was doing that twelve times a minute. Measured against real engine output (389-928 bytes a second, sampled from live sessions), that is 2.3 MB/s across 18 working sessions and 0.17 TB written per day; at 200 sessions, 25.6 MB/s.
+
+A periodic freeze now waits until the session has actually produced 64KB, or a minute has passed, whichever comes first. Measured on the same fleet: 0.21 MB/s at 18 sessions (0.015 TB/day), 0.58 at 50, 2.33 at 200 — an 11x cut. A session that really does emit a lot, such as a build log, still writes on the same five-second floor as before.
+
+What this trades: a host that dies without warning — a crash, a reboot, a `kill -9` — now loses up to a minute of the very end of a terminal's scrollback instead of up to five seconds. Every exit, rename and graceful shutdown still writes in full, and the engine's own `--resume` carries the conversation either way.

--- a/.changeset/worktree-quiet-floor.md
+++ b/.changeset/worktree-quiet-floor.md
@@ -1,0 +1,11 @@
+---
+"@sma1lboy/rove": patch
+---
+
+An idle fleet forks a third as many `git status` processes
+
+The daemon polls `git status` per worktree to draw the sidebar's `+N −M` chips. A fingerprint of the git metadata already relaxes that poll for a worktree nothing has touched, but the floor under it was 15 seconds — so a fully idle fleet still forked 18 processes per worktree every 5 minutes to confirm nothing had changed. Measured at both 20 and 50 worktrees, which is flat per worktree and therefore linear: about 3600 processes per 5 minutes at 200 worktrees.
+
+The floor is now a minute. Measured on the same fleet: 360 → 100 processes per 5 minutes at 20 worktrees, 900 → 250 at 50.
+
+Nothing you watch goes stale for it. A worktree whose git metadata moves, or whose engine is working, still drops to the fast cadence on the very next tick: measured, an idle worktree polled zero times in 30 seconds and then polled 1 second after a file appeared in it. The ahead/behind half of the chip rides ref files the fingerprint sees directly. What can now lag by up to a minute is the changed-file count for a file created in a subdirectory, by hand, in a worktree with no engine running.

--- a/packages/kobe-daemon/src/daemon/pty-freeze-policy.ts
+++ b/packages/kobe-daemon/src/daemon/pty-freeze-policy.ts
@@ -1,0 +1,70 @@
+/**
+ * WHEN a hosted PTY session's scrollback is worth writing to disk.
+ *
+ * `pty-host.ts` owns the set of sessions and `pty-freeze-store.ts` owns the
+ * durable record; neither is the right home for the arithmetic that decides
+ * whether a periodic write earns its cost, which is a policy with measured
+ * numbers behind it and no dependency on either.
+ *
+ * The cost being rationed: one freeze re-encodes and rewrites the session's
+ * WHOLE ring (512KB → ~683KB of base64), however few bytes moved. Engines
+ * repaint their status line at >=1 Hz while a turn runs, so a plain 5s
+ * throttle meant every working session rewrote its entire ring eleven times
+ * a minute. Measured against a passively-observed 389-928 B/s of real engine
+ * output, that is a 160x write amplification: 2.3 MB/s and 0.17 TB/day at 18
+ * working sessions, 25.6 MB/s at 200.
+ */
+
+/** Floor between a session's periodic freeze writes. Exits and shutdowns
+ *  flush immediately; this only rate-limits the live stream. */
+export const FREEZE_INTERVAL_MS = 5_000
+
+/**
+ * Bytes a session must have appended before a periodic freeze is worth its
+ * cost — the gate that makes the write scale with the CHANGE rather than
+ * with the ring.
+ *
+ * 64KB is an eighth of the ring, so a session producing at least that much
+ * per minute pays ~11x its own output rather than 160x; below that rate
+ * {@link FREEZE_STALE_MS} governs instead, and a session producing nothing
+ * writes nothing. A session emitting 64KB faster than
+ * {@link FREEZE_INTERVAL_MS} — a build log, a `cat` of something big — still
+ * freezes on the 5s floor exactly as before.
+ */
+export const FREEZE_MIN_APPENDED_BYTES = 64 * 1024
+
+/**
+ * How long a session may hold unfrozen output before the byte gate is
+ * overridden. This — not {@link FREEZE_INTERVAL_MS} — is the crash-loss
+ * bound for an ordinary working session: a host that dies (crash, reboot,
+ * SIGKILL) loses at most this much of the ring's tail, where it used to lose
+ * at most 5s. A graceful stop and every exit still flush in full, and the
+ * engine's own `--resume` carries the conversation either way; what a crash
+ * costs is up to a minute of terminal repaint at the very end of the
+ * scrollback.
+ */
+export const FREEZE_STALE_MS = 60_000
+
+/** The session fields the gate reads — `PtySessionState` satisfies it. */
+export interface FreezeGateState {
+  /** Monotonic total the child has ever written. */
+  readonly totalBytes: number
+  /** `totalBytes` as of the last persisted snapshot. Absent = none yet. */
+  readonly frozenTotalBytes?: number
+  /** Epoch ms of the last persisted snapshot. Zero = never. */
+  readonly lastFreezeAtMs: number
+}
+
+/**
+ * Whether a PERIODIC freeze is worth its whole-ring rewrite at `now`. Pure.
+ *
+ * Forced freezes (exit, rename, shutdown) do not consult this: an exit record
+ * is a change no byte counter can see.
+ */
+export function shouldFreeze(session: FreezeGateState, now: number): boolean {
+  const appended = session.totalBytes - (session.frozenTotalBytes ?? 0)
+  if (appended <= 0) return false
+  const since = now - session.lastFreezeAtMs
+  if (since < FREEZE_INTERVAL_MS) return false
+  return appended >= FREEZE_MIN_APPENDED_BYTES || since >= FREEZE_STALE_MS
+}

--- a/packages/kobe-daemon/src/daemon/pty-host-types.ts
+++ b/packages/kobe-daemon/src/daemon/pty-host-types.ts
@@ -97,6 +97,10 @@ export interface PtySessionState {
   restored: boolean
   /** Freeze bookkeeping: output/exit drift since the last persisted snapshot. */
   lastFreezeAtMs: number
+  /** `totalBytes` as of the last persisted snapshot — the periodic freeze
+   *  gate spends a whole-ring rewrite only once this much has moved. Optional
+   *  so a record thawed by an older host reads as "nothing frozen yet". */
+  frozenTotalBytes?: number
   /** Epoch ms of the most recent write that originated from an attached
    *  client (a human typing). Zero means "never seen a human write". Used by
    *  the delivery gate to refuse auto-pastes while the user is composing. */
@@ -152,6 +156,7 @@ export function freshSessionState(key: string, spec: PtySpawnSpec, argv: readonl
     exit: null,
     restored: false,
     lastFreezeAtMs: 0,
+    frozenTotalBytes: 0,
     lastHumanWriteMs: 0,
   }
 }

--- a/packages/kobe-daemon/src/daemon/pty-host.ts
+++ b/packages/kobe-daemon/src/daemon/pty-host.ts
@@ -74,9 +74,43 @@ function resolveHumanWriteQuietMs(): number {
   return Number.isFinite(n) && n >= 0 ? n : DEFAULT_HUMAN_WRITE_QUIET_MS
 }
 
-/** Minimum gap between a session's periodic freeze writes (crash-loss bound).
- *  Exits and shutdowns flush immediately; this only throttles the live stream. */
+/** Floor between a session's periodic freeze writes. Exits and shutdowns
+ *  flush immediately; this only rate-limits the live stream. */
 export const FREEZE_INTERVAL_MS = 5_000
+
+/**
+ * Bytes a session must have appended before a periodic freeze is worth its
+ * cost — the gate that makes the write scale with the CHANGE rather than
+ * with the ring.
+ *
+ * A freeze re-encodes and rewrites the whole ring (512KB → ~683KB of
+ * base64), however few bytes moved. Engines repaint their status line at
+ * >=1 Hz while a turn runs, so on the 5s floor alone every working session
+ * rewrote its entire ring twelve times a minute: measured at 683KB per
+ * write against a passively-observed 389-928 B/s of real engine output,
+ * that is a 160x write amplification — 2.3 MB/s and 0.17 TB/day at 18
+ * working sessions, 25.6 MB/s at 200.
+ *
+ * 64KB is an eighth of the ring, so a session producing at least that much
+ * per minute pays ~11x its own output rather than 160x; below that rate
+ * {@link FREEZE_STALE_MS} governs instead, and a session producing nothing
+ * writes nothing. A session emitting 64KB faster than
+ * {@link FREEZE_INTERVAL_MS} — a build log, a `cat` of something big — still
+ * freezes on the 5s floor exactly as before.
+ */
+export const FREEZE_MIN_APPENDED_BYTES = 64 * 1024
+
+/**
+ * How long a session may hold unfrozen output before the byte gate is
+ * overridden. This — not {@link FREEZE_INTERVAL_MS} — is the crash-loss
+ * bound for an ordinary working session: a host that dies (crash, reboot,
+ * SIGKILL) loses at most this much of the ring's tail, where it used to lose
+ * at most 5s. A graceful stop and every exit still flush in full, and the
+ * engine's own `--resume` carries the conversation either way; what a crash
+ * costs is up to a minute of terminal repaint at the very end of the
+ * scrollback.
+ */
+export const FREEZE_STALE_MS = 60_000
 
 export class PtyHost {
   private readonly sessions = new Map<string, PtySessionState>()
@@ -451,10 +485,14 @@ export class PtyHost {
   }
 
   /**
-   * Throttled freeze writer. The write happens at most once per
-   * FREEZE_INTERVAL_MS per session (a host crash loses at most that much
-   * scrollback), immediately on exit, and for every session on shutdown.
-   * Internal keys (the warm spare) never freeze.
+   * Throttled freeze writer. A periodic write happens at most once per
+   * {@link FREEZE_INTERVAL_MS} per session and only once the session has
+   * appended {@link FREEZE_MIN_APPENDED_BYTES} or gone
+   * {@link FREEZE_STALE_MS} without one — the whole ring goes to disk every
+   * time, so the gate is what keeps the cost proportional to what actually
+   * changed. `force` (exit, rename, shutdown) writes regardless: an exit
+   * record is a change the byte counter cannot see. Internal keys (the warm
+   * spare) never freeze.
    */
   private maybeFreeze(session: PtySessionState, force = false): void {
     const freeze = this.opts.freeze
@@ -468,8 +506,15 @@ export class PtyHost {
     // this function owes the same promise.
     if (session.closedByRequest) return
     const now = Date.now()
-    if (!force && now - session.lastFreezeAtMs < FREEZE_INTERVAL_MS) return
+    if (!force) {
+      const appended = session.totalBytes - (session.frozenTotalBytes ?? 0)
+      const since = now - session.lastFreezeAtMs
+      if (appended <= 0) return
+      if (since < FREEZE_INTERVAL_MS) return
+      if (appended < FREEZE_MIN_APPENDED_BYTES && since < FREEZE_STALE_MS) return
+    }
     session.lastFreezeAtMs = now
+    session.frozenTotalBytes = session.totalBytes
     freeze.save(freezeSession(session))
   }
 

--- a/packages/kobe-daemon/src/daemon/pty-host.ts
+++ b/packages/kobe-daemon/src/daemon/pty-host.ts
@@ -36,6 +36,7 @@
 
 import type { DaemonFrame, PtyPeekResult } from "./protocol.ts"
 import { PtyChildController } from "./pty-child-controller.ts"
+import { shouldFreeze } from "./pty-freeze-policy.ts"
 import { type FrozenPtySession, freezeSession, thawSession } from "./pty-freeze-store.ts"
 import type { PtyAttachResult, PtyHostOptions, PtySessionState, PtySink, PtySpawnSpec } from "./pty-host-types.ts"
 import {
@@ -74,43 +75,9 @@ function resolveHumanWriteQuietMs(): number {
   return Number.isFinite(n) && n >= 0 ? n : DEFAULT_HUMAN_WRITE_QUIET_MS
 }
 
-/** Floor between a session's periodic freeze writes. Exits and shutdowns
- *  flush immediately; this only rate-limits the live stream. */
-export const FREEZE_INTERVAL_MS = 5_000
-
-/**
- * Bytes a session must have appended before a periodic freeze is worth its
- * cost — the gate that makes the write scale with the CHANGE rather than
- * with the ring.
- *
- * A freeze re-encodes and rewrites the whole ring (512KB → ~683KB of
- * base64), however few bytes moved. Engines repaint their status line at
- * >=1 Hz while a turn runs, so on the 5s floor alone every working session
- * rewrote its entire ring twelve times a minute: measured at 683KB per
- * write against a passively-observed 389-928 B/s of real engine output,
- * that is a 160x write amplification — 2.3 MB/s and 0.17 TB/day at 18
- * working sessions, 25.6 MB/s at 200.
- *
- * 64KB is an eighth of the ring, so a session producing at least that much
- * per minute pays ~11x its own output rather than 160x; below that rate
- * {@link FREEZE_STALE_MS} governs instead, and a session producing nothing
- * writes nothing. A session emitting 64KB faster than
- * {@link FREEZE_INTERVAL_MS} — a build log, a `cat` of something big — still
- * freezes on the 5s floor exactly as before.
- */
-export const FREEZE_MIN_APPENDED_BYTES = 64 * 1024
-
-/**
- * How long a session may hold unfrozen output before the byte gate is
- * overridden. This — not {@link FREEZE_INTERVAL_MS} — is the crash-loss
- * bound for an ordinary working session: a host that dies (crash, reboot,
- * SIGKILL) loses at most this much of the ring's tail, where it used to lose
- * at most 5s. A graceful stop and every exit still flush in full, and the
- * engine's own `--resume` carries the conversation either way; what a crash
- * costs is up to a minute of terminal repaint at the very end of the
- * scrollback.
- */
-export const FREEZE_STALE_MS = 60_000
+/** Freeze cadence policy (`pty-freeze-policy.ts`) — re-exported because the
+ *  host is where callers look for it. */
+export { FREEZE_INTERVAL_MS, FREEZE_MIN_APPENDED_BYTES, FREEZE_STALE_MS } from "./pty-freeze-policy.ts"
 
 export class PtyHost {
   private readonly sessions = new Map<string, PtySessionState>()
@@ -485,14 +452,11 @@ export class PtyHost {
   }
 
   /**
-   * Throttled freeze writer. A periodic write happens at most once per
-   * {@link FREEZE_INTERVAL_MS} per session and only once the session has
-   * appended {@link FREEZE_MIN_APPENDED_BYTES} or gone
-   * {@link FREEZE_STALE_MS} without one — the whole ring goes to disk every
-   * time, so the gate is what keeps the cost proportional to what actually
-   * changed. `force` (exit, rename, shutdown) writes regardless: an exit
-   * record is a change the byte counter cannot see. Internal keys (the warm
-   * spare) never freeze.
+   * Throttled freeze writer. A periodic write happens only when
+   * `shouldFreeze` says the whole-ring rewrite has earned itself (see
+   * `pty-freeze-policy.ts` for the numbers). `force` (exit, rename,
+   * shutdown) writes regardless: an exit record is a change no byte counter
+   * can see. Internal keys (the warm spare) never freeze.
    */
   private maybeFreeze(session: PtySessionState, force = false): void {
     const freeze = this.opts.freeze
@@ -506,13 +470,7 @@ export class PtyHost {
     // this function owes the same promise.
     if (session.closedByRequest) return
     const now = Date.now()
-    if (!force) {
-      const appended = session.totalBytes - (session.frozenTotalBytes ?? 0)
-      const since = now - session.lastFreezeAtMs
-      if (appended <= 0) return
-      if (since < FREEZE_INTERVAL_MS) return
-      if (appended < FREEZE_MIN_APPENDED_BYTES && since < FREEZE_STALE_MS) return
-    }
+    if (!force && !shouldFreeze(session, now)) return
     session.lastFreezeAtMs = now
     session.frozenTotalBytes = session.totalBytes
     freeze.save(freezeSession(session))

--- a/packages/kobe-daemon/src/daemon/worktree-changes-collector.ts
+++ b/packages/kobe-daemon/src/daemon/worktree-changes-collector.ts
@@ -93,8 +93,19 @@ export const WORKTREE_CHANGES_MIN_INTERVAL_MS = 1_500
  * a nested edit. This is the WORST-CASE staleness for such a worktree; a
  * fingerprint that moves, or an engine that starts working, drops it back to
  * {@link WORKTREE_CHANGES_MIN_INTERVAL_MS} on the next tick.
+ *
+ * The safety net is what the whole fleet pays for, every minute, forever: at
+ * a 15s floor a fully idle fleet still forked 18 `git status` per worktree
+ * per 5 minutes — measured at both 20 and 50 worktrees, so flat per worktree
+ * and linear in the fleet, projecting to ~3600 processes at 200. A minute
+ * buys the same safety for a third of the processes. Nothing a person
+ * watches goes stale for it: an engine writing in there is exempt (the
+ * activity registry flags one within ~10s), and the ahead/behind half of the
+ * chip rides ref files the fingerprint DOES see. What can now lag by up to a
+ * minute is the `+N -M` count of a file someone created in a subdirectory,
+ * by hand, in a worktree with no engine running.
  */
-export const WORKTREE_CHANGES_QUIET_INTERVAL_MS = 15_000
+export const WORKTREE_CHANGES_QUIET_INTERVAL_MS = 60_000
 
 /** The task-list slice the collector needs — `Orchestrator` satisfies it. */
 export interface TaskLister {

--- a/packages/kobe/test/daemon/pty-host-freeze.test.ts
+++ b/packages/kobe/test/daemon/pty-host-freeze.test.ts
@@ -13,7 +13,7 @@
 import type { PtyChild, PtyDriver, PtyExit } from "@sma1lboy/kobe-daemon/daemon/pty-driver"
 import type { FrozenPtySession, PtyFreezeSink } from "@sma1lboy/kobe-daemon/daemon/pty-freeze-store"
 import { PtyHost } from "@sma1lboy/kobe-daemon/daemon/pty-host"
-import { describe, expect, it } from "vitest"
+import { describe, expect, it, vi } from "vitest"
 
 class FakeChild {
   static nextPid = 1000
@@ -48,6 +48,9 @@ interface Harness {
   host: PtyHost
   children: FakeChild[]
   saved: Map<string, FrozenPtySession>
+  /** Every save the host asked for, in order — `saved` only keeps the last
+   *  per key, and the freeze gate is about HOW OFTEN a write happens. */
+  writes: FrozenPtySession[]
   requests: Array<{ argv: readonly string[]; cwd: string }>
   failNextSpawn: () => void
 }
@@ -55,6 +58,7 @@ interface Harness {
 function harness(): Harness {
   const children: FakeChild[] = []
   const saved = new Map<string, FrozenPtySession>()
+  const writes: FrozenPtySession[] = []
   const requests: Array<{ argv: readonly string[]; cwd: string }> = []
   let failSpawn = false
   const driver: PtyDriver = (request) => {
@@ -68,12 +72,16 @@ function harness(): Harness {
     return child as unknown as PtyChild
   }
   const freeze: PtyFreezeSink = {
-    save: (record) => saved.set(record.key, record),
+    save: (record) => {
+      writes.push(record)
+      saved.set(record.key, record)
+    },
     drop: (key) => saved.delete(key),
   }
   return {
     children,
     saved,
+    writes,
     requests,
     failNextSpawn: () => {
       failSpawn = true
@@ -105,6 +113,52 @@ describe("PtyHost freeze/restore", () => {
 
     h.host.flushFrozen()
     expect(replayText(h.saved.get("t1::tab-1")?.ringB64 ?? "")).toContain("two")
+  })
+
+  it("periodic freezes follow appended bytes, not the 5s floor alone", () => {
+    // Each freeze rewrites the WHOLE ring (~683KB of base64 at the 512KB
+    // cap), so writing on the 5s floor alone cost 683KB per ~4KB an engine
+    // actually printed. Measured before this gate: 2.3 MB/s across 18
+    // working sessions, 0.17 TB a day.
+    vi.useFakeTimers()
+    try {
+      vi.setSystemTime(new Date("2026-01-01T00:00:00Z"))
+      const h = harness()
+      h.host.open("t1::tab-1", SPEC, TOKEN, SINK)
+      h.children[0].write("boot")
+      expect(h.writes.length).toBe(1)
+
+      // Six 10s rounds of a 1KB trickle — a real engine repainting its
+      // status line. Every round clears the 5s floor; none reaches 64KB, so
+      // only the 60s staleness cap writes, once.
+      for (let i = 0; i < 6; i++) {
+        vi.setSystemTime(Date.now() + 10_000)
+        h.children[0].write("x".repeat(1024))
+      }
+      expect(h.writes.length).toBe(2)
+
+      // A session that really does produce 64KB is not throttled by the
+      // gate: it writes on the next chunk past the floor, as before.
+      vi.setSystemTime(Date.now() + 10_000)
+      h.children[0].write("y".repeat(64 * 1024))
+      expect(h.writes.length).toBe(3)
+
+      // The counter resets on every write, so a trickle AFTER a burst is
+      // throttled again — without that reset one big chunk would put the
+      // session back on the 5s floor for the rest of its life.
+      vi.setSystemTime(Date.now() + 10_000)
+      h.children[0].write("z".repeat(1024))
+      expect(h.writes.length).toBe(3)
+
+      // Nothing appended since — a forced flush still writes (an exit
+      // record is a change the byte counter cannot see), a periodic one
+      // does not.
+      vi.setSystemTime(Date.now() + 120_000)
+      h.host.flushFrozen()
+      expect(h.writes.length).toBe(4)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it("a thawed corpse respawns IN PLACE on open: ring kept, caller spec wins", () => {


### PR DESCRIPTION
Two items from the r20 scale exploration (`.scratch/loop-r20-scale/scale.md`): the hosted-PTY scrollback write volume (B2) and the `git status` quiet floor (C4). `pty-freeze-store.ts`, `pr-status-collector.ts` and `core/base-ref-cache.ts` are untouched — other workers own those. Nothing in the exploration's "measured flat, do not optimize" list was touched either.

**No screenshots: neither item changes a pixel.** Both are counted byte/process measurements at three and two fleet sizes respectively, which is the proof standard this exploration set. Every number below was measured on this machine, not derived from reading the code.

---

## Item 1 — a working terminal rewrote its whole 512KB ring every 5s

**What changed.** `PtyHost.maybeFreeze` gained a byte gate: a *periodic* freeze now needs 64KB appended since the last one, or 60s elapsed, whichever comes first. The 5s floor is unchanged, and every forced freeze (exit, rename, shutdown) still writes unconditionally.

Each freeze re-encodes and rewrites the **entire** ring — ~683KB of base64 — however few bytes moved. Engines repaint at ≥1 Hz while a turn runs, so on the 5s floor alone every working session did that 11 times a minute.

**PASS criterion.** Bytes written per session per freeze must scale with bytes *appended*, not with the ring cap; at 18 sessions the rate must land under 0.3 MB/s.

### The append rate is measured, not assumed

Two passive snapshots of `~/.rove/pty-sessions/*.json` 122s apart — read-only, `totalBytes` + `updatedAt` only, nothing attached and nothing written — caught three genuinely-working sessions:

```
928 B/s  (+112963 bytes over 122s)  01M1PYFYVXT7PDKEA0K6HBBAB2::tab-1
775 B/s  (+94642 bytes over 122s)   01M1PZ4GRFXX126DKNM66SEJ73::tab-1
389 B/s  (+52493 bytes over 135s)   01M1PSGZPX65JDTSW0NA2TGN03::tab-3
```

Every row below uses 800 B/s, the median.

### Measured

Real `PtyHost` + real `fileFreezeSink` into a private tmp dir; the only fake is the PTY child. Bytes counted by `statSync`ing the record file after **every save the host actually performed** — filesystem, not arithmetic.

| working sessions | BEFORE | AFTER | writes/session/min | amplification |
|---|---|---|---|---|
| 18 (today's fleet) | 2.305 MB/s · **0.166 TB/day** | 0.210 MB/s · **0.015 TB/day** | 11 → 1 | 160× → 14.6× |
| 50 | 6.404 MB/s · 0.461 TB/day | 0.583 MB/s · 0.042 TB/day | 11 → 1 | 160× → 14.6× |
| 200 | 25.619 MB/s · 1.845 TB/day | 2.331 MB/s · 0.168 TB/day | 11 → 1 | 160× → 14.6× |

**0.210 MB/s at 18 clears the 0.3 threshold. 11× cut at every size.**

### Negative control — the fast case must not regress

A session emitting 200 KB/s (a build log) still writes on the 5s floor: `savesPerSessionPerMin: 10`, the same as BEFORE. The gate only thins the trickle; it cannot slow down a session that genuinely produces bytes.

### What this trades

A host that dies without warning — crash, reboot, `kill -9` — now loses up to **60s** of the ring's tail instead of up to 5s. Exits, renames and graceful shutdown still flush in full, and the engine's own `--resume` carries the conversation either way; what a crash costs is terminal repaint at the very end of the scrollback.

The old doc comment claimed `FREEZE_INTERVAL_MS` *was* the crash-loss bound. That sentence moved to the new `FREEZE_STALE_MS` rather than being left to rot.

### Regression test

`test/daemon/pty-host-freeze.test.ts` → "periodic freezes follow appended bytes, not the 5s floor alone". Mutation-verified at **two different sites**:

| mutation | result |
|---|---|
| delete the byte-gate line | `expected 7 to be 2` |
| stop advancing `frozenTotalBytes` | `expected 4 to be 3` |

The second matters: without the counter reset, one 64KB burst would put a session back on the 5s floor for the rest of its life — a regression the first assertion alone does not catch.

---

## Item 2 — an idle fleet forked 18 `git status` per worktree per 5 minutes

Ranked last in the exploration and explicitly "an optimization, not a broken promise". The fix is one constant plus an honest doc rewrite; no code path changed.

**What changed.** `WORKTREE_CHANGES_QUIET_INTERVAL_MS` 15s → 60s. This is the safety poll *underneath* `worktreeFingerprint`, which cannot see a nested edit — it fires only for a worktree that is fingerprint-quiet **and** has no working engine.

**PASS criterion.** Under 300 `git status` per 5 min at N=50, with the fast path intact — a fingerprint that moves, or an engine that starts working, must still drop to the 1.5s floor on the next tick. *Verify that second half or this becomes a latency regression.*

### Measured — isolated daemon from source, `git` counted through a PATH shim

| worktrees | BEFORE | AFTER |
|---|---|---|
| 20 | 360 / 5 min (18.0 per worktree) | **100 / 5 min (5.0 per worktree)** |
| 50 | 900 / 5 min (18.0 per worktree) | **250 / 5 min (5.0 per worktree)** |

250 at N=50 clears the ≤300 threshold. Flat per worktree in both arms, so still linear — ~3600 → ~1000 processes per 5 min projected to 200 worktrees.

`merge-base` and `rev-list` were **0** in all four runs, at both fleet sizes, before and after. That independently re-confirms the base-ref cache the brief told me to leave alone; I did.

### The fast path, measured

```json
{"label":"fastpath-after","worktree":"wt3","quietPollsIn30s":0,"secondsFromTouchToPoll":1}
```

An idle worktree polled **zero times in 30 seconds** (the 60s floor is genuinely in effect), then polled **1 second** after a file appeared in it. Not a latency regression.

The engine-busy half of the fast path is pinned by `test/daemon/worktree-quiet-backoff.test.ts`, which injects its own interval and so is independent of this constant; production wiring is `activity.currentNonIdle()` in `collectors.ts`, refreshed on a 10s observer poll.

### What this trades

Worst-case staleness for a fingerprint-quiet, engine-idle worktree goes 15s → 60s. The ahead/behind half of the chip rides ref files the fingerprint sees directly, so only the `+N −M` count can lag, and only for a file created in a subdirectory by hand in a worktree with no engine running.

### File-size cap — a real seam, not an exemption

Documenting the gate pushed `pty-host.ts` to 528 lines and `file-size-cap` failed on the first push. Rather than ask for an exemption, the third commit extracts `pty-freeze-policy.ts`: `pty-host.ts` owns the set of sessions and `pty-freeze-store.ts` owns the durable record, so the arithmetic deciding whether a periodic write earns its cost belongs to neither. It leaves as a pure `shouldFreeze()` predicate, the host re-exports the constants so nothing importing them breaks, and `pty-host.ts` lands at 486 — three lines above where it started. Both mutations were re-run against the restructured code and still fail as above.

---

## Could not prove

**Moving the freeze write off the event loop.** The brief asks for `writeFile` async instead of `writeFileSync`. That lives in `fileFreezeSink.save()` in `pty-freeze-store.ts`, which this task is explicitly forbidden to touch. Left for that file's owner. It is the smaller half anyway — measured CPU is ~2% of one core even at 200 sessions; the write volume was the cost, and that is what this fixes.

## Unrelated, flagged not worked around

Repo-root `bun run lint` fails locally on `packages/kobe/test/daemon/worktree-probe.test.ts` (line 23 is 122 chars against a 120 `lineWidth`). That file landed in #852, is byte-identical on `origin/main`, and is **not in this diff** — and CI's `typecheck-and-test`, which runs `bun run lint`, is green on main with that exact content. So the local failure does not reflect CI. I did not touch it; if CI here disagrees with CI on main, that is the signal.

## Probes (re-runnable, resolve their own checkout, refuse to guess)

- `.scratch/loop-r20-bk/freeze-volume.ts` — write volume vs fleet size
- `.scratch/loop-r20-bk/run-walk.sh` — `git status` count over a 5-minute steady state
- `.scratch/loop-r20-bk/fastpath.sh` — touch-to-poll latency

Evidence outside `.scratch/`, absolute paths:

```
/tmp/loop-r20-bk-0aff3858/freeze-before.jsonl
/tmp/loop-r20-bk-0aff3858/freeze-after.jsonl
/tmp/loop-r20-bk-0aff3858/freeze-after-firehose.jsonl
/tmp/loop-r20-bk-0aff3858/walk-before.jsonl
/tmp/loop-r20-bk-0aff3858/walk-after.jsonl
/tmp/loop-r20-bk-0aff3858/fastpath-after.jsonl
/tmp/loop-r20-bk-0aff3858/append-sample-2.txt
```

## Gates

`typecheck` clean · `test:fast` 4527 passed (458 files) · `test:socket` 835 passed (100 files) · rebased on `origin/main` (db1eb2bdb, which brought in the sibling freeze-store change — no conflict, suites re-run green after).
