### PR TITLE
docs: align eight user-doc claims with what the code does

### DIFF
--- a/.changeset/eight-doc-code-mismatches.md
+++ b/.changeset/eight-doc-code-mismatches.md
@@ -1,0 +1,19 @@
+---
+"@sma1lboy/rove": patch
+---
+
+**The user docs now match what the code does, in seven places they had drifted
+from.** The sidebar row stopped drawing the board status when the PR chip
+collapsed to three glyphs, but CONCEPTS still promised a status mark; the
+`ctrl+a p` table row described one chord as two actions when it is one handler
+that follows focus; the row menu's chord-less entries were counted as "four"
+and had grown to six; `KOBE_FILETREE_WATCH` never followed the rename to
+`ROVE_`; and the welcome panel's engine line has been three readings — usable,
+installed-but-signed-out, none — since it stopped calling a logged-out CLI
+ready, while TUI said only "detected".
+
+`--delete-branch` on `rove api delete` is now documented as what git actually
+does: `git branch -d`, so it keeps a branch neither the repo's HEAD nor the
+branch's upstream contains (work that was never pushed and never landed),
+`--force` upgrades it to `-D`, and **the remote branch is never touched** in
+any case. The outcome is in the daemon log, not the reply.

--- a/docs/API.md
+++ b/docs/API.md
@@ -826,9 +826,15 @@ nothing to do), `skipped_missed`, `skipped_unavailable`, and
   **`--delete-branch` is best-effort and its outcome is in the daemon log, not
   this reply.** `git branch -d` refuses a branch whose commits the base cannot
   reach — the ordinary case for work that never landed — and the removal
-  succeeds anyway, by design. The reply cannot carry that verdict: by the time
-  `--wait` resolves, the task row it would ride on has been removed, which is
-  how `--wait` knows the deletion finished. So a refusal is logged instead, as
+  succeeds anyway, by design. It is git's own rule, so a branch that was pushed
+  deletes even unmerged: `-d` also accepts anything the branch's upstream
+  already contains. `--force` upgrades the delete to `git branch -D` and takes
+  the unmerged case too. **Neither spelling touches the remote** —
+  `git push origin --delete <branch>` stays yours to run.
+
+  The reply cannot carry that verdict: by the time `--wait` resolves, the task
+  row it would ride on has been removed, which is how `--wait` knows the
+  deletion finished. So a refusal is logged instead, as
   `branch kept task <id> branch=<name> — git refused the delete: <reason>` in
   `~/.rove/daemon.log`, next to the `removed …` line. Check `git branch` if
   you need the answer programmatically.

--- a/docs/CONCEPTS.md
+++ b/docs/CONCEPTS.md
@@ -45,7 +45,8 @@ more: `canceled` does not stop a session or remove a worktree, and `done` does
 not close anything. Rove moves a Task from `backlog` to `in_progress` by itself
 when its engine starts a turn, and the system prompt asks the agent to set
 `in_review` when it finishes; everything past that is yours. The sidebar row
