### PR TITLE
Five probes that reported a neutral answer when they had failed

### DIFF
--- a/.changeset/five-neutral-failures.md
+++ b/.changeset/five-neutral-failures.md
@@ -1,0 +1,25 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Five probes that reported a neutral answer when they had actually failed.
+
+`delete --delete-branch` discarded `git branch -d`'s exit code, so a branch git
+refused to delete (the ordinary case for work that never landed) left the
+daemon log confirming `removed … branch=<name>`. The refusal is now carried out
+of the removal and logged as its own `branch kept …` line, with git's reason.
+The delete itself is unchanged — still best-effort, still never fails the
+removal.
+
+"Fix failing checks" told users the checks were probably no longer red whenever
+`gh` could not answer at all. A missing `gh`, an expired `gh auth login`, and a
+genuinely green PR were one empty list; the read now reports which, and the
+toast quotes `gh`'s own stderr.
+
+Three probes stopped encoding "could not look" as "nothing there": the
+non-force delete gate now refuses when `git status --ignored` fails instead of
+reading the empty result as permission; `rove doctor` says
+`could not read process environments` instead of `orphans: ✓ none` when the
+environment probe never ran; and the three copies of the dirty-worktree check
+share one definition, so a `git status` output of just a newline no longer
+reads dirty to the delete gate and clean to landing.

--- a/docs/API.md
+++ b/docs/API.md
@@ -734,6 +734,20 @@ nothing to do), `skipped_missed`, `skipped_unavailable`, and
   passed; git is the durable record, the task row is not. Needs `--force` on a
   dirty worktree; `--force` never implies `--delete-branch`.
 
+  **`--delete-branch` is best-effort and its outcome is in the daemon log, not
+  this reply.** `git branch -d` refuses a branch whose commits the base cannot
+  reach — the ordinary case for work that never landed — and the removal
+  succeeds anyway, by design. The reply cannot carry that verdict: by the time
+  `--wait` resolves, the task row it would ride on has been removed, which is
+  how `--wait` knows the deletion finished. So a refusal is logged instead, as
+  `branch kept task <id> branch=<name> — git refused the delete: <reason>` in
+  `~/.rove/daemon.log`, next to the `removed …` line. Check `git branch` if
+  you need the answer programmatically.
+
+  **The delete gate refuses what it cannot read.** Without `--force`, deletion
+  probes for gitignored work (`git status --ignored`); a probe that fails is a
+  refusal, not a pass. See `docs/WORKTREES.md`.
+
   **The removal runs in the background** — tearing down a worktree can take
   tens of seconds — so the default reply reports only that the request was
   taken: `{ taskId, queued, status }` with `status` either `queued` or

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -134,6 +134,18 @@ On macOS the environment of an Apple-signed system binary is unreadable without
 root, so those are never listed. What actually leaks — `bun`, `node`, a browser,
 a CLI tool — reads fine.
 
+A probe that could not run at all is a different answer, and doctor now prints
+it as one:
+
+```text
+orphans: ✗ could not read process environments — ps eww exited 127
+```
+
+That is the step which turns a candidate into a finding, so when it fails
+every candidate stays unclassified. `✓ none` used to cover that case too,
+which made a machine nothing had looked at indistinguishable from a clean one.
+The realistic triggers are Linux `hidepid=2` and reading across uids.
+
 ## Who deleted my task?
 
 Every task deletion is recorded in `~/.rove/daemon.log`, whether it succeeds

--- a/docs/WORKTREES.md
+++ b/docs/WORKTREES.md
@@ -150,6 +150,13 @@ those paths, because `git status` will not. An ignored entry OVER the budget
 (a `node_modules/`, a build directory) is not treated as work: it neither
 blocks the delete nor lands in the snapshot.
 
+If that `git status --ignored` cannot run at all, the delete is **refused**,
+not allowed. An empty list is this gate's permission to destroy the directory,
+so a listing that failed used to hand out that permission on the strength of
+having failed. The refusal says the listing failed rather than naming paths,
+and `--force` still overrides it — which is the safer order, because the
+forced path takes a salvage snapshot first.
+
 ### Landing with `--delete-branch`
 
 `land --delete-branch` deletes the branch with `git branch -D`, which removes

--- a/docs/design/task-lifecycle.md
+++ b/docs/design/task-lifecycle.md
@@ -38,6 +38,14 @@ The new contract:
 
 - `delete` → worktree gone, index entry gone, **branch stays**. Always.
 - `delete --delete-branch` → also `git branch -d` (or `-D` under `--force`).
+  git can refuse that: `-d` will not drop a branch whose commits the base
+  cannot reach, and neither spelling touches a branch some other worktree
+  still has checked out. The delete stays best-effort — a refused branch never
+  fails the removal — but it is no longer silent: `~/.rove/daemon.log` gets a
+  `branch kept task <id> branch=<name> — git refused the delete: <git's own
+  reason>` line just before the `removed …` line. Without it that `removed …
+  branch=<name>` line read as confirmation the branch had gone with the
+  worktree.
 - `--force` continues to mean "I accept losing uncommitted work in the
   worktree". It never implies `--delete-branch`; the two escalations are
   orthogonal and must be requested separately.

--- a/packages/kobe-daemon/src/daemon/pr-failing-checks.ts
+++ b/packages/kobe-daemon/src/daemon/pr-failing-checks.ts
@@ -34,7 +34,7 @@
  * touches a subprocess.
  */
 
-import { logDaemonError } from "./crash-log.ts"
+import { logDaemonError, logDaemonInfo } from "./crash-log.ts"
 import { PR_VIEW_TIMEOUT_MS, spawnGh } from "./pr-status-collector.ts"
 
 /** At most this many failing jobs are reported — the rest are counted, not read. */
@@ -55,10 +55,30 @@ export interface PrFailingCheck {
   readonly tail: string
 }
 
+/** Why no answer could be obtained, as opposed to "the answer was none". */
+export interface PrChecksUnavailable {
+  /** `gh_failed` — the CLI ran and refused (not installed, not authenticated,
+   *  no network, no such PR); `gh_error` — the read threw before/while parsing. */
+  readonly reason: "gh_failed" | "gh_error"
+  /** `gh`'s own stderr (or the thrown message), trimmed. The only thing in
+   *  here that tells a user WHICH of those it was. */
+  readonly detail: string
+}
+
 export interface PrFailingChecksResult {
   readonly checks: readonly PrFailingCheck[]
   /** How many failing checks existed before the {@link MAX_FAILING_JOBS} cap. */
   readonly totalFailing: number
+  /**
+   * Set when the rollup could not be read at all.
+   *
+   * `checks: []` alone had to mean three different things — `gh` missing, `gh`
+   * unauthenticated, and the checks genuinely turning green — and the UI could
+   * only render the third. A user staring at a red PR badge was told the
+   * checks were probably no longer red; the actual answer was an expired
+   * `gh auth login`.
+   */
+  readonly unavailable?: PrChecksUnavailable
 }
 
 /** A failing rollup entry reduced to what the log fetch needs. */
@@ -161,13 +181,28 @@ export function joinFailingChecks(
   return { checks, totalFailing: targets.length }
 }
 
