### PR TITLE
fix: bound daemon buffering and fairly schedule worktree status

### DIFF
--- a/.changeset/bounded-daemon-streams.md
+++ b/.changeset/bounded-daemon-streams.md
@@ -1,0 +1,4 @@
+---
+"@sma1lboy/rove": patch
+---
+Bound slow daemon clients and incoming daemon/PTY requests to prevent unbounded buffering. Keep the latest complete snapshot for each channel under backpressure while preserving RPC, lifecycle, command and terminal byte ordering until disconnection.

--- a/.changeset/index-filetree-children.md
+++ b/.changeset/index-filetree-children.md
@@ -1,0 +1,4 @@
+---
+"@sma1lboy/rove": patch
+---
+Build wide file trees with indexed child lookup so large directories no longer cause quadratic insertion work.

--- a/.changeset/schedule-worktree-status.md
+++ b/.changeset/schedule-worktree-status.md
@@ -1,0 +1,4 @@
+---
+"@sma1lboy/rove": patch
+---
+Limit worktree status collection to four concurrent runs, queue due work fairly, and batch result publications. Stop cancels queued work and aborts running status reads.

--- a/docs/API.md
+++ b/docs/API.md
@@ -17,6 +17,38 @@ this page. The rest of the binary is documented in the
 To teach a coding agent this surface, install the bundled agent skill with
 `rove skill install` instead of pasting this page into a prompt.
 
+## Socket limits and recovery
+
+Daemon and standalone PTY Host requests use newline-delimited JSON. Each request
+may contain at most **8 MiB of UTF-8 wire bytes**, excluding its terminating newline.
+This includes JSON escaping and envelope fields. The receiver closes the connection
+as soon as an unfinished or complete frame exceeds the limit; it sends no parse-error
+response for that frame. Multiple smaller frames may share a chunk. Split UTF-8
+characters survive chunk boundaries.
+
+The limit uses the existing 8 MiB outbound queue budget as a per-connection resource
+envelope. It allows multi-megabyte prompts and PTY input; it is not an OS socket limit.
+Shorten oversized request fields. PTY writers can divide input into ordered `pty.write`
+requests. Receive framing scans each new chunk once and grows storage geometrically,
+so a long line sent in small chunks does not repeatedly scan its accumulated prefix.
+
+A slow reader also has an 8 MiB queue of unsent response/event bytes, in addition to
+the socket's already accepted write. Complete snapshots for `task.snapshot`,
+`active-task`, `update`, `attention.inbox`, `ui-prefs`, `worktree.changes`,
+`transcript.activity`, `usage.snapshot`, and `usage.context` replace only an older
+queued snapshot of the same channel. Other frames retain their order, including
+per-task engine/job updates, per-repo issues, commands, keybinding notifications,
+RPC responses, lifecycle events and PTY bytes. If the remaining queue exceeds the
+budget, the server disconnects that reader. It never silently discards the last
+snapshot of a different channel to make room.
+
+Rove's GUI and pane orchestrators reconnect and subscribe again to receive current
+snapshots. Outstanding RPCs reject on disconnect, including requests without a
+normal deadline. One-shot API callers see a failure; commands are not automatically
+retried because the server may already have applied them. Transient events have no
+replay log, so a disconnection does not promise recovery of every command or event.
+PTY client disconnection detaches the reader and leaves its hosted children running.
+
 ## The orchestration loop
 
 Running many agents well is graph engineering, not prompt engineering:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -144,6 +144,22 @@ from creating duplicate children.
 
 Never treat browser storage as authoritative for local product state.
 
+### Worktree status collection
+
+The daemon collects at most four worktree status runs concurrently. Due paths join
+an insertion-ordered queue; later ticks refresh queued demand without moving it to
+the back. A path that finishes and becomes due again joins behind waiting paths,
+so continuously active tasks cannot starve the rest of the fleet. Completion starts
+waiting work without waiting for the next two-second tick.
+
+Per-path timeouts, hard backoff, quiet fingerprints and active-engine cadence still
+apply. A timed-out run retains its global slot until its runner settles, preventing
+an uncooperative runner from allowing extra concurrent work. Subscriber absence
+pauses new starts. Pruning drops queued demand and ignores old in-flight results,
+including when a path is removed and re-added. Stop clears the queue, aborts running
+reads and prevents delayed publications. Results arriving within a 10 ms window
+share one full-map publication; unchanged counts still publish nothing.
+
 ## 7. Reference projects
 
 `refs/` is gitignored and read-only study material. Consult the relevant

