### PR TITLE
A blank ROVE_* value was a value, and five guards nobody was measuring

### DIFF
--- a/.changeset/blank-rove-env-is-unset.md
+++ b/.changeset/blank-rove-env-is-unset.md
@@ -1,0 +1,16 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Treat a blank `ROVE_*` environment variable as unset instead of as a value.
+`VAR=` is how a shell says "unset", but `readRoveEnv` resolved the two
+namespaces with `??`, so a defined-but-empty `ROVE_*` shadowed the real
+`KOBE_*` beside it — and the mirror step copied the blank over it as well.
+For `HOME_DIR` that produced `""` as the home and then state paths relative
+to the process's cwd (the user's repository, for the TUI), in a module that
+`renameSync`s the plugin tree; for the daemon/PTY socket and pid overrides it
+dropped an isolated run back onto the production daemon.
+
+An engine switched off in Settings → Engines is now also skipped by
+`rove api add`'s repo default, and a `ui-prefs` payload from an older daemon
+no longer turns remote panes opaque.

--- a/docs/API.md
+++ b/docs/API.md
@@ -364,7 +364,8 @@ replacement in `nextCommandArgs`.
   sibling's engine). This was the `fan-out` verb, which no longer exists.
 
   `--command` picks the engine (an id from `engine-list`, or a full command
-  line). Omitted, the repo's default engine is used.
+  line). Omitted, the repo's default engine is used — skipping any engine
+  switched off in Settings → Engines, the same as the TUI's picker.
 
   `--repo` accepts paths `rove add` refuses — a checkout under `.scratch/`,
   `.dev-sandbox/` or `$TMPDIR` gets a task here and gets

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -274,8 +274,11 @@ register any other CLI from **Settings → Engines**, or by hand:
 
 Switching an engine OFF in **Settings → Engines** (`space`) records it under
 `disabledEngineIds`; it keeps every override and simply stops being offered
-when you pick an engine for a task. The global default engine can't be left
-disabled; switching it off hands the default to the first engine still on.
+when you pick an engine for a task. That covers the headless path too: a
+disabled engine is skipped by `rove api add`'s repo default, so switching one
+off after using it in a project does not leave that project still launching it.
+The global default engine can't be left disabled; switching it off hands the
+default to the first engine still on.
 
 Being in `customEngineIds` *is* the registration. There's no other step.
 Stick to `^[a-z][a-z0-9_-]{0,47}$` for ids: the web settings API enforces

--- a/packages/kobe-daemon/package.json
+++ b/packages/kobe-daemon/package.json
@@ -47,6 +47,7 @@
     "./daemon/lifetime": "./src/daemon/lifetime.ts",
     "./daemon/log-rotate": "./src/daemon/log-rotate.ts",
     "./daemon/notes-store": "./src/daemon/notes-store.ts",
+    "./daemon/owner-only": "./src/daemon/owner-only.ts",
     "./daemon/paths": "./src/daemon/paths.ts",
     "./daemon/platform-shell": "./src/daemon/platform-shell.js",
     "./daemon/context-usage-collector": "./src/daemon/context-usage-collector.ts",

--- a/packages/kobe-daemon/src/compat-env.ts
+++ b/packages/kobe-daemon/src/compat-env.ts
@@ -34,33 +34,32 @@ export function legacyKobeEnvKey(roveKey: string): string | undefined {
   return `${LEGACY_KOBE_ENV_PREFIX}${roveKey.slice(ROVE_ENV_PREFIX.length)}`
 }
 
-/** Read one renamed variable without mutating the supplied environment. */
-export function readRoveEnv(suffix: string, env: NodeJS.ProcessEnv = process.env): string | undefined {
-  return env[`${ROVE_ENV_PREFIX}${suffix}`] ?? env[`${LEGACY_KOBE_ENV_PREFIX}${suffix}`]
-}
-
 /**
- * `ROVE_HOME_DIR` / `KOBE_HOME_DIR` as a home directory, or `undefined`.
+ * Read one renamed variable without mutating the supplied environment.
  *
- * The ONE place that decides an empty value is not a home. `VAR=` is how a
- * shell says "unset" — the visual fixture writes `ROVE_TASK_ID=` for exactly
- * that meaning — but every path accessor read the raw variable, so an empty
- * `HOME_DIR` produced `""` as the home and then RELATIVE state paths: `.rove`,
- * `.config/rove/state.json`, `.rove/daemon.pid`. Relative to whatever the
- * process's cwd happened to be, which for the TUI is the user's repository.
- * Blank is unset, and the caller's `?? homedir()` takes over.
+ * Blank is UNSET, decided per namespace rather than on the combined result.
+ * `VAR=` is how a shell says "unset" — the visual fixture writes
+ * `ROVE_TASK_ID=` for exactly that meaning — so a `??` chain over the raw
+ * values would treat a DEFINED empty `ROVE_*` as an answer and shadow the
+ * real `KOBE_*` beside it. That is not a cosmetic difference for a path: an
+ * empty `HOME_DIR` produced `""` as the home and then RELATIVE state paths
+ * (`.rove`, `.config/rove/state.json`), relative to whatever the process's
+ * cwd happened to be — the user's repository, for the TUI. For the socket
+ * and pid overrides it silently dropped an isolated daemon back onto the
+ * production one. Blank in the new name means unset, which is exactly when
+ * the legacy name is supposed to answer.
  */
