### PR TITLE
One plugin's shutdown failure took the other plugins' hooks with it (A, B, C–H)

### DIFF
--- a/.changeset/plugin-shutdown-isolation.md
+++ b/.changeset/plugin-shutdown-isolation.md
@@ -1,0 +1,25 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Stop one plugin's failure from abandoning every other plugin's shutdown hook.
+`runPluginHook` documented itself as never rejecting, but two paths broke that:
+the `mkdirSync` calls that create a hook's config/state dirs sat outside any
+try, and a manifest may write a TOML `\u0000` escape into its argv, which makes
+`spawn` throw synchronously. Either one escaped into `PluginHost.stop()`, where
+`Promise.all` short-circuited and returned while the other plugins' hooks were
+still running — unawaited, so the daemon's `process.exit` destroyed their grace
+timers and left the orphaned children the method exists to prevent. The dir
+failure is now recorded as a `spawnError` in that plugin's own `rove plugin
+log`, the contract is enforced where every hook call site goes through, and the
+reap uses `allSettled`. Event dispatch is likewise isolated per plugin rather
+than per batch, and the registry-reload timer — the last dispatch path with no
+guard above it — no longer turns a throw into an uncaught daemon exception.
+
+Docs: `[[engines]]` needs a Rove restart (only daemon-run hooks hot-reload);
+`turn.interrupted` is TUI-emulated on Claude and Codex, so it never fires with
+no TUI attached; `RoveRunOptions` / `RoveRunResult` are documented; the SDK's
+socket table no longer presents instance methods as named exports;
+`delivery.composerGate` no longer claims that turning it off removes all
+typing protection; and `experimental.remoteProjects` says that it gates
+`rove add --remote` alone.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -195,7 +195,7 @@ for background consumers, but the current PureTUI tree does not consume it.
 
 | Key | Type | Default | What it does |
 |---|---|---|---|
-| `delivery.composerGate` | boolean | `true` | The screen-based check that runs before a peer or `rove api` prompt is written into an engine: a composer holding half-typed text defers the prompt to your Inbox instead of pasting over it. Turning this **off removes that safety check** — deliveries land unconditionally, and a message you were mid-way through typing can be interleaved with one |
+| `delivery.composerGate` | boolean | `true` | The **screen-read** half of the check that runs before a peer or `rove api` prompt is written into an engine: it renders the session and defers the prompt to your Inbox when the composer already holds text. Turning it off drops that read only. The other half — a ~10s window since your last keystroke in that session — is not switchable and still defers, so a composer you are actively typing into stays protected either way. Turn this off when a vendor moves its composer and the screen rule starts holding every delivery |
 
 ### Experimental
 
@@ -203,7 +203,7 @@ Off by default. These can change without notice.
 
 | Key | What it enables |
 |---|---|
-| `experimental.remoteProjects` | Projects over SSH |
+| `experimental.remoteProjects` | Lets `rove add --remote` register a NEW project over SSH. Gates that one command only: remote projects already registered keep working — worktree routing and engine launch never read the flag — so turning it off does not disable them |
 | `experimental.autoStatus` | Tasks move to `in_progress` and self-report `in_review` |
 | `experimental.dispatcher` | Per-repo routing of field notes between sessions |
 

--- a/docs/PLUGIN-AUTHORING.md
+++ b/docs/PLUGIN-AUTHORING.md
@@ -37,6 +37,12 @@ your `rove-plugin.toml` within about half a second — add an `[[events]]` hook,
 fire the event, and `rove plugin log` shows the run. Re-run `link` only when
 you move the plugin, or when its id or version changes.
 
+That half-second applies to the parts the DAEMON runs: `[[events]]`,
+`[[startup]]`, `[[shutdown]]`, `[[actions]]`, `[[panes]]`, `[[settings]]`. An
+`[[engines]]` table is read once per Rove process instead, so a running TUI
+keeps the engine list it booted with — see the `[[engines]]` note under
+[Manifest reference](#manifest-reference).
+
 ## Optional SDK (TypeScript)
 
 The contract above is the API: any language, no SDK required. For
@@ -202,6 +208,14 @@ any = ["ctrl-c to interrupt"]    # at least one must appear
 # bottom_lines = 12              # trailing non-empty lines examined (default 12)
 ```
 
+An `[[engines]]` edit is **not** picked up by a running TUI. The engine table
+is process-level state, built once at Rove start from the enabled plugins'
+manifests, so `rove plugin install` / `link` / `enable` from another terminal
+registers the engine on disk without any running TUI seeing it. Restart the
+TUI, or toggle the plugin off and on again in Settings → Plugins, which
+reloads the table in place. The same applies to the same-session dev loop:
+edit the `[[engines]]` table, then restart.
+
 `command` is argv, never a shell, for events, startup, shutdown and
 actions: no expansion, no pipes, no globs. **Panes are the exception** — a
 pane runs through the user's interactive login shell (`sh -ilc`, the same