--- a/packages/kobe-daemon/src/daemon/client-connection.ts
+++ b/packages/kobe-daemon/src/daemon/client-connection.ts
@@ -20,12 +20,11 @@ export type ClientState = DaemonClientConnection & {
   /**
    * Backpressure-aware writer for this socket (fix E). Every server→client
    * frame goes through it so a slow/stalled client buffers in a bounded
-   * per-client queue (oldest droppable frames shed past the high-water mark)
+   * per-client queue (full snapshots replaced only by newer snapshots)
    * instead of letting Node queue unbounded heap on the long-lived daemon.
    * Lifecycle/response frames are never dropped. See {@link ClientWriter}.
    */
   writer: ClientWriter
-  buffer: string
   /** True once the client has called `subscribe` (broadcast target). */
   subscribed: boolean
   /**
@@ -49,21 +48,28 @@ export type ClientState = DaemonClientConnection & {
   channels: ReadonlySet<ChannelName> | null
 }
 
-/**
- * Critical frames are never dropped under backpressure (fix E): the
- * `daemon.stopping` lifecycle signal (every client must learn the daemon is
- * going down) and every RPC `response` (dropping one would hang the client's
- * pending request). Channel `event` frames are droppable — the bus
- * last-value-coalesces them, so a dropped intermediate is superseded by the
- * next publish.
- */
-function isCriticalFrame(frame: DaemonFrame): boolean {
-  if (frame.type === "event") return frame.name === "daemon.stopping"
-  return true
+/** Only full-channel snapshots are replaceable. Per-task/repo updates and
+ * commands retain every frame: replay alone cannot reconstruct their history. */
+function replacementKey(frame: DaemonFrame): string | null {
+  if (frame.type !== "event") return null
+  switch (frame.name) {
+    case "task.snapshot":
+    case "active-task":
+    case "update":
+    case "attention.inbox":
+    case "ui-prefs":
+    case "worktree.changes":
+    case "transcript.activity":
+    case "usage.snapshot":
+    case "usage.context":
+      return frame.name
+    default:
+      return null
+  }
 }
 
 export function writeFrame(client: Pick<ClientState, "writer">, frame: DaemonFrame): void {
-  client.writer.write(frameToLine(frame), isCriticalFrame(frame))
+  client.writer.write(frameToLine(frame), replacementKey(frame))
 }
 
 export function broadcast(clients: ReadonlySet<ClientState>, frame: DaemonFrame): void {
@@ -81,45 +87,38 @@ export function broadcast(clients: ReadonlySet<ClientState>, frame: DaemonFrame)
   // Backpressure (fix E): each client's writer obeys its own socket's drain
   // signal and buffers in a bounded per-client queue, so one slow client can
   // neither stall the fan-out for healthy clients nor grow the daemon heap
-  // unbounded. Critical-ness is identical for all clients, so compute it once.
-  const critical = isCriticalFrame(frame)
+  // unbounded. Replacement policy is identical for all clients, so compute it once.
+  const replaceKey = replacementKey(frame)
   let line: string | null = null
   for (const client of clients) {
     if (!client.subscribed && frame.type === "event") continue
     if (channel && client.channels && !client.channels.has(channel)) continue
     line ??= frameToLine(frame)
-    client.writer.write(line, critical)
+    client.writer.write(line, replaceKey)
   }
 }
 
 /**
- * Split the client's accumulated buffer on newlines and hand each complete
- * request frame to `onRequest`. A malformed line (bad JSON / non-request
+ * Parse one complete request line from LineReceiver and hand it to `onRequest`. A malformed line (bad JSON / non-request
  * frame) answers with a bare `{ message }` parse-error response — it never
  * carried an Error `name` on the wire, and keeping that here preserves the
  * exact bytes.
  */
-export function drainClientBuffer(
+export function handleClientLine(
   client: ClientState,
+  line: string,
   onRequest: (req: Extract<DaemonFrame, { type: "request" }>, client: ClientState) => void,
 ): void {
-  let nl = client.buffer.indexOf("\n")
-  while (nl !== -1) {
-    const line = client.buffer.slice(0, nl)
-    client.buffer = client.buffer.slice(nl + 1)
-    if (line.trim().length > 0) {
-      try {
-        const frame = JSON.parse(line) as DaemonFrame
-        if (frame.type !== "request") throw new Error("daemon only accepts request frames from clients")
-        onRequest(frame, client)
-      } catch (err) {
-        writeFrame(client, {
-          type: "response",
-          id: "parse-error",
-          error: { message: err instanceof Error ? err.message : String(err) },
-        })
-      }
-    }
-    nl = client.buffer.indexOf("\n")
+  if (line.trim().length === 0) return
+  try {
+    const frame = JSON.parse(line) as DaemonFrame
+    if (frame.type !== "request") throw new Error("daemon only accepts request frames from clients")
+    onRequest(frame, client)
+  } catch (err) {
+    writeFrame(client, {
+      type: "response",
+      id: "parse-error",
+      error: { message: err instanceof Error ? err.message : String(err) },
+    })
   }
 }

--- a/packages/kobe-daemon/src/daemon/client-writer.ts
+++ b/packages/kobe-daemon/src/daemon/client-writer.ts
@@ -1,193 +1,113 @@
-/**
- * Per-client outbound write with backpressure (fix E — daemon socket write
- * backpressure).
- *
- * The daemon is a single long-lived writer that fans channel frames out to
- * every subscribed socket. `net.Socket.write()` returns `false` when the OS
- * send buffer is full (a slow/stalled client), but the data is STILL accepted
- * and buffered in the daemon's heap. Ignoring that return value — and writing
- * the next frame anyway — lets Node queue megabytes per slow client under a
- * fast event stream (many tasks / rapid `engine-state` publishes), so the
- * daemon can grow to GBs and risk OOM.
- *
- * This wrapper makes the daemon obey backpressure PER CLIENT, in isolation:
- *
- *   - **Stop on `false`, resume on `'drain'`.** Once `write()` returns false
- *     we stop handing the socket more bytes and buffer subsequent frames in a
- *     small in-process queue. We resume — flushing the queue in order — only
- *     when the socket emits `'drain'`. One slow client never blocks or slows a
- *     healthy one: each client owns its own writer + queue.
- *
- *   - **Bounded queue, oldest-droppable-first.** If a client never drains, the
- *     queue itself would grow unbounded. So the queue has a byte high-water
- *     mark; when exceeded we drop the OLDEST *droppable* (non-critical) frames
- *     first. Channel frames are droppable because they are last-value-coalesced
- *     by design (a dropped `task.snapshot`/`engine-state` is superseded by the
- *     next one the bus pushes) — the client just skips an intermediate state.
- *
- *   - **Critical frames are never dropped, never reordered.** `daemon.stopping`
- *     (lifecycle) and RPC `response` frames are marked critical: they are kept
- *     in the queue regardless of the high-water mark and surviving frames keep
- *     their relative order, so a single client's stream is never reordered.
- *
- *   - **Best-effort + crash-proof.** A `write()` that throws (socket already
- *     destroyed) is swallowed; the `'close'` handler in server.ts removes the
- *     client. One socket's failure never crashes the daemon or touches others.
- */
-
-/**
- * Minimal socket surface {@link ClientWriter} needs. `net.Socket` satisfies it;
- * tests inject a fake whose `write` returns false then emits `'drain'`.
- */
+/** Per-connection FIFO with bounded backpressure and explicit snapshot replacement. */
 export interface BackpressureSocket {
+  destroy(): void
   write(data: string): boolean
   once(event: "drain", listener: () => void): void
 }
 
 export interface ClientWriterOptions {
-  /**
-   * Max bytes allowed to sit in the per-client queue before the writer starts
-   * dropping the oldest droppable (non-critical) frames. Defaults to
-   * {@link DEFAULT_WRITE_HIGH_WATER_MARK}.
-   */
   readonly highWaterMark?: number
-  /**
-   * Called when critical frames alone exceed the queue cap. The caller must
-   * tear down the connection: ordered streams such as PTY bytes cannot be
-   * dropped or reordered to make room.
-   */
+  /** Observe overflow and disconnect. Defaults to socket.destroy(). */
   readonly onOverflow?: () => void
 }
 
-/** 8 MiB of queued-but-unsent frames per client before we shed droppable load. */
 export const DEFAULT_WRITE_HIGH_WATER_MARK = 8 * 1024 * 1024
 
 interface QueuedFrame {
   readonly line: string
   readonly bytes: number
-  /** Lifecycle/response frames — kept even when the queue overflows. */
-  readonly critical: boolean
+  readonly replaceKey: string | null
 }
 
 export class ClientWriter {
-  private readonly socket: BackpressureSocket
   private readonly highWaterMark: number
-  private readonly onOverflow: (() => void) | undefined
-  private queue: QueuedFrame[] = []
+  private readonly onOverflow: () => void
+  private readonly queue = new Map<number, QueuedFrame>()
+  private readonly snapshots = new Map<string, number>()
+  private sequence = 0
   private queuedBytes = 0
-  /** True while we are waiting for `'drain'` — every write is queued, not sent. */
   private paused = false
-  /** True while a one-shot `'drain'` listener is registered (avoids doubling up). */
-  private draining = false
   private droppedFrames = 0
-  /** The connection is being torn down after critical-only overflow. */
   private overflowed = false
 
-  constructor(socket: BackpressureSocket, options: ClientWriterOptions = {}) {
-    this.socket = socket
+  constructor(
+    private readonly socket: BackpressureSocket,
+    options: ClientWriterOptions = {},
+  ) {
     this.highWaterMark = options.highWaterMark ?? DEFAULT_WRITE_HIGH_WATER_MARK
-    this.onOverflow = options.onOverflow
+    this.onOverflow = options.onOverflow ?? (() => socket.destroy())
   }
 
-  /** True while the socket is saturated and frames are queued, not sent. */
   get isPaused(): boolean {
     return this.paused
   }
-
-  /** Bytes currently buffered in the per-client queue (0 when flowing). */
   get pendingBytes(): number {
     return this.queuedBytes
   }
-
-  /** Frames currently buffered in the per-client queue. */
   get pendingCount(): number {
-    return this.queue.length
+    return this.queue.size
   }
-
-  /** Total droppable frames shed to stay under the high-water mark. */
+  /** Superseded snapshots, never arbitrary events. */
   get dropped(): number {
     return this.droppedFrames
   }
 
-  /**
-   * Hand a serialized frame line to this client. `critical` frames (lifecycle
-   * `daemon.stopping` + RPC responses) are never dropped; non-critical channel
-   * frames may be dropped oldest-first once the queue exceeds the high-water
-   * mark. Order among surviving frames is always preserved.
-   */
-  write(line: string, critical: boolean): void {
+  /** Only complete, independently replaceable state gets a key. All other
+   * frames use null and retain their order, including RPC and PTY bytes. */
+  write(line: string, replaceKey: string | null = null): void {
     if (this.overflowed) return
     if (!this.paused) {
-      // Flowing: hand the line straight to the socket. A `false` return means
-      // Node's buffer is now full — the line WAS accepted (so we don't requeue
-      // it), but we must stop writing more until `'drain'`.
-      if (this.safeWrite(line)) return
-      this.pause()
+      if (!this.safeWrite(line)) this.pause()
       return
     }
-    // Saturated: buffer the frame and shed droppable load if we're over budget.
-    this.enqueue({ line, bytes: Buffer.byteLength(line), critical })
-  }
-
-  private enqueue(frame: QueuedFrame): void {
-    this.queue.push(frame)
+    if (replaceKey !== null) {
+      const previous = this.snapshots.get(replaceKey)
+      if (previous !== undefined) {
+        this.dequeue(previous)
+        this.droppedFrames++
+      }
+    }
+    const id = this.sequence++
+    const frame = { line, bytes: Buffer.byteLength(line), replaceKey }
+    this.queue.set(id, frame)
+    if (replaceKey !== null) this.snapshots.set(replaceKey, id)
     this.queuedBytes += frame.bytes
     if (this.queuedBytes <= this.highWaterMark) return
-    // Over budget → drop the oldest droppable frames (front→back) until back
-    // under the mark or only criticals remain. Criticals are skipped, not
-    // dropped, and survivors keep their relative order (no reordering).
-    const survivors: QueuedFrame[] = []
-    for (const queued of this.queue) {
-      if (this.queuedBytes > this.highWaterMark && !queued.critical) {
-        this.queuedBytes -= queued.bytes
-        this.droppedFrames++
-        continue
-      }
-      survivors.push(queued)
-    }
-    this.queue = survivors
-    if (this.queuedBytes <= this.highWaterMark || !this.onOverflow) return
-    // No droppable frames remain. Keeping critical bytes is correct only
-    // while the connection can recover; otherwise this queue is unbounded.
+    // A latest snapshot cannot be discarded: there may never be another publish.
     this.overflowed = true
-    this.queue = []
+    this.queue.clear()
+    this.snapshots.clear()
     this.queuedBytes = 0
     this.onOverflow()
   }
 
-  private pause(): void {
-    if (this.draining) return
-    this.paused = true
-    this.draining = true
-    this.socket.once("drain", () => {
-      this.draining = false
-      this.paused = false
-      this.flush()
-    })
+  private dequeue(id: number): void {
+    const frame = this.queue.get(id)
+    if (!frame) return
+    this.queue.delete(id)
+    this.queuedBytes -= frame.bytes
+    if (frame.replaceKey !== null) this.snapshots.delete(frame.replaceKey)
   }
 
-  private flush(): void {
-    while (this.queue.length > 0) {
-      const frame = this.queue[0]
-      const ok = this.safeWrite(frame.line)
-      // The line was handed to the socket either way → dequeue it.
-      this.queue.shift()
-      this.queuedBytes -= frame.bytes
-      if (!ok) {
-        // Saturated again → re-arm the drain wait; the rest stays queued.
-        this.pause()
-        return
+  private pause(): void {
+    this.paused = true
+    this.socket.once("drain", () => {
+      this.paused = false
+      if (this.overflowed) return
+      for (const [id, frame] of this.queue) {
+        this.dequeue(id)
+        if (!this.safeWrite(frame.line)) {
+          this.pause()
+          return
+        }
       }
-    }
+    })
   }
 
   private safeWrite(line: string): boolean {
     try {
       return this.socket.write(line)
     } catch {
-      // Socket already destroyed. Report "accepted" so we neither re-queue nor
-      // register a `'drain'` listener that will never fire; the server's
-      // `'close'` handler drops the client.
       return true
     }
   }

--- a/packages/kobe-daemon/src/daemon/line-receiver.ts
+++ b/packages/kobe-daemon/src/daemon/line-receiver.ts
@@ -1,0 +1,48 @@
+/** Request limit excludes the newline and counts wire bytes, not UTF-16 characters.
+ * Matches the outbound queue budget; permits multi-megabyte prompts and PTY input.
+ * Larger requests must be split by the caller before sending. */
+export const MAX_REQUEST_FRAME_BYTES = 8 * 1024 * 1024
+
+/** Each incoming byte is scanned once. Geometric storage growth amortizes copies;
+ * decoding only complete lines preserves UTF-8 codepoints split across chunks. */
+export class LineReceiver {
+  private storage = Buffer.alloc(0)
+  private length = 0
+  private failed = false
+
+  constructor(private readonly maxBytes = MAX_REQUEST_FRAME_BYTES) {}
+
+  get pendingBytes(): number {
+    return this.length
+  }
+
+  push(chunk: Buffer, onLine: (line: string) => void): boolean {
+    if (this.failed) return false
+    let start = 0
+    while (start < chunk.length) {
+      const newline = chunk.indexOf(10, start)
+      const end = newline === -1 ? chunk.length : newline
+      const size = this.length + end - start
+      if (size > this.maxBytes) {
+        this.failed = true
+        this.storage = Buffer.alloc(0)
+        this.length = 0
+        return false
+      }
+      if (size > this.storage.length) {
+        const capacity = Math.min(this.maxBytes, Math.max(size, this.storage.length * 2, 1024))
+        const grown = Buffer.allocUnsafe(capacity)
+        this.storage.copy(grown, 0, 0, this.length)
+        this.storage = grown
+      }
+      chunk.copy(this.storage, this.length, start, end)
+      this.length = size
+      if (newline === -1) return true
+      const line = this.storage.toString("utf8", 0, this.length)
+      this.length = 0
+      onLine(line)
+      start = newline + 1
+    }
+    return true
+  }
+}

--- a/packages/kobe-daemon/src/daemon/pty-server.ts
+++ b/packages/kobe-daemon/src/daemon/pty-server.ts
@@ -26,11 +26,11 @@ import { readFileSync } from "node:fs"
 import { mkdir, unlink, writeFile } from "node:fs/promises"
 import { type Server, type Socket, createServer } from "node:net"
 import { dirname } from "node:path"
-import { StringDecoder } from "node:string_decoder"
 import { ClientWriter } from "./client-writer.ts"
 import { linkLegacyRuntimePath } from "./compat-link.ts"
 import { logDaemonError } from "./crash-log.ts"
 import { objectPayload, requireString } from "./handler-validators.ts"
+import { LineReceiver } from "./line-receiver.ts"
 import { ensureOwnerOnlyStateDir } from "./owner-only.ts"
 import {
   defaultPtyFreezeDir,
@@ -119,7 +119,6 @@ export interface PtyHostServer {
 interface PtyClientState {
   socket: Socket
   writer: ClientWriter
-  buffer: string
 }
 
 export async function startPtyHostServer(options: PtyHostServerOptions = {}): Promise<PtyHostServer> {
@@ -274,13 +273,14 @@ export async function startPtyHostServer(options: PtyHostServerOptions = {}): Pr
           socket.destroy()
         },
       }),
-      buffer: "",
     }
     clients.add(client)
-    const decoder = new StringDecoder("utf8")
-    socket.on("data", (chunk) => {
-      client.buffer += decoder.write(chunk)
-      drain(client)
+    const receiver = new LineReceiver()
+    socket.on("data", (chunk: Buffer) => {
+      if (!receiver.push(chunk, (line) => handleLine(client, line))) {
+        log("framing", "disconnecting PTY client whose request exceeded 8MiB")
+        socket.destroy()
+      }
     })
     socket.on("error", () => {})
     socket.on("close", () => {
@@ -415,36 +415,30 @@ export async function startPtyHostServer(options: PtyHostServerOptions = {}): Pr
     }
   }
 
-  function drain(client: PtyClientState): void {
-    let nl = client.buffer.indexOf("\n")
-    while (nl !== -1) {
-      const line = client.buffer.slice(0, nl)
-      client.buffer = client.buffer.slice(nl + 1)
-      if (line.trim().length > 0) {
-        let frame: DaemonFrame | null = null
-        try {
-          frame = JSON.parse(line) as DaemonFrame
-        } catch {
-          writeFrame(client, { type: "response", id: "parse-error", error: { message: "malformed frame" } })
-        }
-        if (frame) {
-          if (frame.type !== "request") {
-            writeFrame(client, { type: "response", id: "parse-error", error: { message: "requests only" } })
-          } else {
-            try {
-              writeFrame(client, { type: "response", id: frame.id, name: frame.name, payload: dispatch(frame, client) })
-            } catch (err) {
-              writeFrame(client, {
-                type: "response",
-                id: frame.id,
-                name: frame.name,
-                error: { message: err instanceof Error ? err.message : String(err) },
-              })
-            }
+  function handleLine(client: PtyClientState, line: string): void {
+    if (line.trim().length > 0) {
+      let frame: DaemonFrame | null = null
+      try {
+        frame = JSON.parse(line) as DaemonFrame
+      } catch {
+        writeFrame(client, { type: "response", id: "parse-error", error: { message: "malformed frame" } })
+      }
+      if (frame) {
+        if (frame.type !== "request") {
+          writeFrame(client, { type: "response", id: "parse-error", error: { message: "requests only" } })
+        } else {
+          try {
+            writeFrame(client, { type: "response", id: frame.id, name: frame.name, payload: dispatch(frame, client) })
+          } catch (err) {
+            writeFrame(client, {
+              type: "response",
+              id: frame.id,
+              name: frame.name,
+              error: { message: err instanceof Error ? err.message : String(err) },
+            })
           }
         }
       }
-      nl = client.buffer.indexOf("\n")
     }
   }
 
@@ -468,5 +462,5 @@ export async function startPtyHostServer(options: PtyHostServerOptions = {}): Pr
 function writeFrame(client: Pick<PtyClientState, "writer">, frame: DaemonFrame): void {
   // Everything on this socket is critical: RPC responses and ordered PTY
   // byte-stream frames — dropping either corrupts the client.
-  client.writer.write(frameToLine(frame), true)
+  client.writer.write(frameToLine(frame))
 }

--- a/packages/kobe-daemon/src/daemon/server.ts
+++ b/packages/kobe-daemon/src/daemon/server.ts
@@ -7,12 +7,11 @@
 import { mkdir, unlink, writeFile } from "node:fs/promises"
 import { type Server, createServer } from "node:net"
 import { dirname } from "node:path"
-import { StringDecoder } from "node:string_decoder"
 import { probeDaemonSocket } from "../client/daemon-process.ts"
 import { ptyHostHasLiveSessions, sweepPtyHostSessions } from "../client/pty-process.ts"
 import { tightenInstalledPluginPermissions } from "../plugins/permissions.ts"
 import { maybeStartPluginHost } from "../plugins/runtime.ts"
-import { type ClientState, broadcast, drainClientBuffer, writeFrame } from "./client-connection.ts"
+import { type ClientState, broadcast, handleClientLine, writeFrame } from "./client-connection.ts"
 import { ClientWriter } from "./client-writer.ts"
 import { startDaemonCollectors } from "./collectors.ts"
 import { linkLegacyRuntimePath } from "./compat-link.ts"
@@ -30,6 +29,7 @@ import {
 import { assertHomeUnclaimed, claimHome, releaseHomeClaim } from "./home-owner.ts"
 import { IssuesStore, defaultIssuesStorePath } from "./issues-store.ts"
 import { DaemonLifetime, FIRST_GUI_GRACE_MS, resolveIdleGraceMs } from "./lifetime.ts"
+import { LineReceiver } from "./line-receiver.ts"
 import { NotesStore, defaultNotesStorePath } from "./notes-store.ts"
 import { ensureOwnerOnlyStateDir } from "./owner-only.ts"
 import {
@@ -175,22 +175,24 @@ export async function startDaemonServer(orch: DaemonOrchestrator, options: Daemo
       id: nextClientId++,
       connectedAt: new Date(),
       socket,
-      writer: new ClientWriter(socket),
-      buffer: "",
+      writer: new ClientWriter(socket, {
+        onOverflow: () => {
+          logDaemonInfo("backpressure", "disconnecting daemon client whose queue exceeded 8MiB")
+          socket.destroy()
+        },
+      }),
       subscribed: false,
       holdsLifetime: false,
       channels: null,
     }
     clients.add(client)
 
-    // Per-connection decoder: holds a partial multibyte UTF-8 sequence (CJK,
-    // em-dash, emoji) across TCP chunk boundaries. Decoding each chunk with a
-    // bare `toString("utf8")` would emit U+FFFD for a codepoint split between
-    // two chunks, silently corrupting task titles / field notes / prompts.
-    const decoder = new StringDecoder("utf8")
-    socket.on("data", (chunk) => {
-      client.buffer += decoder.write(chunk)
-      drainClientBuffer(client, (req, c) => void handleRequest(req, c))
+    const receiver = new LineReceiver()
+    socket.on("data", (chunk: Buffer) => {
+      if (!receiver.push(chunk, (line) => handleClientLine(client, line, (req, c) => void handleRequest(req, c)))) {
+        logDaemonInfo("framing", "disconnecting daemon client whose request exceeded 8MiB")
+        socket.destroy()
+      }
     })
     socket.on("error", () => {})
     socket.on("close", () => {

--- a/packages/kobe-daemon/src/daemon/worktree-changes-collector.ts
+++ b/packages/kobe-daemon/src/daemon/worktree-changes-collector.ts
@@ -54,7 +54,6 @@
  * value, never throws, never publishes garbage.
  */
 
-import { spawn } from "node:child_process"
 import type { DaemonTask as Task, WorktreeChanges } from "./contracts.ts"
 import { logDaemonError } from "./crash-log.ts"
 import type { DaemonEventBus } from "./event-bus.ts"
@@ -62,6 +61,8 @@ import { type PollCadenceConfig, type PollScheduleState, maybeStartScheduledRun 
 import type { WorktreeChangesPayload } from "./protocol.ts"
 import type { DaemonRuntimeAdapter } from "./runtime.ts"
 import { startTicker } from "./ticker.ts"
+import { runGitStatus } from "./worktree-status-runner.ts"
+export { runGitStatus, parseAheadBehind, countPorcelain, type AheadBehind } from "./worktree-status-runner.ts"
 import { worktreeFingerprint } from "./worktree-probe.ts"
 
 /** Shared empty set — avoids allocating one per tick per collector. */
@@ -81,6 +82,8 @@ function sameWorktreeChanges(a: WorktreeChanges, b: WorktreeChanges): boolean {
 
 /** Tick cadence — matches the sidebar's ~2s `branchTick` the pane pollers rode. */
 export const DEFAULT_WORKTREE_CHANGES_TICK_MS = 2_000
+/** Bound filesystem and git pressure across the entire collector, not per path. */
+export const WORKTREE_CHANGES_CONCURRENCY = 4
 /** Kill a `git status` that runs longer than this; the repo is too big to poll. */
 export const WORKTREE_CHANGES_TIMEOUT_MS = 4_000
 /** After a timeout, leave the worktree alone for this long before retrying. */
@@ -125,102 +128,6 @@ export type WorktreeStatusRunner = (
   baseRef?: string,
 ) => Promise<WorktreeChanges>
 
-/** One lock-free `git` read in a worktree; null stdout on any non-zero exit. */
-function runGit(worktreePath: string, args: readonly string[], signal: AbortSignal): Promise<string | null> {
-  return new Promise((resolve) => {
-    let stdout = ""
-    let settled = false
-    const finish = (status: number | null) => {
-      if (settled) return
-      settled = true
-      resolve(status === 0 ? stdout : null)
-    }
-    const child = spawn("git", args.slice(), {
-      cwd: worktreePath,
-      stdio: ["ignore", "pipe", "ignore"],
-      env: { ...process.env, GIT_OPTIONAL_LOCKS: "0" },
-      signal,
-      killSignal: "SIGKILL",
-    })
-    child.stdout?.on("data", (chunk: Buffer | string) => {
-      stdout += String(chunk)
-    })
-    child.on("error", () => finish(null))
-    child.on("close", finish)
-  })
-}
-
-/**
- * How far the worktree has drifted from `baseRef`, both ways, in ONE process.
- * `null` when the ref does not resolve or the counts are unreadable — the
- * chips then do not draw, which is the honest answer for a repo with no base
- * rather than a fabricated zero.
- *
- * The daemon does NOT own the `origin/HEAD → origin/main → main → master`
- * fallback ladder: that lives in kobe's `cli/api/branch-signals.ts`, and the
- * PRODUCTION runner is kobe's `runtime.runWorktreeStatus`, which resolves it
- * before calling in. This default runner (tests, and any daemon wired without
- * a runtime) only measures against a base it was handed.
- */
-async function countDrift(worktreePath: string, baseRef: string, signal: AbortSignal): Promise<AheadBehind | null> {
-  return parseAheadBehind(
-    await runGit(worktreePath, ["rev-list", "--left-right", "--count", `${baseRef}...HEAD`], signal),
-  )
-}
-
-/** Both halves of one drift measurement. */
-export interface AheadBehind {
-  readonly behind: number
-  readonly ahead: number
-}
-
-/**
- * Parse `git rev-list --left-right --count <base>...HEAD`, whose one line is
- * `<behind>\t<ahead>` — left is the base side (commits the base has that we
- * do not), right is ours. `null` for anything that is not two non-negative
- * integers, including the `null` a failed run hands in: a half-read line must
- * leave BOTH numbers absent rather than let one of them be guessed.
- *
- * @public — imported by kobe's production runner (`core/daemon-runtime.ts`) so
- * the two collection paths cannot disagree about what the counts mean.
- */
-export function parseAheadBehind(stdout: string | null): AheadBehind | null {
-  if (stdout === null) return null
-  const parts = stdout.trim().split(/\s+/)
-  if (parts.length !== 2) return null
-  const behind = Number.parseInt(parts[0] ?? "", 10)
-  const ahead = Number.parseInt(parts[1] ?? "", 10)
-  if (!Number.isInteger(behind) || behind < 0 || !Number.isInteger(ahead) || ahead < 0) return null
-  return { behind, ahead }
-}
-
-/** Aggregate `git status --porcelain=v1` output into `+N −M`. */
-export function countPorcelain(stdout: string): { added: number; deleted: number } {
-  let added = 0
-  let deleted = 0
-  for (const line of stdout.split("\n")) {
-    if (line.length < 3 || line.startsWith("##")) continue
-    if (line[0] === "D" || line[1] === "D") deleted++
-    else added++
-  }
-  return { added, deleted }
-}
-
-/** The default runner: async `git status --porcelain=v1`, lock-free read,
- *  plus the ahead/behind drift when a base ref was supplied. */
-export async function runGitStatus(
-  worktreePath: string,
-  signal: AbortSignal,
-  baseRef?: string,
-): Promise<WorktreeChanges> {
-  const stdout = await runGit(worktreePath, ["status", "--porcelain=v1"], signal)
-  if (stdout === null) throw new Error("git status failed")
-  const counts = countPorcelain(stdout)
-  if (!baseRef) return counts
-  const drift = await countDrift(worktreePath, baseRef, signal)
-  return drift === null ? counts : { ...counts, ...drift }
-}
-
 /**
  * The worktree paths the collector tracks: tasks with a
  * non-empty LOCAL worktree. Remote (`ssh://`) projects are excluded by
@@ -262,6 +169,7 @@ interface CollectorEntry extends PollScheduleState {
 }
 
 export interface WorktreeChangesCollectorOptions {
+  readonly publishDelayMs?: number
   readonly cadence?: PollCadenceConfig
   /** Injectable status runner — tests avoid real git/worktrees. */
   readonly run?: WorktreeStatusRunner
@@ -295,14 +203,19 @@ export interface WorktreeChangesCollectorOptions {
  * prunes entries for worktrees the daemon stopped tracking (deleted/remote
  * tasks), starts guarded status runs for due worktrees, and
  * publishes the full map when — and only when — membership or a value
- * changed. Run completions publish as they land (each is a real change
- * by construction). Exposed as a class so tests drive `tick()` directly
+ * changed. Run completions batch publications over a short timer window. Exposed as a class so tests drive `tick()` directly
  * with a fake lister/bus/runner; `startWorktreeChangesCollector` is the
  * production interval binding.
  */
 export class WorktreeChangesCollector {
   private readonly entries = new Map<string, CollectorEntry>()
   private stopped = false
+  private readonly queued = new Map<string, { baseRef?: string; busy: boolean }>()
+  private active = 0
+  private readonly activePaths = new Set<string>()
+  private drainHandle: ReturnType<typeof setImmediate> | undefined
+  private publishTimer: ReturnType<typeof setTimeout> | undefined
+  private readonly controllers = new Set<AbortController>()
 
   constructor(
     private readonly orch: TaskLister,
@@ -331,18 +244,52 @@ export class WorktreeChangesCollector {
         // object — its completion checks membership before publishing.
         if (entry?.value) pruned = true
         this.entries.delete(path)
+        this.queued.delete(path)
       }
+      for (const path of this.queued.keys()) if (!tracked.has(path)) this.queued.delete(path)
       if (pruned) this.publish()
       const busy = this.busyPaths(tasks)
-      for (const [path, baseRef] of tracked) this.maybeCollect(path, baseRef, busy.has(path))
+      for (const [path, baseRef] of tracked) {
+        if (!this.entries.get(path)?.inFlight) this.queued.set(path, { baseRef, busy: busy.has(path) })
+      }
+      this.drain()
     } catch (err) {
       logDaemonError("worktree-changes", err)
     }
   }
 
-  /** Stop publishing; in-flight children die with their AbortSignal timers. */
+  /** Cancel queued work, abort running children and suppress late publications. */
   stop(): void {
     this.stopped = true
+    this.queued.clear()
+    if (this.drainHandle) clearImmediate(this.drainHandle)
+    if (this.publishTimer) clearTimeout(this.publishTimer)
+    for (const controller of this.controllers) controller.abort()
+  }
+
+  private drain(): void {
+    if (this.stopped || this.options.hasSubscribers?.() === false) return
+    const limit = WORKTREE_CHANGES_CONCURRENCY
+    for (const [path, demand] of this.queued) {
+      if (this.active >= limit) break
+      if (this.activePaths.has(path)) continue
+      this.queued.delete(path)
+      try {
+        this.maybeCollect(path, demand.baseRef, demand.busy)
+      } catch (err) {
+        logDaemonError("worktree-changes", err)
+      }
+    }
+  }
+
+  private runFinished(path: string): void {
+    this.active--
+    this.activePaths.delete(path)
+    if (this.stopped || this.drainHandle) return
+    this.drainHandle = setImmediate(() => {
+      this.drainHandle = undefined
+      this.drain()
+    })
   }
 
   /** Worktrees whose task has a working engine — exempt from quiet backoff. */
@@ -394,7 +341,23 @@ export class WorktreeChangesCollector {
         // clean row. A TIMEOUT still rejects the run (the signal aborts and the
         // callback is skipped either way), so a slow repo keeps its last value
         // and backs off exactly as before.
-        return run(worktreePath, signal, baseRef).catch((): typeof UNREADABLE => UNREADABLE)
+        this.active++
+        this.activePaths.add(worktreePath)
+        const controller = new AbortController()
+        this.controllers.add(controller)
+        const abort = () => controller.abort()
+        signal.addEventListener("abort", abort, { once: true })
+        return (async () => {
+          try {
+            return await run(worktreePath, controller.signal, baseRef)
+          } catch {
+            return UNREADABLE
+          } finally {
+            signal.removeEventListener("abort", abort)
+            this.controllers.delete(controller)
+            this.runFinished(worktreePath)
+          }
+        })()
       },
       (value) => {
         if (this.stopped) return
@@ -425,6 +388,14 @@ export class WorktreeChangesCollector {
   }
 
   private publish(): void {
+    if (this.publishTimer || this.stopped) return
+    this.publishTimer = setTimeout(() => {
+      this.publishTimer = undefined
+      if (!this.stopped) this.publishNow()
+    }, this.options.publishDelayMs ?? 10)
+  }
+
+  private publishNow(): void {
     const changes: WorktreeChangesPayload["changes"] = {}
     const unreadable: string[] = []
     for (const [path, entry] of this.entries) {

--- a/packages/kobe-daemon/src/daemon/worktree-status-runner.ts
+++ b/packages/kobe-daemon/src/daemon/worktree-status-runner.ts
@@ -1,0 +1,98 @@
+import { spawn } from "node:child_process"
+import type { WorktreeChanges } from "./contracts.ts"
+
+/** One lock-free `git` read in a worktree; null stdout on any non-zero exit. */
+function runGit(worktreePath: string, args: readonly string[], signal: AbortSignal): Promise<string | null> {
+  return new Promise((resolve) => {
+    let stdout = ""
+    let settled = false
+    const finish = (status: number | null) => {
+      if (settled) return
+      settled = true
+      resolve(status === 0 ? stdout : null)
+    }
+    const child = spawn("git", args.slice(), {
+      cwd: worktreePath,
+      stdio: ["ignore", "pipe", "ignore"],
+      env: { ...process.env, GIT_OPTIONAL_LOCKS: "0" },
+      signal,
+      killSignal: "SIGKILL",
+    })
+    child.stdout?.on("data", (chunk: Buffer | string) => {
+      stdout += String(chunk)
+    })
+    child.on("error", () => finish(null))
+    child.on("close", finish)
+  })
+}
+
+/**
+ * How far the worktree has drifted from `baseRef`, both ways, in ONE process.
+ * `null` when the ref does not resolve or the counts are unreadable — the
+ * chips then do not draw, which is the honest answer for a repo with no base
+ * rather than a fabricated zero.
+ *
+ * The daemon does NOT own the `origin/HEAD → origin/main → main → master`
+ * fallback ladder: that lives in kobe's `cli/api/branch-signals.ts`, and the
+ * PRODUCTION runner is kobe's `runtime.runWorktreeStatus`, which resolves it
+ * before calling in. This default runner (tests, and any daemon wired without
+ * a runtime) only measures against a base it was handed.
+ */
+async function countDrift(worktreePath: string, baseRef: string, signal: AbortSignal): Promise<AheadBehind | null> {
+  return parseAheadBehind(
+    await runGit(worktreePath, ["rev-list", "--left-right", "--count", `${baseRef}...HEAD`], signal),
+  )
+}
+
+/** Both halves of one drift measurement. */
+export interface AheadBehind {
+  readonly behind: number
+  readonly ahead: number
+}
+
+/**
+ * Parse `git rev-list --left-right --count <base>...HEAD`, whose one line is
+ * `<behind>\t<ahead>` — left is the base side (commits the base has that we
+ * do not), right is ours. `null` for anything that is not two non-negative
+ * integers, including the `null` a failed run hands in: a half-read line must
+ * leave BOTH numbers absent rather than let one of them be guessed.
+ *
+ * @public — imported by kobe's production runner (`core/daemon-runtime.ts`) so
+ * the two collection paths cannot disagree about what the counts mean.
+ */
+export function parseAheadBehind(stdout: string | null): AheadBehind | null {
+  if (stdout === null) return null
+  const parts = stdout.trim().split(/\s+/)
+  if (parts.length !== 2) return null
+  const behind = Number.parseInt(parts[0] ?? "", 10)
+  const ahead = Number.parseInt(parts[1] ?? "", 10)
+  if (!Number.isInteger(behind) || behind < 0 || !Number.isInteger(ahead) || ahead < 0) return null
+  return { behind, ahead }
+}
+
+/** Aggregate `git status --porcelain=v1` output into `+N −M`. */
+export function countPorcelain(stdout: string): { added: number; deleted: number } {
+  let added = 0
+  let deleted = 0
+  for (const line of stdout.split("\n")) {
+    if (line.length < 3 || line.startsWith("##")) continue
+    if (line[0] === "D" || line[1] === "D") deleted++
+    else added++
+  }
+  return { added, deleted }
+}
+
+/** The default runner: async `git status --porcelain=v1`, lock-free read,
+ *  plus the ahead/behind drift when a base ref was supplied. */
+export async function runGitStatus(
+  worktreePath: string,
+  signal: AbortSignal,
+  baseRef?: string,
+): Promise<WorktreeChanges> {
+  const stdout = await runGit(worktreePath, ["status", "--porcelain=v1"], signal)
+  if (stdout === null) throw new Error("git status failed")
+  const counts = countPorcelain(stdout)
+  if (!baseRef) return counts
+  const drift = await countDrift(worktreePath, baseRef, signal)
+  return drift === null ? counts : { ...counts, ...drift }
+}

--- a/packages/kobe/src/tui/panes/filetree/tree.ts
+++ b/packages/kobe/src/tui/panes/filetree/tree.ts
@@ -25,6 +25,7 @@ export type TreeNode = {
  */
 export function buildTree(paths: readonly string[]): TreeNode {
   const root: TreeNode = { name: "", path: "", isDir: true, children: [] }
+  const indexes = new Map<TreeNode, Map<string, TreeNode>>()
   for (const p of paths) {
     if (!p) continue
     const segs = p.split("/").filter((s) => s.length > 0)
@@ -34,7 +35,13 @@ export function buildTree(paths: readonly string[]): TreeNode {
       const seg = segs[i] as string
       const isLast = i === segs.length - 1
       const isDir = !isLast
-      let child = cur.children.find((c) => c.name === seg && c.isDir === isDir)
+      let index = indexes.get(cur)
+      if (!index) {
+        index = new Map()
+        indexes.set(cur, index)
+      }
+      const key = `${isDir ? "d" : "f"}:${seg}`
+      let child = index.get(key)
       if (!child) {
         child = {
           name: seg,
@@ -43,6 +50,7 @@ export function buildTree(paths: readonly string[]): TreeNode {
           children: [],
         }
         cur.children.push(child)
+        index.set(key, child)
       }
       cur = child
     }

--- a/packages/kobe/test/daemon/backpressure-reconnect.test.ts
+++ b/packages/kobe/test/daemon/backpressure-reconnect.test.ts
@@ -1,0 +1,111 @@
+import { createServer } from "node:net"
+import { join } from "node:path"
+import { KobeDaemonClient } from "@sma1lboy/kobe-daemon/client"
+import { ClientWriter } from "@sma1lboy/kobe-daemon/daemon/client-writer"
+import {
+  DAEMON_PROTOCOL_VERSION,
+  MIN_COMPATIBLE_PROTOCOL_VERSION,
+  frameToLine,
+} from "@sma1lboy/kobe-daemon/daemon/protocol"
+import { expect, it } from "vitest"
+import { LineReceiver } from "../../../kobe-daemon/src/daemon/line-receiver.ts"
+import { RemoteOrchestrator } from "../../src/client/remote-orchestrator.ts"
+import { bootDaemonHarness, waitFor } from "./harness.ts"
+
+it.each(["pane", "gui"] as const)(
+  "the real %s client rejects outstanding RPCs and reconnects with final subscribe replay after overflow",
+  async (role) => {
+    const h = await bootDaemonHarness()
+    const path = join(h.dir, "slow.sock")
+    let subscriptions = 0
+    let overflows = 0
+    const raw = createServer((socket) => {
+      let blocked = false
+      const writer = new ClientWriter(
+        {
+          write: (line) => {
+            socket.write(line)
+            return !blocked
+          },
+          once: (event, listener) => {
+            if (!blocked) socket.once(event, listener)
+          },
+          destroy: () => socket.destroy(),
+        },
+        {
+          highWaterMark: 1024,
+          onOverflow: () => {
+            overflows++
+            socket.destroy()
+          },
+        },
+      )
+      const receiver = new LineReceiver()
+      socket.on("error", () => {})
+      socket.on("data", (chunk: Buffer) =>
+        receiver.push(chunk, (line) => {
+          const request = JSON.parse(line)
+          if (request.name === "task.ensureWorktree") {
+            blocked = true
+            writer.write(frameToLine({ type: "event", name: "active-task", payload: { taskId: null } }))
+            for (let i = 0; i < 100; i++)
+              writer.write(frameToLine({ type: "response", id: `other-${i}`, payload: "x".repeat(1024) }))
+            return
+          }
+          const payload =
+            request.name === "hello"
+              ? {
+                  tasks: [],
+                  protocolVersion: DAEMON_PROTOCOL_VERSION,
+                  minProtocolVersion: MIN_COMPATIBLE_PROTOCOL_VERSION,
+                }
+              : {}
+          writer.write(frameToLine({ type: "response", id: request.id, payload }))
+          if (request.name === "subscribe") {
+            subscriptions++
+            writer.write(
+              frameToLine({
+                type: "event",
+                name: "task.snapshot",
+                payload: {
+                  tasks:
+                    subscriptions === 1
+                      ? []
+                      : [
+                          {
+                            id: "final",
+                            title: "FINAL",
+                            repo: "/repo",
+                            branch: "final",
+                            worktreePath: "/wt/final",
+                            status: "backlog",
+                            createdAt: "",
+                            updatedAt: "",
+                          },
+                        ],
+                },
+              }),
+              "task.snapshot",
+            )
+          }
+        }),
+      )
+    })
+    await new Promise<void>((resolve) => raw.listen(path, resolve))
+    const client = new KobeDaemonClient(path)
+    const orch = new RemoteOrchestrator(client, { role, ensureReachable: async () => {} })
+    try {
+      await orch.init()
+      // Blocking RPCs have no deadline; rejection must come from the connection close.
+      await expect(client.request("task.ensureWorktree", { id: "pending" })).rejects.toThrow("connection closed")
+      expect(overflows).toBe(1)
+      expect(await waitFor(() => orch.listTasks()[0]?.title === "FINAL", 3000)).toBe(true)
+      expect(subscriptions).toBe(2)
+      expect(orch.connectionStateSignal()()).toBe("online")
+    } finally {
+      orch.dispose()
+      await new Promise<void>((resolve) => raw.close(() => resolve()))
+      await h.close()
+    }
+  },
+)

--- a/packages/kobe/test/daemon/channel-backpressure.test.ts
+++ b/packages/kobe/test/daemon/channel-backpressure.test.ts
@@ -1,0 +1,69 @@
+import { expect, it } from "vitest"
+import { writeFrame } from "../../../kobe-daemon/src/daemon/client-connection.ts"
+import { ClientWriter } from "../../../kobe-daemon/src/daemon/client-writer.ts"
+import type { DaemonFrame } from "../../../kobe-daemon/src/daemon/protocol.ts"
+
+it("a slow consumer recovers final full snapshots without losing commands, per-task state or ordered bytes", () => {
+  const received: DaemonFrame[] = []
+  let drain = () => {}
+  let paused = true
+  let destroyed = false
+  const writer = new ClientWriter(
+    {
+      write: (line) => {
+        received.push(JSON.parse(line))
+        return !paused
+      },
+      once: (_event, cb) => {
+        drain = cb
+      },
+      destroy: () => {
+        destroyed = true
+      },
+    },
+    { highWaterMark: 32 * 1024 },
+  )
+  const client = { writer }
+  const send = (frame: DaemonFrame) => writeFrame(client, frame)
+  send({ type: "response", id: "initial", payload: {} })
+  send({ type: "event", name: "task.snapshot", payload: { tasks: ["old"] } })
+  send({ type: "event", name: "task.snapshot", payload: { tasks: ["FINAL"] } })
+  const ordered: DaemonFrame[] = [
+    ...Array.from(
+      { length: 30 },
+      (_, i): DaemonFrame => ({ type: "event", name: "engine-state", payload: { taskId: `t${i}`, state: "idle" } }),
+    ),
+    ...(
+      [
+        "session.deliver",
+        "task.jobs",
+        "issue.snapshot",
+        "keybindings",
+        "notice.event",
+        "tab.open",
+        "tab.close",
+        "engine.lifecycle",
+        "ui.prompt",
+        "pty.data",
+        "pty.exit",
+        "daemon.stopping",
+      ] as const
+    ).flatMap((name): DaemonFrame[] => [
+      { type: "event", name, payload: { value: 1 } },
+      { type: "event", name, payload: { value: 2 } },
+    ]),
+    { type: "response", id: "rpc", payload: "done" },
+  ]
+  for (const frame of ordered) send(frame)
+  for (let i = 0; i < 1000; i++) send({ type: "event", name: "worktree.changes", payload: { changes: { latest: i } } })
+  expect(destroyed).toBe(false)
+  paused = false
+  drain()
+  expect(received).toEqual([
+    { type: "response", id: "initial", payload: {} },
+    { type: "event", name: "task.snapshot", payload: { tasks: ["FINAL"] } },
+    ...ordered,
+    { type: "event", name: "worktree.changes", payload: { changes: { latest: 999 } } },
+  ])
+  expect(writer.pendingBytes).toBe(0)
+})

--- a/packages/kobe/test/daemon/client-writer.test.ts
+++ b/packages/kobe/test/daemon/client-writer.test.ts
@@ -1,13 +1,4 @@
-/**
- * Per-client socket write backpressure (fix E). The daemon is a single
- * long-lived writer fanning channel frames out to every subscribed socket;
- * `socket.write()` returning `false` (OS send buffer full for a slow client)
- * must not be ignored: Node then queues unbounded heap and the daemon grows
- * to GBs and OOMs. {@link ClientWriter} obeys backpressure per client: it pauses on
- * `false`, resumes on `'drain'`, bounds its queue (dropping the oldest
- * droppable frames), and NEVER drops a critical (lifecycle/response) frame nor
- * reorders a single client's stream.
- */
+/** Socket backpressure preserves ordered frames and replaces only superseded snapshots. */
 
 import { ClientWriter } from "@sma1lboy/kobe-daemon/daemon/client-writer"
 import { describe, expect, it } from "vitest"
@@ -20,6 +11,10 @@ import { describe, expect, it } from "vitest"
 class FakeSocket {
   writes: string[] = []
   accept = true
+  destroyed = false
+  destroy(): void {
+    this.destroyed = true
+  }
   private drainListeners: Array<() => void> = []
 
   write(data: string): boolean {
@@ -46,13 +41,13 @@ describe("ClientWriter backpressure", () => {
     // Socket buffer is full: the first frame is accepted by the kernel but
     // write() reports false → the writer must pause.
     sock.accept = false
-    writer.write("a\n", false)
+    writer.write("a\n", null)
     expect(sock.writes).toEqual(["a\n"])
     expect(writer.isPaused).toBe(true)
 
     // While paused, further frames are buffered, NOT handed to the socket.
-    writer.write("b\n", false)
-    writer.write("c\n", false)
+    writer.write("b\n", null)
+    writer.write("c\n", null)
     expect(sock.writes).toEqual(["a\n"])
     expect(writer.pendingCount).toBe(2)
 
@@ -64,51 +59,41 @@ describe("ClientWriter backpressure", () => {
     expect(writer.pendingCount).toBe(0)
   })
 
-  it("drops the oldest droppable frames past the high-water mark but never a critical frame", () => {
+  it("replaces only superseded snapshots and preserves lifecycle order", () => {
     const sock = new FakeSocket()
     const writer = new ClientWriter(sock, { highWaterMark: 12 })
 
     // Saturate the socket so subsequent frames queue.
     sock.accept = false
-    writer.write("PAUSE", false)
+    writer.write("PAUSE", null)
     expect(writer.isPaused).toBe(true)
 
-    // Fill the queue past 12 bytes (each line is 5 bytes):
-    //   old01 (5) → STOP! critical (10) → new02 (15 > 12) → drop oldest
-    //   droppable (old01); STOP! is kept regardless.
-    writer.write("old01", false)
-    writer.write("STOP!", true)
-    writer.write("new02", false)
+    // A newer snapshot replaces the same channel while the lifecycle frame stays queued.
+    writer.write("old01", "task.snapshot")
+    writer.write("STOP!", null)
+    writer.write("new02", "task.snapshot")
     expect(writer.dropped).toBe(1)
     expect(writer.pendingCount).toBe(2)
 
     sock.accept = true
     sock.emitDrain()
 
-    // The lifecycle frame survived; the dropped droppable frame did not; order
-    // is preserved among survivors.
+    // Surviving frames keep their original order.
     expect(sock.writes).toEqual(["PAUSE", "STOP!", "new02"])
     expect(sock.writes).toContain("STOP!")
     expect(sock.writes).not.toContain("old01")
   })
 
-  it("never drops a critical frame even when every queued frame would overflow", () => {
+  it("bounds critical responses even without an overflow callback", () => {
     const sock = new FakeSocket()
-    const writer = new ClientWriter(sock, { highWaterMark: 4 })
-
+    const writer = new ClientWriter(sock, { highWaterMark: 1024 })
     sock.accept = false
-    writer.write("PAUSE", false)
-
-    // Three criticals, each 5 bytes, all over a 4-byte mark: none may be shed.
-    writer.write("L1!!!", true)
-    writer.write("L2!!!", true)
-    writer.write("L3!!!", true)
-    expect(writer.dropped).toBe(0)
-    expect(writer.pendingCount).toBe(3)
-
-    sock.accept = true
+    writer.write("PAUSE", null)
+    for (let i = 0; i < 100; i++) writer.write("x".repeat(1024), null)
+    expect(sock.destroyed).toBe(true)
+    expect(writer.pendingBytes).toBe(0)
     sock.emitDrain()
-    expect(sock.writes).toEqual(["PAUSE", "L1!!!", "L2!!!", "L3!!!"])
+    expect(sock.writes).toEqual(["PAUSE"])
   })
 
   it("disconnects a critical-only slow stream instead of retaining an unbounded queue", () => {
@@ -120,14 +105,14 @@ describe("ClientWriter backpressure", () => {
     })
 
     sock.accept = false
-    writer.write("PAUSE", false)
-    writer.write("L1!!!", true)
+    writer.write("PAUSE", null)
+    writer.write("L1!!!", null)
 
     expect(overflows).toBe(1)
     expect(writer.pendingBytes).toBe(0)
     expect(writer.pendingCount).toBe(0)
 
-    writer.write("L2!!!", true)
+    writer.write("L2!!!", null)
     expect(overflows).toBe(1)
     expect(writer.pendingCount).toBe(0)
   })
@@ -137,9 +122,9 @@ describe("ClientWriter backpressure", () => {
     const writer = new ClientWriter(sock)
 
     sock.accept = false
-    writer.write("a\n", false) // pause
-    writer.write("b\n", false)
-    writer.write("c\n", false)
+    writer.write("a\n", null) // pause
+    writer.write("b\n", null)
+    writer.write("c\n", null)
 
     // First drain: socket accepts exactly one more frame then saturates again.
     let served = 0
@@ -168,7 +153,7 @@ describe("ClientWriter backpressure", () => {
     sock.write = () => {
       throw new Error("EPIPE: socket destroyed")
     }
-    expect(() => writer.write("a\n", true)).not.toThrow()
+    expect(() => writer.write("a\n", null)).not.toThrow()
     // Swallowed write is treated as accepted → no pause, no queue leak.
     expect(writer.isPaused).toBe(false)
     expect(writer.pendingCount).toBe(0)

--- a/packages/kobe/test/daemon/line-receiver.test.ts
+++ b/packages/kobe/test/daemon/line-receiver.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest"
+import { LineReceiver, MAX_REQUEST_FRAME_BYTES } from "../../../kobe-daemon/src/daemon/line-receiver.ts"
+
+describe("bounded request framing", () => {
+  it("preserves UTF-8 at every chunk boundary and drains multiple frames", () => {
+    const bytes = Buffer.from("任务🚀\nsecond\n\n尾巴")
+    for (let split = 0; split <= bytes.length; split++) {
+      const receiver = new LineReceiver()
+      const lines: string[] = []
+      expect(receiver.push(bytes.subarray(0, split), (line) => lines.push(line))).toBe(true)
+      expect(receiver.push(bytes.subarray(split), (line) => lines.push(line))).toBe(true)
+      expect(lines).toEqual(["任务🚀", "second", ""])
+      expect(receiver.pendingBytes).toBe(Buffer.byteLength("尾巴"))
+      receiver.push(Buffer.from("\n"), (line) => lines.push(line))
+      expect(lines.at(-1)).toBe("尾巴")
+    }
+  })
+  it("accepts the exact byte limit, including many complete frames in one chunk", () => {
+    const receiver = new LineReceiver(6)
+    const lines: string[] = []
+    expect(receiver.push(Buffer.from("任务\n123456\na\n"), (line) => lines.push(line))).toBe(true)
+    expect(lines).toEqual(["任务", "123456", "a"])
+  })
+  it("rejects terminated and unterminated oversized frames without processing their suffix", () => {
+    for (const ending of ["", "\nvalid\n"]) {
+      const receiver = new LineReceiver(6)
+      const lines: string[] = []
+      expect(receiver.push(Buffer.from(`任务x${ending}`), (line) => lines.push(line))).toBe(false)
+      expect(receiver.pendingBytes).toBe(0)
+      expect(receiver.push(Buffer.from("valid\n"), (line) => lines.push(line))).toBe(false)
+      expect(lines).toEqual([])
+    }
+  })
+  it("accepts a multi-megabyte prompt in small chunks and rejects 16MiB without a newline", () => {
+    const receiver = new LineReceiver()
+    const chunk = Buffer.alloc(1024, 120)
+    for (let i = 0; i < MAX_REQUEST_FRAME_BYTES / chunk.length; i++) {
+      expect(
+        receiver.push(chunk, () => {
+          throw new Error("unexpected frame")
+        }),
+      ).toBe(true)
+    }
+    let length = 0
+    expect(
+      receiver.push(Buffer.from("\n"), (line) => {
+        length = line.length
+      }),
+    ).toBe(true)
+    expect(length).toBe(MAX_REQUEST_FRAME_BYTES)
+    expect(receiver.push(Buffer.alloc(16 * 1024 * 1024), () => {})).toBe(false)
+    expect(receiver.pendingBytes).toBe(0)
+  })
+})

--- a/packages/kobe/test/daemon/socket-limits.test.ts
+++ b/packages/kobe/test/daemon/socket-limits.test.ts
@@ -1,0 +1,78 @@
+import { connect } from "node:net"
+import { join } from "node:path"
+import { KobeDaemonClient } from "@sma1lboy/kobe-daemon/client"
+import { startPtyHostServer } from "@sma1lboy/kobe-daemon/daemon/pty-server"
+import { afterEach, expect, it } from "vitest"
+import { type DaemonHarness, bootDaemonHarness, fakeOrchestrator, waitFor } from "./harness.ts"
+
+let h: DaemonHarness | undefined
+afterEach(async () => {
+  await h?.close()
+})
+
+it.each(["daemon", "pty"])(
+  "%s disconnects an oversized isolated request while healthy clients still work",
+  async (kind) => {
+    h = await bootDaemonHarness()
+    const path = kind === "daemon" ? h.socketPath : join(h.dir, "pty.sock")
+    const host =
+      kind === "pty"
+        ? await startPtyHostServer({
+            socketPath: path,
+            pidPath: join(h.dir, "pty.pid"),
+            freezeDir: join(h.dir, "freeze"),
+          })
+        : undefined
+    const bad = connect(path)
+    const good = new KobeDaemonClient(path)
+    try {
+      bad.on("error", () => {})
+      await new Promise<void>((resolve) => bad.once("connect", resolve))
+      bad.write(Buffer.alloc(16 * 1024 * 1024, 120))
+      expect(await waitFor(() => bad.destroyed)).toBe(true)
+      await expect(good.request(kind === "daemon" ? "daemon.status" : "pty.list")).resolves.toBeDefined()
+    } finally {
+      bad.destroy()
+      good.close()
+      await host?.close()
+    }
+  },
+)
+
+it("accepts large legal requests, UTF-8 splits, and consecutive frames on the daemon socket", async () => {
+  h = await bootDaemonHarness()
+  const raw = await h.rawSocket()
+  const bytes = Buffer.from(
+    `${JSON.stringify({ type: "request", id: "large", name: "daemon.status", payload: { text: `任务🚀${"x".repeat(4 * 1024 * 1024)}` } })}\n${JSON.stringify({ type: "request", id: "next", name: "daemon.status" })}\n`,
+  )
+  const split = bytes.indexOf(Buffer.from("任务")) + 1
+  raw.socket.write(bytes.subarray(0, split))
+  raw.socket.write(bytes.subarray(split))
+  expect((await raw.nextFrame((f) => f.id === "large")).error).toBeUndefined()
+  expect((await raw.nextFrame((f) => f.id === "next")).error).toBeUndefined()
+})
+
+it("the daemon disconnects a stalled reader whose queued RPC responses exceed the budget", async () => {
+  h = await bootDaemonHarness({
+    orchestrator: fakeOrchestrator({
+      listTasks: () => [
+        {
+          id: "large",
+          title: "x".repeat(1024 * 1024),
+          repo: "/repo",
+          branch: "large",
+          worktreePath: "/wt/large",
+          status: "backlog",
+          createdAt: "",
+          updatedAt: "",
+        },
+      ],
+    }),
+  })
+  const slow = await h.rawSocket()
+  slow.socket.pause()
+  for (let i = 0; i < 20; i++) slow.request("task.list", {}, `rpc-${i}`)
+  expect(await waitFor(() => h?.server.clients.size === 0, 3000)).toBe(true)
+  const healthy = h.client()
+  await expect(healthy.request("daemon.status")).resolves.toBeDefined()
+})

--- a/packages/kobe/test/daemon/worktree-changes-collector.test.ts
+++ b/packages/kobe/test/daemon/worktree-changes-collector.test.ts
@@ -65,6 +65,7 @@ function harness(initialTasks: Task[], counts: Record<string, WorktreeChanges>) 
   const runs: string[] = []
   const collector = new WorktreeChangesCollector({ listTasks: () => tasks }, bus, {
     cadence: FAST,
+    publishDelayMs: 0,
     run: async (worktreePath) => {
       runs.push(worktreePath)
       const value = counts[worktreePath]
@@ -176,6 +177,7 @@ describe("WorktreeChangesCollector", () => {
     const runs: string[] = []
     const collector = new WorktreeChangesCollector({ listTasks: () => [task({ id: "a" })] }, bus, {
       cadence: FAST,
+      publishDelayMs: 0,
       run: (worktreePath) => {
         runs.push(worktreePath)
         return new Promise((r) => {
@@ -201,6 +203,7 @@ describe("WorktreeChangesCollector", () => {
     })
     const collector = new WorktreeChangesCollector({ listTasks: () => tasks.current }, bus, {
       cadence: FAST,
+      publishDelayMs: 0,
       run: () =>
         new Promise((r) => {
           release = r
@@ -224,6 +227,7 @@ describe("WorktreeChangesCollector", () => {
     const runs: string[] = []
     const collector = new WorktreeChangesCollector({ listTasks: () => [task({ id: "a" })] }, bus, {
       cadence: FAST,
+      publishDelayMs: 0,
       hasSubscribers: () => subscribed,
       run: async (worktreePath) => {
         runs.push(worktreePath)
@@ -262,7 +266,7 @@ describe("WorktreeChangesCollector", () => {
         },
       },
       bus,
-      { cadence: FAST, run: async () => ({ added: 0, deleted: 0 }) },
+      { cadence: FAST, publishDelayMs: 0, run: async () => ({ added: 0, deleted: 0 }) },
     )
     expect(() => collector.tick()).not.toThrow()
   })
@@ -285,6 +289,7 @@ describe("the behind-base count", () => {
       bus,
       {
         cadence: FAST,
+        publishDelayMs: 0,
         run: async (_path, _signal, baseRef) => {
           seenBaseRefs.push(baseRef)
           return { added: 1, deleted: 0, behind }
@@ -318,6 +323,7 @@ describe("the behind-base count", () => {
     })
     const collector = new WorktreeChangesCollector({ listTasks: () => [task({ id: "a" })] }, bus, {
       cadence: FAST,
+      publishDelayMs: 0,
       run: async () => ({ added: 0, deleted: 2 }),
     })
     collector.tick()
@@ -365,6 +371,7 @@ describe("the ahead-of-base count", () => {
     let ahead = 0
     const collector = new WorktreeChangesCollector({ listTasks: () => [task({ id: "a" })] }, bus, {
       cadence: FAST,
+      publishDelayMs: 0,
       run: async () => ({ added: 0, deleted: 0, behind: 0, ahead }),
     })
     collector.tick()

--- a/packages/kobe/test/daemon/worktree-quiet-backoff.test.ts
+++ b/packages/kobe/test/daemon/worktree-quiet-backoff.test.ts
@@ -52,6 +52,7 @@ function harness(opts: HarnessOptions) {
   const runs = new Map<string, number>()
   const collector = new WorktreeChangesCollector({ listTasks: () => opts.tasks ?? [task("a")] }, new DaemonEventBus(), {
     cadence: FAST,
+    publishDelayMs: 0,
     quietIntervalMs: QUIET_MS,
     probe: opts.probe,
     ...(opts.activeTaskIds ? { activeTaskIds: opts.activeTaskIds } : {}),

--- a/packages/kobe/test/daemon/worktree-scheduling.test.ts
+++ b/packages/kobe/test/daemon/worktree-scheduling.test.ts
@@ -1,0 +1,158 @@
+import type { DaemonTask, WorktreeChanges } from "@sma1lboy/kobe-daemon/daemon/contracts"
+import { DaemonEventBus } from "@sma1lboy/kobe-daemon/daemon/event-bus"
+import type { WorktreeChangesPayload } from "@sma1lboy/kobe-daemon/daemon/protocol"
+import { WorktreeChangesCollector } from "@sma1lboy/kobe-daemon/daemon/worktree-changes-collector"
+import { afterEach, expect, it, vi } from "vitest"
+
+const tasks = (count: number): DaemonTask[] =>
+  Array.from({ length: count }, (_, i) => ({
+    id: `t${i}`,
+    title: `t${i}`,
+    repo: "/repo",
+    branch: `t${i}`,
+    worktreePath: `/wt/${i}`,
+    status: "backlog",
+    createdAt: "",
+    updatedAt: "",
+  }))
+const collectors: WorktreeChangesCollector[] = []
+afterEach(() => {
+  for (const c of collectors.splice(0)) c.stop()
+  vi.useRealTimers()
+})
+
+function fixture(count = 200) {
+  let current = tasks(count)
+  let subscribed = true
+  const pending = new Map<string, { resolve: (v: WorktreeChanges) => void; signal: AbortSignal }>()
+  const runs: string[] = []
+  const published: WorktreeChangesPayload[] = []
+  const bus = new DaemonEventBus()
+  bus.onPublish((e) => {
+    if (e.channel === "worktree.changes") published.push(e.payload as WorktreeChangesPayload)
+  })
+  const c = new WorktreeChangesCollector({ listTasks: () => current }, bus, {
+    probe: () => null,
+    hasSubscribers: () => subscribed,
+    activeTaskIds: () => ["t0", "t1", "t2", "t3"],
+    cadence: { timeoutMs: 100, slowRetryMs: 1000, minIntervalMs: 0 },
+    run: (path, signal) => {
+      runs.push(path)
+      return new Promise((resolve) => pending.set(path, { resolve, signal }))
+    },
+  })
+  collectors.push(c)
+  const finish = () => {
+    const batch = [...pending.values()]
+    pending.clear()
+    for (const p of batch) p.resolve({ added: 1, deleted: 0 })
+  }
+  return {
+    c,
+    runs,
+    pending,
+    published,
+    finish,
+    setTasks: (next: DaemonTask[]) => {
+      current = next
+    },
+    setSubscribed: (next: boolean) => {
+      subscribed = next
+    },
+  }
+}
+
+it("caps 200 due runs at four and serves the tail before continuously active front entries", async () => {
+  vi.useFakeTimers()
+  const h = fixture()
+  h.c.tick()
+  let peak = 0
+  for (let wave = 0; wave < 50; wave++) {
+    peak = Math.max(peak, h.pending.size)
+    h.c.tick()
+    h.finish()
+    await vi.advanceTimersByTimeAsync(1)
+    h.c.tick()
+  }
+  expect(peak).toBe(4)
+  expect(h.runs.slice(0, 200)).toEqual(tasks(200).map((t) => t.worktreePath))
+  await vi.advanceTimersByTimeAsync(10)
+  expect(Object.keys(h.published.at(-1)?.changes ?? {})).toHaveLength(200)
+  expect(h.published.length).toBeLessThan(20)
+})
+
+it("prunes queued and in-flight results, including deleting and re-adding the same path", async () => {
+  vi.useFakeTimers()
+  const h = fixture(10)
+  h.c.tick()
+  h.setTasks([])
+  h.c.tick()
+  h.setTasks(tasks(1))
+  h.c.tick()
+  expect(h.runs).toHaveLength(4)
+  h.finish()
+  await vi.advanceTimersByTimeAsync(1)
+  expect(h.runs).toEqual(["/wt/0", "/wt/1", "/wt/2", "/wt/3", "/wt/0"])
+  await vi.advanceTimersByTimeAsync(10)
+  expect(h.published).toEqual([])
+  h.finish()
+  await vi.advanceTimersByTimeAsync(11)
+  expect(h.published.at(-1)).toEqual({ changes: { "/wt/0": { added: 1, deleted: 0 } } })
+})
+
+it("stop cancels queued work, aborts running work and suppresses delayed and late publications", async () => {
+  vi.useFakeTimers()
+  const h = fixture()
+  h.c.tick()
+  const running = [...h.pending.values()]
+  h.c.stop()
+  expect(running.every((p) => p.signal.aborted)).toBe(true)
+  h.finish()
+  await vi.advanceTimersByTimeAsync(1000)
+  h.c.tick()
+  expect(h.runs).toHaveLength(4)
+  expect(h.published).toEqual([])
+})
+
+it("subscriber loss pauses the queue until the next subscribed tick", async () => {
+  vi.useFakeTimers()
+  const h = fixture(8)
+  h.c.tick()
+  h.setSubscribed(false)
+  h.finish()
+  await vi.advanceTimersByTimeAsync(20)
+  expect(h.runs).toHaveLength(4)
+  h.setSubscribed(true)
+  h.c.tick()
+  expect(h.runs.slice(4)).toEqual(["/wt/4", "/wt/5", "/wt/6", "/wt/7"])
+})
+
+it("timed-out runs keep their slots until settlement and retain hard backoff", async () => {
+  vi.useFakeTimers()
+  const h = fixture(8)
+  h.c.tick()
+  await vi.advanceTimersByTimeAsync(101)
+  expect([...h.pending.values()].every((p) => p.signal.aborted)).toBe(true)
+  expect(h.runs).toHaveLength(4)
+  h.finish()
+  await vi.advanceTimersByTimeAsync(1)
+  h.c.tick()
+  expect(h.runs.slice(4)).toEqual(["/wt/4", "/wt/5", "/wt/6", "/wt/7"])
+  h.finish()
+  await vi.advanceTimersByTimeAsync(20)
+  h.c.tick()
+  expect(h.runs.filter((p) => p === "/wt/0")).toHaveLength(1)
+  expect(h.published.at(-1)?.changes["/wt/0"]).toBeUndefined()
+})
+
+it("stop also cancels a publication that was already scheduled", async () => {
+  vi.useFakeTimers()
+  const h = fixture(1)
+  h.c.tick()
+  h.finish()
+  await vi.advanceTimersByTimeAsync(1)
+  expect(h.published).toEqual([])
+  h.c.stop()
+  await vi.advanceTimersByTimeAsync(100)
+  expect(h.published).toEqual([])
+})

--- a/packages/kobe/test/daemon/worktree-status-runner.test.ts
+++ b/packages/kobe/test/daemon/worktree-status-runner.test.ts
@@ -1,0 +1,29 @@
+import { execFileSync } from "node:child_process"
+import { mkdtempSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { runGitStatus } from "@sma1lboy/kobe-daemon/daemon/worktree-changes-collector"
+import { expect, it } from "vitest"
+
+it("the extracted runner reads real status and drift, and degrades when the base ref is missing", async () => {
+  const repo = mkdtempSync(join(tmpdir(), "rove-status-runner-"))
+  const git = (...args: string[]) =>
+    execFileSync("git", ["-C", repo, ...args], { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] }).trim()
+  git("init")
+  writeFileSync(join(repo, "first.txt"), "first\n")
+  git("add", "first.txt")
+  git("-c", "user.name=Fixture", "-c", "user.email=fixture@example.test", "commit", "-m", "Initial fixture")
+  const base = git("rev-parse", "HEAD")
+  writeFileSync(join(repo, "second.txt"), "second\n")
+  git("add", "second.txt")
+  git("-c", "user.name=Fixture", "-c", "user.email=fixture@example.test", "commit", "-m", "Advance fixture")
+  writeFileSync(join(repo, "untracked.txt"), "untracked\n")
+  const signal = new AbortController().signal
+  await expect(runGitStatus(repo, signal, base)).resolves.toEqual({ added: 1, deleted: 0, behind: 0, ahead: 1 })
+  await expect(runGitStatus(repo, signal)).resolves.toEqual({ added: 1, deleted: 0 })
+  await expect(runGitStatus(repo, signal, "missing-reference")).resolves.toEqual({ added: 1, deleted: 0 })
+  await expect(runGitStatus(join(repo, "missing"), signal)).rejects.toThrow("git status failed")
+  const aborted = new AbortController()
+  aborted.abort()
+  await expect(runGitStatus(repo, aborted.signal)).rejects.toThrow("git status failed")
+})

--- a/packages/kobe/test/tui/filetree-build.test.ts
+++ b/packages/kobe/test/tui/filetree-build.test.ts
@@ -1,0 +1,23 @@
+import { expect, it } from "vitest"
+import { buildTree } from "../../src/tui/panes/filetree/tree.ts"
+
+it("deduplicates paths while preserving same-name files and directories and sort order", () => {
+  const paths = ["z", "same", "same/a", "/same//a/", "a", "", "/", "same/b", "other/c"]
+  const root = buildTree(paths)
+  expect(root.children.map(({ name, isDir }) => [name, isDir])).toEqual([
+    ["other", true],
+    ["same", true],
+    ["a", false],
+    ["same", false],
+    ["z", false],
+  ])
+  expect(root.children[1]?.children.map(({ path }) => path)).toEqual(["same/a", "same/b"])
+  expect(buildTree([...paths].reverse())).toEqual(root)
+})
+
+it("builds a wide directory with all unique leaves and stable sorted output", () => {
+  const paths = Array.from({ length: 20000 }, (_, i) => `wide/file-${String(i).padStart(5, "0")}`)
+  const tree = buildTree([...paths].reverse().concat(paths))
+  expect(tree.children).toHaveLength(1)
+  expect(tree.children[0]?.children.map((node) => node.path)).toEqual(paths)
+})


### PR DESCRIPTION
Slow socket readers could grow daemon memory without a bound or permanently miss a channel's final snapshot. Large unfinished requests, wide directories and many due worktrees also caused unbounded buffering or quadratic work. This change bounds those paths and preserves ordered delivery until an explicit disconnect.

| Finding / trigger | Change | Regression evidence |
| --- | --- | --- |
| Critical-only response queue, write returns false, then 100 × 1024-byte responses with a 1024-byte budget: 102400 bytes retained | Writer defaults to socket destruction on overflow; daemon wires an explicit disconnect callback. Standalone PTY retains ordered semantics. | Default-callback unit regression; real daemon socket fills with RPC responses and the stalled connection is removed while a healthy client still answers. |
| 16 MiB without newline stays retained; each new chunk rescans the accumulated prefix | Shared byte-oriented receiver for daemon and PTY Host, 8 MiB per request excluding newline, geometric storage growth, scans only incoming chunks | Every UTF-8 split, exact byte boundary, multiple frames, terminated/unfinished overflow, multi-megabyte legal request, and isolated daemon/PTY socket refusal. Original drain retained 16777216 bytes. |
| FINAL task.snapshot displaced by later engine-state events | Only explicit full-channel snapshots replace older queued snapshots of the same channel. Per-task/repo updates, commands, lifecycle, RPC and PTY frames stay ordered. Remaining overflow disconnects. | Slow-consumer regression preserves FINAL through 30 task events and 1000 other-channel snapshots; repeated command/lifecycle/PTY events survive. Real KobeDaemonClient + RemoteOrchestrator pane/gui tests reject a no-deadline pending RPC, reconnect, resubscribe and receive final task state. |
| buildTree searches existing siblings for every insertion | Temporary per-parent child indexes distinguish file and directory names; output type and sorting stay intact | Existing filetree tests plus 20000-file output and same-name file/directory regression. Before/after benchmark compares serialized output as well as timing. |
| One tick starts all 200 due runners, each completion builds a full map | Four concurrent runs, insertion-ordered waiting queue, 10 ms publication batching. Stop clears pending work and aborts running reads. Git runner extracted from scheduling as an ownership seam. | 200-worktree fairness test while front tasks stay active; final full map; queued/in-flight prune and same-path re-add; stop before/after publication scheduling; subscriber pause; timeout slots and hard backoff; existing quiet/active cadence tests. |

The 8 MiB receive limit is an explicit resource envelope aligned with the existing outbound queue budget, not an OS limit. It permits multi-megabyte prompts and input, but oversized fields must be shortened or PTY input split into separate ordered writes. Documentation covers the byte accounting, queue policy, recovery and four-run collector.

Benchmarks on this Mac, Bun 1.3.14:

| Workload | Before | After |
| --- | --- | --- |
| Tree, 5000 files, median of 7 | 27.76 ms | 1.61 ms |
| Tree, 10000 files | 114.14 ms | 2.82 ms |
| Tree, 20000 files | 447.36 ms | 6.03 ms |
| 1 KiB chunks, 1 / 2 / 4 MiB unfinished line, median of 5 | 14.37 / 55.07 / 222.13 ms | 0.26 / 0.45 / 0.89 ms |
| 200 injected status runners, 1 ms resolution delay | peak 200, 200 publications, 20100 total map entries | peak 4, 7 publications, 848 total map entries |

Publication counts depend on timer grouping. These are injected-runner operation counts, not a claim about real git speed. No history-cache work is included.

Validation:

- Worktree dependencies installed with `bun install` before testing.
- Root lint, all package typechecks, build, changeset validation, diff check and touched-file size gate pass.
- Full fast suite: 462 files / 4553 tests pass. Full socket suite with coverage: 105 files / 852 tests pass; the subsequently added real-Git runner regression also passes.
- Filetree focused suite: 5 files / 88 tests pass. Socket/reconnect/collector focused suite: 10 files / 55 tests pass, plus the added targeted regressions.
- Full behavior suite under process-local canonical `TMPDIR`: 11 files / 33 tests pass. The first run had one failure across its three attempts because editor argv used `/private/var/...` while the fixture expected `/var/...`. This is a path-alias difference, not baseline-confirmed. No behavior test, keybinding, or global environment was changed. Original and canonical-run logs are retained in `.scratch/socket-review/behavior.log` and `behavior-canonical.log` in the task checkout.
- Built CLI in an isolated temporary HOME/XDG/ROVE environment: daemon startup, `daemon restart`, `api inspect`, PID 99434 → 16564, then `daemon stop`. Production engines were not restarted. Isolated PTY server restart tests also pass.
- Default local socket coverage emitted an empty report because Vitest excludes hidden-directory paths and this checkout lives below `.rove`. A command-local `--coverage.exclude='**/node_modules/**'` override, retaining the source-only include, produces real coverage without changing repository configuration. Touched-file line coverage: tree, ClientWriter, client connection, LineReceiver and daemon server 100%; worktree collector 98.98%; PTY server 75.09%; extracted Git runner 100% in its isolated real-Git regression. `BASE_REF=main bun scripts/coverage-gate.mjs` passes for the applicable package files; daemon percentages were also checked directly.

Limits: a transport disconnect fails outstanding RPCs; commands are not retried automatically because effects may already have happened. Transient events have no complete replay log. A timed-out injected runner that ignores abort retains its concurrency slot until it settles; production git runners honor abort. Final review, merge and release belong to the dispatcher; this PR is an intermediate handoff.

CI at final HEAD `69b70590c1d052a0ec6d5830f7f7ff353af712dd`: all seven jobs pass (typecheck/test, behavior, render, visual, docs, file size, changeset). [Run 33920475169](https://github.com/Sma1lboy/rove/actions/runs/33920475169).
