### PR TITLE
The tested parser was not the running parser, and three more copies that had drifted

### DIFF
--- a/.changeset/three-drifted-duplications.md
+++ b/.changeset/three-drifted-duplications.md
@@ -1,0 +1,37 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Merge three pieces of logic that were written twice and had drifted apart.
+
+**Worktree adoption ignored your worktree location setting.** The daemon
+computed managed worktree roots from its own copy of the layout, and that copy
+never learned about `worktree.basePath`. If you moved your worktree location in
+Settings → General, an engine starting inside one of those worktrees was not
+recognized, so the worktree never became a task — with no error to explain it.
+Both sides now derive the roots, and the meaning of the stored setting, from
+one module.
+
+**Sidebar `+N −M` chips counted lines the parser rejects.** The daemon's
+counter re-scanned `git status` output with a looser filter than the shared
+porcelain parser: a status pair with no path, and any line without a separator
+in column 3 (a stray warning, a truncated read), were each billed as one added
+file. The counter is now built on the parser, which is also the one the
+porcelain edge-case tests cover — previously they covered a copy that was no
+longer in this path.
+
+**A whitespace-only `.rove/pr-instructions.md` blanked the prompt.** The
+`.rove/` → `.kobe/` fallback was implemented three times with two different
+ideas of "non-empty". A file holding just a newline was returned as the PR/CI
+template (producing an empty prompt) while the same file was correctly skipped
+for `init-prompt.md`. Trimming now applies everywhere: a file of pure
+whitespace is a placeholder, and the next candidate — or the built-in
+template — is used.
+
+**`rove repo show` said the opposite of what runs.** It reported "present
+(wins)" from a bare existence check, so an empty `.rove/init-prompt.md` was
+shown as winning while the runtime actually used `.kobe/` or your saved
+override — in the one situation the command exists to resolve. It now reports
+from the same rules the runtime applies, and distinguishes a file that is
+shadowed by a higher-precedence one from a file that is ignored for being
+empty.

--- a/packages/kobe-daemon/package.json
+++ b/packages/kobe-daemon/package.json
@@ -77,6 +77,7 @@
     "./daemon/ui-prefs-watcher": "./src/daemon/ui-prefs-watcher.ts",
     "./daemon/web-server": "./src/daemon/web-server.ts",
     "./daemon/web-token": "./src/daemon/web-token.ts",
+    "./daemon/worktree-paths": "./src/daemon/worktree-paths.ts",
     "./daemon/web-session": "./src/daemon/web-session.ts",
     "./daemon/worktree-changes-collector": "./src/daemon/worktree-changes-collector.ts",
     "./daemon/worktree-probe": "./src/daemon/worktree-probe.ts",

--- a/packages/kobe-daemon/package.json
+++ b/packages/kobe-daemon/package.json
@@ -39,6 +39,7 @@
     "./daemon/deferred-prompts-store": "./src/daemon/deferred-prompts-store.ts",
     "./daemon/engine-events-log": "./src/daemon/engine-events-log.ts",
     "./daemon/event-bus": "./src/daemon/event-bus.ts",
+    "./daemon/git-porcelain": "./src/daemon/git-porcelain.ts",
     "./daemon/file-watch-trigger": "./src/daemon/file-watch-trigger.ts",
     "./daemon/issues-store": "./src/daemon/issues-store.ts",
     "./daemon/keybindings-watcher": "./src/daemon/keybindings-watcher.ts",

--- a/packages/kobe-daemon/src/daemon/cwd-task.ts
+++ b/packages/kobe-daemon/src/daemon/cwd-task.ts
@@ -25,50 +25,9 @@
  * return undefined → the event is dropped.
  */
 
-import { createHash } from "node:crypto"
 import { existsSync } from "node:fs"
-import { homedir } from "node:os"
 import path from "node:path"