@@ -262,7 +276,7 @@ This table is the one-line index. **Per-event trigger semantics, exact
 | `tab.opened` / `tab.closed` | a workspace tab appeared/went away (restores don't fire) | `tabId`, `kind`, `title`, `vendor`, `purpose` |
 | `agent.running` / `agent.idle` / `agent.turn-complete` / `agent.permission-needed` / `agent.rate-limited` / `agent.error` | activity-STATE transitions, deduped per task+tab | `tabId` when the source state identifies a tab |
 | `session.start` / `session.end` | engine session lifecycle (C, K; X start only) | |
-| `turn.prompt` / `turn.complete` / `turn.failed` / `turn.interrupted` | one event per turn edge (C, X, K; failed: C, K) | `failure` class on failed; `turn` (id/model/usage/startedAt/endedAt) on complete when the transcript yielded one |
+| `turn.prompt` / `turn.complete` / `turn.failed` / `turn.interrupted` | one event per turn edge (C, X, K; failed: C, K; **interrupted** is a native hook on K only — on C and X the attached TUI emulates it, so it never fires with no TUI attached) | `failure` class on failed; `turn` (id/model/usage/startedAt/endedAt) on complete when the transcript yielded one |
 | `tool.pre` / `tool.post` / `tool.failed` | every tool call (C, X, K; failed: C, K); **installed into engine config only while some enabled plugin subscribes** | `tool.name`, `tool.id` |
 | `attention.permission` / `attention.question` | the engine blocked on a human (permission: C, K; question: C) | `waiting` |
 | `context.pre-compact` / `context.post-compact` | context compaction (C, X, K) | `compact.trigger: manual\|auto` |

--- a/docs/PLUGIN-EVENTS.md
+++ b/docs/PLUGIN-EVENTS.md
@@ -256,11 +256,20 @@ carries it (absent otherwise, never fabricated):
 A `rate_limit` failure also arms auto-resume, so expect a `quota.exhausted`
 right after when the quota probe finds a reset time.
 
-### `turn.interrupted` · C, X (emulated), K (native)
+### `turn.interrupted` · C (emulated), X (emulated), K (native)
 
 The user interrupted the turn. Exists because Kimi fires `Interrupt` INSTEAD
 of `Stop`. Without this verb an interrupted Kimi turn would strand in
 `running`.
+
+Kimi is the only engine with a hook for this. On Claude and Codex the event is
+**emulated by the attached TUI**, which watches the session's terminal title
+for the engine dropping back to rest and reports the interrupt itself — so on
+those two engines it behaves like a [UI moment](#ui-moments): **no attached
+TUI, no event**. A headless daemon, a `rove api` driver, or a plugin that
+only ever sees background sessions will never observe `turn.interrupted` on
+C or X. Subscribe to `agent.idle` as well if you need the interrupt to be
+noticed without a TUI.
 
 ## Tools: the high-volume family
 

--- a/docs/PLUGIN-SDK.md
+++ b/docs/PLUGIN-SDK.md
@@ -121,20 +121,60 @@ await openPane("you.example.board")
 the prompt exceeded `timeoutMs`, no TUI was attached, or the underlying
 `rove api prompt` exited non-zero. Always branch on `null`.
 
+Every helper above takes the same optional `RoveRunOptions`:
+
+| Field | Type | Default | Meaning |
+|---|---|---|---|
+| `binPath` | string? | `$ROVE_BIN_PATH`, then `$KOBE_BIN_PATH` | The Rove binary to exec. Rejects when neither is set. |
+| `cwd` | string? | the process's cwd | Working directory for the child. |
+| `env` | `Record<string, string>`? | — | Merged **over** the inherited environment. |
+| `timeoutMs` | number? | `30_000` | Millis before the child is killed. |
+
+`cwd` is the field to think about from an `[[events]]` hook: a hook runs with
+its cwd set to your PLUGIN ROOT, not the task's worktree, so a `rove` call
+that has to resolve a repo needs `{ cwd: worktreePath }` — take the path from
+the event envelope rather than assuming the process inherited it.
+
+`timeoutMs` defaults to 30_000 — the same number as the host's deadline for a
+`[[startup]]` or `[[events]]` hook, but measured from a later instant: the
+host starts its clock when it spawns your hook, this one starts when your hook
+calls `rove()`. At the defaults the host's deadline therefore always expires
+first, and it SIGKILLs the hook's whole process group, the `rove` child
+included — so at 30s you never see this rejection, you see your hook
+disappear. Raising `timeoutMs` alone changes nothing; raise the hook's
+`timeout_ms` in the manifest first.
+
+They resolve with `RoveRunResult`:
+
+| Field | Type | Meaning |
+|---|---|---|
+| `code` | number | Child exit code. Non-zero is a resolved value, not a rejection. |
+| `stdout` | string | Captured stdout (8 MB cap). |
+| `stderr` | string | Captured stderr. |
+
+`KobeRunOptions` and `KobeRunResult` are deprecated aliases of these two,
+kept for plugins written against the original package name.
+
 ## Socket client
 
 `RoveSocket` is a newline-delimited JSON client for the daemon unix socket. It
 gives you live broadcast channels that the CLI cannot push.
 
-| Export | Signature | Purpose |
+`RoveSocket` is the only export here; everything under it is a method you
+call on an instance (`new RoveSocket().connect()`), not a named import.
+
+| Member | Signature | Purpose |
 |---|---|---|
-| `RoveSocket` | class | Daemon socket client. |
-| `connect` | `(opts?) => Promise<void>` | Connect to `ROVE_SOCKET_PATH`. |
-| `request` | `<T>(name, payload?) => Promise<T>` | One request → response; rejects on daemon error frames. |
-| `subscribe` | `(handler, channels?) => Promise<void>` | Subscribe to channels (`role: "pane"`); omit channels for all. |
-| `hello` | `() => Promise<DaemonInfo>` | Ask the RUNNING daemon its build version and channel list. |
-| `onClose` | `(handler) => void` | Called once when the connection dies (restart, crash, error). Not called for your own `close()`. |
-| `close` | `() => void` | End the socket. |
+| `RoveSocket` | class (export) | Daemon socket client. |
+| `KobeSocket` | alias (export) | Deprecated alias of `RoveSocket`. |
+| `RoveSocketOptions` | type (export) | `{ socketPath?: string }` — `connect()`'s argument. Defaults to `$ROVE_SOCKET_PATH`, then `$KOBE_SOCKET_PATH`; rejects when neither is set. `KobeSocketOptions` is its deprecated alias. |
+| `DaemonInfo` | type (export) | What `hello()` resolves with (fields below). |
+| `.connect` | method: `(opts?: RoveSocketOptions) => Promise<void>` | Connect to the daemon socket. |
+| `.request` | method: `<T>(name, payload?) => Promise<T>` | One request → response; rejects on daemon error frames. |
+| `.subscribe` | method: `(handler, channels?) => Promise<void>` | Subscribe to channels (`role: "pane"`); omit channels for all. |
+| `.hello` | method: `() => Promise<DaemonInfo>` | Ask the RUNNING daemon its build version and channel list. |
+| `.onClose` | method: `(handler) => void` | Called once when the connection dies (restart, crash, error). Not called for your own `close()`. |
+| `.close` | method: `() => void` | End the socket. |
 
 SDK consumers must always subscribe with `role: "pane"`. The SDK enforces this
 so plugins never hold the daemon's GUI lifetime open.

--- a/packages/kobe-daemon/src/plugins/hook-run.ts
+++ b/packages/kobe-daemon/src/plugins/hook-run.ts
@@ -93,8 +93,31 @@ export async function runPluginHook(opts: HookRunOptions): Promise<void> {
   const startedAt = Date.now()
   // 0700: config holds the settings .env (documented home for API keys) and
   // state is plugin-owned durable data; neither is anyone else's business.
-  mkdirSync(pluginConfigDir(pluginId, homeDir), { recursive: true, mode: 0o700 })
-  mkdirSync(pluginStateDir(pluginId, homeDir), { recursive: true, mode: 0o700 })
+  //
+  // Guarded because this is the one place the "never rejects" contract used to
+  // break: a config/state path occupied by a same-named FILE (EEXIST), or an
+  // unwritable/full disk (EACCES, ENOSPC), threw out of this function and out
+  // of every caller. In `PluginHost.stop` that abandoned the OTHER plugins'
+  // shutdown hooks — unawaited and unreaped, which is the orphan the doc
+  // comment there warns about. A plugin that has no config/state dir cannot
+  // honour the ROVE_PLUGIN_*_DIR contract, so record the failure and skip the
+  // spawn rather than launching a hook into a broken environment.
+  try {
+    mkdirSync(pluginConfigDir(pluginId, homeDir), { recursive: true, mode: 0o700 })
+    mkdirSync(pluginStateDir(pluginId, homeDir), { recursive: true, mode: 0o700 })
+  } catch (err) {
+    appendRecord(pluginId, homeDir, {
+      at: startedAt,
+      kind,
+      label,
+      command: spec.command,
+      exitCode: null,
+      durationMs: Date.now() - startedAt,
+      spawnError: String(err),
+    })
+    opts.log?.(`plugin ${pluginId} ${label}: ${String(err)}`)
+    return
+  }
   let exitCode: number | null = null
   let stdout = ""
   let stderr = ""

--- a/packages/kobe-daemon/src/plugins/runtime.ts
+++ b/packages/kobe-daemon/src/plugins/runtime.ts
@@ -158,7 +158,12 @@ export class PluginHost {
         runs.push(this.run(plugin, hook, "shutdown", { ROVE_PLUGIN_EVENT: "shutdown" }, `shutdown[${i}]`))
       }
     }
-    await Promise.all(runs)
+    // allSettled, not all: `run` below makes the "never rejects" contract
+    // true, but a short-circuit here would return while the OTHER plugins'
+    // hooks are still running — unawaited, so the caller's `process.exit`
+    // destroys their grace timers and leaves exactly the orphans the doc
+    // comment above is about. One plugin must not cost the rest their reap.
+    await Promise.allSettled(runs)
   }
 
   /** Feed every bus publish through here (server wires `bus.onPublish`). */
@@ -236,39 +241,54 @@ export class PluginHost {
   /** Fire one event at ONE plugin's matching hooks (registry transitions). */
   private dispatchTo(plugin: LoadedPlugin, event: PluginEvent): void {
     const platform = currentPluginPlatform()
-    for (const hook of plugin.manifest.events) {
-      if (hook.on !== event.event) continue
-      if (!supportsPlatform(hook, plugin.manifest, platform)) continue
-      void this.run(
-        plugin,
-        hook,
-        "event",
-        { ROVE_PLUGIN_EVENT: event.event, ROVE_PLUGIN_EVENT_JSON: JSON.stringify(event) },
-        hook.on,
-      )
+    // One plugin's data must not cost another plugin its event — and this
+    // path runs from the reload timer, where a throw is an uncaughtException
+    // rather than a caught batch. Same reason as the entry-point guards.
+    try {
+      for (const hook of plugin.manifest.events) {
+        if (hook.on !== event.event) continue
+        if (!supportsPlatform(hook, plugin.manifest, platform)) continue
+        void this.run(
+          plugin,
+          hook,
+          "event",
+          { ROVE_PLUGIN_EVENT: event.event, ROVE_PLUGIN_EVENT_JSON: JSON.stringify(event) },
+          hook.on,
+        )
+      }
+    } catch (err) {
+      this.opts.log?.(`plugin ${plugin.manifest.id}: ${event.event} dispatch failed — ${String(err)}`)
     }
   }
 
   private dispatch(event: PluginEvent): void {
     const platform = currentPluginPlatform()
     for (const plugin of this.plugins) {
-      for (const hook of plugin.manifest.events) {
-        if (hook.on !== event.event) continue
-        if (!supportsPlatform(hook, plugin.manifest, platform)) continue
-        // Task id/title also ride as plain env vars so shell plugins don't
-        // need a JSON parser for the common case.
-        void this.run(
-          plugin,
-          hook,
-          "event",
-          {
-            ROVE_PLUGIN_EVENT: event.event,
-            ROVE_PLUGIN_EVENT_JSON: JSON.stringify(event),
-            ...(event.taskId ? { ROVE_PLUGIN_TASK_ID: event.taskId } : {}),
-            ...(event.task?.title ? { ROVE_PLUGIN_TASK_TITLE: event.task.title } : {}),
-          },
-          hook.on,
-        )
+      // Per PLUGIN, not per batch: the callers' guards already keep a throw
+      // off the channel, but they catch at the batch, so one plugin's data
+      // would silently cost every plugin after it in this loop the event —
+      // and, from `handleChannel`, the rest of the batch as well.
+      try {
+        for (const hook of plugin.manifest.events) {
+          if (hook.on !== event.event) continue
+          if (!supportsPlatform(hook, plugin.manifest, platform)) continue
+          // Task id/title also ride as plain env vars so shell plugins don't
+          // need a JSON parser for the common case.
+          void this.run(
+            plugin,
+            hook,
+            "event",
+            {
+              ROVE_PLUGIN_EVENT: event.event,
+              ROVE_PLUGIN_EVENT_JSON: JSON.stringify(event),
+              ...(event.taskId ? { ROVE_PLUGIN_TASK_ID: event.taskId } : {}),
+              ...(event.task?.title ? { ROVE_PLUGIN_TASK_TITLE: event.task.title } : {}),
+            },
+            hook.on,
+          )
+        }
+      } catch (err) {
+        this.opts.log?.(`plugin ${plugin.manifest.id}: ${event.event} dispatch failed — ${String(err)}`)
       }
     }
   }
@@ -324,31 +344,49 @@ export class PluginHost {
       if (this.reloadTimer) clearTimeout(this.reloadTimer)
       this.reloadTimer = setTimeout(() => {
         if (this.stopped) return
-        const loadedBefore = new Map(this.plugins.map((p) => [p.manifest.id, p]))
-        const enabledBefore = this.enabledIds
-        this.plugins = this.loadPlugins()
-        this.opts.log?.(`plugin registry reloaded (${this.plugins.length} enabled)`)
-        // Registry transitions, delivered ONLY to the affected plugin, and
-        // diffed against REGISTRY membership: a manifest that started or
-        // stopped parsing has not been enabled or disabled by anyone, and
-        // teardown must not fire on a syntax error.
-        const at = Date.now()
-        for (const plugin of this.plugins) {
-          if (!enabledBefore.has(plugin.manifest.id)) {
-            this.dispatchTo(plugin, { event: "plugin.enabled", detail: { pluginId: plugin.manifest.id }, at })
+        // The reload is the last dispatch path with no guard above it: it runs
+        // from a timer, so a throw here is an uncaughtException in the daemon
+        // rather than one lost event batch — and nothing restarts the poll
+        // timer afterwards, so the host would stop seeing registry edits for
+        // the rest of the daemon's life.
+        try {
+          const loadedBefore = new Map(this.plugins.map((p) => [p.manifest.id, p]))
+          const enabledBefore = this.enabledIds
+          this.plugins = this.loadPlugins()
+          this.opts.log?.(`plugin registry reloaded (${this.plugins.length} enabled)`)
+          // Registry transitions, delivered ONLY to the affected plugin, and
+          // diffed against REGISTRY membership: a manifest that started or
+          // stopped parsing has not been enabled or disabled by anyone, and
+          // teardown must not fire on a syntax error.
+          const at = Date.now()
+          for (const plugin of this.plugins) {
+            if (!enabledBefore.has(plugin.manifest.id)) {
+              this.dispatchTo(plugin, { event: "plugin.enabled", detail: { pluginId: plugin.manifest.id }, at })
+            }
           }
-        }
-        for (const [id, plugin] of loadedBefore) {
-          if (!this.enabledIds.has(id)) {
-            this.dispatchTo(plugin, { event: "plugin.disabled", detail: { pluginId: id }, at })
+          for (const [id, plugin] of loadedBefore) {
+            if (!this.enabledIds.has(id)) {
+              this.dispatchTo(plugin, { event: "plugin.disabled", detail: { pluginId: id }, at })
+            }
           }
+        } catch (err) {
+          this.opts.log?.(`plugin registry reload failed — ${String(err)}`)
         }
       }, RELOAD_DEBOUNCE_MS)
     }, REGISTRY_POLL_MS)
     this.pollTimer.unref?.()
   }
 
-  /** Fire one hook. Bounded and logged by `hook-run.ts`; never rejects. */
+  /**
+   * Fire one hook. Bounded and logged by `hook-run.ts`; never rejects — and
+   * that is enforced HERE rather than assumed, because a manifest can still
+   * make `spawn` throw synchronously: TOML accepts `\u0000`, so
+   * `command = ["ec\u0000ho"]` parses fine and reaches `spawn` as argv with a
+   * NUL byte, which throws `ERR_INVALID_ARG_VALUE` inside the hook's promise
+   * executor. Every event/startup call site `void`s the result, so an
+   * escaping rejection is an unhandledRejection in a long-lived daemon; only
+   * `stop()` awaits, and there it would abandon the other plugins' hooks.
+   */
   private run(
     plugin: LoadedPlugin,
     spec: PluginCommandSpec,
@@ -368,6 +406,8 @@ export class PluginHost {
       binPath: this.opts.binPath,
       log: this.opts.log,
       inFlight: this.inFlight,
+    }).catch((err) => {
+      this.opts.log?.(`plugin ${plugin.manifest.id} ${label}: ${String(err)}`)
     })
   }
 }

--- a/packages/kobe/test/plugins/plugin-shutdown-isolation.test.ts
+++ b/packages/kobe/test/plugins/plugin-shutdown-isolation.test.ts
@@ -1,0 +1,157 @@
+/**
+ * `PluginHost.stop()` is documented as resolving only once EVERY shutdown
+ * hook has exited or been SIGKILLed, "or `process.exit` destroys the grace
+ * timers and the hook children become unbounded orphans". That promise held
+ * only while `runPluginHook` never rejected — which nothing enforced. Two
+ * manifests reach `spawn` through a reject, and one bad plugin then returned
+ * `stop()` early while every other plugin's hook was still running,
+ * unawaited and unreaped.
+ *
+ * Both are driven through a REAL `PluginHost` against a real registry in an
+ * isolated home — no stubbed hook runner, because the thing under test is
+ * whether the host actually waits for a child process it spawned.
+ */
+
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { pluginConfigDir, pluginLogPath } from "@sma1lboy/kobe-daemon/plugins/plugin-paths"
+import { type PluginRegistryEntry, savePluginRegistry } from "@sma1lboy/kobe-daemon/plugins/registry"
+import { PluginHost } from "@sma1lboy/kobe-daemon/plugins/runtime"
+import { afterEach, describe, expect, it } from "vitest"
+
+const dirs: string[] = []
+function tmp(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix))
+  dirs.push(dir)
+  return dir
+}
+afterEach(() => {
+  for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true })
+})
+
+/** TOML's escape for a NUL byte. A manifest may write it, the parser accepts
+ *  it, and the argv reaching `spawn` then holds a real NUL — which throws
+ *  ERR_INVALID_ARG_VALUE synchronously, inside the hook's promise executor.
+ *  Written as an escape here so this source file stays free of control bytes. */
+const NUL_ESCAPE = "\\u0000"
+
+function manifest(id: string, section: string, hook: string): string {
+  return [`id = "${id}"`, `name = "${id}"`, 'version = "0.1.0"', 'min_rove_version = "0.1.0"', "", section, hook].join(
+    "\n",
+  )
+}
+
+/** A hook that appends a marker to a file the test can read, so "the hook ran
+ *  to completion" is observed rather than assumed. */
+function healthyShutdown(markerPath: string): string {
+  return manifest("example.healthy", "[[shutdown]]", `command = ["sh", "-c", "echo done > '${markerPath}'"]`)
+}
+
+function install(home: string, plugins: readonly (readonly [string, string])[]): void {
+  mkdirSync(join(home, ".rove"), { recursive: true })
+  const entries: PluginRegistryEntry[] = []
+  for (const [id, text] of plugins) {
+    const root = tmp(`rove-shutdown-root-${id.replace(/\W/g, "-")}-`)
+    writeFileSync(join(root, "rove-plugin.toml"), text)
+    entries.push({ id, source: { kind: "link" }, root, enabled: true, version: "0.1.0", installedAt: 1 })
+  }
+  savePluginRegistry({ plugins: entries }, home)
+}
+
+function host(home: string, log?: (line: string) => void): PluginHost {
+  return new PluginHost({
+    homeDir: home,
+    socketPath: join(home, "fake.sock"),
+    binPath: "rove-test-bin",
+    ...(log ? { log } : {}),
+  })
+}
+
+function records(home: string, id: string): Record<string, unknown>[] {
+  try {
+    return readFileSync(pluginLogPath(id, home), "utf8")
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as Record<string, unknown>)
+  } catch {
+    return []
+  }
+}
+
+async function waitFor(predicate: () => boolean, ms = 5_000): Promise<void> {
+  const start = Date.now()
+  while (!predicate()) {
+    if (Date.now() - start > ms) throw new Error("timed out")
+    await new Promise((r) => setTimeout(r, 25))
+  }
+}
+
+describe("one plugin's failure does not abandon another plugin's shutdown hook", () => {
+  it("records a spawnError when the hook's config dir is occupied by a file", async () => {
+    const home = tmp("rove-shutdown-dir-")
+    const marker = join(tmp("rove-shutdown-marker-"), "healthy")
+    install(home, [
+      ["example.broken", manifest("example.broken", "[[shutdown]]", 'command = ["sh", "-c", "true"]')],
+      ["example.healthy", healthyShutdown(marker)],
+    ])
+    // A FILE where the 0700 config dir has to go, so `mkdirSync` answers
+    // EEXIST. Same shape as EACCES on an unwritable home or ENOSPC on a full
+    // disk — the three reasons this call was ever going to fail in the field.
+    mkdirSync(join(home, ".rove", "plugins", "example.broken"), { recursive: true })
+    writeFileSync(pluginConfigDir("example.broken", home), "not a directory")
+
+    const h = host(home)
+    h.start()
+    await h.stop()
+
+    // The author's one diagnostic surface (`rove plugin log`) has to say what
+    // happened, rather than go silent on the failure that took the host down.
+    const broken = records(home, "example.broken")
+    expect(broken.filter((r) => typeof r.spawnError === "string")).toHaveLength(1)
+    expect(String(broken[0]?.spawnError)).toMatch(/EEXIST|ENOTDIR|EACCES|ENOSPC/)
+    // ...and the healthy plugin's hook was still awaited to completion.
+    expect(readFileSync(marker, "utf8").trim()).toBe("done")
+    expect(records(home, "example.healthy").some((r) => r.exitCode === 0)).toBe(true)
+  })
+
+  it("survives a manifest whose argv cannot be spawned at all", async () => {
+    const home = tmp("rove-shutdown-nul-")
+    const marker = join(tmp("rove-shutdown-marker2-"), "healthy")
+    install(home, [
+      // Registered first, so a short-circuiting `Promise.all` abandons the
+      // healthy hook while it is still in flight.
+      ["example.broken", manifest("example.broken", "[[shutdown]]", `command = ["ec${NUL_ESCAPE}ho", "bye"]`)],
+      ["example.healthy", healthyShutdown(marker)],
+    ])
+
+    const h = host(home)
+    h.start()
+    await expect(h.stop()).resolves.toBeUndefined()
+
+    expect(readFileSync(marker, "utf8").trim()).toBe("done")
+    expect(records(home, "example.healthy").some((r) => r.exitCode === 0)).toBe(true)
+  })
+
+  it("logs an unspawnable event hook instead of leaving an unhandled rejection", async () => {
+    const home = tmp("rove-event-nul-")
+    install(home, [
+      [
+        "example.broken",
+        manifest("example.broken", "[[events]]", `on = "task.opened"\ncommand = ["ec${NUL_ESCAPE}ho"]`),
+      ],
+    ])
+    const lines: string[] = []
+    const h = host(home, (line) => lines.push(line))
+    h.start()
+    try {
+      // Event hooks are fired with `void`, so a rejection escaping here is an
+      // unhandledRejection in a daemon that runs for days.
+      h.handleUiReport({ kind: "task.opened", taskId: "t1" })
+      await waitFor(() => lines.some((l) => l.startsWith("plugin example.broken task.opened:")))
+    } finally {
+      await h.stop()
+    }
+    expect(lines.some((l) => l.includes("ERR_INVALID_ARG_VALUE"))).toBe(true)
+  })
+})


