### PR TITLE
Six surfaces that never followed the vocabulary the rest of the UI already agreed on

### DIFF
--- a/.changeset/six-ui-token-drifts.md
+++ b/.changeset/six-ui-token-drifts.md
@@ -1,0 +1,23 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Six places where the UI had drifted from the vocabulary the rest of it already speaks
+
+The narrow tab strip painted every turn state one colour, so `● running` and
+`! error` differed only by glyph on a phone-width terminal. The chip now takes
+the same tone the wide strip does — and sits outside the active-tab fill,
+because on that orange fill the error red lands at a 1.02 contrast ratio.
+
+The update and worktrees pages each had their own cursor row: a solid `primary`
+bar and a `▸ ` prefix. Both now use the shared row chrome, so the cursor is the
+same `▌` everywhere and transparent mode stops painting opaque patches onto the
+host wallpaper. `▸` also goes back to meaning only "collapsed", which is what it
+means in the sidebar and the file tree.
+
+The right-click menu now reads `backgroundMenu` — a token every bundled theme
+defines and nothing read — so the popup separates from the panel it covers
+instead of sharing its exact fill. The set-branch dialog's field takes the
+shared dialog label and well. The update and versions pages drop a scrollbar
+track no other page draws. And the `q / esc` close hint in those two page
+headers is translated, like the title beside it.

--- a/packages/kobe/src/tui-react/component/branch-picker-dialog.tsx
+++ b/packages/kobe/src/tui-react/component/branch-picker-dialog.tsx
@@ -31,6 +31,7 @@ import { useTheme } from "../context/theme"
 import { useT } from "../i18n"
 import { useBindings } from "../lib/keymap"
 import { type DialogContext, showDialog, useDialog, useDialogPaddingX } from "../ui/dialog"
