### PR TITLE
A bare promise return wedged the deferred-prompt queue, and a ps that never answered could wedge it again

### DIFF
--- a/.changeset/deferred-discard-queue-deadlock.md
+++ b/.changeset/deferred-discard-queue-deadlock.md
@@ -1,0 +1,9 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Fix a deadlock that wedged the deferred-prompt store, and with it every task deletion.
+
+`discard()` returned the in-flight claim's promise bare from inside the store's write queue. `serialized()` runs `tail.then(fn)`, so the queue slot ADOPTED that promise: the slot could not settle until the claim did, while the claim's own `releaseClaim`/`markDelivered` were queued behind that same slot. A dismiss arriving during a delivery closed the cycle and no later operation on the store ever ran — `deleteTask` (and so `task.delete`) sat at `phase=running` indefinitely, and `rove api deferred-list` timed out.
+
+The wait now happens outside the queue, exactly as `waitForClaims` already did: the enqueued callback hands the promise back wrapped and the wait runs after the slot has settled. Discard semantics are unchanged — it still waits for an in-flight claim before dropping the record.

--- a/.changeset/ps-probe-deadline.md
+++ b/.changeset/ps-probe-deadline.md
@@ -1,0 +1,9 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Bound the `ps` probe that every engine-presence check runs, and stop a failed probe from reading as "no engine".
+
+`psSnapshot` awaited `ps -A` with no deadline and no kill. Every caller wraps the probe in try/catch, which catches a throw and never a hang, so a `ps` that did not exit froze whichever gate asked it — including prompt delivery, which sits between a deferred prompt's `beginDelivery` marker and its release. It now gives up after 5s (`ps -A` answers in ~20ms) and kills the child rather than leaving it holding a pipe nobody reads.
+
+Failure is also an answer now. `enginePresence` reports `"engine" | "none" | "unknown"`, and `send` refuses an unreadable probe with `ENGINE_PROBE_FAILED` instead of telling you a running tab "has no live engine process — it is a plain shell right now". The write gate itself is unchanged: `sessionHasEngine` still refuses on anything but a positive walk, because a prompt pasted into a bare shell is executed.

--- a/docs/API.md
+++ b/docs/API.md
@@ -152,6 +152,7 @@ Separate from the daemon's refusals above — these never cross the socket:
 | `COMPOSER_BUSY` | The target composer held un-sent text; nothing was pasted. |
 | `TAB_RESTORED` | The `--tab` exists with its scrollback but nothing runs in it; pass `--respawn`. |
 | `ENGINE_NOT_RUNNING` | The tab's engine exited into a plain shell, so a paste would run as shell commands. |
+| `ENGINE_PROBE_FAILED` | The `ps` probe behind that check failed or blew its deadline, so the tab was never read either way. |
 | `DISPATCHER_UNREACHABLE` | A bare `send` whose dispatcher tab is dead and whose task has no live engine. |
 | `NOT_DELIVERED` | The task was created but the prompt never reached its engine. |
 | `EMPTY_SUCCESS_REPORT` | A `succeeded:` report from a branch with 0 commits; commit, or pass `--allow-empty`. |
@@ -483,8 +484,10 @@ branch included, live in the Rove agent skill. Prompts into existing sessions
   existing tab is a `BAD_FLAG` error rather than a silent switch.
   Delivery needs a live engine in that tab: one that exited into the
   keep-alive shell refuses with `ENGINE_NOT_RUNNING` and a `--tab new` hint
-  instead of pasting into a shell. Any registered engine passes, so a tab may
-  run a different vendor than its task. Without `--tab`, the canonical target
+  instead of pasting into a shell. When the `ps` probe behind that check fails
+  or blows its deadline the refusal is `ENGINE_PROBE_FAILED` instead — the tab
+  was never looked at, so nothing is claimed about its engine. Any registered
+  engine passes, so a tab may run a different vendor than its task. Without `--tab`, the canonical target
   is a live engine tab (`tab-1` first, then any surviving engine tab); when
   live tabs exist but none resolves as an engine, `send` refuses with
   `NO_ENGINE_TAB` rather than silently spawning a duplicate engine. Only a