-import { LEGACY_KOBE_STATE_DIR_BASENAME, ROVE_STATE_DIR_BASENAME, readRoveHomeDirEnv } from "../compat-env.ts"
-
-const KOBE_WORKTREE_ROOT_DIR = "worktrees"
-const REPO_LOCAL_ROVE_WORKTREE_ROOT_SUBPATH = ".rove/worktrees"
-const REPO_LOCAL_KOBE_WORKTREE_ROOT_SUBPATH = ".kobe/worktrees"
-const LEGACY_KOBE_WORKTREE_ROOT_SUBPATH = ".claude/worktrees"
-const REPO_LOCAL_KOBE_MANAGED_WORKTREE_ROOT_SUBPATHS = [
-  REPO_LOCAL_ROVE_WORKTREE_ROOT_SUBPATH,
-  REPO_LOCAL_KOBE_WORKTREE_ROOT_SUBPATH,
-  LEGACY_KOBE_WORKTREE_ROOT_SUBPATH,
-] as const
-
-function stateDir(basename: string): string {
-  return path.join(readRoveHomeDirEnv() ?? homedir(), basename)
-}
-
-function repoWorktreeDirName(repo: string): string {
-  const base = path.basename(repo) || "repo"
-  const safeBase = base.replace(/[^a-zA-Z0-9._-]+/g, "-").replace(/^-+|-+$/g, "") || "repo"
-  const hash = createHash("sha1").update(path.resolve(repo)).digest("hex").slice(0, 12)
-  return `${safeBase}-${hash}`
-}
-
-function worktreeRootFor(repo: string): string {
-  if (!path.isAbsolute(repo)) {
-    throw new Error(`worktreeRootFor: repo must be an absolute path, got: ${repo}`)
-  }
-  return path.join(stateDir(ROVE_STATE_DIR_BASENAME), KOBE_WORKTREE_ROOT_DIR, repoWorktreeDirName(repo))
-}
-
-function managedWorktreeRootsFor(repo: string): readonly string[] {
-  if (!path.isAbsolute(repo)) {
-    throw new Error(`managedWorktreeRootsFor: repo must be an absolute path, got: ${repo}`)
-  }
-  return [
-    worktreeRootFor(repo),
-    path.join(stateDir(LEGACY_KOBE_STATE_DIR_BASENAME), KOBE_WORKTREE_ROOT_DIR, repoWorktreeDirName(repo)),
-    ...REPO_LOCAL_KOBE_MANAGED_WORKTREE_ROOT_SUBPATHS.map((subpath) => path.join(repo, subpath)),
-  ]
-}
+import { managedWorktreeRootsFor, readWorktreeBaseOverride } from "./worktree-paths.ts"
 
 export interface CwdMatchTask {
   readonly id: string
@@ -184,7 +143,9 @@ export function findAdoptableWorktree(
     if (t.worktreePath) known.add(normalize(t.worktreePath))
   }
   for (const repo of repos) {
-    for (const root of managedWorktreeRootsFor(repo).map(normalize)) {
+    // The base override is read per repo: a `$project_dir` value expands
+    // against THIS repo, so one global setting yields a per-project root.
+    for (const root of managedWorktreeRootsFor(repo, readWorktreeBaseOverride(repo)).map(normalize)) {
       const prefix = `${root}/`
       if (!target.startsWith(prefix)) continue
       // First path segment after the managed root is the worktree dir.

--- a/packages/kobe-daemon/src/daemon/git-porcelain.ts
+++ b/packages/kobe-daemon/src/daemon/git-porcelain.ts
@@ -1,0 +1,208 @@
+/**
+ * Shared `git status --porcelain` (v1) parser, with correct C-string unquoting.
+ *
+ * It lives in kobe-daemon because BOTH sides parse this format: the TUI's
+ * file-tree pane and worktree-changes view want per-file rows, and the
+ * daemon's worktree-changes collector — the one that actually feeds the
+ * sidebar's `+N −M` chips today — wants aggregate counts. They used to hold
+ * separate parsers, and only kobe's was covered by the porcelain edge-case
+ * tests, so the tested implementation was not the one in production. Now
+ * there is one parser and the tests land on it.
+ *
+ * Git emits any filename containing a space (porcelain renames), a
+ * tab/newline/quote, or a non-ASCII byte as a double-quoted, C-escaped string
+ * (e.g. `"a\tb.txt"`, `"\303\274.txt"`). Quoting/rename facts encoded here,
+ * verified against real git:
+ *   - Porcelain rename: `XY orig -> new`. Each side is quoted INDEPENDENTLY
+ *     (only when it needs quoting); the ` -> ` separator is literal. Porcelain
+ *     quotes a path that merely contains a space.
+ *   - C-quoting escapes `\a \b \t \n \v \f \r \" \\` and otherwise emits a
+ *     three-digit OCTAL escape per BYTE (`\303\274` = the UTF-8 bytes of `ü`),
+ *     so octal runs must be decoded as bytes, then UTF-8 decoded.
+ *
+ * `unquoteGitPath` is exported for the numstat parser in kobe's
+ * `lib/git-parsers.ts`: unquoting BOTH formats to one canonical path is what
+ * lets numstat's +/- counts join their porcelain status row.
+ */
+
+/** One parsed row of `git status --porcelain` (v1). */
+export interface PorcelainRow {
+  /** Index-side status char (X). May be a space. */
+  readonly x: string
+  /** Worktree-side status char (Y). May be a space. */
+  readonly y: string
+  /** Canonical path (post-rename for `R`/`C`), C-unquoted. */
+  readonly path: string
+  /** Original path for a rename/copy (`R`/`C`), C-unquoted. Absent otherwise. */
+  readonly origPath?: string
+}
+
+const ENCODER = new TextEncoder()
+const DECODER = new TextDecoder()
+
+function isOctalDigit(ch: string): boolean {
+  return ch >= "0" && ch <= "7"
+}
+
+/**
+ * Parse one C-quoted token starting at `field[start]` (which MUST be `"`).
+ * Returns the unquoted value and `end`, the index just past the closing
+ * quote (or the end of input if the quote was unterminated). Octal escapes
+ * are decoded as raw bytes and the whole token is UTF-8 decoded, so
+ * multi-byte names (`\303\274` → `ü`) round-trip correctly.
+ */
+function readQuoted(field: string, start: number): { value: string; end: number } {
+  const bytes: number[] = []
+  let lit = ""
+  const flush = () => {
+    if (lit.length > 0) {
+      for (const b of ENCODER.encode(lit)) bytes.push(b)
+      lit = ""
+    }
+  }
+  let i = start + 1 // skip opening quote
+  while (i < field.length) {
+    const ch = field[i] as string
+    if (ch === '"') {
+      i++ // consume closing quote
+      break
+    }
+    if (ch === "\\") {
+      const n = field[i + 1]
+      if (n === undefined) {
+        // Trailing backslash with nothing after — keep it literal.
+        lit += "\\"
+        i++
+        continue
+      }
+      switch (n) {
+        case "a":
+          flush()
+          bytes.push(0x07)
+          i += 2
+          break
+        case "b":
+          flush()
+          bytes.push(0x08)
+          i += 2
+          break
+        case "t":
+          flush()
+          bytes.push(0x09)
+          i += 2
+          break
+        case "n":
+          flush()
+          bytes.push(0x0a)
+          i += 2
+          break
+        case "v":
+          flush()
+          bytes.push(0x0b)
+          i += 2
+          break
+        case "f":
+          flush()
+          bytes.push(0x0c)
+          i += 2
+          break
+        case "r":
+          flush()
+          bytes.push(0x0d)
+          i += 2
+          break
+        case '"':
+          lit += '"'
+          i += 2
+          break
+        case "\\":
+          lit += "\\"
+          i += 2
+          break
+        default:
+          if (isOctalDigit(n)) {
+            let oct = ""
+            let j = i + 1
+            while (j < field.length && oct.length < 3 && isOctalDigit(field[j] as string)) {
+              oct += field[j]
+              j++
+            }
+            flush()
+            bytes.push(Number.parseInt(oct, 8) & 0xff)
+            i = j
+          } else {
+            // Unknown escape — keep the escaped character verbatim.
+            lit += n
+            i += 2
+          }
+          break
+      }
+    } else {
+      lit += ch
+      i++
+    }
+  }
+  flush()
+  return { value: DECODER.decode(new Uint8Array(bytes)), end: i }
+}
+
+/**
+ * Unquote a single git path field. If `field` is C-quoted (starts with `"`)
+ * it is decoded; otherwise it is returned verbatim (git only quotes when a
+ * path needs it). Pure and total — never throws.
+ */
+export function unquoteGitPath(field: string): string {
+  if (field.length === 0 || field[0] !== '"') return field
+  return readQuoted(field, 0).value
+}
+
+/**
+ * Split a porcelain rename field (`orig -> new`) into its two unquoted
+ * sides, respecting independent C-quoting on each side. Returns `null` when
+ * no separator is present (i.e. not a rename).
+ */
+function splitRenameField(field: string, sep: string): { orig: string; neu: string } | null {
+  if (field[0] === '"') {
+    const left = readQuoted(field, 0)
+    if (field.startsWith(sep, left.end)) {
+      return { orig: left.value, neu: unquoteGitPath(field.slice(left.end + sep.length)) }
+    }
+    // Quoted opener but no separator after it — not a rename we can split.
+    return null
+  }
+  const idx = field.indexOf(sep)
+  if (idx < 0) return null
+  return { orig: field.slice(0, idx), neu: unquoteGitPath(field.slice(idx + sep.length)) }
+}
+
+/**
+ * Parse the raw stdout of `git status --porcelain` (v1) into typed rows.
+ *
+ * LENIENT by design: every line of the `XY <path>` shape is returned with
+ * its raw status pair and canonical unquoted path; branch-header (`## …`),
+ * blank, and too-short lines are skipped. Consumers apply their own
+ * status whitelist / directory filtering — this parser does not editorialize,
+ * so the sidebar can count every entry while the file tree filters to the
+ * statuses it colours.
+ */
+export function parsePorcelainRows(raw: string): PorcelainRow[] {
+  const rows: PorcelainRow[] = []
+  for (const rawLine of raw.split("\n")) {
+    const line = rawLine.replace(/\r$/, "")
+    if (line.length < 4) continue // need at least "XY p"
+    if (line.startsWith("##")) continue // branch header (`--branch`)
+    const x = line[0] as string
+    const y = line[1] as string
+    if (line[2] !== " ") continue
+    const rest = line.slice(3)
+    if (x === "R" || x === "C" || y === "R" || y === "C") {
+      const split = splitRenameField(rest, " -> ")
+      if (split) {
+        rows.push({ x, y, path: split.neu, origPath: split.orig })
+        continue
+      }
+    }
+    rows.push({ x, y, path: unquoteGitPath(rest) })
+  }
+  return rows
+}

--- a/packages/kobe-daemon/src/daemon/worktree-paths.ts
+++ b/packages/kobe-daemon/src/daemon/worktree-paths.ts
@@ -1,0 +1,171 @@
+/**
+ * Canonical filesystem layout for Rove-managed worktrees — the ONE derivation
+ * both packages read.
+ *
+ * A managed worktree lives at `<worktrees-root>/<repo-key>/<slug>`. The root
+ * defaults to `<home>/.rove/worktrees` and is relocated wholesale by the user's
+ * `worktree.basePath` setting; `<repo-key>` is `<basename>-<sha1-12>` of the
+ * repo path, so two repos never collide under a shared base.
+ *
+ * This lives in kobe-daemon (kobe -> kobe-daemon, never back) because BOTH
+ * sides compute it: the TUI/orchestrator to CREATE and list worktrees, and the
+ * daemon's `cwd-task.ts` to recognize one an engine started inside. They used
+ * to hold separate copies, and the copies drifted — the daemon's never learned
+ * about the base override, so a user who moved their worktree location got
+ * silent adoption failures. Same move `product-paths.ts` and
+ * `lib/poll-scheduling.ts` already made.
+ *
+ * I/O policy stays with each caller: kobe reads `state.json` through its State
+ * Store (which owns the corrupt-file backup), the daemon reads it here with a
+ * plain best-effort read. Only the INTERPRETATION of the stored value is
+ * shared, via {@link normalizeWorktreeBase} — the two must never disagree
+ * about what a given `state.json` means.
+ *
+ * `repo` is always absolute. Callers must normalize before invoking.
+ */
+
+import { createHash } from "node:crypto"
+import { readFileSync } from "node:fs"
+import path from "node:path"
+import { LEGACY_KOBE_STATE_DIR_BASENAME, ROVE_STATE_DIR_BASENAME } from "../compat-env.ts"
+import { defaultUiPrefsStatePath, resolveProductHomeDir } from "./product-paths.ts"
+
+/** Directory under Rove's state dir holding all of its worktrees. */
+const WORKTREE_ROOT_DIR = "worktrees"
+
+export const REPO_LOCAL_ROVE_WORKTREE_ROOT_SUBPATH = ".rove/worktrees"
+export const REPO_LOCAL_KOBE_WORKTREE_ROOT_SUBPATH = ".kobe/worktrees"
+export const LEGACY_KOBE_WORKTREE_ROOT_SUBPATH = ".claude/worktrees"
+
+/**
+ * Repo-local compatibility roots. Creation does not use these; recognition and
+ * listing keep old task records working.
+ */
+export const REPO_LOCAL_MANAGED_WORKTREE_ROOT_SUBPATHS = [
+  REPO_LOCAL_ROVE_WORKTREE_ROOT_SUBPATH,
+  REPO_LOCAL_KOBE_WORKTREE_ROOT_SUBPATH,
+  LEGACY_KOBE_WORKTREE_ROOT_SUBPATH,
+] as const
+
+/** `state.json` key holding the raw, un-normalized worktree base override. */
+export const WORKTREE_BASE_KEY = "worktree.basePath"
+
+/** Leading-segment token that expands to the task's project root. */
+export const PROJECT_DIR_TOKEN = "$project_dir"
+
+/** The per-repo directory name under a worktrees root: `<basename>-<sha1-12>`. */
+export function repoWorktreeDirName(repo: string): string {
+  const base = path.basename(repo) || "repo"
+  const safeBase = base.replace(/[^a-zA-Z0-9._-]+/g, "-").replace(/^-+|-+$/g, "") || "repo"
+  const hash = createHash("sha1").update(path.resolve(repo)).digest("hex").slice(0, 12)
+  return `${safeBase}-${hash}`
+}
+
+/** True iff `raw` starts with `$project_dir` as its first path segment. */
+export function hasProjectDirToken(raw: string): boolean {
+  const trimmed = raw.trim()
+  return trimmed === PROJECT_DIR_TOKEN || trimmed.startsWith(`${PROJECT_DIR_TOKEN}/`)
+}
+
+/**
+ * Normalize a raw user-entered base path to an absolute directory, or `null`
+ * when it's unset/blank (meaning "use Rove's default root").
+ *
+ * A leading `~` / `~/` expands to the OS home; relative paths resolve against
+ * it too, so a user who types `code/worktrees` gets a stable absolute location
+ * instead of one that depends on the process's cwd.
+ *
+ * A leading `$project_dir` segment expands to `projectDir` (the repo root of
+ * the task being created), with `..` segments collapsed — so
+ * `$project_dir/../wt` lands next to each project. When the token is present
+ * but no `projectDir` context exists (a global read with no repo at hand), the
+ * result is `null`: fall back to the default root rather than inventing a
+ * literal `$project_dir` directory.
+ */
+export function normalizeWorktreeBase(raw: string | undefined | null, projectDir?: string): string | null {
+  if (typeof raw !== "string") return null
+  const trimmed = raw.trim()
+  if (!trimmed) return null
+  if (hasProjectDirToken(trimmed)) {
+    if (!projectDir) return null
+    const rest = trimmed.slice(PROJECT_DIR_TOKEN.length).replace(/^\/+/, "")
+    return path.resolve(projectDir, rest)
+  }
+  const home = resolveProductHomeDir()
+  if (trimmed === "~") return home
+  const expanded = trimmed.startsWith("~/") ? path.join(home, trimmed.slice(2)) : trimmed
+  return path.isAbsolute(expanded) ? expanded : path.resolve(home, expanded)
+}
+
+/**
+ * Daemon-side read of the configured base override. Best-effort and read-only:
+ * a missing / malformed `state.json` yields `null` (the default root), and
+ * unlike kobe's State Store this never moves the file aside — the daemon must
+ * not rewrite a user file it merely observes.
+ */
+export function readWorktreeBaseOverride(projectDir?: string): string | null {
+  try {
+    const raw = JSON.parse(readFileSync(defaultUiPrefsStatePath(), "utf8")) as unknown
+    if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null
+    const value = (raw as Record<string, unknown>)[WORKTREE_BASE_KEY]
+    return normalizeWorktreeBase(typeof value === "string" ? value : null, projectDir)
+  } catch {
+    return null
+  }
+}
+
+/** The built-in default worktrees root, ignoring any override. */
+export function defaultLocalWorktreesRoot(): string {
+  return path.join(resolveProductHomeDir(), ROVE_STATE_DIR_BASENAME, WORKTREE_ROOT_DIR)
+}
+
+/** Pre-rename global root. Existing worktree records and discovery keep it live. */
+export function legacyLocalWorktreesRoot(): string {
+  return path.join(resolveProductHomeDir(), LEGACY_KOBE_STATE_DIR_BASENAME, WORKTREE_ROOT_DIR)
+}
+
+/**
+ * Absolute path of the ACTIVE worktree root for `repo` — where a new task's
+ * worktree is created. `override` is the already-normalized base (see
+ * {@link normalizeWorktreeBase}), or `null` for the built-in default.
+ *
+ * Example: `worktreeRootFor("/Users/x/proj", null)` →
+ * `/Users/x/.rove/worktrees/proj-a1b2c3d4e5f6`.
+ */
+export function worktreeRootFor(repo: string, override: string | null): string {
+  if (!path.isAbsolute(repo)) {
+    throw new Error(`worktreeRootFor: repo must be an absolute path, got: ${repo}`)
+  }
+  return path.join(override ?? defaultLocalWorktreesRoot(), repoWorktreeDirName(repo))
+}
+
+/**
+ * Absolute paths of every worktree root Rove recognizes for `repo`. The active
+ * root (override-aware) is first; the built-in default follows when an override
+ * moved it (so worktrees created before the override stay discoverable for
+ * listing + slug allocation), then the legacy global root and the repo-local
+ * roots that older task records used.
+ *
+ * KNOWN LIMITATION: only the CURRENT override and the built-in default are
+ * recognized — we don't persist a history of past override paths. If a user
+ * points the base at A, creates tasks, then re-points it at B, the worktrees
+ * under A fall out of managed listing + slug allocation. Those tasks are NOT
+ * lost — each task record pins its own absolute `worktreePath`, so
+ * opening/removing them keeps working; they just stop appearing in "list
+ * Rove-managed worktrees" and their slugs stop blocking reuse. Recording every
+ * base ever used would close the gap but is deliberately out of scope here.
+ */
+export function managedWorktreeRootsFor(repo: string, override: string | null): readonly string[] {
+  if (!path.isAbsolute(repo)) {
+    throw new Error(`managedWorktreeRootsFor: repo must be an absolute path, got: ${repo}`)
+  }
+  const dirName = repoWorktreeDirName(repo)
+  return [
+    ...new Set([
+      worktreeRootFor(repo, override),
+      path.join(defaultLocalWorktreesRoot(), dirName),
+      path.join(legacyLocalWorktreesRoot(), dirName),
+      ...REPO_LOCAL_MANAGED_WORKTREE_ROOT_SUBPATHS.map((subpath) => path.join(repo, subpath)),
+    ]),
+  ]
+}

--- a/packages/kobe-daemon/src/daemon/worktree-status-runner.ts
+++ b/packages/kobe-daemon/src/daemon/worktree-status-runner.ts
@@ -1,5 +1,6 @@
 import { spawn } from "node:child_process"
 import type { WorktreeChanges } from "./contracts.ts"
+import { parsePorcelainRows } from "./git-porcelain.ts"
 
 /** One lock-free `git` read in a worktree; null stdout on any non-zero exit. */
 function runGit(worktreePath: string, args: readonly string[], signal: AbortSignal): Promise<string | null> {
@@ -74,9 +75,11 @@ export function parseAheadBehind(stdout: string | null): AheadBehind | null {
 export function countPorcelain(stdout: string): { added: number; deleted: number } {
   let added = 0
   let deleted = 0
-  for (const line of stdout.split("\n")) {
-    if (line.length < 3 || line.startsWith("##")) continue
-    if (line[0] === "D" || line[1] === "D") deleted++
+  // Shared parser (`git-porcelain.ts`), not a local re-scan: this counter feeds
+  // the sidebar chips while kobe's file tree renders rows from the same bytes,
+  // and a second, laxer line filter here counted junk the real parser rejects.
+  for (const row of parsePorcelainRows(stdout)) {
+    if (row.x === "D" || row.y === "D") deleted++
     else added++
   }
   return { added, deleted }

--- a/packages/kobe/src/cli/repo-cmd.ts
+++ b/packages/kobe/src/cli/repo-cmd.ts
@@ -112,22 +112,19 @@ export async function runRepoSubcommand(args: readonly string[]): Promise<void> 
   if (!SUBCOMMAND_VERBS.repo.includes(verb)) usageError(`unknown verb "${verb}"`)
 
   const { getRepoInitOverride, setRepoInitOverride, resolveRepoRoot } = await import("../state/repos.ts")
-  const { existsSync } = await import("node:fs")
-  const { join } = await import("node:path")
 
   if (verb === "show") {
     const [pathArg] = rest.filter((a) => !a.startsWith("-"))
     const repo = resolveRepoRoot(resolve(process.cwd(), expandTilde(pathArg ?? ".")))
     const override = getRepoInitOverride(repo)
-    const hasRoveScript = existsSync(join(repo, ".rove", "init.sh"))
-    const hasRovePrompt = existsSync(join(repo, ".rove", "init-prompt.md"))
-    const hasKobeScript = existsSync(join(repo, ".kobe", "init.sh"))
-    const hasKobePrompt = existsSync(join(repo, ".kobe", "init-prompt.md"))
+    const { describeRepoInitSources } = await import("../state/repo-init.ts")
+    const sources = describeRepoInitSources(repo)
     console.log(`repo: ${repo}`)
-    console.log(`  .rove/init.sh:        ${hasRoveScript ? "present (wins)" : "absent"}`)
-    console.log(`  .rove/init-prompt.md: ${hasRovePrompt ? "present (wins)" : "absent"}`)
-    console.log(`  .kobe/init.sh:        ${hasKobeScript ? "present (legacy fallback)" : "absent"}`)
-    console.log(`  .kobe/init-prompt.md: ${hasKobePrompt ? "present (legacy fallback)" : "absent"}`)
+    for (const group of [sources.script, sources.prompt]) {
+      group.forEach((source, index) => {
+        console.log(`  ${`${source.rel}:`.padEnd(22)}${describeSource(group, index)}`)
+      })
+    }
     console.log(`  override initScript:  ${override.initScript ? quotePreview(override.initScript) : "(unset)"}`)
     console.log(`  override initPrompt:  ${override.initPrompt ? quotePreview(override.initPrompt) : "(unset)"}`)
     return
@@ -165,6 +162,23 @@ export async function runRepoSubcommand(args: readonly string[]): Promise<void> 
   // Unreachable via the gate above; kept so a verb added to SUBCOMMAND_VERBS
   // without a branch here fails loud instead of silently doing nothing.
   usageError(`unknown verb "${verb}"`)
+}
+
+/**
+ * How `repo show` labels one repo-init candidate. "wins" comes from
+ * `describeRepoInitSources`, which applies the SAME rules as the runtime — a
+ * file present but empty is reported as ignored rather than winning, which is
+ * exactly the confusion this command is run to resolve.
+ */
+function describeSource(group: readonly { present: boolean; effective: boolean }[], index: number): string {
+  const source = group[index]
+  if (!source) return "absent"
+  if (source.effective) return "present (wins)"
+  if (!source.present) return "absent"
+  // Present but not used: either a higher-precedence candidate took it, or it
+  // holds nothing but whitespace and the runtime skipped it.
+  const shadowed = group.slice(0, index).some((earlier) => earlier.effective)
+  return shadowed ? "present (shadowed)" : "present but empty (ignored)"
 }
 
 /** Single-line preview of a possibly multi-line value for `repo show`. */

--- a/packages/kobe/src/lib/git-parsers.ts
+++ b/packages/kobe/src/lib/git-parsers.ts
@@ -34,17 +34,15 @@
  *     so octal runs must be decoded as bytes, then UTF-8 decoded.
  */
 
-/** One parsed row of `git status --porcelain` (v1). */
-export interface PorcelainRow {
-  /** Index-side status char (X). May be a space. */
-  readonly x: string
-  /** Worktree-side status char (Y). May be a space. */
-  readonly y: string
-  /** Canonical path (post-rename for `R`/`C`), C-unquoted. */
-  readonly path: string
-  /** Original path for a rename/copy (`R`/`C`), C-unquoted. Absent otherwise. */
-  readonly origPath?: string
-}
+/**
+ * The porcelain half of this module now lives in
+ * `@sma1lboy/kobe-daemon/daemon/git-porcelain` — the daemon's worktree-changes
+ * collector parses the same format and had grown its own, laxer copy. Both
+ * consumers import the one parser; this re-export keeps kobe's callers (and
+ * `test/lib/git-parsers.test.ts`) addressing it here.
+ */
+export { type PorcelainRow, parsePorcelainRows, unquoteGitPath } from "@sma1lboy/kobe-daemon/daemon/git-porcelain"
+import { unquoteGitPath } from "@sma1lboy/kobe-daemon/daemon/git-porcelain"
 
 /** One parsed row of `git diff --numstat`. */
 export interface NumstatRow {
@@ -56,176 +54,6 @@ export interface NumstatRow {
   readonly added: number | null
   /** Lines deleted. `null` for a binary file (git emits `-`). */
   readonly deleted: number | null
-}
-
-const ENCODER = new TextEncoder()
-const DECODER = new TextDecoder()
-
-function isOctalDigit(ch: string): boolean {
-  return ch >= "0" && ch <= "7"
-}
-
-/**
- * Parse one C-quoted token starting at `field[start]` (which MUST be `"`).
- * Returns the unquoted value and `end`, the index just past the closing
- * quote (or the end of input if the quote was unterminated). Octal escapes
- * are decoded as raw bytes and the whole token is UTF-8 decoded, so
- * multi-byte names (`\303\274` → `ü`) round-trip correctly.
- */
-function readQuoted(field: string, start: number): { value: string; end: number } {
-  const bytes: number[] = []
-  let lit = ""
-  const flush = () => {
-    if (lit.length > 0) {
-      for (const b of ENCODER.encode(lit)) bytes.push(b)
-      lit = ""
-    }
-  }
-  let i = start + 1 // skip opening quote
-  while (i < field.length) {
-    const ch = field[i] as string
-    if (ch === '"') {
-      i++ // consume closing quote
-      break
-    }
-    if (ch === "\\") {
-      const n = field[i + 1]
-      if (n === undefined) {
-        // Trailing backslash with nothing after — keep it literal.
-        lit += "\\"
-        i++
-        continue
-      }
-      switch (n) {
-        case "a":
-          flush()
-          bytes.push(0x07)
-          i += 2
-          break
-        case "b":
-          flush()
-          bytes.push(0x08)
-          i += 2
-          break
-        case "t":
-          flush()
-          bytes.push(0x09)
-          i += 2
-          break
-        case "n":
-          flush()
-          bytes.push(0x0a)
-          i += 2
-          break
-        case "v":
-          flush()
-          bytes.push(0x0b)
-          i += 2
-          break
-        case "f":
-          flush()
-          bytes.push(0x0c)
-          i += 2
-          break
-        case "r":
-          flush()
-          bytes.push(0x0d)
-          i += 2
-          break
-        case '"':
-          lit += '"'
-          i += 2
-          break
-        case "\\":
-          lit += "\\"
-          i += 2
-          break
-        default:
-          if (isOctalDigit(n)) {
-            let oct = ""
-            let j = i + 1
-            while (j < field.length && oct.length < 3 && isOctalDigit(field[j] as string)) {
-              oct += field[j]
-              j++
-            }
-            flush()
-            bytes.push(Number.parseInt(oct, 8) & 0xff)
-            i = j
-          } else {
-            // Unknown escape — keep the escaped character verbatim.
-            lit += n
-            i += 2
-          }
-          break
-      }
-    } else {
-      lit += ch
-      i++
-    }
-  }
-  flush()
-  return { value: DECODER.decode(new Uint8Array(bytes)), end: i }
-}
-
-/**
- * Unquote a single git path field. If `field` is C-quoted (starts with `"`)
- * it is decoded; otherwise it is returned verbatim (git only quotes when a
- * path needs it). Pure and total — never throws.
- */
-export function unquoteGitPath(field: string): string {
-  if (field.length === 0 || field[0] !== '"') return field
-  return readQuoted(field, 0).value
-}
-
-/**
- * Split a porcelain rename field (`orig -> new`) into its two unquoted
- * sides, respecting independent C-quoting on each side. Returns `null` when
- * no separator is present (i.e. not a rename).
- */
-function splitRenameField(field: string, sep: string): { orig: string; neu: string } | null {
-  if (field[0] === '"') {
-    const left = readQuoted(field, 0)
-    if (field.startsWith(sep, left.end)) {
-      return { orig: left.value, neu: unquoteGitPath(field.slice(left.end + sep.length)) }
-    }
-    // Quoted opener but no separator after it — not a rename we can split.
-    return null
-  }
-  const idx = field.indexOf(sep)
-  if (idx < 0) return null
-  return { orig: field.slice(0, idx), neu: unquoteGitPath(field.slice(idx + sep.length)) }
-}
-
-/**
- * Parse the raw stdout of `git status --porcelain` (v1) into typed rows.
- *
- * LENIENT by design: every line of the `XY <path>` shape is returned with
- * its raw status pair and canonical unquoted path; branch-header (`## …`),
- * blank, and too-short lines are skipped. Consumers apply their own
- * status whitelist / directory filtering — this parser does not editorialize,
- * so the sidebar can count every entry while the file tree filters to the
- * statuses it colours.
- */
-export function parsePorcelainRows(raw: string): PorcelainRow[] {
-  const rows: PorcelainRow[] = []
-  for (const rawLine of raw.split("\n")) {
-    const line = rawLine.replace(/\r$/, "")
-    if (line.length < 4) continue // need at least "XY p"
-    if (line.startsWith("##")) continue // branch header (`--branch`)
-    const x = line[0] as string
-    const y = line[1] as string
-    if (line[2] !== " ") continue
-    const rest = line.slice(3)
-    if (x === "R" || x === "C" || y === "R" || y === "C") {
-      const split = splitRenameField(rest, " -> ")
-      if (split) {
-        rows.push({ x, y, path: split.neu, origPath: split.orig })
-        continue
-      }
-    }
-    rows.push({ x, y, path: unquoteGitPath(rest) })
-  }
-  return rows
 }
 
 function parseCount(token: string): number | null {

--- a/packages/kobe/src/lib/repo-config-file.ts
+++ b/packages/kobe/src/lib/repo-config-file.ts
@@ -1,0 +1,57 @@
+/**
+ * One reader for the `.rove/` → `.kobe/` per-repo config-file fallback.
+ *
+ * A repo can ship `init.sh`, `init-prompt.md`, `pr-instructions.md` and
+ * `ci-instructions.md` under `.rove/`, with the legacy `.kobe/` spelling kept
+ * as a fallback so repos that committed one before the rename keep working.
+ * Three call sites hand-rolled that loop and disagreed about what counts as a
+ * file worth using: `state/repo-init.ts` skipped whitespace-only files, while
+ * `tui/ops/pr-prompt.ts` and `tui/ops/ci-prompt.ts` accepted them — so a
+ * `.rove/pr-instructions.md` holding a single newline was returned as the
+ * template and blanked the prompt, where the same file in `repo-init.ts` fell
+ * through to `.kobe/`.
+ *
+ * `repo-init.ts` had the rule the comments in all three describe, so trimming
+ * is the shared answer: a file of nothing but whitespace is a placeholder, not
+ * an instruction to blank the output.
+ *
+ * Sync on purpose. These are two small repo-local files read once per engine
+ * launch or per user-triggered action, and one shared reader beats a sync and
+ * an async copy that can drift apart again.
+ */
+
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+
+/** Config dirs a repo may ship, canonical spelling first. */
+export const REPO_CONFIG_DIRS = [".rove", ".kobe"] as const
+
+/** Every candidate path for `filename`, in precedence order. */
+export function repoConfigCandidates(repoDir: string, filename: string): string[] {
+  return REPO_CONFIG_DIRS.map((dir) => join(repoDir, dir, filename))
+}
+
+/**
+ * Contents of the first candidate that exists and holds more than whitespace,
+ * or `undefined` when none does. An unreadable or absent file never blocks the
+ * next candidate.
+ */
+export function readFirstNonEmptyRepoFile(repoDir: string, filename: string): string | undefined {
+  for (const candidate of repoConfigCandidates(repoDir, filename)) {
+    if (isNonEmptyRepoFile(candidate)) return readFileSync(candidate, "utf8")
+  }
+  return undefined
+}
+
+/**
+ * True when `absolutePath` is readable and holds more than whitespace — the
+ * single definition of "this candidate counts", so a diagnostic that reports
+ * which file wins cannot answer differently from the code that picks it.
+ */
+export function isNonEmptyRepoFile(absolutePath: string): boolean {
+  try {
+    return readFileSync(absolutePath, "utf8").trim().length > 0
+  } catch {
+    return false
+  }
+}

--- a/packages/kobe/src/orchestrator/worktree/paths.ts
+++ b/packages/kobe/src/orchestrator/worktree/paths.ts
@@ -21,59 +21,28 @@
  * `<repo>` is always absolute. Callers must normalize before invoking.
  */
 
-import { createHash } from "node:crypto"
 import fs from "node:fs"
 import path from "node:path"
-import { legacyKobeStateDir, roveStateDir } from "../../env.ts"
+import {
+  defaultLocalWorktreesRoot,
+  legacyLocalWorktreesRoot,
+  managedWorktreeRootsFor as managedWorktreeRootsForBase,
+  worktreeRootFor as worktreeRootForBase,
+} from "@sma1lboy/kobe-daemon/daemon/worktree-paths"
 import { execHostForRepo } from "../../exec/resolve.ts"
 import { getRemoteRepoConfig, isRemoteRepoKey } from "../../state/repos.ts"
 import { getWorktreeBaseOverride } from "../../state/worktree-base.ts"
 
 /**
- * Directory under kobe's state dir where kobe stores all of its worktrees.
- *
- * Exposed so the worktree manager's `list()` implementation can scope
- * its enumeration to "kobe-managed only" without reaching into another
- * module's private constant.
+ * Repo-local compatibility roots, re-exported from the shared derivation in
+ * `@sma1lboy/kobe-daemon/daemon/worktree-paths` so the daemon's own recognition
+ * pass and this module can no longer disagree about the layout.
  */
-const KOBE_WORKTREE_ROOT_DIR = "worktrees"
-export const REPO_LOCAL_ROVE_WORKTREE_ROOT_SUBPATH = ".rove/worktrees"
-export const REPO_LOCAL_KOBE_WORKTREE_ROOT_SUBPATH = ".kobe/worktrees"
-export const LEGACY_KOBE_WORKTREE_ROOT_SUBPATH = ".claude/worktrees"
-
-/**
- * Repo-local compatibility roots. Creation does not use these; recognition and
- * listing keep old task records working.
- */
-const REPO_LOCAL_KOBE_MANAGED_WORKTREE_ROOT_SUBPATHS = [
-  REPO_LOCAL_ROVE_WORKTREE_ROOT_SUBPATH,
-  REPO_LOCAL_KOBE_WORKTREE_ROOT_SUBPATH,
+export {
   LEGACY_KOBE_WORKTREE_ROOT_SUBPATH,
-] as const
-
-/**
- * The `worktrees` root that new LOCAL tasks are created under. Defaults
- * to `<home>/.rove/worktrees`; a user-configured global override
- * (Settings → General → Worktree location) relocates it wholesale. The
- * override IS the worktrees root — the per-repo `<repo-key>` subdir is
- * still appended below it by {@link worktreeRootFor}. An override with
- * a leading `$project_dir` token expands against `repo`, so the root
- * lands relative to each project (e.g. `$project_dir/../`). Read fresh
- * so a settings change needs no daemon restart.
- */
-function localWorktreesRoot(repo: string): string {
-  return getWorktreeBaseOverride(repo) ?? path.join(roveStateDir(), KOBE_WORKTREE_ROOT_DIR)
-}
-
-/** The built-in default worktrees root, ignoring any override. */
-function defaultLocalWorktreesRoot(): string {
-  return path.join(roveStateDir(), KOBE_WORKTREE_ROOT_DIR)
-}
-
-/** Pre-rename global root. Existing worktree records and discovery keep it live. */
-function legacyLocalWorktreesRoot(): string {
-  return path.join(legacyKobeStateDir(), KOBE_WORKTREE_ROOT_DIR)
-}
+  REPO_LOCAL_KOBE_WORKTREE_ROOT_SUBPATH,
+  REPO_LOCAL_ROVE_WORKTREE_ROOT_SUBPATH,
+} from "@sma1lboy/kobe-daemon/daemon/worktree-paths"
 
 /**
  * Absolute path of the worktree root for a given repo.
@@ -83,10 +52,7 @@ function legacyLocalWorktreesRoot(): string {
  * is set, `<override>/proj-a1b2c3d4e5f6`).
  */
 export function worktreeRootFor(repo: string): string {
-  if (!path.isAbsolute(repo)) {
-    throw new Error(`worktreeRootFor: repo must be an absolute path, got: ${repo}`)
-  }
-  return path.join(localWorktreesRoot(repo), repoWorktreeDirName(repo))
+  return worktreeRootForBase(repo, getWorktreeBaseOverride(repo))
 }
 
 /**
@@ -107,19 +73,7 @@ export function worktreeRootFor(repo: string): string {
  * deliberately out of scope here.
  */
 export function managedWorktreeRootsFor(repo: string): readonly string[] {
-  if (!path.isAbsolute(repo)) {
-    throw new Error(`managedWorktreeRootsFor: repo must be an absolute path, got: ${repo}`)
-  }
-  const active = worktreeRootFor(repo)
-  const fallback = path.join(defaultLocalWorktreesRoot(), repoWorktreeDirName(repo))
-  const legacy = path.join(legacyLocalWorktreesRoot(), repoWorktreeDirName(repo))
-  const primaryRoots = [active, fallback, legacy]
-  return [
-    ...new Set([
-      ...primaryRoots,
-      ...REPO_LOCAL_KOBE_MANAGED_WORKTREE_ROOT_SUBPATHS.map((subpath) => path.join(repo, subpath)),
-    ]),
-  ]
+  return managedWorktreeRootsForBase(repo, getWorktreeBaseOverride(repo))
 }
 
 /**
@@ -319,11 +273,4 @@ export function canonicalize(p: string): string {
   } catch {
     return path.resolve(p)
   }
-}
-
-function repoWorktreeDirName(repo: string): string {
-  const base = path.basename(repo) || "repo"
-  const safeBase = base.replace(/[^a-zA-Z0-9._-]+/g, "-").replace(/^-+|-+$/g, "") || "repo"
-  const hash = createHash("sha1").update(path.resolve(repo)).digest("hex").slice(0, 12)
-  return `${safeBase}-${hash}`
 }

--- a/packages/kobe/src/state/repo-init.ts
+++ b/packages/kobe/src/state/repo-init.ts
@@ -24,6 +24,7 @@ import { existsSync, readFileSync } from "node:fs"
 import { join } from "node:path"
 import { type ObservedLanguage, detectLanguage } from "@sma1lboy/kobe-daemon/prompts/observed-language"
 import { kobeApiInvocation } from "../engine/interactive-command.ts"
+import { REPO_CONFIG_DIRS, isNonEmptyRepoFile, readFirstNonEmptyRepoFile } from "../lib/repo-config-file.ts"
 import { getRepoInitOverride } from "./repos.ts"
 
 export interface ResolvedRepoInit {
@@ -110,8 +111,8 @@ export function missingDependenciesCoda(worktreePath: string, language?: Observe
   return `PS: this worktree has no installed dependencies (${dirs} missing beside a committed lockfile). Run the repo's install step before trusting build/test results — a failure here is most likely the missing install, not a regression. If this repo always needs one, consider adding \`.rove/init.sh\`.`
 }
 
-const INIT_SCRIPT_RELS = [join(".rove", "init.sh"), join(".kobe", "init.sh")] as const
-const INIT_PROMPT_RELS = [join(".rove", "init-prompt.md"), join(".kobe", "init-prompt.md")] as const
+export const INIT_SCRIPT_FILENAME = "init.sh"
+export const INIT_PROMPT_FILENAME = "init-prompt.md"
 
 function repoFileScript(worktreePath: string): string | undefined {
   // Run the committed file by relative path: cwd is the worktree, so
@@ -119,27 +120,55 @@ function repoFileScript(worktreePath: string): string | undefined {
   //
   // Native `join` paths are only for probing. The shell command stays a POSIX
   // literal because Git Bash treats a backslash as an escape.
-  for (const [relative, command] of [
-    [INIT_SCRIPT_RELS[0], "sh .rove/init.sh"],
-    [INIT_SCRIPT_RELS[1], "sh .kobe/init.sh"],
-  ] as const) {
-    if (existsSync(join(worktreePath, relative))) return command
+  //
+  // A script is picked on EXISTENCE, not content: an empty `init.sh` is a
+  // deliberate "run nothing" that must still beat the state.json override.
+  for (const dir of REPO_CONFIG_DIRS) {
+    if (existsSync(join(worktreePath, dir, INIT_SCRIPT_FILENAME))) return `sh ${dir}/${INIT_SCRIPT_FILENAME}`
   }
   return undefined
 }
 
 function repoFilePrompt(worktreePath: string): string | undefined {
-  for (const relative of INIT_PROMPT_RELS) {
-    const p = join(worktreePath, relative)
-    if (!existsSync(p)) continue
-    try {
-      const text = readFileSync(p, "utf8")
-      if (text.trim().length > 0) return text
-    } catch {
-      // An unreadable file does not block the next candidate or user fallback.
-    }
+  return readFirstNonEmptyRepoFile(worktreePath, INIT_PROMPT_FILENAME)
+}
+
+/** One candidate repo-init file, as `rove repo show` reports it. */
+export interface RepoInitSource {
+  /** Repo-relative path, e.g. `.rove/init.sh`. */
+  readonly rel: string
+  /** The file exists on disk. */
+  readonly present: boolean
+  /** This candidate is the one {@link resolveRepoInit} actually uses. */
+  readonly effective: boolean
+}
+
+/**
+ * Which repo-init candidates exist and which one WINS, by the same rules
+ * {@link resolveRepoInit} applies.
+ *
+ * `rove repo show` used to answer this with a bare `existsSync` per file, so
+ * an EMPTY `.rove/init-prompt.md` printed "present (wins)" while the runtime
+ * silently fell through to `.kobe/` or the state.json override. That is the
+ * one question the command exists to answer, so it has to come from here.
+ */
+export function describeRepoInitSources(repoRoot: string): {
+  script: readonly RepoInitSource[]
+  prompt: readonly RepoInitSource[]
+} {
+  const describe = (filename: string, counts: (absolute: string) => boolean): RepoInitSource[] => {
+    let taken = false
+    return REPO_CONFIG_DIRS.map((dir) => {
+      const absolute = join(repoRoot, dir, filename)
+      const effective = !taken && counts(absolute)
+      if (effective) taken = true
+      return { rel: `${dir}/${filename}`, present: existsSync(absolute), effective }
+    })
   }
-  return undefined
+  return {
+    script: describe(INIT_SCRIPT_FILENAME, existsSync),
+    prompt: describe(INIT_PROMPT_FILENAME, isNonEmptyRepoFile),
+  }
 }
 
 /**

--- a/packages/kobe/src/state/worktree-base.ts
+++ b/packages/kobe/src/state/worktree-base.ts
@@ -27,11 +27,23 @@
  * remote host under the project's own `basePath` (`remoteWorktreeRootFor`).
  */
 
-import { isAbsolute, join, resolve } from "node:path"
-import { homeDir } from "../env.ts"
+import {
+  PROJECT_DIR_TOKEN,
+  WORKTREE_BASE_KEY,
+  hasProjectDirToken,
+  normalizeWorktreeBase,
+} from "@sma1lboy/kobe-daemon/daemon/worktree-paths"
 import { loadStateFile } from "./store.ts"
 
-export const WORKTREE_BASE_KEY = "worktree.basePath"
+/**
+ * The key and its interpretation live in
+ * `@sma1lboy/kobe-daemon/daemon/worktree-paths` — the daemon resolves the very
+ * same setting when it decides whether an engine's cwd is an adoptable
+ * worktree, and a second copy of "what does this string mean" is exactly what
+ * drifted before. Only the READ policy is this module's (the State Store's
+ * corrupt-file backup); the meaning is shared.
+ */
+export { PROJECT_DIR_TOKEN, WORKTREE_BASE_KEY, hasProjectDirToken, normalizeWorktreeBase }
 
 /**
  * TUI-only companion key remembering the last custom path the user
@@ -39,9 +51,6 @@ export const WORKTREE_BASE_KEY = "worktree.basePath"
  * instead of forcing a retype. The daemon never reads this.
  */
 export const WORKTREE_BASE_CUSTOM_KEY = "worktree.basePath.custom"
-
-/** Leading-segment token that expands to the task's project root. */
-export const PROJECT_DIR_TOKEN = "$project_dir"
 
 /**
  * The stored value behind the "next to project" preset: worktrees land
@@ -61,43 +70,6 @@ export function worktreeBaseKindOf(raw: string): WorktreeBaseKind {
   if (!trimmed) return "default"
   if (trimmed.replace(/\/+$/, "") === PROJECT_SIBLING_BASE) return "nextToProject"
   return "custom"
-}
-
-/** True iff `raw` starts with `$project_dir` as its first path segment. */
-export function hasProjectDirToken(raw: string): boolean {
-  const trimmed = raw.trim()
-  return trimmed === PROJECT_DIR_TOKEN || trimmed.startsWith(`${PROJECT_DIR_TOKEN}/`)
-}
-
-/**
- * Normalize a raw user-entered base path to an absolute directory, or
- * `null` when it's unset/blank (meaning "use Rove's default root").
- *
- * A leading `~` / `~/` expands to the OS home; relative paths resolve
- * against it too, so a user who types `code/worktrees` gets a stable
- * absolute location instead of one that depends on kobe's cwd.
- *
- * A leading `$project_dir` segment expands to `projectDir` (the repo
- * root of the task being created), with `..` segments collapsed — so
- * `$project_dir/../wt` lands next to each project. When the token is
- * present but no `projectDir` context exists (a global read with no
- * repo at hand), the result is `null`: fall back to the default root
- * rather than inventing a literal `$project_dir` directory.
- */
-export function normalizeWorktreeBase(raw: string | undefined | null, projectDir?: string): string | null {
-  if (typeof raw !== "string") return null
-  const trimmed = raw.trim()
-  if (!trimmed) return null
-  if (hasProjectDirToken(trimmed)) {
-    if (!projectDir) return null
-    const rest = trimmed.slice(PROJECT_DIR_TOKEN.length).replace(/^\/+/, "")
-    return resolve(projectDir, rest)
-  }
-  // homeDir() already falls back to os.homedir() when KOBE_HOME_DIR is unset.
-  const home = homeDir()
-  if (trimmed === "~") return home
-  const expanded = trimmed.startsWith("~/") ? join(home, trimmed.slice(2)) : trimmed
-  return isAbsolute(expanded) ? expanded : resolve(home, expanded)
 }
 
 /**

--- a/packages/kobe/src/tui/ops/ci-prompt.ts
+++ b/packages/kobe/src/tui/ops/ci-prompt.ts
@@ -16,6 +16,7 @@
 
 import { promises as fs } from "node:fs"
 import path from "node:path"
+import { readFirstNonEmptyRepoFile } from "../../lib/repo-config-file.ts"
 
 /** One failing check as the daemon's `pr.failingChecks` returns it. */
 export interface CIFailingCheck {
@@ -99,21 +100,10 @@ export function renderCIPrompt(template: string, state: CIPromptState): string {
  * `.rove/` → `.kobe/` fallback pair `pr-prompt.ts` reads for its own template.
  * First readable NON-EMPTY file wins.
  */
-const CI_INSTRUCTION_RELS = [
-  path.join(".rove", "ci-instructions.md"),
-  path.join(".kobe", "ci-instructions.md"),
-] as const
+const CI_INSTRUCTION_FILENAME = "ci-instructions.md"
 
-async function loadTemplate(worktree: string): Promise<string> {
-  for (const relative of CI_INSTRUCTION_RELS) {
-    try {
-      const text = await fs.readFile(path.join(worktree, relative), "utf8")
-      if (text.length > 0) return text
-    } catch {
-      // An unreadable/absent file does not block the next candidate.
-    }
-  }
-  return DEFAULT_CI_PROMPT_TEMPLATE
+function loadTemplate(worktree: string): string {
+  return readFirstNonEmptyRepoFile(worktree, CI_INSTRUCTION_FILENAME) ?? DEFAULT_CI_PROMPT_TEMPLATE
 }
 
 /** Pure entry point (the unit-tested one): default template + state. */
@@ -123,5 +113,5 @@ export function buildCIPrompt(state: CIPromptState): string {
 
 /** The repo-aware build the action uses — same shape as `buildPRPrompt`. */
 export async function buildCIPromptForWorktree(worktree: string, state: CIPromptState): Promise<string> {
-  return renderCIPrompt(await loadTemplate(worktree), state)
+  return renderCIPrompt(loadTemplate(worktree), state)
 }

--- a/packages/kobe/src/tui/ops/pr-prompt.ts
+++ b/packages/kobe/src/tui/ops/pr-prompt.ts
@@ -1,6 +1,7 @@
 import { promises as fs } from "node:fs"
 import path from "node:path"
 import { readOnlyGitProcessEnv } from "@/lib/git-env"
+import { readFirstNonEmptyRepoFile } from "../../lib/repo-config-file.ts"
 import { spawnCapture } from "../lib/background-poll"
 
 export interface PRPromptState {
@@ -122,24 +123,13 @@ export function renderPRPrompt(template: string, state: PRPromptState): string {
  * file wins — an empty `.rove/pr-instructions.md` is a no-op placeholder,
  * not an instruction to blank the prompt.
  */
-const PR_INSTRUCTION_RELS = [
-  path.join(".rove", "pr-instructions.md"),
-  path.join(".kobe", "pr-instructions.md"),
-] as const
+const PR_INSTRUCTION_FILENAME = "pr-instructions.md"
 
-async function loadTemplate(worktree: string): Promise<string> {
-  for (const relative of PR_INSTRUCTION_RELS) {
-    try {
-      const text = await fs.readFile(path.join(worktree, relative), "utf8")
-      if (text.length > 0) return text
-    } catch {
-      // An unreadable/absent file does not block the next candidate.
-    }
-  }
-  return DEFAULT_PR_PROMPT_TEMPLATE
+function loadTemplate(worktree: string): string {
+  return readFirstNonEmptyRepoFile(worktree, PR_INSTRUCTION_FILENAME) ?? DEFAULT_PR_PROMPT_TEMPLATE
 }
 
 export async function buildPRPrompt(worktree: string, state?: PRPromptState): Promise<string> {
-  const [template, resolved] = await Promise.all([loadTemplate(worktree), state ?? gatherPRPromptState(worktree)])
-  return renderPRPrompt(template, resolved)
+  const resolved = state ?? (await gatherPRPromptState(worktree))
+  return renderPRPrompt(loadTemplate(worktree), resolved)
 }

--- a/packages/kobe/test/cli/repo-cmd.test.ts
+++ b/packages/kobe/test/cli/repo-cmd.test.ts
@@ -96,9 +96,45 @@ describe("kobe repo set / show / unset round-trip", () => {
     expect(out).toContain(".rove/init.sh:        present (wins)")
     expect(out).toContain(".rove/init-prompt.md: absent")
     expect(out).toContain(".kobe/init.sh:        absent")
-    expect(out).toContain(".kobe/init-prompt.md: present (legacy fallback)")
+    // `.rove/init-prompt.md` is absent, so the legacy file IS the effective
+    // prompt. The old fixed "legacy fallback" label understated that.
+    expect(out).toContain(".kobe/init-prompt.md: present (wins)")
     expect(out).toContain('override initScript:  "echo hi"')
     expect(out).toContain("override initPrompt:  (unset)")
+  })
+
+  it("show does not call a whitespace-only file the winner (it loses to .kobe)", async () => {
+    // The one case `repo show` exists to resolve: which source is live. It used
+    // to answer with a bare existsSync, so a blank `.rove/init-prompt.md`
+    // printed "present (wins)" while the runtime actually used `.kobe/`.
+    mkdirSync(join(repo, ".rove"), { recursive: true })
+    mkdirSync(join(repo, ".kobe"), { recursive: true })
+    writeFileSync(join(repo, ".rove", "init-prompt.md"), "\n", "utf8")
+    writeFileSync(join(repo, ".kobe", "init-prompt.md"), "real", "utf8")
+    logSpy.mockClear()
+
+    await runRepoSubcommand(["show", repo])
+    const out = output()
+    expect(out).toContain(".rove/init-prompt.md: present but empty (ignored)")
+    expect(out).toContain(".kobe/init-prompt.md: present (wins)")
+    expect(out).not.toContain(".rove/init-prompt.md: present (wins)")
+
+    // …and the report agrees with what the engine would actually be handed.
+    const { resolveRepoInit } = await import("../../src/state/repo-init.ts")
+    expect(resolveRepoInit(repo, repo).initPrompt).toBe("real")
+  })
+
+  it("show marks a shadowed legacy file as shadowed, not empty", async () => {
+    mkdirSync(join(repo, ".rove"), { recursive: true })
+    mkdirSync(join(repo, ".kobe"), { recursive: true })
+    writeFileSync(join(repo, ".rove", "init-prompt.md"), "canonical", "utf8")
+    writeFileSync(join(repo, ".kobe", "init-prompt.md"), "legacy", "utf8")
+    logSpy.mockClear()
+
+    await runRepoSubcommand(["show", repo])
+    const out = output()
+    expect(out).toContain(".rove/init-prompt.md: present (wins)")
+    expect(out).toContain(".kobe/init-prompt.md: present (shadowed)")
   })
 
   it("show truncates a long override to a 60-char one-line preview", async () => {

--- a/packages/kobe/test/daemon/cwd-task.test.ts
+++ b/packages/kobe/test/daemon/cwd-task.test.ts
@@ -240,3 +240,82 @@ describe("findAdoptableWorktree", () => {
     expect(findAdoptableWorktree(withRemote, wt)).toEqual({ repo: "/repo", worktreePath: wt })
   })
 })
+
+/**
+ * The daemon used to compute managed worktree roots from its OWN copy of the
+ * layout, and that copy never learned about `worktree.basePath`. A user who
+ * moved their worktree location in Settings → General got worktrees the
+ * adoption path could not see: no error, the worktree simply never became a
+ * task. Both sides now derive the roots from
+ * `@sma1lboy/kobe-daemon/daemon/worktree-paths`, so these assert the daemon
+ * reads the same setting the TUI writes.
+ */
+describe("findAdoptableWorktree honours the worktree.basePath override", () => {
+  let home: string
+  let prev: string | undefined
+
+  const writeBase = (value: string) => {
+    const dir = path.join(home, ".config", "rove")
+    mkdirSync(dir, { recursive: true })
+    writeFileSync(path.join(dir, "state.json"), JSON.stringify({ "worktree.basePath": value }), "utf8")
+  }
+
+  beforeEach(() => {
+    prev = process.env.KOBE_HOME_DIR
+    home = mkdtempSync(path.join(tmpdir(), "rove-wt-base-"))
+    process.env.KOBE_HOME_DIR = home
+  })
+
+  afterEach(() => {
+    if (prev === undefined) Reflect.deleteProperty(process.env, "KOBE_HOME_DIR")
+    else process.env.KOBE_HOME_DIR = prev
+    rmSync(home, { recursive: true, force: true })
+  })
+
+  it("adopts a worktree under an absolute custom base (the regression)", () => {
+    const base = path.join(home, "custom-worktrees")
+    writeBase(base)
+    const wt = path.join(worktreeRootFor("/repo"), "external")
+    expect(wt.startsWith(base)).toBe(true)
+    expect(findAdoptableWorktree([{ id: "main", repo: "/repo", worktreePath: "/repo" }], wt)).toEqual({
+      repo: "/repo",
+      worktreePath: wt,
+    })
+  })
+
+  it("expands a leading $project_dir against the task's own repo", () => {
+    writeBase("$project_dir/..")
+    const repo = path.join(home, "code", "proj")
+    const wt = path.join(worktreeRootFor(repo), "external")
+    // `$project_dir/..` puts the worktrees root beside the repo, not under it.
+    expect(wt.startsWith(path.join(home, "code"))).toBe(true)
+    expect(wt.startsWith(`${repo}/`)).toBe(false)
+    expect(findAdoptableWorktree([{ id: "main", repo, worktreePath: repo }], wt)).toEqual({ repo, worktreePath: wt })
+  })
+
+  it("keeps recognizing the default and legacy global roots while an override is set", () => {
+    writeBase(path.join(home, "custom-worktrees"))
+    const roots = managedWorktreeRootsFor("/repo")
+    const defaultRoot = roots.find((r) => r.startsWith(path.join(home, ".rove", "worktrees")))!
+    const legacyRoot = roots.find((r) => r.startsWith(path.join(home, ".kobe", "worktrees")))!
+    for (const root of [defaultRoot, legacyRoot]) {
+      const wt = path.join(root, "external")
+      expect(findAdoptableWorktree([{ id: "main", repo: "/repo", worktreePath: "/repo" }], wt)).toEqual({
+        repo: "/repo",
+        worktreePath: wt,
+      })
+    }
+  })
+
+  it("does not let one repo-key root prefix-match a longer sibling's", () => {
+    const base = path.join(home, "custom-worktrees")
+    writeBase(base)
+    // Two repo keys where one is a strict string prefix of the other. Matching
+    // on the bare root instead of `<root>/` would bill the shorter repo for a
+    // worktree that belongs to the longer one.
+    const shortRoot = worktreeRootFor("/repo")
+    const longRoot = `${shortRoot}extra`
+    const wt = path.join(longRoot, "external")
+    expect(findAdoptableWorktree([{ id: "main", repo: "/repo", worktreePath: "/repo" }], wt)).toBeUndefined()
+  })
+})

--- a/packages/kobe/test/daemon/porcelain-count.test.ts
+++ b/packages/kobe/test/daemon/porcelain-count.test.ts
@@ -1,0 +1,47 @@
+/**
+ * `countPorcelain` — the sidebar's `+N −M` chips — must agree with the shared
+ * porcelain parser it is now built on.
+ *
+ * The daemon-side counter used to re-scan the lines itself with a laxer filter
+ * (`line.length < 3` and no separator check) than `parsePorcelainRows`
+ * (`line.length < 4` plus `line[2] === " "`). Both survived because the twelve
+ * porcelain edge-case tests in `test/lib/git-parsers.test.ts` exercised kobe's
+ * parser while the daemon's copy was the one actually feeding the UI. These
+ * cover the two inputs where the two implementations disagreed, so a
+ * re-introduced local scan fails here.
+ */
+import { countPorcelain } from "@sma1lboy/kobe-daemon/daemon/worktree-changes-collector"
+import { describe, expect, it } from "vitest"
+
+describe("countPorcelain agrees with parsePorcelainRows", () => {
+  it("skips a status pair with no path (the laxer counter added it)", () => {
+    // "M  " is 3 chars: status pair + separator, empty path. Long enough for
+    // the old `length < 3` guard, too short to name a file.
+    expect(countPorcelain("M  ")).toEqual({ added: 0, deleted: 0 })
+    expect(countPorcelain("M  a.txt\nM  ")).toEqual({ added: 1, deleted: 0 })
+  })
+
+  it("skips a line with no separator in column 3 (the laxer counter added it)", () => {
+    // Anything that is not `XY <path>` — a stray warning, a truncated read —
+    // is not a change. The old counter billed it as an addition.
+    expect(countPorcelain("fatal: not a git repository")).toEqual({ added: 0, deleted: 0 })
+    expect(countPorcelain("MMM")).toEqual({ added: 0, deleted: 0 })
+  })
+
+  it("still counts the real shapes: staged/unstaged, deletes on either side, renames, quoted paths", () => {
+    const out = [
+      "M  src/a.ts", // staged modify
+      " M src/b.ts", // unstaged modify
+      "D  src/gone.ts", // staged delete (X)
+      " D src/vanished.ts", // unstaged delete (Y)
+      '?? "src/has space.txt"', // untracked, quoted
+      'R  "src/old name.txt" -> "src/new name.txt"', // rename, both sides quoted
+      "## main...origin/main", // branch header — never a change
+    ].join("\n")
+    expect(countPorcelain(out)).toEqual({ added: 4, deleted: 2 })
+  })
+
+  it("tolerates CRLF and a trailing blank line", () => {
+    expect(countPorcelain("M  a.txt\r\nD  b.txt\r\n")).toEqual({ added: 1, deleted: 1 })
+  })
+})

--- a/packages/kobe/test/tui/ci-prompt.test.ts
+++ b/packages/kobe/test/tui/ci-prompt.test.ts
@@ -1,4 +1,7 @@
-import { type CIFailingCheck, buildCIPrompt, renderCIPrompt } from "@/tui/ops/ci-prompt"
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { type CIFailingCheck, buildCIPrompt, buildCIPromptForWorktree, renderCIPrompt } from "@/tui/ops/ci-prompt"
 import { describe, expect, it } from "vitest"
 
 const check = (over: Partial<CIFailingCheck> = {}): CIFailingCheck => ({
@@ -50,5 +53,44 @@ describe("buildCIPrompt", () => {
 
   it("leaves unknown template tokens alone (a repo override may use its own)", () => {
     expect(renderCIPrompt("{{branch}} {{nope}}", { branch: "b", checks: [] })).toBe("b {{nope}}")
+  })
+})
+
+/**
+ * The `.rove/` → `.kobe/` template fallback, which had no coverage here at all
+ * while `loadTemplate` accepted a whitespace-only file as a real template and
+ * blanked the prompt. All three readers now share `lib/repo-config-file.ts`.
+ */
+describe("buildCIPromptForWorktree per-repo override", () => {
+  const state = { branch: "feat/x", checks: [check()] }
+  const write = (dir: string, relDir: string, body: string) => {
+    mkdirSync(join(dir, relDir), { recursive: true })
+    writeFileSync(join(dir, relDir, "ci-instructions.md"), body)
+  }
+  const tmp = () => mkdtempSync(join(tmpdir(), "rove-ci-instructions-"))
+
+  it("reads the canonical .rove/ci-instructions.md", async () => {
+    const dir = tmp()
+    write(dir, ".rove", "canonical")
+    await expect(buildCIPromptForWorktree(dir, state)).resolves.toBe("canonical")
+  })
+
+  it("falls back to the legacy .kobe spelling", async () => {
+    const dir = tmp()
+    write(dir, ".kobe", "legacy")
+    await expect(buildCIPromptForWorktree(dir, state)).resolves.toBe("legacy")
+  })
+
+  it("does not let a whitespace-only canonical file shadow the legacy one", async () => {
+    const dir = tmp()
+    write(dir, ".rove", "\n   \n")
+    write(dir, ".kobe", "legacy")
+    await expect(buildCIPromptForWorktree(dir, state)).resolves.toBe("legacy")
+  })
+
+  it("falls back to the built-in template when the only file is whitespace", async () => {
+    const dir = tmp()
+    write(dir, ".rove", "  \n")
+    await expect(buildCIPromptForWorktree(dir, state)).resolves.toBe(buildCIPrompt(state))
   })
 })

--- a/packages/kobe/test/tui/pr-prompt.test.ts
+++ b/packages/kobe/test/tui/pr-prompt.test.ts
@@ -97,6 +97,22 @@ describe("per-repo pr-instructions override", () => {
     await expect(buildPRPrompt(dir, STATE)).resolves.toBe("legacy")
   })
 
+  // The drift: `text.length > 0` accepted a file of pure whitespace and
+  // returned it as the template, blanking the prompt. `repo-init.ts` trimmed,
+  // and its rule is the one all three comments describe.
+  test("a whitespace-only .rove file does not shadow the legacy one", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "rove-pr-instructions-"))
+    writeInstructions(dir, ".rove", "\n   \n")
+    writeInstructions(dir, ".kobe", "legacy")
+    await expect(buildPRPrompt(dir, STATE)).resolves.toBe("legacy")
+  })
+
+  test("a whitespace-only file alone falls back to the built-in template", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "rove-pr-instructions-"))
+    writeInstructions(dir, ".rove", "  \n")
+    await expect(buildPRPrompt(dir, STATE)).resolves.not.toBe("  \n")
+  })
+
   test("no override file falls back to the built-in template", async () => {
     const dir = mkdtempSync(join(tmpdir(), "rove-pr-instructions-"))
     await expect(buildPRPrompt(dir, STATE)).resolves.toContain("The user requested a PR.")


### PR DESCRIPTION
Four places where the same logic was written twice and the copies had already drifted apart, so each one was producing a real behavior difference.

## 1. Worktree adoption never saw the worktree-location setting

`cwd-task.ts` computed managed worktree roots from the daemon's own copy of the layout, and that copy had no branch for `worktree.basePath`. Set Settings → General → Worktree location, and an engine starting inside one of those worktrees prefix-matched nothing: the worktree silently never became a task.

Both packages now derive the roots — and the meaning of the stored setting — from `kobe-daemon/daemon/worktree-paths.ts`. Each side keeps its own read policy: kobe through the State Store (which owns the corrupt-file backup), the daemon read-only, since a daemon must not rewrite a user file it merely observes.

**End-to-end A/B** — real isolated home + daemon, real git worktree under a custom base, real `rove hook session-start`, same worktree both times:

| daemon | result |
|---|---|
| override ignored (pre-fix) | not adopted, no error |
| override honoured (this PR) | adopted as task `adoptme2` |

## 2. The `+N −M` chips counted lines the parser rejects

`countPorcelain` re-scanned `git status` output with a looser filter than `parsePorcelainRows`: `length < 3` instead of `< 4`, and no check that column 3 is the separator. Since the daemon collector is what feeds the sidebar today, the twelve porcelain edge-case tests in `test/lib/git-parsers.test.ts` were covering an implementation no longer in that path.

Measured divergence (`countPorcelain`, before → after):

| input | before | after |
|---|---|---|
| `"M  "` (status pair, empty path) | `added: 1` | `added: 0` |
| `"MMM"` (no separator at col 3) | `added: 1` | `added: 0` |
| `"fatal: not a git repository"` | `added: 1` | `added: 0` |
| `"M  a.txt\r\nD  b.txt\r\n"` | `+1 −1` | `+1 −1` (unchanged) |

Rename/quoted-path handling differed too, but only in the parsed path, which a counter never reads — so those were not a behavior difference and are not claimed as one.

Parsing only. The four-way fair queue, 10 ms publish coalescing, subscriber gate, and stop/abort/late-result protection from #901 are untouched.

## 3. Two different definitions of "non-empty" in the `.rove/` → `.kobe/` fallback

Written three times: `repo-init.ts` trimmed before deciding a candidate counted; `pr-prompt.ts` and `ci-prompt.ts` did not. A `.rove/pr-instructions.md` holding a single newline was returned as the template and **blanked the PR prompt**, while the same file was correctly skipped for `init-prompt.md`. Both comments in `tui/ops` described `repo-init`'s rule, so trimming is the shared answer.

All three now go through `lib/repo-config-file.ts`. `buildCIPromptForWorktree` had no test coverage at all; it has some now.

## 4. `rove repo show` said the opposite of what runs

It answered "present (wins)" from a bare `existsSync`, so an empty `.rove/init-prompt.md` printed as the winner while the runtime fell through to `.kobe/` or the saved override — in the one situation the command exists to resolve. `describeRepoInitSources` now applies `resolveRepoInit`'s own rules, and the output separates *shadowed by a higher-precedence file* from *ignored for being empty*.

One existing assertion changed: a `.kobe/init-prompt.md` that is the effective source used to print "present (legacy fallback)". It wins, and now says so.

## Grep counts (before → after)

| check | before | after |
|---|---|---|
| `repoWorktreeDirName` regex across `packages/` | 2 | 1 |
| `"worktrees"` literal in `cwd-task.ts` | 1 | 0 |
| `line.length < 3` in `worktree-status-runner.ts` | 1 | 0 |
| `parsePorcelainRows` in `kobe-daemon/src` | 0 | 3 |
| `if (text.length > 0) return text` in `tui/ops` | 2 | 0 |
| `"\.kobe"` literal dir in `kobe/src` | 4 | 1 (the shared constant) |
| `existsSync(join(repo, ".rove"\|".kobe"` in `repo-cmd.ts` | 4 | 0 |

## Mutation verification

Each merged implementation was reverted to the copy it replaced; only the intended tests went red.

| mutation | red |
|---|---|
| daemon passes `null` instead of the override | 2 (the two override tests; default/legacy-compat and sibling-boundary stayed green — correct, they don't depend on it) |
| `findAdoptableWorktree` prefix loses its trailing `/` | 11, including the sibling-boundary test |
| `countPorcelain` back to the local laxer scan | 2 (the two divergence tests; the CRLF and real-shape tests stayed green) |
| shared reader drops `.trim()` | 6, across all three former call sites |
| `describeRepoInitSources` reports from existence only | 1 (the diagnostic test; runtime tests stayed green — correct, that mutation only breaks the report) |

## Gates

`bun run lint` (root) · `bun run typecheck` · `test:fast` 479 files / 4698 tests · `test:socket` 112 files / 901 tests · `bun test test/render` 484 tests. Every touched file is under the 500-line cap; `paths.ts`, `cwd-task.ts` and `git-parsers.ts` all shrank.

## Notes for review

- Dependency direction verified before starting: `kobe` → `@sma1lboy/kobe-daemon`, never back — so the shared code lands in kobe-daemon and kobe re-exports.
- No persisted-config semantics changed. `normalizeWorktreeBase` moved verbatim and is now the single interpreter of `worktree.basePath`; kobe's `homeDir()` is literally `resolveProductHomeDir()`, so the daemon-side home resolution is identical to what kobe already did.
- One deliberate behavior change beyond de-duplication, called out in the changeset: a whitespace-only PR/CI instruction file now falls through instead of blanking the prompt.
