### PR TITLE
ci: run the typecheck-and-test chain on windows-latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,6 +163,46 @@ jobs:
       - name: Build (kobe package)
         run: bun run build
 
+  windows:
+    # Windows is a supported platform (README) but until this job nothing in
+    # CI ran there, which is how a migration bug that fired on every Windows
+    # launch shipped unnoticed (#931). Mirrors typecheck-and-test's chain on
+    # windows-latest.
+    #
+    # HARVEST PHASE: the unit-test step is continue-on-error while this job
+    # collects the real Windows-failing set from a real runner. Once that set
+    # is pinned as a vitest exclude ratchet, drop continue-on-error so the
+    # job gates like the others.
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.13
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Lint (monorepo)
+        run: bun run lint
+
+      - name: No silent catch handlers in the TUI
+        run: node scripts/no-silent-catch.mjs
+
+      - name: Typecheck (kobe package)
+        run: bun run typecheck
+
+      - name: Unit tests (kobe package)
+        working-directory: packages/kobe
+        continue-on-error: true
+        run: bun run test:fast
+
+      - name: Build (kobe package)
+        run: bun run build
+
   docs-site:
     # The public docs site (packages/kobe-docs) had no CI coverage at all:
     # root `lint` and `typecheck` skip the package, and its only path to

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,12 +167,9 @@ jobs:
     # Windows is a supported platform (README) but until this job nothing in
     # CI ran there, which is how a migration bug that fired on every Windows
     # launch shipped unnoticed (#931). Mirrors typecheck-and-test's chain on
-    # windows-latest.
-    #
-    # HARVEST PHASE: the unit-test step is continue-on-error while this job
-    # collects the real Windows-failing set from a real runner. Once that set
-    # is pinned as a vitest exclude ratchet, drop continue-on-error so the
-    # job gates like the others.
+    # windows-latest. Test files that do not pass on Windows yet are listed
+    # in packages/kobe/test/windows-known-failing.txt (a shrink-only ratchet
+    # that vitest.config.ts excludes on win32) so this job gates on the rest.
     runs-on: windows-latest
     steps:
       - name: Checkout
@@ -197,7 +194,6 @@ jobs:
 
       - name: Unit tests (kobe package)
         working-directory: packages/kobe
-        continue-on-error: true
         run: bun run test:fast
 
       - name: Build (kobe package)