### PR DESCRIPTION
Six contract gaps in the plugin system: two in code, four in docs, plus two
config-doc lines that described gates stronger than they are.

## A — one plugin's shutdown failure abandoned every other plugin's hook

`PluginHost.stop()` carries a comment saying the caller MUST await it "or
`process.exit` destroys the grace timers and the hook children become
unbounded orphans", and then reaps with `Promise.all`. `runPluginHook`
likewise documents itself as never rejecting. Nothing enforced either.

Two reject paths, both reachable from an ordinary manifest:

1. The two `mkdirSync` calls that create a hook's 0700 config/state dirs sat
   outside any `try`. A config path occupied by a same-named FILE answers
   EEXIST; an unwritable home answers EACCES; a full disk answers ENOSPC.
2. A manifest may write a TOML `\u0000` escape into its argv. The parser
   accepts it (`asPlatforms`/`asCommand` validate shape, not control bytes),
   and `spawn` then throws `ERR_INVALID_ARG_VALUE` **synchronously**, inside
   `runPluginHook`'s promise executor — so it becomes a rejection.

Either one short-circuited `Promise.all` and returned from `stop()` while the
other plugins' hooks were still running. The `inFlight` kill loop has already
finished by then and later hooks register their kill only after `spawn`, so
nobody reaps them; `server-resources.ts` catches and the daemon exits anyway.