--- a/packages/kobe-daemon/src/daemon/deferred-prompts-store.ts
+++ b/packages/kobe-daemon/src/daemon/deferred-prompts-store.ts
@@ -373,7 +373,16 @@ export class DeferredPromptsStore {
   /** Drop exactly one prompt referenced by an Inbox item, never its replacement. */
   async discard(id: string, reason: DeferredPromptDiscardReason): Promise<DeferredPromptRecord | null> {
     for (;;) {
-      const waiting = await this.enqueue(async () => this.claims.get(id)?.done)
+      // Hand the claim's promise back WRAPPED, exactly as `waitForClaims`
+      // does. Returning it bare makes the queue slot adopt it, so the slot
+      // cannot settle until the claim does — while that claim's own
+      // `releaseClaim`/`markDelivered` are queued behind this very slot. That
+      // cycle wedged the whole store: `deleteTask` (task deletion) and
+      // `list()` waited forever behind a discard that was waiting on them.
+      const [waiting] = await this.enqueue(async () => {
+        const active = this.claims.get(id)
+        return active ? [active.done] : []
+      })
       if (!waiting) break
       await waiting
     }

--- a/packages/kobe-daemon/src/daemon/json-file.ts
+++ b/packages/kobe-daemon/src/daemon/json-file.ts
@@ -51,6 +51,13 @@ const locks = new Map<string, Promise<unknown>>()
  * must not wedge the queue for every later caller — and the map entry is
  * dropped once nobody is behind it, so a long-lived daemon does not accumulate
  * an entry per file it has ever touched.
+ *
+ * `fn` must NOT return a promise as its value. `tail.then(fn)` adopts whatever
+ * `fn` resolves to, so a returned promise extends the slot until that promise
+ * settles and every later caller queues behind it. TypeScript cannot catch
+ * this — `async () => somePromise` is typed `Promise<T>`, not `Promise<
+ * Promise<T>>`. To hand a promise back to the caller, wrap it (`[done]`,
+ * `{ done }`) and await it OUTSIDE the queue.
  */
 export function serialized<T>(key: string, fn: () => Promise<T>): Promise<T> {
   const tail = locks.get(key) ?? Promise.resolve()

--- a/packages/kobe/src/cli/api/exact-tab-delivery.ts
+++ b/packages/kobe/src/cli/api/exact-tab-delivery.ts
@@ -21,7 +21,7 @@ import {
   awaitEngineProcess,
   hostedSessionFailureLine,
 } from "../../engine/hosted-session.ts"
-import { sessionHasEngine } from "../../engine/session-engine-presence.ts"
+import { enginePresence } from "../../engine/session-engine-presence.ts"
 import type { EngineSessionLaunch } from "../../engine/session-launch.ts"
 import { readPersistedTerminalDefaultColors } from "../../tui/lib/terminal-colors.ts"
 import type { VendorId } from "../../types/vendor.ts"
@@ -121,7 +121,19 @@ export async function deliverToExactTab(
   // engine exited (or that always was a shell tab) must not have the prompt
   // pasted into its shell. ANY running engine passes — the addressed tab's
   // engine need not match the task's vendor (cross-vendor send).
-  if (!(await sessionHasEngine(session.pid, opts?.engineBin, opts?.snapshot))) {
+  const presence = await enginePresence(session.pid, opts?.engineBin, opts?.snapshot)
+  if (presence === "unknown") {
+    // Refuse, but do not claim the tab is a shell — we never got to look.
+    throw new ApiError(
+      `could not read the process table, so tab ${tabId} on task ${taskId} could not be checked for a live engine`,
+      "ENGINE_PROBE_FAILED",
+      {
+        hint: "the `ps` probe failed or timed out; retry, or check the machine's process table",
+        nextCommandArgs: ["api", "pty-list"],
+      },
+    )
+  }
+  if (presence !== "engine") {
     throw new ApiError(
       `tab ${tabId} on task ${taskId} has no live engine process — it is a plain shell right now`,
       "ENGINE_NOT_RUNNING",

--- a/packages/kobe/src/cli/api/pty-delivery.ts
+++ b/packages/kobe/src/cli/api/pty-delivery.ts
@@ -37,16 +37,17 @@ import {
 } from "../../engine/hosted-session.ts"
 import { engineEntry } from "../../engine/registry.ts"
 import type { EngineScreenManifest } from "../../engine/screen-state.ts"
-import { sessionHasEngine } from "../../engine/session-engine-presence.ts"
+import { enginePresence } from "../../engine/session-engine-presence.ts"
 import type { EngineSessionLaunch } from "../../engine/session-launch.ts"
 import { readPersistedTerminalDefaultColors } from "../../tui/lib/terminal-colors.ts"
 import type { VendorId } from "../../types/vendor.ts"
 import { restoredTabsOf } from "./tab-respawn.ts"
 import { ApiError, type DeliveredPrompt, type PromptDeferralSink } from "./types.ts"
 
-// `sessionHasEngine` is the foreground gate for delivery into an existing
+// `enginePresence` is the foreground gate for delivery into an existing
 // hosted session: an alive PTY may now be a fallback shell after the engine
-// exits, and pasting there would execute the prompt as shell commands.
+// exits, and pasting there would execute the prompt as shell commands. Its
+// third answer, "unknown", refuses without claiming the engine is gone.
 /**
  * The narrow pty-host surface this module needs: request/response RPC plus
  * cleanup. `KobeDaemonClient` satisfies it; tests inject a fake that
@@ -164,9 +165,21 @@ export async function deliverHostedPrompt(
   if (existingKey) {
     // Foreground gate: the session's SPAWN argv matched an engine, but the
     // engine may have exited into the keepAlive shell since — pasting there
-    // executes the prompt as shell commands. See {@link sessionHasEngine}.
+    // executes the prompt as shell commands. See {@link enginePresence}.
     const pid = sessions.find((s) => s.key === existingKey)?.pid
-    if (!(await sessionHasEngine(pid, target.engineBin, opts?.snapshot))) {
+    const presence = await enginePresence(pid, target.engineBin, opts?.snapshot)
+    if (presence === "unknown") {
+      // Refuse, but do not claim the engine exited — we never got to look.
+      throw new ApiError(
+        `could not read the process table, so task ${target.id}'s engine tab (${existingKey}) could not be checked for a live engine`,
+        "ENGINE_PROBE_FAILED",
+        {
+          hint: "the `ps` probe failed or timed out; retry, or check the machine's process table",
+          nextCommandArgs: ["api", "pty-list"],
+        },
+      )
+    }
+    if (presence !== "engine") {
       throw new ApiError(
         `task ${target.id}'s engine tab (${existingKey}) has no live engine process — its engine exited into a plain shell`,
         "ENGINE_NOT_RUNNING",
@@ -306,7 +319,7 @@ export async function deliverHostedPrompt(
       ...disclose,
     }
     if (launch.initMarkerPath && !existsSync(launch.initMarkerPath)) return pendingInit
-    // Otherwise walk for the process — the same `sessionHasEngine` the
+    // Otherwise walk for the process — the same presence walk the
     // existing-session gate above uses, in the loop `awaitEngineProcess`
     // already owns, not a third implementation of the same question.
     const enginePid = await awaitEngineProcess(rpc, launch.key, target.engineBin, {

--- a/packages/kobe/src/engine/foreground.ts
+++ b/packages/kobe/src/engine/foreground.ts
@@ -185,10 +185,71 @@ export function engineProcessIn(
 /** Injectable so tests never shell out. */
 export type PsSnapshot = () => Promise<string>
 
-export const psSnapshot: PsSnapshot = async () => {
-  const proc = Bun.spawn(["ps", "-A", "-o", "pid=,ppid=,args="], { stdout: "pipe", stderr: "ignore" })
-  return await new Response(proc.stdout).text()
+/**
+ * A running `ps`: the text it will produce, and the kill the deadline needs.
+ * Injectable separately from {@link PsSnapshot} so a test can stand up a child
+ * that never exits — the failure this deadline exists for.
+ */
+export interface PsProcess {
+  readonly text: Promise<string>
+  kill(): void
 }
+
+export type PsSpawn = () => PsProcess
+
+/**
+ * `ps -A` answers in ~20ms on a healthy machine, so 5s only fires on a
+ * genuinely stuck process table — wide enough to never cost a true answer.
+ *
+ * It has to be bounded at all because nothing downstream can time this out:
+ * every caller wraps the probe in try/catch, which catches a THROW and not a
+ * hang, so an unbounded await here freezes whichever gate asked until the
+ * process is restarted.
+ */
+export const PS_PROBE_TIMEOUT_MS = 5_000
+
+/**
+ * The probe could not answer — distinct from "it answered, no engine". Callers
+ * that report to a human must say "couldn't look", never invent an absence.
+ */
+export class PsProbeUnavailableError extends Error {
+  constructor(reason: string) {
+    super(`process probe unavailable: ${reason}`)
+    this.name = "PsProbeUnavailableError"
+  }
+}
+
+const bunPsSpawn: PsSpawn = () => {
+  const proc = Bun.spawn(["ps", "-A", "-o", "pid=,ppid=,args="], { stdout: "pipe", stderr: "ignore" })
+  return { text: new Response(proc.stdout).text(), kill: () => proc.kill() }
+}
+
+/** {@link psSnapshot} with its two seams exposed, for tests. */
+export async function psSnapshotWith(spawn: PsSpawn, timeoutMs = PS_PROBE_TIMEOUT_MS): Promise<string> {
+  const proc = spawn()
+  let timer: ReturnType<typeof setTimeout> | undefined
+  try {
+    return await Promise.race([
+      proc.text,
+      new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(() => {
+          // Kill first: an abandoned `ps` holding a pipe nobody reads is how a
+          // one-off hang becomes a permanent leak in a long-lived daemon.
+          try {
+            proc.kill()
+          } catch {
+            /* already gone */
+          }
+          reject(new PsProbeUnavailableError(`ps did not answer within ${timeoutMs}ms`))
+        }, timeoutMs)
+      }),
+    ])
+  } finally {
+    if (timer) clearTimeout(timer)
+  }
+}
+
+export const psSnapshot: PsSnapshot = () => psSnapshotWith(bunPsSpawn)
 
 /**
  * The engine running under `rootPid` (a tab's PTY shell), or null when

--- a/packages/kobe/src/engine/session-engine-presence.ts
+++ b/packages/kobe/src/engine/session-engine-presence.ts
@@ -1,6 +1,17 @@
 import { type PsSnapshot, engineProcessIn, parsePsSnapshot, psSnapshot } from "./foreground.ts"
 
 /**
+ * What the process walk found: an engine, nothing, or no answer at all.
+ *
+ * The third case is the one worth a name. A `ps` that fails or blows its
+ * deadline tells you nothing about the session, and collapsing it into
+ * "no engine" turns a failed LOOK into a confident claim about the world —
+ * which is how `send` came to tell users "its engine exited into a plain
+ * shell" about a tab whose engine was running fine.
+ */
+export type EnginePresence = "engine" | "none" | "unknown"
+
+/**
  * Is an engine process running inside this hosted session's tree right now?
  *
  * The one answer to "is the engine actually there", shared by every gate that
@@ -11,21 +22,37 @@ import { type PsSnapshot, engineProcessIn, parsePsSnapshot, psSnapshot } from ".
  * liveness answers a different question, and a paste into that shell is
  * EXECUTED as shell commands rather than read.
  *
- * A failed `ps` reads as `false` here on purpose: for a gate, only a positive
- * walk may license a write. Readers must NOT reuse this — `false` from a
- * failed look would tell a cleanup loop a live task had stopped. They walk
- * one shared snapshot with {@link engineProcessIn} and publish the failure as
- * `null` (see `cli/api/runtime.ts`'s `taskTabs`).
+ * A missing pid is `"none"`: there is no tree to walk, which is an answer.
+ */
+export async function enginePresence(
+  pid: number | null | undefined,
+  extraLaunch?: string | readonly string[],
+  snapshot: PsSnapshot = psSnapshot,
+): Promise<EnginePresence> {
+  if (!pid) return "none"
+  try {
+    return engineProcessIn(parsePsSnapshot(await snapshot()), pid, extraLaunch) ? "engine" : "none"
+  } catch {
+    return "unknown"
+  }
+}
+
+/**
+ * {@link enginePresence} collapsed for a GATE: only a positive walk licenses a
+ * write, so both "none" and "unknown" refuse. Deliberate — a prompt pasted
+ * into a bare shell is executed, and that must not happen because a probe
+ * hiccupped.
+ *
+ * Callers that REPORT the verdict to a human must use {@link enginePresence}
+ * instead and say which of the two it was. Readers (liveness, cleanup) must
+ * use neither: `false` from a failed look would tell them a live task stopped.
+ * They walk one shared snapshot with {@link engineProcessIn} and publish the
+ * failure as `null` (see `cli/api/runtime.ts`'s `taskTabs`).
  */
 export async function sessionHasEngine(
   pid: number | null | undefined,
   extraLaunch?: string | readonly string[],
   snapshot: PsSnapshot = psSnapshot,
 ): Promise<boolean> {
-  if (!pid) return false
-  try {
-    return engineProcessIn(parsePsSnapshot(await snapshot()), pid, extraLaunch)
-  } catch {
-    return false
-  }
+  return (await enginePresence(pid, extraLaunch, snapshot)) === "engine"
 }

--- a/packages/kobe/test/daemon/deferred-prompts-queue-deadlock.test.ts
+++ b/packages/kobe/test/daemon/deferred-prompts-queue-deadlock.test.ts
@@ -1,0 +1,114 @@
+/**
+ * `discard()` waits for an in-flight claim BEFORE it takes the store's write
+ * queue, not from inside it. Returning `claim.done` bare from the enqueued
+ * callback made the slot adopt that promise, so the slot could only settle
+ * once the claim did — while the claim's own `releaseClaim`/`markDelivered`
+ * were queued behind that same slot. The cycle wedged every later caller:
+ * seven task deletions sat at `phase=running` for two hours because
+ * `deleteTask` → `waitForClaims` never reached the front of the queue.
+ *
+ * The first test below is the concurrency contract (it fails on the bare
+ * return); the second is the discard SEMANTICS the fix must not change, and
+ * deliberately stays green under that same mutation.
+ */
+import { mkdtemp, readFile, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { DeferredPromptsStore } from "@sma1lboy/kobe-daemon/daemon/deferred-prompts-store"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+/** Resolves to "TIMEOUT" instead of hanging the runner when the queue wedges. */
+function within<T>(work: Promise<T>, ms = 200): Promise<T | "TIMEOUT"> {
+  return Promise.race([
+    work,
+    new Promise<"TIMEOUT">((resolve) => {
+      setTimeout(() => resolve("TIMEOUT"), ms).unref?.()
+    }),
+  ])
+}
+
+describe("deferred-prompts store queue under an in-flight claim", () => {
+  let dir: string | null = null
+  let path = ""
+  const now = 1_000_000
+  const base = { tabId: "tab-1", prompt: "queued text", layer: "composer-not-empty" as const }
+
+  beforeEach(async () => {
+    // Silence the discard's daemon-log line; the assertions are the contract.
+    vi.spyOn(process.stderr, "write").mockImplementation((() => true) as typeof process.stderr.write)
+    dir = await mkdtemp(join(tmpdir(), "kobe-deferred-deadlock-"))
+    path = join(dir, "deferred-prompts.json")
+  })
+
+  afterEach(async () => {
+    if (dir) await rm(dir, { recursive: true, force: true })
+    dir = null
+    vi.restoreAllMocks()
+  })
+
+  const create = () => new DeferredPromptsStore(path, () => now)
+
+  /** Read the records off disk — the one look that never touches the queue. */
+  async function recordIdsOnDisk(): Promise<string[]> {
+    const parsed = JSON.parse(await readFile(path, "utf8")) as { records: { id: string }[] }
+    return parsed.records.map((record) => record.id)
+  }
+
+  it("keeps serving the store while a discard waits on a live claim", async () => {
+    const store = create()
+    const held = await store.file({ ...base, taskId: "task-held", at: now })
+    await store.file({ ...base, taskId: "task-other", at: now })
+
+    const claimed = await store.claim(held.id)
+    if (claimed.kind !== "claimed") throw new Error(`expected a claim, got ${claimed.kind}`)
+
+    // A dismiss arriving mid-delivery: it must WAIT for the claim, not sit on
+    // the queue while it waits.
+    const discarding = store.discard(held.id, "Inbox item dismissed")
+    await new Promise((resolve) => setTimeout(resolve, 10))
+
+    // Asserted together so a regression reports every wedged path, not just
+    // whichever one `expect` reached first.
+    const settled = {
+      list: (await within(store.list())) === "TIMEOUT" ? "TIMEOUT" : "ok",
+      // The incident's own path: task deletion drains another task's records.
+      deleteTask: (await within(store.deleteTask("task-other"))) === "TIMEOUT" ? "TIMEOUT" : "ok",
+      // The claim's settle path is the deadlock's other half — it is what
+      // `discard` waits FOR, so it must never queue behind it.
+      releaseClaim: (await within(store.releaseClaim(claimed.claim))) === "TIMEOUT" ? "TIMEOUT" : "ok",
+    }
+    expect(settled).toEqual({ list: "ok", deleteTask: "ok", releaseClaim: "ok" })
+
+    // Released, so the discard resumes and drops exactly its own record.
+    const dropped = await within(discarding, 2_000)
+    expect(dropped).not.toBe("TIMEOUT")
+    expect((dropped as { id: string } | null)?.id).toBe(held.id)
+    expect(await recordIdsOnDisk()).toEqual([])
+  })
+
+  it("never drops a claimed record out from under its claim", async () => {
+    const store = create()
+    const claimedRecord = await store.file({ ...base, taskId: "task-held", at: now })
+    const sibling = await store.file({ ...base, taskId: "task-other", at: now })
+
+    const claimed = await store.claim(claimedRecord.id)
+    if (claimed.kind !== "claimed") throw new Error(`expected a claim, got ${claimed.kind}`)
+
+    const discarding = store.discard(claimedRecord.id, "Inbox item dismissed")
+    void discarding.catch(() => {})
+    await new Promise((resolve) => setTimeout(resolve, 50))
+    // The claim owns the delivery transaction, so a dismiss may not erase the
+    // record while that transaction is open — it waits for it.
+    expect(await recordIdsOnDisk()).toEqual([claimedRecord.id, sibling.id])
+  })
+
+  it("drops exactly the record it names when no claim is in flight", async () => {
+    const store = create()
+    const target = await store.file({ ...base, taskId: "task-a", at: now })
+    const keep = await store.file({ ...base, taskId: "task-b", at: now })
+
+    expect((await store.discard(target.id, "Inbox item dismissed"))?.id).toBe(target.id)
+    expect(await recordIdsOnDisk()).toEqual([keep.id])
+    expect(await store.discard(target.id, "Inbox item dismissed")).toBeNull()
+  })
+})

--- a/packages/kobe/test/engine/ps-probe-deadline.test.ts
+++ b/packages/kobe/test/engine/ps-probe-deadline.test.ts
@@ -1,0 +1,72 @@
+/**
+ * `psSnapshot` used to await `ps` with no deadline and no kill. Every caller
+ * wraps the probe in try/catch, which catches a THROW and never a hang, so a
+ * `ps` that did not exit froze whichever gate asked it until the process was
+ * restarted — there was no other backstop anywhere on the path.
+ *
+ * The deadline exists so that failure becomes an ANSWER: "unknown", which
+ * readers already publish as such and reporting gates must not restate as
+ * "no engine".
+ */
+import { PS_PROBE_TIMEOUT_MS, type PsProcess, PsProbeUnavailableError, psSnapshotWith } from "../../src/engine/foreground.ts"
+import { enginePresence, sessionHasEngine } from "../../src/engine/session-engine-presence.ts"
+import { describe, expect, it } from "vitest"
+
+/** A `ps` that never exits — the failure the deadline exists for. */
+function neverExits(): { spawn: () => PsProcess; killed: () => number } {
+  let kills = 0
+  return {
+    spawn: () => ({ text: new Promise<string>(() => {}), kill: () => { kills++ } }),
+    killed: () => kills,
+  }
+}
+
+const PS_LINE = "  100     1 /bin/zsh -ilc\n  200   100 claude --session-id abc\n"
+
+describe("ps probe deadline", () => {
+  it("gives up on a ps that never exits, and kills it", async () => {
+    const stub = neverExits()
+    const started = Date.now()
+    await expect(psSnapshotWith(stub.spawn, 150)).rejects.toBeInstanceOf(PsProbeUnavailableError)
+    // Bounded: the whole point is that this returns at all.
+    expect(Date.now() - started).toBeLessThan(2_000)
+    // An abandoned `ps` holding a pipe nobody reads leaks in a long-lived daemon.
+    expect(stub.killed()).toBe(1)
+  })
+
+  it("returns the output and leaves the child alone when ps answers", async () => {
+    const stub = neverExits()
+    const spawn = (): PsProcess => ({ text: Promise.resolve(PS_LINE), kill: stub.spawn().kill })
+    expect(await psSnapshotWith(spawn, 150)).toBe(PS_LINE)
+    expect(stub.killed()).toBe(0)
+  })
+
+  it("ships a deadline wide enough that a healthy ps never hits it", () => {
+    // `ps -A` measures ~20ms on a healthy machine; the constant is the
+    // stuck-process-table threshold, not a latency budget.
+    expect(PS_PROBE_TIMEOUT_MS).toBeGreaterThanOrEqual(1_000)
+    expect(PS_PROBE_TIMEOUT_MS).toBeLessThanOrEqual(30_000)
+  })
+})
+
+describe("engine presence when the probe cannot answer", () => {
+  const hang = () => psSnapshotWith(neverExits().spawn, 100)
+
+  it("reports unknown rather than inventing an absence", async () => {
+    expect(await enginePresence(200, undefined, hang)).toBe("unknown")
+  })
+
+  it("still walks to a real verdict when ps answers", async () => {
+    const ok = async () => PS_LINE
+    expect(await enginePresence(100, undefined, ok)).toBe("engine")
+    expect(await enginePresence(999, undefined, ok)).toBe("none")
+    // No pid is an answer, not a failed look.
+    expect(await enginePresence(null, undefined, ok)).toBe("none")
+  })
+
+  it("keeps the write GATE closed on unknown — refusing is not the same as reporting", async () => {
+    // sessionHasEngine must stay false: a prompt pasted into a bare shell is
+    // executed. The distinction is for what callers SAY, not what they allow.
+    expect(await sessionHasEngine(200, undefined, hang)).toBe(false)
+  })
+})


### PR DESCRIPTION
## The incident

2026-09-05 05:17Z: seven `task.delete` calls on the production daemon sat at `phase=running` for over two hours. `rove api deferred-list` timed out. Every other store answered normally.

The chain:

```
task.delete → clearTaskState → deferredPrompts.deleteTask → waitForClaims
            → enqueue → queued behind a poisoned slot → never returns
```

## Root cause

`serialized()` (`json-file.ts`) runs `const run = tail.then(fn)`. `.then` **adopts** whatever `fn` resolves to, so a callback that returns a promise extends its queue slot until that promise settles.

`discard()` did exactly that:

```ts
const waiting = await this.enqueue(async () => this.claims.get(id)?.done)
```

`claim.done` resolves only in `completeClaim` / `releaseClaim` — and both of those are themselves `enqueue`d, so they were queued *behind* the slot that was waiting on them. A dismiss arriving while a delivery was in flight closed the cycle, and no later operation on the store ever ran.

`waitForClaims()` returns `[active.done]` — an **array**, not a thenable — which is why it never had this bug. `discard` was the only call site returning a bare promise.

Isolated reproduction (plain JS, no Rove):

```ts
const never = new Promise<void>(() => {})
serialized("k", async () => never)                          // discard's shape
await Promise.race([serialized("k", async () => "ok"), timeout(2000)])   // → "TIMEOUT"
// swap line 2 for `async () => [never]` and it resolves "ok"
```

## The fix

One call site. `discard()` hands the promise back wrapped and awaits it *after* the slot settles, exactly as `waitForClaims` already did. `serialized()`'s semantics are untouched — wrapping there would be too late, since `tail.then(fn)` has already adopted by then. Discard still waits for an in-flight claim before dropping the record.

Plus a note on `serialized()`'s doc comment: TypeScript cannot catch this shape (`async () => somePromise` is typed `Promise<T>`, not `Promise<Promise<T>>`), so the constraint has to be written down and tested rather than typed.

## Call-site audit

Every `serialized(…, async () => …)` / `this.enqueue(async () => …)` in the repo, and what its callback returns:

| Store | Call sites | Returns | Verdict |
|---|---|---|---|
| `deferred-prompts-store.ts` | `file`, `get`, `claim`, `beginDelivery`, `resetDelivery`, `markDelivered`, `completeClaim`, `releaseClaim`, `list`, `resolve`, `discardTab`, `listForTask`, `deleteTask` | record / array / boolean / `null` / void | safe |
| `deferred-prompts-store.ts` | `waitForClaims` | `Promise<void>[]` (array) | safe — the correct shape |
| `deferred-prompts-store.ts` | **`discard`** | **`Promise<void> \| undefined`** | **the bug — fixed here** |
| `attention-inbox.ts` | 9 sites | void / boolean | safe |
| `automations-store.ts` | 7 sites | `Automation` / `AutomationRun` / boolean / `null` / void | safe |
| `agent-turns-store.ts` | 3 sites | number / void | safe |
| `issues-store.ts` | 5 sites | response object / `null` | safe |
| `notes-store.ts` | 2 sites | `FieldNote[]` / void | safe |

One call site, one shape error. No global serializer wrapper: the invariant belongs in `serialized()`'s contract, enforced by the test below.

## Tests — `test/daemon/deferred-prompts-queue-deadlock.test.ts`

1. **Concurrency.** With a live claim and a `discard` waiting on it: `list()`, `deleteTask(otherTask)` (the incident's own path) and `releaseClaim(thatClaim)` (the deadlock's other half) all settle inside 200ms; the discard then resumes and drops its record.
2. **Semantics.** A dismiss never erases a record out from under a live claim (read straight off disk, bypassing the queue).
3. **Semantics.** With no claim in flight, discard drops exactly the record it names and is idempotent.

### Mutation verification

| Mutation | Test 1 (concurrency) | Tests 2–3 (semantics) |
|---|---|---|
| revert to the bare `claim.done` return | **RED** — `{list: TIMEOUT, deleteTask: TIMEOUT, releaseClaim: TIMEOUT}` | green |
| make `discard` skip the claim wait entirely | green | **RED** — record deleted under its claim |

Two different mutation sites, opposite failure signatures: the concurrency test cannot pass for semantic reasons, and the semantics tests cannot pass for timing reasons.

## Live verification

Real daemon, isolated `KOBE_HOME_DIR`, sentinel engine on a hosted PTY that never announces bracketed paste (so `awaitPasteReady` burns its 15s deadline and holds the claim open). `deferred-release` claims → `deferred-dismiss` lands inside that window → `deferred-list` and `task delete --wait` are timed. Both runs confirmed the claim was in flight (`deliveryStartedAt` present on disk).

```
### [BEFORE-BUGGY] deliveryStartedAt written by beginDelivery?
"deliveryStartedAt":
### [BEFORE-BUGGY] deferred-list exit=124 elapsed=10s    ← wedged (124 = timeout)
### [BEFORE-BUGGY] delete     exit=0   elapsed=15s       ← burned its whole budget, no output

### [AFTER-FIXED]  deliveryStartedAt written by beginDelivery?
"deliveryStartedAt":
### [AFTER-FIXED]  deferred-list exit=0 elapsed=0s       ← returns the still-held record
### [AFTER-FIXED]  delete        exit=0 elapsed=1s
```

Note on the originally proposed live recipe (`send` → `deferred-dismiss` → `deferred-list`): it cannot reproduce this. With no claim in flight, `claims.get(id)` is empty and `discard` takes the fast path on both versions. The window only opens when a dismiss races an in-flight delivery, which is what the script above stages.

## Why the delivery "hung" — there is no second bug

The incident log showed `beginDelivery` writing at 04:55:17Z and `deferred-prompts.json` never being written again: no `markDelivered`, no `resetDelivery`, no `releaseClaim`. That reads like a hung PTY write, but it is the same deadlock seen from the other side — **all three of those calls are `enqueue`d**, and they were queued behind the poisoned discard slot. The delivery did not hang; its bookkeeping never got a turn. The BEFORE run above reproduces exactly that signature.

Ruled out along `deliverClaim` → `deliverPromptToLiveEngineTabDetailed`, all bounded:

- `pty.peek` / `pty.write` — 20s client deadline (`rpcTimeoutMs`; `pty.*` is not in `BLOCKING_RPCS`, so the exemption does not apply)
- `awaitPasteReady` — 15s deadline
- `confirmPromptLanded` — 2s deadline
- `KobeDaemonClient.connect()` — a unix connect either errors or succeeds; no pending state
- `assertComposerClear` — pure screen parse, no I/O
- the attention-inbox queue reached via `cleanupDeliveredClaim` — audited above, no adopted promises

## Second commit: the one unbounded await that WAS real

`psSnapshot()` (`engine/foreground.ts`) did `Bun.spawn(["ps","-A",…])` and awaited its stdout with no timeout and no kill. It sits on this very path — after `beginDelivery`, inside the delivery adapter — so a `ps` that never exits wedges a delivery exactly the way the queue bug did, and nothing downstream can catch it: every caller's `try/catch` catches a *throw*, never a hang.

It now gives up after 5s and kills the child first (an abandoned `ps` holding a pipe nobody reads is how one hang becomes a permanent leak in a long-lived daemon). `ps -A` measures 0.02s on this machine, so the constant is a stuck-process-table threshold, not a latency budget.

**Failure is an answer, not an absence.** A timed-out probe told users something confidently false: `send` refused with *"its engine exited into a plain shell"* about a tab whose engine was running fine. So `enginePresence` now reports `"engine" | "none" | "unknown"`, and the two gates that REPORT a verdict to a human refuse an unreadable probe with `ENGINE_PROBE_FAILED` and say they could not look. Readers (`handlers-inspect`, `runtime.ts` `taskTabs`, `dispatcher`) already mapped a throwing probe to `null`/`"unknown"` — the hang is what made those branches unreachable, so they needed no change.

The write gate is deliberately unchanged: `sessionHasEngine` still returns `false` on both `"none"` and `"unknown"`, because a prompt pasted into a bare shell is *executed*. The distinction is about what callers SAY, not what they allow — and a test pins that separation.

### Mutation verification (`test/engine/ps-probe-deadline.test.ts`, 6 tests)

| Mutation | Result |
|---|---|
| drop the deadline, await the child unbounded (the original bug) | **3 RED**, all by hanging to the runner's 5s timeout — the exact original failure mode; the happy-path and constant tests stay green |
| keep the deadline, collapse `"unknown"` into `"none"` | **1 RED** — the distinction test; the gate test stays green, showing the two concerns really are separated |

### Live verification — a `ps` that never answers

Same rig as the first fix: real daemon, isolated `KOBE_HOME_DIR` and sockets, sentinel engine on a hosted PTY, never touching `~/.rove`. A wedged process table is stood up by putting a fake `ps` (`#!/bin/sh` / `sleep 600`) first on `PATH` — **for the measured `send` only**, since a fake `ps` for the whole run would break the daemon's own bookkeeping and measure that instead. Both runs then time `send --tab tab-1` against a live engine tab.

Each run carries its own control: the **identical command with a working `ps`**, which must get past the gate. It delivers on both versions, so the difference below is the wedged probe and not a broken fixture.

```
### [BEFORE-BUGGY] >>> control: identical send, real ps, 25s budget <<<
{"ok":true,…,"delivered":true,"bytes":7,"promptEcho":"confirmed"}
### [BEFORE-BUGGY] control exit=0 elapsed=16s
### [BEFORE-BUGGY] >>> send --tab tab-1 with a `ps` that never answers, 20s budget <<<
### [BEFORE-BUGGY] send exit=124 elapsed=20s          ← wedged, no output at all

### [AFTER-FIXED]  >>> control: identical send, real ps, 25s budget <<<
{"ok":true,…,"delivered":true,"bytes":7,"promptEcho":"confirmed"}
### [AFTER-FIXED]  control exit=0 elapsed=16s
### [AFTER-FIXED]  >>> send --tab tab-1 with a `ps` that never answers, 20s budget <<<
{"error":{"message":"could not read the process table, so tab tab-1 on task … could not
be checked for a live engine","code":"ENGINE_PROBE_FAILED","hint":"the `ps` probe failed
or timed out; retry, or check the machine's process table","nextCommandArgs":["api","pty-list"]}}
### [AFTER-FIXED]  send exit=1 elapsed=5s             ← refuses on the deadline, and says why
```

BEFORE is the branch's own parent commit (`aec7522e0`, the deadlock fix), so the pair isolates this commit alone. Sources were swapped file-by-file with `git show <rev>:<f> > <f>` rather than `git checkout <rev> -- src`, which would stage them.

Captured the same way as the first pair — a real pty at a fixed size, replayed into xterm.js in headless Chromium — so the images are the bytes the CLI actually wrote to a tty, not text typeset into a picture. Raw streams and PNGs are archived alongside the run.

The 20s budget is what makes BEFORE's number a floor rather than a measurement: nothing was going to return, so `timeout` chose 20. AFTER's 5s is the deadline itself.

## Gates

Rebased onto `origin/main` @ `824d956b5` (v0.9.158). `bun run test:fast` **4804 ✓** (487 files) · root `bun run lint` ✓ · `packages/kobe` `bun run typecheck` ✓

`docs/API.md` gains `ENGINE_PROBE_FAILED` twice: the prose next to `ENGINE_NOT_RUNNING`, and — new since #923 landed its closed-list checker — a row in the **Codes the CLI itself raises** table. Without that row `test/cli/api-error-codes-documented.test.ts` fails on this branch; it is green now.

Two failures in the local socket suite are NOT from this branch: `automation-bound-delivery.test.ts`'s three "after precheck began" cases arrived with #919 and reproduce on pristine `origin/main` with zero changes of mine.
