### PR TITLE
fix: settle socket requests and avoid init retry false failures

### DIFF
--- a/.changeset/patient-init-probe.md
+++ b/.changeset/patient-init-probe.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Keep a new session unconfirmed when its launch shell retries repository initialization during the engine startup probe. A live PTY with an absent init marker no longer reports a failed launch; completed initialization and dead sessions retain their existing failure checks.

--- a/.changeset/quiet-sockets-settle.md
+++ b/.changeset/quiet-sockets-settle.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove-plugin-sdk": patch
+---
+
+Settle pending socket requests when a plugin closes or loses its connection. Reconnecting the same client isolates the new connection from late socket events, and invalid JSON frame shapes no longer crash plugin subscribers.

--- a/docs/HARNESS.md
+++ b/docs/HARNESS.md
@@ -129,26 +129,22 @@ var — the ground-truth path is unchanged.
 
 ### What the harness replaces, and therefore cannot prove
 
-The harness swaps out the daemon spec fetch. `KOBE_PTY_DEV_COMMAND` is set by
-`packages/kobe-harness/playwright.config.ts`, `e2e/visual-serve.ts` and
-`e2e/hero-serve.ts`, and `createSpecFetcher` returns on that variable before it
-ever asks the daemon — so the whole visual track spawns a command the harness
-chose, not the one a task resolves to. **A green `bun run visual` says nothing
-about task-to-PTY resolution**: not the `engine` vs `shell` route choice, not
-the bearer token `/api/*` requires, not the error a failed lookup surfaces.
-That gap is how a web terminal broken from 0.9.60 to 0.9.102 passed ~40 CI runs.
+The sidecar resolves its launch command from `KOBE_PTY_DEV_COMMAND`. The visual
+runners set that variable and `KOBE_PTY_DEV_CWD` to launch the isolated fixture.
+`createSpecFetcher` returns the same spec for engine and shell modes and throws
+when the command is unset. It does not fetch launch specs from the daemon.
 
-`packages/kobe-harness/test/pty-spec.test.ts` is the track that does cover it: it
-drives the real branch with an injected `fetch` and a stub daemon, and fails
-if the `authorization` header is dropped. Run it with
-`cd packages/kobe-harness && bun run test`.
+The visual track proves browser input and rendering through xterm.js, the PTY
+sidecar and the real OpenTUI process. It does not exercise production task-to-PTY
+launch resolution. Changes to that path need the relevant CLI or hosted-session
+tests in addition to any visual checks.
 
-The remaining blind spot the harness cannot close is the live hop itself — a
-real sidecar talking to a real daemon over a real socket. Manual recipe when a
-change touches that path:
+`packages/kobe-harness/test/pty-spec.test.ts` checks command and cwd selection,
+mode equivalence and the missing-command error. The session lifecycle tests
+inject their own spec fetcher and cover spawn, attachment and teardown.
 
 ```bash
-cd packages/kobe-harness && bun run test   # test/pty-spec.test.ts covers fetchSpec directly
+cd packages/kobe-harness && bun run test
 ```
 
 ### `shift+<letter>` is pressed as the uppercase letter

--- a/packages/kobe-docs/scripts/sync-docs.mjs
+++ b/packages/kobe-docs/scripts/sync-docs.mjs
@@ -200,21 +200,19 @@ function rewriteAssetTarget(target) {
   return target
 }
 