-shows the status as a mark once it leaves `backlog`/`in_progress`
+does not draw it: the one mark in that cell is the PR's, and the status is
+something you already know because you set it
 (see [TUI](./TUI.md#status-glyphs-in-the-sidebar)).
 
 **Delete is explicit and kind-aware.** A project-main Task cannot go through
@@ -55,7 +56,15 @@ managed Tasks. Deleting a directory Task removes only its Rove record, never
 the directory.
 Deleting a managed Task removes its worktree after the dirty-worktree safety
 check. **The task branch stays.** Git is the durable record of the work;
-pass `--delete-branch` on `rove api delete` to drop it too. The separate
+pass `--delete-branch` on `rove api delete` to drop it too. That runs
+`git branch -d`, which refuses a branch whose commits neither the repo's HEAD
+nor the branch's own upstream already contains — so work that was never pushed
+and never landed survives the flag, and `--force` is what upgrades the delete
+to `git branch -D`. **The remote branch is never touched** in any case:
+`git push origin --delete <branch>` stays yours to run. The reply reports only
+that the task was removed; whether the branch went is in the daemon log.
+
+The separate
 [Worktrees page](WORKTREES.md) is an audit/cleanup tool: removing a directory
 there keeps its Task record and branch so the worktree can be materialized
 again later. `rove api remove-worktree --task-id ID` is the same operation

--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -56,7 +56,7 @@ shows only actions that can run right now.
 | `ctrl+a` `1` / `2` / `3` | Kanban / Routines / Issues |
 | `ctrl+a` `z` | Toggle zen mode |
 | `ctrl+a` `,` | Open Settings |
-| `ctrl+a` `p` / `P` | Create a PR from the active task, or from the sidebar row under the cursor |
+| `ctrl+a` `p` (`P` is the same key) | Create a PR — for the active task, or for the row under the cursor while the sidebar has focus ([the focus rule](#sidebar-and-files)) |
 | `ctrl+a` `k` | Pull the failing PR checks' logs into the task's engine (**proposed — awaiting owner sign-off**) |
 | `ctrl+a` `u` | Merge the base branch into the task's worktree (**proposed — awaiting owner sign-off**) |
 
@@ -194,14 +194,17 @@ anywhere else, or `esc`, dismisses it. Common row actions also have direct
 chords. A Task or tab row also offers **New conversation** (the `ctrl+e`
 engine/shell picker) and **New shell** (a bare shell tab) for that worktree,
 both enter the Task first, exactly as pressing the chord there would.
-Four entries have no chord. **Set status** opens a picker over the six Task
-statuses and writes the one you choose. **Copy branch name** and **Copy path**
-put the Task's branch or recorded worktree path on the system clipboard (local
-clipboard command plus OSC 52, so it also works over SSH); copying never
-creates the worktree, and a project-main or directory row, whose stored branch
-is empty, offers only Copy path. **Land into base branch** runs the same land
-the Worktrees page's `l` does, and appears only on a managed Task row that has
-a branch — a project-main or directory row owns no Rove branch to land.
+These entries have no chord of their own. **Set status** opens a picker over
+the six Task statuses and writes the one you choose. **Copy branch name** and
+**Copy path** put the Task's branch or recorded worktree path on the system
+clipboard (local clipboard command plus OSC 52, so it also works over SSH);
+copying never creates the worktree, and a project-main or directory row, whose
+stored branch is empty, offers only Copy path. **Run again** re-fires the
+Task's stored brief as a new Task, and appears only on a row that recorded
+one. **Land into base branch** runs the same land the Worktrees page's `l`
+does, and appears only on a managed Task row that has a branch — a
+project-main or directory row owns no Rove branch to land. On a project
+header, **Field notes** reads the repo's durable notes (`rove api note`).
 **Open in editor**, **Rename branch**, and
 **Change engine** are the `o`, `b`, and `v` chords for the row you clicked;
 the engine entry opens a picker over your available engines instead of

--- a/docs/TUI.md
+++ b/docs/TUI.md
@@ -40,8 +40,14 @@ The Tasks rail remains visible. Below 70 columns, the separate
 With no tasks at all (a first launch, or all tasks deleted), the workspace
 column shows a welcome panel instead of an empty pane: the keys to create a
 task and open help (read from your live keymap, so rebinds show correctly),
-which engine CLIs were detected, and — when something is missing (no engine
-CLI, no git) — what to install, with `rove doctor` as the full diagnosis.
+and one line about the engines. That line reads one of three ways, because
+"installed" and "usable" are different questions: the engines that can run a
+task (installed **and** signed in), or — when none can — the ones that are
+installed but whose login Rove cannot find, or, failing that, none at all. It
+is the same `probeEngines` check `rove doctor` runs, so the two surfaces
+cannot reach opposite verdicts. When something is missing (no engine CLI, no
+git) the panel also says what to install, with `rove doctor` as the full
+diagnosis.
 Creating your first task replaces it with the normal workspace.
 
 ## Status glyphs in the sidebar
@@ -246,7 +252,7 @@ engine without submitting it, and `o` sends audio, video, or PDF files to the
 system application. Remote files cannot use a local system viewer.
 
 The pane watches local worktrees for changes and also supports `r` for an
-explicit refresh. Set `KOBE_FILETREE_WATCH=0` to turn the watcher off and leave
+explicit refresh. Set `ROVE_FILETREE_WATCH=0` to turn the watcher off and leave
 `r` as the only way to repopulate the list. See
 [Keybindings](KEYBINDINGS.md#sidebar-and-files) for the complete navigation
 table.

--- a/packages/kobe/src/tui/i18n/messages/tasks.ts
+++ b/packages/kobe/src/tui/i18n/messages/tasks.ts
@@ -38,8 +38,8 @@ export const en = {
     reorder: "Reorder row",
     /** Re-fire the task's stored brief as a new task. Menu-only. */
     runAgain: "Run again",
-    /** The one entry with no chord behind it — status has no key yet, so the
-     *  menu is its only route. */
+    /** Menu-only, like `runAgain`, `land`, `fieldNotes` and the two copies —
+     *  status has no key yet, so the menu is its only route. */
     setStatus: "Set status",
     /** Also chord-less: put the row's branch / worktree path on the clipboard. */
     copyBranch: "Copy branch name",


### PR DESCRIPTION
Eight doc/code mismatches, one pass. Ordered as investigated: **#8 first** (it decides #2), then #2, then the rest.

Every measurement below ran against an **isolated** harness fixture (`.scratch/opentui-visual-5473/home`, ports 5473-5475) or an isolated Rove home (`.scratch/puma-delbranch/home`). Nothing touched `~/.rove`.

---

## 8 — Do the four shipped `shift+<letter>` chords actually arrive? **All four do.**

Path: fixed-viewport Chromium → `/harness` → xterm.js → PTY sidecar → real OpenTUI (`packages/kobe-harness` `visual:shot`). Focus was placed by the runner's own sidebar click (footer reads `j/k move · ⏎ open`), and for `shift+D` by two explicit `ctrl+a l` (the Files pane picks up its focus border, and the chord log prints `ctrl+a + l → Focus next` twice).

**Positive control first** — the transport can carry Shift at all: rename dialog + `shift+q shift+w` typed **`QW`**, not `qw`.
`/tmp/puma-shots/E-shift-transport-probe.png`

| chord | id | verdict | decisive cell |
|---|---|---|---|
| `shift+p` | `sidebar.pin` | **live** | `▴` (warning tone) appears at the right of the cursor row |
| `shift+m` | `sidebar.localMerge` | **live** | blue `move` chip appears on the cursor row |
| `shift+g` | `sidebar.goto` slot 1 | **live** | cursor jumps from the top row to the bottom row |
| `shift+D` | `files.diffAll` | **live** | a workspace tab named `all` opens with `all files diff vs HEAD` and the README diff |

BEFORE/AFTER pairs (PNG, local):

```
A1-before-shift-p.png   A2-after-shift-p.png
B1-before-shift-m.png   B2-after-shift-m.png     (same one-task BEFORE as A1)
C1-before-shift-g.png   C2-after-shift-g.png
D1-before-shift-d.png   D2-after-shift-d.png
```
all under `/tmp/puma-shots/`.

`shift+g` needed a second row to be falsifiable — the stock fixture has exactly one task, and `pressShiftG()` is `jumpTo(getFlatIds().length - 1)`, so with one row it is a no-op indistinguishable from a dead key. A second task was seeded into the fixture's `tasks.json`, and then the result is byte-exact: `C2-after-shift-g.png` and `C3-control-j.png` (`j` from the top row) are the **same file hash** `80229ad7814c`, and both differ from `C1`.

**No chord is dead, so nothing gets downgraded to `keys: []`.**

### Does the harness send the kitty protocol, and what bytes does it send for `shift+<letter>`?

**No kitty protocol, and that is why the measurement is trustworthy.** `visual-shot.ts:chord()` maps a lone `shift+<letter>` to the **uppercase letter keypress**, so xterm.js emits the plain `0x44`-class byte a legacy terminal emits for Shift+D; opentui's parser turns `s >= "A" && s <= "Z"` back into `{name:"d", shift:true}`. This is already recorded in `docs/HARNESS.md` ("`shift+<letter>` is pressed as the uppercase letter") — it was a real false-negative source once, and it is fixed. The corollary still holds and is unchanged by this PR: **`ctrl+shift+<letter>` remains unmeasurable here**, because legacy terminals send it as the same C0 byte as the unshifted chord.

---

## 2 — `KEYBINDINGS.md:177` says `shift+D` is "proposed, awaiting sign-off" → **the doc is right. No change on either side.**

The brief's decision rule assumed "proposed" implies "not wired". #8 shows the third possibility, and it is the one the repo actually means:

- `keybindings-files.ts:95-96` — `// PROPOSED, awaiting owner sign-off (docs/design/keybinding-decisions.md).` on the `files.diffAll` entry, and `keys: ["shift+d"]`.
- `docs/design/keybinding-decisions.md:539` — `## PROPOSED (not decided): shift+D` … `Status: **proposed, awaiting owner sign-off.**` The open question is recorded as "whether a capital letter belongs in the Files table at all".
- The same shape ships twice more: `files.fixChecks` (`prefixKeys: ["k"]`) and `files.syncBase` (`prefixKeys: ["u"]`) both carry `PROPOSED CHORD — awaiting owner sign-off` **and** are bound, and `KEYBINDINGS.md:60-61` marks both exactly the way :177 marks `shift+D`.

So "proposed" in these tables means *the binding exists, the letter is not signed off* — consistently, in three places. Deleting "proposed" would report an open decision as settled and contradict a decisions doc I have no authority to close; clearing `keys` would be me making the chord call. **Left alone, surfaced here.** The one thing #8 adds is evidence the owner did not have: the chord reaches the pane in a real terminal transport, so the decision is purely about taste, not about whether it works.

---

## 1 — `CONCEPTS.md:48` "the sidebar row shows the status as a mark" → **doc fixed**

`row-chips.ts:33-41` `prChip()` returns only `≠` / `✗` / `✓`, and its module comment says the board status "draws nothing … because a human already knows it". `TUI.md:73-74` already said so. CONCEPTS was the straggler from #921 (e29c08f68). Rewrote the half-sentence to match, keeping the link to the TUI table.

## 3 — `KEYBINDINGS.md:59` writes `ctrl+a p` / `P` as two semantics → **doc fixed**

`host-keybindings.ts:158-163` is ONE handler that branches on focus (`focus.focused === "sidebar" ? cursorTaskId() : null`), and `keybindings-files.ts` registers `shift+p` as an uppercase alias on the same id (`prefixKeys: ["p", "shift+p"]`). The prose at `KEYBINDINGS.md:159-163` already stated the focus rule correctly. Table row now states the single semantic, marks `P` as the same key, and links to that prose.

## 4 — `CONCEPTS.md:58` "`--delete-branch` … to drop it too" → **doc fixed, and the measured rule is sharper than the brief's**

Three runs in an isolated home (`.scratch/puma-delbranch`, fake `origin` bare repo, task branch carrying one unmerged commit):

| case | branch state | flags | local branch after | remote branch after |
|---|---|---|---|---|
| A | unmerged, **never pushed** | `--delete-branch` | **kept** (`casea`) | — |
| B | unmerged, **pushed to origin** | `--delete-branch` | **gone** | **survives** (`caseb`) |
| C | unmerged, pushed | `--delete-branch --force` | **gone** | **survives** (`casec`) |

Case A's daemon log:

```
[task-deletion-audit]: branch kept task 01M1SMBMQSGJ6S7N7F5PZ9A4GN branch=casea
  — git refused the delete: error: the branch 'casea' is not fully merged
  hint: If you are sure you want to delete it, run 'git branch -D casea' …
```

and all three replies were just `{"taskId":"…","queued":true,"status":"removed"}` — the branch verdict is never in the reply.

So the qualifier is **git's `-d` rule**, not "unmerged needs `--force`": `git branch -d` also accepts a branch its own **upstream** contains, which is why case B deleted while case A did not. `--force` is what reaches `-D` (`manager-branch.ts:69`). And **the remote is never touched** — `git grep -nE "push[^\n]*--delete|:refs/heads" -- packages/kobe/src` is empty. Wrote all three facts into `CONCEPTS.md` and into the `delete` bullet in `API.md`, whose wording they now match.

`CLI.md` has no `rove api delete` passage to update (it documents the `rove` CLI, not `rove api`); `grep -n delete docs/CLI.md` hits only an SSH-password line and `reset --hard`.

## 5 — `TUI.md:240` `KOBE_FILETREE_WATCH=0` → **doc fixed**

`FileTree.tsx:241` reads `readRoveEnv("FILETREE_WATCH")`; `CLI.md:415` and `CONFIGURATION.md:104` already say `ROVE_`. Now: `git grep -n "KOBE_FILETREE_WATCH" -- docs` → empty.

## 6 — `KEYBINDINGS.md:197` "Four entries have no chord" → **doc fixed (it is six)**

Menu items in `tree-menu.ts` with no `bindingId`:

```
{ action: "newShell",   labelKey: "tasks.menu.newShell" }
{ action: "runAgain",   labelKey: "tasks.menu.runAgain" }
{ action: "setStatus",  labelKey: "tasks.menu.setStatus" }
{ action: "copyBranch", labelKey: "tasks.menu.copyBranch" }
{ action: "copyPath",   labelKey: "tasks.menu.copyPath" }
{ action: "land",       labelKey: "tasks.menu.land" }
{ action: "fieldNotes", labelKey: "tasks.menu.fieldNotes" }
```

`newShell` is deliberately outside the list — the module comment calls it "a row inside that dialog, not a chord of its own", and the preceding paragraph already describes it with **New conversation**. That leaves the six the module comment names (`setStatus`, the two copies, `fieldNotes`, `land`, `runAgain`). Dropped the hardcoded count and added **Run again** and **Field notes** to the list, so the documented set == the `bindingId`-absent set.

Also fixed the stale comment at `src/tui/i18n/messages/tasks.ts:41-42` ("The one entry with no chord behind it"). Comment only — no message string changed, so no locale sync was needed; `bun run check-i18n` → `930 keys × 2 locales in sync`.

## 7 — `TUI.md:36` "which engine CLIs were detected" → **doc fixed, with a shot**

`welcome-pane.tsx:88-96` is a three-way ternary, not a list: usable (installed **and** signed in) → else installed-but-signed-out → else none. `probeWelcomeEnv()` runs `probeableEngineIds() → detectEngineStatuses → summarizeEngines`, the same probe as `rove doctor`, and the code comment says why: every CLI installed and none logged in used to fall into the `✓` branch.

Captured both readings against an isolated home with no tasks:

- `/tmp/puma-shots/F1-welcome-engines-found.png` — `✓ engines: opencode · cursor`
- `/tmp/puma-shots/F2-welcome-signed-out.png` — `✗ installed but not signed in: claude · codex — run one of them in a shell and log in`, plus the `rove doctor` hint line

Two fixture facts worth recording for the next person: `setupVisualFixture()` **re-seeds** the Visual Fixture task on every `visual:serve`, so a zero-task capture must start `dev.ts` directly with `VISUAL_ENV` and skip the seeding step; and the signed-out branch is only reachable with `KOBE_VISUAL_MIN_PATH` set to a PATH without `/opt/homebrew/bin` and `/usr/local/bin`, because the contrib engines (`opencode`, `cursor`) resolve through `Bun.which` and have no account concept, so they keep `engines.length > 0` and hide the branch.

---

## Verification

- `bun run test:fast` — 485 files / 4789 tests passed
- root `bun run lint` — clean (1524 files)
- `bun run typecheck` — clean
- `bun run check-i18n` — 930 keys × 2 locales in sync
- No keybinding source changed, so the render track is untouched by this diff.

Changeset: `patch`.
