### PR TITLE
fix: five user-visible defects in task creation and activity badges

### DIFF
--- a/.changeset/lazy-pandas-repeat.md
+++ b/.changeset/lazy-pandas-repeat.md
@@ -1,0 +1,16 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Five user-visible fixes around task creation and activity badges. A task
+titled in a non-Latin script (Chinese, Japanese, emoji) now gets a branch
+keyed on its task id instead of every such task colliding on `task`,
+`task-2`, `task-3`. `add --branch` is checked against `git check-ref-format`
+before anything is created, so an unusable name is an `INVALID_BRANCH` with a
+hint rather than a raw git transcript at `ensure-worktree` and a backlog row
+that can never materialize. A task title is flattened to one line wherever
+titles are written, so a newline can no longer break a sidebar row's height.
+An engine whose adapter emits no hooks (copilot) no longer wears a `dead`
+badge forever after one death — fresh output in the tab now outranks it.
+And `add` reports `repoResolvedFrom` when `--repo` pointed at a subdirectory
+and resolved up to the repository root.

--- a/docs/API.md
+++ b/docs/API.md
@@ -140,6 +140,7 @@ Separate from the daemon's refusals above — these never cross the socket:
 | `TASK_NOT_FOUND` | An id WAS named and does not resolve. |
 | `TAB_NOT_FOUND` | A `--tab tab-N` the task has no live (or restorable) tab for. |
 | `NOT_A_REPO` | `--repo` does not point at a git repository. |
+| `INVALID_BRANCH` | `--branch` is a name git will not accept (`git check-ref-format --branch`). |
 | `REPO_UNRESOLVABLE` | `--repo` resolved, but the repository is gone or unreadable. |
 | `NO_WORKTREE` | The task has no materialized worktree yet. |
 | `BASE_CHECKOUT` | `delete` was aimed at the project's own checkout, not a Rove worktree. |
@@ -392,7 +393,17 @@ replacement in `nextCommandArgs`.
   auto-derived from the title following the repo's own branch-naming
   convention (inferred from its existing local + origin branches, e.g.
   `feat/login-flow` in a type-prefixed repo, `login-flow` in a bare-slug or
-  empty repo; name collisions get a short `-2`/`-3` suffix).
+  empty repo; name collisions get a short `-2`/`-3` suffix). A title that
+  kebab-cases to nothing — written in a non-Latin script, or all emoji /
+  punctuation — falls back to `task-<last 6 of the task id>`, so two such
+  tasks get two distinct names instead of `task` and `task-2`.
+  An explicit `--branch` is checked against `git check-ref-format --branch`
+  BEFORE the task is created; a name git would refuse is `INVALID_BRANCH`
+  and nothing is written.
+
+  A `--title` is flattened to one line: newlines, tabs and other control
+  characters collapse to single spaces (the sidebar row does not wrap, and a
+  raw newline breaks its height).
   `--base-branch` cuts the new branch from that ref instead of the repo's
   current HEAD and is persisted on the task (`.task.baseRef`) — the fork
   point `collect` measures against, durable across daemon restarts. The

--- a/docs/API.md
+++ b/docs/API.md
@@ -401,6 +401,11 @@ replacement in `nextCommandArgs`.
   BEFORE the task is created; a name git would refuse is `INVALID_BRANCH`
   and nothing is written.
 
+  `--repo` is resolved to the repository root, so a path pointing at a
+  SUBDIRECTORY is accepted and climbs. When it does, the result carries
+  `repoResolvedFrom` with the path you passed — absent when `--repo` already
+  named the root.
+
   A `--title` is flattened to one line: newlines, tabs and other control
   characters collapse to single spaces (the sidebar row does not wrap, and a
   raw newline breaks its height).

--- a/packages/kobe-daemon/src/daemon/activity-arbitrate.ts
+++ b/packages/kobe-daemon/src/daemon/activity-arbitrate.ts
@@ -19,14 +19,18 @@
  * `recomputeTabActivity` is the ONE place the priority order lives — add a
  * source by adding a slot and a rule here, never by special-casing a writer:
  *
+ *   0. an observed `running` newer than a hook `dead` wins — see rule 1.
  *   1. a hook entry in a STICKY state (`turn_complete` / `permission_needed`
  *      / `error` / `rate_limited` / `dead`) always wins — those mean "a human
  *      should look", carry no output by nature, and observation must never dim
  *      them. `dead` is the strongest case: the process is GONE, so no live
- *      claim about it can be true, and observation can only ever answer "at
- *      rest" — which is precisely what made a killed engine read as an idle
- *      one. It is displaced only by a newer hook event, i.e. a new session in
- *      the same tab.
+ *      claim about it can be true, and an observed REST about it says nothing
+ *      new — which is precisely what made a killed engine read as an idle one.
+ *      Its one escape (rule 0) is an observed `running` newer than the death:
+ *      a dead process emits no output, so that fact can only come from a new
+ *      engine in the tab. Needed because an engine with a `NoopHookAdapter`
+ *      never emits the session-start that would otherwise displace the slot,
+ *      leaving its badge `dead` for the life of the daemon.
  *   2. a hook `running` wins UNLESS an observed `rest` fact is fresher than
  *      the claim (herdr's `fallback_not_older_than_hook` — a stale
  *      observation must never idle a fresh turn) AND the claim is at least