Fixed at three levels, each with a test:

- `hook-run.ts`: the `mkdirSync` pair is guarded and the failure lands as a
  `spawnError` record in that plugin's `log.jsonl` — `rove plugin log` is, per
  that file's own comment, "the one surface an author checks", and it was
  going silent on exactly the failure that leaked. The spawn is skipped: a
  plugin with no config/state dir cannot honour the `ROVE_PLUGIN_*_DIR`
  contract anyway.
- `runtime.ts` `run()`: one `.catch` at the single point all four hook call
  sites funnel through, making "never rejects" true rather than asserted.
  This is the root-cause fix — event and startup hooks are fired with `void`,
  so before it, path 2 was an **unhandledRejection in a daemon that runs for
  days**, not just a shutdown problem.
- `runtime.ts` `stop()`: `Promise.allSettled`, so the reap can never be
  short-circuited by a future reject path.

### Test + mutation matrix

`packages/kobe/test/plugins/plugin-shutdown-isolation.test.ts` — a **real**
`PluginHost` against a real registry in an isolated home, no stubbed hook
runner, since the property under test is whether the host actually waits for a
child process it spawned. It sits next to the existing real-`PluginHost` tests
(`plugin-file-modes.test.ts`) and is a NEW file; `plugin-event-emits.test.ts`
is untouched.

