### PR TITLE
fix: a routine precheck can no longer outlive the daemon that started it

### DIFF
--- a/.changeset/precheck-orphan-busy-wait.md
+++ b/.changeset/precheck-orphan-busy-wait.md
@@ -1,0 +1,9 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Bound a routine precheck inside the shell that runs it, so it cannot outlive the daemon.
+
+A precheck's timeout lived only in a `setTimeout` on the daemon side. A daemon that was SIGKILLed took that timer with it and left the shell running with nothing that would ever stop it — a precheck shaped like `while [ ! -f flag ]; do sleep 0.01; done` then span at roughly a hundred forks a second until the machine was rebooted. Thirty-three such orphans held a Mac at load 170 with 86% of its CPU in the kernel.
+
+The spawned shell now carries the same deadline itself, and a timeout kills its whole process group rather than the shell alone, so a command's own children (`gh pr list | grep …`) go with it.

--- a/packages/kobe-daemon/src/daemon/automation-precheck.ts
+++ b/packages/kobe-daemon/src/daemon/automation-precheck.ts
@@ -38,6 +38,64 @@ const MAX_OUTPUT_CHARS = 4000
 const MAX_TIMEOUT_SECONDS = 600
 
 /**
+ * SIGKILL the shell's whole process group, falling back to the shell alone.
+ *
+ * A precheck is a shell command, so the processes that matter are usually the
+ * shell's children (`gh pr list | grep …`). Signalling only the shell's pid
+ * leaves those running, so kill the group the `detached` spawn made it leader
+ * of. Windows has no process groups; there the child itself is all we can
+ * reach.
+ */
+function killGroup(child: ReturnType<typeof spawn>): void {
+  const pid = child.pid
+  if (pid === undefined) return
+  try {
+    process.kill(-pid, "SIGKILL")
+  } catch {
+    try {
+      child.kill("SIGKILL")
+    } catch {
+      // Already reaped — nothing to signal.
+    }
+  }
+}
+
+/**
+ * Wrap the command so the SHELL enforces the timeout on itself, instead of
+ * trusting us to still be alive when it expires.
+ *
+ * The Node-side timer only fires while this process lives. A daemon that is
+ * SIGKILLed — or any crash that skips cleanup — takes the timer with it and
+ * leaves the shell running forever. A precheck shaped like
+ * `while [ ! -f release ]; do sleep 0.01; done` then spins at ~100 forks a
+ * second with nothing left that will ever create `release`: 33 such orphans
+ * held a Mac at load 170 with 86% of the CPU in the kernel, and they survive
+ * until the machine reboots. The watchdog keeps the same bound the user asked
+ * for without depending on the daemon.
+ *
+ * `set +m` turns off job control so the background watchdog neither prints
+ * `[1] 12345` into the captured stderr nor gets its own process group, which
+ * would put it out of reach of the group kill. The EXIT trap reaps the
+ * watchdog when the command finishes first, and POSIX keeps a trap from
+ * changing the exit status the caller decides on.
+ *
+ * The watchdog gets its own stdio (`>/dev/null 2>&1 </dev/null`) because a
+ * background job inherits the captured pipes otherwise, and Node reports
+ * `close` only once every writer has let go of them. A precheck that exits in
+ * milliseconds would then sit in the sweep until the watchdog's `sleep`
+ * expired — the timeout turned into a floor instead of a ceiling.
+ */
+export function withWatchdog(command: string, timeoutSeconds: number): string {
+  return [
+    "set +m 2>/dev/null",
+    `{ sleep ${timeoutSeconds} && { kill -9 -$$ 2>/dev/null || kill -9 $$ ; } ; } >/dev/null 2>&1 </dev/null &`,
+    "__rove_watchdog=$!",
+    `trap 'kill "$__rove_watchdog" 2>/dev/null' EXIT`,
+    command,
+  ].join("\n")
+}
+
+/**
  * Decode captured stream chunks to text, keeping only the last
  * `MAX_OUTPUT_CHARS`.
  *
@@ -89,13 +147,10 @@ export function runAutomationPrecheck(
     const out: (Buffer | string)[] = []
     const err: (Buffer | string)[] = []
     let settled = false
-    // Aborting fires the child's `error` event synchronously, BEFORE control
-    // returns to the abort call site. Without this flag that error settles the
-    // result first and a timeout gets misreported as a generic spawn failure —
-    // which matters, because "your precheck hangs" and "your precheck is
-    // broken" send the user to different places.
+    // Distinguishes the two ways a run ends without an exit code, because
+    // "your precheck hangs" and "your precheck is broken" send the user to
+    // different places.
     let timedOut = false
-    const controller = new AbortController()
 
     const finish = (exitCode: number | null, timedOut: boolean): void => {
       if (settled) return
@@ -112,19 +167,25 @@ export function runAutomationPrecheck(
 
     const timer = setTimeout(() => {
       timedOut = true
-      controller.abort()
-      // Belt and braces: if abort somehow did not settle us, do it here.
+      if (child) killGroup(child)
+      // The group kill should close the child, but a shell that is already
+      // unreachable would otherwise leave the sweep waiting on a promise that
+      // never settles.
       finish(null, true)
     }, timeoutMs)
     timer.unref?.()
 
-    let child: ReturnType<typeof spawn>
+    let child: ReturnType<typeof spawn> | undefined
     try {
-      child = spawn(shell, ["-ilc", precheck.command], {
+      // A second of slack so that whenever the daemon IS alive its own timer
+      // wins the race and reports a timeout, rather than the watchdog killing
+      // the shell first and surfacing as a bare signal death.
+      child = spawn(shell, ["-ilc", withWatchdog(precheck.command, timeoutMs / 1000 + 1)], {
         cwd,
         stdio: ["ignore", "pipe", "pipe"],
-        signal: controller.signal,
-        killSignal: "SIGKILL",
+        // Leader of its own process group, so a timeout can take the command's
+        // children down with the shell rather than orphaning them.
+        detached: process.platform !== "win32",
       })
     } catch (spawnError) {
       // A bad shell path throws synchronously; same verdict as a bad exit.
@@ -135,8 +196,6 @@ export function runAutomationPrecheck(
 
     child.stdout?.on("data", (chunk: Buffer | string) => out.push(chunk))
     child.stderr?.on("data", (chunk: Buffer | string) => err.push(chunk))
-    // Our own abort arrives as an `error` too — attribute it to the timeout
-    // rather than logging "The operation was aborted" as a spawn failure.
     child.on("error", (spawnError) => {
       if (timedOut) {
         finish(null, true)

--- a/packages/kobe/test/daemon/automation-precheck.test.ts
+++ b/packages/kobe/test/daemon/automation-precheck.test.ts
@@ -1,12 +1,14 @@
+import { execSync, spawn } from "node:child_process"
 import { chmodSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
-import { describe, expect, it } from "vitest"
+import { describe, expect, it, vi } from "vitest"
 import {
   formatPrecheckSkip,
   precheckPassed,
   runAutomationPrecheck,
   tail,
+  withWatchdog,
 } from "../../../kobe-daemon/src/daemon/automation-precheck.ts"
 
 const CWD = process.cwd()
@@ -100,7 +102,13 @@ describe("runAutomationPrecheck", () => {
     chmodSync(spy, 0o755)
     const result = await runAutomationPrecheck({ command: "true", timeoutSeconds: 10 }, CWD, spy)
     expect(result.exitCode).toBe(0)
-    expect(readFileSync(argsFile, "utf8")).toBe("-ilc\ntrue\n")
+    // The script argument is itself multi-line, so read the file whole rather
+    // than splitting it back into arguments.
+    const argv = readFileSync(argsFile, "utf8")
+    expect(argv.startsWith("-ilc\n")).toBe(true)
+    // The user's command is the last line, below the watchdog preamble that
+    // bounds it when the daemon is not around to do so.
+    expect(argv.trimEnd().endsWith("\ntrue")).toBe(true)
   })
 
   it("truncates runaway output instead of buffering it all", async () => {
@@ -111,4 +119,65 @@ describe("runAutomationPrecheck", () => {
     )
     expect(result.stdout.length).toBeLessThanOrEqual(4000)
   })
+})
+
+describe("orphan containment", () => {
+  // A precheck that outlives the daemon is not a tidiness problem. The shape
+  // that shipped — `while [ ! -f release ]; do sleep 0.01; done` in a test
+  // fixture — spins at ~100 forks a second, and nothing is left to ever
+  // create `release`. Thirty-three of them held a Mac at load 170 with 86% of
+  // the CPU in the kernel, surviving every daemon restart. Both tests below
+  // assert on the PROCESSES, because the old timeout test asserted only that
+  // the result said `timedOut` and passed the whole time the leak existed.
+
+  // `pgrep -fx` matches the whole argv, and the markers below are durations
+  // nothing else would pick, so this cannot collide with unrelated sleeps on
+  // a dev machine.
+  const sleepersFor = (marker: string): number =>
+    Number(execSync(`pgrep -fx 'sleep ${marker}' | wc -l`).toString().trim())
+
+  it.skipIf(process.platform === "win32")(
+    "a timeout kills the command's children, not just the shell",
+    async () => {
+      const marker = "24771"
+      // Three seconds, not one: the interactive shell sources the user's rc
+      // files before it reaches the command, so a tighter timeout can fire
+      // before the children exist and pass vacuously — which is how the leak
+      // stayed invisible.
+      const result = await runAutomationPrecheck(
+        { command: `sleep ${marker} & sleep ${marker} | cat`, timeoutSeconds: 3 },
+        CWD,
+      )
+      expect(result.timedOut).toBe(true)
+      await new Promise((r) => setTimeout(r, 500))
+      expect(sleepersFor(marker)).toBe(0)
+      execSync(`pkill -fx 'sleep ${marker}' || true`)
+    },
+    20_000,
+  )
+
+  it.skipIf(process.platform === "win32")(
+    "the wrapped command bounds itself with no one watching",
+    async () => {
+      // The real leak: a SIGKILLed daemon takes its timer with it, so anything
+      // depending on this process still running is already gone. So run the
+      // wrapped command the way an abandoned precheck ends up — detached, with
+      // nothing that will ever signal it — and require it to end on its own.
+      const marker = "24772"
+      const child = spawn("/bin/sh", ["-c", withWatchdog(`sleep ${marker}`, 3)], {
+        detached: true,
+        stdio: "ignore",
+      })
+      child.unref()
+      try {
+        await vi.waitFor(() => expect(sleepersFor(marker)).toBe(1), { timeout: 10_000, interval: 100 })
+        // Before the fix this sleep outlived every daemon restart; the only
+        // deadline it has now is the one the shell carries itself.
+        await vi.waitFor(() => expect(sleepersFor(marker)).toBe(0), { timeout: 15_000, interval: 250 })
+      } finally {
+        execSync(`pkill -fx 'sleep ${marker}' || true`)
+      }
+    },
+    30_000,
+  )
 })


### PR DESCRIPTION
## Summary

A precheck's timeout lived only in a `setTimeout` on the daemon side. A daemon that was SIGKILLed took that timer with it and left the shell running with nothing that would ever stop it.

Found in the wild: 33 orphaned prechecks, all `ppid=1`, all running the `while [ ! -f "$release" ]; do sleep 0.01; done` fixture from `automation-bound-delivery.test.ts`, some for over 90 minutes. Nothing was left that could ever create the `release` file they were waiting on, so each one forked `sleep` about a hundred times a second — roughly 3,300 process creations per second between them. The machine sat at load 172 with **86% of its CPU in the kernel and 0% idle**, while memory looked fine (93% free, zero swap), which is why it read as "the whole computer is slow" rather than as a runaway process. They survived every daemon restart; only a reboot or a manual kill cleared them.

Two changes:

- **The spawned shell carries its own deadline.** A watchdog inside the script kills the shell when the timeout expires, so the bound holds whether or not the daemon is still alive to enforce it. The daemon's timer gets a second of slack so that when it *is* alive it still wins the race and reports `timedOut` rather than a bare signal death.
- **A timeout kills the process group, not just the shell.** `detached` makes the shell its group leader, so a command's own children (`gh pr list | grep …`) go down with it instead of being orphaned.

The watchdog gets its own stdio, because a background job otherwise inherits the captured pipes and Node reports `close` only once every writer releases them — that would have turned the timeout into a floor rather than a ceiling. The first version of this patch did exactly that and hung two existing tests; both are green now.

## Why the tests did not catch it

The existing timeout test asserted only that the *result* said `timedOut`. That was true the entire time the leak existed. The two tests added here assert on the **processes** instead: that a timeout leaves no children behind, and that the wrapped command terminates itself with nothing watching it.

## Test plan

- [x] `bun x vitest run packages/kobe/test/daemon/automation-precheck.test.ts` — 26/26 pass
- [x] Reproduced the leak against `main`: SIGKILL the parent, precheck shell survives as `ppid=1` forever
- [x] Verified the fix against the same scenario: orphan reaps itself at 8.5s on a 9s watchdog budget
- [x] `bun run lint` clean; `kobe-daemon typecheck` clean
- [ ] Reviewer: `packages/kobe/test/daemon/home-owner-process.test.ts` fails on my machine on `main` too (vitest cannot spawn `bun` subprocesses here) — please confirm it is green in CI
- [ ] Reviewer: sanity-check the watchdog under `bash` as login shell; I verified under `zsh` and `/bin/sh`