### PR TITLE
CI finishing on one of your tasks was silent — the poller had no subscriber

### DIFF
--- a/.changeset/pr-check-toast.md
+++ b/.changeset/pr-check-toast.md
@@ -1,0 +1,24 @@
+---
+"@sma1lboy/rove": patch
+---
+
+CI finishing on one of your tasks now says so, instead of only changing a chip
+
+The daemon has polled `gh pr list` per task for a while, and it already wrote
+`checkState` onto the task and pushed it to every client. Nothing in the TUI
+ever read that field. So the only signal that a PR's checks had landed was the
+sidebar chip changing colour — which you see if you happen to be looking at
+that row, and which is exactly the wrong shape for the case the poller was
+built for: four tasks in flight, you in the fifth.
+
+Checks resolving now raise a toast naming the task, whether they passed or
+failed, and which PR. Only the resolution is announced: a run that merely
+started (no checks → pending) stays quiet, as does every flap in between, and a
+task whose checks were already settled when the daemon came back does not
+re-announce itself on restart. The rule was written and unit-tested when the
+poller shipped (`checkResolutionNotify`); it had no subscriber until now.
+
+Two call sites that were each deriving "is this task's repo a remote `ssh://`
+project?" by hand — the engine launch builder and the workspace centre column —
+now ask `remoteKeyForRepo`, the helper that was already written to be the one
+place that decision is made.

--- a/packages/kobe/src/engine/session-launch.ts
+++ b/packages/kobe/src/engine/session-launch.ts
@@ -1,9 +1,9 @@
 import { toPosixPath } from "@sma1lboy/kobe-daemon/daemon/platform-shell"
 import { worktreeInitMarkerPath } from "../env.ts"
+import { remoteKeyForRepo } from "../exec/resolve.ts"
 import { quoteShellArg, quoteShellArgv } from "../lib/shell-command.ts"
 import { readFieldNotes } from "../state/field-notes.ts"
 import { type PromptDeliveryIntent, resolveEngineLaunchInit } from "../state/repo-init.ts"
-import { isRemoteRepoKey } from "../state/repos.ts"
 import type { VendorId } from "../types/vendor.ts"
 import { protocolEntry } from "./engine-presets.ts"
 import { withDispatcherProtocol, withWorktreeProtocol } from "./worktree-protocol.ts"
@@ -239,7 +239,7 @@ export function buildEngineSessionLaunch(input: EngineSessionLaunchInput): Engin
   // point funnels through — the Workspace host's tab open, `rove api send`,
   // and a prompted `add` alike (docs/ARCHITECTURE.md names it the canonical
   // launch builder). A per-caller check would leave whichever caller came next.
-  const remoteKey = [input.task.repo, input.worktreePath].find((key) => key && isRemoteRepoKey(key))
+  const remoteKey = remoteKeyForRepo(input.task.repo) ?? remoteKeyForRepo(input.worktreePath)
   if (remoteKey) throw new RemoteEngineLaunchError(remoteKey)
   const protocolTaskId = input.task.kind === "main" ? undefined : input.task.id
   const dispatcherTaskId = input.task.kind === "main" ? input.task.id : undefined

--- a/packages/kobe/src/tui-react/workspace/host.tsx
+++ b/packages/kobe/src/tui-react/workspace/host.tsx
@@ -43,6 +43,7 @@ import { useEditorHandles } from "./use-editor-handles"
 import { useHostNotifiers } from "./use-host-notifiers"
 import { useInboxHost } from "./use-inbox-host"
 import { useIssueChat } from "./use-issue-chat"
+import { usePrCheckNotifier } from "./use-pr-check-notifier"
 import { useScratchShell } from "./use-scratch-shell"
 import { useWorkspaceSelection } from "./use-workspace-selection"
 import { useZenMode } from "./use-zen-mode"
@@ -142,6 +143,10 @@ export function WorkspaceRoot(props: { orchestrator: RemoteOrchestrator }) {
     openAttention: inbox.openItem,
     noTasksMessage: t("workspace.attention.none"),
   })