| Mutation | Result |
|---|---|
| M1 — remove the `mkdirSync` try/catch | **RED** (1 failed) — no `spawnError` record |
| M2 — `allSettled`→`all` **and** drop `run()`'s catch | **RED** (2 failed) — healthy plugin's hook abandoned, event hook rejects unhandled |
| M3 — drop `run()`'s catch only | **RED** (1 failed) — unspawnable event hook logs nothing |
| M4 — `allSettled`→`all` only | **GREEN** |

M4 is the mutation the brief specified, and it is honestly green: once `run()`
honours the contract, `allSettled` can no longer observe a rejection. It is
kept as the structural guarantee at the reap site (M2 shows the pre-fix state
is red). Each of the three fixes is isolated by exactly one of M1/M2/M3.

## B — dispatch guards were per batch, and the reload path had none

Guards existed at the three entry points (`handleChannel`, `handleUiReport`,
`handleEngineReport`) but not inside `dispatch()`'s plugin loop, so one
plugin's data would cost every plugin after it in the loop — and, from
`handleChannel`, the rest of the batch. `dispatchTo()` and the
registry-reload `setTimeout` callback had no guard at any level; a throw there
is an uncaughtException, and nothing restarts the poll timer, so the host
would stop seeing registry edits for the rest of the daemon's life.