@@ -120,6 +124,20 @@ export function recomputeTabActivity(
 ): EffectiveActivity | undefined {
   const { hook, observed } = slots
   if (hook) {
+    // `dead` is sticky because a dead engine writes nothing — but that
+    // reasoning inverts the moment observation sees NEW output in the tab:
+    // a dead process cannot produce any. For an engine with hooks the slot
+    // clears on the next session-start; an engine with a `NoopHookAdapter`
+    // (copilot) never emits one, so its `dead` badge — written by the
+    // pty-exit record, which needs no hook — outlived every restart forever.
+    // Only `running` may win, and only if it was observed AFTER the death:
+    // a shell still alive around a genuinely dead engine walks as idle, and
+    // idle must not un-dim the badge. The observer's own vendor gate does
+    // the rest — it claims `working` only for a walked engine in the tab's
+    // foreground, never for a bare shell.
+    if (hook.state === "dead" && observed?.state === "running" && observed.at > hook.at) {
+      return fromObserved(observed, hook)
+    }
     if (STICKY_STATES.has(hook.state)) return fromHook(hook)
     if (
       hook.state === "running" &&

--- a/packages/kobe-daemon/src/daemon/activity-registry.ts
+++ b/packages/kobe-daemon/src/daemon/activity-registry.ts
@@ -307,9 +307,9 @@ export class DaemonActivityRegistry {
     )
     if (!effective) return "noop" // unreachable — the observed slot was just written
 
-    // A hook `running` that observation just DISPROVED is dead — retire the
-    // slot (and its watchdog) instead of leaving it to win the next
-    // arbitration. Keeping it resurrects the corrected tab as a phantom
+    // A hook claim that observation just DISPROVED — a `running` corrected to
+    // rest, or a `dead` outlived by fresh output — is retired along with its
+    // watchdog, instead of being left to win the next arbitration. Keeping it resurrects the corrected tab as a phantom
     // `running` on the very next ungated pass (the host-unreachable retire
     // path passes no correction gate, so the Infinity default re-elects the
     // stale claim at its original `at`), and its lapse watchdog then re-arms

--- a/packages/kobe-daemon/src/daemon/channels.ts
+++ b/packages/kobe-daemon/src/daemon/channels.ts
@@ -64,10 +64,12 @@ export interface ChannelPayloads {
    * request/response RPCs instead. The channel stays because it is a public
    * plugin API — it is in `DAEMON_CHANNELS` (`kobe-plugin-sdk`) and
    * documented in `docs/PLUGIN-SDK.md`, so out-of-repo subscribers nobody
-   * here can enumerate depend on it. If the cost of publishing a full
-   * snapshot per task mutation ever shows up in a profile, gate the publish
-   * on `lifetime.hasSubscribersFor("issue.snapshot")` — the same gate
-   * `startDaemonCollectors` uses — rather than removing the channel.
+   * here can enumerate depend on it. So the publish is GATED rather than
+   * removed: every writer goes through `publishIssueSnapshot`
+   * (`handlers-issues.ts`), which asks `lifetime.hasSubscribersFor` — the
+   * same per-channel gate `startDaemonCollectors` uses — before serializing a
+   * repo's whole issue state. With nobody attached it costs nothing; with a
+   * plugin attached it behaves exactly as before.
    */
   "issue.snapshot": RepoIssues
   /**

--- a/packages/kobe-daemon/src/daemon/handlers-issues.ts
+++ b/packages/kobe-daemon/src/daemon/handlers-issues.ts
@@ -3,7 +3,30 @@
  *  from one truth instead of patching its own copy. */
 
 import { requireString } from "./handler-validators.ts"
-import type { DaemonRequestHandler } from "./handlers.ts"
+import type { DaemonHandlerContext, DaemonRequestHandler } from "./handlers.ts"
+import type { RepoIssues } from "./issues-store.ts"
+
+/**
+ * Publish a repo's issue snapshot — but only when somebody is subscribed to
+ * the channel.
+ *
+ * `issue.snapshot` has no in-repo subscriber (its one consumer, the browser
+ * Issues pane, was deleted in #855; the TUI kanban uses the `issue.list` /
+ * `issue.mutate` RPCs). The channel survives because it is a public plugin
+ * API, so out-of-repo subscribers nobody here can enumerate may hold it — but
+ * with nobody attached, every task delete, every task→done transition and
+ * every issue edit was serializing a repo's ENTIRE issue state for no reader.
+ * `channels.ts` named this exact gate as the fix; this is it.
+ *
+ * `hasSubscribersFor` is optional on the context (older test doubles omit the
+ * whole thing), and its absence must mean "publish" — the safe direction: a
+ * missing gate costs one wasted publish, a wrongly-closed one silently drops a
+ * plugin's events.
+ */
+export function publishIssueSnapshot(ctx: DaemonHandlerContext, state: RepoIssues): void {
+  if (ctx.daemon.hasSubscribersFor?.("issue.snapshot") === false) return
+  ctx.bus.publish("issue.snapshot", state)
+}
 
 export const ISSUE_HANDLERS: readonly DaemonRequestHandler[] = [
   {
@@ -45,8 +68,7 @@ export const ISSUE_HANDLERS: readonly DaemonRequestHandler[] = [
         }
       }
       const state = await ctx.issues.mutate(repoRoot, payload.op)
-      // Write-only in this repo; kept as a plugin API — see `channels.ts`.
-      ctx.bus.publish("issue.snapshot", state)
+      publishIssueSnapshot(ctx, state)
       ctx.plugins?.handleUiReport({
         kind: "issue.changed",
         detail: {

--- a/packages/kobe-daemon/src/daemon/handlers-task.ts
+++ b/packages/kobe-daemon/src/daemon/handlers-task.ts
@@ -14,6 +14,7 @@
 
 import { logDaemonError } from "./crash-log.ts"
 import { optionalBoolean, optionalString, optionalVendor, requireString } from "./handler-validators.ts"
+import { publishIssueSnapshot } from "./handlers-issues.ts"
 import type { DaemonHandlerContext, DaemonRequestHandler } from "./handlers.ts"
 import { serializeTask } from "./protocol.ts"
 import { auditDeletionRequested } from "./task-deletion-audit.ts"
@@ -164,8 +165,7 @@ export const TASK_HANDLERS: readonly DaemonRequestHandler[] = [
       if (task) {
         try {
           const next = await ctx.issues.unlinkTask(task.repo, taskId)
-          // Write-only in this repo; kept as a plugin API — see `channels.ts`.
-          if (next) ctx.bus.publish("issue.snapshot", next)
+          if (next) publishIssueSnapshot(ctx, next)
         } catch (err) {
           logDaemonError("issue-delete-unlink", err)
         }
@@ -270,8 +270,7 @@ export const TASK_HANDLERS: readonly DaemonRequestHandler[] = [
       if (status === "done" && prevStatus !== "done" && linked) {
         try {
           const next = await ctx.issues.mirrorTaskDone(linked.repo, taskId)
-          // Write-only in this repo; kept as a plugin API — see `channels.ts`.
-          if (next) ctx.bus.publish("issue.snapshot", next)
+          if (next) publishIssueSnapshot(ctx, next)
         } catch (err) {
           logDaemonError("issue-done-mirror", err)
         }

--- a/packages/kobe-daemon/src/daemon/handlers.ts
+++ b/packages/kobe-daemon/src/daemon/handlers.ts
@@ -33,6 +33,7 @@ import type { DaemonActivityRegistry } from "./activity-registry.ts"
 import type { AgentTurnsStore } from "./agent-turns-store.ts"
 import type { AttentionInboxStore } from "./attention-inbox.ts"
 import type { AutomationsStore } from "./automations-store.ts"
+import type { ChannelName } from "./channels.ts"
 import type { DaemonOrchestrator } from "./contracts.ts"
 import { logDaemonError } from "./crash-log.ts"
 import type { DeferredPromptsStore } from "./deferred-prompts-store.ts"
@@ -146,6 +147,11 @@ export interface DaemonHandlerContext {
      *  whichever client hosts the session, so this — not the GUI refcount —
      *  is what says a dispatch could reach anyone. */
     clientCount(): number
+    /** Is anyone subscribed who would actually RECEIVE a publish on this
+     *  channel? The same per-channel gate the background collectors use, so a
+     *  handler can skip building a payload nobody is listening for. Absent in
+     *  older test doubles — treat `undefined` as "publish anyway". */
+    hasSubscribersFor?(channel: ChannelName): boolean
     /** Graceful self-stop (`daemon.stop`). The reason rides out on the
      *  `daemon.stopping` broadcast — see {@link DaemonStopReason}. */
     stopSoon(reason?: DaemonStopReason): Promise<void>

--- a/packages/kobe-daemon/src/daemon/server.ts
+++ b/packages/kobe-daemon/src/daemon/server.ts
@@ -414,6 +414,7 @@ async function startOwnedServer(
         pid: process.pid,
         guiCount: () => lifetime.guiCount(),
         clientCount: () => clients.size,
+        hasSubscribersFor: (channel) => lifetime.hasSubscribersFor(channel),
         stopSoon,
         reevaluateIdle: () => lifetime.reevaluateIdle(),
       },

--- a/packages/kobe/src/cli/api/handlers-add.ts
+++ b/packages/kobe/src/cli/api/handlers-add.ts
@@ -72,7 +72,8 @@ async function applyPostCreateFlags(daemon: DaemonRpc, taskId: string, args: Ver
 
 export async function add(ctx: VerbContext): Promise<unknown> {
   const { args, runtime } = ctx
-  const repo = await runtime.resolveRepoRoot(args.requireRepo("repo"))
+  const requestedRepo = args.requireRepo("repo")
+  const repo = await runtime.resolveRepoRoot(requestedRepo)
   // A task's isolation unit is a git worktree + branch, so a `--repo` that is
   // not a git repo has nothing to cut one from. Without this the create
   // SUCCEEDS: `resolveRepoRoot` falls back to the path verbatim, the row
@@ -103,8 +104,22 @@ export async function add(ctx: VerbContext): Promise<unknown> {
   }
   const count = args.int("count")
   const agentsSpec = args.str("agents")
-  if (count !== undefined || agentsSpec) return addParallel(ctx, repo, count, agentsSpec)
-  return addOne(ctx, repo)
+  // A `--repo` pointing at a SUBDIRECTORY resolves up to the repo root, and
+  // said nothing about it: `--repo my-repo/packages/app/src` came back as
+  // `"repo": "…/my-repo"` with no trace of the four levels it climbed, so a
+  // typo'd path and an intended one produce identical output. Reported
+  // beside `identityWarning` — the other "we accepted this, but not as you
+  // wrote it" field.
+  //
+  // Gated on ANCESTRY, not on `!==`: `resolveRepoRoot` shells git, which
+  // reports the realpath, so a plain `--repo /tmp/x` on macOS comes back as
+  // `/private/tmp/x` and a `!==` test would flag every correct path there.
+  // A symlink rewrite is not a prefix of the path it rewrote; a climbed-out-of
+  // subdirectory always is.
+  const resolvedFrom = requestedRepo.startsWith(`${repo}/`) ? { repoResolvedFrom: requestedRepo } : undefined
+  const result =
+    count !== undefined || agentsSpec ? await addParallel(ctx, repo, count, agentsSpec) : await addOne(ctx, repo)
+  return resolvedFrom && result && typeof result === "object" ? { ...result, ...resolvedFrom } : result
 }
 
 async function addOne(ctx: VerbContext, repo: string): Promise<unknown> {

--- a/packages/kobe/src/cli/api/handlers-add.ts
+++ b/packages/kobe/src/cli/api/handlers-add.ts
@@ -88,13 +88,20 @@ export async function add(ctx: VerbContext): Promise<unknown> {
       helpStep("add"),
     )
   }
+  const count = args.int("count")
+  const agentsSpec = args.str("agents")
+  const parallel = count !== undefined || agentsSpec !== undefined
   // `--branch` was type-checked and passed straight through, so an unusable
   // name landed in the store and `add` still exited 0. The failure surfaced
   // at `ensure-worktree` as a raw `git worktree add` transcript under
   // `RPC_ERROR` — no code naming the cause, no hint, and a backlog row left
   // behind that can never materialize. git is asked here, before anything is
   // created, because git is what runs `worktree add -b` later.
-  const branch = args.str("branch")
+  //
+  // Skipped for a parallel round, which refuses `--branch` outright further
+  // down: siblings cannot share one branch, and "you cannot pass this flag
+  // here at all" is the more useful answer than "this name is malformed".
+  const branch = parallel ? undefined : args.str("branch")
   if (branch && !(await runtime.isValidBranchName(branch))) {
     throw new ApiError(
       `--branch ${JSON.stringify(branch)} is not a valid git branch name (no spaces, no leading "-", no "..", "~^:?*[\\", no trailing ".lock") — see \`git check-ref-format --branch\``,
@@ -102,8 +109,6 @@ export async function add(ctx: VerbContext): Promise<unknown> {
       helpStep("add"),
     )
   }
-  const count = args.int("count")
-  const agentsSpec = args.str("agents")
   // A `--repo` pointing at a SUBDIRECTORY resolves up to the repo root, and
   // said nothing about it: `--repo my-repo/packages/app/src` came back as
   // `"repo": "…/my-repo"` with no trace of the four levels it climbed, so a
@@ -117,8 +122,7 @@ export async function add(ctx: VerbContext): Promise<unknown> {
   // A symlink rewrite is not a prefix of the path it rewrote; a climbed-out-of
   // subdirectory always is.
   const resolvedFrom = requestedRepo.startsWith(`${repo}/`) ? { repoResolvedFrom: requestedRepo } : undefined
-  const result =
-    count !== undefined || agentsSpec ? await addParallel(ctx, repo, count, agentsSpec) : await addOne(ctx, repo)
+  const result = parallel ? await addParallel(ctx, repo, count, agentsSpec) : await addOne(ctx, repo)
   return resolvedFrom && result && typeof result === "object" ? { ...result, ...resolvedFrom } : result
 }
 

--- a/packages/kobe/src/cli/api/handlers-add.ts
+++ b/packages/kobe/src/cli/api/handlers-add.ts
@@ -87,6 +87,20 @@ export async function add(ctx: VerbContext): Promise<unknown> {
       helpStep("add"),
     )
   }
+  // `--branch` was type-checked and passed straight through, so an unusable
+  // name landed in the store and `add` still exited 0. The failure surfaced
+  // at `ensure-worktree` as a raw `git worktree add` transcript under
+  // `RPC_ERROR` — no code naming the cause, no hint, and a backlog row left
+  // behind that can never materialize. git is asked here, before anything is
+  // created, because git is what runs `worktree add -b` later.
+  const branch = args.str("branch")
+  if (branch && !(await runtime.isValidBranchName(branch))) {
+    throw new ApiError(
+      `--branch ${JSON.stringify(branch)} is not a valid git branch name (no spaces, no leading "-", no "..", "~^:?*[\\", no trailing ".lock") — see \`git check-ref-format --branch\``,
+      "INVALID_BRANCH",
+      helpStep("add"),
+    )
+  }
   const count = args.int("count")
   const agentsSpec = args.str("agents")
   if (count !== undefined || agentsSpec) return addParallel(ctx, repo, count, agentsSpec)

--- a/packages/kobe/src/cli/api/runtime.ts
+++ b/packages/kobe/src/cli/api/runtime.ts
@@ -394,6 +394,7 @@ export const defaultApiRuntime: ApiRuntime = {
     const { isGitRepo, isRemoteRepoKey } = await import("../../state/repos.ts")
     return isRemoteRepoKey(absPath) || isGitRepo(absPath)
   },
+  isValidBranchName: async (branch) => (await import("../../state/repos.ts")).isValidBranchName(branch),
   defaultVendor: async (repo) => {
     const { getGlobalDefaultVendor, getRepoLastActiveVendor } = await import("../../state/vendor-prefs.ts")
     return (repo ? getRepoLastActiveVendor(repo) : undefined) ?? getGlobalDefaultVendor()

--- a/packages/kobe/src/cli/api/types.ts
+++ b/packages/kobe/src/cli/api/types.ts
@@ -372,6 +372,10 @@ export interface ApiRuntime {
    *  handler test need a real repo on disk. Remote (`ssh://…`) keys answer true:
    *  the remote-add flow validates those. */
   isUsableRepo(absPath: string): Promise<boolean>
+  /** Would git accept this as a branch name? On the same seam and for the
+   *  same reason as {@link isUsableRepo}: the answer comes from `git
+   *  check-ref-format`, and handler tests must not have to spawn git. */
+  isValidBranchName(branch: string): Promise<boolean>
   /** Preferred engine for new tasks in `repo`; undefined delegates to daemon defaults. */
   defaultVendor(repo?: string): Promise<VendorId | undefined>
   /** Uncommitted +/− counts for a worktree; `null` when git could not be

--- a/packages/kobe/src/engine/claude-code-local/capabilities.ts
+++ b/packages/kobe/src/engine/claude-code-local/capabilities.ts
@@ -12,6 +12,5 @@ import type { EngineCapabilities, EngineIdentity } from "@/types/engine"
 export const claudeCapabilities: EngineCapabilities = {}
 
 export const claudeIdentity: EngineIdentity = {
-  vendorId: "claude",
   shortName: "Claude",
 }

--- a/packages/kobe/src/engine/codex-local/capabilities.ts
+++ b/packages/kobe/src/engine/codex-local/capabilities.ts
@@ -11,6 +11,5 @@ export const codexCapabilities: EngineCapabilities = {
 }
 
 export const codexIdentity: EngineIdentity = {
-  vendorId: "codex",
   shortName: "Codex",
 }

--- a/packages/kobe/src/engine/codex-local/history-parse.ts
+++ b/packages/kobe/src/engine/codex-local/history-parse.ts
@@ -292,6 +292,16 @@ function normalizeCodexToolResult(
   return { role: "user", blocks: [block], timestamp, sessionId }
 }
 
+/**
+ * Statuses a rollout's single-record tool is NOT reporting a failure with.
+ * `completed` is what a successful record carries; `in_progress` is the
+ * Responses-API "still running", which is not a failure either. Anything
+ * else — `failed` in the wild, `incomplete` in the API's own enum — is.
+ * Written as an allow-list so a spelling nobody here has seen reads as an
+ * error rather than silently as a success.
+ */
+const CODEX_OK_STATUSES: ReadonlySet<string> = new Set(["completed", "in_progress"])
+
 function normalizeSingleRecordTool(
   payload: Record<string, unknown>,
   timestamp: string,
@@ -303,13 +313,26 @@ function normalizeSingleRecordTool(
   const name = stringOr(payload.name, type)
   const input = stripPayload(payload, ["type", "call_id", "status"])
   const output = stripPayload(payload, ["type", "call_id"])
+  // This record carries its own verdict — the same `status` the line above
+  // strips out of the tool ARGUMENTS, because it is metadata about the call
+  // rather than an argument to it. It used to be dropped on both sides and
+  // the result was hard-coded `isError: false`, so a failed web search or
+  // local shell call rendered in the transcript as a success.
+  //
+  // The `*_output` paths (`normalizeCodexToolResult`) genuinely cannot do
+  // this: `custom_tool_call_output` / `function_call_output` records are
+  // `{type, id, call_id, output}` and carry no verdict at all. Codex records
+  // theirs on `item_completed.item.status`, a record type this parser does
+  // not read.
+  const status = payload.status
+  const isError = typeof status === "string" && !CODEX_OK_STATUSES.has(status)
   return {
     role: "assistant",
     timestamp,
     sessionId,
     blocks: [
       { type: "tool_call", callId, name, input },
-      { type: "tool_result", callId, output, isError: false },
+      { type: "tool_result", callId, output, isError },
     ],
   }
 }

--- a/packages/kobe/src/engine/plugin-engines.ts
+++ b/packages/kobe/src/engine/plugin-engines.ts
@@ -34,7 +34,6 @@ export function loadPluginEngines(homeDir?: string): readonly string[] {
           // shortName falls back to the engine's display name — a plugin
           // declaring nothing still gets a sensible label.
           const identity = {
-            vendorId: engine.id,
             shortName: engine.identity?.shortName ?? engine.name,
           }
           const ok = registerPluginEngine(engine.id, {

--- a/packages/kobe/src/orchestrator/branch-style.ts
+++ b/packages/kobe/src/orchestrator/branch-style.ts
@@ -100,19 +100,41 @@ function capSlug(tokens: readonly string[]): string {
 }
 
 /**
+ * Fallback slug for a title that kebab-cases down to nothing.
+ *
+ * `slugTokens` keeps only `[a-z0-9]`, so EVERY title written in a non-Latin
+ * script — Chinese, Japanese, Korean, Cyrillic — plus emoji-only and
+ * punctuation-only titles reduce to zero tokens. The old fallback was the
+ * constant `"task"`, so those titles didn't just lose their meaning, they
+ * all collided: `uniqueBranchName` handed the second one `task-2` and the
+ * third `task-3`, and a sidebar of Chinese-titled tasks read as a numbered
+ * pile whose branch names said nothing about which was which.
+ *
+ * The task id is the one thing that distinguishes them without inventing a
+ * transliteration. Same 6-char suffix `uniqueBranchName` already falls back
+ * to, so the two last resorts read alike.
+ */
+function identitySlug(taskId: string): string {
+  return `task-${taskId.slice(-6).toLowerCase()}`
+}
+
+/**
  * Derive a convention-following branch name from a task title. In a typed
  * repo, a leading type word in the title becomes the prefix ("Fix login
  * flow" → `fix/login-flow`); otherwise the repo's most common prefix is
- * used. In a bare repo the slug stands alone. Empty slug → "task".
+ * used. In a bare repo the slug stands alone. A title with no slug-able
+ * characters falls back to {@link identitySlug}, which is why `taskId` is
+ * required rather than optional — a caller that could omit it would get the
+ * colliding constant back.
  */
-export function deriveConventionBranch(title: string, style: BranchStyle): string {
+export function deriveConventionBranch(title: string, style: BranchStyle, taskId: string): string {
   const tokens = slugTokens(title)
   if (style.kind === "typed") {
     const first = tokens[0]
     const prefix = first !== undefined && TYPE_PREFIXES.has(first) ? (tokens.shift() as string) : style.defaultPrefix
-    return `${prefix}/${capSlug(tokens) || "task"}`
+    return `${prefix}/${capSlug(tokens) || identitySlug(taskId)}`
   }
-  return capSlug(tokens) || "task"
+  return capSlug(tokens) || identitySlug(taskId)
 }
 
 /**

--- a/packages/kobe/src/orchestrator/core-create.ts
+++ b/packages/kobe/src/orchestrator/core-create.ts
@@ -17,7 +17,7 @@ import { canonPath, normalizeMainRepo, randomDirTaskSuffix, titleFromRepo } from
 import type { CreateTaskInput } from "./create-task-input.ts"
 import type { TaskIndexStore } from "./index/store.ts"
 import type { MainTaskCoordinator } from "./main-task.ts"
-import { PLACEHOLDER_TASK_TITLE } from "./title.ts"
+import { PLACEHOLDER_TASK_TITLE, sanitizeTaskTitle } from "./title.ts"
 
 /** The store alone — all a directory/scratch row needs. */
 export interface StoreDeps {
@@ -66,7 +66,7 @@ export async function createTaskRow(deps: CreateDeps, input: CreateTaskInput): P
   // so pinning a user-owned directory is unaffected.
   const mainTask = await deps.mainTasks.ensureIfEligible(input.repo, input.projectIntent ?? "explicit")
   const repo = mainTask?.repo ?? normalizeMainRepo(input.repo).repo
-  const title = (input.title ?? PLACEHOLDER_TASK_TITLE).trim() || PLACEHOLDER_TASK_TITLE
+  const title = sanitizeTaskTitle(input.title ?? PLACEHOLDER_TASK_TITLE) || PLACEHOLDER_TASK_TITLE
   // Leave the branch EMPTY for a lazily-allocated task (unless the caller
   // gave an explicit one): {@link ensureWorktree} derives a repo-convention
   // name (branch-style.ts) with collision suffixes when the worktree

--- a/packages/kobe/src/orchestrator/task-editor.ts
+++ b/packages/kobe/src/orchestrator/task-editor.ts
@@ -24,7 +24,7 @@ import type {
 import { deriveConventionBranch, inferBranchStyle, uniqueBranchName } from "./branch-style.ts"
 import { IllegalTransitionError, TaskNotFoundError } from "./errors.ts"
 import type { TaskIndexStore } from "./index/store.ts"
-import { isPlaceholderDerivedBranch } from "./title.ts"
+import { isPlaceholderDerivedBranch, sanitizeTaskTitle } from "./title.ts"
 import type { GitWorktreeManager } from "./worktree/manager.ts"
 
 /**
@@ -49,7 +49,7 @@ export class TaskEditor {
    *  SCRATCH task is the "keep this" gesture — it clears the
    *  flag, so the row survives its shell exiting. */
   async setTitle(id: TaskId | string, title: string): Promise<void> {
-    const trimmed = title.trim()
+    const trimmed = sanitizeTaskTitle(title)
     if (!trimmed) throw new Error("setTitle: title is required (empty or whitespace-only rejected)")
     const task = this.requireTask(id)
     if (task.title === trimmed && task.scratch !== true) return
@@ -82,7 +82,7 @@ export class TaskEditor {
     if (!isPlaceholderDerivedBranch(taskBefore.branch, taskBefore.id)) return
     try {
       const names = await this.worktrees.listBranchNames(taskBefore.repo)
-      const base = deriveConventionBranch(newTitle, inferBranchStyle(names))
+      const base = deriveConventionBranch(newTitle, inferBranchStyle(names), taskBefore.id)
       if (base === taskBefore.branch) return
       if (await this.worktrees.branchHasUpstream(taskBefore.worktreePath, taskBefore.branch)) return
       // Exclude the branch we're renaming FROM so a placeholder like

--- a/packages/kobe/src/orchestrator/title.ts
+++ b/packages/kobe/src/orchestrator/title.ts
@@ -24,6 +24,29 @@ export const TITLE_CHAR_CAP = 40
 export const PLACEHOLDER_TASK_TITLE = "(new task)"
 
 /**
+ * Flatten a title to a single line and trim it.
+ *
+ * The sidebar renders a title in a `<text wrapMode="none">` row, and
+ * `lib/display-width.ts` measures every codepoint below `0x20` as ZERO cells
+ * — so a newline is invisible to the truncator, passes through untouched, and
+ * blows the row's height open at render time. The TUI's new-task dialog has
+ * stripped newlines at its input edge for years; nothing did for a title
+ * arriving over the daemon RPC, which is how `add --title $'line1\nline2'`
+ * landed verbatim in the store.
+ *
+ * So the guard moves to the two orchestrator entry points every title passes
+ * through — `createTask` and `setTitle` — where an agent-written title and a
+ * hand-typed one meet. All C0 controls, not just `\n`: they share the
+ * zero-width measurement, and a title carrying a raw `\x1b` is no better.
+ * Whitespace runs collapse to ONE space rather than vanishing, so
+ * `"line1\nline2"` stays two readable words instead of becoming `line1line2`.
+ */
+export function sanitizeTaskTitle(title: string): string {
+  // biome-ignore lint/suspicious/noControlCharactersInRegex: these bytes are exactly what the sidebar cannot render.
+  return title.replace(/[\u0000-\u0020\u007f]+/g, " ").trim()
+}
+
+/**
  * Reduce an arbitrary user prompt to a one-line sidebar label.
  */
 export function deriveTitleFromPrompt(prompt: string): string {

--- a/packages/kobe/src/orchestrator/worktree-coordinator.ts
+++ b/packages/kobe/src/orchestrator/worktree-coordinator.ts
@@ -188,7 +188,7 @@ export class WorktreeCoordinator {
    */
   private async deriveAutoBranch(task: Task): Promise<string> {
     const names = await this.worktrees.listBranchNames(task.repo)
-    const base = deriveConventionBranch(task.title, inferBranchStyle(names))
+    const base = deriveConventionBranch(task.title, inferBranchStyle(names), task.id)
     const taken = new Set([...names, ...this.reservedBranches])
     const branch = uniqueBranchName(base, taken, task.id)
     this.reservedBranches.add(branch)

--- a/packages/kobe/src/state/repos.ts
+++ b/packages/kobe/src/state/repos.ts
@@ -97,6 +97,23 @@ export function isGitRepo(absPath: string): boolean {
 }
 
 /**
+ * Whether git would accept `branch` as a branch name — asked of git itself
+ * (`check-ref-format --branch`) rather than reimplemented, because the rules
+ * are a long tail (`..`, `@{`, a trailing `.lock`, a leading `-`, control
+ * bytes) and the authority has to be the same program that later runs
+ * `git worktree add -b`.
+ *
+ * No repo needed: this is a pure string check, so it runs from wherever the
+ * caller is and cannot be confused by the surrounding checkout. `-rf`-style
+ * names are safe to pass — the arg vector is fixed (`shell: false`) and git
+ * reads `--branch`'s value positionally.
+ */
+export function isValidBranchName(branch: string): boolean {
+  const r = spawnSync("git", ["check-ref-format", "--branch", branch], { encoding: "utf8", shell: false })
+  return r.status === 0
+}
+
+/**
  * Resolve a local path to the repository's PRIMARY checkout. `git rev-parse
  * --show-toplevel` returns the linked worktree when called from a task
  * worktree; scripted task creation wants the source repo instead so new tasks

--- a/packages/kobe/src/types/engine.ts
+++ b/packages/kobe/src/types/engine.ts
@@ -72,7 +72,6 @@ export interface EngineCapabilities {
  * strings in TUI code.
  */
 export interface EngineIdentity {
-  readonly vendorId: VendorId
   readonly shortName: string
 }
 

--- a/packages/kobe/test/cli/api-handler-fixtures.ts
+++ b/packages/kobe/test/cli/api-handler-fixtures.ts
@@ -73,6 +73,7 @@ export function stubRuntime(overrides: Partial<ApiRuntime> = {}): ApiRuntime {
     },
     resolveRepoRoot: async (path) => path,
     isUsableRepo: async () => true,
+    isValidBranchName: async () => true,
     defaultVendor: async () => undefined,
     readWorktreeChanges: async () => ({ added: 0, deleted: 0 }),
     readBranchSignals: async () => ({ baseRef: null, ahead: null, behind: null, diff: null }),

--- a/packages/kobe/test/cli/api-handlers-more.test.ts
+++ b/packages/kobe/test/cli/api-handlers-more.test.ts
@@ -53,6 +53,7 @@ function stubRuntime(): ApiRuntime {
     },
     resolveRepoRoot: async (p) => p,
     isUsableRepo: async () => true,
+    isValidBranchName: async () => true,
     defaultVendor: async () => undefined,
     readWorktreeChanges: async () => ({ added: 0, deleted: 0 }),
     readBranchSignals: async () => ({ baseRef: null, ahead: null, behind: null, diff: null }),

--- a/packages/kobe/test/cli/api-handlers.test.ts
+++ b/packages/kobe/test/cli/api-handlers.test.ts
@@ -58,6 +58,31 @@ describe("add handler", () => {
     expect(client.requestNames).toEqual([])
   })
 
+  it("refuses a --branch git will not accept, before anything is created", async () => {
+    // `--branch` was only type-checked, so `add --branch "a b"` exited 0 with
+    // the row in the backlog and the failure deferred to `ensure-worktree`,
+    // where it surfaced as a raw `git worktree add` transcript under
+    // `RPC_ERROR` — no code, no hint, and a row that can never materialize.
+    const client = new FakeClient({ "task.create": () => ({ taskId: "t1", task: taskFixture() }) })
+    for (const bad of ["a b", "-rf", "feat/x..y"]) {
+      await expectApiError(
+        () =>
+          invokeVerb("add", ["--repo", "/repo/x", "--branch", bad], {
+            client,
+            runtime: stubRuntime({ isValidBranchName: async () => false }),
+          }),
+        "INVALID_BRANCH",
+      )
+    }
+    expect(client.requestNames).toEqual([])
+  })
+
+  it("still accepts a branch name git allows", async () => {
+    const client = new FakeClient({ "task.create": () => ({ taskId: "t1", task: taskFixture() }) })
+    await invokeVerb("add", ["--repo", "/repo/x", "--branch", "feat/ok"], { client, runtime: stubRuntime() })
+    expect(client.requests[0].payload).toMatchObject({ branch: "feat/ok" })
+  })
+
   it("names the home it wrote to, so a collapsed isolation is visible in a success", async () => {
     // Four fan-out tasks once landed in a production `~/.rove` behind
     // `failures: []` because the payload never said where it had written.

--- a/packages/kobe/test/cli/api-handlers.test.ts
+++ b/packages/kobe/test/cli/api-handlers.test.ts
@@ -83,6 +83,35 @@ describe("add handler", () => {
     expect(client.requests[0].payload).toMatchObject({ branch: "feat/ok" })
   })
 
+  it("says so when --repo resolved UP out of a subdirectory", async () => {
+    // `--repo my-repo/packages/app` came back as `"repo": "…/my-repo"` with
+    // no trace of the levels it climbed, so a typo'd path and an intended one
+    // produced identical output.
+    const client = new FakeClient({ "task.create": () => ({ taskId: "t1", task: taskFixture() }) })
+    const result = (await invokeVerb("add", ["--repo", "/repo/x/packages/app"], {
+      client,
+      runtime: stubRuntime({ resolveRepoRoot: async () => "/repo/x" }),
+    })) as { repoResolvedFrom?: string }
+    expect(result.repoResolvedFrom).toBe("/repo/x/packages/app")
+    expect(client.requests[0].payload).toMatchObject({ repo: "/repo/x" })
+  })
+
+  it("stays quiet when --repo already named the root, or git only realpath'd it", async () => {
+    // The field must not fire on a CORRECT path. `resolveRepoRoot` shells
+    // git, which reports the realpath, so `/tmp/x` comes back as
+    // `/private/tmp/x` on macOS — a rewrite, not a climb, and not a prefix.
+    const client = new FakeClient({ "task.create": () => ({ taskId: "t1", task: taskFixture() }) })
+    const exact = (await invokeVerb("add", ["--repo", "/repo/x"], { client, runtime: stubRuntime() })) as {
+      repoResolvedFrom?: string
+    }
+    expect(exact.repoResolvedFrom).toBeUndefined()
+    const symlinked = (await invokeVerb("add", ["--repo", "/tmp/x"], {
+      client,
+      runtime: stubRuntime({ resolveRepoRoot: async () => "/private/tmp/x" }),
+    })) as { repoResolvedFrom?: string }
+    expect(symlinked.repoResolvedFrom).toBeUndefined()
+  })
+
   it("names the home it wrote to, so a collapsed isolation is visible in a success", async () => {
     // Four fan-out tasks once landed in a production `~/.rove` behind
     // `failures: []` because the payload never said where it had written.

--- a/packages/kobe/test/cli/api-handlers.test.ts
+++ b/packages/kobe/test/cli/api-handlers.test.ts
@@ -77,6 +77,21 @@ describe("add handler", () => {
     expect(client.requestNames).toEqual([])
   })
 
+  it("leaves a parallel round's --branch refusal to the parallel path", async () => {
+    // `--count` rejects `--branch` outright (siblings cannot share one
+    // branch), and that is the more useful answer than "this name is
+    // malformed" — so the name check must not get there first and shadow it.
+    const client = new FakeClient({ "task.create": () => ({ taskId: "t1", task: taskFixture() }) })
+    await expectApiError(
+      () =>
+        invokeVerb("add", ["--repo", "/repo/x", "--count", "3", "--prompt", "p", "--branch", "a b"], {
+          client,
+          runtime: stubRuntime({ isValidBranchName: async () => false }),
+        }),
+      "BAD_FLAG",
+    )
+  })
+
   it("still accepts a branch name git allows", async () => {
     const client = new FakeClient({ "task.create": () => ({ taskId: "t1", task: taskFixture() }) })
     await invokeVerb("add", ["--repo", "/repo/x", "--branch", "feat/ok"], { client, runtime: stubRuntime() })

--- a/packages/kobe/test/daemon/activity-arbitrate.test.ts
+++ b/packages/kobe/test/daemon/activity-arbitrate.test.ts
@@ -101,6 +101,47 @@ describe("recomputeTabActivity", () => {
     expect(eff).toMatchObject({ state: "idle", source: "observed", vendor: "claude", session: { id: "s1" } })
   })
 
+  it("a NEWER observed running unsticks a hook dead (the no-hook-engine escape)", () => {
+    // A dead process emits nothing, so observed output after the death can
+    // only come from a NEW engine. Without this an engine whose adapter never
+    // emits session-start (copilot's NoopHookAdapter) wore `dead` forever:
+    // the only other way to clear the slot is a hook event it never sends.
+    const eff = recomputeTabActivity(
+      {
+        hook: { state: "dead", at: 0, vendor: "copilot", session: { id: "s1" } },
+        observed: { state: "running", at: T },
+      },
+      T,
+    )
+    expect(eff).toMatchObject({ state: "running", source: "observed" })
+    // Lineage survives the hand-off — the liveness probe still needs it.
+    expect(eff).toMatchObject({ vendor: "copilot", session: { id: "s1" } })
+  })
+
+  it("an observed IDLE never unsticks a hook dead — a live shell is not a live engine", () => {
+    // The counter-case that keeps the escape honest: a killed engine leaves
+    // its shell running, and that shell walks as at-rest on every pass. If
+    // rest could clear `dead`, the death badge would evaporate one poll later
+    // for every engine, hooks or not.
+    const eff = recomputeTabActivity({ hook: { state: "dead", at: 0 }, observed: { state: "idle", at: T } }, T, 0)
+    expect(eff).toMatchObject({ state: "dead", source: "hook" })
+  })
+
+  it("an observed running OLDER than the death leaves dead standing", () => {
+    // Ordering is the whole proof. A `running` recorded before the exit is
+    // evidence about the engine that died, not about a new one — mutating the
+    // `at` comparison away must fail here.
+    const eff = recomputeTabActivity(
+      { hook: { state: "dead", at: T }, observed: { state: "running", at: T - 1_000 } },
+      T,
+    )
+    expect(eff).toMatchObject({ state: "dead", source: "hook" })
+    // Same instant is not "after" either.
+    expect(
+      recomputeTabActivity({ hook: { state: "dead", at: T }, observed: { state: "running", at: T } }, T),
+    ).toMatchObject({ state: "dead", source: "hook" })
+  })
+
   it("hook detail rides the effective payload (badge subtitles read it)", () => {
     const eff = recomputeTabActivity(
       { hook: { state: "permission_needed", at: T, detail: { waiting: "permission" } } },

--- a/packages/kobe/test/daemon/issue-snapshot-gate.test.ts
+++ b/packages/kobe/test/daemon/issue-snapshot-gate.test.ts
@@ -1,0 +1,59 @@
+/**
+ * `issue.snapshot` publishes only when somebody is subscribed.
+ *
+ * The channel has no in-repo consumer — the browser Issues pane was deleted
+ * in #855 and the TUI kanban uses the `issue.list` / `issue.mutate` RPCs — but
+ * it is a public plugin API, so it cannot be removed. Every task delete, every
+ * task→done transition and every issue edit was therefore serializing a repo's
+ * WHOLE issue state for nobody. `channels.ts` named this gate as the fix.
+ *
+ * The two directions matter differently: a gate that fails open costs one
+ * wasted publish, a gate that fails closed silently drops a plugin's events.
+ * So "no answer available" must publish, and only an explicit `false` may
+ * suppress.
+ */
+
+import type { DaemonHandlerContext } from "@sma1lboy/kobe-daemon/daemon/server"
+import { describe, expect, it } from "vitest"
+import { dispatch, fakeCtx } from "./handler-test-context.ts"
+
+/** Overwrite the context's `daemon.hasSubscribersFor` with a fixed answer. */
+function withSubscribers(ctx: DaemonHandlerContext, answer: boolean | undefined): DaemonHandlerContext {
+  return {
+    ...ctx,
+    daemon: { ...ctx.daemon, ...(answer === undefined ? {} : { hasSubscribersFor: () => answer }) },
+  }
+}
+
+const MUTATE = { repoRoot: "/repo", op: { type: "create", title: "t" } }
+
+async function snapshotsPublished(answer: boolean | undefined): Promise<number> {
+  const { ctx, rec } = fakeCtx()
+  await dispatch("issue.mutate", MUTATE, withSubscribers(ctx, answer))
+  return rec.published.filter((p) => p.channel === "issue.snapshot").length
+}
+
+describe("issue.snapshot publish gate", () => {
+  it("publishes when a subscriber is attached", async () => {
+    expect(await snapshotsPublished(true)).toBe(1)
+  })
+
+  it("skips the publish when nobody is subscribed", async () => {
+    expect(await snapshotsPublished(false)).toBe(0)
+  })
+
+  it("publishes when the daemon cannot answer at all (older contexts)", async () => {
+    // `hasSubscribersFor` is optional; its absence must NOT be read as "no
+    // subscribers" — that would suppress a plugin's events on any host that
+    // does not supply it.
+    expect(await snapshotsPublished(undefined)).toBe(1)
+  })
+
+  it("still returns the snapshot to the CALLER when the publish is skipped", async () => {
+    // Gating the broadcast must not gate the RPC result — the caller asked
+    // for this state directly and always gets it.
+    const { ctx } = fakeCtx()
+    const result = await dispatch("issue.mutate", MUTATE, withSubscribers(ctx, false))
+    expect(result).toMatchObject({ repoRoot: "/repo" })
+  })
+})

--- a/packages/kobe/test/engine/codex-history-edge-cases.test.ts
+++ b/packages/kobe/test/engine/codex-history-edge-cases.test.ts
@@ -232,6 +232,35 @@ describe("parseJsonl — tool call / result records", () => {
     }
   })
 
+  it("reads a single-record tool's own status instead of hard-coding isError:false", () => {
+    // `status` shapes taken from real `~/.codex/sessions` rollouts: call
+    // records carry `"completed"`, and Codex's own failure verdict spells
+    // itself `"failed"` (221 of them across one month of local sessions).
+    // `in_progress` is the Responses-API "still running", not a failure.
+    const cases: ReadonlyArray<[string | undefined, boolean]> = [
+      ["completed", false],
+      ["in_progress", false],
+      ["failed", true],
+      ["incomplete", true],
+      [undefined, false], // no verdict recorded ⇒ no failure claimed
+    ]
+    for (const [status, isError] of cases) {
+      const raw = meta({ type: "local_shell_call", call_id: "c9", ...(status ? { status } : {}), query: "x" })
+      const result = parseJsonl(raw, SID)[0]?.blocks[1]
+      expect({ status, isError: (result as { isError: boolean }).isError }).toEqual({ status, isError })
+    }
+  })
+
+  it("keeps `status` out of the tool_call INPUT — it is metadata, not an argument", () => {
+    const raw = meta({ type: "local_shell_call", call_id: "c9", status: "failed", query: "x" })
+    expect(parseJsonl(raw, SID)[0]?.blocks[0]).toEqual({
+      type: "tool_call",
+      callId: "c9",
+      name: "local_shell_call",
+      input: { query: "x" },
+    })
+  })
+
   it("synthesizes a call_id for a single-record tool when none is given", () => {
     const raw = meta({ type: "web_search_call", query: "x" })
     const out = parseJsonl(raw, SID)

--- a/packages/kobe/test/engine/plugin-engines-load.test.ts
+++ b/packages/kobe/test/engine/plugin-engines-load.test.ts
@@ -77,14 +77,14 @@ describe("loadPluginEngines", () => {
     expect(entry.displayName).toBe("Aider")
     // The manifest sets `input_placeholder`, a key the loader does not know:
     // it must register without throwing, and the field is simply absent.
-    expect(entry.identity).toEqual({ vendorId: "aider", shortName: "Aid" })
+    expect(entry.identity).toEqual({ shortName: "Aid" })
   })
 
   it("shortName falls back to the engine name when identity is absent", () => {
     const bare = MANIFEST.replace(/\[engines\.identity\][^\[]*/, "")
     homeWith([{ id: "acme.engines", root: pluginRoot(bare) }])
     expect(loadPluginEngines()).toEqual(["aider"])
-    expect(engineEntry("aider").identity).toEqual({ vendorId: "aider", shortName: "Aider" })
+    expect(engineEntry("aider").identity).toEqual({ shortName: "Aider" })
   })
 
   it("skips disabled plugins and unreadable manifests without throwing", () => {

--- a/packages/kobe/test/engine/plugin-engines.test.ts
+++ b/packages/kobe/test/engine/plugin-engines.test.ts
@@ -118,7 +118,7 @@ describe("plugin engine registration", () => {
       displayName: "Aider",
       defaultCommand: ["aider"],
       screenManifest: { rules: [{ state: "working", any: ["ctrl-c to interrupt"] }] },
-      identity: { vendorId: "aider", shortName: "Aider" },
+      identity: { shortName: "Aider" },
     })
     expect(ok).toBe(true)
     expect(pluginEngineIds()).toEqual(["aider"])
@@ -128,7 +128,7 @@ describe("plugin engine registration", () => {
     expect(entry.screenManifest).toBeDefined()
     expect(entry.builtin).toBe(false)
     // Identity rides the overlay — TUI copy comes from here, never hard-coded.
-    expect(entry.identity).toEqual({ vendorId: "aider", shortName: "Aider" })
+    expect(entry.identity).toEqual({ shortName: "Aider" })
   })
 
   it("a shipped catalog id cannot be overridden by a plugin", () => {

--- a/packages/kobe/test/orchestrator/branch-style.test.ts
+++ b/packages/kobe/test/orchestrator/branch-style.test.ts
@@ -33,34 +33,55 @@ describe("inferBranchStyle", () => {
 describe("deriveConventionBranch", () => {
   const typed = { kind: "typed", defaultPrefix: "feat" } as const
   const bare = { kind: "bare" } as const
+  const ID = "01K9ZZZZZZZZZZZZZZZABC123"
 
   it("applies the repo's default prefix in a typed repo", () => {
-    expect(deriveConventionBranch("Add login flow", typed)).toBe("feat/add-login-flow")
+    expect(deriveConventionBranch("Add login flow", typed, ID)).toBe("feat/add-login-flow")
   })
 
   it("lifts a leading type word out of the title as the prefix", () => {
-    expect(deriveConventionBranch("Fix login flow", typed)).toBe("fix/login-flow")
-    expect(deriveConventionBranch("docs update quickstart", typed)).toBe("docs/update-quickstart")
+    expect(deriveConventionBranch("Fix login flow", typed, ID)).toBe("fix/login-flow")
+    expect(deriveConventionBranch("docs update quickstart", typed, ID)).toBe("docs/update-quickstart")
   })
 
   it("emits a bare kebab slug in a bare repo", () => {
-    expect(deriveConventionBranch("Fix login flow", bare)).toBe("fix-login-flow")
+    expect(deriveConventionBranch("Fix login flow", bare, ID)).toBe("fix-login-flow")
   })
 
   it("NEVER contains rove/kobe brand tokens", () => {
     for (const style of [typed, bare]) {
-      const branch = deriveConventionBranch("rove kobe integration for Rove", style)
+      const branch = deriveConventionBranch("rove kobe integration for Rove", style, ID)
       expect(branch).not.toMatch(/rove|kobe/)
     }
   })
 
-  it("falls back to 'task' when the title has no slug-able chars", () => {
-    expect(deriveConventionBranch("!!!", bare)).toBe("task")
-    expect(deriveConventionBranch("", typed)).toBe("feat/task")
+  it("falls back to the TASK ID when the title has no slug-able chars", () => {
+    // Not the bare constant `task`: that made every such title collide, and
+    // `uniqueBranchName` then numbered them `task`, `task-2`, `task-3`.
+    expect(deriveConventionBranch("!!!", bare, ID)).toBe("task-abc123")
+    expect(deriveConventionBranch("", typed, ID)).toBe("feat/task-abc123")
+  })
+
+  it("gives non-Latin titles distinct, id-keyed branches instead of task/task-2", () => {
+    // The bug this fixes: `slugTokens` keeps only [a-z0-9], so a Chinese,
+    // Japanese, or emoji title kebab-cases to nothing. Two such tasks must
+    // still get two DIFFERENT branch names.
+    const zh = deriveConventionBranch("修复中文标题的分支推导", bare, "01AAAAAAAAAAAAAAAAA111111")
+    const emoji = deriveConventionBranch("😀😀😀", bare, "01BBBBBBBBBBBBBBBBB222222")
+    const ja = deriveConventionBranch("ログイン画面を直す", bare, "01CCCCCCCCCCCCCCCCC333333")
+    expect([zh, emoji, ja]).toEqual(["task-111111", "task-222222", "task-333333"])
+    expect(new Set([zh, emoji, ja]).size).toBe(3)
+  })
+
+  it("still slugs the Latin part of a mixed-script title", () => {
+    // Mixed titles are NOT pushed onto the id fallback — a readable token
+    // survives, so the branch keeps saying something.
+    expect(deriveConventionBranch("修复 login flow", bare, ID)).toBe("login-flow")
+    expect(deriveConventionBranch("fix 中文标题", typed, ID)).toBe("fix/task-abc123")
   })
 
   it("caps the slug at 32 chars without a trailing hyphen", () => {
-    const branch = deriveConventionBranch("fix the very long feature name that exceeds the cap", typed)
+    const branch = deriveConventionBranch("fix the very long feature name that exceeds the cap", typed, ID)
     const slug = branch.slice("fix/".length)
     expect(slug.length).toBeLessThanOrEqual(32)
     expect(slug.endsWith("-")).toBe(false)

--- a/packages/kobe/test/orchestrator/title.test.ts
+++ b/packages/kobe/test/orchestrator/title.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest"
-import { TITLE_CHAR_CAP, deriveTitleFromPrompt, isPlaceholderDerivedBranch } from "../../src/orchestrator/title.ts"
+import {
+  TITLE_CHAR_CAP,
+  deriveTitleFromPrompt,
+  isPlaceholderDerivedBranch,
+  sanitizeTaskTitle,
+} from "../../src/orchestrator/title.ts"
 
 describe("isPlaceholderDerivedBranch", () => {
   it("recognizes the convention-era placeholder shapes", () => {
@@ -52,5 +57,37 @@ describe("deriveTitleFromPrompt", () => {
     // No lone surrogate: a UTF-8 round-trip is lossless only if every surrogate
     // is paired.
     expect(Buffer.from(out, "utf8").toString("utf8")).toBe(out)
+  })
+})
+
+describe("sanitizeTaskTitle", () => {
+  it("flattens a newline into a single space instead of letting it through", () => {
+    // `add --title $'line1\nline2'` used to land verbatim in the store. The
+    // sidebar row is `wrapMode="none"` and display-width measures a newline
+    // as ZERO cells, so the truncator never sees it and the row grows a
+    // second line at render time.
+    expect(sanitizeTaskTitle("line1\nline2")).toBe("line1 line2")
+    expect(sanitizeTaskTitle("a\r\nb")).toBe("a b")
+  })
+
+  it("strips every C0 control, not just the newline — they all measure zero", () => {
+    expect(sanitizeTaskTitle("a\tb")).toBe("a b")
+    expect(sanitizeTaskTitle("red\u001b[31mtext")).toBe("red [31mtext")
+    expect(sanitizeTaskTitle("a\u0000b")).toBe("a b")
+  })
+
+  it("collapses runs and trims the edges, so nothing becomes a wall of spaces", () => {
+    expect(sanitizeTaskTitle("  \n\n a  \n b \n ")).toBe("a b")
+  })
+
+  it("leaves an ordinary title — including a non-Latin one — byte-for-byte alone", () => {
+    expect(sanitizeTaskTitle("fix the login flow")).toBe("fix the login flow")
+    expect(sanitizeTaskTitle("修复中文标题的分支推导")).toBe("修复中文标题的分支推导")
+    expect(sanitizeTaskTitle("😀😀😀")).toBe("😀😀😀")
+  })
+
+  it("reduces a control-only title to the empty string, so callers can fall back", () => {
+    // `createTask` swaps this for the placeholder; `setTitle` rejects it.
+    expect(sanitizeTaskTitle("\n\n\t ")).toBe("")
   })
 })


### PR DESCRIPTION
Five user-visible defects around task creation and activity badges, plus three
cleanups. One commit each; every commit body carries its own before/after
payloads.

All CLI evidence was captured against an isolated home
(`KOBE_HOME_DIR` + every `KOBE_*_SOCKET_PATH` / `*_PID_PATH` inlined) with a
throwaway git repo. Nothing touched `~/.rove`.

---

## 1. A non-Latin title got a colliding branch — `20b1afc6`

`slugTokens` keeps only `[a-z0-9]`, so a Chinese / Japanese / Korean / emoji
title kebab-cased to nothing and fell back to the constant `"task"`.
`uniqueBranchName` then numbered them.

```
BEFORE                                AFTER
修复中文标题的分支推导 -> task           -> task-zavrge
😀😀😀                -> task-2         -> task-htjfan
ログイン画面を直す      (n/a)            -> task-77qpg5
```

`deriveConventionBranch` now takes a required `taskId` — the same 6-char
suffix `uniqueBranchName` already uses as its own last resort. No
transliteration library. A mixed-script title still slugs its Latin half
(`修复 login flow` → `login-flow`); only a title with nothing slug-able
reaches the fallback, which also fixes `"!!!"` and `""` for free — same root
cause, same line.

## 2. `add --branch "<name git refuses>"` succeeded, then failed later — `c1989d04`

```
BEFORE  $ rove api add --branch "a b"          -> exit 0, row in backlog
        $ rove api ensure-worktree --task-id … -> RPC_ERROR, raw git transcript, no hint

AFTER   $ rove api add --branch "a b"          -> INVALID_BRANCH + hint + nextCommandArgs, exit 1
        $ rove api add --branch "-rf"          -> same
        $ rove api add --branch feat/ok        -> branch= feat/ok
```

Neither refusal left a row behind. A follow-up commit (`7bcbe172`) keeps the
check out of a parallel round's way: `add --count N --branch X` is refused by
the parallel path because siblings cannot share one branch, and that is the
more useful answer than "this name is malformed".

git is the authority (`check-ref-format
--branch` — the same program that later runs `worktree add -b`), on the
`ApiRuntime` seam beside `isUsableRepo` so handler tests need no real repo.
`INVALID_BRANCH` is in the docs/API.md table that
`api-error-codes-documented.test.ts` enforces.

## 3. A task title could carry a newline and break the sidebar row — `481465c9`

`display-width.ts` measures every codepoint below `0x20` as ZERO cells, so the
truncator never saw a newline and it reached a `wrapMode="none"` row.

```
BEFORE  $ rove api add --title $'line1\nline2'  -> title= 'line1\nline2'
AFTER   $ rove api add --title $'line1\nline2'  -> title= 'line1 line2'
        $ rove api rename --title $'a\nb'       -> title= 'a b'
```

Harness pair, 46×24, real BEFORE/AFTER builds against two FRESH fixtures
(`.scratch/fawn/evidence/title-{before,after}.png`): before, the row is two
lines tall — `line1` carries the `3` shortcut and `line2` spills onto its own
unnumbered line, pushing the tree out of shape; after, one row reading
`line1 line2`.

The guard sits at the two orchestrator entry points every title passes through
(`createTask` / `setTitle`), not at the dialog — an agent-written title and a
hand-typed one now meet the same rule. Collapsed to a space, not deleted, so
the two words stay readable. All C0 controls, since they share the zero-width
measurement.

## 4. A hook-less engine wore `dead` forever — `193ab9d1`

`dead` is sticky, and its documented escape is the next hook event. copilot's
adapter is a `NoopHookAdapter`, so it never sends one — while the `dead` state
itself needs no hook (it comes from the pty-exit record). One death pinned the
badge for the life of the daemon, across every restart of the engine in that
tab.

Arbitration gains rule 0: an observed `running` NEWER than the death wins. A
dead process emits no output, so that fact can only come from a new engine.
Only `running` — a killed engine leaves its shell alive and that shell walks as
at-rest every pass, so letting rest clear `dead` would evaporate the death
badge one poll later for every engine. The observer's vendor gate supplies the
rest (`activity-observer.ts` claims `working` only for a walked engine in the
tab's foreground; a bare shell takes the `applyRest` branch).

Mutation-verified, both halves:

| mutation | test that goes red |
| --- | --- |
| drop `observed.at > hook.at` | "an observed running OLDER than the death leaves dead standing" |
| drop `observed.state === "running"` | "an observed IDLE never unsticks a hook dead" |

**Not delivered: the harness pair for this one.** Driving the badge through
`/harness` needs a live walked sentinel engine in a fixture tab (the fixture
ships no logged-in engine) *plus* a fabricated `pty-exits.json` record injected
after the watch's baseline read — and the image would be exercising the
pre-existing `observeTab → publish → engineTabState → tabRowActivity` wiring,
since the change itself is three lines of a pure function that the two
mutations above already pin. Flagging rather than claiming it.

## 5. `--repo <subdir>` silently climbed — `5be64502`

```
BEFORE  $ rove api add --repo "$R/sub/deep"  -> repo= …/repo   repoResolvedFrom= <absent>
AFTER   $ rove api add --repo "$R/sub/deep"  -> repo= …/repo2  repoResolvedFrom= …/repo2/sub/deep
        $ rove api add --repo "$R"           -> repoResolvedFrom= <absent>
```

Gated on ANCESTRY, not `!==`: `resolveRepoRoot` shells git, which reports the
realpath, so a plain `--repo /tmp/x` comes back `/private/tmp/x` on macOS and a
`!==` test would flag every correct path there. A symlink rewrite is not a
prefix of what it rewrote; a climbed-out-of subdirectory always is. Pinned by a
test for both.

---

## Item 6 — located, NOT fixed, and here is why

**Finding: the task-level rollup is real and a hook-less engine never writes
it — but the sidebar is not the surface that suffers.**

- The sidebar TASK row shows no engine badge at all; only the TAB row does, via
  `tabRowActivity` (`tree-rows.tsx:322`), which prefers this tab's own entry.
  `observeTab` DOES write per-tab state, so copilot tab rows are fine.
- The rollup (`activity-registry.ts` `this.activity`) reaches a non-idle state
  ONLY through `report()`, which is hook-driven. `observeTab` never writes it —
  it can only clear it, via `clearHookRollup` → `publishIdle`.
- Two surfaces DO read the rollup and therefore never light up for a hook-less
  engine: the kanban card's live chip (`kanban-board.tsx:91`) and the attention
  inbox's `recent + running` filter (`AttentionInboxPane.tsx:250`).

I did not add the observed→rollup write. `report()` arms a lapse watchdog for
`running` and `clearHookRollup` only clears an entry whose `sourceHook`
matches; an observation-sourced rollup entry would have neither, so the fix as
sketched trades "never running" for "stuck running forever" on exactly the
engines it was meant to help. That is a bigger regression than the bug, and
sizing the watchdog/clear path properly is its own change. Worth a follow-up
issue rather than a rider on this PR.

---

## Cleanups

**`3722785f` — codex `isError`.** Confirmed against real rollouts in
`~/.codex/sessions` (read-only, one month): `custom_tool_call` records carry
`status: "completed"`; Codex spells failure `"failed"` (221 occurrences).
`normalizeSingleRecordTool` had that field in hand — it is the same `status`
the line above strips out of the tool ARGUMENTS — and threw it away for a
hard-coded `isError: false`.

The brief's premise held for that path only. `normalizeCodexToolResult` is
NOT changed and its `isError: false` is not the same defect: the
`custom_tool_call_output` / `function_call_output` records it parses are
`{type, id, call_id, output}` and carry no verdict at all. Codex records
theirs on `item_completed.item.status` (2484 `completed` / 221 `failed`
CommandExecutions in the same corpus) — a record type this parser does not
read, and wiring it up is a feature, not a cleanup.

**`4c5497ce` — `EngineIdentity.vendorId`.** Three writers, zero readers,
audited across the whole tree including `packages/kobe-plugin-sdk`. Not a
plugin-facing field either: `plugin-engines.ts` derived it from `engine.id`
internally while a manifest only ever declares `identity.shortName`.

**`7ecdcdf3` — `issue.snapshot` gate.** Channel kept (public plugin API), all
three publish sites now go through one `publishIssueSnapshot` asking
`lifetime.hasSubscribersFor` — the gate `channels.ts` itself named. Fails
OPEN: optional on the context, and only an explicit `false` suppresses,
because a missing gate costs one wasted publish while a wrongly-closed one
silently drops a plugin's events. Mutation: flipping to fail-closed turns the
"cannot answer at all" case red.

---

## Verification

`bun run lint` · `bun run typecheck` (all three packages) · `test:fast`
(495 files / 4914 tests) · `bun test test/render` (513 tests) ·
`KOBE_INCLUDE_SOCKET=1 test:socket` (122 files / 956 tests) — all green.
One `patch` changeset.

Untouched per the brief: `cli/api/verbs-*.ts`, `task-running.ts`,
`.scratch/bugsafari-61769/`. No files deleted, no `git stash`.

---

## CI note

`render-track` went red once on the first run of the final commit — two
input-driven tests, `sidebar frame golden: search-tab-title` (typed keys) and
`footer hint clicks > clicking the help caption opens the F1 reference`
(click), against a log full of `not wrapped in act(...)` warnings. Green on
rerun, and the same commit runs 513/513 locally (twice), with
`sidebar-frames.test.tsx` 22/22 in isolation.

Of the 21 changed source files only four are reachable from the TUI at all,
and each change is inert there: `state/repos.ts` gained a NEW exported
function and touched nothing existing, `types/engine.ts` lost a type field
(zero runtime), `plugin-engines.ts` stopped writing a property with zero
readers, and `cli/api/*` is the `add` verb. The sidebar golden scenes build
`Task` literals directly — they never call `createTask`, so the title
sanitizer is not in that path.

I could not run the strict fourth flake criterion (origin/main red on the same
Linux runner), so this is the evidence, not a proof.
