### PR TITLE
fix: Windows dev-loop — pre-commit hook path and clipboard test path

### DIFF
--- a/packages/kobe/test/tui/clipboard-copy.test.ts
+++ b/packages/kobe/test/tui/clipboard-copy.test.ts
@@ -19,7 +19,10 @@ describe("pipeToClipboardCommand", () => {
   test("a command that accepts the text reports success, and gets all of it", async () => {
     const out = join(dir, "sink.txt")
     const text = "feat/some-branch\nwith a second line"
-    expect(await pipeToClipboardCommand(text, ["sh", "-c", `cat > ${out}`])).toBe(true)
+    // Single-quoted and forward-slashed: unquoted, `sh` eats the backslashes
+    // of a Windows path and `cat` lands `C:Users…sink.txt` in the cwd.
+    const shellPath = out.replaceAll("\\", "/")
+    expect(await pipeToClipboardCommand(text, ["sh", "-c", `cat > '${shellPath}'`])).toBe(true)
     expect(readFileSync(out, "utf8")).toBe(text)
   })
 

--- a/scripts/check-changeset.mjs
+++ b/scripts/check-changeset.mjs
@@ -20,8 +20,11 @@
 
 import { readFileSync, readdirSync, existsSync } from "node:fs"
 import { join, basename } from "node:path"
+import { fileURLToPath } from "node:url"
 
-const ROOT = new URL("..", import.meta.url).pathname
+// `fileURLToPath`, not `.pathname`: on Windows the latter is `/C:/…`, which
+// `join` turns into `\C:\…` and every fs call rejects with ENOENT.
+const ROOT = fileURLToPath(new URL("..", import.meta.url))
 const DIR = join(ROOT, ".changeset")
 
 /**


### PR DESCRIPTION
## What

Two small Windows breakages in the development loop. Neither changes published behavior, so no changeset (the `changeset-cap` gate only fires for `packages/*/src`).

### `scripts/check-changeset.mjs` — pre-commit hook could not run

`ROOT` came from `new URL("..", import.meta.url).pathname`. On Windows that is `/C:/Users/…`, and `join` turns it into `\C:\Users\…`, so `readdirSync(DIR)` fails:

```
ENOENT: no such file or directory, scandir '\C:\Users\jackson\rove\.changeset'
```

Use `fileURLToPath`, which is what `.pathname` is a shortcut for on POSIX.

### `test/tui/clipboard-copy.test.ts` — wrote junk files into `packages/kobe/`

The test passes a temp path unquoted into `sh -c "cat > ${out}"`. On Windows `sh` (Git Bash) consumes the backslashes as escapes, so `cat` receives `C:UsersjacksonAppDataLocalTemprove-clipboard-XXXXXXsink.txt`, creates it relative to the cwd (MSYS maps the illegal `:` to U+F03A), and the assertion then fails on ENOENT. Every test run left another such file in the package directory. Single-quote the path and use forward slashes.

## Verification (Windows 11, bun 1.4.2)

- `bun run changeset:check` — exit 0 (previously crashed before checking anything)
- `bun x vitest run test/tui/clipboard-copy.test.ts` — 5/5 pass, no stray files in `packages/kobe/`
- `bun run lint` — clean

Related: #931 (the fsync migration fix that surfaced these).
