### PR TITLE
fix: legacy state migration failed on every Windows launch

### DIFF
--- a/.changeset/olive-moons-repeat.md
+++ b/.changeset/olive-moons-repeat.md
@@ -1,0 +1,21 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Migrating a legacy `kobe` install to the Rove layout now succeeds on Windows.
+
+Every launch reported `state migration will retry: state.json: EPERM:
+operation not permitted, fsync` and then migrated nothing, so a machine
+upgrading from `kobe` kept its old settings, themes and attachments stranded
+under `~/.kobe` and `~/.config/kobe` forever — the failure left the completion
+marker unwritten, which is what makes the next launch retry, so the warning
+repeated indefinitely.
+
+The migration flushes each copied file before publishing it, and it was
+reopening the file read-only to do so. Windows backs `fsync` with
+`FlushFileBuffers`, which requires a writable handle and rejects a read-only
+one; POSIX flushes an `O_RDONLY` descriptor without complaint, so the bug was
+invisible everywhere CI runs. Because `copyFileSync` also carries the source
+file's mode onto the copy, a legacy file with no write bit defeats a writable
+reopen just as thoroughly — on Windows and POSIX alike. The flush now widens
+the temporary file's mode when it has to, then restores the mode it publishes.

--- a/packages/kobe/src/state/layout-migration.ts
+++ b/packages/kobe/src/state/layout-migration.ts
@@ -4,6 +4,7 @@ import { randomUUID } from "node:crypto"
 import type { Stats } from "node:fs"
 import {
   constants,
+  chmodSync,
   closeSync,
   copyFileSync,
   fsyncSync,
@@ -14,6 +15,7 @@ import {
   readdirSync,
   readlinkSync,
   renameSync,
+  statSync,
   symlinkSync,
   unlinkSync,
   writeFileSync,
@@ -80,12 +82,30 @@ function removeTemp(path: string): void {
   }
 }
 
+/**
+ * Flush a just-published temp file to disk.
+ *
+ * The handle must be WRITABLE: Windows backs fsync with FlushFileBuffers,
+ * which requires write access and returns EPERM on a read-only handle, while
+ * POSIX flushes an O_RDONLY descriptor happily. `copyFileSync` carries the
+ * source's mode onto the temp on both platforms, so a legacy file with no
+ * write bit yields a temp we cannot open "r+" either. The temp is exclusively
+ * ours (pid + uuid in the name), so widen it for the flush and restore the
+ * mode we intend to publish.
+ */
 function syncFile(path: string): void {
-  const handle = openSync(path, "r")
+  const mode = statSync(path).mode
+  const writable = (mode & 0o200) !== 0
+  if (!writable) chmodSync(path, mode | 0o200)
   try {
-    fsyncSync(handle)
+    const handle = openSync(path, "r+")
+    try {
+      fsyncSync(handle)
+    } finally {
+      closeSync(handle)
+    }
   } finally {
-    closeSync(handle)
+    if (!writable) chmodSync(path, mode)
   }
 }
 

--- a/packages/kobe/test/state/layout-migration.test.ts
+++ b/packages/kobe/test/state/layout-migration.test.ts
@@ -104,6 +104,27 @@ describe("migrateRoveStateLayout", () => {
     expect(readlinkSync(migrated)).toBe("base.json")
   })
 
+  // Regression: the temp file is flushed through a handle that must be
+  // writable on Windows, and `copyFileSync` carries the legacy file's mode
+  // onto it. A read-only source therefore breaks a naive "r" open (EPERM on
+  // Windows) and a naive "r+" open (EACCES on POSIX) alike.
+  test("migrates a read-only legacy file", () => {
+    root = mkdtempSync(join(tmpdir(), "rove-layout-"))
+    write(".config/kobe/state.json", "legacy prefs")
+    const source = join(root, ".config/kobe/state.json")
+    chmodSync(source, 0o444)
+
+    try {
+      const result = migrateRoveClientStateLayout({ ROVE_HOME_DIR: root })
+
+      expect(result.warnings).toEqual([])
+      expect(readFileSync(join(root, ".config/rove/state.json"), "utf8")).toBe("legacy prefs")
+      expect(existsSync(join(root, ".rove/.layout-client-migration-v1"))).toBe(true)
+    } finally {
+      chmodSync(source, 0o644)
+    }
+  })
+
   test.skipIf(process.platform === "win32")("leaves the marker absent after a partial failure and retries", () => {
     root = mkdtempSync(join(tmpdir(), "rove-layout-"))
     write(".kobe/settings/keybindings.yaml", "ctrl+x: task.close")


### PR DESCRIPTION
## What

Migrating a legacy `kobe` install to the Rove layout failed on every Windows launch with

```
[rove] state migration will retry: state.json: EPERM: operation not permitted, fsync
```

and migrated nothing. Because the failure leaves the completion marker unwritten, the next launch retried and failed again, forever — a machine upgrading from `kobe` kept its settings, themes and attachments stranded under `~/.kobe` and `~/.config/kobe`.

## Why

`syncFile` reopened each copied temp file **read-only** to `fsync` it. Windows backs `fsync` with `FlushFileBuffers`, which requires a writable handle and rejects a read-only one with EPERM. POSIX flushes an `O_RDONLY` descriptor fine, so the bug was invisible everywhere CI runs (ubuntu + macos only).

Simply switching to `"r+"` is not enough: `copyFileSync` carries the source file's mode onto the temp on both platforms, so a legacy file with no write bit (0444) defeats a writable reopen too — EACCES on POSIX, EPERM on Windows. The flush now widens the temp's mode when it has to, then restores the mode it publishes. The temp is exclusively ours (pid + uuid in its name), so this is safe.

## Verification

- `test/state/layout-migration.test.ts` on Windows: 6 failing → 2 failing. The remaining 2 create symlinks in test setup and need Developer Mode; they are environmental, not product bugs (the product catches its own `symlinkSync` failure).
- New regression test `migrates a read-only legacy file` — confirmed it fails against both the naive `"r"` and naive `"r+"` variants, passes with this change.
- `bun run test:fast` on Windows: failing-file set identical to `main` baseline (70 = 70), zero new failures.
- lint + typecheck clean.
- End-to-end on a real Windows machine with a leftover `~/.config/kobe/state.json`: warning gone, file migrated, marker written.

## Follow-ups (separate PRs)

- `scripts/check-changeset.mjs` builds `ROOT` from `new URL().pathname`, which yields `\C:\...` on Windows and breaks the pre-commit hook.
- A clipboard test writes files named after a mangled Windows path into `packages/kobe/`.
- CI has no Windows runner, which is how this shipped.
