### PR TITLE
fix: resolve the behavior suite's temp HOME so macOS path assertions hold

### DIFF
--- a/.changeset/behavior-home-realpath.md
+++ b/.changeset/behavior-home-realpath.md
@@ -1,0 +1,7 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Resolve the behavior suite's temporary HOME so its path assertions hold on macOS.
+
+`tmpdir()` there is the `/var` symlink to `/private/var`. Rove reports the real path, so every test comparing a path it built against one Rove printed differed by that prefix and failed locally while passing on Linux CI.

--- a/packages/kobe/test/behavior/harness.ts
+++ b/packages/kobe/test/behavior/harness.ts
@@ -6,7 +6,7 @@
 
 import { execFileSync, spawnSync } from "node:child_process"
 import { existsSync } from "node:fs"
-import { chmod, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
+import { chmod, mkdir, mkdtemp, realpath, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { dirname, join, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
@@ -56,7 +56,10 @@ function teardownIsolationError(env: NodeJS.ProcessEnv, home: string): string | 
 
 export async function makeBehaviorEnv(): Promise<BehaviorEnv> {
   requireDistBuild()
-  const home = await mkdtemp(join(tmpdir(), "kobe-behavior-"))
+  // Resolved, because on macOS `tmpdir()` is the `/var` symlink to
+  // `/private/var`. Rove reports the real path, so an unresolved home makes
+  // every path a test compares against Rove's output differ by that prefix.
+  const home = await realpath(await mkdtemp(join(tmpdir(), "kobe-behavior-")))
   const bin = join(home, "bin")
   const xdgConfig = join(home, ".config")
   const xdgData = join(home, ".local", "share")


### PR DESCRIPTION
## Summary

`makeBehaviorEnv` builds its disposable HOME with `mkdtemp(tmpdir())`. On macOS that is `/var/folders/…`, a symlink to `/private/var/folders/…`. Rove resolves and reports the real path, so any test comparing a path the harness built against one Rove printed differs by that prefix:

```
- "/var/folders/…/kobe-behavior-xkfftA/scratch-repo"
+ "/private/var/folders/…/kobe-behavior-xkfftA/scratch-repo"
```

`pure-tui-open-worktree.test.ts` fails on that locally and passes on Linux CI, where `/tmp` is not a symlink. It blocks `scripts/release.sh`, whose local gate runs `test:behavior` before it will cut a version.

Resolving the home once at the root of the harness fixes every derived path at the same time, rather than normalizing at each assertion.

Found while releasing #924 / #925; unrelated to those changes, which is why this is its own PR.

## Test plan

- [x] `bun run test:behavior` — 11 files, 33/33 pass (1 failed before this change)
- [x] `pure-tui-open-worktree.test.ts` on its own — passes
- [ ] Reviewer: invisible on Linux CI either way, since `/tmp` there is not a symlink