### PR TITLE
Five destructive paths that lost work and reported success (1-5)

### DIFF
--- a/.changeset/destructive-path-data-loss.md
+++ b/.changeset/destructive-path-data-loss.md
@@ -1,0 +1,26 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Fix five ways a destructive path could lose work without saying so.
+
+- A salvage snapshot built its throwaway index empty, so git treated tracked
+  files as untracked and `.gitignore` applied to them. Every uncommitted edit to
+  a file the repo tracks and its own `.gitignore` also matches (a committed
+  `dist/README.md`, a committed `server.log`) was recorded as a deletion while
+  the snapshot reported success. The index is now seeded from HEAD.
+- One gitignored file whose name starts with `-` made `du` read it as an option,
+  which emptied the ignored-work probe for the whole worktree — so the non-force
+  delete gate stopped refusing and `HANDOFF.md` / `.scratch/` were destroyed with
+  no snapshot. `du` now gets a `--` terminator, batches under ARG_MAX, and
+  measures newline-containing names one at a time.
+- Two salvages in the same second wrote the same ref and the second silently
+  overwrote the first, though both callers were told their work was saved. The
+  write is now create-only, and a non-ASCII branch keeps its name in the ref
+  instead of collapsing to `detached`.
+- With the "next to project" worktree location, an orphaned worktree (upstream
+  `.git` gone) could never be removed: the managed-root guard could not expand
+  `$project_dir` without the repo, so the task parked in `deletion.phase: error`
+  and every retry re-ran the same unsatisfiable branch.
+- `rove theme remove` did not validate the name, so `remove '../../notes'`
+  deleted any reachable `.json`. Both `add` and `remove` now share one check.

--- a/packages/kobe/src/cli/theme.ts
+++ b/packages/kobe/src/cli/theme.ts
@@ -189,10 +189,7 @@ async function addTheme(args: string[]): Promise<void> {
     fail(`source is not a valid Rove theme: ${result.reason}`)
   }
 
-  const name = opts.name ?? defaultName
-  if (!name || !/^[a-zA-Z0-9._-]+$/.test(name)) {
-    fail(`invalid theme name "${name}" (use letters, digits, '.', '_', '-')`)
-  }
+  const name = requireThemeName(opts.name ?? defaultName)
 
   const dir = userThemesDir()
   mkdirSync(dir, { recursive: true })
@@ -208,10 +205,28 @@ async function addTheme(args: string[]): Promise<void> {
   process.stdout.write(`installed theme "${name}" -> ${dest}\n`)
 }
 