--- a/packages/kobe/test/exec/local-exec-host.test.ts
+++ b/packages/kobe/test/exec/local-exec-host.test.ts
@@ -33,7 +33,10 @@ describe("LocalExecHost", () => {
   })
 
   it("run executes in the given cwd with merged env and captures stdout", async () => {
-    const result = await host.run(["sh", "-c", "printf '%s' \"$KOBE_PROBE:$(pwd)\""], {
+    // `$PWD`, not `$(pwd)`: the subshell forks, and under a parallel test
+    // run MSYS sh on Windows CI occasionally fails that fork and exits with
+    // a raw 0x8000000x status. The variable carries the same answer.
+    const result = await host.run(["sh", "-c", "printf '%s' \"$KOBE_PROBE:$PWD\""], {
       cwd: dir,
       env: { KOBE_PROBE: "yes" },
     })

--- a/packages/kobe/test/windows-known-failing.txt
+++ b/packages/kobe/test/windows-known-failing.txt
@@ -1,0 +1,91 @@
+# Test files known to fail on windows-latest — the Windows CI ratchet.
+#
+# ci.yml's `windows` job excludes these so it can gate on everything else.
+# Harvested from a real windows-latest run (ci.yml run 34030859567, base
+# 6c12ee7f6). This list may only SHRINK: fix a file on Windows, delete its
+# line. Never add a line to get a PR green — fix the test or skipIf(win32)
+# the specific case with a reason.
+#
+# Lines are vitest exclude globs relative to packages/kobe. `#` comments and
+# blank lines are ignored.
+test/architecture/claude-plugin.test.ts
+test/architecture/package-distribution.test.ts
+test/cli/api-capability-symmetry.test.ts
+test/cli/api-dispatcher.test.ts
+test/cli/api-handlers-digest.test.ts
+test/cli/api-handlers-lifecycle.test.ts
+test/cli/api-handlers-more.test.ts
+test/cli/api-handlers-send.test.ts
+test/cli/api-handlers.test.ts
+test/cli/bun-runtime.test.ts
+test/cli/dev-sandbox-args.test.ts
+test/cli/hook-profile-cleanup.test.ts
+test/cli/index-add-remove-adopt.test.ts
+test/cli/plugin-bin-path.test.ts
+test/cli/plugin-install.test.ts
+test/cli/rename-compat.test.ts
+test/cli/repo-cmd.test.ts
+test/client/daemon-process.test.ts
+test/core/base-ref-cache.test.ts
+test/core/daemon-worktree-adapter.test.ts
+test/engine/account-detect-edge-cases.test.ts
+test/engine/binary-default-deps.test.ts
+test/engine/binary-discovery.test.ts
+test/engine/claude-history-incremental.test.ts
+test/engine/claude-usage-snapshot.test.ts
+test/engine/codex-copilot-history-incremental.test.ts
+test/engine/codex-history-edge-cases.test.ts
+test/engine/codex-local.test.ts
+test/engine/config-file-permissions.test.ts
+test/engine/config-write-safety.test.ts
+test/engine/copilot-history-edge-cases.test.ts
+test/engine/copilot-history.test.ts
+test/engine/engine-status.test.ts
+test/engine/file-bounds-race.test.ts
+test/engine/file-bounds-strict-sync.test.ts
+test/engine/kimi-history.test.ts
+test/engine/rollout-catalog.test.ts
+test/engine/session-discovery-limits.test.ts
+test/engine/session-launch.test.ts
+test/engine/transcript-bounds.test.ts
+test/engine/transcript-mtime.test.ts
+test/engine/trust-worktree.test.ts
+test/engine/vendor-home.test.ts
+test/env.test.ts
+test/lib/path-home.test.ts
+test/lib/skill-install.test.ts
+test/monitor/auto-title.test.ts
+test/orchestrator/adopt.test.ts
+test/orchestrator/branch-anchor.test.ts
+test/orchestrator/branch-follow.test.ts
+test/orchestrator/dir-task.test.ts
+test/orchestrator/ensure-worktree.test.ts
+test/orchestrator/failure-collapsed-to-neutral.test.ts
+test/orchestrator/git-runner.test.ts
+test/orchestrator/land.test.ts
+test/orchestrator/main-task.test.ts
+test/orchestrator/salvage-ignored.test.ts
+test/orchestrator/worktree-manager-edges.test.ts
+test/orchestrator/worktree-remote.test.ts
+test/orchestrator/worktree-remove-partial.test.ts
+test/orchestrator/worktree-salvage.test.ts
+test/orchestrator/worktree.test.ts
+test/plugins/events-pipeline.test.ts
+test/plugins/hook-bounds.test.ts
+test/plugins/lifecycle-events.test.ts
+test/plugins/plugin-file-modes.test.ts
+test/plugins/plugin-shutdown-isolation.test.ts
+test/plugins/registry.test.ts
+test/state/file-modes.test.ts
+test/state/project-eligibility.test.ts
+test/state/repos-roots.test.ts
+test/state/repos.test.ts
+test/tui-react/file-open-actions.test.ts
+test/tui-react/ops-preview-core.test.ts
+test/tui-react/ops-preview-paths.test.ts
+test/tui/lib/attachments.test.ts
+test/tui/pty-dispatch-budget.test.ts
+test/tui/render-path-sync-guard.test.ts
+test/tui/terminal-pipe-env.test.ts
+test/tui/terminal-pty-redraw-budget.test.ts
+test/tui/worktree-opener.test.ts

--- a/packages/kobe/vitest.config.ts
+++ b/packages/kobe/vitest.config.ts
@@ -20,8 +20,7 @@ if (!includeSocket) {
 // — see the header of test/windows-known-failing.txt.
 if (process.platform === "win32") {
   const listed = readFileSync(path.resolve(__dirname, "test/windows-known-failing.txt"), "utf8")
-    .split("
-")
+    .split("\n")
     .map((line) => line.trim())
     .filter((line) => line.length > 0 && !line.startsWith("#"))
   exclude.push(...listed)

--- a/packages/kobe/vitest.config.ts
+++ b/packages/kobe/vitest.config.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs"
 import path from "node:path"
 import { defineConfig } from "vitest/config"
 
@@ -13,6 +14,17 @@ const exclude: string[] = ["test/render/**"]
 if (!includeBehavior) exclude.push("test/behavior/**")
 if (!includeSocket) {
   exclude.push("test/daemon/**", "test/orchestrator/bridge.test.ts")
+}
+// Windows ratchet: files known to fail on windows-latest, harvested from
+// ci.yml's `windows` job so it can gate on the rest. The list may only shrink
+// — see the header of test/windows-known-failing.txt.
+if (process.platform === "win32") {
+  const listed = readFileSync(path.resolve(__dirname, "test/windows-known-failing.txt"), "utf8")
+    .split("
+")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0 && !line.startsWith("#"))
+  exclude.push(...listed)
 }
 
 export default defineConfig({

--- a/scripts/no-silent-catch.mjs
+++ b/scripts/no-silent-catch.mjs
@@ -30,7 +30,9 @@ const root = process.argv[2] ?? "packages/kobe/src/tui-react"
 function sources(dir) {
   const out = []
   for (const entry of readdirSync(dir)) {
-    const path = join(dir, entry)
+    // POSIX separators regardless of host: GRANDFATHERED is keyed by "/"
+    // paths, and GitHub's `::error file=` annotation wants them too.
+    const path = join(dir, entry).replaceAll("\\", "/")
     if (statSync(path).isDirectory()) out.push(...sources(path))
     else if (/\.tsx?$/.test(entry)) out.push(path)
   }


### PR DESCRIPTION
## What

Adds a `windows` job to CI that mirrors `typecheck-and-test` on `windows-latest`: install → lint → `no-silent-catch` → typecheck → `test:fast` → build.

Nothing in CI ran on Windows before this, although the README lists it as supported. That is how #931 (legacy-state migration failing on every Windows launch) shipped unnoticed.

Also fixes `scripts/no-silent-catch.mjs`, which sits on this chain and produced a false positive on Windows: `GRANDFATHERED` is keyed by `/` paths but `join` produced `\` ones, so the Set never matched and a grandfathered file was reported as a new violation. Paths are now normalised to POSIX at the source, which also makes the `::error file=` annotation GitHub-friendly.

## The ratchet

A first, `continue-on-error` run of this job on a real `windows-latest` runner (run 34030859567) reported **83 failing test files** out of 491. Two of those were fixed by #931/#932, which this branch has since been rebased onto. The remaining **81** are pinned in `packages/kobe/test/windows-known-failing.txt`; `vitest.config.ts` excludes them on `process.platform === "win32"` only, and the job now gates on the other 407 files exactly like the ubuntu chain.

The list is **shrink-only**: fix a file on Windows, delete its line. Never add a line to get a PR green — fix the test, or `skipIf(win32)` the specific case with a reason. The file header says the same.

The local dev-machine failure set (~70 files) differs from the runner's; the runner is the authority for this list.

## Verified

- windows-latest, harvest run: install, lint, `no-silent-catch` (exit 0 after the fix), typecheck and build all pass on the real runner.
- Windows 11 locally (bun 1.4.2): the ratchet loads, an excluded file is filtered, a non-excluded file runs, lint clean.

Related: #931, #932.