Each loop that executes plugin data now has its own `try`, logging with the
plugin id, and the reload callback is guarded around `loadPlugins()` too.

**Constructing a throw:** the brief asked me to try. I could not make
`dispatch()`'s loop body throw — `asPlatforms` validates `platforms` to a
real array so `supportsPlatform` can't throw, `loadPluginRegistry` swallows
corrupt JSON, and `JSON.stringify(event)` doesn't vary per plugin. I DID
construct a manifest that is legal to the parser and blows up at execution:
the `\u0000` argv above. It surfaces as a rejection from the async
`runPluginHook`, not a throw at the loop, so it is fixed by A's `run()` catch
rather than by these guards — the guards remain a structural symmetry fix.

## C — `[[engines]]` does not hot-reload

`PLUGIN-AUTHORING.md` promised edits are picked up "within about half a
second". True only for what the daemon runs. The engine table is per-Rove-
process state; `reloadPluginEngines` has exactly one production call site:

```
$ grep -rn "reloadPluginEngines" packages --include='*.ts' --include='*.tsx' | grep -v test
packages/kobe/src/tui-react/component/settings-dialog/plugins-core.ts:27
packages/kobe/src/tui-react/component/settings-dialog/plugins-core.ts:217
packages/kobe/src/engine/plugin-engines.ts:75    (the definition)
$ grep -c "reloadPluginEngines" packages/kobe/src/cli/plugin-cmd.ts
0
```