-/** Run one `gh` command under a timeout; "" on any failure (best-effort). */
-async function ghText(args: readonly string[], cwd: string, timeoutMs: number): Promise<string> {
+/**
+ * Run one `gh` command under a timeout.
+ *
+ * Returns the failure instead of flattening it to `""`. `spawnGh` already
+ * captures `stderr` and `spawnError` precisely so a caller can tell an absent
+ * `gh` from an unauthenticated one from a real empty answer — this function
+ * used to throw all three away one line after receiving them.
+ */
+async function ghText(
+  args: readonly string[],
+  cwd: string,
+  timeoutMs: number,
+): Promise<{ ok: true; stdout: string } | { ok: false; detail: string }> {
   const controller = new AbortController()
   const timer = setTimeout(() => controller.abort(), timeoutMs)
   try {
     const res = await spawnGh(args, cwd, controller.signal)
-    return res.status === 0 ? res.stdout : ""
+    if (res.status === 0) return { ok: true, stdout: res.stdout }
+    const stderr = res.stderr.trim()
+    if (res.spawnError) return { ok: false, detail: stderr || "gh could not be started — is the GitHub CLI installed?" }
+    if (controller.signal.aborted) return { ok: false, detail: `gh timed out after ${timeoutMs}ms` }
+    return { ok: false, detail: stderr || `gh exited ${res.status}` }
   } finally {
     clearTimeout(timer)
   }
@@ -184,13 +219,19 @@ export async function readFailingChecks(opts: {
   readonly prNumber: number
 }): Promise<PrFailingChecksResult> {
   try {
-    const rollupJson = await ghText(
+    const rollupRead = await ghText(
       ["pr", "view", String(opts.prNumber), "--json", "statusCheckRollup"],
       opts.worktreePath,
       PR_VIEW_TIMEOUT_MS,
     )
-    if (!rollupJson) return { checks: [], totalFailing: 0 }
-    const parsed = JSON.parse(rollupJson) as { statusCheckRollup?: unknown }
+    if (!rollupRead.ok) {
+      // The toast can only carry one truncated line, so the whole of `gh`'s
+      // stderr goes here — this is the only place the hint after the first
+      // line ("please run: gh auth login") survives.
+      logDaemonInfo("pr-failing-checks", `gh could not read PR #${opts.prNumber}: ${rollupRead.detail}`)
+      return { checks: [], totalFailing: 0, unavailable: { reason: "gh_failed", detail: rollupRead.detail } }
+    }
+    const parsed = JSON.parse(rollupRead.stdout) as { statusCheckRollup?: unknown }
     const rollup = Array.isArray(parsed.statusCheckRollup) ? parsed.statusCheckRollup : []
     const targets = failingCheckTargets(rollup)
     if (targets.length === 0) return { checks: [], totalFailing: 0 }
@@ -203,12 +244,20 @@ export async function readFailingChecks(opts: {
     }
     const logsByJob = new Map<string, string[]>()
     for (const runId of runIds) {
-      const text = await ghText(["run", "view", runId, "--log-failed"], opts.worktreePath, RUN_LOG_TIMEOUT_MS)
-      for (const [job, lines] of parseFailedRunLog(text)) if (!logsByJob.has(job)) logsByJob.set(job, lines)
+      // A log download that fails still degrades quietly: the check list is
+      // already known, and `joinFailingChecks` reports a job with an empty
+      // tail rather than dropping it. That is a partial answer, not none.
+      const log = await ghText(["run", "view", runId, "--log-failed"], opts.worktreePath, RUN_LOG_TIMEOUT_MS)
+      if (!log.ok) continue
+      for (const [job, lines] of parseFailedRunLog(log.stdout)) if (!logsByJob.has(job)) logsByJob.set(job, lines)
     }
     return joinFailingChecks(targets, logsByJob)
   } catch (err) {
     logDaemonError("pr-failing-checks", err)
-    return { checks: [], totalFailing: 0 }
+    return {
+      checks: [],
+      totalFailing: 0,
+      unavailable: { reason: "gh_error", detail: err instanceof Error ? err.message : String(err) },
+    }
   }
 }

--- a/packages/kobe-daemon/src/daemon/task-deletion-audit.ts
+++ b/packages/kobe-daemon/src/daemon/task-deletion-audit.ts
@@ -86,6 +86,21 @@ export function auditDeletionRemoved(taskId: string, task: DaemonTask | undefine
 }
 
 /**
+ * `--delete-branch` was asked for and git refused. Logged BEFORE the `removed`
+ * line, which names the branch and would otherwise be the only record — and
+ * reads as confirmation that the branch went with the worktree.
+ *
+ * Not an error: the branch surviving is the recoverable half, and refusing to
+ * delete an unmerged one is git protecting work. It just has to be SAID.
+ */
+export function auditDeletionBranchKept(taskId: string, branch: string, reason: string): void {
+  logDaemonInfo(
+    SUBSYSTEM,
+    `branch kept task ${taskId} branch=${branch} — git refused the delete: ${reason.replace(/\s+/g, " ").trim()}. Nothing else will remove it; \`git branch -D ${branch}\` does, and drops its reflog with it.`,
+  )
+}
+
+/**
  * The worktree removal threw. The task stays in `deletion.phase === "error"`,
  * but its session was already torn down and its Inbox/activity state cleared —
  * so this line also names what has ALREADY been undone, which is the half a

--- a/packages/kobe/src/cli/doctor-orphans.ts
+++ b/packages/kobe/src/cli/doctor-orphans.ts
@@ -43,7 +43,10 @@
  * failure is closed by construction — the sweep skips what it cannot verify —
  * and it costs nothing in practice, because what actually leaks is the
  * long-running third-party program (`bun`, `node`, a browser, a CLI tool),
- * whose environment reads fine.
+ * whose environment reads fine. A probe that could not run AT ALL is a
+ * different thing and is reported as one: `ps eww` failing to spawn, or Linux
+ * refusing every `/proc/<pid>/environ` under `hidepid=2`, leaves every
+ * candidate unclassified, and "none" there is a claim nothing checked.
  */
 
 import { readFileSync } from "node:fs"
@@ -67,7 +70,32 @@ export interface Orphan extends PsRow {
   readonly pgid: number
 }
 
-async function run(argv: readonly string[]): Promise<{ code: number; stdout: string }> {
+/** How a probe subprocess reports back. `code` is load-bearing: a spawn that
+ *  never ran returns 127 with empty stdout, which is indistinguishable from a
+ *  successful probe that found nothing unless somebody reads the code. */
+export interface ProbeResult {
+  readonly code: number
+  readonly stdout: string
+}
+
+export type ProbeRunner = (argv: readonly string[]) => Promise<ProbeResult>
+
+/**
+ * Test seam for the two probes the predicate rests on.
+ *
+ * `platform` is here because the environment read has two entirely different
+ * implementations (procfs on Linux, `ps eww` everywhere else) and a test that
+ * cannot pick one only ever exercises whichever OS it happens to run on —
+ * which is how a check nobody runs on Linux ships broken on Linux.
+ */
+export interface OrphanProbeDeps {
+  readonly run?: ProbeRunner
+  readonly platform?: string
+  /** Reads `/proc/<pid>/environ`; throws with an errno `code` like the real one. */
+  readonly readEnviron?: (pid: number) => string
+}
+
+const run: ProbeRunner = async (argv) => {
   try {
     const proc = Bun.spawn([...argv], { stdin: "ignore", stdout: "pipe", stderr: "ignore" })
     const [stdout, code] = await Promise.all([new Response(proc.stdout).text().catch(() => ""), proc.exited])
@@ -120,31 +148,58 @@ export function orphanCandidates(
  * the word-boundary match, so an argv that merely CONTAINS the marker text
  * cannot pass for the variable itself.
  */
-async function markedPids(pids: readonly number[]): Promise<Set<number>> {
+export interface MarkedPidsResult {
+  readonly marked: Set<number>
+  /**
+   * Why the environment read could not be TRUSTED, or null when it ran.
+   *
+   * This is the step that turns a candidate into a finding, so a probe that
+   * never ran produces the same empty set as a machine with nothing wrong —
+   * and doctor printed "✓ none" either way. A process that simply exited
+   * between the two passes is still not a finding (ENOENT is an answer); a
+   * refusal to read (`hidepid=2`, another uid, a `ps` that would not spawn)
+   * is not.
+   */
+  readonly failed: string | null
+}
+
+export async function markedPids(pids: readonly number[], deps: OrphanProbeDeps = {}): Promise<MarkedPidsResult> {
+  const runProbe = deps.run ?? run
+  const readEnviron = deps.readEnviron ?? ((pid: number) => readFileSync(`/proc/${pid}/environ`, "utf8"))
   const marked = new Set<number>()
-  if (pids.length === 0) return marked
-  if (process.platform === "linux") {
+  if (pids.length === 0) return { marked, failed: null }
+  if ((deps.platform ?? process.platform) === "linux") {
+    let refused: string | null = null
     for (const pid of pids) {
       try {
-        if (readFileSync(`/proc/${pid}/environ`, "utf8").split("\0").includes(PTY_MARKER)) marked.add(pid)
-      } catch {
-        // Gone between the two passes, or not ours to read — not a finding.
+        if (readEnviron(pid).split("\0").includes(PTY_MARKER)) marked.add(pid)
+      } catch (err) {
+        // ENOENT means it exited between the two passes — an answer, not a
+        // failure. EACCES/EPERM means the kernel refused us, which under
+        // `hidepid=2` or across uids is EVERY candidate, and reporting that
+        // as "none" is the bug.
+        const code = (err as NodeJS.ErrnoException).code
+        if (code !== "ENOENT" && code !== "ESRCH") refused ??= `/proc/${pid}/environ: ${code ?? "unreadable"}`
       }
     }
-    return marked
+    return { marked, failed: refused }
   }
-  const result = await run(["ps", "eww", "-o", "pid=,command=", "-p", pids.join(",")])
+  const result = await runProbe(["ps", "eww", "-o", "pid=,command=", "-p", pids.join(",")])
+  // A macOS `ps eww` that RAN but omitted a SIP-protected binary's environment
+  // stays closed by construction (see the file header) — only a `ps` that did
+  // not run at all is reported here.
+  if (result.code !== 0) return { marked, failed: `ps eww exited ${result.code}` }
   const marker = new RegExp(`(^|\\s)${PTY_MARKER}(\\s|$)`)
   for (const line of result.stdout.split("\n")) {
     const pid = Number.parseInt(line.trim().split(/\s+/)[0] ?? "", 10)
     if (Number.isFinite(pid) && marker.test(line)) marked.add(pid)
   }
-  return marked
+  return { marked, failed: null }
 }
 
 /** Our own process group, so the sweep can never signal the shell running it. */
-async function ownPgid(): Promise<number> {
-  const result = await run(["ps", "-o", "pgid=", "-p", String(process.pid)])
+async function ownPgid(runProbe: ProbeRunner): Promise<number> {
+  const result = await runProbe(["ps", "-o", "pgid=", "-p", String(process.pid)])
   const pgid = Number.parseInt(result.stdout.trim(), 10)
   return Number.isFinite(pgid) ? pgid : -1
 }
@@ -157,13 +212,23 @@ async function ownPgid(): Promise<number> {
  */
 export async function collectOrphans(
   liveSessionPids: ReadonlySet<number>,
+  deps: OrphanProbeDeps = {},
 ): Promise<{ orphans: Orphan[]; error: string | null }> {
-  if (process.platform === "win32") return { orphans: [], error: null }
-  const ps = await run(["ps", "-A", "-o", "pid=,ppid=,pgid=,etime=,rss=,command="])
-  if (ps.code !== 0) return { orphans: [], error: `ps exited ${ps.code}` }
+  const runProbe = deps.run ?? run
+  if ((deps.platform ?? process.platform) === "win32") return { orphans: [], error: null }
+  const ps = await runProbe(["ps", "-A", "-o", "pid=,ppid=,pgid=,etime=,rss=,command="])
+  if (ps.code !== 0) return { orphans: [], error: `could not read the process table — ps exited ${ps.code}` }
   const rows = parsePsRows(ps.stdout)
-  const candidates = orphanCandidates(rows, await ownPgid(), liveSessionPids)
-  const marked = await markedPids(candidates.map((row) => row.pid))
+  const candidates = orphanCandidates(rows, await ownPgid(runProbe), liveSessionPids)
+  // The SECOND probe gets the same treatment as the first. It did not, and it
+  // is the one that decides: with the environment read broken every candidate
+  // stays unmarked, the filter empties the list, and doctor reported a clean
+  // machine it had never managed to look at.
+  const { marked, failed } = await markedPids(
+    candidates.map((row) => row.pid),
+    deps,
+  )
+  if (failed) return { orphans: [], error: `could not read process environments — ${failed}` }
   return { orphans: candidates.filter((row) => marked.has(row.pid)), error: null }
 }
 
@@ -178,7 +243,7 @@ export function orphanDoctorLines(
   cliName: string,
   killing = false,
 ): string[] {
-  if (error) return [`orphans: ✗ could not inspect the process table — ${error}`]
+  if (error) return [`orphans: ✗ ${error}`]
   if (orphans.length === 0) return ["orphans: ✓ none — no processes left behind by a dead PTY session"]
   const totalMb = orphans.reduce((sum, row) => sum + row.rssKb, 0) / 1024
   const lines = [

--- a/packages/kobe/src/client/remote-orchestrator-writes.ts
+++ b/packages/kobe/src/client/remote-orchestrator-writes.ts
@@ -19,7 +19,7 @@ import type { LandPreflight } from "../orchestrator/land-preflight.ts"
 import type { LandResult } from "../orchestrator/land.ts"
 import type { WorktreeResidue } from "../orchestrator/worktree/manager-remove.ts"
 import type { StoredFieldNote } from "../state/field-notes.ts"
-import type { CIFailingCheck } from "../tui/ops/ci-prompt.ts"
+import type { CIFailingCheck, CIFailingChecksRead } from "../tui/ops/ci-prompt.ts"
 import type { Task, TaskId, TaskStatus, VendorId } from "../types/task.ts"
 import type { AdoptableWorktree, WorktreeProject } from "../types/worktree.ts"
 import { deserializeTask } from "./remote-orchestrator-payloads.ts"
@@ -342,14 +342,20 @@ export async function syncBaseOp(
  * sidebar's "Fix failing checks". On demand only; the daemon spawns `gh` per
  * call, so this must never be wired to a poll.
  */
-export async function failingChecksOp(
-  client: KobeDaemonClient,
-  taskId: string,
-): Promise<{ checks: readonly CIFailingCheck[]; totalFailing: number }> {
-  const res = await client.request<{ checks?: readonly CIFailingCheck[]; totalFailing?: number }>("pr.failingChecks", {
-    taskId,
-  })
-  return { checks: res.checks ?? [], totalFailing: res.totalFailing ?? 0 }
+export async function failingChecksOp(client: KobeDaemonClient, taskId: string): Promise<CIFailingChecksRead> {
+  const res = await client.request<{
+    checks?: readonly CIFailingCheck[]
+    totalFailing?: number
+    unavailable?: { reason: string; detail: string }
+  }>("pr.failingChecks", { taskId })
+  return {
+    checks: res.checks ?? [],
+    totalFailing: res.totalFailing ?? 0,
+    // Carried through verbatim. An empty `checks` is three different answers
+    // on the daemon side and only this field separates them; dropping it here
+    // would put the collapse back one layer down.
+    ...(res.unavailable ? { unavailable: res.unavailable } : {}),
+  }
 }
 
 /** A repo's daemon-owned issues (`issue.list`) — the TUI kanban page's read. */

--- a/packages/kobe/src/core/index.ts
+++ b/packages/kobe/src/core/index.ts
@@ -7,7 +7,11 @@
 
 import { homedir } from "node:os"
 import { readRoveHomeDirEnv } from "@sma1lboy/kobe-daemon/compat-env"
-import { auditDeletionResidue, auditDeletionSalvaged } from "@sma1lboy/kobe-daemon/daemon/task-deletion-audit"
+import {
+  auditDeletionBranchKept,
+  auditDeletionResidue,
+  auditDeletionSalvaged,
+} from "@sma1lboy/kobe-daemon/daemon/task-deletion-audit"
 import { Orchestrator } from "../orchestrator/core.ts"
 import { TaskIndexStore } from "../orchestrator/index/store.ts"
 import { GitWorktreeManager } from "../orchestrator/worktree/manager.ts"
@@ -43,6 +47,10 @@ export async function createKobeCore(options: KobeCoreOptions = {}): Promise<Kob
     // directory git could not unlink. Same log, same reason as the salvage
     // line: it is where a user is already told to look.
     onWorktreeResidue: (taskId, residue) => auditDeletionResidue(String(taskId), residue.path, residue.reason),
+    // Same log, same reason again: the task row is gone by the time the
+    // deletion resolves, so this line is the only place a kept branch is ever
+    // mentioned.
+    onBranchKept: (taskId, kept) => auditDeletionBranchKept(String(taskId), kept.branch, kept.reason),
     // A landed worktree is about to be unlinked; anything the engine writes
     // into it after that is written to nothing. Same ordering the task-
     // deletion runner already uses.

--- a/packages/kobe/src/orchestrator/core.ts
+++ b/packages/kobe/src/orchestrator/core.ts
@@ -59,6 +59,10 @@ export interface OrchestratorDeps {
    *  the only record of the leftover, so the daemon binds it to the same audit
    *  log the rest of the deletion trail goes to. */
   readonly onWorktreeResidue?: (taskId: TaskId, residue: { readonly path: string; readonly reason: string }) => void
+  /** Called when a deletion asked for `--delete-branch` and git refused (an
+   *  unmerged branch, one another worktree has checked out). The deletion still
+   *  succeeds; this is what keeps the audit line from claiming otherwise. */
+  readonly onBranchKept?: (taskId: TaskId, kept: { readonly branch: string; readonly reason: string }) => void
   /**
    * Kill a task's engine session. Bound by the composition root to the hosted
    * session host; a TUI-local orchestrator leaves it unset. `landTask` calls
@@ -113,6 +117,7 @@ export class Orchestrator {
       (id) => this.worktreeCoordinator.forget(id),
       deps.onSalvage,
       deps.onWorktreeResidue,
+      deps.onBranchKept,
     )
     this.tasksAcc = createStateCell<Task[]>(this.store.list())
     // Seed focus from the persisted `lastActive` record (state/last-active

--- a/packages/kobe/src/orchestrator/dirty-paths.ts
+++ b/packages/kobe/src/orchestrator/dirty-paths.ts
@@ -27,3 +27,17 @@ export function parseDirtyPaths(stdout: string): string[] {
     .map((line) => line.slice(3).trim())
     .filter((line) => line.length > 0)
 }
+
+/**
+ * Whether `git status --porcelain` output means the tree is dirty.
+ *
+ * Deliberately defined AS "{@link parseDirtyPaths} found something": the gate
+ * and the message it prints must never disagree, and they did — three call
+ * sites had three notions of empty (`stdout.length > 0`, `stdout.trim()`,
+ * and this parse), so a stdout of `"\n"` read dirty to the worktree manager's
+ * delete gate and clean to landing and syncing. A remote `ExecHost` is where
+ * that trailing newline actually comes from.
+ */
+export function isDirtyOutput(stdout: string): boolean {
+  return parseDirtyPaths(stdout).length > 0
+}

--- a/packages/kobe/src/orchestrator/errors.ts
+++ b/packages/kobe/src/orchestrator/errors.ts
@@ -52,16 +52,23 @@ export const DIRTY_WORKTREE_CODE = "DIRTY_WORKTREE"
  * is what did. `git status` cannot see those, so a user told only "uncommitted
  * or untracked changes" would go looking with a command that reports nothing
  * — the paths are the only way that refusal is actionable.
+ *
+ * `"unknown"` is the third answer: the ignored listing did not run, so nothing
+ * can say whether this worktree holds such work. It refuses through the SAME
+ * error on purpose — the UI already turns this one into a force-delete
+ * re-prompt, which is exactly the choice an unverifiable worktree needs.
  */
 export class DirtyWorktreeError extends Error {
   constructor(
     public readonly taskId: string,
-    public readonly ignored: readonly string[] = [],
+    public readonly ignored: readonly string[] | "unknown" = [],
   ) {
     const what =
-      ignored.length > 0
-        ? `gitignored work git status cannot see: ${ignored.join(", ")}`
-        : "uncommitted or untracked changes"
+      ignored === "unknown"
+        ? "gitignored work this check could not read (git status --ignored failed) — nothing here can confirm it is empty"
+        : ignored.length > 0
+          ? `gitignored work git status cannot see: ${ignored.join(", ")}`
+          : "uncommitted or untracked changes"
     super(`${DIRTY_WORKTREE_CODE}: task ${taskId} worktree has ${what}`)
     this.name = "DirtyWorktreeError"
   }

--- a/packages/kobe/src/orchestrator/land-preflight.ts
+++ b/packages/kobe/src/orchestrator/land-preflight.ts
@@ -21,7 +21,7 @@
 import type { ExecHost } from "../exec/exec-host.ts"
 import { READ_ONLY_GIT_ENV } from "../lib/git-env.ts"
 import type { Task } from "../types/task.ts"
-import { parseDirtyPaths } from "./dirty-paths.ts"
+import { isDirtyOutput, parseDirtyPaths } from "./dirty-paths.ts"
 import { EmptyBranchDirtyWorktreeError, EmptyBranchError, MainCheckoutDirtyError, MissingRefError } from "./errors.ts"
 import { type WorktreeExecDeps, defaultExecDeps } from "./worktree/exec-deps.ts"
 import { GitWorktreeManager } from "./worktree/manager.ts"
@@ -99,7 +99,7 @@ export async function landGit(
 
 /** `git status --porcelain` non-empty in `dir` (untracked counts). */
 export async function isDirty(exec: ExecHost, dir: string): Promise<boolean> {
-  return (await landGit(exec, dir, ["status", "--porcelain"], { readOnly: true })).stdout.trim().length > 0
+  return isDirtyOutput((await landGit(exec, dir, ["status", "--porcelain"], { readOnly: true })).stdout)
 }
 
 /**

--- a/packages/kobe/src/orchestrator/land.ts
+++ b/packages/kobe/src/orchestrator/land.ts
@@ -126,12 +126,17 @@ export async function landTaskWithCleanup(task: Task, opts: LandTaskOpts, deps: 
       reason: worktree?.reason ?? `worktree ${task.worktreePath} was kept, and still has the branch checked out`,
     }
   } else if (opts.deleteBranch) {
-    await deps.worktrees.deleteBranch(task.repo, result.branch, {
+    // And when the worktree IS gone, the delete can still be refused — another
+    // task's worktree on the same branch, a lock, a ref that moved. That used
+    // to be discarded with the exit code; `branchKept` now carries git's own
+    // reason instead of only the one this function predicted.
+    const outcome = await deps.worktrees.deleteBranch(task.repo, result.branch, {
       force: true,
       onAnchor: (record) => {
         branchAnchor = record
       },
     })
+    if (!outcome.deleted) branchKept = { reason: outcome.reason }
   }
   return {
     ...result,

--- a/packages/kobe/src/orchestrator/task-deletion.ts
+++ b/packages/kobe/src/orchestrator/task-deletion.ts
@@ -4,6 +4,7 @@ import { CannotDeleteMainTaskError, DirtyWorktreeError, WorktreeRemoveFailedErro
 import type { TaskIndexStore } from "./index/store.ts"
 import type { WorktreeResidue } from "./worktree/manager-remove.ts"
 import type { GitWorktreeManager } from "./worktree/manager.ts"
+import type { IgnoredWorkProbe } from "./worktree/salvage-ignored.ts"
 import type { SalvageRecord } from "./worktree/salvage.ts"
 
 /** Caller options for a task deletion. `deleteBranch` is a separate opt-in,
@@ -36,6 +37,14 @@ export class TaskDeletionCoordinator {
      * the only record that a directory is still on disk.
      */
     private readonly onResidue?: (taskId: TaskId, residue: WorktreeResidue) => void,
+    /**
+     * Notified when `deleteBranch` was asked for and git refused. Wired to the
+     * same audit log for the same reason as the two above: `finish()` removes
+     * the task row, so by the time anyone could ask, there is nothing left to
+     * ask. Without it the `removed … branch=<name>` line confirmed a deletion
+     * that had not happened.
+     */
+    private readonly onBranchKept?: (taskId: TaskId, kept: { branch: string; reason: string }) => void,
   ) {}
 
   /** Persist acceptance after the destructive dirty-worktree safety check. */
@@ -57,14 +66,24 @@ export class TaskDeletionCoordinator {
       // gitignored in this very repo. Gating on the porcelain alone let a
       // worktree whose only work was a session's notes delete with no force,
       // no confirm, and no salvage ref.
-      let ignored: readonly string[] = []
+      let ignored: IgnoredWorkProbe = []
+      let probed = true
       try {
         dirty = await this.worktrees.isDirty(task.worktreePath)
-        if (!dirty) ignored = await this.worktrees.ignoredWork(task.worktreePath)
       } catch {
-        // A missing/unreadable path is resolved by remove(), as before.
+        // A missing/unreadable path is resolved by remove(), as before — and
+        // the ignored probe is skipped with it: `git status --ignored` in a
+        // directory that is already gone answers "unknown", and refusing on
+        // that would break deleting a task whose worktree someone removed by
+        // hand.
+        probed = false
       }
-      if (dirty || ignored.length > 0) throw new DirtyWorktreeError(task.id, ignored)
+      // NOT inside that catch. The two probes used to share one `try` with an
+      // empty body, so an ignored listing that failed left `ignored = []` and
+      // the gate below read it as permission — "could not look" and "there is
+      // nothing here" were the same value.
+      if (probed && !dirty) ignored = await this.worktrees.ignoredWork(task.worktreePath)
+      if (dirty || ignored === "unknown" || ignored.length > 0) throw new DirtyWorktreeError(task.id, ignored)
     }
 
     await this.store.update(task.id, {
@@ -132,6 +151,9 @@ export class TaskDeletionCoordinator {
           // problem — and never deleted from under the user, since whatever
           // made it undeletable may be something they want.
           onResidue: (residue) => this.onResidue?.(task.id, residue),
+          // The delete stays best-effort — a refused branch never fails the
+          // removal — but it is no longer SILENT.
+          onBranchKept: (kept) => this.onBranchKept?.(task.id, kept),
         })
       }
     } catch (cause) {

--- a/packages/kobe/src/orchestrator/worktree/manager-branch.ts
+++ b/packages/kobe/src/orchestrator/worktree/manager-branch.ts
@@ -38,10 +38,25 @@ export async function branchExists(deps: BranchDeps, ctx: ExecCtx, branch: strin
 }
 
 /**
+ * What happened to the branch a caller asked to delete.
+ *
+ * `deleted: false` is the whole point of this type. The delete is
+ * best-effort by design — it must never fail a removal the caller already
+ * committed to — but "best-effort" had been implemented as `allowFail` with
+ * the exit code dropped on the floor, so a branch git REFUSED to delete was
+ * indistinguishable from one that went away. `git branch -d` refuses an
+ * unmerged branch (the ordinary case for `delete --delete-branch` on work
+ * that never landed) and both spellings refuse a branch some worktree still
+ * has checked out. `land.ts` already had to invent its own `branchKept` to
+ * work around this; the answer now comes from the delete itself.
+ */
+export type BranchDeleteOutcome = { readonly deleted: true } | { readonly deleted: false; readonly reason: string }
+
+/**
  * Delete a branch in `repo`. `git branch -d` (safe: refuses an unmerged
- * branch) unless `force`, which uses `-D`. Best-effort — a branch that's
- * checked out elsewhere, unmerged (without force), or already gone just
- * returns; the caller (task delete / land cleanup) treats it as non-fatal.
+ * branch) unless `force`, which uses `-D`. Never throws — a branch that's
+ * checked out elsewhere, unmerged (without force), or already gone comes back
+ * as an outcome the caller reports rather than an error it has to handle.
  */
 async function deleteBranchIn(
   deps: BranchDeps,
@@ -49,9 +64,19 @@ async function deleteBranchIn(
   repo: string,
   branch: string,
   force: boolean,
-): Promise<void> {
-  if (!branch || branch === "HEAD") return
-  await deps.runGit(exec, ["branch", force ? "-D" : "-d", branch], { cwd: repo, allowFail: true })
+): Promise<BranchDeleteOutcome> {
+  if (!branch || branch === "HEAD") return { deleted: false, reason: "no branch to delete" }
+  const out = await deps.runGit(exec, ["branch", force ? "-D" : "-d", branch], { cwd: repo, allowFail: true })
+  if (out.exitCode === 0) return { deleted: true }
+  // Re-probe rather than trust the exit code, the same way `removeWorktree`
+  // classifies a failed `git worktree remove`: a branch that is already gone
+  // IS the end state the caller asked for, and git spells that refusal
+  // ("branch 'x' not found") in whatever language it is running in.
+  if (!(await branchExists(deps, { exec, dir: repo, remote: exec.isRemote }, branch))) return { deleted: true }
+  return {
+    deleted: false,
+    reason: out.stderr.trim() || out.stdout.trim() || `git branch exited ${out.exitCode}`,
+  }
 }
 
 /**
@@ -76,9 +101,9 @@ export async function deleteBranchAnchored(
   repo: string,
   branch: string,
   opts: { readonly force: boolean; readonly onAnchor?: (record: SalvageRecord | null) => void },
-): Promise<void> {
+): Promise<BranchDeleteOutcome> {
   if (opts.force) opts.onAnchor?.(await anchorBranchTip(deps, exec, repo, branch))
-  await deleteBranchIn(deps, exec, repo, branch, opts.force)
+  return await deleteBranchIn(deps, exec, repo, branch, opts.force)
 }
 
 /**

--- a/packages/kobe/src/orchestrator/worktree/manager-remove.ts
+++ b/packages/kobe/src/orchestrator/worktree/manager-remove.ts
@@ -33,6 +33,7 @@ import type { ExecHost } from "../../exec/exec-host.ts"
 import { GitCommandError, type GitRunOpts, type GitRunResult } from "./git.ts"
 import { type BranchDeps, deleteBranchAnchored } from "./manager-branch.ts"
 import { canonicalize, isUnderManagedWorktreesRoot, requireAbsolute } from "./paths.ts"
+import type { IgnoredWorkProbe } from "./salvage-ignored.ts"
 import { type SalvageRecord, salvageWorktree } from "./salvage.ts"
 import { parseWorktreeListPorcelain } from "./worktree-list.ts"
 
@@ -75,6 +76,13 @@ export interface RemoveOpts {
    * there. A task carries `task.branch`; a bare worktree path does not.
    */
   readonly branch?: string
+  /**
+   * Notified when `deleteBranch` was asked for and git REFUSED — an unmerged
+   * branch (`-d` without force), one another worktree still has checked out.
+   * The removal itself still succeeds, exactly as before; this is the only
+   * thing that stops the caller reporting a branch it never deleted.
+   */
+  readonly onBranchKept?: (kept: { readonly branch: string; readonly reason: string }) => void
   /** Notified with the snapshot a force-removal took (null = nothing to
    *  save, or the snapshot could not be written). */
   readonly onSalvage?: (record: SalvageRecord | null) => void
@@ -95,8 +103,9 @@ export interface RemoveDeps {
   currentBranch(worktreePath: string): Promise<string | null>
   /** Whether the worktree has uncommitted or untracked changes. */
   isDirty(worktreePath: string): Promise<boolean>
-  /** The gitignored paths a removal would destroy — work `isDirty` is blind to. */
-  ignoredWork(worktreePath: string): Promise<readonly string[]>
+  /** The gitignored paths a removal would destroy — work `isDirty` is blind to,
+   *  or `"unknown"` when the listing did not run. */
+  ignoredWork(worktreePath: string): Promise<IgnoredWorkProbe>
   /** Deps for the opt-in post-removal branch delete. */
   branchDeps(): BranchDeps
 }
@@ -223,7 +232,8 @@ export async function removeWorktree(deps: RemoveDeps, worktreePath: string, opt
       // believes a worktree has checked out). Best-effort, like every other
       // branch delete: it runs after the removal is otherwise complete.
       if (opts?.deleteBranch === true && opts.branch) {
-        await deleteBranchAnchored(deps.branchDeps(), exec, goneRepo, opts.branch, { force })
+        const outcome = await deleteBranchAnchored(deps.branchDeps(), exec, goneRepo, opts.branch, { force })
+        if (!outcome.deleted) opts.onBranchKept?.({ branch: opts.branch, reason: outcome.reason })
       }
     }
     return
@@ -332,7 +342,18 @@ export async function removeWorktree(deps: RemoveDeps, worktreePath: string, opt
     // removal above would destroy it with no salvage snapshot (the force path
     // is the only one that takes one). Same rule as the snapshot, so the
     // refusal names exactly what a `--force` retry would rescue.
-    const ignored = await deps.ignoredWork(worktreePath).catch(() => [])
+    // NOT `.catch(() => [])`. An empty list is this gate's permission to
+    // destroy the directory, so a probe that threw or exited non-zero used to
+    // hand out that permission on the strength of having failed — the same
+    // shape as the `isDirty` call above, which deliberately lets its failure
+    // throw (`daemon-worktree-adapter.ts` names that as why a destructive path
+    // may not read an unverified verdict).
+    const ignored = await deps.ignoredWork(worktreePath)
+    if (ignored === "unknown") {
+      throw new Error(
+        `remove(): refusing to remove worktree at ${worktreePath} — git status --ignored failed, so nothing can confirm it holds no gitignored work (pass { force: true } to override, which salvages first)`,
+      )
+    }
     if (ignored.length > 0) {
       throw new Error(
         `remove(): refusing to remove worktree at ${worktreePath} — it holds gitignored work git status cannot see: ${ignored.join(", ")} (pass { force: true } to override)`,
@@ -366,5 +387,8 @@ export async function removeWorktree(deps: RemoveDeps, worktreePath: string, opt
   // worktree's own reflog died with the directory a few lines up. Runs on the
   // residue path too: by then the branch is checked out nowhere, which is the
   // only thing that makes it undeletable.
-  if (branch) await deleteBranchAnchored(deps.branchDeps(), exec, repo, branch, { force })
+  if (branch) {
+    const outcome = await deleteBranchAnchored(deps.branchDeps(), exec, repo, branch, { force })
+    if (!outcome.deleted) opts?.onBranchKept?.({ branch, reason: outcome.reason })
+  }
 }

--- a/packages/kobe/src/orchestrator/worktree/manager.ts
+++ b/packages/kobe/src/orchestrator/worktree/manager.ts
@@ -29,9 +29,11 @@ import path from "node:path"
 import type { ExecHost } from "../../exec/exec-host.ts"
 import { READ_ONLY_GIT_ENV } from "../../lib/git-env.ts"
 import type { AdoptableWorktree, WorktreeInfo, WorktreeManager } from "../../types/worktree.ts"
+import { isDirtyOutput } from "../dirty-paths.ts"
 import { type ExecCtx, type WorktreeExecDeps, defaultExecDeps } from "./exec-deps.ts"
 import { GitCommandError, type GitRunOpts, type GitRunResult } from "./git.ts"
 import {
+  type BranchDeleteOutcome,
   type BranchDeps,
   branchExists,
   branchHasUpstream,
@@ -49,7 +51,7 @@ import {
 } from "./manager-list.ts"
 import { type RemoveOpts, removeWorktree } from "./manager-remove.ts"
 import { canonicalize, remoteWorktreePathFor, requireAbsolute, worktreePathFor } from "./paths.ts"
-import { smallIgnoredPaths } from "./salvage-ignored.ts"
+import { type IgnoredWorkProbe, smallIgnoredPaths } from "./salvage-ignored.ts"
 import { type SalvageRecord, salvageWorktree } from "./salvage.ts"
 import { parseWorktreeListPorcelain } from "./worktree-list.ts"
 
@@ -232,10 +234,10 @@ export class GitWorktreeManager implements WorktreeManager {
        *  or the anchor could not be written). */
       readonly onAnchor?: (record: SalvageRecord | null) => void
     },
-  ): Promise<void> {
+  ): Promise<BranchDeleteOutcome> {
     const ctx = this.ctxFor(repo)
     requireAbsolute("repo", ctx.dir)
-    await deleteBranchAnchored(this.branchDeps(), ctx.exec, ctx.dir, branch, {
+    return await deleteBranchAnchored(this.branchDeps(), ctx.exec, ctx.dir, branch, {
       force: opts?.force === true,
       onAnchor: opts?.onAnchor,
     })
@@ -339,7 +341,7 @@ export class GitWorktreeManager implements WorktreeManager {
       cwd: worktreePath,
       readOnly: true,
     })
-    return out.stdout.length > 0
+    return isDirtyOutput(out.stdout)
   }
 
   /**
@@ -358,8 +360,11 @@ export class GitWorktreeManager implements WorktreeManager {
    * refuses for exactly what the `--force` retry would then rescue: a
    * multi-gigabyte `node_modules/` is over the size ceiling, so it neither
    * blocks the delete nor bloats the snapshot.
+   *
+   * `"unknown"` — the listing did not run — is passed through, never flattened
+   * to `[]`: for a gate, "I could not look" is not "there is nothing here".
    */
-  async ignoredWork(worktreePath: string): Promise<readonly string[]> {
+  async ignoredWork(worktreePath: string): Promise<IgnoredWorkProbe> {
     return smallIgnoredPaths(this.execAt(worktreePath), worktreePath)
   }
 

--- a/packages/kobe/src/orchestrator/worktree/salvage-ignored.ts
+++ b/packages/kobe/src/orchestrator/worktree/salvage-ignored.ts
@@ -103,15 +103,29 @@ async function duKb(exec: ExecHost, worktreePath: string, paths: readonly string
 }
 
 /**
- * The ignored paths in `worktreePath` small enough to be worth snapshotting.
+ * What a caller learns about a worktree's ignored work: the small entries, or
+ * `"unknown"` when the listing itself did not run.
  *
- * Returns `[]` on any failure — salvage must degrade to its old
- * ignored-files-excluded behaviour rather than fail the removal a caller
- * already asked for. An entry whose size cannot be read is SKIPPED, not
- * guessed at: an unmeasurable path is more likely a huge tree than a note,
- * and a snapshot that swallows one is worse than one that misses it.
+ * The two are NOT the same answer and had been encoded as one. Salvage reads
+ * this to decide what to add to a snapshot, where "nothing found" and "could
+ * not look" both correctly degrade to a smaller snapshot. The non-force delete
+ * GATE reads it too, and there an empty list is the permission to destroy the
+ * directory — so a `git status --ignored` that never ran was authorising the
+ * exact deletion it exists to refuse.
  */
-export async function smallIgnoredPaths(exec: ExecHost, worktreePath: string): Promise<string[]> {
+export type IgnoredWorkProbe = readonly string[] | "unknown"
+
+/**
+ * The ignored paths in `worktreePath` small enough to be worth snapshotting,
+ * or `"unknown"` when `git status --ignored` failed or threw.
+ *
+ * An entry whose SIZE cannot be read is still SKIPPED, not guessed at: an
+ * unmeasurable path is more likely a huge tree than a note, and a snapshot
+ * that swallows one is worse than one that misses it. That is a per-entry
+ * verdict on a listing that succeeded; `"unknown"` is the absence of a
+ * listing, which no caller can read as "there is nothing here".
+ */
+export async function smallIgnoredPaths(exec: ExecHost, worktreePath: string): Promise<IgnoredWorkProbe> {
   try {
     // Lock-free, like every other status probe (`lib/git-env.ts`): this now
     // runs on the ORDINARY delete path, not just the force one, so it must not
@@ -120,7 +134,7 @@ export async function smallIgnoredPaths(exec: ExecHost, worktreePath: string): P
       cwd: worktreePath,
       env: READ_ONLY_GIT_ENV,
     })
-    if (status.exitCode !== 0) return []
+    if (status.exitCode !== 0) return "unknown"
     const paths = parseIgnoredPaths(status.stdout)
     if (paths.length === 0) return []
 
@@ -130,6 +144,6 @@ export async function smallIgnoredPaths(exec: ExecHost, worktreePath: string): P
       return kb !== undefined && kb <= MAX_IGNORED_ENTRY_KB
     })
   } catch {
-    return []
+    return "unknown"
   }
 }

--- a/packages/kobe/src/orchestrator/worktree/salvage.ts
+++ b/packages/kobe/src/orchestrator/worktree/salvage.ts
@@ -168,7 +168,12 @@ export async function salvageWorktree(
     // the worktrees it exists for.
     const status = await git(["status", "--porcelain"])
     if (status.exitCode !== 0) return null
-    const ignored = await smallIgnoredPaths(exec, worktreePath)
+    // `"unknown"` (the listing itself failed) degrades to the old
+    // ignored-files-excluded snapshot: salvage must never fail the removal a
+    // caller already asked for. The DELETE GATE reads the same probe and must
+    // do the opposite — see `manager-remove.ts`.
+    const probe = await smallIgnoredPaths(exec, worktreePath)
+    const ignored = probe === "unknown" ? [] : probe
     if (status.stdout.trim().length === 0 && ignored.length === 0) return null
 
     // A throwaway index INSIDE the worktree's own git dir, so staging never

--- a/packages/kobe/src/tui-react/workspace/use-fix-ci.ts
+++ b/packages/kobe/src/tui-react/workspace/use-fix-ci.ts
@@ -22,7 +22,7 @@
  */
 
 import type { MutableRefObject } from "react"
-import { type CIFailingCheck, buildCIPromptForWorktree } from "../../tui/ops/ci-prompt"
+import { type CIFailingChecksRead, buildCIPromptForWorktree } from "../../tui/ops/ci-prompt"
 import { useT } from "../i18n"
 
 /** The row facts the prompt names — read at call time, not captured. */
@@ -40,8 +40,18 @@ export type FixCIDeps = {
   /** The row's branch + PR number; `null` when the task is gone. */
   getTask: (taskId: string) => FixCITask | null
   /** `RemoteOrchestrator.failingChecks`. */
-  fetchChecks: (taskId: string) => Promise<{ checks: readonly CIFailingCheck[]; totalFailing: number }>
+  fetchChecks: (taskId: string) => Promise<CIFailingChecksRead>
   build?: typeof buildCIPromptForWorktree
+}
+
+/** `gh`'s stderr is multi-line (an error plus hints); a toast gets one line. */
+function firstLine(detail: string): string {
+  return (
+    detail
+      .split("\n")
+      .find((line) => line.trim().length > 0)
+      ?.trim() ?? detail.trim()
+  )
 }
 
 export function fixCIAction(deps: FixCIDeps): (taskId: string) => Promise<void> {
@@ -51,9 +61,21 @@ export function fixCIAction(deps: FixCIDeps): (taskId: string) => Promise<void> 
     const send = deps.sendToEngineFn.current
     const task = deps.getTask(taskId)
     if (!wt || !send || !task) return
-    const { checks, totalFailing } = await deps.fetchChecks(taskId)
-    // `gh` unavailable, the run expired, or the checks turned green while the
-    // menu was open. Saying so beats pasting a prompt with no evidence in it.
+    const { checks, totalFailing, unavailable } = await deps.fetchChecks(taskId)
+    // `gh` never answered — not installed, not authenticated, no network. The
+    // old toast covered this case with "the checks are no longer red", which
+    // is the one thing it definitely does not mean while the badge is red, so
+    // this branch names `gh` as the thing that failed.
+    //
+    // The toast card is 39 cells of text, so the VERDICT leads and `gh`'s own
+    // line trails: the first line is what has to survive truncation. The full
+    // stderr goes to `~/.rove/daemon.log`, which is where a multi-line hint
+    // ("please run: gh auth login") is actually readable.
+    if (unavailable) {
+      return deps.notifyError(deps.t("files.toast.ciChecksUnavailable", { detail: firstLine(unavailable.detail) }))
+    }
+    // Nothing red: the run expired, or the checks turned green while the menu
+    // was open. Saying so beats pasting a prompt with no evidence in it.
     if (checks.length === 0) return deps.notifyError(deps.t("files.toast.ciNoFailingChecks"))
     const prompt = await build(wt, {
       branch: task.branch || "HEAD",

--- a/packages/kobe/src/tui/i18n/messages/files.ts
+++ b/packages/kobe/src/tui/i18n/messages/files.ts
@@ -50,6 +50,7 @@ export const en = {
     /** `gh` unavailable, the run expired, or the checks went green while the
      *  menu was open — better than pasting a prompt with no evidence in it. */
     ciNoFailingChecks: "No failing check logs to read — the run may have expired, or the checks are no longer red",
+    ciChecksUnavailable: "gh could not read this PR's checks: {detail}",
   },
 }
 
@@ -90,5 +91,6 @@ export const zh: typeof en = {
   toast: {
     prOnTargetBranch: "当前就在目标分支（{branch}）— 请在任务分支上让 agent 创建 PR",
     ciNoFailingChecks: "没有可读的失败检查日志——运行记录可能已过期，或检查已不再是红的",
+    ciChecksUnavailable: "gh 读不到这个 PR 的检查状态：{detail}",
   },
 }

--- a/packages/kobe/src/tui/ops/ci-prompt.ts
+++ b/packages/kobe/src/tui/ops/ci-prompt.ts
@@ -26,6 +26,19 @@ export interface CIFailingCheck {
   readonly tail: string
 }
 
+/**
+ * What a `pr.failingChecks` read came back with.
+ *
+ * `unavailable` is the difference between "no check is red" and "nothing could
+ * be asked". Both arrive as `checks: []`, and only one of them means the user
+ * can stop worrying about the red badge they are looking at.
+ */
+export interface CIFailingChecksRead {
+  readonly checks: readonly CIFailingCheck[]
+  readonly totalFailing: number
+  readonly unavailable?: { readonly reason: string; readonly detail: string }
+}
+
 export interface CIPromptState {
   readonly branch: string
   readonly prNumber?: number

--- a/packages/kobe/test/cli/doctor-orphans.test.ts
+++ b/packages/kobe/test/cli/doctor-orphans.test.ts
@@ -94,7 +94,9 @@ describe("orphanDoctorLines", () => {
   })
 
   it("reports an inspection failure instead of a clean bill of health", () => {
-    expect(orphanDoctorLines([], "ps exited 1", "rove")[0]).toContain("could not inspect")
+    expect(orphanDoctorLines([], "could not read the process table — ps exited 1", "rove")[0]).toContain(
+      "could not read the process table",
+    )
   })
 
   it("is a ✓ line when nothing is orphaned", () => {

--- a/packages/kobe/test/client/remote-orchestrator-rpc.test.ts
+++ b/packages/kobe/test/client/remote-orchestrator-rpc.test.ts
@@ -139,6 +139,31 @@ describe("RemoteOrchestrator RPC wire mapping", () => {
     errSpy.mockRestore()
   })
 
+  it("carries pr.failingChecks' `unavailable` through instead of dropping it", async () => {
+    // `checks: []` means three things on the daemon side — `gh` missing, `gh`
+    // unauthenticated, and the checks genuinely green — and only this field
+    // separates them. Dropping it here would put the collapse back one layer
+    // down, where the toast can no longer tell the user which one it was.
+    // Its own client rather than `fakeClient()`: this is the one reply shape
+    // that reply table does not model, and widening it there would let every
+    // other wire test accept a `pr.failingChecks` payload it never asserts.
+    const client = {
+      on: () => () => {},
+      onLifecycle: () => () => {},
+      request: async () => ({
+        checks: [],
+        totalFailing: 0,
+        unavailable: { reason: "gh_failed", detail: "gh auth login" },
+      }),
+    } as unknown as KobeDaemonClient
+    const local = new RemoteOrchestrator(client)
+    expect(await local.failingChecks("t1")).toEqual({
+      checks: [],
+      totalFailing: 0,
+      unavailable: { reason: "gh_failed", detail: "gh auth login" },
+    })
+  })
+
   it("getTask finds by id from the current snapshot", () => {
     expect(orch.getTask("nope")).toBeUndefined()
     expect(orch.listTasks()).toEqual([])

--- a/packages/kobe/test/daemon/pr-failing-checks.test.ts
+++ b/packages/kobe/test/daemon/pr-failing-checks.test.ts
@@ -1,11 +1,15 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
 import {
   MAX_FAILING_JOBS,
   failingCheckTargets,
   joinFailingChecks,
   parseFailedRunLog,
+  readFailingChecks,
   runIdFromDetailsUrl,
 } from "@sma1lboy/kobe-daemon/daemon/pr-failing-checks"
-import { describe, expect, it } from "vitest"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
 
 describe("runIdFromDetailsUrl", () => {
   it("pulls the workflow run id out of a CheckRun details url", () => {
@@ -114,5 +118,48 @@ describe("joinFailingChecks", () => {
   it("still reports a job whose log could not be read, with an empty tail", () => {
     const result = joinFailingChecks([target("a")], new Map())
     expect(result.checks).toEqual([{ jobName: "a", conclusion: "FAILURE", url: "u/a", tail: "" }])
+  })
+})
+
+/**
+ * `readFailingChecks` against a REAL `gh` on PATH — a fake one that exits
+ * non-zero the way an expired `gh auth login` does.
+ *
+ * A stub of `spawnGh` would prove nothing here: the bug was that `ghText`
+ * received `status`, `stderr` and `spawnError` and dropped all three one line
+ * later, so the test has to go through the actual spawn to show they survive.
+ */
+describe("readFailingChecks when gh cannot answer", () => {
+  let binDir: string
+  let cwd: string
+  let previousPath: string | undefined
+
+  beforeEach(() => {
+    binDir = mkdtempSync(join(tmpdir(), "rove-fake-gh-"))
+    cwd = mkdtempSync(join(tmpdir(), "rove-gh-cwd-"))
+    writeFileSync(
+      join(binDir, "gh"),
+      '#!/bin/sh\necho "gh: To get started with GitHub CLI, please run: gh auth login" >&2\nexit 4\n',
+      { mode: 0o755 },
+    )
+    previousPath = process.env.PATH
+    process.env.PATH = `${binDir}:${previousPath ?? ""}`
+  })
+
+  afterEach(() => {
+    process.env.PATH = previousPath ?? ""
+    rmSync(binDir, { recursive: true, force: true })
+    rmSync(cwd, { recursive: true, force: true })
+  })
+
+  it("says gh failed, and quotes it, instead of returning a bare empty list", async () => {
+    const res = await readFailingChecks({ worktreePath: cwd, prNumber: 7 })
+
+    expect(res.checks).toEqual([])
+    expect(res.totalFailing).toBe(0)
+    // The whole point: an empty `checks` used to be the ONLY thing the caller
+    // saw, and it renders as "the checks are no longer red".
+    expect(res.unavailable?.reason).toBe("gh_failed")
+    expect(res.unavailable?.detail).toContain("gh auth login")
   })
 })

--- a/packages/kobe/test/daemon/task-deletion-background.test.ts
+++ b/packages/kobe/test/daemon/task-deletion-background.test.ts
@@ -37,6 +37,7 @@ describe("background deletion over the daemon socket", () => {
     )
     const worktrees = {
       isDirty: vi.fn(async () => false),
+      ignoredWork: vi.fn(async () => []),
       remove,
     } as unknown as GitWorktreeManager
     const orch = new Orchestrator({ store, worktrees })

--- a/packages/kobe/test/orchestrator/core-mutations.test.ts
+++ b/packages/kobe/test/orchestrator/core-mutations.test.ts
@@ -33,6 +33,7 @@ let store: TaskIndexStore
 let orch: Orchestrator
 let fakeWorktrees: {
   isDirty: ReturnType<typeof vi.fn>
+  ignoredWork: ReturnType<typeof vi.fn>
   remove: ReturnType<typeof vi.fn>
 }
 
@@ -42,6 +43,7 @@ beforeEach(async () => {
   await store.load()
   fakeWorktrees = {
     isDirty: vi.fn(async () => false),
+    ignoredWork: vi.fn(async () => []),
     remove: vi.fn(async () => {}),
   }
   orch = new Orchestrator({ store, worktrees: fakeWorktrees as unknown as GitWorktreeManager })

--- a/packages/kobe/test/orchestrator/failure-collapsed-to-neutral.test.ts
+++ b/packages/kobe/test/orchestrator/failure-collapsed-to-neutral.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Five probes that reported a NEUTRAL answer when they had failed.
+ *
+ * One file because they are one bug wearing five costumes: an error path
+ * folded into the value a healthy run produces, so the layer above cannot tell
+ * "nothing is wrong" from "nothing was checked". Each test below fails if its
+ * fix is reverted, and only that one.
+ *
+ * The delete-gate and branch-delete halves need real git — a stub cannot
+ * produce git's own refusal of an unmerged branch, which is the whole subject.
+ */
+
+import { execFileSync } from "node:child_process"
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { collectOrphans, markedPids } from "../../src/cli/doctor-orphans.ts"
+import { isDirtyOutput } from "../../src/orchestrator/dirty-paths.ts"
+import { isDirty as landIsDirty } from "../../src/orchestrator/land-preflight.ts"
+import { GitWorktreeManager } from "../../src/orchestrator/worktree/manager.ts"
+import { smallIgnoredPaths } from "../../src/orchestrator/worktree/salvage-ignored.ts"
+
+const GIT_ENV = {
+  ...process.env,
+  GIT_AUTHOR_NAME: "t",
+  GIT_AUTHOR_EMAIL: "t@t",
+  GIT_COMMITTER_NAME: "t",
+  GIT_COMMITTER_EMAIL: "t@t",
+}
+
+function git(cwd: string, ...args: string[]): string {
+  return execFileSync("git", args, { cwd, env: GIT_ENV, encoding: "utf8" })
+}
+
+describe("a git-refused branch delete is reported, not swallowed", () => {
+  let root: string
+  let repo: string
+  let worktree: string
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "rove-branch-kept-"))
+    repo = join(root, "repo")
+    worktree = join(root, "wt")
+    execFileSync("mkdir", ["-p", repo])
+    git(repo, "init", "-q", "-b", "main", ".")
+    writeFileSync(join(repo, "f.txt"), "base\n")
+    git(repo, "add", "-A")
+    git(repo, "commit", "-qm", "base")
+    git(repo, "worktree", "add", "-q", "-b", "feature", worktree)
+    writeFileSync(join(worktree, "NEW.txt"), "work\n")
+    git(worktree, "add", "-A")
+    git(worktree, "commit", "-qm", "unmerged")
+  })
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true })
+  })
+
+  it("hands back git's refusal for an unmerged branch instead of reporting success", async () => {
+    const kept: { branch: string; reason: string }[] = []
+    // `git branch -d` on a branch with commits the base cannot reach: git
+    // refuses, exit 1. Before, that exit code was discarded and `delete
+    // --delete-branch` finished quietly with the branch still on disk.
+    await new GitWorktreeManager().remove(worktree, {
+      force: false,
+      deleteBranch: true,
+      onBranchKept: (k) => kept.push(k),
+    })
+
+    expect(kept).toHaveLength(1)
+    expect(kept[0]?.branch).toBe("feature")
+    expect(kept[0]?.reason).toMatch(/not fully merged/)
+    // The removal itself still succeeded, and the branch still exists — the
+    // fix changes what is REPORTED, never what is destroyed.
+    expect(git(repo, "branch", "--format=%(refname:short)")).toContain("feature")
+  })
+
+  it("stays silent when the branch really did go away", async () => {
+    git(repo, "checkout", "-q", "main")
+    git(repo, "merge", "-q", "--no-ff", "-m", "merge", "feature")
+    const kept: unknown[] = []
+    await new GitWorktreeManager().remove(worktree, {
+      force: false,
+      deleteBranch: true,
+      onBranchKept: (k) => kept.push(k),
+    })
+    expect(kept).toEqual([])
+    expect(git(repo, "branch", "--format=%(refname:short)")).not.toContain("feature")
+  })
+})
+
+describe("one definition of a dirty porcelain", () => {
+  // A remote ExecHost is where a bare trailing newline actually comes from.
+  // It used to read DIRTY to the worktree manager's delete gate and CLEAN to
+  // landing — the same worktree, two verdicts, and the destructive one was
+  // the odd man out.
+  const newlineOnly = {
+    isRemote: true,
+    run: async () => ({ stdout: "\n", stderr: "", exitCode: 0 }),
+    exists: async () => true,
+  }
+
+  it('agrees that "\\n" is clean', async () => {
+    expect(isDirtyOutput("\n")).toBe(false)
+    expect(isDirtyOutput("")).toBe(false)
+    expect(isDirtyOutput(" M src/a.ts\n")).toBe(true)
+  })
+
+  it("gives all three call sites the same verdict on the same stdout", async () => {
+    // Asserting the shared helper alone would not notice a call site quietly
+    // going back to its own notion of empty, which is exactly the drift.
+    const manager = new GitWorktreeManager({
+      execForRepo: () => newlineOnly as never,
+      execForPath: () => newlineOnly as never,
+      remoteBasePath: () => "/remote/base",
+    })
+    expect(await manager.isDirty("/remote/base/wt")).toBe(false)
+    expect(await landIsDirty(newlineOnly as never, "/repo")).toBe(false)
+    // sync calls `parseDirtyPaths` directly, which is what `isDirtyOutput`
+    // is defined as — so this assertion covers that third site too.
+    expect(isDirtyOutput("\n")).toBe(false)
+  })
+})
+
+describe("an ignored-work probe that did not run is not an empty worktree", () => {
+  const worktreePath = "/wt/x"
+
+  function execWith(statusExit: number) {
+    return {
+      isRemote: false,
+      exists: async () => true,
+      run: async (argv: readonly string[]) =>
+        argv[0] === "git"
+          ? { stdout: "", stderr: "fatal: not a git repository", exitCode: statusExit }
+          : { stdout: "", stderr: "", exitCode: 0 },
+    }
+  }
+
+  it('reports "unknown" when `git status --ignored` exits non-zero', async () => {
+    expect(await smallIgnoredPaths(execWith(128) as never, worktreePath)).toBe("unknown")
+    expect(await smallIgnoredPaths(execWith(0) as never, worktreePath)).toEqual([])
+  })
+
+  it("refuses the removal rather than treating the unread listing as permission", async () => {
+    const manager = new GitWorktreeManager()
+    // The gate reads `ignoredWork`; stub only that, so the rest of `remove()`
+    // is the real thing and the refusal has to come from the gate.
+    Object.defineProperty(manager, "ignoredWork", {
+      value: async () => "unknown" as const,
+      configurable: true,
+    })
+    Object.defineProperty(manager, "isDirty", { value: async () => false, configurable: true })
+    const root = mkdtempSync(join(tmpdir(), "rove-ignored-unknown-"))
+    try {
+      const repo = join(root, "repo")
+      const wt = join(root, "wt")
+      execFileSync("mkdir", ["-p", repo])
+      git(repo, "init", "-q", "-b", "main", ".")
+      writeFileSync(join(repo, "f.txt"), "base\n")
+      git(repo, "add", "-A")
+      git(repo, "commit", "-qm", "base")
+      git(repo, "worktree", "add", "-q", "-b", "feature", wt)
+
+      await expect(manager.remove(wt, { force: false })).rejects.toThrow(/status --ignored failed/)
+      // Refused means NOT destroyed: the point of the gate.
+      expect(git(repo, "worktree", "list")).toContain(wt)
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+})
+
+describe("doctor's orphan sweep says so when it could not look", () => {
+  // ppid 1 and a process group whose leader (4000) is NOT in the table: an
+  // orphan CANDIDATE. Only the environment read decides whether it is a
+  // finding, which is exactly the step that used to fail silently.
+  const psRow = "4242     1  4000 01:00 1024 bun run something\n"
+
+  it("reports a `ps eww` that never ran instead of a clean machine", async () => {
+    const { orphans, error } = await collectOrphans(new Set(), {
+      platform: "darwin",
+      run: async (argv) =>
+        // the structural pass answers; the ENVIRONMENT pass — the one that
+        // turns a candidate into a finding — is the one that fails.
+        argv[1] === "-A" ? { code: 0, stdout: psRow } : { code: 127, stdout: "" },
+    })
+    expect(orphans).toEqual([])
+    expect(error).toMatch(/could not read process environments/)
+  })
+
+  it("reports a refused /proc read, but not a process that simply exited", async () => {
+    const enoent = Object.assign(new Error("ENOENT"), { code: "ENOENT" })
+    const eacces = Object.assign(new Error("EACCES"), { code: "EACCES" })
+    const gone = await markedPids([1], {
+      platform: "linux",
+      readEnviron: () => {
+        throw enoent
+      },
+    })
+    expect(gone.failed).toBeNull()
+
+    const refused = await markedPids([1], {
+      platform: "linux",
+      readEnviron: () => {
+        throw eacces
+      },
+    })
+    expect(refused.failed).toMatch(/EACCES/)
+  })
+})

--- a/packages/kobe/test/orchestrator/task-deletion.test.ts
+++ b/packages/kobe/test/orchestrator/task-deletion.test.ts
@@ -12,6 +12,7 @@ let store: TaskIndexStore
 let orch: Orchestrator
 let worktrees: {
   isDirty: ReturnType<typeof vi.fn>
+  ignoredWork: ReturnType<typeof vi.fn>
   remove: ReturnType<typeof vi.fn>
 }
 
@@ -21,6 +22,7 @@ beforeEach(async () => {
   await store.load()
   worktrees = {
     isDirty: vi.fn(async () => false),
+    ignoredWork: vi.fn(async () => []),
     remove: vi.fn(async () => {}),
   }
   orch = new Orchestrator({ store, worktrees: worktrees as unknown as GitWorktreeManager })

--- a/packages/kobe/test/tui-react/use-fix-ci.test.ts
+++ b/packages/kobe/test/tui-react/use-fix-ci.test.ts
@@ -49,6 +49,27 @@ describe("fixCIAction", () => {
     expect(seen).toEqual([{ branch: "feat/x", prNumber: 7, checks: [CHECK], totalFailing: 1 }])
   })
 
+  test("distinguishes an unreadable gh from checks that are no longer red", async () => {
+    // Both arrive as `checks: []`. Only one of them means the user can stop
+    // worrying about the red badge they clicked on.
+    const { base, sent, errors } = deps({
+      fetchChecks: async () => ({
+        checks: [],
+        totalFailing: 0,
+        unavailable: {
+          reason: "gh_failed",
+          detail: "gh: To get started with GitHub CLI, please run: gh auth login\nhint: more",
+        },
+      }),
+      t: (key: string, params?: Record<string, string | number>) => `${key}:${params?.detail ?? ""}`,
+    })
+    await fixCIAction(base)("t1")
+    expect(sent).toEqual([])
+    expect(errors).toEqual([
+      "files.toast.ciChecksUnavailable:gh: To get started with GitHub CLI, please run: gh auth login",
+    ])
+  })
+
   test("toasts instead of sending when the daemon reports no failing checks", async () => {
     const { base, sent, errors } = deps({ fetchChecks: async () => ({ checks: [], totalFailing: 0 }) })
     await fixCIAction(base)("t1")


### PR DESCRIPTION
Five probes reported a **neutral** answer when they had actually failed. One bug in five costumes: an error path folded into the value a healthy run produces, so the layer above cannot tell "nothing is wrong" from "nothing was checked".

## 1. `delete --delete-branch` discarded git's exit code

`git branch -d` refuses a branch whose commits the base cannot reach — the ordinary case for work that never landed. The removal is best-effort by design and must never fail, but "best-effort" was `allowFail` with the exit code dropped, so the daemon log's `removed … branch=<name>` line read as confirmation the branch had gone with the worktree.

Real repro against an isolated daemon (`KOBE_HOME_DIR` + private socket), same fixture both times — a task worktree with one unmerged commit, then `rove api delete --delete-branch --wait`:

**BEFORE** (`origin/main`) — `~/.rove/daemon.log`:
```
[…] daemon [task-deletion-audit]: removed task 01M1R2X4Q7QGJ6DF0G9RHA924F title="branch-kept-repro" kind=task branch=branch-kept-repro worktree=…/stilt
```
```
$ git -C repo branch
branch-kept-repro     ← still there, and nothing said so
main
```

**AFTER**:
```
[…] daemon [task-deletion-audit]: branch kept task 01M1R2VX1DT411KHMQK228YJ81 branch=branch-kept-repro — git refused the delete: error: the branch 'branch-kept-repro' is not fully merged hint: If you are sure you want to delete it, run 'git branch -D branch-kept-repro' … Nothing else will remove it; `git branch -D branch-kept-repro` does, and drops its reflog with it.
[…] daemon [task-deletion-audit]: removed task 01M1R2VX1DT411KHMQK228YJ81 title="branch-kept-repro" kind=task branch=branch-kept-repro worktree=…/scorpion
```

The `delete` **reply** is byte-identical in both runs (`{taskId, queued, status:"removed"}`) and deliberately so: by the time `--wait` resolves, the task row a verdict would ride on has been removed — that removal is how `--wait` knows the deletion finished. `docs/API.md` now says this and points at the log line.

## 2. "Fix failing checks" said the checks were probably green when `gh` never answered

`ghText` received `status`, `stderr` and `spawnError` from `spawnGh` and threw all three away one line later. A missing `gh`, an expired `gh auth login`, and a genuinely green PR were one empty list, and the UI could only render the third.

Captured through the browser `/harness` → xterm → PTY → real OpenTUI path, isolated fixture on its own port base, with a fake `gh` first on `PATH` that answers `pr list` with a `FAILURE` rollup (so `checkState` is `failing` and the menu entry exists) and exits 4 with `gh: To get started with GitHub CLI, please run: gh auth login` on the `--json statusCheckRollup` read `readFailingChecks` makes:

| | toast |
| --- | --- |
| BEFORE | `× No failing check logs to read — the ru…` |
| AFTER | `× gh could not read this PR's checks: gh…` |

Full-frame PNGs (identical viewport, pixel-comparable everywhere except the toast) are on the author's machine at `.scratch/before-fixci-toast.png` and `.scratch/after-fixci-toast.png` — not committed, since `.scratch/` is gitignored and a 1280×800 screenshot is not review material a repo should carry.

The card is 39 cells, so the verdict leads and `gh`'s own line trails — the full multi-line stderr (where `please run: gh auth login` actually lives) goes to `~/.rove/daemon.log`.

## 3. Three notions of an empty porcelain

`stdout.length > 0` (worktree manager's delete gate), `stdout.trim()` (landing), and `parseDirtyPaths` (sync). A `git status --porcelain` of just `"\n"` — which is what a remote `ExecHost` produces — read **dirty** to the destructive path and **clean** to the other two. One `isDirtyOutput`, defined as `parseDirtyPaths(...).length > 0`, so the gate and the message it prints can never disagree.

## 4. The non-force delete gate treated an unread listing as permission

`await deps.ignoredWork(worktreePath).catch(() => [])` — and an empty list is this gate's permission to destroy the directory, so a `git status --ignored` that threw handed out that permission on the strength of having failed. `smallIgnoredPaths` now answers `"unknown"`, the gate refuses it, and `--force` still overrides (which is the safer order: the forced path salvages first). Salvage reads the same probe and correctly does the opposite — a smaller snapshot, never a failed removal.

**This is the one behavior change in the PR.** Nothing previously destroyed is spared and nothing new is destroyed.

## 5. `rove doctor` reported `orphans: ✓ none` when the probe never ran

The environment read is the step that turns a candidate into a finding. With it broken every candidate stays unmarked, the filter empties the list, and doctor printed a clean bill of health for a machine it had never looked at. Now: `orphans: ✗ could not read process environments — ps eww exited 127`. A macOS `ps eww` that *ran* but omitted a SIP-protected binary's environment is still closed by construction; `ENOENT` on `/proc/<pid>/environ` is still an answer (it exited), `EACCES` under `hidepid=2` is not.

## Verification

- `test:fast` 4745 ✓ · `test:socket` 910 ✓ · `bun test test/render` 491 ✓ · root `lint` ✓ · `typecheck` (kobe + kobe-daemon) ✓ · `check-i18n` 913 × 2 ✓
- **Mutation**: each fix reverted individually reds exactly one test and only that one — all eight sites, including the two that share `test/orchestrator/failure-collapsed-to-neutral.test.ts`'s ignored-work block (the probe and the gate are separate sites). The gate mutation resolves the removal instead of rejecting — i.e. the worktree gets destroyed, which is the bug.
- The client passthrough in `failingChecksOp` had **no** test: deleting it left every suite green. Added one to `remote-orchestrator-rpc.test.ts`, and verified it reds when the field is dropped.
