### PR TITLE
fix: read packed refs correctly when the worktree path contains a "refs" substring

### DIFF
--- a/.changeset/packed-ref-refs-substring.md
+++ b/.changeset/packed-ref-refs-substring.md
@@ -1,0 +1,7 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Read a worktree's packed refs correctly when the checkout's own path contains a `refs` substring.
+
+The daemon's file-level ref reader (`readRefSha`) recovered a ref name from its joined loose-ref path with a non-greedy `/^.*?(refs\/)/` strip, which stopped at the FIRST `refs/` anywhere in the absolute path — so a repo under a segment like `prefs/`, `andrefs/`, or a directory literally named `refs` matched that inner occurrence instead of the ref namespace, and any ref living in `packed-refs` (the normal state after a clone or `git gc`) read as absent. That fed `base-ref-cache.ts` and `behind-cache.ts` an empty base ladder, so the sidebar's base-drift and behind counts for those worktrees silently degraded or resolved against the wrong branch. The reader now matches `packed-refs` entries on the ref names directly, so the path the repo sits under no longer changes what a ref resolves to.

--- a/packages/kobe-daemon/src/daemon/worktree-probe.ts
+++ b/packages/kobe-daemon/src/daemon/worktree-probe.ts
@@ -88,13 +88,23 @@ export function resolveGitDirs(worktreePath: string): GitDirs | null {
   return { gitDir, commonDir }
 }
 