+
+  // PR checks landing (pending → passing/failing) is the OTHER cross-task
+  // edge worth a toast, and the one the daemon's PR poller was persisting for.
+  usePrCheckNotifier({ tasks, notif })
 
   // Task-action callbacks (new/delete/rename/branch/engine/pin/move)
   // — the shared lib/task-actions flows live in host-task-actions.ts.

--- a/packages/kobe/src/tui-react/workspace/show-workspace.tsx
+++ b/packages/kobe/src/tui-react/workspace/show-workspace.tsx
@@ -10,7 +10,7 @@
 import type { ReactNode } from "react"
 import type { RemoteOrchestrator } from "../../client/remote-orchestrator.ts"
 import { engineLaunchArgv } from "../../engine/engine-presets.ts"
-import { isRemoteRepoKey } from "../../state/repos.ts"
+import { remoteKeyForRepo } from "../../exec/resolve.ts"
 import { DEFAULT_TASK_VENDOR, type Task, type VendorId } from "../../types/task.ts"
 import type { QuickTaskResult } from "../component/quick-task-composer"
 import { useOptionalKV } from "../context/kv"
@@ -77,7 +77,7 @@ export function ShowWorkspace(props: {
   // refuses. Say so here instead of mounting TerminalTabs and letting that
   // refusal throw through the render path — a thrown launch reaches the user as
   // "This pane crashed", which tells them nothing about what is unimplemented.
-  const remoteKey = [props.task?.repo, path].find((key) => key && isRemoteRepoKey(key))
+  const remoteKey = remoteKeyForRepo(props.task?.repo) ?? remoteKeyForRepo(path)
   if (remoteKey) {
     return (
       <box flexGrow={1} alignItems="center" justifyContent="center">

--- a/packages/kobe/src/tui-react/workspace/use-pr-check-notifier.ts
+++ b/packages/kobe/src/tui-react/workspace/use-pr-check-notifier.ts
@@ -1,0 +1,68 @@
+/**
+ * PR check-resolution toasts — the subscriber the daemon's PR poller was
+ * written for.
+ *
+ * `pr-status-collector.ts` persists `task.prStatus.checkState` and fans it out
+ * on `task.snapshot`, but nothing in the TUI read that field, so a CI run
+ * finishing was silent: the only signal was the sidebar chip, which you have
+ * to be looking at. That is the wrong shape for the case the poller exists for
+ * — several tasks in flight while you sit in one of them.
+ *
+ * What counts as an edge is NOT decided here. `checkResolutionNotify`
+ * (monitor/pr-status.ts) owns that rule — pending → passing/failing only — so
+ * "CI started" (none → pending) and the flaps in between stay quiet. This hook
+ * only diffs successive snapshots and hands each landing to `notif`.
+ *
+ * The SELECTED task toasts too, unlike `useAttention`'s engine-state edges:
+ * check state has no middle-column indicator to defer to, only the same
+ * sidebar chip every other task shows.
+ */
+
+import { useEffect, useRef } from "react"
+import { checkResolutionNotify } from "../../monitor/pr-status"
+import type { PRCheckState, Task } from "../../types/task"
+import type { NotificationsContext } from "../context/notifications"
+import { useT } from "../i18n"
+import { useLatest } from "../lib/use-latest"
+
+export function usePrCheckNotifier(args: {
+  readonly tasks: readonly Task[]
+  readonly notif: NotificationsContext
+}): void {
+  // Held by REF, not listed as deps: the notifications context is rebuilt on
+  // every toast (its `toasts` array is in the provider's useMemo deps), so
+  // depending on it would re-enter this effect after each notification it
+  // raises — and re-entry also rewrites `prev`, the very thing the edge is
+  // measured against. Same useLatest shape use-workspace-selection uses for
+  // its worktree-gone notifier, for the same reason.
+  const notif = useLatest(args.notif)
+  const t = useLatest(useT())
+  // Last snapshot's check state per task. No first-render seed guard is needed
+  // (unlike useAttention's): an edge requires `prev === "pending"`, so a task
+  // first SEEN as passing/failing — a restart replaying an already-settled
+  // snapshot — cannot fire.
+  const prev = useRef<ReadonlyMap<string, PRCheckState>>(new Map())
+  useEffect(() => {
+    const next = new Map<string, PRCheckState>()
+    for (const task of args.tasks) {
+      const state = task.prStatus?.checkState
+      if (state === undefined) continue
+      next.set(task.id, state)
+      const landed = checkResolutionNotify(prev.current.get(task.id), state)
+      if (!landed) continue
+      notif.current.notify({
+        kind: landed === "passing" ? "done" : "error",
+        taskId: task.id,
+        tabId: "",
+        title: t.current(landed === "passing" ? "tasks.toast.checksPassingTitle" : "tasks.toast.checksFailingTitle", {
+          title: task.title,
+        }),
+        body: t.current("tasks.toast.checksResolvedBody", {
+          pr: task.prStatus?.number === undefined ? "—" : `#${task.prStatus.number}`,
+          branch: task.branch || "—",
+        }),
+      })
+    }
+    prev.current = next
+  }, [args.tasks])
+}

--- a/packages/kobe/src/tui/i18n/messages/tasks.ts
+++ b/packages/kobe/src/tui/i18n/messages/tasks.ts
@@ -190,6 +190,12 @@ export const en = {
     worktreeGoneTitle: 'Worktree for "{title}" is gone',
     worktreeGoneBody:
       "Closed {count} tab(s). The branch {branch} is still there — reopen the task to re-create its worktree.",
+    // PR checks RESOLVING is the edge worth interrupting for — a run that
+    // merely STARTED (none → pending) is not. `checkResolutionNotify` in
+    // monitor/pr-status.ts owns that rule; these are its two landings.
+    checksPassingTitle: 'Checks passed for "{title}"',
+    checksFailingTitle: 'Checks failed for "{title}"',
+    checksResolvedBody: "PR {pr} on {branch}",
     copiedBranch: "Copied branch {text}",
     copiedPath: "Copied path {text}",
     // Both clipboard channels refused: no platform clipboard command on PATH
@@ -356,6 +362,9 @@ export const zh: typeof en = {
     scratchCloseFailed: "无法关闭临时任务:{message}",
     worktreeGoneTitle: '"{title}" 的 worktree 已消失',
     worktreeGoneBody: "已关闭 {count} 个标签页。分支 {branch} 仍在——重新打开该任务会重建 worktree。",
+    checksPassingTitle: "「{title}」的 PR 检查已通过",
+    checksFailingTitle: "「{title}」的 PR 检查失败了",
+    checksResolvedBody: "PR {pr}，分支 {branch}",
     copiedBranch: "已复制分支 {text}",
     copiedPath: "已复制路径 {text}",
     copyFailed: "无法访问剪贴板——PATH 上没有剪贴板命令，这个终端也拒绝了 OSC 52。",

--- a/packages/kobe/test/render/host-pr-checks-toast.test.tsx
+++ b/packages/kobe/test/render/host-pr-checks-toast.test.tsx
@@ -1,0 +1,153 @@
+/** @jsxImportSource @opentui/react */
+/**
+ * The PR check-resolution toast's WIRING, through the real host.
+ *
+ * The daemon has always persisted and broadcast `task.prStatus.checkState`;
+ * for a long time nothing in the TUI subscribed, so a CI run finishing was
+ * silent. `usePrCheckNotifier` is that subscriber, and deleting its one call
+ * in `host.tsx` is not a type error — it is a toast that quietly stops
+ * appearing. So this mounts `WorkspaceRoot` and drives the tasks signal the
+ * daemon writes, the same way host-worktree-gone-toast does.
+ *
+ * The two edges asserted here are the whole rule: `none → pending` ("CI
+ * started") must stay quiet, `pending → failing` must announce itself once. A
+ * test against `checkResolutionNotify` alone already covers the rule and would
+ * stay green with the subscription deleted, which is why this one exists.
+ *
+ * As in the sibling test, the selected task deliberately has NO worktree —
+ * TerminalTabs would mount PTYs and fs watchers that outlive the test in this
+ * single-process track.
+ */
+
+import { afterAll, afterEach, beforeAll, expect, test } from "bun:test"
+import { mkdtempSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import type { RemoteOrchestrator } from "../../src/client/remote-orchestrator"
+import { createStateCell } from "../../src/lib/external-store"
+import { WorkspaceRoot } from "../../src/tui-react/workspace/host"
+import { setUiEventReporter } from "../../src/tui-react/workspace/terminal-tabs-shared"
+import { type PRCheckState, type Task, toTaskId } from "../../src/types/task"
+import { act, renderComponent, settle } from "./harness"
+
+let previousHome: string | undefined
+
+beforeAll(() => {
+  previousHome = process.env.KOBE_HOME_DIR
+  process.env.KOBE_HOME_DIR = mkdtempSync(join(tmpdir(), "kobe-pr-checks-"))
+})
+
+afterAll(() => {
+  if (previousHome === undefined) Reflect.deleteProperty(process.env, "KOBE_HOME_DIR")
+  else process.env.KOBE_HOME_DIR = previousHome
+})
+
+afterEach(() => {
+  setUiEventReporter(null)
+})
+
+// `useAccessor` re-renders on snapshot IDENTITY change, so every constant is
+// hoisted — a getter returning a fresh value each call spins forever.
+const NULL_CELL = createStateCell(null)
+const EMPTY_MAP = createStateCell(new Map())
+const EMPTY_ARR = createStateCell(Object.freeze([]))
+
+function task(id: string, over: Partial<Task> = {}): Task {
+  return {
+    id: toTaskId(id),
+    title: id,
+    repo: "/repos/rove",
+    branch: `feat/${id}`,
+    worktreePath: `/wt/${id}`,
+    kind: "task",
+    status: "in_progress",
+    createdAt: "2026-08-01T00:00:00.000Z",
+    updatedAt: "2026-08-01T00:00:00.000Z",
+    ...over,
+  }
+}
+
+/** What the poller writes: an open PR whose checks are at `checkState`. */
+function withChecks(checkState: PRCheckState): Task {
+  return task("beta", {
+    prStatus: { provider: "github", lifecycle: "open", checkState, number: 7 },
+  })
+}
+
+/** The task the user is sitting on. No worktree, so no TerminalTabs mount. */
+const HELD = task("held", { worktreePath: "" })
+
+function fakeOrchestrator(initial: readonly Task[]) {
+  const tasks = createStateCell<readonly Task[]>(initial)
+  const orchestrator = {
+    tasksSignal: () => tasks,
+    listTasks: () => tasks(),
+    activeTaskSignal: () => createStateCell<string | null>(HELD.id),
+    setActiveTask: async () => {},
+    connectionStateSignal: () => createStateCell("online"),
+    staleInstallSignal: () => NULL_CELL,
+    daemonStaleSignal: () => createStateCell(false),
+    daemonVersionSignal: () => NULL_CELL,
+    engineStateSignal: () => EMPTY_MAP,
+    engineLifecycleSignal: () => EMPTY_MAP,
+    engineTabStatesSignal: () => EMPTY_MAP,
+    attentionInboxSignal: () => EMPTY_ARR,
+    taskJobsSignal: () => EMPTY_MAP,
+    worktreeChangesSignal: () => NULL_CELL,
+    transcriptActivitySignal: () => NULL_CELL,
+    transcriptActivityStore: () => NULL_CELL,
+    usageSnapshotSignal: () => NULL_CELL,
+    contextUsageSignal: () => NULL_CELL,
+    uiPrefsSignal: () => NULL_CELL,
+    keybindingsRevSignal: () => NULL_CELL,
+    updateSignal: () => NULL_CELL,
+    tabOpenStore: () => NULL_CELL,
+    tabCloseStore: () => NULL_CELL,
+    uiPromptStore: () => NULL_CELL,
+    noticeStore: () => NULL_CELL,
+    reportUiEvent: () => {},
+    reportEngineInterrupt: () => {},
+  } as unknown as RemoteOrchestrator
+  return { orchestrator, tasks }
+}
+
+function occurrences(text: string, needle: string): number {
+  return text.split(needle).length - 1
+}
+
+test("checks resolving on an unselected task raise the host's toast — starting is silent", async () => {
+  const { orchestrator, tasks } = fakeOrchestrator([HELD, withChecks("none")])
+  const { frame } = await renderComponent(<WorkspaceRoot orchestrator={orchestrator} />, {
+    width: 80,
+    height: 24,
+    providers: { kv: true, focus: true, dialog: true, notifications: true },
+  })
+  await settle(120)
+  expect(await frame()).not.toContain("Checks")
+
+  // CI starts. Not a resolution — the user learns nothing from being told a
+  // run began, and this is the flap the rule exists to swallow.
+  await act(async () => {
+    tasks.set([HELD, withChecks("pending")])
+  })
+  await settle(120)
+  expect(await frame()).not.toContain("Checks")
+
+  // CI lands red: the edge worth interrupting for.
+  await act(async () => {
+    tasks.set([HELD, withChecks("failing")])
+  })
+  await settle(120)
+  const text = await frame()
+  expect(text).toContain('Checks failed for "beta"')
+  // The body names WHICH pr — the sidebar chip can't, and a parallel-task user
+  // has several in flight.
+  expect(text).toContain("#7")
+
+  // A re-broadcast snapshot sitting at the same state is not a second edge.
+  await act(async () => {
+    tasks.set([HELD, withChecks("failing")])
+  })
+  await settle(120)
+  expect(occurrences(await frame(), "Checks failed")).toBe(1)
+})


### PR DESCRIPTION
## What this does

The daemon's PR-status poller has persisted and broadcast `task.prStatus.checkState` for a long time with **no subscriber in the TUI**. `checkResolutionNotify` (`monitor/pr-status.ts:326`) — the rule for which transitions are worth interrupting for — had one `src` hit in the whole tree: its own definition line. The design comment naming its consumer (`pr-status-collector.ts:12`, "mirroring `useCompletionNotifications`") pointed at a hook that has never existed anywhere in the repo. So a CI run landing was silent; the only signal was the sidebar chip.

`usePrCheckNotifier` is the missing subscriber. It diffs successive task snapshots and hands each landing to `checkResolutionNotify`, which keeps owning the rule: `pending → passing/failing` only. `none → pending` ("CI started") and the flaps in between stay quiet, and a task whose checks were already settled when the daemon came back cannot re-announce itself (an edge requires `prev === "pending"`, so no seed guard is needed).

Also routes the two hand-rolled remote-key derivations to `remoteKeyForRepo`, the helper written to be the one place that decision is made.

## Visual acceptance

Real browser `/harness` → xterm.js → PTY sidecar → real OpenTUI, isolated fixture on port base 5873. The transition is driven by the **real** `pr-status-collector` shelling a fake `gh` on the fixture's PATH — not by hand-writing the field — and each screenshot's `checkState` was read back out of the fixture's `tasks.json`.

| | path |
|---|---|
| BEFORE (unpatched `packages/kobe/src`, same `pending → failing`) | `/Users/jacksonc/.rove/worktrees/kobe-0aff3858ab76/cassowary/.scratch/prcheck/before.png` |
| AFTER | `/Users/jacksonc/.rove/worktrees/kobe-0aff3858ab76/cassowary/.scratch/prcheck/after.png` |

BEFORE shows checks settling with no on-screen trace. AFTER shows the toast: `Checks failed for "Visual Fixture"` / `PR #412 on visual-fixture`. The BEFORE run reverted `packages/kobe/src` to the base commit **and killed the fixture's PTY host first** — a reused hosted session would have kept the old TUI process (and its already-loaded new code) alive and produced a false BEFORE.

## Verification

**Mutation (two different sites, both red):**

| site removed | result |
|---|---|
| the `usePrCheckNotifier({ tasks, notif })` call in `host.tsx` | red at the positive assertion (`Checks failed for "beta"`) |
| the `checkResolutionNotify` call in the hook (notify on any non-`none` state) | red at the negative control (`none → pending` must stay quiet) |

Restored: green. The test mounts the real `WorkspaceRoot` and drives the tasks signal, mirroring `host-worktree-gone-toast.test.tsx` — a test against `checkResolutionNotify` alone stays green with the subscription deleted, which is the whole reason this one exists.

**Item 2 grep counts** (`grep -rnw remoteKeyForRepo packages/kobe/src`): **1 → 5** (definition + 2 imports + 2 call sites). `.find((key) => key && isRemoteRepoKey(key))` returns **0** hits tree-wide. Both sites are `remoteKeyForRepo(a) ?? remoteKeyForRepo(b)`, which is per-case identical to the `.find` over `[a, b]` it replaces.

**Gates:** typecheck ✓ · `check-i18n` ✓ (910 keys × 2 locales) · root `bun run lint` ✓ · `test:fast` 4551/4551 ✓ · render track 480/480 ✓ · **both coverage gates pass with no exemption** — `use-pr-check-notifier.ts` 100%, `host.tsx` 89.94%, `show-workspace.tsx` 83.91%, `session-launch.ts` 97.69%, i18n `tasks.ts` 100%.

## Two things for the reviewer

**The toast is built in the watcher hook, not in `use-host-notifiers.ts`.** The brief asked for the latter. Measured reason not to: `use-host-notifiers.ts` has no *value* import from react, so `coverage-gate.mjs` classifies it onto the **vitest** track, where its line coverage is **0.00%** — touching it fails the gate and needs an exemption for an eight-line addition. The repo's own guidance is to move the line rather than exempt. `use-attention.ts` is the in-repo precedent: it already raises two cross-task rising-edge toasts through `NotificationsContext.notify` directly. Same mechanism, same context, no second notification path. Happy to switch it if you'd rather carry the exemption.

**`notif` is held by ref, not listed as a dep** — and this is load-bearing, not style. The notifications provider rebuilds its context value whenever `toasts` changes, so depending on `notif` re-enters the effect after every toast it raises, and re-entry also rewrites the `prev` map the edge is measured against. With the correct rule the loop terminates after one pass; under mutation 2 it did **not**, and the render test hung for two minutes instead of failing. `use-workspace-selection.ts:127-132` documents this exact trap for `notifyWorktreeGone`; this uses the same `useLatest` shape.

## `worktreeUsable` / `localSpawnCwd` — left alone, as instructed

Re-verified: still `src=1` each (definition line only), and there is no inline duplication to route to them — no second `existsSync(worktreePath)` and no second `isRemote ? homeDir()` anywhere in `src/`. They are dead code hanging off the unfinished remote-projects feature, whose own guard (`RemoteEngineLaunchError`, `session-launch.ts`) still refuses hosted engine launch over SSH. Not deleted and no caller manufactured for them — your call.

## Residual risk

- The visual capture needed two temporary local patches (`dev.ts`'s `KOBE_PTY_SERVER_CMD` fallback, and `DEFAULT_PR_STATUS_POLL_MS` 30s → 2s so the transition landed inside the toast's 4.5s TTL). **Both reverted; the working tree matches HEAD exactly** and neither file appears in the diff.
- `packages/kobe && bun run lint` reports a pre-existing format issue in `test/daemon/worktree-probe.test.ts` (from #898, not this branch). The root `bun run lint` that CI runs is clean.
- The toast is not gated by `notifications.crossTask.enabled`. That pref is documented for engine-state cross-task attention; extending it to CI status is a product call I did not make.
