### PR TITLE
The error path you selected is not the path you paste, and "Copied" was a guess (A, B, C, E)

### DIFF
--- a/.changeset/wrapped-lines-and-honest-clipboard.md
+++ b/.changeset/wrapped-lines-and-honest-clipboard.md
@@ -1,0 +1,42 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Copying a soft-wrapped terminal line pastes as one line, and search can find text that straddles the wrap
+
+The terminal snapshot builds one row per GRID row and never read xterm's
+`isWrapped`, so a line the emulator broke across columns arrived downstream as
+several unrelated rows. Two things a user does constantly fell out of that.
+Drag-selecting a path out of a build log copied
+`…/packages\n/kobe/src/…\narch.ts:41:9` — three broken shell commands where one
+path was selected. And the `/` scrollback search, which ran `indexOf` per row,
+reported `no matches` for a needle spanning the break: a confident negative for
+text visible two rows above the query. xterm.app, iTerm2 and tmux all rejoin
+soft-wrapped rows; Rove was the outlier.
+
+The flags now travel with the snapshot, and both consumers group rows into
+logical lines from them. The highlight is unchanged — you selected two visual
+rows and still see two highlighted rows; only the extraction joins. A search hit
+across a wrap is a multi-row range, which the existing paint already handles.
+
+**Clipboard writes now report whether anything was copied.**
+`copyTextToSystemClipboard` returned `void` and discarded both channels'
+answers: the local pipe's exit status was never read (a missing command exits
+127 without throwing; `xclip` with no `$DISPLAY` passes the `which` probe and
+then fails), and OSC 52's boolean could not survive a `(text) => void`
+signature. So on a headless box with no `wl-copy`/`xclip`/`xsel`, in a terminal
+that refuses OSC 52, **Copy branch name** toasted `Copied branch feat/whatever`
+over an untouched clipboard. It now says it could not reach a clipboard, and the
+pane's copy-on-select — silent on success, as it should be — speaks on failure.
+Windows also gets a local clipboard command for the first time (`clip`, then
+PowerShell's `Set-Clipboard`): the `where` probe written for it was unreachable
+behind a platform check that returned null, leaving OSC 52 as its only channel.
+
+**The parked search hit no longer drifts out from under its counter.** The hit
+you walked to was remembered as a position in the match array, which a
+scrollback trim renumbers — the counter kept reading `3/5` while the accent
+highlight had moved to a different occurrence, and `enter` walked on from the
+wrong place. It is now remembered by absolute line id, re-derived each frame,
+falling forward to the next surviving hit when that line is trimmed and dropped
+outright when a resize resets line numbering — the same discipline
+`followWindowShift` already applies to a selection.

--- a/packages/kobe/src/lib/clipboard-command.ts
+++ b/packages/kobe/src/lib/clipboard-command.ts
@@ -4,21 +4,29 @@ import { spawnSync } from "node:child_process"
 
 export type ClipboardProbe = (binary: string) => boolean
 
-const LINUX_CLIPBOARD_CANDIDATES: readonly { readonly binary: string; readonly command: string }[] = [
-  { binary: "wl-copy", command: "wl-copy" },
-  { binary: "xclip", command: "xclip -selection clipboard -in" },
-  { binary: "xsel", command: "xsel --clipboard --input" },
-]
+/** Argv, not a shell string: Windows has no `sh` to hand a command line to. */
+const CLIPBOARD_CANDIDATES: Readonly<Record<string, readonly (readonly string[])[]>> = {
+  darwin: [["pbcopy"]],
+  linux: [["wl-copy"], ["xclip", "-selection", "clipboard", "-in"], ["xsel", "--clipboard", "--input"]],
+  // Windows is a supported platform, and without this its only clipboard
+  // channel is OSC 52 — which the terminals shipping on Windows may refuse.
+  // `clip` has been in every Windows since XP; PowerShell's `Set-Clipboard`
+  // is the fallback for a stripped image.
+  win32: [["clip"], ["powershell", "-NoProfile", "-Command", "Set-Clipboard"]],
+}
 
+/**
+ * The argv that pipes stdin into this platform's clipboard, or null when the
+ * platform has none on PATH. `pbcopy` is probed like everything else: a macOS
+ * without it should say "no clipboard" rather than spawn a command that fails
+ * where nobody reads the exit code.
+ */
 export function resolveClipboardCopyCommand(
   platform: NodeJS.Platform | string,
   hasCommand: ClipboardProbe,
-): string | null {
-  if (platform === "darwin") return "pbcopy"
-  if (platform === "linux") {
-    for (const candidate of LINUX_CLIPBOARD_CANDIDATES) {
-      if (hasCommand(candidate.binary)) return candidate.command
-    }
+): readonly string[] | null {
+  for (const candidate of CLIPBOARD_CANDIDATES[platform] ?? []) {
+    if (hasCommand(candidate[0] as string)) return candidate
   }
   return null
 }

--- a/packages/kobe/src/tui-react/context/notifications.tsx
+++ b/packages/kobe/src/tui-react/context/notifications.tsx
@@ -126,3 +126,10 @@ export function useNotifications(): NotificationsContext {
   if (!value) throw new Error("useNotifications must be used within a NotificationsProvider")
   return value
 }
+
+/** Null instead of throwing, for panes that must also mount in render tests
+ *  and mock hosts (which intentionally omit the provider) — the same escape
+ *  hatch `useOptionalKV` gives the KV store. */
+export function useOptionalNotifications(): NotificationsContext | null {
+  return useContext(ctx)
+}

--- a/packages/kobe/src/tui-react/panes/terminal/Terminal.tsx
+++ b/packages/kobe/src/tui-react/panes/terminal/Terminal.tsx
@@ -149,7 +149,7 @@ export function Terminal(props: TerminalProps) {
     [props.terminalPresentation, defaultColors],
   )
 
-  const { pty, snapshot, snapshotWindow, cursor, exited, acquireError, forceReacquire } = useTerminalPty({
+  const { pty, snapshot, snapshotWindow, wrapped, cursor, exited, acquireError, forceReacquire } = useTerminalPty({
     cwd: props.cwd,
     taskId: props.taskId,
     command: props.command,
@@ -214,6 +214,7 @@ export function Terminal(props: TerminalProps) {
     visibleRangeStart: visibleRange.start,
     snapshot,
     snapshotWindow,
+    wrapped,
     scrollBy: scrollFromPointer,
     // Same `mouseTrackingMode` the forwarded press is gated on, read rather
     // than clicked — the pane has to notice the app taking the mouse under a
@@ -227,6 +228,7 @@ export function Terminal(props: TerminalProps) {
     focused,
     snapshot,
     snapshotWindow,
+    wrapped,
     bodyRows,
     onAlternateScreen: pty?.onAlternateScreen ?? false,
     scrollState,

--- a/packages/kobe/src/tui-react/panes/terminal/use-terminal-pty.ts
+++ b/packages/kobe/src/tui-react/panes/terminal/use-terminal-pty.ts
@@ -24,7 +24,11 @@ import type {
   TerminalSnapshotWindow,
 } from "../../../tui/panes/terminal/pty"
 import type { PtyRegistry } from "../../../tui/panes/terminal/registry"
+import type { RowWrapFlags } from "../../../tui/panes/terminal/terminal-wrap"
 import { useLatest } from "../../lib/use-latest"
+
+/** Shared empty flags — a stable reference for backends that report none. */
+const NO_WRAP: RowWrapFlags = []
 
 export interface UseTerminalPtyOpts {
   cwd: string | null
@@ -58,6 +62,8 @@ export interface UseTerminalPtyResult {
   pty: TaskPty | null
   snapshot: readonly TerminalRow[]
   snapshotWindow: TerminalSnapshotWindow | null
+  /** Soft-wrap flags parallel to `snapshot` — see `DataListener`. */
+  wrapped: RowWrapFlags
   cursor: CursorPos | null
   exited: boolean
   acquireError: string | null
@@ -71,6 +77,10 @@ export function useTerminalPty(opts: UseTerminalPtyOpts): UseTerminalPtyResult {
   const [acquireError, setAcquireError] = useState<string | null>(null)
   const [snapshot, setSnapshot] = useState<readonly TerminalRow[]>([])
   const snapshotWindowRef = useRef<TerminalSnapshotWindow | null>(null)
+  // A ref for the same reason `snapshotWindow` is one: it is written in the
+  // same `onData` callback that calls `setSnapshot`, so the render triggered
+  // by that state change already sees the flags belonging to those rows.
+  const wrappedRef = useRef<RowWrapFlags>(NO_WRAP)
   const [cursor, setCursor] = useState<CursorPos | null>(null)
   // Dead-shell flag (revival checklist #5): flips when the PTY reports
   // exit for any reason. The last snapshot stays visible; the banner +
@@ -103,6 +113,7 @@ export function useTerminalPty(opts: UseTerminalPtyOpts): UseTerminalPtyResult {
       setPty(null)
       setSnapshot([])
       snapshotWindowRef.current = null
+      wrappedRef.current = NO_WRAP
       setCursor(null)
       setAcquireError(null)
       return
@@ -126,12 +137,14 @@ export function useTerminalPty(opts: UseTerminalPtyOpts): UseTerminalPtyResult {
       setPty(null)
       setSnapshot([])
       snapshotWindowRef.current = null
+      wrappedRef.current = NO_WRAP
       setCursor(null)
       return
     }
     setAcquireError(null)
     setSnapshot([])
     snapshotWindowRef.current = null
+    wrappedRef.current = NO_WRAP
     setCursor(null)
     setExited(handle.killed)
     setPty(handle)
@@ -157,8 +170,9 @@ export function useTerminalPty(opts: UseTerminalPtyOpts): UseTerminalPtyResult {
       setExited(true)
       onExitRef.current?.({ deadOnAttach: pty.deadOnAttach === true })
     })
-    const unsubscribe = pty.onData((snap, c, window) => {
+    const unsubscribe = pty.onData((snap, c, window, wrapped) => {
       snapshotWindowRef.current = window
+      wrappedRef.current = wrapped ?? NO_WRAP
       setSnapshot(snap)
       setCursor(c)
     })
@@ -168,6 +182,7 @@ export function useTerminalPty(opts: UseTerminalPtyOpts): UseTerminalPtyResult {
     try {
       const initial = pty.capture()
       snapshotWindowRef.current = pty.captureWindow()
+      wrappedRef.current = pty.captureWrapped?.() ?? NO_WRAP
       if (initial.length > 0) setSnapshot(initial)
       setCursor(pty.captureCursor())
     } catch {
@@ -202,6 +217,7 @@ export function useTerminalPty(opts: UseTerminalPtyOpts): UseTerminalPtyResult {
         setPty(fresh)
         setSnapshot([])
         snapshotWindowRef.current = null
+        wrappedRef.current = NO_WRAP
         setCursor(null)
         onFreshPtyRef.current()
       } catch (err) {
@@ -214,6 +230,7 @@ export function useTerminalPty(opts: UseTerminalPtyOpts): UseTerminalPtyResult {
         setPty(null)
         setSnapshot([])
         snapshotWindowRef.current = null
+        wrappedRef.current = NO_WRAP
         setCursor(null)
       }
     },
@@ -240,5 +257,14 @@ export function useTerminalPty(opts: UseTerminalPtyOpts): UseTerminalPtyResult {
     // satisfies the linter without changing when this effect re-fires.
   }, [opts.resetToken, forceReacquire])
 
-  return { pty, snapshot, snapshotWindow: snapshotWindowRef.current, cursor, exited, acquireError, forceReacquire }
+  return {
+    pty,
+    snapshot,
+    snapshotWindow: snapshotWindowRef.current,
+    wrapped: wrappedRef.current,
+    cursor,
+    exited,
+    acquireError,
+    forceReacquire,
+  }
 }

--- a/packages/kobe/src/tui-react/panes/terminal/use-terminal-search.ts
+++ b/packages/kobe/src/tui-react/panes/terminal/use-terminal-search.ts
@@ -29,8 +29,16 @@ import { searchQueryKeystroke } from "../../../tui/panes/sidebar/view-core"
 import type { TerminalRow } from "../../../tui/panes/terminal/pty"
 import type { TerminalSnapshotWindow } from "../../../tui/panes/terminal/pty-types"
 import type { Chunk } from "../../../tui/panes/terminal/sgr"
-import { findMatches, overlayMatches, scrollOffsetForRow } from "../../../tui/panes/terminal/terminal-search"
+import {
+  type ParkedHit,
+  findMatches,
+  overlayMatches,
+  parkHit,
+  resolveParkedIndex,
+  scrollOffsetForRow,
+} from "../../../tui/panes/terminal/terminal-search"
 import type { SelectionRange } from "../../../tui/panes/terminal/terminal-selection"
+import type { RowWrapFlags } from "../../../tui/panes/terminal/terminal-wrap"
 import {
   type ViewportScrollState,
   moveViewportScroll,
@@ -46,6 +54,9 @@ export interface UseTerminalSearchOpts {
   readonly focused: boolean
   readonly snapshot: readonly TerminalRow[]
   readonly snapshotWindow: TerminalSnapshotWindow | null
+  /** Soft-wrap flags parallel to `snapshot`: a needle straddling a wrap point
+   *  is in no single row, so the scan runs over logical lines. */
+  readonly wrapped: RowWrapFlags
   readonly bodyRows: number
   /** The child owns its own scrollback right now — there is nothing local to walk. */
   readonly onAlternateScreen: boolean
@@ -76,7 +87,11 @@ export interface TerminalSearch {
 export function useTerminalSearch(opts: UseTerminalSearchOpts): TerminalSearch {
   const [active, setActive] = useState(false)
   const [query, setQuery] = useState("")
-  const [index, setIndex] = useState(-1)
+  // The parked hit is stored by IDENTITY, not by array position — `matches` is
+  // rebuilt every PTY frame and a scrollback trim renumbers it. `index` is
+  // re-derived from it below, so the counter and the accent highlight name the
+  // occurrence the user actually walked to.
+  const [parked, setParked] = useState<ParkedHit | null>(null)
   const { theme } = useTheme()
   const optsRef = useLatest(opts)
 
@@ -89,10 +104,14 @@ export function useTerminalSearch(opts: UseTerminalSearchOpts): TerminalSearch {
   // frame, so an always-on memo would re-walk the whole ring for each line of
   // streaming output — for a query nobody typed.
   const matches = useMemo(
-    () => (active && !unavailable ? findMatches(opts.snapshot, query) : NO_MATCHES),
-    [active, unavailable, opts.snapshot, query],
+    () => (active && !unavailable ? findMatches(opts.snapshot, query, opts.wrapped) : NO_MATCHES),
+    [active, unavailable, opts.snapshot, opts.wrapped, query],
   )
   const matchesRef = useLatest(matches)
+  const index = useMemo(
+    () => resolveParkedIndex(parked, matches, opts.snapshotWindow),
+    [parked, matches, opts.snapshotWindow],
+  )
   const indexRef = useLatest(index)
 
   const jumpToRow = useCallback((row: number): void => {
@@ -111,7 +130,7 @@ export function useTerminalSearch(opts: UseTerminalSearchOpts): TerminalSearch {
   const open = useCallback((): void => {
     bookmarkRef.current = optsRef.current.scrollState
     setQuery("")
-    setIndex(-1)
+    setParked(null)
     setActive(true)
   }, [])
 
@@ -120,7 +139,7 @@ export function useTerminalSearch(opts: UseTerminalSearchOpts): TerminalSearch {
     bookmarkRef.current = null
     setActive(false)
     setQuery("")
-    setIndex(-1)
+    setParked(null)
     if (saved) optsRef.current.setScrollState(saved)
   }, [])
 
@@ -128,25 +147,26 @@ export function useTerminalSearch(opts: UseTerminalSearchOpts): TerminalSearch {
     (delta: 1 | -1): void => {
       const list = matchesRef.current
       if (list.length === 0) return
-      // No hit parked yet: `enter` starts at the first, `shift+enter` at the last.
+      // No hit parked yet: `enter` (older) starts at the last, `↓` (newer) at
+      // the first — both land on an end of the list rather than nowhere.
       const from = indexRef.current < 0 ? (delta > 0 ? -1 : 0) : indexRef.current
       const next = (((from + delta) % list.length) + list.length) % list.length
-      setIndex(next)
+      setParked(parkHit(list, next, optsRef.current.snapshotWindow))
       jumpToRow((list[next] as SelectionRange).anchor.row)
     },
     [jumpToRow],
   )
 
   // A scrollback is read newest-first — the occurrence you want is nearly
-  // always the last one — so every new query parks on it and `shift+enter`
-  // walks back through history from there. Keyed on the QUERY and not on
-  // `matches`: the array is rebuilt on every PTY frame, and re-parking then
-  // would yank the viewport off the hit you had walked to.
+  // always the last one — so every new query parks on it and `enter` walks
+  // back through history from there. Keyed on the QUERY and not on `matches`:
+  // the array is rebuilt on every PTY frame, and re-parking then would yank
+  // the viewport off the hit you had walked to.
   // biome-ignore lint/correctness/useExhaustiveDependencies: keyed on the typed query; `matches` is re-derived per frame and must not re-trigger.
   useEffect(() => {
     if (!active) return
     const last = matches.length - 1
-    setIndex(last)
+    setParked(parkHit(matches, last, optsRef.current.snapshotWindow))
     if (last >= 0) jumpToRow((matches[last] as SelectionRange).anchor.row)
   }, [active, query])
 

--- a/packages/kobe/src/tui-react/panes/terminal/use-terminal-selection.ts
+++ b/packages/kobe/src/tui-react/panes/terminal/use-terminal-selection.ts
@@ -63,6 +63,9 @@ import {
   followWindowShift,
   pointerCell,
 } from "../../../tui/panes/terminal/terminal-selection"
+import type { RowWrapFlags } from "../../../tui/panes/terminal/terminal-wrap"
+import { useOptionalNotifications } from "../../context/notifications"
+import { useT } from "../../i18n"
 
 /** Auto-scroll cadence while a drag hangs past an edge, and its per-tick cap. */
 const AUTO_SCROLL_MS = 50
@@ -81,6 +84,9 @@ export interface UseTerminalSelectionOpts {
    * from the front, so this is what keeps the selection on its content.
    */
   snapshotWindow: TerminalSnapshotWindow | null
+  /** Soft-wrap flags parallel to `snapshot`: a copied logical line must not
+   *  grow the newlines the emulator's column limit put on screen. */
+  wrapped: RowWrapFlags
   /**
    * Scroll for a drag hanging past an edge: negative goes up into history,
    * positive toward live. The pointer's absolute coords come along because the
@@ -123,6 +129,8 @@ export function useTerminalSelection(opts: UseTerminalSelectionOpts): UseTermina
   const draggingRef = useRef(false)
   const anchorRef = useRef<CellPoint | null>(null)
   const renderer = useRenderer()
+  const notifications = useOptionalNotifications()
+  const t = useT()
 
   const selection = useMemo<SelectionRange | null>(() => {
     if (!selAnchor || !selHead) return null
@@ -340,10 +348,30 @@ export function useTerminalSelection(opts: UseTerminalSelectionOpts): UseTermina
     [],
   )
 
+  /**
+   * Copy-on-release. Success stays SILENT — a toast on every drag would be
+   * noise on the pane's most frequent gesture — but a failure has to speak,
+   * or the highlight is the only thing that ever acknowledged the drag and it
+   * acknowledged something that did not happen.
+   *
+   * A selection with nothing but whitespace in it is skipped rather than
+   * failed: a stray click is a zero-width selection, and clobbering the
+   * clipboard with a run of spaces every time the pointer twitches is worse
+   * than doing nothing. There is nothing to report because nothing was tried.
+   *
+   * ponytail: on a box where NEITHER channel exists this fires once per drag.
+   * That is a machine-wide configuration the user fixes once, not a transient
+   * error, so it is left un-deduped rather than growing a suppression cache.
+   */
   const copySelection = (): void => {
     if (!selection) return
-    const text = extractShadowedSelection(opts.snapshot, shadowRef.current, selection)
-    if (text.trim().length > 0) copyTextToSystemClipboard(text, (payload) => renderer?.copyToClipboardOSC52(payload))
+    const text = extractShadowedSelection(opts.snapshot, shadowRef.current, selection, opts.wrapped)
+    if (text.trim().length === 0) return
+    void copyTextToSystemClipboard(text, (payload) => renderer?.copyToClipboardOSC52(payload)).then((copied) => {
+      // Empty task/tab ids: the toast queue is what this needs, not the tab's
+      // unread badge — same pattern as the standalone pages' `notifyError`.
+      if (!copied) notifications?.notify({ kind: "error", taskId: "", tabId: "", title: t("tasks.toast.copyFailed") })
+    })
   }
 
   return {

--- a/packages/kobe/src/tui-react/workspace/host-task-actions.ts
+++ b/packages/kobe/src/tui-react/workspace/host-task-actions.ts
@@ -247,7 +247,9 @@ export function useWorkspaceTaskActions(deps: WorkspaceTaskActionDeps): Workspac
     togglePin,
     moveTask,
     setStatus: (id) => setStatusFlow(taskActions, id),
-    copyTaskField: (id, field) => copyTaskFieldFlow(taskActions, id, field),
+    copyTaskField: (id, field) => {
+      void copyTaskFieldFlow(taskActions, id, field)
+    },
     showFieldNotes: (repo) => FieldNotesDialog.show(dialog, { repo, load: () => orchestrator.listFieldNotes(repo) }),
     confirmRunAgain,
     landTask,

--- a/packages/kobe/src/tui/i18n/messages/tasks.ts
+++ b/packages/kobe/src/tui/i18n/messages/tasks.ts
@@ -192,6 +192,9 @@ export const en = {
       "Closed {count} tab(s). The branch {branch} is still there — reopen the task to re-create its worktree.",
     copiedBranch: "Copied branch {text}",
     copiedPath: "Copied path {text}",
+    // Both clipboard channels refused: no platform clipboard command on PATH
+    // (a headless box), and a terminal that answers "no" to OSC 52.
+    copyFailed: "Couldn't reach a clipboard — no clipboard command on PATH, and this terminal refused OSC 52.",
 
     /** Action failures. Each names the state that SURVIVED the failure —
      *  the `kanban.*` block's shape, and the thing a user needs in order to
@@ -355,6 +358,7 @@ export const zh: typeof en = {
     worktreeGoneBody: "已关闭 {count} 个标签页。分支 {branch} 仍在——重新打开该任务会重建 worktree。",
     copiedBranch: "已复制分支 {text}",
     copiedPath: "已复制路径 {text}",
+    copyFailed: "无法访问剪贴板——PATH 上没有剪贴板命令，这个终端也拒绝了 OSC 52。",
 
     forgetProjectFailed: "移除项目失败——它仍在项目列表里：{error}",
     deleteFailed: "删除「{title}」失败——任务和它的 worktree 都没有被改动：{error}",

--- a/packages/kobe/src/tui/lib/clipboard-copy.ts
+++ b/packages/kobe/src/tui/lib/clipboard-copy.ts
@@ -3,18 +3,29 @@
  * OSC52 alone is not enough:
  * several terminals ship with it disabled (iTerm2) or unsupported
  * (Terminal.app), so the selection is ALSO piped into the platform
- * clipboard command when one exists (pbcopy / wl-copy / xclip / xsel).
+ * clipboard command when one exists (pbcopy / clip / wl-copy / xclip / xsel).
  * Both channels fire — the local pipe covers strict terminals, OSC52
  * covers SSH/remote sessions where the local pipe lands on the wrong
  * machine's clipboard.
+ *
+ * Both channels can REFUSE, and the caller has to be able to see it: a
+ * headless Linux box with no `wl-copy`/`xclip`/`xsel` has no local pipe at
+ * all, and `isOsc52Supported()` says no on the terminals named above. A
+ * "Copied branch X" toast printed over that pair is feedback for an event
+ * that did not happen, so the result is reported rather than discarded.
  */
 
+import { spawn } from "node:child_process"
 import { clipboardBinaryOnPath, resolveClipboardCopyCommand } from "../../lib/clipboard-command"
 
-/** Resolved once per process — the probe shells out to `which`. */
-let resolvedCommand: string | null | undefined
+/** The OSC 52 half. opentui's `copyToClipboardOSC52` returns whether the
+ *  terminal accepted it; a host with no renderer yields `undefined`. */
+export type Osc52Writer = (text: string) => boolean | undefined
 
-function clipboardCommand(): string | null {
+/** Resolved once per process — the probe shells out to `which`. */
+let resolvedCommand: readonly string[] | null | undefined
+
+function clipboardCommand(): readonly string[] | null {
   if (resolvedCommand === undefined) {
     resolvedCommand = resolveClipboardCopyCommand(process.platform, clipboardBinaryOnPath)
   }
@@ -22,23 +33,49 @@ function clipboardCommand(): string | null {
 }
 
 /**
- * Best-effort copy: local clipboard command (when available) + the
- * caller-supplied OSC52 writer. Never throws.
+ * Whether `cmd` took the text. Null argv (no clipboard command on this
+ * platform's PATH) is a refusal, not an error.
+ *
+ * The exit status is the ONLY place a clipboard failure shows up: a spawn
+ * neither throws nor writes anywhere the pane can see when the command is
+ * missing (127 / ENOENT) or refuses (`xclip` on a box with no `$DISPLAY`
+ * passes the `which` probe, spawns fine, and exits non-zero). Discarding it
+ * is what let "Copied branch X" print over a clipboard nothing reached.
  */
-export function copyTextToSystemClipboard(text: string, osc52: (text: string) => void): void {
-  const cmd = clipboardCommand()
-  if (cmd) {
+export function pipeToClipboardCommand(text: string, cmd: readonly string[] | null): Promise<boolean> {
+  if (!cmd || cmd.length === 0) return Promise.resolve(false)
+  return new Promise((resolve) => {
     try {
-      const proc = Bun.spawn(["sh", "-c", cmd], { stdin: "pipe", stdout: "ignore", stderr: "ignore" })
-      proc.stdin.write(text)
-      void proc.stdin.end()
+      const proc = spawn(cmd[0] as string, cmd.slice(1), { stdio: ["pipe", "ignore", "ignore"] })
+      let settled = false
+      const done = (ok: boolean): void => {
+        if (settled) return
+        settled = true
+        resolve(ok)
+      }
+      // ENOENT arrives here, not as an exit code, and a closed stdin raises
+      // EPIPE on the write below — neither may reach the caller as a throw.
+      proc.on("error", () => done(false))
+      proc.stdin.on("error", () => done(false))
+      proc.on("close", (code) => done(code === 0))
+      proc.stdin.end(text)
     } catch {
-      /* fall through to OSC52 */
+      resolve(false)
     }
-  }
+  })
+}
+
+/**
+ * Copy through both channels; resolves true when EITHER accepted the text.
+ * Never throws.
+ */
+export async function copyTextToSystemClipboard(text: string, osc52: Osc52Writer): Promise<boolean> {
+  const piped = await pipeToClipboardCommand(text, clipboardCommand())
+  let escaped = false
   try {
-    osc52(text)
+    escaped = osc52(text) === true
   } catch {
     /* best-effort */
   }
+  return piped || escaped
 }

--- a/packages/kobe/src/tui/lib/task-actions.ts
+++ b/packages/kobe/src/tui/lib/task-actions.ts
@@ -83,7 +83,7 @@ export interface TaskActionContext {
    * a renderer to hand the OSC52 half to; a host that omits it makes the flow
    * a no-op.
    */
-  readonly copyText?: (text: string) => void
+  readonly copyText?: (text: string) => Promise<boolean>
   readonly logger: TaskActionLogger
   /** Forensic log tag — `[rove]` (outer monitor) vs `[rove tasks]` (Tasks pane). */
   readonly logPrefix: string
@@ -412,13 +412,23 @@ export async function setStatusFlow(ctx: TaskActionContext, taskId: string): Pro
  * entries then (tree-menu.ts); the empty-string guard here is the backstop.
  *
  * The success toast is the only feedback a clipboard write can have on screen,
- * so it echoes what was copied rather than a bare "copied".
+ * so it echoes what was copied rather than a bare "copied" — and it is printed
+ * only once `copyText` has said the text actually landed. Neither channel is
+ * guaranteed: a headless box may have no clipboard command at all, and OSC 52
+ * is refused outright by some terminals.
  */
-export function copyTaskFieldFlow(ctx: TaskActionContext, taskId: string, field: "branch" | "path"): void {
+export async function copyTaskFieldFlow(
+  ctx: TaskActionContext,
+  taskId: string,
+  field: "branch" | "path",
+): Promise<void> {
   const task = ctx.tasks().find((candidate) => candidate.id === taskId)
   if (!task || !ctx.copyText) return
   const text = field === "branch" ? task.branch : task.worktreePath
   if (text === "") return
-  ctx.copyText(text)
+  if (!(await ctx.copyText(text))) {
+    ctx.notifyError?.(t("tasks.toast.copyFailed"))
+    return
+  }
   ctx.notifyInfo?.(t(field === "branch" ? "tasks.toast.copiedBranch" : "tasks.toast.copiedPath", { text }))
 }

--- a/packages/kobe/src/tui/panes/terminal/pty-listeners.ts
+++ b/packages/kobe/src/tui/panes/terminal/pty-listeners.ts
@@ -7,6 +7,7 @@
  */
 
 import type { CursorPos, DataListener, TerminalRow, TerminalSnapshotWindow } from "./pty-types"
+import type { RowWrapFlags } from "./terminal-wrap"
 
 type TitleListener = (title: string) => void
 type ExitListener = () => void
@@ -35,10 +36,15 @@ export class PtyListeners {
     return () => this.titles.delete(listener)
   }
 
-  publishData(snapshot: readonly TerminalRow[], cursor: CursorPos | null, window: TerminalSnapshotWindow | null): void {
+  publishData(
+    snapshot: readonly TerminalRow[],
+    cursor: CursorPos | null,
+    window: TerminalSnapshotWindow | null,
+    wrapped?: RowWrapFlags,
+  ): void {
     for (const listener of this.data) {
       try {
-        listener(snapshot, cursor, window)
+        listener(snapshot, cursor, window, wrapped)
       } catch {
         /* one listener must not break the others */
       }

--- a/packages/kobe/src/tui/panes/terminal/pty-types.ts
+++ b/packages/kobe/src/tui/panes/terminal/pty-types.ts
@@ -4,6 +4,7 @@ import { resolveLoginShell } from "@sma1lboy/kobe-daemon/daemon/platform-shell"
 import type { TerminalDefaultColors } from "@sma1lboy/kobe-daemon/daemon/terminal-colors"
 import type { TerminalInputModes } from "./keys-pure"
 import type { Chunk } from "./sgr"
+import type { RowWrapFlags } from "./terminal-wrap"
 
 /** One rendered row: a list of opentui-ready style runs. */
 export type TerminalRow = readonly Chunk[]
@@ -111,6 +112,11 @@ export type DataListener = (
   rows: readonly TerminalRow[],
   cursor: CursorPos | null,
   window: TerminalSnapshotWindow | null,
+  /** Parallel to `rows`: row i is a soft-wrap CONTINUATION of row i-1 — one
+   *  logical line the emulator broke because it ran out of columns. Omitted
+   *  by backends with no emulator behind them (`PipeTaskPty`, mocks), where
+   *  every row counts as its own line. */
+  wrapped?: RowWrapFlags,
 ) => void
 
 /** Cursor position within the rendered pane, 0-based. */
@@ -209,6 +215,8 @@ export interface TaskPtyLike {
   captureCursor(): CursorPos | null
   /** Address paired with `capture()`; null for backends without stable line ids. */
   captureWindow(): TerminalSnapshotWindow | null
+  /** Soft-wrap flags paired with `capture()`; see {@link DataListener}. */
+  captureWrapped?(): RowWrapFlags
   kill(): void
   /**
    * Drop this handle WITHOUT ending the session, when the backend can

--- a/packages/kobe/src/tui/panes/terminal/pty-xterm-base.ts
+++ b/packages/kobe/src/tui/panes/terminal/pty-xterm-base.ts
@@ -11,12 +11,14 @@ import {
   type CursorPos,
   DEFAULT_COLS,
   DEFAULT_ROWS,
+  type DataListener,
   type TaskPtyLike,
   type TaskPtyOpts,
   type TerminalRow,
   type TerminalSnapshotWindow,
 } from "./pty-types"
 import { XtermSnapshotEngine } from "./pty-xterm-snapshot"
+import type { RowWrapFlags } from "./terminal-wrap"
 import { XtermRefreshTracker, wireXtermChannels, wireXtermDefaultColorQueries } from "./xterm-refresh"
 
 /**
@@ -46,6 +48,7 @@ export abstract class XtermTaskPty implements TaskPtyLike {
   private snapshot: readonly TerminalRow[] = []
   private cursor: CursorPos | null = null
   private snapshotWindow: TerminalSnapshotWindow | null = null
+  private snapshotWrapped: RowWrapFlags = []
   /** Output arrived while nobody was subscribed — snapshot is stale and
    * will be rebuilt lazily on the next capture()/subscribe. Keeps the N
    * background sessions of a multi-task workspace from re-converting
@@ -255,16 +258,14 @@ export abstract class XtermTaskPty implements TaskPtyLike {
     }
   }
 
-  onData(
-    cb: (snapshot: readonly TerminalRow[], cursor: CursorPos | null, window: TerminalSnapshotWindow | null) => void,
-  ): () => void {
+  onData(cb: DataListener): () => void {
     // Refresh before registering so the lazy rebuild cannot double-notify.
     this.ensureFreshSnapshot()
     const off = this.listeners.addData(cb)
     this._unwatchedSince = null
     if (this.snapshot.length > 0) {
       try {
-        cb(this.snapshot, this.cursor, this.snapshotWindow)
+        cb(this.snapshot, this.cursor, this.snapshotWindow, this.snapshotWrapped)
       } catch {
         /* one listener must not break the others */
       }
@@ -336,6 +337,11 @@ export abstract class XtermTaskPty implements TaskPtyLike {
   captureWindow(): TerminalSnapshotWindow | null {
     this.ensureFreshSnapshot()
     return this.snapshotWindow
+  }
+
+  captureWrapped(): RowWrapFlags {
+    this.ensureFreshSnapshot()
+    return this.snapshotWrapped
   }
 
   /** Rebuild a lazily-deferred snapshot unless synchronized output is mid-frame. */
@@ -415,13 +421,14 @@ export abstract class XtermTaskPty implements TaskPtyLike {
     this.snapshot = result.snapshot
     this.cursor = result.cursor
     this.snapshotWindow = result.snapshotWindow
+    this.snapshotWrapped = result.wrapped
     this.snapshotDirty = false
     if (result.changed) this.publishSnapshot()
   }
 
   private publishSnapshot(): void {
     profileTick("publish")
-    this.listeners.publishData(this.snapshot, this.cursor, this.snapshotWindow)
+    this.listeners.publishData(this.snapshot, this.cursor, this.snapshotWindow, this.snapshotWrapped)
   }
 
   /** Free the emulator's cell buffers NOW instead of waiting for GC — the

--- a/packages/kobe/src/tui/panes/terminal/pty-xterm-snapshot.ts
+++ b/packages/kobe/src/tui/panes/terminal/pty-xterm-snapshot.ts
@@ -7,6 +7,7 @@ import type { TerminalStyleRewrite } from "@/types/terminal-presentation"
 import type { IMarker, Terminal as XtermHeadless } from "@xterm/headless"
 import type { CursorPos, TerminalRow, TerminalSnapshotWindow } from "./pty-types"
 import { reconcileTerminalCursor, reconcileTerminalRow, reconcileTerminalRows } from "./terminal-snapshot"
+import type { RowWrapFlags } from "./terminal-wrap"
 import { xtermLineToChunks } from "./xterm-chunks"
 import {
   type SnapshotMeta,
@@ -21,12 +22,28 @@ export type XtermSnapshotRefreshResult = {
   snapshot: readonly TerminalRow[]
   cursor: CursorPos | null
   snapshotWindow: TerminalSnapshotWindow | null
+  /** Parallel to `snapshot`: row i is a soft-wrap continuation of row i-1. */
+  wrapped: RowWrapFlags
   changed: boolean
+}
+
+/** Retain the previous flags array when the wrap layout did not move. */
+function sameFlags(previous: RowWrapFlags, next: readonly boolean[]): boolean {
+  if (previous.length !== next.length) return false
+  for (let i = 0; i < next.length; i++) if (previous[i] !== next[i]) return false
+  return true
 }
 
 export class XtermSnapshotEngine {
   /** Frozen-scrollback conversion cache: absolute line id → converted row. */
   private readonly scrollbackCache = new Map<number, TerminalRow>()
+  /** Same keys as {@link scrollbackCache}: the frozen row's `isWrapped` flag.
+   *  Cached beside the row so the frozen fast path never has to allocate a
+   *  `getLine` wrapper for scrollback it already converted. */
+  private readonly wrappedCache = new Map<number, boolean>()
+  /** Last published flags — returned by reference when nothing changed, so a
+   *  consumer memoizing on them does not re-scan the ring every frame. */
+  private wrapped: RowWrapFlags = []
   private anchor: IMarker | undefined
   private anchorId = 0
   private snapshotEpoch = 0
@@ -37,6 +54,8 @@ export class XtermSnapshotEngine {
   /** Drop the cache and anchor; called on resize/reflow or teardown. */
   invalidate(): void {
     this.scrollbackCache.clear()
+    this.wrappedCache.clear()
+    this.wrapped = []
     this.anchor?.dispose()
     this.anchor = undefined
     this.anchorId = 0
@@ -85,6 +104,7 @@ export class XtermSnapshotEngine {
         snapshot: previousSnapshot,
         cursor: nextCursor,
         snapshotWindow: previousWindow,
+        wrapped: this.wrapped,
         changed: nextCursor !== previousCursor,
       }
     }
@@ -93,6 +113,7 @@ export class XtermSnapshotEngine {
     const canAnchor = !alt && active.baseY > 0
     if (canAnchor && (this.anchor === undefined || this.anchor.isDisposed)) {
       this.scrollbackCache.clear()
+      this.wrappedCache.clear()
       const fresh = term.registerMarker(-active.cursorY - 1)
       if (fresh) {
         this.snapshotEpoch += 1
@@ -103,7 +124,9 @@ export class XtermSnapshotEngine {
     const anchorAlive = canAnchor && this.anchor !== undefined && !this.anchor.isDisposed
     const absBase = anchorAlive ? this.anchorId - (this.anchor as IMarker).line : 0
     const cache = this.scrollbackCache
+    const wrappedCache = this.wrappedCache
     const rowsOut: TerminalRow[] = []
+    const wrappedOut: boolean[] = []
     const cursorY = active.baseY + active.cursorY
     const start = currentMeta.start
     for (let y = start; y < active.length; y++) {
@@ -112,19 +135,29 @@ export class XtermSnapshotEngine {
         const cached = cache.get(absBase + y)
         if (cached) {
           rowsOut.push(cached)
+          wrappedOut.push(wrappedCache.get(absBase + y) ?? false)
           continue
         }
       }
       const line = active.getLine(y)
       const minLast = !cursorHidden && y === cursorY ? active.cursorX - 1 : -1
       const row: TerminalRow = line ? xtermLineToChunks(line, minLast, styleRewrites) : []
+      // The first row of the window can be a continuation of a row the ring
+      // already dropped; there is nothing left to join it to, so it starts a
+      // logical line like any other orphan.
+      const wraps = y > start && line?.isWrapped === true
       const stableRow = frozen ? reconcileTerminalRow(previousSnapshot[rowsOut.length], row) : row
       rowsOut.push(stableRow)
-      if (frozen) cache.set(absBase + y, stableRow)
+      wrappedOut.push(wraps)
+      if (frozen) {
+        cache.set(absBase + y, stableRow)
+        wrappedCache.set(absBase + y, wraps)
+      }
     }
     if (anchorAlive) {
       const min = absBase + start
       for (const id of cache.keys()) if (id < min) cache.delete(id)
+      for (const id of wrappedCache.keys()) if (id < min) wrappedCache.delete(id)
     }
     if (canAnchor) {
       const next = term.registerMarker(-active.cursorY - 1)
@@ -143,7 +176,13 @@ export class XtermSnapshotEngine {
       : null
     refreshTracker.clear()
     this.publishedMeta = currentMeta
-    const changed = snapshot !== previousSnapshot || nextCursor !== previousCursor || snapshotWindow !== previousWindow
-    return { snapshot, cursor: nextCursor, snapshotWindow, changed }
+    const wrapLayoutMoved = !sameFlags(this.wrapped, wrappedOut)
+    if (wrapLayoutMoved) this.wrapped = wrappedOut
+    const changed =
+      snapshot !== previousSnapshot ||
+      nextCursor !== previousCursor ||
+      snapshotWindow !== previousWindow ||
+      wrapLayoutMoved
+    return { snapshot, cursor: nextCursor, snapshotWindow, wrapped: this.wrapped, changed }
   }
 }

--- a/packages/kobe/src/tui/panes/terminal/terminal-search.ts
+++ b/packages/kobe/src/tui/panes/terminal/terminal-search.ts
@@ -15,6 +15,7 @@
 import { charWidth } from "../../../lib/display-width"
 import type { Chunk } from "./sgr"
 import { type SelectionRange, type SpanPaint, overlaySelection } from "./terminal-selection"
+import { type LogicalLine, type RowWrapFlags, logicalLines, rowAtOffset } from "./terminal-wrap"
 
 /** Terminal-cell width of text: wide glyphs count 2, combining marks 0. */
 function cellWidth(text: string): number {
@@ -45,26 +46,55 @@ function foldCase(text: string): string {
 }
 
 /**
+ * Turn `[at, to)` within one logical line into a snapshot `SelectionRange`.
+ * A hit that crosses a soft wrap spans rows, which is the shape `rowSpan`
+ * already means by "first row from the start column, last row to the end
+ * column" — so the existing highlight paints it with no changes.
+ * Null when the hit covers no cells (zero-width marks only).
+ */
+function matchRange(line: LogicalLine, at: number, to: number): SelectionRange | null {
+  if (cellWidth(line.text.slice(at, to)) <= 0) return null
+  const head = rowAtOffset(line, to - 1)
+  const anchor = rowAtOffset(line, at)
+  const headFrom = Math.max(at, head.start)
+  const headCol = cellWidth(line.text.slice(head.start, headFrom))
+  return {
+    anchor: { row: anchor.row, col: cellWidth(line.text.slice(anchor.start, at)) },
+    head: { row: head.row, col: headCol + cellWidth(line.text.slice(headFrom, to)) - 1 },
+  }
+}
+
+/**
  * Every occurrence of `query` in `rows`, top-first, in ABSOLUTE snapshot
  * coordinates. An empty query yields nothing: it matches everywhere, which
  * is the same as matching nothing worth painting.
+ *
+ * Searching is done over LOGICAL lines: a row the emulator soft-wrapped is
+ * half of the line above it, and a per-row `indexOf` cannot see a needle
+ * straddling that break — it answers "no matches" for text the user can read
+ * two rows up. `wrapped` is the snapshot's per-row flags; without them every
+ * row is its own line, which is the pre-wrap behavior.
  */
-export function findMatches(rows: readonly (readonly Chunk[])[], query: string): readonly SelectionRange[] {
+export function findMatches(
+  rows: readonly (readonly Chunk[])[],
+  query: string,
+  wrapped?: RowWrapFlags,
+): readonly SelectionRange[] {
   const needle = foldCase(query)
   if (needle.length === 0) return []
   const out: SelectionRange[] = []
-  for (let row = 0; row < rows.length; row++) {
-    const text = rowText(rows[row] ?? [])
-    const haystack = foldCase(text)
+  for (const line of logicalLines(
+    rows.map((row) => rowText(row ?? [])),
+    wrapped,
+  )) {
+    const haystack = foldCase(line.text)
     let from = 0
     for (;;) {
       const at = haystack.indexOf(needle, from)
       if (at < 0) break
       from = at + needle.length
-      const col = cellWidth(text.slice(0, at))
-      const width = cellWidth(text.slice(at, from))
-      // A hit made only of zero-width marks covers no cells to highlight.
-      if (width > 0) out.push({ anchor: { row, col }, head: { row, col: col + width - 1 } })
+      const range = matchRange(line, at, from)
+      if (range) out.push(range)
     }
   }
   return out
@@ -93,7 +123,9 @@ export function overlayMatches(
   let out = rows
   for (let i = 0; i < matches.length; i++) {
     const match = matches[i] as SelectionRange
-    if (match.anchor.row < firstRow || match.anchor.row > lastRow) continue
+    // Compared on the whole SPAN, not the anchor alone: a hit across a soft
+    // wrap starts one row above the viewport and still has a tail inside it.
+    if (match.head.row < firstRow || match.anchor.row > lastRow) continue
     out = overlaySelection(out, match, firstRow, width, i === current ? currentPaint : "inverse")
   }
   return out
@@ -110,4 +142,64 @@ export function scrollOffsetForRow(total: number, height: number, row: number): 
   const body = Math.max(1, height)
   const max = Math.max(0, total - body)
   return Math.min(max, Math.max(0, total - body + Math.floor(body / 3) - row))
+}
+
+/**
+ * Which hit the viewport is parked on, addressed so it survives the buffer
+ * moving underneath it.
+ *
+ * An array POSITION does not: the local scrollback is bounded, so once it
+ * saturates every new line drops a hit off the front and every survivor
+ * shifts down one slot — the counter keeps saying `3/5` while the accent
+ * highlight has walked to a different occurrence. The absolute line id is the
+ * same address `moveViewportScroll` anchors the viewport by, and it is stable
+ * across a trim.
+ *
+ * `position` is the degraded form for backends with no stable line ids
+ * (`PipeTaskPty`, mocks, the alternate screen): there is nothing better to
+ * park on there, so it keeps the old behavior rather than pretending.
+ */
+export type ParkedHit =
+  | { readonly kind: "line"; readonly epoch: number; readonly line: number; readonly col: number }
+  | { readonly kind: "position"; readonly at: number }
+
+/** Address match `at` for parking, given the snapshot's current window. */
+export function parkHit(
+  matches: readonly SelectionRange[],
+  at: number,
+  window: { readonly epoch: number; readonly startLine: number } | null,
+): ParkedHit | null {
+  const match = matches[at]
+  if (!match) return null
+  if (!window) return { kind: "position", at }
+  return { kind: "line", epoch: window.epoch, line: window.startLine + match.anchor.row, col: match.anchor.col }
+}
+
+/**
+ * Re-derive the parked hit's position in a freshly recomputed match list.
+ *
+ * Returns -1 when the park cannot be honoured rather than pointing at a
+ * neighbour: a resize reflows history and bumps `epoch`, so the recorded id
+ * names content that no longer exists under that numbering —
+ * `followWindowShift` drops a selection on exactly that signal, and guessing
+ * here would put the accent on a line the user never walked to. A hit the
+ * scrollback trimmed away falls forward to the next surviving hit, which is
+ * where `enter` would have taken them anyway.
+ */
+export function resolveParkedIndex(
+  parked: ParkedHit | null,
+  matches: readonly SelectionRange[],
+  window: { readonly epoch: number; readonly startLine: number } | null,
+): number {
+  if (!parked || matches.length === 0) return -1
+  if (parked.kind === "position") return Math.min(parked.at, matches.length - 1)
+  if (!window || window.epoch !== parked.epoch) return -1
+  let fallback = -1
+  for (let i = 0; i < matches.length; i++) {
+    const match = matches[i] as SelectionRange
+    const line = window.startLine + match.anchor.row
+    if (line === parked.line && match.anchor.col === parked.col) return i
+    if (fallback < 0 && line >= parked.line) fallback = i
+  }
+  return fallback >= 0 ? fallback : matches.length - 1
 }

--- a/packages/kobe/src/tui/panes/terminal/terminal-selection.ts
+++ b/packages/kobe/src/tui/panes/terminal/terminal-selection.ts
@@ -19,6 +19,7 @@
 import { charWidth } from "../../../lib/display-width"
 import type { TerminalSnapshotWindow } from "./pty-types"
 import { ATTR, type Chunk, type RGB } from "./sgr"
+import { type RowWrapFlags, isWrapContinuation } from "./terminal-wrap"
 
 export type CellPoint = { readonly row: number; readonly col: number }
 export type SelectionRange = { readonly anchor: CellPoint; readonly head: CellPoint }
@@ -144,15 +145,28 @@ function sliceTextByCells(text: string, from: number, to: number): CellSlice {
  * survives, matching what `overlaySelection` highlights. Dropping it collapsed
  * two visibly-selected lines into one on copy.
  */
-export function extractSelection(rows: readonly (readonly Chunk[])[], range: SelectionRange): string {
+export function extractSelection(
+  rows: readonly (readonly Chunk[])[],
+  range: SelectionRange,
+  wrapped?: RowWrapFlags,
+): string {
   const { start, end } = orderRange(range)
+  const first = Math.max(0, start.row)
   const lines: string[] = []
-  for (let r = Math.max(0, start.row); r <= Math.min(rows.length - 1, end.row); r++) {
+  for (let r = first; r <= Math.min(rows.length - 1, end.row); r++) {
     const text = rowText(rows[r] ?? [])
     const span = rowSpan(range, r, Math.max(textCells(text), 1))
-    lines.push(span ? sliceTextByCells(text, span[0], span[1]).selected.trimEnd() : "")
+    const slice = span ? sliceTextByCells(text, span[0], span[1]).selected : ""
+    // A soft-wrap continuation is the SAME line the emulator ran out of
+    // columns on, so it appends with no separator. Only a row that starts a
+    // logical line opens a new one; the row the selection starts on always
+    // does, since its predecessor is outside the selection.
+    if (r > first && isWrapContinuation(wrapped, r) && lines.length > 0) lines[lines.length - 1] += slice
+    else lines.push(slice)
   }
-  return lines.join("\n")
+  // Trimmed per LOGICAL line, not per row: the padding a user never selected
+  // sits at the end of the line, and a wrap point is mid-line.
+  return lines.map((line) => line.trimEnd()).join("\n")
 }
 
 /**
@@ -356,14 +370,26 @@ export function extractShadowedSelection(
   snapshot: readonly (readonly Chunk[])[],
   shadow: SelectionShadow,
   range: SelectionRange,
+  wrapped?: RowWrapFlags,
 ): string {
-  if (shadow.above.length === 0 && shadow.below.length === 0) return extractSelection(snapshot, range)
+  if (shadow.above.length === 0 && shadow.below.length === 0) return extractSelection(snapshot, range, wrapped)
   const offset = shadow.above.length
   const rows = [...shadow.above, ...snapshot, ...shadow.below]
-  return extractSelection(rows, {
-    anchor: { row: range.anchor.row + offset, col: range.anchor.col },
-    head: { row: range.head.row + offset, col: range.head.col },
-  })
+  // Shadow rows are whole screens banked during an ALT-screen drag, and this
+  // path only runs there. They carry no wrap flags of their own — an app that
+  // owns its own scrollback positions each row itself rather than letting the
+  // emulator wrap — so they count as line starts.
+  const shifted = wrapped
+    ? [...new Array<boolean>(offset).fill(false), ...wrapped, ...new Array<boolean>(shadow.below.length).fill(false)]
+    : undefined
+  return extractSelection(
+    rows,
+    {
+      anchor: { row: range.anchor.row + offset, col: range.anchor.col },
+      head: { row: range.head.row + offset, col: range.head.col },
+    },
+    shifted,
+  )
 }
 
 /**

--- a/packages/kobe/src/tui/panes/terminal/terminal-wrap.ts
+++ b/packages/kobe/src/tui/panes/terminal/terminal-wrap.ts
@@ -1,0 +1,60 @@
+/**
+ * Soft-wrap grouping for the terminal snapshot.
+ *
+ * The snapshot is a GRID: one entry per terminal row. xterm marks a row
+ * `isWrapped` when it is the continuation of the row above — the emulator ran
+ * out of columns and broke ONE logical line across several rows. Nothing
+ * downstream can recover that from the cells, so both places a user touches
+ * text would otherwise read the break as a real newline: a copied path comes
+ * back in pieces, and a needle lying across the boundary exists in no single
+ * row and is reported as "no matches".
+ *
+ * One definition of "continuation" lives here. `extractSelection` reads it
+ * directly (it only needs "does this row continue the last one"), and
+ * `findMatches` reads it through {@link logicalLines}, which also carries the
+ * offsets a hit needs to map back onto grid coordinates.
+ */
+
+/** Per-snapshot-row soft-wrap flags, parallel to the snapshot rows. */
+export type RowWrapFlags = readonly boolean[]
+
+/** Row `row` is the soft-wrap continuation of `row - 1`. */
+export function isWrapContinuation(wrapped: RowWrapFlags | undefined, row: number): boolean {
+  return row > 0 && wrapped?.[row] === true
+}
+
+/** One logical line: the rows it spans, joined, plus where each row starts in the join. */
+export type LogicalLine = {
+  readonly text: string
+  /** Absolute snapshot index of the first row. */
+  readonly firstRow: number
+  /** `starts[i]` is the offset in `text` at which row `firstRow + i` begins. */
+  readonly starts: readonly number[]
+}
+
+/**
+ * Group row texts into logical lines. With no flags (a backend that cannot
+ * report wrapping) every row is its own logical line, which is exactly
+ * today's behavior.
+ */
+export function logicalLines(rowTexts: readonly string[], wrapped: RowWrapFlags | undefined): readonly LogicalLine[] {
+  const out: { text: string; firstRow: number; starts: number[] }[] = []
+  for (let row = 0; row < rowTexts.length; row++) {
+    const text = rowTexts[row] ?? ""
+    const last = out[out.length - 1]
+    if (last && isWrapContinuation(wrapped, row)) {
+      last.starts.push(last.text.length)
+      last.text += text
+      continue
+    }
+    out.push({ text, firstRow: row, starts: [0] })
+  }
+  return out
+}
+
+/** The row of `line` holding `offset`, and that row's start offset within the join. */
+export function rowAtOffset(line: LogicalLine, offset: number): { row: number; start: number } {
+  let i = line.starts.length - 1
+  while (i > 0 && (line.starts[i] as number) > offset) i--
+  return { row: line.firstRow + i, start: line.starts[i] as number }
+}

--- a/packages/kobe/test/tui/clipboard-command.test.ts
+++ b/packages/kobe/test/tui/clipboard-command.test.ts
@@ -9,36 +9,49 @@ const none = () => false
 const all = () => true
 
 describe("resolveClipboardCopyCommand", () => {
-  test("darwin → pbcopy (probe irrelevant)", () => {
-    expect(resolveClipboardCopyCommand("darwin", none)).toBe("pbcopy")
-    expect(resolveClipboardCopyCommand("darwin", all)).toBe("pbcopy")
+  test("darwin → pbcopy, and null when even pbcopy is not on PATH", () => {
+    expect(resolveClipboardCopyCommand("darwin", all)).toEqual(["pbcopy"])
+    // Probed like every other platform: an honest "no clipboard command" beats
+    // spawning one that exits non-zero where the caller now reads the status.
+    expect(resolveClipboardCopyCommand("darwin", none)).toBeNull()
   })
 
   test("linux with wl-copy available → wl-copy (Wayland preferred)", () => {
-    expect(resolveClipboardCopyCommand("linux", all)).toBe("wl-copy")
+    expect(resolveClipboardCopyCommand("linux", all)).toEqual(["wl-copy"])
   })
 
   test("linux with only xclip → xclip clipboard command", () => {
     const onlyXclip = (bin: string) => bin === "xclip"
-    expect(resolveClipboardCopyCommand("linux", onlyXclip)).toBe("xclip -selection clipboard -in")
+    expect(resolveClipboardCopyCommand("linux", onlyXclip)).toEqual(["xclip", "-selection", "clipboard", "-in"])
   })
 
   test("linux with only xsel → xsel clipboard command", () => {
     const onlyXsel = (bin: string) => bin === "xsel"
-    expect(resolveClipboardCopyCommand("linux", onlyXsel)).toBe("xsel --clipboard --input")
+    expect(resolveClipboardCopyCommand("linux", onlyXsel)).toEqual(["xsel", "--clipboard", "--input"])
   })
 
   test("linux preference order: wl-copy beats xclip beats xsel", () => {
     const noWayland = (bin: string) => bin === "xclip" || bin === "xsel"
-    expect(resolveClipboardCopyCommand("linux", noWayland)).toBe("xclip -selection clipboard -in")
+    expect(resolveClipboardCopyCommand("linux", noWayland)).toEqual(["xclip", "-selection", "clipboard", "-in"])
   })
 
   test("linux with no clipboard tool → null", () => {
     expect(resolveClipboardCopyCommand("linux", none)).toBeNull()
   })
 
+  test("win32 resolves clip.exe — Windows is supported and OSC 52 is not its only hope", () => {
+    expect(resolveClipboardCopyCommand("win32", all)).toEqual(["clip"])
+    const onlyPowershell = (bin: string) => bin === "powershell"
+    expect(resolveClipboardCopyCommand("win32", onlyPowershell)).toEqual([
+      "powershell",
+      "-NoProfile",
+      "-Command",
+      "Set-Clipboard",
+    ])
+    expect(resolveClipboardCopyCommand("win32", none)).toBeNull()
+  })
+
   test("unknown platform → null", () => {
-    expect(resolveClipboardCopyCommand("win32", all)).toBeNull()
     expect(resolveClipboardCopyCommand("freebsd", all)).toBeNull()
   })
 })

--- a/packages/kobe/test/tui/clipboard-copy.test.ts
+++ b/packages/kobe/test/tui/clipboard-copy.test.ts
@@ -1,0 +1,41 @@
+/**
+ * The local clipboard pipe against REAL processes: the point of the change is
+ * that a command which is missing or fails is reported as a failure, and
+ * `Bun.spawn` signals both only through the exit status. Nothing here touches
+ * the operator's clipboard — `cat > file` stands in for `pbcopy` on the
+ * identical spawn path.
+ */
+
+import { mkdtempSync, readFileSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterAll, describe, expect, test } from "vitest"
+import { pipeToClipboardCommand } from "../../src/tui/lib/clipboard-copy"
+
+const dir = mkdtempSync(join(tmpdir(), "rove-clipboard-"))
+afterAll(() => rmSync(dir, { recursive: true, force: true }))
+
+describe("pipeToClipboardCommand", () => {
+  test("a command that accepts the text reports success, and gets all of it", async () => {
+    const out = join(dir, "sink.txt")
+    const text = "feat/some-branch\nwith a second line"
+    expect(await pipeToClipboardCommand(text, ["sh", "-c", `cat > ${out}`])).toBe(true)
+    expect(readFileSync(out, "utf8")).toBe(text)
+  })
+
+  test("a command that is not installed reports failure instead of throwing", async () => {
+    expect(await pipeToClipboardCommand("x", ["rove-no-such-clipboard-binary"])).toBe(false)
+  })
+
+  test("a shell that cannot find the binary exits 127 — the headless-Linux case", async () => {
+    expect(await pipeToClipboardCommand("x", ["sh", "-c", "rove-no-such-clipboard-binary"])).toBe(false)
+  })
+
+  test("a command that runs and fails reports failure — the xclip-without-DISPLAY case", async () => {
+    expect(await pipeToClipboardCommand("x", ["sh", "-c", "exit 3"])).toBe(false)
+  })
+
+  test("no clipboard command on this platform is a refusal, not a throw", async () => {
+    expect(await pipeToClipboardCommand("x", null)).toBe(false)
+  })
+})

--- a/packages/kobe/test/tui/pty-listeners.test.ts
+++ b/packages/kobe/test/tui/pty-listeners.test.ts
@@ -18,7 +18,7 @@ describe("PtyListeners", () => {
     listeners.publishData([], null, null)
     listeners.publishTitle("claude")
 
-    expect(data).toHaveBeenCalledWith([], null, null)
+    expect(data).toHaveBeenCalledWith([], null, null, undefined)
     expect(title).toHaveBeenCalledWith("claude")
     expect(listeners.dataCount).toBe(2)
   })

--- a/packages/kobe/test/tui/task-actions-rename.test.ts
+++ b/packages/kobe/test/tui/task-actions-rename.test.ts
@@ -65,6 +65,7 @@ function makeCtx(opts: {
   wirePickStatus?: boolean
   /** Same shape as `wirePickStatus`: false = a host with no clipboard writer. */
   wireCopyText?: boolean
+  copyTextResult?: boolean
 }): {
   ctx: TaskActionContext
   promptText: ReturnType<typeof vi.fn>
@@ -76,7 +77,7 @@ function makeCtx(opts: {
 } {
   const promptText = vi.fn(async () => opts.promptTextResult)
   const pickStatus = vi.fn(async () => opts.pickStatusResult)
-  const copyText = vi.fn()
+  const copyText = vi.fn(async () => opts.copyTextResult ?? true)
   const notifyError = vi.fn()
   const notifyInfo = vi.fn()
   const reload = vi.fn(async () => {})
@@ -373,45 +374,60 @@ describe("setStatusFlow", () => {
 })
 
 describe("copyTaskFieldFlow", () => {
-  test("branch: copies the stored branch verbatim and toasts it", () => {
+  test("branch: copies the stored branch verbatim and toasts it", async () => {
     const tasks = [makeTask({ id: "t1", branch: "feat/copy" })]
     const { ctx, copyText, notifyInfo } = makeCtx({ tasks, orch: makeOrch() })
 
-    copyTaskFieldFlow(ctx, "t1", "branch")
+    await copyTaskFieldFlow(ctx, "t1", "branch")
 
     expect(copyText).toHaveBeenCalledWith("feat/copy")
     expect(notifyInfo).toHaveBeenCalledTimes(1)
     expect(notifyInfo.mock.calls[0][0]).toContain("feat/copy")
   })
 
-  test("path: copies the RECORDED worktree path — never materializes it", () => {
+  test("both clipboard channels refused → the failure is named, not a copy toast", async () => {
+    const tasks = [makeTask({ id: "t1", branch: "feat/copy" })]
+    const { ctx, notifyInfo, notifyError } = makeCtx({
+      tasks,
+      orch: makeOrch(),
+      copyTextResult: false,
+    })
+
+    await copyTaskFieldFlow(ctx, "t1", "branch")
+
+    expect(notifyInfo).not.toHaveBeenCalled()
+    expect(notifyError).toHaveBeenCalledTimes(1)
+    expect(notifyError.mock.calls[0][0]).toContain("clipboard")
+  })
+
+  test("path: copies the RECORDED worktree path — never materializes it", async () => {
     // The path may not exist yet (a task opened once never ran ensureWorktree);
     // a copy is a read, so the flow has no orchestrator call to make at all.
     const orch = makeOrch()
     const tasks = [makeTask({ id: "t1", worktreePath: "/wt/not-yet" })]
     const { ctx, copyText } = makeCtx({ tasks, orch })
 
-    copyTaskFieldFlow(ctx, "t1", "path")
+    await copyTaskFieldFlow(ctx, "t1", "path")
 
     expect(copyText).toHaveBeenCalledWith("/wt/not-yet")
     for (const fn of Object.values(orch)) expect(fn).not.toHaveBeenCalled()
   })
 
-  test("an empty branch (main/dir row) copies nothing and shows no toast", () => {
+  test("an empty branch (main/dir row) copies nothing and shows no toast", async () => {
     const tasks = [makeTask({ id: "t1", branch: "", kind: "main" })]
     const { ctx, copyText, notifyInfo } = makeCtx({ tasks, orch: makeOrch() })
 
-    copyTaskFieldFlow(ctx, "t1", "branch")
+    await copyTaskFieldFlow(ctx, "t1", "branch")
 
     expect(copyText).not.toHaveBeenCalled()
     expect(notifyInfo).not.toHaveBeenCalled()
   })
 
-  test("a host with no clipboard writer is a silent no-op, not a crash", () => {
+  test("a host with no clipboard writer is a silent no-op, not a crash", async () => {
     const tasks = [makeTask({ id: "t1" })]
     const { ctx, notifyInfo } = makeCtx({ tasks, orch: makeOrch(), wireCopyText: false })
 
-    expect(() => copyTaskFieldFlow(ctx, "t1", "path")).not.toThrow()
+    await expect(copyTaskFieldFlow(ctx, "t1", "path")).resolves.toBeUndefined()
     expect(notifyInfo).not.toHaveBeenCalled()
   })
 })

--- a/packages/kobe/test/tui/terminal-search-park.test.ts
+++ b/packages/kobe/test/tui/terminal-search-park.test.ts
@@ -1,0 +1,73 @@
+/**
+ * The parked search hit, across a scrollback trim and a reflow.
+ *
+ * `matches` is recomputed on every PTY frame. Keeping the user's place as an
+ * ARRAY POSITION means a trim — which drops hits off the front and shifts
+ * every survivor down a slot — silently re-points it at a neighbouring
+ * occurrence while the counter still reads the old number.
+ */
+
+import { describe, expect, it } from "vitest"
+import { type ParkedHit, parkHit, resolveParkedIndex } from "../../src/tui/panes/terminal/terminal-search"
+import type { SelectionRange } from "../../src/tui/panes/terminal/terminal-selection"
+
+const hit = (row: number): SelectionRange => ({ anchor: { row, col: 0 }, head: { row, col: 3 } })
+
+// Five hits at absolute lines 100, 102, 104, 105, 106.
+const BEFORE = [hit(0), hit(2), hit(4), hit(5), hit(6)]
+const WINDOW_BEFORE = { epoch: 1, startLine: 100 }
+// The bounded ring trimmed lines 100 and 101: the first hit is gone and every
+// survivor moved two rows up AND one slot down the array.
+const AFTER = [hit(0), hit(2), hit(3), hit(4)]
+const WINDOW_AFTER = { epoch: 1, startLine: 102 }
+
+describe("resolveParkedIndex", () => {
+  it("keeps naming the SAME occurrence after a scrollback trim", () => {
+    const parked = parkHit(BEFORE, 2, WINDOW_BEFORE) as ParkedHit
+    expect(parked).toEqual({ kind: "line", epoch: 1, line: 104, col: 0 })
+    // The array position moved from 2 to 1; the occurrence did not.
+    const at = resolveParkedIndex(parked, AFTER, WINDOW_AFTER)
+    expect(at).toBe(1)
+    expect(WINDOW_AFTER.startLine + (AFTER[at]?.anchor.row ?? -1)).toBe(104)
+    // Position-parking is what used to happen, and it names a different hit.
+    expect(WINDOW_AFTER.startLine + (AFTER[2]?.anchor.row ?? -1)).toBe(105)
+  })
+
+  it("falls forward to the next surviving hit when the parked line was trimmed away", () => {
+    const parked = parkHit(BEFORE, 0, WINDOW_BEFORE) as ParkedHit // line 100, trimmed
+    const at = resolveParkedIndex(parked, AFTER, WINDOW_AFTER)
+    expect(at).toBe(0)
+    expect(WINDOW_AFTER.startLine + (AFTER[at]?.anchor.row ?? -1)).toBe(102)
+  })
+
+  it("clamps to the last hit when everything at or after the parked line is gone", () => {
+    const parked = { kind: "line", epoch: 1, line: 999, col: 0 } as const
+    expect(resolveParkedIndex(parked, BEFORE, WINDOW_BEFORE)).toBe(BEFORE.length - 1)
+  })
+
+  it("drops the park when a reflow resets line numbering, rather than mis-mapping it", () => {
+    const parked = parkHit(BEFORE, 2, WINDOW_BEFORE) as ParkedHit
+    expect(resolveParkedIndex(parked, AFTER, { epoch: 2, startLine: 0 })).toBe(-1)
+  })
+
+  it("two hits on the same line are told apart by column", () => {
+    const matches = [
+      { anchor: { row: 0, col: 0 }, head: { row: 0, col: 3 } },
+      { anchor: { row: 0, col: 10 }, head: { row: 0, col: 13 } },
+    ]
+    const parked = parkHit(matches, 1, WINDOW_BEFORE) as ParkedHit
+    expect(resolveParkedIndex(parked, matches, WINDOW_BEFORE)).toBe(1)
+  })
+
+  it("without a window there are no stable ids — the position is all there is", () => {
+    expect(parkHit(BEFORE, 3, null)).toEqual({ kind: "position", at: 3 })
+    expect(resolveParkedIndex({ kind: "position", at: 3 }, BEFORE, null)).toBe(3)
+    expect(resolveParkedIndex({ kind: "position", at: 3 }, BEFORE.slice(0, 2), null)).toBe(1)
+  })
+
+  it("no park and no matches resolve to nothing parked", () => {
+    expect(resolveParkedIndex(null, BEFORE, WINDOW_BEFORE)).toBe(-1)
+    expect(resolveParkedIndex(parkHit(BEFORE, 0, WINDOW_BEFORE), [], WINDOW_BEFORE)).toBe(-1)
+    expect(parkHit(BEFORE, 99, WINDOW_BEFORE)).toBeNull()
+  })
+})

--- a/packages/kobe/test/tui/terminal-wrap.test.ts
+++ b/packages/kobe/test/tui/terminal-wrap.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Soft-wrapped lines, in the two places a user touches text.
+ *
+ * The snapshot is a grid, so one logical line the emulator broke across
+ * columns arrives as several rows. Without xterm's `isWrapped` both consumers
+ * read that break as a real newline: a copied path comes back in pieces, and a
+ * needle lying across the boundary is reported as "no matches" for text that
+ * is on screen.
+ *
+ * Both functions take the flags as an OPTIONAL trailing argument; the calls
+ * without it here are the pre-change behavior, kept as the contrast.
+ */
+
+import { describe, expect, it } from "vitest"
+import { findMatches } from "../../src/tui/panes/terminal/terminal-search"
+import { extractSelection } from "../../src/tui/panes/terminal/terminal-selection"
+import type { Chunk } from "../../src/tui/panes/terminal/sgr"
+
+const row = (text: string): readonly Chunk[] => [{ text }]
+
+// One 40-column line: `ERROR in /Users/me/src/panes/terminal/search.ts:41:9`
+const WRAPPED = [row("ERROR in /Users/me/src/panes/terminal/se"), row("arch.ts:41:9")]
+const WRAP_FLAGS = [false, true]
+const WHOLE = { anchor: { row: 0, col: 0 }, head: { row: 1, col: 11 } }
+
+describe("copying a soft-wrapped line", () => {
+  it("joins the continuation row with no separator — the path pastes as one", () => {
+    expect(extractSelection(WRAPPED, WHOLE, WRAP_FLAGS)).toBe(
+      "ERROR in /Users/me/src/panes/terminal/search.ts:41:9",
+    )
+    expect(extractSelection(WRAPPED, WHOLE, WRAP_FLAGS)).not.toContain("\n")
+  })
+
+  it("without the flags it still splits — that is the shape being fixed", () => {
+    expect(extractSelection(WRAPPED, WHOLE)).toContain("\n")
+  })
+
+  it("a REAL newline between two rows still separates them", () => {
+    const rows = [row("first"), row("second"), row("third")]
+    const range = { anchor: { row: 0, col: 0 }, head: { row: 2, col: 4 } }
+    expect(extractSelection(rows, range, [false, false, false])).toBe("first\nsecond\nthird")
+  })
+
+  it("trailing padding is trimmed per LOGICAL line, so a wrap point keeps its spaces", () => {
+    // "a b" wrapped mid-way: the break falls between "a " and "b", and the
+    // space the user selected is inside the line, not padding at its end.
+    const rows = [row("hello world "), row("again    ")]
+    const range = { anchor: { row: 0, col: 0 }, head: { row: 1, col: 8 } }
+    expect(extractSelection(rows, range, [false, true])).toBe("hello world again")
+  })
+
+  it("a selection that STARTS on a continuation row opens its own line", () => {
+    const range = { anchor: { row: 1, col: 0 }, head: { row: 1, col: 11 } }
+    expect(extractSelection(WRAPPED, range, WRAP_FLAGS)).toBe("arch.ts:41:9")
+  })
+})
+
+describe("searching across a soft wrap", () => {
+  it("finds a needle that straddles the wrap point and spans both rows", () => {
+    const hits = findMatches(WRAPPED, "terminal/search.ts", WRAP_FLAGS)
+    expect(hits).toHaveLength(1)
+    expect(hits[0]?.anchor).toEqual({ row: 0, col: 29 })
+    expect(hits[0]?.head.row).toBe(1)
+    expect(hits[0]?.head.col).toBe(6)
+  })
+
+  it("without the flags the same needle is unfindable — the confident negative", () => {
+    expect(findMatches(WRAPPED, "terminal/search.ts")).toHaveLength(0)
+  })
+
+  it("a needle inside one row is unchanged by the grouping", () => {
+    expect(findMatches(WRAPPED, "ERROR in", WRAP_FLAGS)).toEqual([
+      { anchor: { row: 0, col: 0 }, head: { row: 0, col: 7 } },
+    ])
+  })
+
+  it("does not join rows the emulator did not wrap", () => {
+    const rows = [row("abc"), row("def")]
+    expect(findMatches(rows, "cd", [false, false])).toHaveLength(0)
+    expect(findMatches(rows, "cd", [false, true])).toHaveLength(1)
+  })
+
+  it("wide glyphs still measure in cells across the join", () => {
+    const rows = [row("找不"), row("到了")]
+    const hits = findMatches(rows, "不到", [false, true])
+    expect(hits).toEqual([{ anchor: { row: 0, col: 2 }, head: { row: 1, col: 1 } }])
+  })
+})

--- a/packages/kobe/test/tui/terminal-wrap.test.ts
+++ b/packages/kobe/test/tui/terminal-wrap.test.ts
@@ -12,9 +12,9 @@
  */
 
 import { describe, expect, it } from "vitest"
+import type { Chunk } from "../../src/tui/panes/terminal/sgr"
 import { findMatches } from "../../src/tui/panes/terminal/terminal-search"
 import { extractSelection } from "../../src/tui/panes/terminal/terminal-selection"
-import type { Chunk } from "../../src/tui/panes/terminal/sgr"
 
 const row = (text: string): readonly Chunk[] => [{ text }]
 
@@ -25,9 +25,7 @@ const WHOLE = { anchor: { row: 0, col: 0 }, head: { row: 1, col: 11 } }
 
 describe("copying a soft-wrapped line", () => {
   it("joins the continuation row with no separator — the path pastes as one", () => {
-    expect(extractSelection(WRAPPED, WHOLE, WRAP_FLAGS)).toBe(
-      "ERROR in /Users/me/src/panes/terminal/search.ts:41:9",
-    )
+    expect(extractSelection(WRAPPED, WHOLE, WRAP_FLAGS)).toBe("ERROR in /Users/me/src/panes/terminal/search.ts:41:9")
     expect(extractSelection(WRAPPED, WHOLE, WRAP_FLAGS)).not.toContain("\n")
   })
 


### PR DESCRIPTION
Batches **A**, **B**, **C** and **E** from `.scratch/loop-r21-text/text.md`. **Batch D is not implemented** — it is marked NEEDS OWNER SIGN-OFF and the choice between copy-on-mouse-up, a new chord, and `selectable={false}` on panes where selection is meaningless is a placement call. Its stated prerequisite is now in place: `copyTextToSystemClipboard` returns whether anything was copied, so whichever way D goes it will not ship a second surface claiming a copy it never verified.

Screenshots and command output: `/tmp/loop-r21-bm-quoll/`. Private harness port base **7623**, fixture home `.scratch/opentui-visual-7623/`; the fixture daemon **and** its PTY host were stopped and verified gone (no process holds a path under `opentui-visual-7623`).

---

## Batch A — soft wrap, one root cause, two defects

`pty-xterm-snapshot.ts` built one `TerminalRow` per xterm **grid** row and never read `line.isWrapped`. The flags now ride the snapshot (`DataListener`'s 4th argument + `captureWrapped()`, both optional so backends without an emulator are untouched), and `terminal-wrap.ts` holds the single definition of "this row continues the one above" that both consumers read.

**PASS (A1):** a wrapped line pastes as ONE line, and `copied.includes(<the path>)` is true.
**PASS (A2):** a needle straddling the wrap reads `1/1` and paints across both rows; the one-row control stays `1/1`.

### Proof — the terminal buffer, through the real `XtermSnapshotEngine`

`/tmp/loop-r21-bm-quoll/A-buffer-proof.txt` (`bun .scratch/repro-wrap-fixed.ts` from `packages/kobe`). BEFORE = calling the consumers without the flags, which is byte-for-byte the old path since both parameters are optional.

```
row 0 wrapped=false :: "ERROR in /Users/jacksonc/i/kobe/packages"
row 1 wrapped=true  :: "/kobe/src/tui/panes/terminal/terminal-se"
row 2 wrapped=true  :: "arch.ts:41:9"

A2  needle "ckages/kobe/" (present on screen: true)
    BEFORE findMatches(rows, needle)          -> 0 match(es)
    AFTER  findMatches(rows, needle, wrapped) -> 1 match(es), spans rows 0..1
    control (needle inside one row)           -> 1 match(es)

A1  BEFORE copied: "ERROR in /Users/jacksonc/i/kobe/packages\n/kobe/src/tui/panes/terminal/terminal-se\narch.ts:41:9"
    AFTER  copied: "ERROR in /Users/jacksonc/i/kobe/packages/kobe/src/tui/panes/terminal/terminal-search.ts:41:9"
    BEFORE newline the user did not select: true    pasteable path survives: false
    AFTER  newline the user did not select: false   pasteable path survives: true
```

### Proof — `/harness` → xterm.js → PTY sidecar → real OpenTUI

| | BEFORE | AFTER |
|---|---|---|
| straddling needle `ROVEWRAP` | `A2-before-straddle.png` — `/ROVEWRAP  no matches`, with `…XXXROVE` ending one row and `WRAPZZZ…` starting the next | `A2-after-straddle.png` — `/ROVEWRAP  1/1`, hit painted in accent across BOTH rows |
| control needle `WRAPZ` (fits one row) | `A2-before-control.png` — `1/1` | `A2-after-control.png` — `1/1`, unchanged |
| drag highlight over the wrapped line | `A1-before-highlight.png` | `A1-after-highlight.png` — identical two-row highlight |

The highlight pair is the "**do not change the highlight**" check: you selected two visual rows and still see two highlighted rows; only the extraction joins. The drag driver (`packages/kobe-harness/.scratch/drag-highlight-shot.ts`, gitignored) deliberately screenshots mid-drag and **never releases** — the release is what fires copy-on-select, which on this machine pipes into the operator's real `pbcopy`.

### Regression tests (mutation-verified)

`test/tui/terminal-wrap.test.ts` (10 tests). Mutation 1 — `isWrapContinuation` → always false: 5 red. Mutation 2, different site — `rowAtOffset` always answers the first row: 2 red. Both restored, all green.

`overlayMatches` now compares a match's whole span against the viewport instead of its anchor alone: a hit across a wrap starts one row above the visible window and still has a tail inside it.

---

## Batch B — the answer is no longer discarded

`copyTextToSystemClipboard` returns `Promise<boolean>`: the local pipe's exit status is read, and the OSC 52 writer is typed `(text) => boolean | undefined` so opentui's return value can survive the signature. `copyTaskFieldFlow` awaits it and toasts the failure instead of `Copied branch X`. `copySelection` stays silent on success (a toast per drag would be noise) and speaks on failure.

**PASS:** a copy where both channels refuse says so.

### Proof — a genuinely failing channel, measured

`/tmp/loop-r21-bm-quoll/B-clipboard-proof.txt`. Nothing here writes to the operator's clipboard — `cat > file` stands in for `pbcopy` on the identical spawn path:

```
resolveClipboardCopyCommand:
  darwin (all binaries present)              -> ["pbcopy"]
  darwin (no binaries present)               -> null
  linux  (headless: no wl-copy/xclip/xsel)   -> null
  win32                                      -> ["clip"]      (was null)

sh -c <missing binary> exit code: 127        (Bun.spawn does NOT throw)
pipeToClipboardCommand(text, ["sh","-c","rove-no-such-clipboard-binary"]) -> false
pipeToClipboardCommand(text, ["sh","-c","exit 3"])  (xclip w/o $DISPLAY)  -> false
pipeToClipboardCommand(text, null)                  (headless Linux)      -> false
pipeToClipboardCommand(text, ["sh","-c","cat > f"]) (a channel that works)-> true, file holds "feat/some-branch"
```

`test/tui/clipboard-copy.test.ts` pins all four against real processes.

### Proof — the toast, through the harness

Both shots were taken with the SAME two forced-failure lines applied — `darwin` resolving to `rove-no-such-clipboard-binary`, and the OSC 52 writer returning `false` (what `copyToClipboardOSC52` returns on Terminal.app). That reproduces the described environment on a mac; the only difference between the two builds is the fix. Neither line is in this PR (`grep -rn TEMP-EXPERIMENT packages/kobe/src` → nothing).

| BEFORE | AFTER |
|---|---|
| `B-before-copy-lie.png` — green **✓ Copied branch visual-fixture** over a clipboard neither channel reached | `B-after-copy-failed.png` — red **✕ Couldn't reach a clipboard — no clipboard command on PATH, and this terminal refused OSC 52.** |

Worth recording: `B-probe-osc52.png` is the same build with ONLY the local pipe forced to fail, and it correctly still says **Copied** — xterm.js accepts OSC 52, so one channel really did take the text. The fixed code is not just pessimistic.

### B2 — Windows

`resolveClipboardCopyCommand` now returns argv rather than a shell string, because there is no `sh` on Windows to hand a command line to; the spawn goes direct. `win32` resolves `clip`, falling back to `powershell -NoProfile -Command Set-Clipboard`. The `where` probe already written for Windows is now reachable. `darwin` is probed like every other platform — a mac without `pbcopy` now reports "no clipboard" rather than spawning a command that fails where nobody reads the status.

### B3 — whitespace-only selection

Kept as a deliberate skip, now stated in the code: a stray click is a zero-width selection, and clobbering the clipboard with a run of spaces on every pointer twitch is worse than doing nothing. Nothing is reported because nothing was attempted.

---

## Batch C — the parked hit is addressed by line id

`index` was an array position kept across recomputes. `ParkedHit` now records the absolute line id (+ column) the viewport is anchored by, and `index` is re-derived from the recomputed list each frame. A trimmed line falls forward to the next surviving hit; an epoch change (a resize reflows history) **drops** the park rather than mis-mapping it — the same discipline `followWindowShift` applies to a selection. Backends with no stable line ids keep the positional form, explicitly named as such.

**PASS:** after a trim the reported index still names the same occurrence.

**Proof — mutation-verified unit test**, `test/tui/terminal-search-park.test.ts` (7 tests). Mutation: `resolveParkedIndex` returns the array position (the pre-change behaviour) → 4 red, including "keeps naming the SAME occurrence after a scrollback trim". Second mutation at a different site (identity match removed + epoch guard dropped) → 2 red.

**Could NOT prove with screenshots.** The drift needs a saturated scrollback plus output arriving while the query row is open, and its symptom is "the counter says 3/5 while the accent sits on a different occurrence" — which a still frame cannot distinguish from a correct 3/5. I did not stage it in the harness and am not claiming a screenshot pair for C.

---

## Batch E — one stale comment

`use-terminal-search.ts` documented `shift+enter` walking back through history. The bindings are `terminal.search.older: ["up", "return"]` / `terminal.search.newer: ["down"]`, and `keybindings-table.ts:395` explains why the chord cannot exist (without the kitty protocol a terminal sends the same CR for both). Comment corrected; keys untouched. No chord added or moved anywhere in this PR.

---

## One thing I got wrong

The first run of my Batch B evidence script called `copyTextToSystemClipboard` directly, which resolves the REAL platform command — so it ran `pbcopy` once and left the string `x` on this machine's clipboard. That crossed the "do not write to the operator's clipboard" line. The script no longer calls it (the composition is covered by tests instead), and every other clipboard claim here is measured against `cat > file` or the resolver's return value.

## Gates

`bun run lint` · `bun run typecheck` · `bun run test:fast` (461 files / 4551 tests) · `bun test test/render` (479) · `KOBE_INCLUDE_SOCKET=1 bun run test:socket` (100 files / 834) — all green, rebased on `origin/main` @ `cf7fb5b75`.