+/**
+ * The full ref NAMES a bare or qualified ref could resolve to, canonical
+ * namespace first. A name already under `refs/` is taken as-is; a bare
+ * `origin/main` becomes the remote-tracking `refs/remotes/origin/main` with
+ * the local-branch `refs/heads/origin/main` as a fallback. These are the
+ * exact keys `packed-refs` lists, so the packed lookup matches on them
+ * directly rather than trying to recover a name from a joined path.
+ */
+function refNameCandidates(ref: string): string[] {
+  if (ref.startsWith("refs/")) return [ref]
+  return [`refs/remotes/${ref}`, `refs/heads/${ref}`]
+}
+
 /** Candidate files a ref could live in, loose, per-worktree first. */
 function looseRefPaths(dirs: GitDirs, ref: string): string[] {
-  const rel = ref.startsWith("refs/") ? ref : `refs/remotes/${ref}`
-  const alt = ref.startsWith("refs/") ? null : `refs/heads/${ref}`
-  const names = alt ? [rel, alt] : [rel]
   const out: string[] = []
-  for (const name of names) {
+  for (const name of refNameCandidates(ref)) {
     out.push(join(dirs.gitDir, name))
     if (dirs.commonDir !== dirs.gitDir) out.push(join(dirs.commonDir, name))
   }
@@ -114,7 +124,13 @@ export function readRefSha(dirs: GitDirs, ref: string): string | null {
   }
   const packed = readText(join(dirs.commonDir, "packed-refs"))
   if (!packed) return null
-  const wanted = new Set(looseRefPaths(dirs, ref).map((p) => p.replace(/^.*?(refs\/)/, "$1")))
+  // Match packed-refs entries on the ref NAMES directly. Deriving them from
+  // the joined loose paths with a `/^.*?(refs\/)/` strip broke whenever the
+  // git-dir path itself contained a `refs/` substring (a repo under `prefs/`,
+  // a user dir like `andrefs/`, or a segment literally named `refs`): the
+  // non-greedy match stopped at that first `refs/`, so the key never matched
+  // the packed entry and a ref that plainly existed read as `null`.
+  const wanted = new Set(refNameCandidates(ref))
   for (const line of packed.split("\n")) {
     if (!line || line.startsWith("#") || line.startsWith("^")) continue
     const [sha, name] = line.split(" ", 2)

--- a/packages/kobe/test/daemon/worktree-probe.test.ts
+++ b/packages/kobe/test/daemon/worktree-probe.test.ts
@@ -153,4 +153,26 @@ describe("ref reads", () => {
     const probeDirs = resolveGitDirs(repo) as NonNullable<ReturnType<typeof resolveGitDirs>>
     expect(readRefSha(probeDirs, "origin/nope")).toBeNull()
   })
+
+  test("readRefSha reads a packed ref when the git-dir path contains a 'refs' substring", () => {
+    // The packed-refs lookup used to recover the ref name from the joined
+    // loose path with a non-greedy `/^.*?(refs\/)/` strip, which stopped at
+    // the FIRST `refs/` in the whole absolute path. A repo whose own path
+    // carries a `refs`-substring segment (`prefs/`, `andrefs/`, a dir named
+    // `refs`) matched that inner occurrence instead of the ref namespace, so
+    // the key never matched and a packed ref read as null.
+    const parent = mkdtempSync(join(tmpdir(), "kobe-probe-andrefs-"))
+    dirs.push(parent)
+    const nested = join(parent, "prefs", "proj")
+    mkdirSync(nested, { recursive: true })
+    git(nested, "init", "-q", "-b", "main", ".")
+    writeFileSync(join(nested, "f.txt"), "x\n")
+    git(nested, "add", "-A")
+    git(nested, ...AUTHOR, "commit", "-qm", "init")
+    git(nested, "pack-refs", "--all") // move `main` out of its loose file
+
+    const probeDirs = resolveGitDirs(nested) as NonNullable<ReturnType<typeof resolveGitDirs>>
+    expect(probeDirs.gitDir).toContain("refs") // the trigger condition
+    expect(readRefSha(probeDirs, "main")).toBe(git(nested, "rev-parse", "main"))
+  })
 })


### PR DESCRIPTION
## Direction

Bugs / correctness — a self-found bug in the daemon's file-level ref reader (no open PR or issue overlaps it; deliberately kept clear of the numstat/porcelain path parsing already in flight).

## Problem

`readRefSha` in `packages/kobe-daemon/src/daemon/worktree-probe.ts` reads a ref's sha straight off disk (loose ref file, else `packed-refs`) to avoid a `git` spawn on the daemon's 2-second worktree poll. For the `packed-refs` branch it built the set of ref names to match by taking each joined loose-ref *path* and stripping the git-dir prefix with a non-greedy regex:

```ts
const wanted = new Set(looseRefPaths(dirs, ref).map((p) => p.replace(/^.*?(refs\/)/, "$1")))
```

`/^.*?(refs\/)/` stops at the **first** `refs/` substring anywhere in the absolute path — which can fall inside a directory name, not the ref namespace. If the checkout's own path contains a `refs` segment — a repo under `prefs/`, a home dir like `/home/andrefs/…`, or a directory literally named `refs` — the match lands on that inner occurrence and yields a garbage key (e.g. `refs/proj/.git/refs/remotes/origin/main`). The real `packed-refs` entry (`refs/remotes/origin/main`) then never matches, so a ref that plainly exists reads as `null`.

Packed refs are the normal state after a clone or `git gc`, so this isn't an edge state. When it hits, `base-ref-cache.ts`'s `ladderFromFiles` silently drops `origin/main`/`origin/master` from the base ladder and `behind-cache.ts` loses its keyed shas, so the sidebar's base-drift and behind counts for those worktrees degrade or resolve against the wrong base branch. The loose-ref path was unaffected — only the packed lookup was broken.

## Fix

Derive the ref-name candidates directly from the ref (`refNameCandidates`) and match `packed-refs` entries on those names, dropping the fragile path round-trip entirely. `looseRefPaths` reuses the same helper, so loose and packed lookups can't disagree. Behavior is identical for any path without a `refs` substring; the path a repo sits under no longer changes what a ref resolves to.

## Verification

- Added a regression test (`test/daemon/worktree-probe.test.ts`) that inits a repo under a `prefs/`-nested path, runs `git pack-refs --all`, and asserts `readRefSha(dirs, "main")` returns the real sha. It **fails** on `main` (reads `null`) and **passes** with the fix.
- `bun run test:socket` for `worktree-probe`, `base-ref-cache`, `behind-cache` — 16 passed.
- `bun run lint` and `bun run typecheck` — both green.

## Follow-ups

- None required. `worktreeFingerprint` in the same file only `stat`s ref *files* (never keys on names), so it was never affected. The `git` spawn fallbacks in `base-ref-cache.ts` masked some of this in practice, which is why it went unnoticed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HbC85xT8YfJ1ZU3piocByj

---
_Generated by [Claude Code](https://claude.ai/code/session_01HbC85xT8YfJ1ZU3piocByj)_