So a CLI install/link/enable registers the engine on disk with no running TUI
seeing it. Both the quickstart claim and the `[[engines]]` section now say so,
naming the two ways out (restart, or toggle in Settings → Plugins).

## D — `turn.interrupted` needs a TUI on Claude and Codex

The heading read `C, X (emulated), K (native)`, which parses as C being
native. Only Kimi has a hook:

```
$ for f in $(find packages/kobe/src/engine -name "hook-adapter*"); do echo "$f: $(grep -c turn-interrupted $f)"; done
packages/kobe/src/engine/hook-adapter.ts: 0
packages/kobe/src/engine/kimi-local/hook-adapter.ts: 2
packages/kobe/src/engine/codex-local/hook-adapter.ts: 0
packages/kobe/src/engine/claude-code-local/hook-adapter.ts: 0
```

C/X come from `tui-react/workspace/use-tab-turn-state.ts` (an `InterruptObserver`
reading the raw OSC title) via `reportEngineInterruptOp` — TUI-side, so with no
TUI attached the event never fires. Heading is now `C (emulated), X (emulated),
K (native)`, the paragraph says no attached TUI means no event and points at
`agent.idle`, and the `PLUGIN-AUTHORING.md` row no longer equates C/X/K.

## E — `RoveRunOptions` was undocumented