+import { DialogField, DialogSection } from "../ui/dialog-parts"
 import { PickerList } from "./new-task-dialog/picker-list"
 
 export function BranchPickerDialogView(props: {
@@ -91,19 +92,20 @@ export function BranchPickerDialogView(props: {
           esc
         </text>
       </box>
-      <box gap={0}>
-        <text fg={theme.accent}>{t("tasks.reBranch.fieldLabel")}</text>
-        <input
-          value={value}
-          placeholder={props.currentBranch}
-          focused={true}
-          onInput={(v: string) => {
-            setValue(stripNewlines(v))
-            setCursor(0)
-          }}
-          onSubmit={() => commit(resolveBaseRef(value, filtered, cursor))}
-        />
-      </box>
+      <DialogSection label={t("tasks.reBranch.fieldLabel")} focused={true}>
+        <DialogField focused={true}>
+          <input
+            value={value}
+            placeholder={props.currentBranch}
+            focused={true}
+            onInput={(v: string) => {
+              setValue(stripNewlines(v))
+              setCursor(0)
+            }}
+            onSubmit={() => commit(resolveBaseRef(value, filtered, cursor))}
+          />
+        </DialogField>
+      </DialogSection>
       {filtered.length === 0 ? (
         <box gap={0} paddingBottom={1}>
           <text fg={theme.textMuted} wrapMode="none">

--- a/packages/kobe/src/tui-react/component/update-page.tsx
+++ b/packages/kobe/src/tui-react/component/update-page.tsx
@@ -28,6 +28,7 @@ import {
 import { useTheme } from "../context/theme"
 import { useT } from "../i18n"
 import { pageCloseBindings, useBindings } from "../lib/keymap"
+import { resolveRowSelectionChrome } from "../ui/row-selection-chrome"
 import { runShellUpdater } from "./run-updater.ts"
 
 type ActionId = "update" | "release" | "close"
@@ -168,7 +169,7 @@ export function UpdatePage(props: { onClose: () => void }) {
           {t("update.pageTitle")}
         </text>
         <text fg={theme.textMuted} wrapMode="none" onMouseUp={() => activate("close")}>
-          q / esc
+          {t("update.closeHint")}
         </text>
       </box>
 
@@ -207,35 +208,42 @@ export function UpdatePage(props: { onClose: () => void }) {
       ) : null}
 
       <box flexDirection="column" flexShrink={0} paddingTop={1} gap={0}>
-        {actions.map((action) => (
-          <box
-            key={action.id}
-            flexDirection="row"
-            gap={1}
-            paddingLeft={1}
-            paddingRight={1}
-            backgroundColor={selected === action.id ? theme.primary : undefined}
-            onMouseUp={() => activate(action.id)}
-          >
-            <box width={4} flexShrink={0}>
-              <text
-                fg={selected === action.id ? theme.selectedListItemText : theme.accent}
-                attributes={TextAttributes.BOLD}
-                wrapMode="none"
-              >
-                [{action.key}]
+        {actions.map((action) => {
+          // Same cursor vocabulary as every other navigable list (▌ marker +
+          // row tint, no fill under transparency) — this page is a full-window
+          // page, so a `primary` bar here painted an opaque patch straight
+          // onto the host wallpaper.
+          const cursor = selected === action.id
+          const chrome = resolveRowSelectionChrome(theme, { cursor })
+          return (
+            <box
+              key={action.id}
+              flexDirection="row"
+              gap={0}
+              backgroundColor={chrome.backgroundColor}
+              onMouseUp={() => activate(action.id)}
+            >
+              <text fg={chrome.markerColor} wrapMode="none">
+                {chrome.marker}
               </text>
+              <box flexDirection="row" gap={1} flexGrow={1} paddingLeft={1} paddingRight={1}>
+                <box width={4} flexShrink={0}>
+                  <text fg={theme.accent} attributes={TextAttributes.BOLD} wrapMode="none">
+                    [{action.key}]
+                  </text>
+                </box>
+                <box width={14} flexShrink={0}>
+                  <text fg={theme.text} attributes={cursor ? TextAttributes.BOLD : undefined} wrapMode="none">
+                    {action.label}
+                  </text>
+                </box>
+                <text fg={theme.textMuted} wrapMode="word">
+                  {action.detail}
+                </text>
+              </box>
             </box>
-            <box width={14} flexShrink={0}>
-              <text fg={selected === action.id ? theme.selectedListItemText : theme.text} wrapMode="none">
-                {action.label}
-              </text>
-            </box>
-            <text fg={selected === action.id ? theme.selectedListItemText : theme.textMuted} wrapMode="word">
-              {action.detail}
-            </text>
-          </box>
-        ))}
+          )
+        })}
       </box>
 
       {status ? (
@@ -256,7 +264,7 @@ export function UpdatePage(props: { onClose: () => void }) {
         flexShrink={1}
         stickyScroll={false}
         verticalScrollbarOptions={{
-          trackOptions: { backgroundColor: theme.background, foregroundColor: theme.borderActive },
+          trackOptions: { foregroundColor: "transparent" },
         }}
       >
         <box flexDirection="column" paddingRight={1} paddingBottom={1} gap={0}>

--- a/packages/kobe/src/tui-react/component/versions-page.tsx
+++ b/packages/kobe/src/tui-react/component/versions-page.tsx
@@ -100,7 +100,7 @@ function VersionsPage(props: { onClose: () => void }) {
           {t("update.versions.pageTitle")}
         </text>
         <text fg={theme.textMuted} wrapMode="none" onMouseUp={props.onClose}>
-          q / esc
+          {t("update.versions.closeHint")}
         </text>
       </box>
 
@@ -153,7 +153,7 @@ function VersionsPage(props: { onClose: () => void }) {
             flexShrink={1}
             stickyScroll={false}
             verticalScrollbarOptions={{
-              trackOptions: { backgroundColor: theme.background, foregroundColor: theme.borderActive },
+              trackOptions: { foregroundColor: "transparent" },
             }}
           >
             <box flexDirection="column" paddingRight={1} paddingBottom={1} gap={0}>

--- a/packages/kobe/src/tui-react/component/worktrees-page.tsx
+++ b/packages/kobe/src/tui-react/component/worktrees-page.tsx
@@ -39,6 +39,7 @@ import { pageCloseBindings, useBindings } from "../lib/keymap"
 import { useCursorFollow } from "../lib/use-cursor-follow"
 import { useDialog } from "../ui/dialog"
 import { DialogConfirm } from "../ui/dialog-confirm"
+import { resolveRowSelectionChrome } from "../ui/row-selection-chrome"
 import { landTaskAction } from "../workspace/land-task-action"
 
 function flattenRows(projects: readonly WorktreeProject[]): readonly WorktreeAuditRow[] {
@@ -312,21 +313,25 @@ export function WorktreesPage(props: { orchestrator: RemoteOrchestrator | null; 
                 project.worktrees.map((row, i) => {
                   const absoluteIndex = base + i
                   const isCursor = absoluteIndex === cursor
+                  // The shared cursor vocabulary (▌ marker + row tint, no fill
+                  // under transparency). `▸` used to mean two things at once
+                  // here — it is the sidebar's and the file tree's "collapsed"
+                  // glyph — and the `primary` text tint was this page's alone.
+                  const chrome = resolveRowSelectionChrome(theme, { cursor: isCursor })
                   return (
                     <box
                       key={row.path}
                       ref={follow.rowRef(absoluteIndex)}
                       gap={0}
+                      backgroundColor={chrome.backgroundColor}
                       onMouseUp={() => setCursor(absoluteIndex)}
                     >
                       <box flexDirection="row">
-                        <text
-                          fg={isCursor ? theme.primary : theme.text}
-                          attributes={isCursor ? TextAttributes.BOLD : undefined}
-                          wrapMode="none"
-                        >
-                          {isCursor ? "▸ " : "  "}
-                          {row.branch || t("worktrees.row.detached")}
+                        <text fg={chrome.markerColor} wrapMode="none">
+                          {chrome.marker}
+                        </text>
+                        <text fg={theme.text} attributes={isCursor ? TextAttributes.BOLD : undefined} wrapMode="none">
+                          {` ${row.branch || t("worktrees.row.detached")}`}
                         </text>
                         {row.kobeManaged ? <text fg={theme.textMuted}> {t("worktrees.badge.kobeManaged")}</text> : null}
                         {row.dirty === true ? <text fg={theme.warning}> {t("worktrees.badge.dirty")}</text> : null}
@@ -341,15 +346,20 @@ export function WorktreesPage(props: { orchestrator: RemoteOrchestrator | null; 
                         {verdictBadge(row)}
                         {busyPath === row.path ? <text fg={theme.textMuted}> …</text> : null}
                       </box>
-                      <box flexDirection="row" justifyContent="space-between" paddingLeft={2}>
-                        <text fg={theme.textMuted} wrapMode="none">
-                          {row.path}
+                      <box flexDirection="row">
+                        <text fg={chrome.markerColor} wrapMode="none">
+                          {chrome.marker}
                         </text>
-                        {row.createdAtMs > 0 ? (
+                        <box flexDirection="row" justifyContent="space-between" flexGrow={1} paddingLeft={1}>
                           <text fg={theme.textMuted} wrapMode="none">
-                            {t("worktrees.row.created", { age: relativeAge(row.createdAtMs) })}
+                            {row.path}
                           </text>
-                        ) : null}
+                          {row.createdAtMs > 0 ? (
+                            <text fg={theme.textMuted} wrapMode="none">
+                              {t("worktrees.row.created", { age: relativeAge(row.createdAtMs) })}
+                            </text>
+                          ) : null}
+                        </box>
                       </box>
                     </box>
                   )

--- a/packages/kobe/src/tui-react/ui/context-menu.tsx
+++ b/packages/kobe/src/tui-react/ui/context-menu.tsx
@@ -67,7 +67,10 @@ export function ContextMenu(props: {
       flexDirection="column"
       {...FRAME}
       borderColor={theme.focusAccent}
-      backgroundColor={theme.backgroundElement}
+      // `backgroundMenu`, not `backgroundElement`: the menu floats OVER panel
+      // insets, and every bundled theme gives it its own lighter step so the
+      // popup separates from the row it covers, not just by its border.
+      backgroundColor={theme.backgroundMenu}
       paddingLeft={1}
       paddingRight={1}
       // The menu swallows its own press so the owner's "a click landed
@@ -89,7 +92,7 @@ export function ContextMenu(props: {
             <text
               // Contrast fg on the accent fill: `background` is alpha-0 in
               // transparent mode, so a filled row must not use it.
-              fg={active ? theme.backgroundElement : entry.danger ? theme.error : theme.text}
+              fg={active ? theme.selectedListItemText : entry.danger ? theme.error : theme.text}
               attributes={active ? TextAttributes.BOLD : undefined}
               wrapMode="none"
               flexGrow={1}
@@ -98,7 +101,7 @@ export function ContextMenu(props: {
             </text>
             {entry.cap ? (
               <text
-                fg={active ? theme.backgroundElement : theme.textMuted}
+                fg={active ? theme.selectedListItemText : theme.textMuted}
                 attributes={active ? undefined : TextAttributes.DIM}
                 wrapMode="none"
                 flexShrink={0}

--- a/packages/kobe/src/tui-react/workspace/tab-strip.tsx
+++ b/packages/kobe/src/tui-react/workspace/tab-strip.tsx
@@ -28,7 +28,7 @@ import { truncateEndCells } from "../../tui/lib/truncate"
 import { type TerminalTab, tabTitle, visibleNativeStatus } from "../../tui/workspace/terminal-tabs-core"
 import type { VendorId } from "../../types/vendor"
 import { useKV } from "../context/kv"
-import { useTheme } from "../context/theme"
+import { type Theme, useTheme } from "../context/theme"
 import { isNarrowWidth } from "../lib/narrow-mode"
 
 export { tabTitle }
@@ -50,6 +50,28 @@ export const TURN_GLYPHS: Record<ChatTabTurnState, string> = {
   needs_input: "?",
   unknown: "?",
   idle: "○",
+}
+
+/**
+ * The tone a turn glyph carries, in BOTH strip forms. Semantic activity
+ * color, never `focusAccent`: several tabs can be running at once, and the
+ * focus orange must keep meaning only "you are here".
+ */
+function turnColor(theme: Theme, turn: ChatTabTurnState) {
+  switch (turn) {
+    case "running":
+      return theme.info
+    case "done":
+      return theme.success
+    case "error":
+    case "dead":
+      return theme.error
+    case "needs_input":
+    case "rate_limited":
+      return theme.warning
+    default:
+      return theme.textMuted
+  }
 }
 
 /** How long the running→done pulse stays emphasized. */
@@ -224,13 +246,17 @@ export function TabStrip(props: {
       // alpha-0 so the host wallpaper shows through — only the active tab's
       // chip fill paints (it must stay legible against any backdrop).
       <box flexDirection="row" flexShrink={0} paddingLeft={1} paddingRight={1} gap={1} overflow="hidden">
+        {/* Chip OUTSIDE the fill, for the reason the wide branch dropped its
+            own fill: on `focusAccent` the error red lands at a 1.02 contrast
+            ratio, so every tone collapses into the orange. On the ambient
+            surface all seven states stay tellable apart. */}
+        {active.chipShown ? (
+          <text fg={turnColor(theme, active.turn)} attributes={pulse ? TextAttributes.BOLD : undefined} wrapMode="none">
+            {TURN_GLYPHS[active.turn]}
+          </text>
+        ) : null}
         <box flexDirection="row" flexShrink={1} paddingLeft={1} paddingRight={1} backgroundColor={theme.focusAccent}>
-          {active.chipShown ? (
-            <text fg={theme.backgroundElement} attributes={pulse ? TextAttributes.BOLD : undefined} wrapMode="none">
-              {`${TURN_GLYPHS[active.turn]} `}
-            </text>
-          ) : null}
-          <text fg={theme.backgroundElement} attributes={TextAttributes.BOLD} wrapMode="none">
+          <text fg={theme.selectedListItemText} attributes={TextAttributes.BOLD} wrapMode="none">
             {truncateEndCells(active.title, titleCells, approxCharCells)}
           </text>
         </box>
@@ -256,19 +282,6 @@ export function TabStrip(props: {
       <box flexDirection="row" gap={0} flexShrink={0} marginLeft={-offset}>
         {entries.map(({ tab, turn, chipShown, title }) => {
           const pulse = pulsing.has(tab.id)
-          const turnColor =
-            turn === "running"
-              ? // Semantic activity color, never `focusAccent`: several tabs
-                // can be running at once, and the focus orange must keep
-                // meaning only "you are here" (the active tab's frame).
-                theme.info
-              : turn === "done"
-                ? theme.success
-                : turn === "error" || turn === "dead"
-                  ? theme.error
-                  : turn === "needs_input" || turn === "rate_limited"
-                    ? theme.warning
-                    : theme.textMuted
           const active = tab.id === props.activeId
           return (
             <box
@@ -296,7 +309,7 @@ export function TabStrip(props: {
                   No fill behind the chip anymore — the active tab is an open
                   frame, so tone colors survive on every tab. */}
               {chipShown ? (
-                <text fg={turnColor} attributes={pulse ? TextAttributes.BOLD : undefined} wrapMode="none">
+                <text fg={turnColor(theme, turn)} attributes={pulse ? TextAttributes.BOLD : undefined} wrapMode="none">
                   {`${TURN_GLYPHS[turn]} `}
                 </text>
               ) : null}

--- a/packages/kobe/src/tui/i18n/messages/update.ts
+++ b/packages/kobe/src/tui/i18n/messages/update.ts
@@ -5,6 +5,9 @@
 
 export const en = {
   pageTitle: "ROVE UPDATE",
+  /** Page-header close affordance, opposite the title. Keys stay literal;
+   *  only the verb is translated — same shape as `versions.footerHint`. */
+  closeHint: "q / esc close",
   /** Brand-row chip — must stay tiny, the rail is the narrowest panel. */
   chip: "↑ {version}",
   current: "current",
@@ -56,11 +59,13 @@ export const en = {
     breakingWarning:
       "⚠ installing this crosses breaking version(s) {versions}. Rove will refuse to start until you run `rove reset`, which stops the daemon, the PTY host, and every live session. Tasks and worktrees are kept.",
     footerHint: "j/k select · enter install · q close",
+    closeHint: "q / esc close",
   },
 }
 
 export const zh: typeof en = {
   pageTitle: "ROVE 更新",
+  closeHint: "q / esc 关闭",
   chip: "↑ {version}",
   current: "当前",
   latest: "最新",
@@ -101,5 +106,6 @@ export const zh: typeof en = {
     breakingWarning:
       "⚠ 安装该版本会跨过 breaking 版本 {versions}。更新后 Rove 会拒绝启动，直到你运行 `rove reset`——它会停掉 daemon、PTY host 和所有活动会话。任务和 worktree 会保留。",
     footerHint: "j/k 选择 · enter 安装 · q 关闭",
+    closeHint: "q / esc 关闭",
   },
 }

--- a/packages/kobe/test/render/branch-picker-field.test.tsx
+++ b/packages/kobe/test/render/branch-picker-field.test.tsx
@@ -1,0 +1,33 @@
+/** @jsxImportSource @opentui/react */
+/**
+ * The set-branch dialog's one input must be built from the shared dialog
+ * parts. It already borrows `PickerList` for its rows, so the label and the
+ * input were the only pieces left speaking a private dialect: a thin `accent`
+ * label and a bare input with no well around it, next to a rename dialog
+ * whose single labelled input looks nothing like it.
+ */
+
+import { expect, test } from "bun:test"
+import { TextAttributes } from "@opentui/core"
+import { BranchPickerDialogView } from "../../src/tui-react/component/branch-picker-dialog"
+import { BUNDLED_THEMES, DEFAULT_THEME, applyDisplayOverlay, resolveTheme } from "../../src/tui/context/theme-core"
+import { renderComponent } from "./harness"
+
+const theme = applyDisplayOverlay(resolveTheme(BUNDLED_THEMES[DEFAULT_THEME], "dark"), "primary", true)
+
+test("the branch field wears the shared dialog label and well", async () => {
+  const { frame, spans } = await renderComponent(
+    <BranchPickerDialogView currentBranch="feat/a" repo="/x/kobe" onSubmit={() => {}} onCancel={() => {}} />,
+    // 34+ rows: below that `FRAMED_DIALOG_MIN_ROWS` drops every well in the
+    // dialog system, this one included.
+    { width: 70, height: 36, providers: { dialog: true } },
+  )
+  const label = (await spans()).lines.flatMap((line) => line.spans).find((span) => span.text.trim() === "branch")
+  expect(label).toBeDefined()
+  // A focused DialogLabel: primary, BOLD *and* UNDERLINE. `accent` + plain
+  // BOLD is what this file used to draw.
+  expect(label?.fg?.toInts()).toEqual(theme.primary.toInts())
+  expect((label?.attributes ?? 0) & TextAttributes.UNDERLINE).toBe(TextAttributes.UNDERLINE)
+  // The well: DialogField's rounded border around the input.
+  expect(await frame()).toContain("╭")
+})

--- a/packages/kobe/test/render/page-chrome-tokens.test.tsx
+++ b/packages/kobe/test/render/page-chrome-tokens.test.tsx
@@ -1,0 +1,179 @@
+/** @jsxImportSource @opentui/react */
+/**
+ * Full-window pages must speak the shell's own vocabulary. Three drifts this
+ * file pins, each of which looked fine in isolation and wrong beside the pane
+ * next to it:
+ *
+ *  - the cursor row: `resolveRowSelectionChrome` (▌ marker, no fill under
+ *    transparency), not a page-local `primary` bar or a `▸ ` prefix that
+ *    already means "collapsed" in the sidebar and the file tree;
+ *  - the page-header close affordance: translated, like the title beside it;
+ *  - the scrollbar: page-side convention is a slider with no track, so a page
+ *    does not hang a `borderActive` rail over the host wallpaper.
+ */
+
+import { afterEach, expect, test } from "bun:test"
+import type { CapturedFrame } from "@opentui/core"
+import type { RemoteOrchestrator } from "../../src/client/remote-orchestrator"
+import { UpdatePage } from "../../src/tui-react/component/update-page"
+import { WorktreesPage } from "../../src/tui-react/component/worktrees-page"
+import { setTransparentBackground } from "../../src/tui-react/context/theme"
+import { BUNDLED_THEMES, DEFAULT_THEME, applyDisplayOverlay, resolveTheme } from "../../src/tui/context/theme-core"
+import { currentLang, setLocaleLang } from "../../src/tui/i18n"
+import { renderComponent, settle } from "./harness"
+
+const LANG = currentLang()
+afterEach(() => {
+  setLocaleLang(LANG)
+  setTransparentBackground(true)
+})
+
+/** The harness's ThemeProvider defaults, resolved for token comparisons. */
+function tokens(transparent: boolean) {
+  return applyDisplayOverlay(resolveTheme(BUNDLED_THEMES[DEFAULT_THEME], "dark"), "primary", transparent)
+}
+
+function spanWith(frame: CapturedFrame, needle: string) {
+  return frame.lines.flatMap((line) => line.spans).find((span) => span.text.includes(needle))
+}
+
+/** No network in the render track: keep both of the page's reads deterministic. */
+async function withOfflineUpdatePage<T>(run: () => Promise<T>): Promise<T> {
+  const prevFake = process.env.KOBE_FAKE_UPDATE ?? ""
+  const realFetch = globalThis.fetch
+  process.env.KOBE_FAKE_UPDATE = ""
+  globalThis.fetch = (async () => {
+    throw new Error("offline")
+  }) as unknown as typeof fetch
+  try {
+    return await run()
+  } finally {
+    globalThis.fetch = realFetch
+    process.env.KOBE_FAKE_UPDATE = prevFake
+  }
+}
+
+test("the update page's cursor row takes the shared chrome, not a page-local fill", async () => {
+  // Transparent mode is the case that made this visible: a `primary` bar on a
+  // full-window page paints an opaque patch straight onto the host wallpaper,
+  // which is exactly what `row-selection-chrome` exists to prevent. Checked
+  // in BOTH modes, because "no fill" alone would also pass with the chrome
+  // deleted — the opaque half pins that the cursor still tints something.
+  for (const transparent of [true, false]) {
+    setTransparentBackground(transparent)
+    const theme = tokens(transparent)
+    const { spans } = await withOfflineUpdatePage(async () => {
+      const handle = await renderComponent(<UpdatePage onClose={() => {}} />, { width: 74, height: 20 })
+      await settle(150)
+      return handle
+    })
+    const frame = await spans()
+    // "Close" is the cursor row until the registry reports something newer,
+    // and offline it never does.
+    const row = spanWith(frame, "Close")
+    expect(row).toBeDefined()
+    // The ▌ marker carries the cursor signal in both modes.
+    expect(spanWith(frame, "▌")).toBeDefined()
+    if (transparent) {
+      expect(row?.bg?.a ?? 0).toBe(0)
+    } else {
+      expect(row?.bg?.toInts()).toEqual(theme.backgroundElement.toInts())
+    }
+    // Never the page-local bar this replaced.
+    expect(row?.bg?.toInts()).not.toEqual(theme.primary.toInts())
+  }
+})
+
+test("the worktrees page marks its cursor with ▌, not the tree's `collapsed` glyph", async () => {
+  const orchestrator = {
+    listWorktrees: async () => [
+      {
+        repo: "/x/kobe",
+        worktrees: [
+          {
+            repo: "/x/kobe",
+            path: "/x/wt/feature-a",
+            branch: "feature-a",
+            head: "abc1234",
+            dirty: false,
+            kobeManaged: true,
+            lastActivityMs: 0,
+            createdAtMs: 0,
+            branchOnRemote: false,
+            verdict: "fresh",
+            verdictReason: "fresh",
+          },
+        ],
+      },
+    ],
+    listTasks: () => [],
+  } as unknown as RemoteOrchestrator
+  const { frame } = await renderComponent(<WorktreesPage orchestrator={orchestrator} onClose={() => {}} />, {
+    width: 74,
+    height: 20,
+    providers: { dialog: true, notifications: true },
+  })
+  await settle(150)
+  const out = await frame()
+  expect(out).toContain("feature-a")
+  expect(out).toContain("▌")
+  // `▸` is the sidebar's and the file tree's "collapsed" marker. Two meanings
+  // for one glyph is the drift, so the cursor must not reintroduce it.
+  expect(out).not.toContain("▸")
+})
+
+test("the update page header's close hint is translated with its title", async () => {
+  setLocaleLang("zh")
+  const { frame } = await withOfflineUpdatePage(async () => {
+    const handle = await renderComponent(<UpdatePage onClose={() => {}} />, { width: 74, height: 20 })
+    await settle(150)
+    return handle
+  })
+  // Pin the HEADER ROW, not the page: `update.actions.close` also renders as
+  // 关闭 further down, so a page-wide `toContain` passed with the hint still
+  // hardcoded in English.
+  const header = (await frame()).split("\n").find((line) => line.includes("ROVE 更新"))
+  expect(header).toBeDefined()
+  expect(header).toContain("关闭")
+  expect(header).not.toContain("q / esc close")
+})
+
+test("a page's scrollbar shows a slider, not a rail", async () => {
+  // Pages draw `{ foregroundColor: "transparent" }` — worktrees, work items,
+  // automations, kanban, settings, the file tree and the ops preview all do.
+  // Dialogs are the ones that draw a track, and they fill it with
+  // `backgroundDialog`. These two pages did neither: a `borderActive` rail on
+  // a `theme.background` bed, and that bed is alpha-0 under transparency, so
+  // the rail hung over the host wallpaper attached to nothing.
+  const theme = tokens(true)
+  const prevFake = process.env.KOBE_FAKE_UPDATE ?? ""
+  const realFetch = globalThis.fetch
+  process.env.KOBE_FAKE_UPDATE = "99.0.0"
+  globalThis.fetch = (async () =>
+    new Response(
+      JSON.stringify([
+        {
+          tag_name: "v99.0.0",
+          html_url: "https://example.invalid/r",
+          // Long enough that the notes pane has to scroll at this height.
+          body: Array.from({ length: 40 }, (_, i) => `- change number ${i}`).join("\n"),
+        },
+      ]),
+      { headers: { "content-type": "application/json" } },
+    )) as unknown as typeof fetch
+  try {
+    const { spans } = await renderComponent(<UpdatePage onClose={() => {}} />, { width: 74, height: 20 })
+    await settle(200)
+    const frame = await spans()
+    // The notes did render, so there IS a scrollbar to assert about.
+    expect(frame.lines.flatMap((l) => l.spans).some((s) => s.text.includes("change number"))).toBe(true)
+    const rail = frame.lines
+      .flatMap((line) => line.spans)
+      .filter((span) => span.text.trim().length > 0)
+      .find((span) => span.fg?.toInts().join() === theme.borderActive.toInts().join())
+    expect(rail).toBeUndefined()
+  } finally {
+    globalThis.fetch = realFetch
+    process.env.KOBE_FAKE_UPDATE = prevFake
+  }
+})

--- a/packages/kobe/test/render/sidebar-tree-menu.test.tsx
+++ b/packages/kobe/test/render/sidebar-tree-menu.test.tsx
@@ -11,6 +11,7 @@
 import { expect, test } from "bun:test"
 import { SidebarTree } from "../../src/tui-react/panes/sidebar/SidebarTree"
 import { tabsByTask } from "../../src/tui-react/workspace/terminal-tabs-shared"
+import { BUNDLED_THEMES, DEFAULT_THEME, applyDisplayOverlay, resolveTheme } from "../../src/tui/context/theme-core"
 import type { Task } from "../../src/types/task"
 import { toTaskId } from "../../src/types/task"
 import { renderComponent } from "./harness"
@@ -317,4 +318,22 @@ test("Set status fires the row's callback with that row's task", async () => {
   await settle()
 
   expect(asked).toEqual(["b"])
+})
+
+test("the menu panel sits on `backgroundMenu`, a step above the inset it covers", async () => {
+  // Every bundled theme defines its own `backgroundMenu` (claude: #33312E vs
+  // element #2B2A27), and nothing read it — the popup shared the exact fill of
+  // the panel inset underneath, so only its border separated the two. The
+  // fallback in `theme-core` is for themes that DON'T define the token; these
+  // do.
+  const theme = applyDisplayOverlay(resolveTheme(BUNDLED_THEMES[DEFAULT_THEME], "dark"), "primary", true)
+  expect(theme.backgroundMenu.toInts()).not.toEqual(theme.backgroundElement.toInts())
+  tabsByTask.clear()
+  const { frame, spans, mockMouse } = await renderComponent(tree(), { width: 40, height: 24 })
+  await settle()
+  await mockMouse.click(2, lineOf(await frame(), "feat/a"), RIGHT)
+  await settle()
+  const rename = (await spans()).lines.flatMap((line) => line.spans).find((span) => span.text.includes("Rename"))
+  expect(rename).toBeDefined()
+  expect(rename?.bg?.toInts()).toEqual(theme.backgroundMenu.toInts())
 })

--- a/packages/kobe/test/render/tab-strip-narrow.test.tsx
+++ b/packages/kobe/test/render/tab-strip-narrow.test.tsx
@@ -14,7 +14,7 @@ import { join } from "node:path"
 import type { ChatTabTurnState } from "../../src/engine/turn-detector"
 import { TAB_STRIP_MODE_KEY } from "../../src/state/tab-strip"
 import { setTransparentBackground } from "../../src/tui-react/context/theme"
-import { TabStrip } from "../../src/tui-react/workspace/tab-strip"
+import { TURN_GLYPHS, TabStrip } from "../../src/tui-react/workspace/tab-strip"
 import type { TerminalTab } from "../../src/tui/workspace/terminal-tabs-core"
 import { renderComponent } from "./harness"
 
@@ -117,4 +117,49 @@ test("narrow strip paints no row background of its own — in either display mod
       setTransparentBackground(false)
     }
   }
+})
+
+test("narrow keeps each turn state its own tone, the way the wide strip does", async () => {
+  // The narrow form used to paint the chip in `backgroundElement` — one
+  // colour for all seven states in `TURN_GLYPHS`, so `● running` and
+  // `! error` differed only by glyph. Painting the tone ON the focusAccent
+  // fill would not have fixed it either: error red lands at a 1.02 contrast
+  // ratio there. The chip therefore sits outside the fill, on ambient.
+  process.env.KOBE_HOME_DIR = mkdtempSync(join(tmpdir(), "kobe-tab-strip-tone-"))
+  mkdirSync(join(process.env.KOBE_HOME_DIR, ".config", "rove"), { recursive: true })
+  writeFileSync(
+    join(process.env.KOBE_HOME_DIR, ".config", "rove", "state.json"),
+    JSON.stringify({ [TAB_STRIP_MODE_KEY]: "always" }),
+  )
+  const turns = new Map<string, ChatTabTurnState>([
+    ["tab-2", "running"],
+    ["tab-3", "error"],
+  ])
+  async function chipFg(activeId: string) {
+    const { spans } = await renderComponent(
+      <TabStrip
+        tabs={TABS}
+        activeId={activeId}
+        turnStates={turns}
+        onSelect={() => {}}
+        vendor="claude"
+        liveTitles={new Map()}
+        turnVendors={new Map()}
+      />,
+      { width: 46, height: 4, providers: { kv: true } },
+    )
+    const glyph = TURN_GLYPHS[turns.get(activeId) as ChatTabTurnState]
+    const span = (await spans()).lines[0]?.spans.find((s) => s.text.includes(glyph))
+    expect(span).toBeDefined()
+    return span
+  }
+  const running = await chipFg("tab-2")
+  const error = await chipFg("tab-3")
+  expect(running?.fg?.toInts()).not.toEqual(error?.fg?.toInts())
+  // And on the ambient surface, not inside the active-tab fill — that fill is
+  // where every tone collapsed back into the orange.
+  const ambient = (
+    await (await renderComponent(strip("tab-2"), { width: 46, height: 4, providers: { kv: true } })).spans()
+  ).lines[2]?.spans[0]
+  expect(running?.bg?.toInts()).toEqual(ambient?.bg?.toInts())
 })


### PR DESCRIPTION
Six places where the UI had drifted from the vocabulary the rest of it already speaks. Each one had an in-repo counter-example, so the direction was already settled — these just hadn't followed.

### 1 · The narrow tab strip flattened every turn tone into one colour
`workspace/tab-strip.tsx` — the wide branch computes a semantic `turnColor` (`info` / `success` / `error` / `warning`); the narrow branch never computed one at all and drew the chip in `theme.backgroundElement`, so `● running` and `! error` differed only by glyph. `docs/TUI.md` lists seven states for this strip.

`turnColor` is now one function both branches call, and the title takes `selectedListItemText` (a background token was being used as a foreground).

**One correction to the brief:** the chip does *not* take the tone *on* the `focusAccent` fill. On that orange, `theme.error` lands at a **1.02** contrast ratio and `info` at 1.33 — the tones would be technically different and visually identical, which is the same bug in new paint. The wide branch already concluded this ("No fill behind the chip anymore … so tone colors survive on every tab"); the chip therefore moves *outside* the fill, onto the ambient surface. The fill stays on the title, where it still marks the active tab and stays legible over any wallpaper (which is why the narrow branch has it at all). Cell budget is unchanged: the glyph's trailing space becomes the row's existing `gap={1}`.

### 2 · Two pages had their own cursor row
`component/update-page.tsx` (solid `theme.primary` bar) and `component/worktrees-page.tsx` (`▸ ` prefix + `primary` text) vs `ui/row-selection-chrome.ts`, whose docblock spells out the policy and which `work-items-page` / `filetree` / `sidebar` / `AttentionInboxPane` all use. Both are full-window pages, so under transparency their `background` is alpha-0 and the bar painted an opaque patch onto the host wallpaper. `▸` also goes back to meaning only "collapsed", which is what it means in the sidebar and the file tree.

### 3 · `q / esc` was the only hardcoded English close hint
`update-page.tsx` / `versions-page.tsx` — the title beside it was already translated. New keys `update.closeHint` / `update.versions.closeHint`, shaped like the sibling `update.versions.footerHint` (keys literal, verb translated): `q / esc close` / `q / esc 关闭`.

`grep -rn 'q / esc' packages/kobe/src/tui-react` → **0** (was 2). The remaining `src/` hits are `messages/workItems.ts`, which is prose already translated on both sides, and the two new keys themselves.

### 4 · `backgroundMenu` was defined by every bundled theme and read by nobody
`ui/context-menu.tsx` used `backgroundElement` for the popup — the exact fill of the panel inset underneath it — so only the border separated them. Now `backgroundMenu` (claude `#33312E` vs element `#2B2A27`). Verified at pixel level in the screenshots below: `(43,42,39)` → `(51,49,46)`, pane inset unchanged at `(20,20,19)`. The two rows that used `backgroundElement` as a *foreground* on the accent fill take `selectedListItemText`.

### 5 · The set-branch field skipped the shared dialog parts
`component/branch-picker-dialog.tsx` already uses the shared `PickerList`; only its label and input were still hand-rolled. Now `DialogSection` + `DialogField`, matching `rename-task-dialog`.

**Note:** `FRAMED_DIALOG_MIN_ROWS = 34` drops every well below 34 rows, so at the 80×24 in the brief only the label change shows. Screenshots at both 24 and 36 rows are attached.

### 6 · Two pages drew a scrollbar track no other page draws
`update-page.tsx` / `versions-page.tsx` had `{ backgroundColor: theme.background, foregroundColor: theme.borderActive }` — neither the dialog convention (`backgroundDialog` bed) nor the page convention (`foregroundColor: "transparent"`, used by worktrees / work-items / automations / kanban / settings / filetree / ops-preview). Under transparency that bed is alpha-0, leaving a `borderActive` rail hanging over the wallpaper. Both take the page convention.

---

## Verification

Six render tests, one per drift. **Mutation-verified**: restoring each old form reds exactly one test and no others.

| mutation | failing test |
|---|---|
| chip fg → `backgroundElement` | `narrow keeps each turn state its own tone…` |
| update row → `primary` fill | `the update page's cursor row takes the shared chrome…` |
| worktrees → `▸ ` prefix | `the worktrees page marks its cursor with ▌…` |
| close hint → hardcoded | `the update page header's close hint is translated…` |
| menu bg → `backgroundElement` | `the menu panel sits on backgroundMenu…` |
| field → bare label + input | `the branch field wears the shared dialog label and well` |
| track → `borderActive` rail | `a page's scrollbar shows a slider, not a rail` |

The i18n assertion needed a second pass: a page-wide `toContain("关闭")` passed with the hint still hardcoded, because `update.actions.close` also renders as 关闭 further down. It pins the header row now.

Visual acceptance through the browser `/harness` → xterm.js → PTY sidecar → real OpenTUI, BEFORE/AFTER on a fresh fixture each round, same viewport and same reach path per pair.

Gates: root `bun run lint`, `bun run typecheck`, `bun run check-i18n` (912 keys × 2 locales), `bun test test/render` (491 pass), `bun run test:fast` (4690 pass).

---

coverage-exemption: packages/kobe/src/tui-react/component/versions-page.tsx — baseline on `main` is **0%**: the render track has never mounted this page, because it is a separate CLI host (`rove update --list` → `startVersionsHost`), not a surface the TUI can reach. The two lines changed here are an i18n key swap and a scrollbar constant, both byte-identical to the update-page change one file over, where the render tests do cover them (update-page: 87.7%). Extracting a shared header/scrollbar would not lift the gate either — it keys on `git diff --name-only`, so any edit to this file counts as touched. Verified by hand instead that both new keys resolve (`check-i18n` only proves locale parity, not call sites): `update.versions.closeHint` → `q / esc close` / `q / esc 关闭`.
