### PR TITLE
fix: bound-delivery tests no longer fail, or leak, on a slow login shell

### DIFF
--- a/.changeset/bound-delivery-slow-shell.md
+++ b/.changeset/bound-delivery-slow-shell.md
@@ -1,0 +1,7 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Stop the bound-delivery routine tests from failing, and leaking a spinning shell, on a machine with a slow login shell.
+
+The precheck they start runs through an interactive login shell, which spends a second or two sourcing rc files before it reaches the command. vitest's default one-second `waitFor` expired first, so the test failed before writing the file its precheck spins on — leaving a shell forking `sleep` a hundred times a second with nothing left that would ever release it. The wait now allows for shell startup, and the release is written even when an assertion throws.

--- a/packages/kobe/test/daemon/automation-bound-delivery.test.ts
+++ b/packages/kobe/test/daemon/automation-bound-delivery.test.ts
@@ -198,12 +198,23 @@ describe("existing-tab routine delivery", () => {
     expect(routine).not.toBeNull()
     const stopped = action === "stop" ? startAutomationRunner(f.deps, 5) : undefined
     const running = stopped ? undefined : sweepAutomations(f.deps)
-    await vi.waitFor(() => expect(existsSync(entered)).toBe(true))
-    const stopping = stopped?.()
-    if (action === "disable") await f.store.update(f.routine.id, { enabled: false })
-    if (action === "edit") await f.store.update(f.routine.id, { prompt: "replacement" })
-    writeFileSync(release, "go")
-    await (stopping ?? running)
+    try {
+      // The precheck runs through an interactive login shell, which spends a
+      // second or two sourcing the developer's rc files before it reaches the
+      // `touch`. vitest's default 1s poll expires first on a machine with a
+      // slow shell, and the test then failed before ever writing `release`.
+      await vi.waitFor(() => expect(existsSync(entered)).toBe(true), { timeout: 15_000, interval: 50 })
+      const stopping = stopped?.()
+      if (action === "disable") await f.store.update(f.routine.id, { enabled: false })
+      if (action === "edit") await f.store.update(f.routine.id, { prompt: "replacement" })
+      writeFileSync(release, "go")
+      await (stopping ?? running)
+    } finally {
+      // Release the spin loop even when an assertion above threw: nothing else
+      // in this test will ever create the file it is waiting on, and until the
+      // precheck's own watchdog expires it burns ~100 forks a second.
+      writeFileSync(release, "go")
+    }
     expect(f.deliverTab).not.toHaveBeenCalled()
     expect(f.store.runsFor(f.routine.id)[0]?.status).toBe("skipped_cancelled")
   })


### PR DESCRIPTION
## Summary

Follow-up to #924, which fixed the daemon side of the same incident. This fixes the thing that was pulling the trigger.

`automation-bound-delivery.test.ts` starts a precheck that spins until the test writes a `release` file. The precheck runs through an interactive login shell, which spends a second or two sourcing rc files before it reaches the `touch`. `vi.waitFor` defaults to a one-second poll, so on a machine with a slow shell it expires first — and the test then fails **before** the line that writes `release`.

That is how the orphans in #924 were produced: three per run of this file, each one forking `sleep` about a hundred times a second, with nothing left in the process tree that would ever create the file it was waiting on. Eleven runs on my machine left 33 of them and put the box at load 172 with 86% of its CPU in the kernel.

Two changes:

- The wait allows for shell startup (`timeout: 15_000`) instead of assuming the command is reached within a second.
- `release` is written from a `finally` block, so a failing assertion still frees the loop rather than abandoning it.

With #924 merged an abandoned precheck now reaps itself after its timeout, so this is no longer unbounded — but not creating the orphan beats cleaning it up four seconds later, and the test failing spuriously was a real problem on its own.

## Test plan

- [x] `bun x vitest run packages/kobe/test/daemon/automation-bound-delivery.test.ts` — 14/14 pass (3 failed before this change)
- [x] Confirmed zero `rove-routine-bound` processes survive the run
- [x] Confirmed the same 3 tests fail identically on `6e305a7a0^`, i.e. this is pre-existing and not introduced by #924
- [ ] Reviewer: CI was green on these tests before, so this is unobservable there — the failure needs a shell that takes >1s to start (mine takes 1.86s)