Zero hits in `PLUGIN-SDK.md` despite appearing in every helper signature. Now
a field table for `RoveRunOptions` and `RoveRunResult`, plus the two points a
reader gets wrong:

- `cwd` — a hook's cwd is the **plugin root**, not the task worktree, so a
  `rove` call needing a repo must pass it from the event envelope.
- `timeoutMs` — 30_000 is also the host's hook deadline, but measured from an
  earlier instant (host clock starts at hook spawn, this one at the `rove()`
  call), so at the defaults the host's SIGKILL of the process group always
  wins and you never see this rejection. Raise `timeout_ms` in the manifest
  first.

## F — the socket table said "Export" over instance methods

`connect`/`request`/`subscribe`/`hello`/`onClose`/`close` are members of the
class at `packages/kobe-plugin-sdk/src/socket.ts:45`; `import { connect }`
gives `undefined`. Header is now "Member", methods are prefixed `.`, and the
row above says `RoveSocket` is the only export there.

Reverse gap closed too — every identifier `index.ts` exports now has a landing
spot (the brief said 23; the actual count is **34**):

```
$ node -e '...' # each export name matched against docs/PLUGIN-SDK.md
exports: 34 | missing from docs: 0 (none)
```

## G — `delivery.composerGate` overstated what turning it off costs

The line claimed deliveries then "land unconditionally". False.
`engine/hosted-session.ts:211-224` runs `recentHumanWriteBlocks` (a ~10s
keystroke-silence window) **before** the switch and outside its control —
`:216` says it "cannot be disabled: someone typing right now is protected
whatever this setting says". The switch drops only the vendor-screen-layout
read. `state/composer-gate.ts:16-21` already had this right. The consequence
of the wrong text is real: a user held by a false positive reads the docs and
is scared off the one escape hatch that exists for it. Rewritten to say which
half goes away and which stays, and when to reach for it.

## H — `experimental.remoteProjects` gates one command

"Projects over SSH", unqualified. The flag has exactly one production reader:

```
$ grep -rn "isRemoteProjectsEnabled" packages --include='*.ts' | grep -v test
packages/kobe/src/cli/add-remote.ts:117
packages/kobe/src/state/remote-repos.ts:52   (the definition)
```

Registered remote projects, worktree routing and engine launch never read it —
as `docs/design/remote-projects.md:79` already documented. Line now says it
lets `rove add --remote` register a new project and that existing ones keep
working with it off.

## Intel corrections

- The specified mutation (`allSettled`→`all` alone) is **green**, because the
  reject is now fixed at its source. M2 covers the real pre-fix state.
- SDK export count is **34**, not 23.
- B's "could not construct a throw" holds for `dispatch()`'s loop, but a
  throwing manifest DOES exist (`\u0000` argv) — it lands as a rejection from
  `runPluginHook`, one layer down.
- Everything else in the brief checked out against the code.

## Verification

- `bun run test:fast` — 481 files, 4748 tests, all pass
- `bun run test:socket` (`KOBE_INCLUDE_SOCKET=1`) — 114 files, 910 tests, all pass
- root `bun run lint` — clean; `packages/kobe` `bun run typecheck` — clean
- all four edited docs pages are already in `sync-docs.mjs` SECTIONS
  (`CONFIGURATION.md`, `PLUGIN-AUTHORING.md`, `PLUGIN-EVENTS.md`,
  `PLUGIN-SDK.md`); the two new intra-doc links target real headings
  (`## Manifest reference`, `## UI moments`) — no raw HTML anchor, since no
  other page in `docs/` uses one

No UI change, so no screenshots.

## Residual risk

- The `\u0000` argv is caught at execution rather than rejected at parse.
  Validating control bytes in `asCommand` would fail the manifest at load with
  a better message; out of scope here, and the runtime is now safe either way.
- `allSettled` is unreachable-by-design given `run()`'s catch. Kept
  deliberately as the reap-site guarantee, which is why M4 is green.
