### PR TITLE
fix: keep file previews tied to the selected path

### DIFF
--- a/.changeset/tidy-files-preview.md
+++ b/.changeset/tidy-files-preview.md
@@ -1,0 +1,7 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Keep file previews tied to the selected path. Filenames containing brackets, wildcards, or leading pathspec syntax now open only their own diff, including after a rename.
+
+Show pure renames and empty-file additions or deletions in both single-file and combined diffs. Missing or unreadable text files report an error with the existing retry action, while valid empty files say so. Switching previews shows loading until that path's result arrives instead of displaying the previous file under the new title.

--- a/docs/TUI.md
+++ b/docs/TUI.md
@@ -228,9 +228,17 @@ active scope says so rather than opening blank.
 the rename and the same `+N −M` as its list row, not the whole file as added. A
 changed binary and a mode-only change each state what changed — in the
 single-file view and in a combined diff's section — because a patch git wrote
-entirely in its preamble has no hunks to draw. If git itself refuses (a pruned
+entirely in its preamble has no hunks to draw. Pure renames name the original
+path; additions and deletions of empty files state the change. These states
+have no review cursor or line comments. Filenames are literal, including
+brackets, `*`, `?`, and leading `:`; selecting one cannot include another
+file's hunks. Directory and whole-worktree diffs still combine their files. If git itself refuses (a pruned
 remote, a renamed base branch), the pane shows git's own error and `r` retries;
-a failed read is never reported as an absence of changes.
+a failed read is never reported as an absence of changes. An unreadable or
+missing text file shows a read error and the same retry action; a valid empty
+file says "empty file". While a different path, worktree, or comparison base
+loads, the preview shows a loading state instead of the previous file's text.
+A late result cannot replace the current preview or reopen a closed tab.
 
 Open a text file with `enter`. Rove uses the configured terminal editor; for a
 changed file it requests that editor's diff mode when Vim or Neovim is

--- a/packages/kobe/src/tui-react/ops/preview.tsx
+++ b/packages/kobe/src/tui-react/ops/preview.tsx
@@ -13,6 +13,7 @@
 import { type DiffRenderable, TextAttributes } from "@opentui/core"
 import { useEffect, useMemo, useRef, useState } from "react"
 import { execHostForWorktreePath } from "../../exec/resolve"
+import { errorMessage } from "../../lib/error-message"
 import { formatBytes } from "../../lib/format-bytes"
 import { openWithSystemViewer } from "../../lib/open-external"
 import type { DiffReviewApi } from "../../tui/ops/diff-comments"
@@ -63,7 +64,9 @@ export function PreviewScreen(props: OpsPreviewArgs) {
   const combined = isCombinedPathspec(props.relPath)
   const pathspecLabel = props.relPath === "." ? t("ops.preview.allFiles") : props.relPath
 
-  const [data, setData] = useState<PreviewData | null>(null)
+  const identity = JSON.stringify([props.worktree, props.relPath, props.base])
+  const [loaded, setLoaded] = useState<{ identity: string; data: PreviewData } | null>(null)
+  const data = loaded?.identity === identity ? loaded.data : null
   const [reloadTick, setReloadTick] = useState(0)
   const base = props.base
   // biome-ignore lint/correctness/useExhaustiveDependencies: reloadTick is a TRIGGER — the effect body doesn't read it.
@@ -71,16 +74,15 @@ export function PreviewScreen(props: OpsPreviewArgs) {
     let disposed = false
     void loadPreviewData(props.worktree, props.relPath, base ? { base } : undefined)
       .then((d) => {
-        if (!disposed) setData(d)
+        if (!disposed) setLoaded({ identity, data: d })
       })
-      .catch(() => {
-        // Failure boundary: a failed read (worktree torn
-        // down mid-open) leaves the loading placeholder rather than crashing.
+      .catch((error: unknown) => {
+        if (!disposed) setLoaded({ identity, data: { kind: "error", message: errorMessage(error) } })
       })
     return () => {
       disposed = true
     }
-  }, [props.worktree, props.relPath, base, reloadTick])
+  }, [props.worktree, props.relPath, base, reloadTick, identity])
 
   // System-open (`o`) only makes sense for a LOCAL worktree — the file the
   // OS viewer would open doesn't exist on this machine for a remote one.