-export function readRoveHomeDirEnv(env: NodeJS.ProcessEnv = process.env): string | undefined {
-  // Per namespace, not on the combined result: `readRoveEnv`'s `??` treats a
-  // DEFINED empty `ROVE_HOME_DIR` as a value, so trimming afterwards would let
-  // it shadow a real `KOBE_HOME_DIR` and land the caller on the OS home.
-  // Blank in the new name means unset, which is exactly when the legacy name
-  // is supposed to answer.
-  for (const key of [`${ROVE_ENV_PREFIX}HOME_DIR`, `${LEGACY_KOBE_ENV_PREFIX}HOME_DIR`]) {
+export function readRoveEnv(suffix: string, env: NodeJS.ProcessEnv = process.env): string | undefined {
+  for (const key of [`${ROVE_ENV_PREFIX}${suffix}`, `${LEGACY_KOBE_ENV_PREFIX}${suffix}`]) {
     const value = env[key]?.trim()
     if (value) return value
   }
   return undefined
+}
+
+/** `ROVE_HOME_DIR` / `KOBE_HOME_DIR` as a home directory, or `undefined`. */
+export function readRoveHomeDirEnv(env: NodeJS.ProcessEnv = process.env): string | undefined {
+  return readRoveEnv("HOME_DIR", env)
 }
 
 /**
@@ -78,11 +77,15 @@ export function setRoveEnv(suffix: string, value: string, env: NodeJS.ProcessEnv
 
 /**
  * Mirror every public ROVE_* control into the legacy internal namespace.
- * Existing KOBE_* values remain when no new-name value was supplied.
+ * Existing KOBE_* values remain when no new-name value was supplied — and a
+ * BLANK `ROVE_*` counts as "not supplied" for the same reason
+ * {@link readRoveEnv} does. Mirroring it copied `""` over a real `KOBE_*`,
+ * which destroys the value in the one namespace that still had it, so the
+ * per-namespace fallback there had nothing left to find.
  */
 export function installRoveEnvCompatibility(env: NodeJS.ProcessEnv = process.env): NodeJS.ProcessEnv {
   for (const [key, value] of Object.entries(env)) {
-    if (value === undefined || key === "ROVE_INVOKED_AS") continue
+    if (value === undefined || value.trim().length === 0 || key === "ROVE_INVOKED_AS") continue
     const legacyKey = legacyKobeEnvKey(key)
     if (legacyKey) env[legacyKey] = value
   }

--- a/packages/kobe-daemon/src/daemon/paths.ts
+++ b/packages/kobe-daemon/src/daemon/paths.ts
@@ -166,7 +166,7 @@ export function fitSocketPath(naturalPath: string, homeDir: string, role: string
  */
 export function defaultDaemonSocketPath(homeDir?: string): string {
   const override = readRoveEnv("DAEMON_SOCKET_PATH")
-  if (override && override.length > 0) return override
+  if (override) return override
   const explicit = homeDir ?? readRoveHomeDirEnv()
   if (explicit && explicit.length > 0) {
     return fitSocketPath(runtimePath(explicit, "daemon.sock", "daemon.pid"), explicit, "daemon")
@@ -192,7 +192,7 @@ export function resolveDaemonHomeDir(homeDir?: string): string {
 
 export function defaultDaemonPidPath(homeDir = readRoveHomeDirEnv() ?? homedir()): string {
   const override = readRoveEnv("DAEMON_PID_PATH")
-  if (override && override.length > 0) return override
+  if (override) return override
   return runtimePath(homeDir, "daemon.pid", "daemon.pid")
 }
 
@@ -261,7 +261,7 @@ export function windowsPipePath(homeDir: string, role: string): string {
 
 export function defaultPtyHostSocketPath(homeDir?: string, platform: NodeJS.Platform = process.platform): string {
   const override = readRoveEnv("PTY_SOCKET_PATH")
-  if (override && override.length > 0) return override
+  if (override) return override
   const explicit = homeDir ?? readRoveHomeDirEnv()
   if (platform === "win32") return windowsPipePath(explicit || homedir(), "pty")
   if (explicit && explicit.length > 0) {
@@ -277,7 +277,7 @@ export function defaultPtyHostSocketPath(homeDir?: string, platform: NodeJS.Plat
 
 export function defaultPtyHostPidPath(homeDir = readRoveHomeDirEnv() ?? homedir()): string {
   const override = readRoveEnv("PTY_PID_PATH")
-  if (override && override.length > 0) return override
+  if (override) return override
   return runtimePath(homeDir, "pty.pid", "pty.pid")
 }
 

--- a/packages/kobe-daemon/src/daemon/ui-prefs-watcher.ts
+++ b/packages/kobe-daemon/src/daemon/ui-prefs-watcher.ts
@@ -63,8 +63,9 @@ export { defaultUiPrefsStatePath }
 /**
  * Read the visual-pref keys out of the state file. Never throws —
  * a missing / corrupt file yields the documented defaults (`claude`
- * theme, opaque, unset accent, `default` sort, expanded keys legend), the
- * same corrupt-file policy as the State Store and `readPersistedUiPrefs`.
+ * theme, TRANSPARENT background, unset accent, `default` sort, expanded keys
+ * legend), the same corrupt-file policy as the State Store and
+ * `readPersistedUiPrefs`.
  * The theme NAME is
  * passed through unvalidated (the daemon has no theme registry); the
  * TUI-side apply validates it against its own registry.

--- a/packages/kobe/src/client/remote-orchestrator-payloads.ts
+++ b/packages/kobe/src/client/remote-orchestrator-payloads.ts
@@ -117,15 +117,20 @@ export function describePayload(value: unknown): string {
  *  - `locale` absent → "" (UNSET): a payload that never mentioned the language
  *    must not yank it back to English; only a real non-empty locale changes it.
  *  - `sortMode` absent → "default"; `keysCollapsed` absent → false (expanded);
- *    `projectFilter` absent/empty → null (all projects); `transparentBackground`
- *    / `focusAccent` default off / null.
+ *    `projectFilter` absent/empty → null (all projects); `focusAccent` → null.
+ *  - `transparentBackground` absent → TRUE, the product default the two other
+ *    decoders (`ui-prefs-watcher`, `persisted-ui-prefs`) already spell as
+ *    `!== false`. Defaulting it off here was the one field that hard-reset
+ *    instead of leaving things alone: against an older daemon whose payload
+ *    omits it, every remote pane turned opaque while the local ones stayed
+ *    transparent, and no setting in the UI explained the difference.
  */
 export function decodeUiPrefsPayload(payload: unknown): UiPrefsPayload | null {
   const p = payload as Partial<UiPrefsPayload> | undefined
   if (typeof p?.theme !== "string") return null
   return {
     theme: p.theme,
-    transparentBackground: p.transparentBackground === true,
+    transparentBackground: p.transparentBackground !== false,
     focusAccent: typeof p.focusAccent === "string" ? p.focusAccent : null,
     locale: typeof p.locale === "string" ? p.locale : "",
     sortMode: p.sortMode === "recent" ? "recent" : "default",

--- a/packages/kobe/src/state/layout-migration.ts
+++ b/packages/kobe/src/state/layout-migration.ts
@@ -20,7 +20,7 @@ import {
 } from "node:fs"
 import { homedir } from "node:os"
 import { dirname, join } from "node:path"
-import { readRoveEnv } from "@sma1lboy/kobe-daemon/compat-env"
+import { readRoveHomeDirEnv } from "@sma1lboy/kobe-daemon/compat-env"
 import {
   LEGACY_KOBE_CONFIG_DIR_BASENAME,
   LEGACY_KOBE_STATE_DIR_BASENAME,
@@ -166,7 +166,7 @@ function migrateStateEntries(
   includeConfig: boolean,
   env: NodeJS.ProcessEnv,
 ): StateLayoutMigrationResult {
-  const home = readRoveEnv("HOME_DIR", env) ?? homedir()
+  const home = readRoveHomeDirEnv(env) ?? homedir()
   const legacyState = join(home, LEGACY_KOBE_STATE_DIR_BASENAME)
   const roveState = join(home, ROVE_STATE_DIR_BASENAME)
   const legacyConfig = join(home, ".config", LEGACY_KOBE_CONFIG_DIR_BASENAME, "state.json")
@@ -224,7 +224,7 @@ function migrateStateEntries(
 const PLUGIN_ENTRIES = ["plugins.json", "plugins", "plugins-outdated.json"] as const
 
 function migrateLegacyPluginTree(env: NodeJS.ProcessEnv): StateLayoutMigrationResult {
-  const home = readRoveEnv("HOME_DIR", env) ?? homedir()
+  const home = readRoveHomeDirEnv(env) ?? homedir()
   const legacyState = join(home, LEGACY_KOBE_STATE_DIR_BASENAME)
   const roveState = join(home, ROVE_STATE_DIR_BASENAME)
   const marker = join(roveState, PLUGIN_MIGRATION_MARKER)

--- a/packages/kobe/src/state/vendor-prefs.ts
+++ b/packages/kobe/src/state/vendor-prefs.ts
@@ -7,17 +7,36 @@
  */
 
 import { DEFAULT_TASK_VENDOR } from "../types/task.ts"
-import { type VendorId, isBuiltinVendor } from "../types/vendor.ts"
-import { getCustomEngineIds, getPersistedString, setPersistedString } from "./repos.ts"
+import { BUILTIN_VENDORS, type VendorId, isBuiltinVendor } from "../types/vendor.ts"
+import { getCustomEngineIds, getDisabledEngineIds, getPersistedString, setPersistedString } from "./repos.ts"
 
 const REPO_KEY_PREFIX = "lastActiveVendor."
 
-/** Validate one persisted value; undefined lets the chain fall through. */
+/**
+ * Validate one persisted value; undefined lets the chain fall through.
+ *
+ * A DISABLED engine falls through too. Switching an engine off in Settings →
+ * Engines is documented as "it stops being offered when you pick an engine
+ * for a task", and the disabled set was read in exactly one place —
+ * `availableEngineIds()`, which only feeds the TUI's picker. Every headless
+ * path (`rove api add`, quick-fork, main-task) resolved its engine through
+ * these preference layers instead and happily launched the engine the user
+ * had turned off. The filter belongs on the layer both sides share.
+ */
 function validVendor(value: string | undefined, customIds: readonly string[]): VendorId | undefined {
   const v = value?.trim()
   if (!v) return undefined
+  if (getDisabledEngineIds().includes(v)) return undefined
   if (isBuiltinVendor(v) || customIds.includes(v)) return v
   return undefined
+}
+
+/** First engine that is not switched off, for when every layer fell through.
+ *  `DEFAULT_TASK_VENDOR` is the last resort even when it is itself disabled —
+ *  a task needs SOME engine, and Settings refuses to disable the last one. */
+function firstEnabledVendor(): VendorId {
+  const disabled = new Set(getDisabledEngineIds())
+  return [...BUILTIN_VENDORS, ...getCustomEngineIds()].find((id) => !disabled.has(id)) ?? DEFAULT_TASK_VENDOR
 }
 
 /** The project's last actively-used engine (undefined = never recorded). */
@@ -44,11 +63,12 @@ export function setGlobalDefaultVendor(vendor: VendorId): void {
 
 /**
  * The vendor a new task / relaunch should default to: the repo's last-active
- * engine, else the Settings global default, else `claude`. Each level is
- * validated independently, so a corrupt repo entry falls through to the
- * global default rather than straight to the built-in fallback.
+ * engine, else the Settings global default, else the first engine that is
+ * still switched on. Each level is validated independently, so a corrupt (or
+ * disabled) repo entry falls through to the global default rather than
+ * straight to the built-in fallback.
  */
 export function resolvePreferredVendor(repo?: string): VendorId {
   const repoPick = repo ? getRepoLastActiveVendor(repo) : undefined
-  return repoPick ?? getGlobalDefaultVendor() ?? DEFAULT_TASK_VENDOR
+  return repoPick ?? getGlobalDefaultVendor() ?? firstEnabledVendor()
 }

--- a/packages/kobe/src/tui/lib/editor-launch.ts
+++ b/packages/kobe/src/tui/lib/editor-launch.ts
@@ -1,10 +1,11 @@
 /**
- * External-editor launch for the Ops pane's file tree (`e` key).
+ * External-editor launch for the Ops pane's file tree (`enter` — `files.open`
+ * in `tui/context/keybindings-files.ts`).
  *
- * The file tree has two open actions:
- *   - `enter` → the in-TUI read-only preview/diff window (`openPreview`).
- *   - `e`     → THIS: open the file in the user's real editor (vim / nano
- *               / a custom command) in an embedded command tab.
+ * `enter` opens the file in the user's real editor (nvim / vim / nano / a
+ * custom command) in an embedded command tab. The in-TUI read-only
+ * preview/diff window (`openPreview`) is the FALLBACK below, not a separate
+ * key: it is where `enter` lands when no editor binary can be resolved.
  *
  * Why shell out instead of editing in-pane: the preview is an opentui
  * `<code>`/`<diff>` renderer with no cursor/insert/save. A real editable
@@ -14,12 +15,12 @@
  * Fallback chain (KOB — file-editor-launch): if the configured editor's
  * binary isn't on PATH (or `custom` is empty with no `$EDITOR`), this
  * returns `false` and the caller falls back to the read-only preview, so
- * `e` is never a dead key. We gate on "binary missing", NOT on the
+ * `enter` is never a dead key. We gate on "binary missing", NOT on the
  * editor's exit code — a `:cq` / non-zero quit is a real edit session,
  * not a launch failure, and must not bounce to preview.
  *
  * nvim/vim diff mode: when the resolved editor is a PLAIN nvim/vim open
- * (`<bin> <file>`, no custom flags) AND the file differs from HEAD, `e`
+ * (`<bin> <file>`, no custom flags) AND the file differs from HEAD, `enter`
  * upgrades to side-by-side diff mode — the committed HEAD blob read-only
  * on the left, the live editable file on the right. This is the sh-`-c`
  * safe form of `nvim -d <file> <(git show HEAD:<file>)`: tmux runs the
@@ -31,7 +32,8 @@
  *
  * Settings (shared `state.json`, read cross-process via getPersistedString
  * since the Ops host is its own process):
- *   - `editor.kind`          "vim" | "nano" | "custom"   (default "vim")
+ *   - `editor.kind`          "auto" | "vim" | "nvim" | "nano" | "emacs" |
+ *                            "custom"   (default "auto" — see `editor-prefs.ts`)
  *   - `editor.customCommand` e.g. `code -w` / `emacsclient` / `subl -w {file}`
  */
 
@@ -105,7 +107,7 @@ export function buildEditorCommand(
  * `relPath` is worktree-relative; `HEAD:./<rel>` pins the blob lookup to
  * the worktree cwd. If the HEAD blob can't be read (e.g. a race removed
  * the diff between the check and the launch), it falls back to a plain
- * `<bin> <file>` open so `e` still lands in an editor.
+ * `<bin> <file>` open so `enter` still lands in an editor.
  */
 export function buildNvimDiffCommand(bin: string, absPath: string, relPath: string): string {
   const file = shellQuote(absPath)

--- a/packages/kobe/src/tui/lib/editor-prefs.ts
+++ b/packages/kobe/src/tui/lib/editor-prefs.ts
@@ -6,12 +6,13 @@
  * `tmux/editor-launch.ts` (which pulls in the tmux client). The launcher
  * imports these same constants so both sides agree on the keys.
  *
- * `e` in the file tree opens the current file in this editor; `editor.kind`
- * picks which, `editor.customCommand` is the command for `kind === "custom"`.
+ * `enter` in the file tree (`files.open`) opens the current file in this
+ * editor; `editor.kind` picks which, `editor.customCommand` is the command
+ * for `kind === "custom"`.
  */
 
 /**
- * Which editor the file tree's `e` key launches.
+ * Which editor the file tree's `enter` key launches.
  *  - `auto`   — the STANDARD behaviour: honour $VISUAL / $EDITOR, and if
  *               neither is set, auto-detect the first installed of nvim →
  *               vim → emacs → nano. This is the default.

--- a/packages/kobe/test/cli/rename-compat.test.ts
+++ b/packages/kobe/test/cli/rename-compat.test.ts
@@ -2,9 +2,16 @@ import {
   installRoveEnvCompatibility,
   legacyKobeEnvKey,
   readRoveEnv,
+  readRoveHomeDirEnv,
   setRoveEnv,
 } from "@sma1lboy/kobe-daemon/compat-env"
-import { describe, expect, test } from "vitest"
+import {
+  defaultDaemonPidPath,
+  defaultDaemonSocketPath,
+  defaultPtyHostPidPath,
+  defaultPtyHostSocketPath,
+} from "@sma1lboy/kobe-daemon/daemon/paths"
+import { afterEach, describe, expect, test } from "vitest"
 import { roveCliInvocation } from "../../src/cli/invocation.ts"
 import {
   activeCliName,
@@ -87,5 +94,85 @@ describe("rove environment compatibility", () => {
       if (original === undefined) Reflect.deleteProperty(process.env, "ROVE_INVOKED_AS")
       else process.env.ROVE_INVOKED_AS = original
     }
+  })
+})
+
+/**
+ * `VAR=` is how a shell says "unset", and this repo's own fixtures spell it
+ * that way (`compat-env.ts` names the visual fixture's `ROVE_TASK_ID=`). Read
+ * through a bare `??` chain a DEFINED empty `ROVE_*` is a value, so it shadows
+ * the real `KOBE_*` beside it — and the two consumers that matters for are the
+ * ones that decide WHERE things are written: the state home, and the daemon /
+ * PTY socket + pid paths that are the whole of an isolated run's isolation.
+ */
+describe("a blank ROVE_* value is unset, not a value", () => {
+  /** Every suffix `readRoveEnv` serves. Blank must fall through for all of
+   *  them — the guard belongs to the reader, not to each call site. */
+  const SUFFIXES = [
+    "DAEMON_SOCKET_PATH",
+    "DAEMON_PID_PATH",
+    "PTY_SOCKET_PATH",
+    "PTY_PID_PATH",
+    "DAEMON_IDLE_GRACE_MS",
+    "RPC_TIMEOUT_MS",
+    "DEV",
+    "FILETREE_WATCH",
+    "HOOK_DEBUG",
+    "OPEN_EDITOR",
+    "HOME_DIR",
+  ] as const
+
+  test.each(SUFFIXES)("%s: blank ROVE_* falls through to KOBE_*", (suffix) => {
+    const env: NodeJS.ProcessEnv = { [`ROVE_${suffix}`]: "", [`KOBE_${suffix}`]: "isolated" }
+    expect(readRoveEnv(suffix, env)).toBe("isolated")
+  })
+
+  test.each(SUFFIXES)("%s: blank in both namespaces reads as absent", (suffix) => {
+    expect(readRoveEnv(suffix, { [`ROVE_${suffix}`]: "", [`KOBE_${suffix}`]: "   " })).toBeUndefined()
+  })
+
+  test("the home accessor answers the same, so a caller's `?? homedir()` takes over", () => {
+    expect(readRoveHomeDirEnv({ ROVE_HOME_DIR: "", KOBE_HOME_DIR: "/isolated-home" })).toBe("/isolated-home")
+    expect(readRoveHomeDirEnv({ ROVE_HOME_DIR: "" })).toBeUndefined()
+  })
+
+  test("mirroring does not overwrite a real KOBE_* with a blank ROVE_*", () => {
+    const env: NodeJS.ProcessEnv = { ROVE_HOME_DIR: "", KOBE_HOME_DIR: "/isolated-home" }
+    installRoveEnvCompatibility(env)
+    // The other half of the same bug: the mirror ran before any read, so it
+    // destroyed the one namespace that still held the isolated value.
+    expect(env.KOBE_HOME_DIR).toBe("/isolated-home")
+    expect(readRoveEnv("HOME_DIR", env)).toBe("/isolated-home")
+  })
+})
+
+describe("blank ROVE_* overrides keep an isolated daemon isolated", () => {
+  const saved = new Map<string, string | undefined>()
+
+  function stub(key: string, value: string): void {
+    if (!saved.has(key)) saved.set(key, process.env[key])
+    process.env[key] = value
+  }
+
+  afterEach(() => {
+    for (const [key, value] of saved) {
+      if (value === undefined) Reflect.deleteProperty(process.env, key)
+      else process.env[key] = value
+    }
+    saved.clear()
+  })
+
+  // The exact shape a harness writes: `ROVE_*=` for "unset", `KOBE_*` pointing
+  // at the isolated runtime. Resolving to the DEFAULT path here is not a
+  // cosmetic miss — it connects the run to the user's production daemon.
+  test.each([
+    ["DAEMON_SOCKET_PATH", "/tmp/iso-daemon.sock", () => defaultDaemonSocketPath()],
+    ["DAEMON_PID_PATH", "/tmp/iso-daemon.pid", () => defaultDaemonPidPath()],
+    ["PTY_SOCKET_PATH", "/tmp/iso-pty.sock", () => defaultPtyHostSocketPath()],
+    ["PTY_PID_PATH", "/tmp/iso-pty.pid", () => defaultPtyHostPidPath()],
+  ] as const)("%s", (suffix, isolated, resolve) => {
+    stub(`ROVE_${suffix}`, "")
+    stub(`KOBE_${suffix}`, isolated)
+    expect(resolve()).toBe(isolated)
   })
 })

--- a/packages/kobe/test/client/remote-orchestrator-ui-prefs.test.ts
+++ b/packages/kobe/test/client/remote-orchestrator-ui-prefs.test.ts
@@ -21,10 +21,15 @@ describe("decodeUiPrefsPayload — backward-compat defaults", () => {
 
   it("an older daemon's theme-only payload resolves every newer field to its absent-sentinel", () => {
     // The footgun this owns: locale MUST be "" (skip), not "en"; sortMode
-    // "default"; keysCollapsed false; projectFilter null; transparent off.
+    // "default"; keysCollapsed false; projectFilter null. And
+    // transparentBackground TRUE — the product default, spelled `!== false` by
+    // the two decoders that read the state file. Defaulting it off here was
+    // the one field that hard-reset instead of leaving things alone: against
+    // an older daemon every remote pane turned opaque while the local ones
+    // stayed transparent, with no setting that explained it.
     expect(decodeUiPrefsPayload({ theme: "claude" })).toEqual({
       theme: "claude",
-      transparentBackground: false,
+      transparentBackground: true,
       focusAccent: null,
       locale: "",
       sortMode: "default",
@@ -38,7 +43,7 @@ describe("decodeUiPrefsPayload — backward-compat defaults", () => {
       decodeUiPrefsPayload({ theme: "tokyonight", locale: "zh-CN", sortMode: "recent", keysCollapsed: true }),
     ).toEqual({
       theme: "tokyonight",
-      transparentBackground: false,
+      transparentBackground: true,
       focusAccent: null,
       locale: "zh-CN",
       sortMode: "recent",
@@ -50,5 +55,7 @@ describe("decodeUiPrefsPayload — backward-compat defaults", () => {
     expect(d?.projectFilter).toBeNull()
     expect(d?.sortMode).toBe("default")
     expect(d?.focusAccent).toBe("#abc")
+    // Only an explicit `false` opts out — the same rule as the state-file side.
+    expect(decodeUiPrefsPayload({ theme: "x", transparentBackground: false })?.transparentBackground).toBe(false)
   })
 })

--- a/packages/kobe/test/daemon/owner-only.test.ts
+++ b/packages/kobe/test/daemon/owner-only.test.ts
@@ -1,0 +1,96 @@
+import { mkdirSync, mkdtempSync, rmSync, statSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { ROVE_STATE_DIR_BASENAME } from "@sma1lboy/kobe-daemon/compat-env"
+import {
+  OWNER_ONLY_DIR_MODE,
+  OWNER_ONLY_FILE_MODE,
+  ensureOwnerOnlyDir,
+  ensureOwnerOnlyStateDir,
+  tightenDirPermissions,
+  tightenFilePermissions,
+} from "@sma1lboy/kobe-daemon/daemon/owner-only"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+
+/**
+ * `<home>/.rove` is the daemon's ONLY access control. `server.ts` accepts
+ * every connection on the socket with no peer-credential check, so reaching
+ * that socket is `add` — launching an engine, which is arbitrary execution as
+ * the owner. Nothing in the daemon may assume the mode without setting it, and
+ * nothing was measuring that it did: a `chmod(path, 0o755)` in this module
+ * left both vitest tracks fully green.
+ *
+ * The population these assertions have to build is the one the module exists
+ * for. `mkdirSync`'s `mode` binds at `O_CREAT` and is a silent no-op for a
+ * path that already exists, so a home created before the mode argument landed
+ * keeps 0755 forever — the repair pass on every start is the only thing that
+ * ever narrows it. So each case here PRE-CREATES the loose path and reads the
+ * real mode back with `statSync`; a fresh-directory-only test would pass with
+ * the repair deleted.
+ *
+ * Real filesystem, no mocks: the thing under test is a syscall's effect.
+ */
+describe("owner-only state tree", () => {
+  let root: string
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "rove-owner-only-"))
+  })
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true })
+  })
+
+  /** Permission bits only — the file-type bits in `st_mode` are not ours. */
+  function mode(path: string): number {
+    return statSync(path).mode & 0o777
+  }
+
+  it("repairs a directory that already exists at a world-readable mode", async () => {
+    const dir = join(root, "state")
+    mkdirSync(dir, { mode: 0o755 })
+    expect(mode(dir)).toBe(0o755)
+
+    await ensureOwnerOnlyDir(dir)
+
+    expect(mode(dir)).toBe(OWNER_ONLY_DIR_MODE)
+    expect(mode(dir)).toBe(0o700)
+  })
+
+  it("creates a missing tree owner-only in the first place", async () => {
+    const dir = join(root, "fresh", "nested")
+
+    await ensureOwnerOnlyDir(dir)
+
+    expect(mode(dir)).toBe(0o700)
+  })
+
+  it("tightens `<home>/.rove` — the directory the socket's security rests on", async () => {
+    const stateDir = join(root, ROVE_STATE_DIR_BASENAME)
+    mkdirSync(stateDir, { mode: 0o777 })
+
+    await ensureOwnerOnlyStateDir(root)
+
+    expect(mode(stateDir)).toBe(0o700)
+  })
+
+  it("tightens an existing group/world-readable file to 0600", async () => {
+    const file = join(root, "web-token")
+    writeFileSync(file, "secret", { mode: 0o644 })
+    expect(mode(file)).toBe(0o644)
+
+    await tightenFilePermissions(file)
+
+    expect(mode(file)).toBe(OWNER_ONLY_FILE_MODE)
+    expect(mode(file)).toBe(0o600)
+  })
+
+  it("never throws on a path that is not there", async () => {
+    // Best-effort is the contract: a chmod that cannot run (absent, foreign
+    // owner, a filesystem with no unix modes) must not keep the daemon from
+    // booting. A loose mode is worse than a tight one; neither is worse than a
+    // daemon that will not start.
+    await expect(tightenDirPermissions(join(root, "gone"))).resolves.toBeUndefined()
+    await expect(tightenFilePermissions(join(root, "gone.json"))).resolves.toBeUndefined()
+  })
+})

--- a/packages/kobe/test/daemon/tab-close-broker.test.ts
+++ b/packages/kobe/test/daemon/tab-close-broker.test.ts
@@ -1,0 +1,63 @@
+import { TabCloseBroker } from "@sma1lboy/kobe-daemon/daemon/tab-close-broker"
+import { describe, expect, it } from "vitest"
+import { TASK, dispatch, fakeCtx } from "./handler-test-context.ts"
+
+/**
+ * The broker's negative-acknowledgement rule: "false acknowledgements do not
+ * pre-empt another TUI". Several TUIs can be attached to one daemon, and the
+ * one that answers first is not necessarily the one holding the tab — so a
+ * reply of "I did not close it" has to leave the request open for a client
+ * with fresher state, and only a confirmed close settles it.
+ *
+ * Deleting the `if (!closed)` guard left all three test tracks green. The only
+ * reply `handlers.test.ts` ever sent was `{ closed: true }`, and
+ * `handlers-ui.ts`'s `optionalBoolean(payload, "closed") ?? false` means a
+ * reply that OMITS the field takes the same never-exercised path — so a TUI
+ * saying "no" would have settled the waiter as a successful close.
+ *
+ * Both levels are covered here: the class in isolation, and the wire path
+ * through `terminalTab.closeReply` that produces the `?? false`.
+ */
+describe("TabCloseBroker", () => {
+  it("a false acknowledgement is accepted but settles nothing", async () => {
+    const broker = new TabCloseBroker()
+    const pending = broker.create("req-1", 10_000)
+    const unsettled = Symbol("still-pending")
+
+    // Accepted — the request id is known — but the waiter stays open.
+    expect(broker.settle("req-1", false)).toBe(true)
+    expect(await Promise.race([pending, Promise.resolve(unsettled)])).toBe(unsettled)
+
+    expect(broker.settle("req-1", true)).toBe(true)
+    expect(await pending).toBe(true)
+    // …and the settled request is gone, so a late duplicate is not accepted.
+    expect(broker.settle("req-1", true)).toBe(false)
+    broker.clear()
+  })
+
+  it("an unknown request id is rejected either way", () => {
+    const broker = new TabCloseBroker()
+    expect(broker.settle("never-created", true)).toBe(false)
+    expect(broker.settle("never-created", false)).toBe(false)
+  })
+
+  it("a TUI that did not close the tab leaves the request open for one that did", async () => {
+    const { ctx, rec } = fakeCtx({ getTask: () => TASK })
+    const pending = dispatch("terminalTab.close", { taskId: "t1", tabId: "tab-3" }, ctx)
+    const requestId = (rec.published[0] as { payload: Record<string, unknown> }).payload.requestId as string
+    const unsettled = Symbol("still-pending")
+
+    // A stale TUI answers first, and answers no.
+    expect(await dispatch("terminalTab.closeReply", { requestId, closed: false }, ctx)).toEqual({ ok: true })
+    expect(await Promise.race([pending, Promise.resolve(unsettled)])).toBe(unsettled)
+
+    // Same for a reply that omits `closed` entirely — `?? false` routes it
+    // through the identical branch.
+    expect(await dispatch("terminalTab.closeReply", { requestId }, ctx)).toEqual({ ok: true })
+    expect(await Promise.race([pending, Promise.resolve(unsettled)])).toBe(unsettled)
+
+    // The TUI with fresher state still gets to answer.
+    expect(await dispatch("terminalTab.closeReply", { requestId, closed: true }, ctx)).toEqual({ ok: true })
+    expect(await pending).toEqual({ ok: true, handled: true })
+  })
+})

--- a/packages/kobe/test/lib/poll-scheduling.test.ts
+++ b/packages/kobe/test/lib/poll-scheduling.test.ts
@@ -126,6 +126,23 @@ describe("applyJitter", () => {
     expect(applyJitter(1000, 0, () => 0)).toBe(1000) // no jitter
     expect(applyJitter(1000, 5, () => 0)).toBe(0) // clamp to ratio 1 → max(0, -1000) extreme
   })
+  /**
+   * The line above is satisfied by EITHER mechanism on its own — with the
+   * ratio clamp gone the floor returns 0, and with the floor gone the clamp
+   * returns exactly 0 — so only deleting both made it red. Each half needs a
+   * case the other cannot cover.
+   */
+  test("an over-1 ratio clamps on the UPPER side too, not just the lower", () => {
+    // Unclamped this is delay·(1+5) = 6000, six times the documented
+    // [0, 2·delay] band, and nothing asserted on it.
+    expect(applyJitter(1000, 5, () => 1)).toBe(2000)
+  })
+  test("a negative delay floors at 0 with the ratio clamp uninvolved", () => {
+    // ratio 0 means the clamp cannot be what produces this; only the
+    // `Math.max(0, …)` can. A delay computed as `deadline - now` goes
+    // negative whenever the deadline has already passed.
+    expect(applyJitter(-100, 0, () => 0.5)).toBe(0)
+  })
 })
 
 describe("exponentialBackoff", () => {
@@ -137,6 +154,15 @@ describe("exponentialBackoff", () => {
   test("caps at capMs and clamps negative attempts to the base", () => {
     expect(exponentialBackoff(1000, 10, 5000)).toBe(5000)
     expect(exponentialBackoff(1000, -1, 60_000)).toBe(1000)
+  })
+  test("the cap still applies on the first attempt, where every poller starts", () => {
+    // `attempt <= 0` returns before the doubling, and both cases above use a
+    // cap ABOVE the base — so `Math.min(baseMs, capMs)` degrading to `baseMs`
+    // was invisible. `pr-status.ts` calls `exponentialBackoff(base,
+    // failures - 1, cap)`, so attempt 0 is the branch a poller's FIRST failure
+    // takes, every time.
+    expect(exponentialBackoff(1000, 0, 500)).toBe(500)
+    expect(exponentialBackoff(1000, -3, 500)).toBe(500)
   })
 })
 

--- a/packages/kobe/test/orchestrator/worktree-remove-partial.test.ts
+++ b/packages/kobe/test/orchestrator/worktree-remove-partial.test.ts
@@ -358,3 +358,33 @@ describe("remove() when the directory is already gone", () => {
     expect(branches.split("\n")).toContain("keep-br")
   })
 })
+
+/**
+ * The `opts.branch` FALLBACK on the live-directory path (`manager-remove.ts`,
+ * the `?? opts.branch` in the pre-removal branch capture).
+ *
+ * The existing "still deletes the branch the caller asked to drop" case is
+ * named for this line and never reaches it: it `rmSync`s the directory first,
+ * so the missing-directory path consumes `opts.branch` and returns long
+ * before. Deleting the fallback here left that test green.
+ *
+ * Its real trigger is a worktree that is present but has no branch name to
+ * read: `currentBranch()` deliberately THROWS on detached HEAD rather than
+ * hand back the literal `HEAD`, which is a state a hard reset produces. The
+ * caller's recorded `task.branch` is then the only name left.
+ */
+describe("remove() when the worktree is on a detached HEAD", () => {
+  it("falls back to the caller's branch name when HEAD cannot be read", async () => {
+    const wt = join(managedRoot, "detached")
+    execSync(`git worktree add -q ${JSON.stringify(wt)} -b detached-br`, { cwd: repo, env: gitEnv })
+    execSync("git checkout -q --detach", { cwd: wt, env: gitEnv })
+    // The premise: the worktree is still there, and git will not name a branch.
+    expect(existsSync(wt)).toBe(true)
+    expect(execSync("git rev-parse --abbrev-ref HEAD", { cwd: wt, env: gitEnv, encoding: "utf8" }).trim()).toBe("HEAD")
+
+    await manager.remove(wt, { repo, deleteBranch: true, branch: "detached-br", force: true })
+
+    const branches = execSync("git branch --format='%(refname:short)'", { cwd: repo, env: gitEnv, encoding: "utf8" })
+    expect(branches.split("\n")).not.toContain("detached-br")
+  })
+})

--- a/packages/kobe/test/state/layout-migration.test.ts
+++ b/packages/kobe/test/state/layout-migration.test.ts
@@ -149,3 +149,56 @@ describe("migrateRoveStateLayout", () => {
     expect(readFileSync(join(root, ".rove/plugins.json"), "utf8")).toContain("from-old-cli")
   })
 })
+
+/**
+ * `ROVE_HOME_DIR=` (defined, blank) is this repo's own spelling of "unset".
+ * Read as a VALUE the home becomes `""`, and every path here turns relative:
+ * `join("", ".kobe")` is `.kobe`, resolved against the process's cwd — which
+ * for the TUI is the user's repository. This module does not only copy; the
+ * plugin tree is a `renameSync`, so a repo that happens to contain a
+ * `.kobe/plugins.json` gets it MOVED out from under it.
+ */
+describe("a blank ROVE_HOME_DIR is unset, not a home", () => {
+  test("falls through to KOBE_HOME_DIR rather than shadowing it", () => {
+    root = mkdtempSync(join(tmpdir(), "rove-layout-"))
+    write(".kobe/tasks.json", "legacy tasks")
+
+    expect(migrateRoveStateLayout({ ROVE_HOME_DIR: "", KOBE_HOME_DIR: root })).toMatchObject({
+      attempted: true,
+      warnings: [],
+    })
+    expect(readFileSync(join(root, ".rove/tasks.json"), "utf8")).toBe("legacy tasks")
+  })
+
+  test("never moves a plugin registry relative to the process cwd", () => {
+    root = mkdtempSync(join(tmpdir(), "rove-layout-"))
+    write(".kobe/plugins.json", '{"plugins":[{"id":"real-home"}]}')
+
+    // The decoy is the bug's exact shape: a checkout that happens to carry a
+    // `.kobe/plugins.json`, with the process sitting inside it.
+    const repoCwd = mkdtempSync(join(tmpdir(), "rove-layout-cwd-"))
+    mkdirSync(join(repoCwd, ".kobe"), { recursive: true })
+    writeFileSync(join(repoCwd, ".kobe/plugins.json"), '{"plugins":[{"id":"users-repo"}]}', "utf8")
+
+    const previousCwd = process.cwd()
+    process.chdir(repoCwd)
+    try {
+      migrateRoveDaemonStateLayout({ ROVE_HOME_DIR: "", KOBE_HOME_DIR: root })
+    } finally {
+      process.chdir(previousCwd)
+    }
+
+    try {
+      // The negative half: the user's repo still holds its own file, as a real
+      // file and not the symlink a completed move leaves behind, and no `.rove`
+      // was created beside it.
+      expect(lstatSync(join(repoCwd, ".kobe/plugins.json")).isSymbolicLink()).toBe(false)
+      expect(readFileSync(join(repoCwd, ".kobe/plugins.json"), "utf8")).toContain("users-repo")
+      expect(existsSync(join(repoCwd, ".rove"))).toBe(false)
+      // The positive half: the isolated home is the one that migrated.
+      expect(readFileSync(join(root, ".rove/plugins.json"), "utf8")).toContain("real-home")
+    } finally {
+      rmSync(repoCwd, { recursive: true, force: true })
+    }
+  })
+})

--- a/packages/kobe/test/state/vendor-prefs.test.ts
+++ b/packages/kobe/test/state/vendor-prefs.test.ts
@@ -11,6 +11,7 @@ import os from "node:os"
 import path from "node:path"
 import { afterEach, beforeEach, describe, expect, test } from "vitest"
 import { setPersistedString } from "../../src/state/repos.ts"
+import { patchStateFile } from "../../src/state/store.ts"
 import {
   getGlobalDefaultVendor,
   getRepoLastActiveVendor,
@@ -61,6 +62,50 @@ describe("vendor preference layers", () => {
     setPersistedString("lastActiveVendor./repo", "gpt9-typo")
     setGlobalDefaultVendor("codex")
     expect(getRepoLastActiveVendor("/repo")).toBeUndefined()
+    expect(resolvePreferredVendor("/repo")).toBe("codex")
+  })
+})
+
+/**
+ * Switching an engine off in Settings -> Engines is documented as "it stops
+ * being offered when you pick an engine for a task". The disabled set was read
+ * in one place — `availableEngineIds()`, which only feeds the TUI picker — so
+ * every headless resolution (`rove api add`, quick-fork, main-task) went
+ * through these layers instead and launched the engine anyway. A user who ran
+ * codex once in a repo and then switched it off got codex back from
+ * `rove api add --repo <that repo>`.
+ */
+describe("a disabled engine is not offered by any layer", () => {
+  /** Settings -> Engines writes this key as a `string[]` through its own kv. */
+  function setDisabled(ids: readonly string[]): void {
+    patchStateFile({ disabledEngineIds: [...ids] })
+  }
+
+  test("the repo's last-active entry falls through when that engine is off", () => {
+    setRepoLastActiveVendor("/repo", "codex")
+    setGlobalDefaultVendor("copilot")
+    setDisabled(["codex"])
+
+    expect(getRepoLastActiveVendor("/repo")).toBeUndefined()
+    expect(resolvePreferredVendor("/repo")).toBe("copilot")
+  })
+
+  test("the global default falls through too, down to the first engine left on", () => {
+    setGlobalDefaultVendor("codex")
+    setDisabled(["codex", "claude"])
+
+    expect(getGlobalDefaultVendor()).toBeUndefined()
+    // claude is the built-in fallback and is itself off, so the resolution
+    // continues to the next enabled built-in rather than handing back a
+    // default nobody is allowed to pick.
+    expect(resolvePreferredVendor("/repo")).toBe("copilot")
+  })
+
+  test("switching it back on restores the stored preference untouched", () => {
+    setRepoLastActiveVendor("/repo", "codex")
+    setDisabled(["codex"])
+    expect(resolvePreferredVendor("/repo")).not.toBe("codex")
+    setDisabled([])
     expect(resolvePreferredVendor("/repo")).toBe("codex")
   })
 })


### PR DESCRIPTION
`VAR=` is how a shell says "unset", and this repo's own fixtures spell it that
way. `readRoveEnv` resolved the two namespaces with `??`, so a defined-but-empty
`ROVE_*` counted as an answer and shadowed the real `KOBE_*` beside it —
and `installRoveEnvCompatibility` mirrored the blank over that value first, so
the per-namespace fallback had nothing left to find either.

Both halves land on paths:

- **`HOME_DIR`** — the home became `""`, so `join("", ".kobe")` is `.kobe`,
  relative to the process's cwd (the user's repository, for the TUI).
  `layout-migration.ts` was the last module still reading it through the
  unsafe accessor, and it `renameSync`s the plugin tree rather than copying
  it: a checkout that happens to carry a `.kobe/plugins.json` gets it moved
  out from under it. 13 other modules already used `readRoveHomeDirEnv`.
- **socket / pid overrides** — `paths.ts` guarded with `override.length > 0`
  *after* the `??`, so a blank `ROVE_DAEMON_SOCKET_PATH` fell through to the
  DEFAULT path rather than to the isolated `KOBE_*` one. An isolated run
  silently reconnected to the production daemon.

Fixed in `readRoveEnv` itself rather than at each call site, so all eleven
suffixes get it; the four now-redundant length guards are gone
(`git grep -c 'override.length > 0' -- packages/kobe-daemon/src/daemon/paths.ts`:
4 → 0), and `readRoveHomeDirEnv` is a one-line wrapper.

### Also in this PR

| | |
|---|---|
| `disabledEngineIds` was read in exactly one place (`availableEngineIds()`, which only feeds the TUI picker), so `rove api add`, quick-fork and main-task all resolved through the vendor preference layers and launched engines the user had switched off. Filtered in `validVendor` — the gate both levels already share — so every caller is covered. Docs updated in `CONFIGURATION.md` + `API.md`. |
| `transparentBackground` defaulted to `false` in the third decoder while the two state-file decoders default it `true`. Against an older daemon whose payload omits the field, every remote pane turned opaque with no setting that explained it. |
| Three stale comments: `editor.kind`'s enum was missing half its values with the wrong default, and both editor modules named `e` as the key that opens the editor when `files.open` is `return`. `CONFIGURATION.md` was already right. |

### Five tests that were green for the wrong reason

Each new assertion is paired with the mutation that used to survive it; every
mutation was applied **alone** and must be red.

| Guard | Mutation that was green | Now |
|---|---|---|
| `owner-only.ts` — zero tests. This module is the daemon socket's entire access control (`server.ts` does no peer-credential check; the directory mode IS the mechanism). | `chmod(path, mode)` → `chmod(path, 0o755)` | 4/5 red. The weak `tighten()`-as-no-op mutation, which only kills the repair pass, is 3/5 red. Tests pre-create a 0755 directory — the population the repair pass exists for — and read the mode back with `statSync` on a real fs. |
| `TabCloseBroker` — "false acknowledgements do not pre-empt another TUI" untested on all three tracks. `handlers-ui.ts`'s `?? false` puts a reply omitting the field on the same path. | delete `if (!closed) return true` | 2 red, in a new `test/daemon/tab-close-broker.test.ts` (the class in isolation + the wire path). It started inside `handlers.test.ts` and pushed that file to 521 lines; the broker owns this contract and had no test file, so that was the seam. |
| `applyJitter` — the one clamp assertion was satisfied by *either* mechanism alone, which is how it got in. | drop the ratio upper clamp | 1 red |
| ″ | drop the zero floor | 1 red (separate case, ratio 0 so the clamp cannot cover it) |
| `exponentialBackoff` — both existing cases used `capMs > baseMs`, so the `attempt <= 0` branch's cap never mattered. `pr-status.ts` calls it with `failures - 1`, so attempt 0 is where every poller's first failure lands. | `return Math.min(baseMs, capMs)` → `return baseMs` | 1 red |
| `remove()`'s `?? opts.branch` — the test named for it `rmSync`s the directory first, so the missing-directory path consumes `opts.branch` and returns long before. | drop `?? opts.branch` | 1 red. Reached in production via detached HEAD: `currentBranch()` throws there rather than return the literal `HEAD`. |

The fixes in the first half carry the same treatment — reverting
`readRoveEnv`'s trim is 30 red, the mirror fix 1 red, `layout-migration`'s
accessor 2 red (including a negative assertion that a relative
`.kobe/plugins.json` under the process cwd is left as a plain file with no
`.rove` beside it), the disabled-engine filter 3 red, and the
`transparentBackground` default 2 red.

`test:fast` 4735 · `test:socket` 907 · typecheck · root lint — all green.
`test:fast` is zero signal for the daemon guards; only `test:socket` kills
those two.