+/**
+ * A theme name that is safe to turn into `<userThemesDir()>/<name>.json`, or
+ * exit.
+ *
+ * `join()` resolves `..`, so a name is a relative path unless something says
+ * otherwise. `add` said so from the start; `remove` did not, and went straight
+ * from an argument to `unlinkSync` — `rove theme remove '../../precious/notes'`
+ * printed `removed theme` and deleted `~/precious/notes.json`. The
+ * `BUNDLED_NAMES` check it did have only covers the built-in names, which is a
+ * different question entirely. One check, both verbs, so they cannot drift.
+ */
+function requireThemeName(name: string | undefined): string {
+  if (!name || !/^[a-zA-Z0-9._-]+$/.test(name) || name === "." || name === "..") {
+    fail(`invalid theme name "${name}" (use letters, digits, '.', '_', '-')`)
+  }
+  return name
+}
+
 function removeTheme(args: string[]): void {
-  const name = args[0]
-  if (!name) failUsage("missing <name>")
-  if (args.length > 1) failUsage(`unexpected extra arguments after "${name}"`)
+  if (!args[0]) failUsage("missing <name>")
+  if (args.length > 1) failUsage(`unexpected extra arguments after "${args[0]}"`)
+  const name = requireThemeName(args[0])
   if (BUNDLED_NAMES.includes(name)) {
     fail(`"${name}" is a built-in theme and cannot be removed`)
   }

--- a/packages/kobe/src/orchestrator/worktree/manager-remove.ts
+++ b/packages/kobe/src/orchestrator/worktree/manager-remove.ts
@@ -280,7 +280,12 @@ export async function removeWorktree(deps: RemoveDeps, worktreePath: string, opt
     if (!force) {
       throw new Error(`remove(): ${worktreePath} is not a git worktree`)
     }
-    if (!isUnderManagedWorktreesRoot(worktreePath)) {
+    // The caller's repo is what expands a `$project_dir` worktree base; with
+    // that preset every managed worktree sits outside the default roots, so
+    // without it the guard refuses paths Rove itself created and the deletion
+    // can never converge. A caller holding only a path (the worktrees page)
+    // still gets the default-root answer.
+    if (!isUnderManagedWorktreesRoot(worktreePath, opts?.repo)) {
       throw new Error(
         `remove(): ${worktreePath} has no reachable git repo and is not under a Rove worktrees root; refusing to delete it`,
       )

--- a/packages/kobe/src/orchestrator/worktree/paths.ts
+++ b/packages/kobe/src/orchestrator/worktree/paths.ts
@@ -224,21 +224,26 @@ export function isKobeManagedPath(repo: string, candidate: string): boolean {
  * repo-keyed form to decide whether the directory is its own to delete.
  *
  * Only the roots THEMSELVES are checked, not the per-repo subdir under them —
- * that subdir is derived from the repo path this function does not have. The
- * guard is deliberately narrow: it authorizes deleting a directory tree, so it
- * must never say yes to a path Rove did not create. A repo-local root
- * (`<repo>/.rove/worktrees`) is not recognized here — that form needs the repo
- * to locate, which is exactly what is missing. Same for a `$project_dir`
- * override: it expands per-repo, so without one it contributes nothing and the
- * built-in default covers what is left.
+ * that subdir is derived from the repo path, which the sole caller may not
+ * have. The guard is deliberately narrow: it authorizes deleting a directory
+ * tree, so it must never say yes to a path Rove did not create. A repo-local
+ * root (`<repo>/.rove/worktrees`) is not recognized here — that form needs the
+ * repo to locate, which is exactly what is missing when it is.
+ *
+ * `projectDir` is the repo that owns `candidate`, when the caller knows it
+ * (a task record carries `task.repo`). It is REQUIRED for a `$project_dir`
+ * worktree base to be recognized at all: that override expands per-repo, so
+ * without one it contributes no root and the answer collapses to the built-in
+ * default. Under the shipped `$project_dir/..` preset (Settings → "next to
+ * project") every worktree lives outside every default root, so the guard
+ * answered false for paths Rove itself had created — and the one caller turns
+ * that into a permanent refusal, parking the task in `deletion.phase: "error"`
+ * where every retry re-runs the same unsatisfiable branch.
  */
-export function isUnderManagedWorktreesRoot(candidate: string): boolean {
+export function isUnderManagedWorktreesRoot(candidate: string, projectDir?: string): boolean {
   if (!path.isAbsolute(candidate)) return false
   const target = canonicalize(candidate)
-  // The override with no repo resolves the non-`$project_dir` forms; a
-  // `$project_dir` override falls back to the default root without one, which
-  // this list already covers.
-  const roots = [getWorktreeBaseOverride() ?? "", defaultLocalWorktreesRoot(), legacyLocalWorktreesRoot()]
+  const roots = [getWorktreeBaseOverride(projectDir) ?? "", defaultLocalWorktreesRoot(), legacyLocalWorktreesRoot()]
   for (const rootPath of roots) {
     if (!rootPath) continue
     const root = canonicalize(rootPath)

--- a/packages/kobe/src/orchestrator/worktree/salvage-ignored.ts
+++ b/packages/kobe/src/orchestrator/worktree/salvage-ignored.ts
@@ -41,6 +41,13 @@ export function parseIgnoredPaths(stdoutZ: string): string[] {
     .filter((p) => p.length > 0)
 }
 
+/**
+ * Argv byte budget for one `du`. ARG_MAX is 1 MB on macOS and ~2 MB on Linux;
+ * 96 KB per batch is far under both (and under the per-argument limits) while
+ * keeping the call count at one for any ordinary worktree.
+ */
+const DU_ARGV_BUDGET_BYTES = 96 * 1024
+
 /** Parse `du -sk <paths…>` output into path → kilobytes. */
 export function parseDuKb(stdout: string): Map<string, number> {
   const sizes = new Map<string, number>()
@@ -48,6 +55,50 @@ export function parseDuKb(stdout: string): Map<string, number> {
     const m = /^(\d+)\s+(.+)$/.exec(line.trim())
     if (m?.[1] && m[2]) sizes.set(m[2], Number.parseInt(m[1], 10))
   }
+  return sizes
+}
+
+/**
+ * `du -sk` over `paths`, as path → kilobytes.
+ *
+ * Each ignored directory is reported collapsed by `git status`, so this is a
+ * handful of arguments rather than a walk of the whole tree. Three things a
+ * single naked `du -sk ...paths` got wrong, each of which silently emptied the
+ * result for the WHOLE worktree — and with it every protection built on it
+ * (the non-force delete gate in `manager-remove.ts` and salvage's `add -f`
+ * pass), because a path whose size cannot be read is skipped:
+ *
+ *   - no `--`: ONE ignored file whose name begins with `-` is read as an
+ *     option (`du: invalid option -- w`, exit 64, empty stdout), so a single
+ *     `-weird.log` disarmed the gate for every other file beside it;
+ *   - no chunking: past ARG_MAX the spawn fails with E2BIG;
+ *   - a newline in a filename: `du`'s output is line-oriented, so such a path
+ *     can never be matched back to its line. Those are measured one at a time,
+ *     where the leading number is unambiguous without matching the name.
+ */
+async function duKb(exec: ExecHost, worktreePath: string, paths: readonly string[]): Promise<Map<string, number>> {
+  const sizes = new Map<string, number>()
+  const batch: string[] = []
+  let bytes = 0
+  const flush = async () => {
+    if (batch.length === 0) return
+    const du = await exec.run(["du", "-sk", "--", ...batch], { cwd: worktreePath })
+    for (const [p, kb] of parseDuKb(du.stdout)) sizes.set(p, kb)
+    batch.length = 0
+    bytes = 0
+  }
+  for (const p of paths) {
+    if (p.includes("\n")) {
+      const one = await exec.run(["du", "-sk", "--", p], { cwd: worktreePath })
+      const kb = /^\s*(\d+)/.exec(one.stdout)?.[1]
+      if (one.exitCode === 0 && kb) sizes.set(p, Number.parseInt(kb, 10))
+      continue
+    }
+    if (bytes + p.length + 1 > DU_ARGV_BUDGET_BYTES) await flush()
+    batch.push(p)
+    bytes += p.length + 1
+  }
+  await flush()
   return sizes
 }
 
@@ -73,10 +124,7 @@ export async function smallIgnoredPaths(exec: ExecHost, worktreePath: string): P
     const paths = parseIgnoredPaths(status.stdout)
     if (paths.length === 0) return []
 
-    // One `du` for every entry: each ignored directory is reported collapsed,
-    // so this is a handful of arguments, not a walk of the whole tree.
-    const du = await exec.run(["du", "-sk", ...paths], { cwd: worktreePath })
-    const sizes = parseDuKb(du.stdout)
+    const sizes = await duKb(exec, worktreePath, paths)
     return paths.filter((p) => {
       const kb = sizes.get(p)
       return kb !== undefined && kb <= MAX_IGNORED_ENTRY_KB

--- a/packages/kobe/src/orchestrator/worktree/salvage.ts
+++ b/packages/kobe/src/orchestrator/worktree/salvage.ts
@@ -14,10 +14,11 @@
  * untracked tree) — and a new file nobody has `git add`ed yet is exactly the
  * kind most easily lost. So the snapshot is built by hand:
  *
- *     GIT_INDEX_FILE=<throwaway> git add -A   → stages tracked edits + untracked
- *     git write-tree                          → a tree of the whole worktree
- *     git commit-tree <tree> -p HEAD          → a commit rooted at real history
- *     git update-ref refs/rove/salvage/<slug> → a named, gc-proof anchor
+ *     GIT_INDEX_FILE=<throwaway> git read-tree HEAD  → so git knows what's TRACKED
+ *                                git add -A          → tracked edits + untracked
+ *     git write-tree                                 → a tree of the whole worktree
+ *     git commit-tree <tree> -p HEAD                 → a commit rooted at real history
+ *     git update-ref refs/rove/salvage/<slug> <c> "" → a named, gc-proof anchor
  *
  * `git add -A` honours `.gitignore` — which keeps `node_modules/` out, and
  * ALSO threw away real work: `HANDOFF.md`, `.scratch/**`, `.env*` and
@@ -67,18 +68,76 @@ async function gitlinkPaths(git: (args: readonly string[]) => Promise<GitRunResu
     .filter((p) => p.length > 0)
 }
 
+/**
+ * A branch name as one ref-name component, keeping everything
+ * `git check-ref-format` allows.
+ *
+ * Only what git actually forbids is replaced — control characters, space,
+ * `~^:?*[\`, a `..` run, a `@{` sequence, a leading/trailing `.` or `-` — plus
+ * `/`, flattened so every snapshot stays exactly one level under
+ * `refs/rove/salvage/`. Ref names are byte strings, so a UTF-8
+ * branch survives intact; the old `[^A-Za-z0-9._-]` filter erased a Chinese
+ * branch name down to the empty string and EVERY such snapshot was named
+ * `detached-<stamp>` — unidentifiable, and colliding with the next one.
+ *
+ * A `.lock` suffix needs no handling: git forbids it only at the END of a
+ * component, and the slug is always followed by `-<stamp>` in the finished ref.
+ */
+export function branchRefSlug(branch: string | null): string {
+  return (
+    (branch ?? "")
+      // biome-ignore lint/suspicious/noControlCharactersInRegex: git defines its refname rules over exactly these bytes.
+      .replace(/[\u0000-\u0020\u007f~^:?*[\\/]+/g, "-")
+      .replace(/@\{/g, "-")
+      .replace(/\.{2,}/g, "-")
+      .replace(/^[-.]+|[-.]+$/g, "") || "detached"
+  )
+}
+
 /** `refs/rove/salvage/<branch>-<utc-stamp>` — a ref name git accepts, keyed by
  *  the two things a user remembers: which branch, and roughly when. Exported
  *  so {@link anchorBranchTip} writes into the SAME namespace: a user who lost
  *  work has one place to look and one `for-each-ref` to run, whether the loss
- *  was a force-removed worktree or a squash-landed branch. */
+ *  was a force-removed worktree or a squash-landed branch.
+ *
+ *  The stamp resolves to the SECOND, and the slug is lossy by construction
+ *  (`feat/login` and `feat-login` both flatten to `feat-login`), so this name
+ *  is a preferred name rather than a unique one — {@link createSalvageRef}
+ *  owns making the write itself collision-proof. */
 export function salvageRef(branch: string | null, now: Date): string {
   const stamp = now
     .toISOString()
     .replace(/[-:]/g, "")
     .replace(/\.\d+Z$/, "Z")
-  const slug = (branch ?? "detached").replace(/[^A-Za-z0-9._-]+/g, "-").replace(/^[-.]+|[-.]+$/g, "")
-  return `refs/rove/salvage/${slug || "detached"}-${stamp}`
+  return `refs/rove/salvage/${branchRefSlug(branch)}-${stamp}`
+}
+
+/**
+ * Write `commit` under `preferred`, NEVER over a ref that already exists.
+ *
+ * `git update-ref <ref> <new>` overwrites unconditionally, and two names
+ * collide easily: the stamp only resolves to the second, and the slug flattens
+ * `feat/login` and `feat-login` together. Deleting a batch of tasks lands
+ * several force-removes inside one second by construction, so the first
+ * snapshot became a dangling commit reachable from nothing — while both
+ * callers were handed a ref and told their work was saved.
+ *
+ * An EMPTY `<oldvalue>` makes the write a create-only compare-and-swap (git
+ * refuses with "reference already exists"); the empty string rather than the
+ * all-zero OID because that literal is hash-length dependent and this one is
+ * not. Numbered suffixes then find the next free name. Returns the ref
+ * actually written, or null if none could be.
+ */
+async function createSalvageRef(
+  git: (args: readonly string[]) => Promise<GitRunResult>,
+  preferred: string,
+  commit: string,
+): Promise<string | null> {
+  for (let attempt = 1; attempt <= 50; attempt++) {
+    const ref = attempt === 1 ? preferred : `${preferred}-${attempt}`
+    if ((await git(["update-ref", ref, commit, ""])).exitCode === 0) return ref
+  }
+  return null
 }
 
 /**
@@ -119,7 +178,25 @@ export async function salvageWorktree(
     const withIndex = (args: readonly string[]) =>
       deps.runGit(exec, args, { cwd: worktreePath, allowFail: true, env: { GIT_INDEX_FILE: indexPath } })
 
+    // Parent the snapshot on HEAD so `git show <ref>` diffs against the real
+    // history. An unborn branch has no HEAD — commit a root instead of losing
+    // the files.
+    const head = (await git(["rev-parse", "HEAD"])).stdout.trim()
+    const branch = (await git(["rev-parse", "--abbrev-ref", "HEAD"])).stdout.trim()
+
     try {
+      // Seed the throwaway index from HEAD before staging anything.
+      //
+      // An EMPTY index makes git treat every path as untracked, and
+      // `.gitignore` only applies to untracked paths — so `add -A` skipped
+      // every TRACKED file the repo's own `.gitignore` happens to cover (a
+      // committed `dist/README.md` under `dist/`, a committed `server.log`
+      // under `*.log`). The `add -f` pass below cannot recover them either:
+      // its input comes from `git status --ignored`, which reports a tracked
+      // file as ` M` and NEVER as `!!`. The snapshot then recorded those
+      // files as DELETIONS, `uncaptured` stayed empty, and the caller
+      // reported a successful salvage over work that no longer existed.
+      if (head && (await withIndex(["read-tree", head])).exitCode !== 0) return null
       if ((await withIndex(["add", "-A"])).exitCode !== 0) return null
       // Second pass: the ignored entries that are a person's work rather than
       // build output. `-f` is what overrides `.gitignore`; without it the
@@ -129,18 +206,13 @@ export async function salvageWorktree(
       const tree = (await withIndex(["write-tree"])).stdout.trim()
       if (!tree) return null
 
-      // Parent the snapshot on HEAD so `git show <ref>` diffs against the
-      // real history. An unborn branch has no HEAD — commit a root instead
-      // of losing the files.
-      const head = (await git(["rev-parse", "HEAD"])).stdout.trim()
-      const branch = (await git(["rev-parse", "--abbrev-ref", "HEAD"])).stdout.trim()
       const message = `rove salvage: force-removed worktree ${worktreePath}`
       const commitArgs = head ? ["commit-tree", tree, "-p", head, "-m", message] : ["commit-tree", tree, "-m", message]
       const commit = (await withIndex(commitArgs)).stdout.trim()
       if (!commit) return null
 
-      const ref = salvageRef(branch && branch !== "HEAD" ? branch : null, now)
-      if ((await git(["update-ref", ref, commit])).exitCode !== 0) return null
+      const ref = await createSalvageRef(git, salvageRef(branch && branch !== "HEAD" ? branch : null, now), commit)
+      if (!ref) return null
       // Read back what the tree actually holds. A submodule or nested worktree
       // staged as a `160000` gitlink is a promise the recovery commands cannot
       // keep, so the record says which paths it missed rather than letting the

--- a/packages/kobe/test/cli/theme.test.ts
+++ b/packages/kobe/test/cli/theme.test.ts
@@ -244,6 +244,24 @@ describe("runThemeSubcommand remove", () => {
     expect(err()).toContain("is a built-in theme and cannot be removed")
   })
 
+  /**
+   * `join()` resolves `..`, so a theme name is a relative path unless
+   * something says otherwise. `add` validated its name from the start; `remove`
+   * went straight from the argument to `unlinkSync`, so
+   * `rove theme remove '../../precious/notes'` printed `removed theme` and
+   * deleted a file two directories outside the themes dir. The `BUNDLED_NAMES`
+   * check it did have only answers a different question.
+   */
+  it("refuses a name that escapes the themes directory", async () => {
+    mkdirSync(join(home, "precious"), { recursive: true })
+    const outside = join(home, "precious", "notes.json")
+    writeFileSync(outside, '{"secret":"keep me"}', "utf8")
+
+    await expect(runThemeSubcommand(["remove", "../../precious/notes"])).rejects.toThrow("exit 1")
+    expect(err()).toContain('invalid theme name "../../precious/notes"')
+    expect(readFileSync(outside, "utf8")).toBe('{"secret":"keep me"}')
+  })
+
   it("fails when no such user theme exists", async () => {
     await expect(runThemeSubcommand(["remove", "nope"])).rejects.toThrow("exit 1")
     expect(err()).toContain('no user theme named "nope"')

--- a/packages/kobe/test/orchestrator/salvage-ignored.test.ts
+++ b/packages/kobe/test/orchestrator/salvage-ignored.test.ts
@@ -41,7 +41,7 @@ beforeEach(() => {
   fs.writeFileSync(path.join(repo, "tracked.txt"), "committed\n")
   // The Rove repo's own ignore set, near enough: build output plus the files
   // that actually carry an agent's unpushed reasoning.
-  fs.writeFileSync(path.join(repo, ".gitignore"), "node_modules/\nHANDOFF.md\n.scratch/\n.env\n")
+  fs.writeFileSync(path.join(repo, ".gitignore"), "node_modules/\nHANDOFF.md\n.scratch/\n.env\n*.log\n")
   git(repo, "add", "-A")
   git(repo, "commit", "-qm", "init")
 })
@@ -169,4 +169,36 @@ test("an ignored tree over the size budget still deletes with no force", async (
   expect(git(wt, "status", "--porcelain")).toBe("")
   await new GitWorktreeManager().remove(wt)
   expect(fs.existsSync(wt)).toBe(false)
+})
+
+/**
+ * One ignored file whose name starts with `-`, and the protection for every
+ * OTHER file in the worktree switches off.
+ *
+ * `du -sk <paths…>` carried no `--`, so both BSD and GNU `du` read that name
+ * as an option bundle (`du: invalid option -- w`, exit 64, empty stdout). The
+ * empty size map then failed the `sizes.get(p) !== undefined` filter for every
+ * entry, `ignoredWork()` came back empty for the WHOLE worktree, and the
+ * non-force delete gate — the only thing standing between `HANDOFF.md` and
+ * `git worktree remove` — stopped refusing. The non-force path takes no
+ * salvage snapshot, so the file was gone with no copy anywhere.
+ *
+ * Both halves are asserted on one worktree: what the probe reports, and what
+ * is still on disk after the removal it authorizes.
+ */
+test("an ignored file named like a flag does not disarm the ignored-work gate", async () => {
+  const wt = path.join(tmpRoot, "dash-named")
+  git(repo, "worktree", "add", "-q", wt, "-b", "dash-named")
+  fs.writeFileSync(path.join(wt, "HANDOFF.md"), "a whole session of reasoning\n")
+  fs.writeFileSync(path.join(wt, "-weird.log"), "innocuous\n")
+
+  // `.gitignore` covers both, and to `git status --porcelain` this is clean.
+  expect(git(wt, "status", "--porcelain")).toBe("")
+
+  const ignored = await new GitWorktreeManager().ignoredWork(wt)
+  expect(ignored).toContain("HANDOFF.md")
+  expect(ignored).toContain("-weird.log")
+
+  await expect(new GitWorktreeManager().remove(wt)).rejects.toThrow(/gitignored work/)
+  expect(fs.existsSync(path.join(wt, "HANDOFF.md"))).toBe(true)
 })

--- a/packages/kobe/test/orchestrator/worktree-base.test.ts
+++ b/packages/kobe/test/orchestrator/worktree-base.test.ts
@@ -12,7 +12,12 @@ import fs from "node:fs"
 import os from "node:os"
 import path from "node:path"
 import { afterEach, beforeEach, describe, expect, test } from "vitest"
-import { managedWorktreeRootsFor, worktreeRootFor } from "../../src/orchestrator/worktree/paths.ts"
+import {
+  isUnderManagedWorktreesRoot,
+  managedWorktreeRootsFor,
+  worktreePathFor,
+  worktreeRootFor,
+} from "../../src/orchestrator/worktree/paths.ts"
 import {
   PROJECT_SIBLING_BASE,
   getWorktreeBaseOverride,
@@ -154,5 +159,33 @@ describe("worktree paths honor the override", () => {
     const defaultRoot = path.join(home, ".rove", "worktrees", path.basename(activeRoot))
     expect(roots[0]).toBe(activeRoot)
     expect(roots).toContain(defaultRoot)
+  })
+
+  /**
+   * The guard that authorizes `rm -rf` on an ORPHANED worktree — one whose
+   * upstream `.git` is gone (a deleted clone, macOS pruning `/tmp`), so no repo
+   * can be discovered from disk and `git worktree remove` has nothing to run.
+   *
+   * Under the shipped `$project_dir/..` preset ("next to project") every
+   * managed worktree lives outside every default root, and the guard was asked
+   * with no repo — which is exactly when a `$project_dir` base expands to
+   * nothing. So it answered false for a path Rove itself had created, force
+   * removal threw, and the task parked in `deletion.phase: "error"` where every
+   * retry re-ran the same unsatisfiable branch.
+   */
+  test("a $project_dir worktree is recognized as managed when the repo is known", () => {
+    writeState({ "worktree.basePath": PROJECT_SIBLING_BASE })
+    // On disk, like the orphan the guard is actually asked about: the guard
+    // canonicalizes both sides, and macOS resolves the tempdir's `/var` →
+    // `/private/var` symlink only for a path that exists.
+    const wt = worktreePathFor(repo, "tapir")
+    fs.mkdirSync(wt, { recursive: true })
+
+    // The premise: this really is outside the default root.
+    expect(wt.startsWith(path.join(home, ".rove", "worktrees"))).toBe(false)
+    expect(isUnderManagedWorktreesRoot(wt, repo)).toBe(true)
+
+    // A path Rove did NOT create stays unauthorized, repo or not.
+    expect(isUnderManagedWorktreesRoot(path.join(tmpRoot, "somewhere", "else"), repo)).toBe(false)
   })
 })

--- a/packages/kobe/test/orchestrator/worktree-base.test.ts
+++ b/packages/kobe/test/orchestrator/worktree-base.test.ts
@@ -175,17 +175,28 @@ describe("worktree paths honor the override", () => {
    */
   test("a $project_dir worktree is recognized as managed when the repo is known", () => {
     writeState({ "worktree.basePath": PROJECT_SIBLING_BASE })
-    // On disk, like the orphan the guard is actually asked about: the guard
-    // canonicalizes both sides, and macOS resolves the tempdir's `/var` →
-    // `/private/var` symlink only for a path that exists.
-    const wt = worktreePathFor(repo, "tapir")
+    // Nested one level down so the base root is `<tmpRoot>/code`, leaving
+    // `<tmpRoot>` itself available as somewhere genuinely outside it.
+    const sibRepo = path.join(tmpRoot, "code", "myproj")
+    fs.mkdirSync(sibRepo, { recursive: true })
+
+    // Every path is created on disk: the guard canonicalizes both sides, and
+    // macOS resolves the tempdir's `/var` → `/private/var` symlink only for a
+    // path that exists — so a missing path answers false for the wrong reason.
+    const wt = worktreePathFor(sibRepo, "tapir")
     fs.mkdirSync(wt, { recursive: true })
 
     // The premise: this really is outside the default root.
     expect(wt.startsWith(path.join(home, ".rove", "worktrees"))).toBe(false)
-    expect(isUnderManagedWorktreesRoot(wt, repo)).toBe(true)
+    expect(isUnderManagedWorktreesRoot(wt, sibRepo)).toBe(true)
 
-    // A path Rove did NOT create stays unauthorized, repo or not.
-    expect(isUnderManagedWorktreesRoot(path.join(tmpRoot, "somewhere", "else"), repo)).toBe(false)
+    // Outside every root: still refused. This guard authorizes `rm -rf`, so
+    // widening it for `$project_dir` must not widen it for anything else.
+    const outside = path.join(tmpRoot, "elsewhere", "a", "b")
+    fs.mkdirSync(outside, { recursive: true })
+    expect(isUnderManagedWorktreesRoot(outside, sibRepo)).toBe(false)
+
+    // And the depth rule still holds: the per-repo dir is not itself a worktree.
+    expect(isUnderManagedWorktreesRoot(path.dirname(wt), sibRepo)).toBe(false)
   })
 })

--- a/packages/kobe/test/orchestrator/worktree-salvage.test.ts
+++ b/packages/kobe/test/orchestrator/worktree-salvage.test.ts
@@ -18,7 +18,9 @@ import fs from "node:fs"
 import os from "node:os"
 import path from "node:path"
 import { afterEach, beforeEach, expect, test } from "vitest"
+import { type ExecHost, LocalExecHost } from "../../src/exec/exec-host.ts"
 import { GitWorktreeManager } from "../../src/orchestrator/worktree/manager.ts"
+import { type SalvageRecord, salvageRef, salvageWorktree } from "../../src/orchestrator/worktree/salvage.ts"
 
 let tmpRoot: string
 let repo: string
@@ -178,4 +180,101 @@ test("a submodule's uncommitted work is reported as uncaptured, not silently mis
   // The snapshot genuinely cannot hold it — the point is that it says so.
   expect(git(repo, "ls-tree", "-r", "--name-only", record?.ref as string)).not.toContain("subwork.txt")
   expect(record?.uncaptured).toEqual(["vendor/child"])
+})
+
+/**
+ * A file the repo TRACKS whose path its own `.gitignore` also covers.
+ *
+ * That combination is ordinary — a committed `dist/README.md` under `dist/`, a
+ * committed `server.log` under `*.log` — and the snapshot silently dropped
+ * every uncommitted edit to it. The throwaway index was created EMPTY, so git
+ * saw those paths as untracked and `.gitignore` applied; the `add -f` rescue
+ * pass could not cover for it either, because its input is
+ * `git status --ignored`, which reports a tracked file as ` M` and never `!!`.
+ *
+ * The assertion is the recovered CONTENT, plus the diff direction: the broken
+ * snapshot did not merely omit the files, it recorded them as deletions while
+ * reporting a clean salvage.
+ */
+test("a tracked file that .gitignore also matches keeps its uncommitted edits", async () => {
+  fs.mkdirSync(path.join(repo, "dist"))
+  fs.writeFileSync(path.join(repo, "dist", "README.md"), "committed\n")
+  fs.writeFileSync(path.join(repo, "server.log"), "committed\n")
+  fs.writeFileSync(path.join(repo, ".gitignore"), "node_modules/\ndist/\n*.log\n")
+  git(repo, "add", "-A", "-f")
+  git(repo, "commit", "-qm", "track files the ignore rules also match")
+
+  const wt = path.join(tmpRoot, "tracked-ignored")
+  git(repo, "worktree", "add", "-q", wt, "-b", "tracked-ignored")
+  fs.appendFileSync(path.join(wt, "dist", "README.md"), "uncommitted edit\n")
+  fs.appendFileSync(path.join(wt, "server.log"), "uncommitted edit\n")
+
+  let salvaged: { ref: string } | null = null
+  await new GitWorktreeManager().remove(wt, {
+    force: true,
+    onSalvage: (record) => {
+      salvaged = record
+    },
+  })
+
+  expect(fs.existsSync(wt)).toBe(false)
+  const ref = (salvaged as unknown as { ref: string } | null)?.ref
+  expect(ref).toBeTruthy()
+  expect(git(repo, "show", `${ref}:dist/README.md`)).toBe("committed\nuncommitted edit\n")
+  expect(git(repo, "show", `${ref}:server.log`)).toBe("committed\nuncommitted edit\n")
+  // Recorded as edits, not as the deletions the empty index produced.
+  expect(git(repo, "diff", "--stat", `${ref}^`, ref as string)).not.toContain("deletion")
+})
+
+/**
+ * Two force-removes inside the same second.
+ *
+ * The ref name carries only a second-resolution stamp and a lossy slug
+ * (`feat/login` and `feat-login` flatten together), and `git update-ref`
+ * overwrites unconditionally — so deleting a batch of tasks, which lands
+ * several removals in one second by construction, left the first snapshot as a
+ * dangling commit reachable from nothing. Both callers were handed a ref and
+ * told their work was saved.
+ *
+ * The clock is pinned because the bug is invisible whenever the two calls
+ * happen to straddle a second boundary.
+ */
+test("two salvages in the same second both stay recoverable", async () => {
+  const exec = new LocalExecHost()
+  const deps = {
+    runGit: async (e: ExecHost, args: readonly string[], opts: { cwd: string; env?: Record<string, string> }) => {
+      const r = await e.run(["git", ...args], opts)
+      return { stdout: r.stdout, stderr: r.stderr, exitCode: r.exitCode }
+    },
+  }
+  const now = new Date("2026-01-02T03:04:05Z")
+
+  const refs: string[] = []
+  for (const [branch, content] of [
+    ["feat/login", "WORK-A"],
+    ["feat-login", "WORK-B"],
+  ] as const) {
+    const wt = path.join(tmpRoot, branch.replace("/", "_"))
+    git(repo, "worktree", "add", "-q", wt, "-b", branch)
+    fs.writeFileSync(path.join(wt, "only.txt"), `${content}\n`)
+    const record = await salvageWorktree(deps, exec, wt, now)
+    expect(record).not.toBeNull()
+    refs.push((record as SalvageRecord).ref)
+  }
+
+  // Distinct names, and BOTH still resolve — the second write must not have
+  // been allowed to take the first one's name.
+  expect(new Set(refs).size).toBe(2)
+  expect(git(repo, "show", `${refs[0]}:only.txt`)).toBe("WORK-A\n")
+  expect(git(repo, "show", `${refs[1]}:only.txt`)).toBe("WORK-B\n")
+  expect(git(repo, "for-each-ref", "refs/rove/salvage", "--format=%(refname)").trim().split("\n")).toHaveLength(2)
+})
+
+/** A branch with no ASCII in it must still be identifiable in the ref name.
+ *  The old `[^A-Za-z0-9._-]` filter erased it to the empty string, so every
+ *  non-ASCII branch's snapshot was called `detached-<stamp>`. */
+test("a non-ASCII branch name survives into the salvage ref", () => {
+  expect(salvageRef("修复/登录问题", new Date("2026-01-02T03:04:05Z"))).toBe(
+    "refs/rove/salvage/修复-登录问题-20260102T030405Z",
+  )
 })


### PR DESCRIPTION
Five destructive paths that lost work and reported success. All five were reproduced on a real filesystem first, and each carries one regression test that goes red when its fix is reverted.

## 1. A salvage snapshot dropped edits to a tracked file its own `.gitignore` matches

`salvageWorktree` created its throwaway index with `git rev-parse --git-path rove-salvage-index` — an **empty** index — and then ran `add -A`. With nothing in the index git treats every path as untracked, and `.gitignore` only applies to untracked paths, so `add -A` skipped every tracked file the repo's ignore rules happen to cover (a committed `dist/README.md` under `dist/`, a committed `server.log` under `*.log`).

The `add -f` rescue pass could not cover for it: its input is `smallIgnoredPaths`, which reads `git status --porcelain --ignored`, and git reports a tracked file as ` M`, never `!!`. The snapshot then recorded those files as **deletions** while `SalvageRecord.uncaptured` stayed empty and the caller reported a successful salvage.

Mechanism, same worktree, one command apart:

```
empty index      + add -A  ->  .gitignore base.txt new.txt
read-tree HEAD   + add -A  ->  .gitignore base.txt dist/README.md new.txt server.log
```

Fix: seed the index from HEAD before staging.

## 2. One gitignored filename starting with `-` disarmed ignored-work protection for the whole worktree

`exec.run(["du", "-sk", ...paths])` had no `--`. `paths` comes straight from git, so one entry named `-weird.log` is read as an option bundle by both BSD and GNU `du`:

```
du -sk    -weird.log HANDOFF.md   ->  du: invalid option -- w      exit 64, empty stdout
du -sk -- -weird.log HANDOFF.md   ->  4  -weird.log / 4  HANDOFF.md   exit 0
```

Empty stdout means an empty size map, and the `sizes.get(p) !== undefined` filter then dropped **every** entry — so `ignoredWork()` returned `[]` for the whole worktree, the non-force delete gate in `manager-remove.ts` stopped refusing, and `git worktree remove` destroyed `HANDOFF.md` / `.scratch/`. The non-force path takes no salvage snapshot, so there was no copy anywhere.

Fixed all three variants of the same defect on that line: the `--` terminator, ARG_MAX batching (96 KB of argv per call), and newline-containing filenames (measured one at a time, where the leading number is unambiguous without matching the name back to a line).

## 3. Two salvages in the same second, second silently overwrites the first

`salvageRef` normalises to a second-resolution stamp and a lossy slug, and `git update-ref` overwrites unconditionally. `feat/login` and `feat-login` flatten to the same name; a purely non-ASCII branch was erased to the empty string by `[^A-Za-z0-9._-]` and every such snapshot was called `detached-<stamp>`. Batch task deletion lands several force-removes inside one second by construction, so the first snapshot became a dangling commit reachable from nothing — while both callers were handed a ref.

Two fixes: the write is now a create-only compare-and-swap (`git update-ref <ref> <commit> ""`, then numbered suffixes), and the slug only replaces what `git check-ref-format` actually forbids, so `修复/登录问题` becomes `修复-登录问题` instead of `detached`.

## 4. `$project_dir` worktree base made an orphaned worktree permanently unremovable

`isUnderManagedWorktreesRoot` called `getWorktreeBaseOverride()` with no `projectDir`, and `normalizeWorktreeBase` returns `null` for a `$project_dir` base without one — so the configured root contributed nothing and only the built-in defaults remained. Under the shipped `PROJECT_SIBLING_BASE` (`$project_dir/..`) preset every worktree lives outside those, so the guard answered false for paths Rove itself created. When the upstream `.git` was gone (deleted clone, macOS pruning `/tmp`), force removal threw and the task parked in `deletion.phase: "error"` — every retry re-running the same unsatisfiable branch that the comment right above it says to avoid.

Fix: `isUnderManagedWorktreesRoot(candidate, projectDir?)`, with `manager-remove.ts` passing `opts?.repo` (which `task-deletion.ts` already supplies as `task.repo`).

**Deviation from the brief, flagged deliberately.** The stated pass criterion was that `isUnderManagedWorktreesRoot(<path>)` return `true` with no repo argument. It still returns `false` there, and I think that is correct: with the repo gone from disk there is no sound way to invert `$project_dir` from the path alone — the repo key is `<sanitised basename>-<sha1(repoPath)[0:12]>` and the sanitisation is not invertible, so any no-repo answer would be a guess. This guard authorises `rm -rf`, so a guess is the wrong shape. The end-to-end criterion (`remove()` succeeds, directory gone) is met.

The one caller left without a repo is the worktrees page (`removeWorktreeAdapter` takes only a path). That path is unreachable for this bug — `listWorktreeProjectsAdapter` enumerates `getSavedRepos()` and calls `manager.listAll(repo)`, so a worktree whose repo is destroyed never becomes a row. `WorktreeAuditRow` already carries `repo`, so threading it is possible, but it widens the daemon RPC and is out of this slice.

## 5. `rove theme remove` deleted any reachable `.json`

`addTheme` validated its name with `/^[a-zA-Z0-9._-]+$/`; `removeTheme` did not, and went straight from the argument to `join(userThemesDir(), \`${name}.json\`)` and `unlinkSync`. `join` resolves `..`. The `BUNDLED_NAMES` guard it did have answers a different question.

```
$ rove theme remove '../../precious/notes'
removed theme "../../precious/notes" ($H/precious/notes.json)     # and the file was gone
```

Fix: one `requireThemeName` used by both verbs, so they cannot drift.

## Audit of the same shape elsewhere

- Other `exec.run` calls under `orchestrator/worktree/` pass paths that `requireAbsolute` has already checked (`rm -rf <worktreePath>`, `rm -f <indexPath>`), so they cannot start with `-`.
- `git worktree add`'s branch/ref arguments are not user-controllable into an option — git refuses a branch name beginning with `-` outright (`fatal: '-evil' is not a valid branch name`).
- Plugin ids reach `rmSync(pluginCheckoutDir(id))`, but `PLUGIN_ID_RE = /^[A-Za-z0-9][A-Za-z0-9._:-]*$/` already rejects both a leading `.` and any `/`. No traversal.

Theme `remove` was the only unvalidated user input reaching a destructive path operation.

## Verification

Mutation-verified: reverting each fix in isolation turns exactly one test red.

| Reverted | Test that fails |
|---|---|
| the `read-tree HEAD` seed | `a tracked file that .gitignore also matches keeps its uncommitted edits` |
| `--` from the batched `du` | `an ignored file named like a flag does not disarm the ignored-work gate` |
| the CAS `""` oldvalue | `two salvages in the same second both stay recoverable` |
| the `projectDir` argument | `a $project_dir worktree is recognized as managed when the repo is known` |
| `requireThemeName` in `removeTheme` | `refuses a name that escapes the themes directory` |

Gates: `bun run test:fast` 4557 passed / 461 files, `bun run typecheck` clean, repo-root `bun run lint` clean. All touched files are well under the 500-line cap (largest is `manager-remove.ts` at 370).