@@ -108,10 +110,18 @@ export function PreviewScreen(props: OpsPreviewArgs) {
   // One vocabulary for a hunk-less patch, shared by the single-file card and
   // a combined diff's sections — the two used to disagree by rendering
   // nothing in different shapes.
-  const noteLabel = (note: PatchNote, path: string): string =>
-    note.kind === "mode"
-      ? t("ops.preview.modeChanged", { from: note.from, to: note.to })
-      : t(isImagePath(path) ? "ops.preview.imageChanged" : "ops.preview.binaryChanged")
+  const noteLabel = (note: PatchNote, path: string): string => {
+    switch (note.kind) {
+      case "mode":
+        return t("ops.preview.modeChanged", { from: note.from, to: note.to })
+      case "rename":
+        return t("ops.preview.renamedFrom", { origPath: note.from })
+      case "empty-file":
+        return t(note.change === "added" ? "ops.preview.emptyAdded" : "ops.preview.emptyDeleted")
+      case "binary":
+        return t(isImagePath(path) ? "ops.preview.imageChanged" : "ops.preview.binaryChanged")
+    }
+  }
 
   const onClose = props.onClose ?? (() => process.exit(0))
   useBindings(() => ({
@@ -161,7 +171,7 @@ export function PreviewScreen(props: OpsPreviewArgs) {
               : data?.kind === "patch-note"
                 ? noteLabel(data.note, props.relPath)
                 : data?.kind === "error"
-                  ? t("ops.preview.gitFailed")
+                  ? t("ops.preview.previewFailed")
                   : t("ops.preview.file")}
         </text>
         {data?.kind === "diff" && data.origPath != null ? (
@@ -265,6 +275,8 @@ export function PreviewScreen(props: OpsPreviewArgs) {
             syntaxStyle={style}
             showLineNumbers={true}
           />
+        ) : data.text.length === 0 ? (
+          <text fg={theme.textMuted}>{t("ops.preview.emptyFile")}</text>
         ) : (
           <code content={data.text} filetype={filetype} syntaxStyle={style} />
         )}

--- a/packages/kobe/src/tui/i18n/messages/ops.ts
+++ b/packages/kobe/src/tui/i18n/messages/ops.ts
@@ -30,7 +30,11 @@ export const en = {
     modeChanged: "mode changed · {from} → {to}",
     /** git refused. Carries git's own stderr rather than presenting the
      *  absent diff as an absence of changes. */
-    gitFailed: "could not read the diff",
+    previewFailed: "could not load preview",
+    readFailed: "Cannot read {path}. The file may be missing or unreadable.",
+    emptyFile: "empty file",
+    emptyAdded: "empty file added",
+    emptyDeleted: "empty file deleted",
     retryHint: "r to retry",
     /** Footer on a combined diff: review notes anchor to ONE path, so a diff
      *  spanning files carries none. Stated so the absence reads as a rule. */
@@ -75,7 +79,11 @@ export const zh: typeof en = {
     binaryChanged: "二进制文件已改动",
     imageChanged: "图片已改动",
     modeChanged: "权限位已改动 · {from} → {to}",
-    gitFailed: "读取 diff 失败",
+    previewFailed: "预览加载失败",
+    readFailed: "无法读取 {path}。文件可能已不存在或不可读。",
+    emptyFile: "空文件",
+    emptyAdded: "新增空文件",
+    emptyDeleted: "删除空文件",
     retryHint: "按 r 重试",
     notesPerFile: "备注按单文件锚定——要加备注请打开单个文件的 diff",
     review: {

--- a/packages/kobe/src/tui/ops/preview-core.ts
+++ b/packages/kobe/src/tui/ops/preview-core.ts
@@ -7,6 +7,7 @@
 
 import { unquoteGitPath } from "@/lib/git-parsers"
 import { readWorktreeFile, runWorktreeGit, worktreeFileSize } from "@/worktree/content"
+import { t } from "../i18n"
 
 /** Map a file extension to an opentui tree-sitter grammar name. */
 export function filetypeOf(relPath: string): string | undefined {
@@ -31,15 +32,16 @@ export function filetypeOf(relPath: string): string | undefined {
 }
 
 /**
- * What a patch that git expressed entirely in its PREAMBLE changed: a binary
- * whose bytes differ, or a file whose mode flipped. Both are real, non-empty
- * patches with no hunks — and `<diff>` draws hunk rows and nothing else, so
+ * What a patch expressed entirely in its preamble changed. Binary, mode,
+ * rename and empty-file changes are real patches with no hunks — and `<diff>` draws hunk rows and nothing else, so
  * without this they render as a blank pane, which is indistinguishable from
  * "nothing changed": the one thing the patch proves false.
  */
 export type PatchNote =
   | { readonly kind: "binary" }
   | { readonly kind: "mode"; readonly from: string; readonly to: string }
+  | { readonly kind: "rename"; readonly from: string; readonly to: string }
+  | { readonly kind: "empty-file"; readonly change: "added" | "deleted" }
 
 export type PreviewData =
   /** Unified diff → opentui `<diff>`. `origPath` is set when the patch is a
@@ -97,12 +99,21 @@ export function hunklessPatchNote(patch: string): PatchNote | null {
   let binary = false
   let from: string | undefined
   let to: string | undefined
+  let renameFrom: string | undefined
+  let renameTo: string | undefined
+  let emptyChange: "added" | "deleted" | undefined
   for (const line of patch.split("\n")) {
     if (line.startsWith("old mode ")) from = line.slice("old mode ".length).trim()
     else if (line.startsWith("new mode ")) to = line.slice("new mode ".length).trim()
+    else if (line.startsWith("rename from ")) renameFrom = unquoteGitPath(line.slice(12))
+    else if (line.startsWith("rename to ")) renameTo = unquoteGitPath(line.slice(10))
+    else if (line.startsWith("new file mode ")) emptyChange = "added"
+    else if (line.startsWith("deleted file mode ")) emptyChange = "deleted"
     else if (line.startsWith("Binary files ") || line.startsWith("GIT binary patch")) binary = true
   }
   if (binary) return { kind: "binary" }
+  if (renameFrom != null && renameTo != null) return { kind: "rename", from: renameFrom, to: renameTo }
+  if (emptyChange) return { kind: "empty-file", change: emptyChange }
   if (from != null && to != null) return { kind: "mode", from, to }
   return null
 }
@@ -172,7 +183,9 @@ export function unifiedDiffFiles(text: string): UnifiedDiffFile[] {
     }
     if (!current) continue
     current.lines.push(line)
-    if (line.startsWith("+++ ")) current.plus = sidePath(line.slice(4)) ?? undefined
+    if (line.startsWith("rename to ")) current.path = unquoteGitPath(line.slice(10))
+    else if (line.startsWith("copy to ")) current.path = unquoteGitPath(line.slice(8))
+    else if (line.startsWith("+++ ")) current.plus = sidePath(line.slice(4)) ?? undefined
     else if (line.startsWith("--- ")) current.minus = sidePath(line.slice(4)) ?? undefined
     // Hunk bodies only: `@@` headers and the `---`/`+++`/`index` preamble are
     // not rendered as rows.
@@ -224,7 +237,7 @@ async function pairRename(
     const neu = fields[i + 2]
     i += 2
     if (orig == null || neu !== relPath) continue
-    const paired = await runWorktreeGit(worktree, ["diff", spec, "--", relPath, orig])
+    const paired = await runWorktreeGit(worktree, ["--literal-pathspecs", "diff", spec, "--", relPath, orig])
     if (paired.status !== 0 || paired.stdout.trim().length === 0) return null
     return { text: paired.stdout, origPath: orig }
   }
@@ -263,31 +276,34 @@ export async function loadPreviewData(
     return { kind: "binary", image: true, sizeBytes: await worktreeFileSize(worktree, relPath) }
   }
   const spec = range ? `${range.base}...HEAD` : "HEAD"
-  const res = await runWorktreeGit(worktree, ["diff", spec, "--", relPath])
-  // A refused diff is only a FAILURE when a base was asked for. Without one,
-  // git declining means there is nothing to diff against — an unborn HEAD, or
-  // a file outside any repo — and the file's own content is the honest answer,
-  // which is what the standalone `rove ops --preview <file>` relies on.
-  if (res.status !== 0 && range) {
+  const res = await runWorktreeGit(worktree, ["--literal-pathspecs", "diff", spec, "--", relPath])
+  // A standalone file may have no repository or no HEAD yet: fall back to
+  // its content. Combined/base comparisons have no such fallback.
+  if (res.status !== 0 && (range || isCombinedPathspec(relPath))) {
     const stderr = (res.stderr ?? "").trim()
     return { kind: "error", message: stderr || `git diff ${spec} exited with code ${res.status ?? -1}` }
   }
-  const diff = res.status === 0 ? res.stdout : ""
+  let diff = res.status === 0 ? res.stdout : ""
+  let origPath: string | undefined
   if (diff.trim().length > 0) {
     if (!isCombinedPathspec(relPath)) {
       // A rename unpaired by the restricted pathspec arrives as a whole-file
       // add, so `new file mode` is the cheap gate on the recovery below.
       if (/^new file mode /m.test(diff)) {
         const paired = await pairRename(worktree, spec, relPath)
-        if (paired) return { kind: "diff", text: paired.text, origPath: paired.origPath }
+        if (paired) {
+          diff = paired.text
+          origPath = paired.origPath
+        }
       }
       const note = hunklessPatchNote(diff)
       if (note) return { kind: "patch-note", note, sizeBytes: await worktreeFileSize(worktree, relPath) }
     }
-    return { kind: "diff", text: diff }
+    return { kind: "diff", text: diff, ...(origPath ? { origPath } : {}) }
   }
   if (isCombinedPathspec(relPath)) return { kind: "empty" }
-  const text = (await readWorktreeFile(worktree, relPath)) ?? ""
+  const text = await readWorktreeFile(worktree, relPath)
+  if (text === null) return { kind: "error", message: t("ops.preview.readFailed", { path: relPath }) }
   if (looksBinaryText(text)) {
     return { kind: "binary", image: false, sizeBytes: await worktreeFileSize(worktree, relPath) }
   }

--- a/packages/kobe/test/render/preview-loading.test.tsx
+++ b/packages/kobe/test/render/preview-loading.test.tsx
@@ -1,0 +1,107 @@
+/** @jsxImportSource @opentui/react */
+import { expect, test } from "bun:test"
+import { execFileSync } from "node:child_process"
+import { mkdtempSync, writeFileSync } from "node:fs"
+import { writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { useState } from "react"
+import { useBindings } from "../../src/tui-react/lib/keymap"
+import { PreviewScreen } from "../../src/tui-react/ops/preview"
+import { renderComponent, settle, waitForFrameText } from "./harness"
+
+function SwitchingPreview({ worktree }: { worktree: string }) {
+  const [path, setPath] = useState<string | null>("first.txt")
+  useBindings(() => ({
+    bindings: [
+      { key: "n", cmd: () => setPath("slow.txt") },
+      { key: "m", cmd: () => setPath("second.txt") },
+    ],
+  }))
+  return path === null ? (
+    <text>preview closed</text>
+  ) : (
+    <PreviewScreen worktree={worktree} relPath={path} onClose={() => setPath(null)} />
+  )
+}
+
+for (const action of ["switch", "close"] as const) {
+  test(`a pending real file read cannot keep old content or publish after ${action}`, async () => {
+    const dir = mkdtempSync(join(tmpdir(), "rove-preview-loading-"))
+    writeFileSync(join(dir, "first.txt"), "FIRST FILE\n")
+    writeFileSync(join(dir, "second.txt"), "SECOND FILE\n")
+    // FIFO holds the filesystem read open until the test supplies its bytes.
+    execFileSync("mkfifo", [join(dir, "slow.txt")])
+    const handle = await renderComponent(<SwitchingPreview worktree={dir} />, {
+      width: 90,
+      height: 14,
+      providers: { dialog: true, notifications: true },
+    })
+    await waitForFrameText(handle.frame, "FIRST FILE")
+    handle.mockInput.typeText("n")
+    await waitForFrameText(handle.frame, "slow.txt")
+    const loading = await handle.frame()
+    // Release even on a failed assertion, so the old implementation cannot hang the runner.
+    const release = writeFile(join(dir, "slow.txt"), "LATE CONTENT\n")
+    expect(loading).not.toContain("FIRST FILE")
+    expect(loading).toContain("loading")
+    handle.mockInput.typeText(action === "switch" ? "m" : "q")
+    const expected = action === "switch" ? "SECOND FILE" : "preview closed"
+    await waitForFrameText(handle.frame, expected)
+    await release
+    await settle(120)
+    expect(await handle.frame()).toContain(expected)
+    expect(await handle.frame()).not.toContain("LATE CONTENT")
+  })
+}
+
+test("a failed read has retry and a valid empty file has its own state", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "rove-preview-errors-"))
+  const handle = await renderComponent(<PreviewScreen worktree={dir} relPath="empty.txt" />, {
+    width: 100,
+    height: 14,
+    providers: { dialog: true, notifications: true },
+  })
+  await waitForFrameText(handle.frame, "Cannot read empty.txt")
+  expect(await handle.frame()).toContain("r to retry")
+  writeFileSync(join(dir, "empty.txt"), "")
+  handle.mockInput.typeText("r")
+  await waitForFrameText(handle.frame, "empty file")
+  expect(await handle.frame()).not.toContain("Cannot read")
+})
+
+test("hunkless previews state the change and cannot anchor a review note", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "rove-preview-notes-"))
+  const git = (...args: string[]) => execFileSync("git", args, { cwd: dir })
+  git("init", "-q")
+  writeFileSync(join(dir, "old.txt"), "unchanged\n")
+  writeFileSync(join(dir, "empty-deleted.txt"), "")
+  writeFileSync(join(dir, "binary.bin"), Buffer.from("before\0bytes"))
+  git("add", ".")
+  git("-c", "user.email=t@t", "-c", "user.name=t", "commit", "-qm", "fixture")
+  git("mv", "old.txt", "new.txt")
+  git("rm", "empty-deleted.txt")
+  writeFileSync(join(dir, "binary.bin"), Buffer.from("after\0bytes"))
+  const added: unknown[] = []
+  for (const [path, label] of [
+    ["new.txt", "renamed from old.txt"],
+    ["empty-deleted.txt", "empty file deleted"],
+    ["binary.bin", "binary file changed"],
+    [".", "renamed from old.txt"],
+  ]) {
+    const handle = await renderComponent(
+      <PreviewScreen
+        worktree={dir}
+        relPath={path ?? "."}
+        review={{ comments: [], add: (note) => added.push(note), remove: () => {}, send: () => false }}
+      />,
+      { width: 100, height: 22, providers: { dialog: true, notifications: true } },
+    )
+    await waitForFrameText(handle.frame, label ?? "")
+    handle.mockInput.typeText("c")
+    await settle(80)
+    expect(await handle.frame()).not.toContain("Review note")
+    expect(added).toEqual([])
+    handle.destroy()
+  }
+})

--- a/packages/kobe/test/tui-react/ops-preview-core.test.ts
+++ b/packages/kobe/test/tui-react/ops-preview-core.test.ts
@@ -57,10 +57,10 @@ describe("loadPreviewData", () => {
     expect(data).toEqual({ kind: "code", text: "export const a = 1\n" })
   })
 
-  test("a missing file degrades to empty content, not a throw", async () => {
+  test("a missing file reports a failed read without throwing", async () => {
     const repo = makeRepo()
     const data = await loadPreviewData(repo, "nope.ts")
-    expect(data).toEqual({ kind: "code", text: "" })
+    expect(data).toMatchObject({ kind: "error" })
   })
 
   // Why: a PNG decoded as utf8 renders as mojibake — image extensions and

--- a/packages/kobe/test/tui-react/ops-preview-paths.test.ts
+++ b/packages/kobe/test/tui-react/ops-preview-paths.test.ts
@@ -1,0 +1,118 @@
+import { execFileSync } from "node:child_process"
+import { chmodSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { describe, expect, test } from "vitest"
+import { loadPreviewData, unifiedDiffFiles } from "../../src/tui/ops/preview-core"
+
+function fixture(files: Record<string, string>) {
+  const repo = mkdtempSync(join(tmpdir(), "rove-preview-paths-"))
+  const git = (...args: string[]) => execFileSync("git", args, { cwd: repo, encoding: "utf8" })
+  const write = (path: string, body: string) => writeFileSync(join(repo, path), body)
+  git("init", "-q")
+  for (const [path, body] of Object.entries(files)) write(path, body)
+  git("add", ".")
+  git("-c", "user.email=t@t", "-c", "user.name=t", "commit", "-qm", "fixture")
+  return { repo, git, write }
+}
+
+describe("preview uses the selected literal git path", () => {
+  test.each([
+    ["a[1].txt", "a1.txt"],
+    ["a*.txt", "abc.txt"],
+    ["a?.txt", "ab.txt"],
+    [":(glob)*.txt", "other.txt"],
+    ["空 格[1].txt", "空 格1.txt"],
+  ])("%s never previews %s", async (selected, other) => {
+    const { repo, write } = fixture({ [selected]: "selected old\n", [other]: "other old\n" })
+    write(selected, "selected new\n")
+    write(other, "other new\n")
+    const data = await loadPreviewData(repo, selected)
+    expect(data.kind).toBe("diff")
+    if (data.kind !== "diff") throw new Error("expected diff")
+    expect(unifiedDiffFiles(data.text).map((file) => file.path)).toEqual([selected])
+    expect(data.text).toContain("+selected new")
+    expect(data.text).not.toContain("other new")
+  })
+
+  test("rename pairing keeps literal source and destination paths", async () => {
+    const source = "old[1].txt"
+    const target = "new?.txt"
+    const content = Array.from({ length: 20 }, (_, i) => `line ${i}\n`).join("")
+    const { repo, git, write } = fixture({ [source]: content, "old1.txt": "other\n", "new1.txt": "other\n" })
+    git("mv", source, target)
+    write(target, `${content}new line\n`)
+    write("old1.txt", "wrong old\n")
+    write("new1.txt", "wrong new\n")
+    const data = await loadPreviewData(repo, target)
+    expect(data.kind).toBe("diff")
+    if (data.kind !== "diff") throw new Error("expected diff")
+    expect(data.origPath).toBe(source)
+    expect(unifiedDiffFiles(data.text).map((file) => file.path)).toEqual([target])
+    expect(data.text).not.toContain("wrong")
+  })
+
+  test("literal directory and whole worktree still aggregate their files", async () => {
+    const { repo, git, write } = fixture({ "root.txt": "root\n" })
+    mkdirSync(join(repo, "dir[1]"))
+    mkdirSync(join(repo, "dir1"))
+    write("dir[1]/a.txt", "a\n")
+    write("dir[1]/b.txt", "b\n")
+    write("dir1/other.txt", "other\n")
+    git("add", ".")
+    const directory = await loadPreviewData(repo, "dir[1]/")
+    const all = await loadPreviewData(repo, ".")
+    if (directory.kind !== "diff" || all.kind !== "diff") throw new Error("expected combined diffs")
+    expect(unifiedDiffFiles(directory.text).map((file) => file.path)).toEqual(["dir[1]/a.txt", "dir[1]/b.txt"])
+    expect(unifiedDiffFiles(all.text)).toHaveLength(3)
+  })
+})
+
+describe("hunkless patches", () => {
+  test("pure Unicode rename states its source and labels its destination in combined diffs", async () => {
+    const { repo, git } = fixture({ "old file.txt": "same\n" })
+    git("mv", "old file.txt", "新 文件.txt")
+    const note = { kind: "rename", from: "old file.txt", to: "新 文件.txt" }
+    expect(await loadPreviewData(repo, "新 文件.txt")).toMatchObject({ kind: "patch-note", note })
+    const all = await loadPreviewData(repo, ".")
+    if (all.kind !== "diff") throw new Error("expected diff")
+    expect(unifiedDiffFiles(all.text)).toMatchObject([{ path: "新 文件.txt", lines: 0, note }])
+  })
+
+  test.each(["added", "deleted"] as const)("empty file %s differs from no changes", async (change) => {
+    const { repo, git, write } = fixture({ "kept.txt": "kept\n", ...(change === "deleted" ? { "empty.txt": "" } : {}) })
+    if (change === "added") {
+      write("empty.txt", "")
+      git("add", "empty.txt")
+    } else git("rm", "empty.txt")
+    expect(await loadPreviewData(repo, "empty.txt")).toMatchObject({
+      kind: "patch-note",
+      note: { kind: "empty-file", change },
+    })
+    const all = await loadPreviewData(repo, ".")
+    if (all.kind !== "diff") throw new Error("expected diff")
+    expect(unifiedDiffFiles(all.text)).toMatchObject([
+      { path: "empty.txt", lines: 0, note: { kind: "empty-file", change } },
+    ])
+  })
+})
+
+describe("failed reads are not empty files or clean diffs", () => {
+  test("missing file differs from valid empty content", async () => {
+    const { repo, write } = fixture({ "kept.txt": "kept\n" })
+    write("empty.txt", "")
+    expect(await loadPreviewData(repo, "empty.txt")).toEqual({ kind: "code", text: "" })
+    expect(await loadPreviewData(repo, "missing.txt")).toMatchObject({ kind: "error" })
+  })
+
+  test.skipIf(process.getuid?.() === 0)("unreadable file makes both single and combined previews fail", async () => {
+    const { repo } = fixture({ "blocked.txt": "blocked\n" })
+    chmodSync(join(repo, "blocked.txt"), 0)
+    try {
+      expect(await loadPreviewData(repo, "blocked.txt")).toMatchObject({ kind: "error" })
+      expect(await loadPreviewData(repo, ".")).toMatchObject({ kind: "error" })
+    } finally {
+      chmodSync(join(repo, "blocked.txt"), 0o644)
+    }
+  })
+})


### PR DESCRIPTION
Selecting `a[1].txt` could display `a1.txt` under its title because git expanded the pathspec and OpenTUI drew the first patch. Pure renames and empty-file changes also opened with no hunk rows, while an unreadable file appeared empty. Switching to a slow preview left the previous file's text under the new title.

This change treats preview paths literally through rename pairing, classifies hunkless changes once for both preview layouts, reports failed reads separately from valid empty files, and binds loaded content to its worktree/path/base. Existing keys, file-tree order, editor/external opening and line comments remain in place; hunkless and combined previews do not accept line comments. Includes a patch changeset and the matching TUI documentation.

Validation:

- Build, lint and workspace typechecks pass.
- 128 relevant Vitest tests pass, including real git paths containing brackets, `*`, `?`, leading pathspec magic, Unicode and spaces, literal rename pairing, directory aggregation, and read failures.
- 10 real OpenTUI render tests pass, including pending FIFO reads across navigation/close and note/retry behavior. The same loading assertions fail against the preserved baseline.
- Fixed 1280×800 Chromium `/harness` captures compare baseline `9ed830566d164e6900298c39b3e422adcfac6cac` with this HEAD using the same isolated filesystem fixture. The [review board](https://share.sma1lboy.me/s/rove-loop-r1-files-preview) contains all nine before/after pairs. All 18 published PNGs match the original screenshot hashes.

Scope extension for `src/tui/i18n/messages/ops.ts` was explicitly approved. No keybinding changes, production daemon restarts, merges or releases are part of this PR.