-function rewriteImageTarget(target) {
-  return rewriteAssetTarget(target)
-}
-
-/** Raw MDX media attributes are invisible to Markdown link rewriting. */
-function rewriteMediaTargets(markdown) {
+/** Rewrite raw media attributes and CommonMark autolinks outside fenced code. */
+function rewriteMdxLines(markdown) {
   let inFence = false
   return markdown
     .split("\n")
     .map((line) => {
       if (/^\s*```/.test(line)) inFence = !inFence
       if (inFence) return line
-      return line.replace(/\b(src|poster)=(['"])([^'"]+)\2/g, (_match, attribute, quote, target) => {
-        return `${attribute}=${quote}${rewriteAssetTarget(target)}${quote}`
-      })
+      return line
+        .replace(/\b(src|poster)=(['"])([^'"]+)\2/g, (_match, attribute, quote, target) => {
+          return `${attribute}=${quote}${rewriteAssetTarget(target)}${quote}`
+        })
+        .replace(/<(https?:\/\/[^>\s]+)>/g, "[$1]($1)")
     })
     .join("\n")
 }
@@ -223,31 +221,15 @@ function rewriteLinks(markdown) {
   return (
     markdown
       // Inline links: [text](target "optional title"). Image targets become
-      // site paths via rewriteImageTarget.
+      // site paths via rewriteAssetTarget.
       .replace(
         /(!?)\[([^\]]*)\]\((<)?([^)\s>]+)(>)?((?:\s+"[^"]*")?)\)/g,
         (match, bang, text, _open, target, _close, title) =>
-          bang ? `![${text}](${rewriteImageTarget(target)}${title})` : `[${text}](${rewriteTarget(target)}${title})`,
+          bang ? `![${text}](${rewriteAssetTarget(target)}${title})` : `[${text}](${rewriteTarget(target)}${title})`,
       )
       // Reference-style definitions: [label]: target
       .replace(/^(\[[^\]]+\]:\s+)(\S+)/gm, (match, label, target) => `${label}${rewriteTarget(target)}`)
   )
-}
-
-/**
- * CommonMark autolinks (`<https://…>`) are not valid MDX — `<` starts JSX.
- * Convert them to explicit links outside fenced code blocks.
- */
-function rewriteAutolinks(markdown) {
-  let inFence = false
-  return markdown
-    .split("\n")
-    .map((line) => {
-      if (/^\s*```/.test(line)) inFence = !inFence
-      if (inFence) return line
-      return line.replace(/<(https?:\/\/[^>\s]+)>/g, "[$1]($1)")
-    })
-    .join("\n")
 }
 
 /**
@@ -282,7 +264,7 @@ function toMdxPage(markdown, sourceFile) {
     "",
   ].join("\n")
 
-  return `${frontmatter}${rewriteAutolinks(rewriteMediaTargets(rewriteLinks(body)))}`
+  return `${frontmatter}${rewriteMdxLines(rewriteLinks(body))}`
 }
 
 await mkdir(docsOutDir, { recursive: true })

--- a/packages/kobe-plugin-sdk/src/socket.ts
+++ b/packages/kobe-plugin-sdk/src/socket.ts
@@ -16,6 +16,12 @@ export interface RoveSocketOptions {
 export type KobeSocketOptions = RoveSocketOptions
 
 type Pending = { resolve: (payload: unknown) => void; reject: (err: Error) => void }
+type Connection = {
+  socket: Socket
+  buffer: string
+  pending: Map<string, Pending>
+  rejectConnect: (err: Error) => void
+}
 
 /** What the daemon answers `hello` with — the runtime compatibility check. */
 export interface DaemonInfo {
@@ -37,40 +43,37 @@ export interface DaemonInfo {
 }
 
 export class RoveSocket {
-  private sock: Socket | null = null
-  private buffer = ""
+  private connection: Connection | null = null
   private nextId = 1
-  private readonly pending = new Map<string, Pending>()
   private eventHandler: ((name: string, payload: unknown) => void) | null = null
   private closeHandler: ((err: Error) => void) | null = null
-  private closeNotified = false
 
   /** Connect; resolves once the socket is up (before any `hello`). */
   connect(opts: RoveSocketOptions = {}): Promise<void> {
     const path = opts.socketPath ?? process.env.ROVE_SOCKET_PATH ?? process.env.KOBE_SOCKET_PATH
     if (!path) return Promise.reject(new Error("ROVE_SOCKET_PATH is not set and no socketPath was given"))
+    this.close()
     return new Promise((resolve, reject) => {
-      const sock = createConnection(path, () => resolve())
-      sock.setEncoding("utf8")
-      sock.on("data", (chunk: string) => this.onData(chunk))
-      sock.on("error", (err) => {
-        reject(err)
-        this.failAll(err)
-      })
-      sock.on("close", () => this.failAll(new Error("daemon socket closed")))
-      this.sock = sock
+      const socket = createConnection(path, resolve)
+      const connection: Connection = { socket, buffer: "", pending: new Map(), rejectConnect: reject }
+      this.connection = connection
+      socket.setEncoding("utf8")
+      socket.on("data", (chunk: string) => this.onData(connection, chunk))
+      socket.on("error", (err) => this.disconnect(connection, err, true))
+      socket.on("close", () => this.disconnect(connection, new Error("daemon socket closed"), true))
     })
   }
 
   /** One request → its response payload (rejects on daemon error frames). */
   request<T = unknown>(name: string, payload?: unknown): Promise<T> {
-    const sock = this.sock
-    if (!sock) return Promise.reject(new Error("not connected — call connect() first"))
+    const connection = this.connection
+    if (!connection) return Promise.reject(new Error("not connected — call connect() first"))
     const id = String(this.nextId++)
     const frame: DaemonFrame = { type: "request", id, name, payload }
     return new Promise<T>((resolve, reject) => {
-      this.pending.set(id, { resolve: resolve as (p: unknown) => void, reject })
-      sock.write(`${JSON.stringify(frame)}\n`)
+      const data = `${JSON.stringify(frame)}\n`
+      connection.pending.set(id, { resolve: resolve as (p: unknown) => void, reject })
+      connection.socket.write(data)
     })
   }
 
@@ -117,45 +120,51 @@ export class RoveSocket {
   }
 
   close(): void {
-    this.closeNotified = true // deliberate teardown is not a lost connection
-    this.sock?.end()
-    this.sock = null
+    const connection = this.connection
+    if (connection) this.disconnect(connection, new Error("daemon socket closed"), false)
   }
 
-  private onData(chunk: string): void {
-    this.buffer += chunk
-    let idx = this.buffer.indexOf("\n")
-    while (idx >= 0) {
-      const line = this.buffer.slice(0, idx)
-      this.buffer = this.buffer.slice(idx + 1)
-      idx = this.buffer.indexOf("\n")
+  private onData(connection: Connection, chunk: string): void {
+    connection.buffer += chunk
+    let idx = connection.buffer.indexOf("\n")
+    while (this.connection === connection && idx >= 0) {
+      const line = connection.buffer.slice(0, idx)
+      connection.buffer = connection.buffer.slice(idx + 1)
+      idx = connection.buffer.indexOf("\n")
       if (!line.trim()) continue
-      let frame: DaemonFrame
+      let frame: unknown
       try {
-        frame = JSON.parse(line) as DaemonFrame
+        frame = JSON.parse(line)
       } catch {
         continue // torn/foreign line — skip, never crash the plugin
       }
-      if (frame.type === "response") {
-        const waiter = this.pending.get(frame.id)
+      if (typeof frame !== "object" || frame === null || !("type" in frame)) continue
+      if (frame.type === "response" && "id" in frame && typeof frame.id === "string") {
+        const waiter = connection.pending.get(frame.id)
         if (!waiter) continue
-        this.pending.delete(frame.id)
-        if (frame.error) waiter.reject(new Error(frame.error.message))
-        else waiter.resolve(frame.payload)
-      } else if (frame.type === "event") {
-        this.eventHandler?.(frame.name, frame.payload)
+        if ("error" in frame && frame.error) {
+          const error = frame.error
+          if (typeof error !== "object" || !("message" in error) || typeof error.message !== "string") continue
+          connection.pending.delete(frame.id)
+          waiter.reject(new Error(error.message))
+        } else {
+          connection.pending.delete(frame.id)
+          waiter.resolve("payload" in frame ? frame.payload : undefined)
+        }
+      } else if (frame.type === "event" && "name" in frame && typeof frame.name === "string") {
+        this.eventHandler?.(frame.name, "payload" in frame ? frame.payload : undefined)
       }
     }
   }
 
-  private failAll(err: Error): void {
-    for (const waiter of this.pending.values()) waiter.reject(err)
-    this.pending.clear()
-    // Pending requests were the ONLY thing this used to fail. A subscriber
-    // has no pending request, so it heard nothing and stayed blind forever.
-    if (this.closeNotified) return
-    this.closeNotified = true
-    this.closeHandler?.(err)
+  private disconnect(connection: Connection, err: Error, notify: boolean): void {
+    if (this.connection !== connection) return
+    this.connection = null
+    connection.rejectConnect(err)
+    for (const waiter of connection.pending.values()) waiter.reject(err)
+    connection.pending.clear()
+    connection.socket.destroy()
+    if (notify) this.closeHandler?.(err)
   }
 }
 

--- a/packages/kobe-plugin-sdk/test/socket-lifecycle.test.ts
+++ b/packages/kobe-plugin-sdk/test/socket-lifecycle.test.ts
@@ -1,0 +1,130 @@
+import { mkdtempSync } from "node:fs"
+import { type Server, type Socket, createServer } from "node:net"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, expect, it, vi } from "vitest"
+import { RoveSocket } from "../src/socket.ts"
+
+const clients: RoveSocket[] = []
+const sockets: Socket[] = []
+const servers: Server[] = []
+
+async function connect(onData: (socket: Socket, data: string) => void, client = new RoveSocket()) {
+  const path = join(mkdtempSync(join(tmpdir(), "rove-sdk-lifecycle-")), "d.sock")
+  const server = createServer({ allowHalfOpen: true }, (socket) => {
+    sockets.push(socket)
+    socket.setEncoding("utf8")
+    socket.on("data", (data: string) => onData(socket, data))
+  })
+  servers.push(server)
+  clients.push(client)
+  await new Promise<void>((resolve) => server.listen(path, resolve))
+  await client.connect({ socketPath: path })
+  return client
+}
+
+function outcome(promise: Promise<unknown>) {
+  return promise.then(
+    (value) => ({ value }),
+    (error: unknown) => ({ error }),
+  )
+}
+
+afterEach(async () => {
+  for (const client of clients.splice(0)) client.close()
+  for (const socket of sockets.splice(0)) socket.destroy()
+  await Promise.all(servers.splice(0).map((server) => new Promise<void>((resolve) => server.close(() => resolve()))))
+})
+
+it("rejects pending requests immediately on close without waiting for a half-open peer", async () => {
+  const received = vi.fn()
+  const client = await connect(received)
+  const closed = vi.fn()
+  client.onClose(closed)
+  const settled = vi.fn()
+  void outcome(client.request("waiting")).then(settled)
+  await vi.waitFor(() => expect(received).toHaveBeenCalledOnce())
+  client.close()
+  await vi.waitFor(() => expect(settled).toHaveBeenCalledWith({ error: expect.any(Error) }), { timeout: 200 })
+  expect(closed).not.toHaveBeenCalled()
+})
+
+it("rejects new requests after the daemon disconnects", async () => {
+  const client = await connect((socket) => socket.destroy())
+  const closed = vi.fn()
+  client.onClose(closed)
+  await expect(client.request("disconnect")).rejects.toThrow()
+  await vi.waitFor(() => expect(closed).toHaveBeenCalledOnce())
+  const settled = vi.fn()
+  void outcome(client.request("too-late")).then(settled)
+  await vi.waitFor(() => expect(settled).toHaveBeenCalledWith({ error: expect.any(Error) }), { timeout: 200 })
+})
+
+it("ignores invalid frame shapes and keeps reading valid responses and events", async () => {
+  const invalid = [null, 42, "text", true, [], {}, { type: "event" }, { type: "response", id: 1 }]
+  const client = await connect((socket, data) => {
+    const { id } = JSON.parse(data)
+    socket.write(`${invalid.map((frame) => JSON.stringify(frame)).join("\n")}\n`)
+    socket.write(`${JSON.stringify({ type: "response", id, error: {} })}\n`)
+    socket.write(`${JSON.stringify({ type: "response", id, payload: "ok" })}\n`)
+    socket.write(`${JSON.stringify({ type: "event", name: "task.snapshot", payload: 7 })}\n`)
+  })
+  const event = vi.fn()
+  await client.subscribe(event)
+  await vi.waitFor(() => expect(event).toHaveBeenCalledWith("task.snapshot", 7))
+  expect(await client.request("read")).toBe("ok")
+})
+
+it("keeps a replacement connection alive when the previous socket closes late", async () => {
+  const firstReceived = vi.fn()
+  const client = await connect(firstReceived)
+  const settled = vi.fn()
+  void outcome(client.request("old")).then(settled)
+  await vi.waitFor(() => expect(firstReceived).toHaveBeenCalledOnce())
+  const oldSocket = sockets[0]
+  if (!oldSocket) throw new Error("expected the first connection")
+  client.close()
+  await connect((socket, data) => {
+    const { id } = JSON.parse(data)
+    oldSocket.destroy()
+    setImmediate(() => socket.write(`${JSON.stringify({ type: "response", id, payload: "new" })}\n`))
+  }, client)
+  const closed = vi.fn()
+  client.onClose(closed)
+  expect(await client.request("new")).toBe("new")
+  expect(settled).toHaveBeenCalledWith({ error: expect.any(Error) })
+  expect(closed).not.toHaveBeenCalled()
+})
+
+it("rejects a connection closed before its handshake completes", async () => {
+  const client = await connect(() => {})
+  const path = servers[0]?.address()
+  if (typeof path !== "string") throw new Error("expected a Unix socket")
+  client.close()
+  const connecting = client.connect({ socketPath: path })
+  client.close()
+  await expect(connecting).rejects.toThrow("closed")
+})
+
+it("notifies once for each connection lost after reconnecting the same client", async () => {
+  const client = await connect((socket) => socket.destroy())
+  const closed = vi.fn()
+  client.onClose(closed)
+  await expect(client.request("first")).rejects.toThrow()
+  await connect((socket) => socket.destroy(), client)
+  await expect(client.request("second")).rejects.toThrow()
+  expect(closed).toHaveBeenCalledTimes(2)
+})
+
+it("replaces an existing connection and rejects its pending requests", async () => {
+  const received = vi.fn()
+  const client = await connect(received)
+  const pending = outcome(client.request("old"))
+  await vi.waitFor(() => expect(received).toHaveBeenCalledOnce())
+  await connect((socket, data) => {
+    const { id } = JSON.parse(data)
+    socket.write(`${JSON.stringify({ type: "response", id, payload: "replacement" })}\n`)
+  }, client)
+  expect(await client.request("new")).toBe("replacement")
+  expect(await pending).toEqual({ error: expect.any(Error) })
+})

--- a/packages/kobe/src/cli/api/pty-delivery.ts
+++ b/packages/kobe/src/cli/api/pty-delivery.ts
@@ -294,24 +294,18 @@ export async function deliverHostedPrompt(
     // `engineReady: true, delivered: true` came back for a binary that had
     // already printed `no such file or directory`.
     //
-    // First, the one case where the walk cannot answer: a repo-init script
-    // runs BEFORE the engine (`.rove/init.sh`, e.g. a
-    // `bun install`), and its marker file appears only when it finishes. So
-    // while that marker is absent "no engine yet" is not a failed launch, and
-    // neither answer the probe could give is right: waiting would hold `add`
-    // open for the length of the install, and reporting failure would reject a
-    // launch that is proceeding normally. Report it as unconfirmed instead.
-    if (launch.initMarkerPath && !existsSync(launch.initMarkerPath)) {
-      return {
-        session: launch.key,
-        pane: launch.key,
-        started,
-        engineReady: false,
-        delivered: true,
-        reason: "repo init script is still running; the engine has not started yet",
-        ...disclose,
-      }
+    // A missing init marker means the launch has not reached the engine yet.
+    // Keep that result unconfirmed without waiting through dependency install.
+    const pendingInit: DeliveredPrompt = {
+      session: launch.key,
+      pane: launch.key,
+      started,
+      engineReady: false,
+      delivered: true,
+      reason: "repo init script is still running; the engine has not started yet",
+      ...disclose,
     }
+    if (launch.initMarkerPath && !existsSync(launch.initMarkerPath)) return pendingInit
     // Otherwise walk for the process — the same `sessionHasEngine` the
     // existing-session gate above uses, in the loop `awaitEngineProcess`
     // already owns, not a third implementation of the same question.
@@ -321,6 +315,16 @@ export async function deliverHostedPrompt(
       snapshot: opts?.snapshot,
     })
     if (enginePid === null) {
+      // The shell may have removed an old failed marker and restarted init
+      // during the probe. Marker absence only confirms pending init while
+      // that same PTY is still alive.
+      if (
+        launch.initMarkerPath &&
+        !existsSync(launch.initMarkerPath) &&
+        (await listSessions(rpc)).some((session) => session.key === launch.key && session.alive)
+      ) {
+        return pendingInit
+      }
       return {
         session: launch.key,
         pane: launch.key,

--- a/packages/kobe/src/cli/api/pty-delivery.ts
+++ b/packages/kobe/src/cli/api/pty-delivery.ts
@@ -315,13 +315,13 @@ export async function deliverHostedPrompt(
       snapshot: opts?.snapshot,
     })
     if (enginePid === null) {
-      // The shell may have removed an old failed marker and restarted init
-      // during the probe. Marker absence only confirms pending init while
-      // that same PTY is still alive.
+      // Init may restart during the probe, then finish while inventory is
+      // loading. Check the marker after that await as well as session liveness.
       if (
         launch.initMarkerPath &&
         !existsSync(launch.initMarkerPath) &&
-        (await listSessions(rpc)).some((session) => session.key === launch.key && session.alive)
+        (await listSessions(rpc)).some((session) => session.key === launch.key && session.alive) &&
+        !existsSync(launch.initMarkerPath)
       ) {
         return pendingInit
       }

--- a/packages/kobe/test/cli/pty-delivery-init.test.ts
+++ b/packages/kobe/test/cli/pty-delivery-init.test.ts
@@ -112,3 +112,25 @@ it("observes an engine that starts after retrying init without pasting the argv 
   expect(await result).toMatchObject({ engineReady: true, delivered: true })
   expect(request.mock.calls.some(([name]) => name === "pty.write")).toBe(false)
 })
+
+it("checks the marker again after the final session inventory request completes", async () => {
+  vi.useFakeTimers()
+  const { marker, deliver, request } = fixture()
+  writeFileSync(marker, "1")
+  let restarted = false
+  const result = deliver(async () => {
+    if (!restarted) {
+      renameSync(marker, `${marker}.previous`)
+      restarted = true
+    }
+    return "123 1 -sh\n456 123 bun install\n"
+  })
+  await vi.advanceTimersByTimeAsync(2900)
+  request.mockImplementationOnce(async (name) => {
+    expect(name).toBe("pty.list")
+    writeFileSync(marker, "1")
+    return { sessions: [{ key: "task::tab-1", alive: true, pid: 123, command: ["codex"], title: "" }] }
+  })
+  await vi.advanceTimersByTimeAsync(400)
+  expect(await result).toMatchObject({ engineReady: false, delivered: false })
+})

--- a/packages/kobe/test/cli/pty-delivery-init.test.ts
+++ b/packages/kobe/test/cli/pty-delivery-init.test.ts
@@ -1,0 +1,114 @@
+import { mkdtempSync, renameSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, expect, it, vi } from "vitest"
+import { type PtyHostRpc, deliverHostedPrompt } from "../../src/cli/api/pty-delivery.ts"
+
+function fixture() {
+  const directory = mkdtempSync(join(tmpdir(), "rove-cli-init-"))
+  const marker = join(directory, "init")
+  const request = vi
+    .fn<PtyHostRpc["request"]>()
+    .mockResolvedValue({ sessions: [{ key: "task::tab-1", alive: true, pid: 123, command: ["codex"], title: "" }] })
+    .mockResolvedValueOnce({ sessions: [] })
+    .mockResolvedValueOnce({ alive: true, created: true })
+  const launch = { key: "task::tab-1", command: ["/bin/sh", "-lc", "init; codex prompt"], initMarkerPath: marker }
+  return {
+    marker,
+    request,
+    deliver: (snapshot: () => Promise<string>) =>
+      deliverHostedPrompt(
+        { request: async <T>(name: string, payload?: unknown) => (await request(name, payload)) as T },
+        { id: "task", engineBin: "codex" },
+        directory,
+        "prompt",
+        launch,
+        { snapshot },
+      ),
+  }
+}
+
+afterEach(() => vi.useRealTimers())
+
+it("reports init as unconfirmed immediately when its marker is absent", async () => {
+  const { deliver, request } = fixture()
+  const snapshot = vi.fn(async () => "123 1 -sh\n")
+  expect(await deliver(snapshot)).toMatchObject({ started: true, engineReady: false, delivered: true })
+  expect(snapshot).not.toHaveBeenCalled()
+  expect(request.mock.calls.map(([name]) => name)).toEqual(["pty.list", "pty.open", "pty.detach"])
+})
+
+it("rechecks init after the launch shell replaces an old failed marker during the process probe", async () => {
+  vi.useFakeTimers()
+  const { marker, deliver } = fixture()
+  writeFileSync(marker, "1")
+  let restarted = false
+  const result = deliver(async () => {
+    if (!restarted) {
+      renameSync(marker, `${marker}.previous`)
+      restarted = true
+    }
+    return "123 1 -sh\n456 123 bun install\n"
+  })
+  await vi.advanceTimersByTimeAsync(3300)
+  expect(await result).toMatchObject({
+    started: true,
+    engineReady: false,
+    delivered: true,
+    reason: "repo init script is still running; the engine has not started yet",
+  })
+})
+
+it("still reports a missing engine as failed after init completes", async () => {
+  vi.useFakeTimers()
+  const { marker, deliver } = fixture()
+  writeFileSync(marker, "0")
+  const result = deliver(async () => "123 1 -sh\n")
+  await vi.advanceTimersByTimeAsync(3300)
+  expect(await result).toMatchObject({ started: true, engineReady: false, delivered: false })
+})
+
+it.each(["0", "1"])("does not call a rebuilt marker with exit code %s pending init", async (code) => {
+  vi.useFakeTimers()
+  const { marker, deliver } = fixture()
+  writeFileSync(marker, "1")
+  let probe = 0
+  const result = deliver(async () => {
+    if (probe++ === 0) renameSync(marker, `${marker}.previous`)
+    else writeFileSync(marker, code)
+    return "123 1 -sh\n"
+  })
+  await vi.advanceTimersByTimeAsync(3300)
+  expect(await result).toMatchObject({ engineReady: false, delivered: false })
+})
+
+it("does not call a dead PTY pending init even when the marker disappeared", async () => {
+  vi.useFakeTimers()
+  const { marker, deliver, request } = fixture()
+  writeFileSync(marker, "1")
+  const result = deliver(async () => {
+    renameSync(marker, `${marker}.previous`)
+    request.mockResolvedValue({ sessions: [] })
+    return "123 1 -sh\n"
+  })
+  await vi.advanceTimersByTimeAsync(3300)
+  expect(await result).toMatchObject({ engineReady: false, delivered: false })
+})
+
+it("observes an engine that starts after retrying init without pasting the argv prompt again", async () => {
+  vi.useFakeTimers()
+  const { marker, deliver, request } = fixture()
+  writeFileSync(marker, "1")
+  let probe = 0
+  const result = deliver(async () => {
+    if (probe++ === 0) {
+      renameSync(marker, `${marker}.previous`)
+      return "123 1 -sh\n"
+    }
+    writeFileSync(marker, "0")
+    return "123 1 -sh\n456 123 codex\n"
+  })
+  await vi.advanceTimersByTimeAsync(3300)
+  expect(await result).toMatchObject({ engineReady: true, delivered: true })
+  expect(request.mock.calls.some(([name]) => name === "pty.write")).toBe(false)
+})


### PR DESCRIPTION
Plugin socket requests could hang after close or disconnection, stale socket callbacks could affect a reconnect, and a JSON `null` frame could crash subscribers. Keep pending requests and input buffers with their connection, settle teardown once, and validate the response/event fields consumed by the SDK. Public constructors, aliases and method signatures remain compatible.

CLI startup could report failure when a launch shell removed an old failed init marker and retried initialization during the engine process probe. Recheck marker absence and PTY liveness before returning the existing unconfirmed result. Completed init, nonzero init markers and dead PTYs retain failure handling. The argv prompt is never pasted again. The reported production incident is not conclusively attributed; this race is independently reproduced.

Combine the docs media/autolink transformations in one fence-aware pass and remove the image forwarding wrapper. Update the authorized harness section to describe command-only spec resolution and its actual test coverage.

Validation:

- `bun run lint`, `bun run typecheck`, `bun run build` pass.
- `env -u ROVE_INVOKED_AS bun run test`: 4,560 fast tests before the final marker check, plus all 26 targeted delivery tests afterward, 853 socket tests and 23 SDK tests pass.
- SDK lifecycle regressions fail before the change and pass afterward using real Unix sockets. CLI marker-race regression fails before the change; eight init cases and the existing delivery tests pass afterward.
- Full built-CLI behavior suite: 33 pass with command-scoped canonical `TMPDIR`. The ordinary macOS temp path exposes a pre-existing `/var` versus `/private/var` assertion mismatch, also reproduced independently on the base branch.
- Harness unit tests: 70 pass. Docs comparison preserves all 18 mapped pages plus a mixed fenced example, and all 19 referenced assets; fence traversals drop from two to one.

Two patch changesets cover Rove and the plugin SDK. The SDK, docs, and CLI changes are separate commits for integration review, with a follow-up covering the final asynchronous marker read.
