### PR TITLE
fix: fold Claude session usage by message id so token totals stop tripling

### DIFF
--- a/.changeset/fix-usage-snapshot-block-inflation.md
+++ b/.changeset/fix-usage-snapshot-block-inflation.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Fix inflated token totals for Claude tasks. The session usage snapshot — the numbers behind the footer's token chip and the settings usage dashboard — summed usage once per transcript record, but Claude Code writes one record per assistant content block (thinking, tool_use, text) and stamps the same usage on each, so a single reply counted its cost two or three times over. Usage is now folded per assistant message id, so each message counts once; the reported context window (the last prompt's size) is unchanged.

--- a/packages/kobe/src/engine/claude-code-local/history-parse.ts
+++ b/packages/kobe/src/engine/claude-code-local/history-parse.ts
@@ -96,6 +96,57 @@ function extractMessage(record: Record<string, unknown>, fallbackSessionId: stri
     : { role, blocks, timestamp: ts, sessionId: sid }
 }
 
+/**
+ * Session usage folded by assistant `message.id`, straight from the raw JSONL.
+ *
+ * Claude Code writes one record per assistant content block (thinking,
+ * tool_use, text) and stamps the SAME `message.usage` on every record of a
+ * message, so summing usage per RECORD multiplies a message's cost by its
+ * block count — the exact quirk {@link import("./turns").parseClaudeTurns}
+ * already folds per turn. This folds it session-wide: one usage per id.
+ * Records with no id (older transcript shapes) each get a distinct key, so
+ * they still count exactly once rather than collapsing together.
+ *
+ * `last` is the usage of the newest record by timestamp (file order breaks
+ * ties and covers records without a timestamp) — the final, largest prompt,
+ * which the snapshot reports as the session's context window.
+ */
+export function foldSessionUsage(raw: string): {
+  byMessage: Map<string, NonNullable<Message["usage"]>>
+  last: NonNullable<Message["usage"]> | undefined
+} {
+  const byMessage = new Map<string, NonNullable<Message["usage"]>>()
+  let last: NonNullable<Message["usage"]> | undefined
+  let lastAt = Number.NEGATIVE_INFINITY
+  let anon = 0
+  for (const line of raw.split("\n")) {
+    const trimmed = line.trim()
+    if (!trimmed || !isJsonlLineWithinBound(trimmed)) continue
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(trimmed)
+    } catch {
+      continue
+    }
+    if (!isObject(parsed) || isSyntheticClaudeRecord(parsed)) continue
+    const inner = isObject(parsed.message) ? (parsed.message as Record<string, unknown>) : parsed
+    if (inner.role !== "assistant") continue
+    const usage = extractUsage(inner.usage)
+    if (!usage) continue
+    const id = typeof inner.id === "string" && inner.id ? inner.id : `#anon-${anon++}`
+    byMessage.set(id, usage)
+    // Newest by timestamp is the context prompt; a record with no parseable
+    // timestamp folds into the running max so the last one in file order wins.
+    const at = typeof parsed.timestamp === "string" ? Date.parse(parsed.timestamp) : Number.NaN
+    const ts = Number.isFinite(at) ? at : lastAt
+    if (ts >= lastAt) {
+      last = usage
+      lastAt = ts
+    }
+  }
+  return { byMessage, last }
+}
+
 function extractUsage(v: unknown): Message["usage"] {
   if (!isObject(v)) return undefined
   const inTok = typeof v.input_tokens === "number" ? v.input_tokens : undefined

--- a/packages/kobe/src/engine/claude-code-local/history.ts
+++ b/packages/kobe/src/engine/claude-code-local/history.ts
@@ -44,7 +44,7 @@ import type { EngineUsageSnapshot, Message } from "@/types/engine"
 import { isJsonlLineWithinBound, readTextFileBounded } from "../file-bounds"
 import { isObject } from "../json-hooks.ts"
 import { vendorConfigHome } from "../vendor-home"
-import { parseSessionRaw } from "./history-parse"
+import { foldSessionUsage, parseSessionRaw } from "./history-parse"
 
 // Parsing (JSONL → Message[], sorting, and the append-aware per-file cache)
 // lives in ./history-parse; re-exported here for existing consumers/tests.
@@ -184,6 +184,22 @@ export async function latestTranscriptMtimeForWorktree(worktree: string): Promis
  * row identity — a rewrite/truncation falls back to a full re-parse.
  */
 export async function readHistory(sessionId: string, deps: HistoryDeps = defaultDeps): Promise<readonly Message[]> {
+  const found = await findSessionRaw(sessionId, deps)
+  return found ? parseSessionRaw(found.path, found.raw, sessionId) : []
+}
+
+/**
+ * Locate the JSONL for `sessionId` and return its raw contents plus the path
+ * (the append-cache key). Scans every `~/.claude/projects/<encoded-cwd>` dir
+ * for `<sessionId>.jsonl` and returns the first readable one — a missing file
+ * throws (see {@link readTextFileBounded}) and is skipped; an oversize/corrupt
+ * one degrades to `""` and stops the scan, same as the history read. Returns
+ * `undefined` when no project dir holds the session.
+ */
+async function findSessionRaw(
+  sessionId: string,
+  deps: HistoryDeps,
+): Promise<{ path: string; raw: string } | undefined> {
   const root = deps.projectsDir()
   const projectDirs = await deps.readdir(root)
 
@@ -195,44 +211,47 @@ export async function readHistory(sessionId: string, deps: HistoryDeps = default
     } catch {
       continue
     }
-    return parseSessionRaw(candidate, raw, sessionId)
+    return { path: candidate, raw }
   }
-  return []
+  return undefined
 }
 
 /**
- * Session-aggregate usage for `sessionId`, folded from the per-turn usage
- * Claude Code persists inline on assistant records. This is the ONE place
- * the vendor's context arithmetic lives: "context" = the LAST turn's full
- * prompt (fresh input + cache read + cache creation), derived — not an
- * engine-reported figure — hence `context_tokens_approximate`. Neutral
- * layers (web transcript header, cost dashboards) render the snapshot and
- * must not re-derive the math from per-message fields.
- * `undefined` when the session has no usage records (nothing reported,
- * which is different from a reported zero).
+ * Session-aggregate usage for `sessionId`, folded from the usage Claude Code
+ * persists inline on assistant records. This is the ONE place the vendor's
+ * context arithmetic lives: "context" = the LAST message's full prompt (fresh
+ * input + cache read + cache creation), derived — not an engine-reported
+ * figure — hence `context_tokens_approximate`. Neutral layers (web transcript
+ * header, cost dashboards) render the snapshot and must not re-derive the math
+ * from per-message fields.
+ *
+ * Usage is folded per assistant `message.id`, not per record: Claude writes one
+ * record per content block and stamps the same `message.usage` on each, so a
+ * per-record sum would multiply every message's cost by its block count (see
+ * {@link foldSessionUsage}). `undefined` when the session has no usage records
+ * (nothing reported, which is different from a reported zero).
  */
 export async function readUsageSnapshot(
   sessionId: string,
   deps: HistoryDeps = defaultDeps,
 ): Promise<EngineUsageSnapshot | undefined> {
-  const messages = await readHistory(sessionId, deps)
+  const found = await findSessionRaw(sessionId, deps)
+  if (!found) return undefined
+  const { byMessage, last } = foldSessionUsage(found.raw)
   let input = 0
   let output = 0
   let cacheRead = 0
   let cacheCreate = 0
-  let lastContext = 0
-  for (const message of messages) {
-    const usage = message.usage
-    if (!usage) continue
+  for (const usage of byMessage.values()) {
     input += usage.input_tokens
     output += usage.output_tokens
-    const read = usage.cache_read_input_tokens ?? 0
-    const create = usage.cache_creation_input_tokens ?? 0
-    cacheRead += read
-    cacheCreate += create
-    lastContext = usage.input_tokens + read + create
+    cacheRead += usage.cache_read_input_tokens ?? 0
+    cacheCreate += usage.cache_creation_input_tokens ?? 0
   }
   if (input === 0 && output === 0) return undefined
+  const lastContext = last
+    ? last.input_tokens + (last.cache_read_input_tokens ?? 0) + (last.cache_creation_input_tokens ?? 0)
+    : 0
   return {
     input_tokens: input,
     output_tokens: output,

--- a/packages/kobe/test/engine/claude-usage-snapshot.test.ts
+++ b/packages/kobe/test/engine/claude-usage-snapshot.test.ts
@@ -12,8 +12,9 @@ import { readUsageSnapshot } from "../../src/engine/claude-code-local/history.ts
  * (undefined) apart from a reported zero.
  */
 
-function record(ts: string, usage: Record<string, number> | undefined): string {
+function record(ts: string, usage: Record<string, number> | undefined, id?: string): string {
   const message: Record<string, unknown> = { role: "assistant", content: "turn" }
+  if (id) message.id = id
   if (usage) message.usage = usage
   return JSON.stringify({ type: "assistant", message, timestamp: ts, sessionId: "s1" })
 }
@@ -49,6 +50,36 @@ describe("readUsageSnapshot", () => {
       cache_creation_input_tokens: 50,
       // context = LAST turn only: 200 + 1000 + 50
       context_tokens: 1250,
+      context_tokens_approximate: true,
+    })
+  })
+
+  it("counts a message once even when Claude splits it across block records", async () => {
+    // One assistant message (id m1) persisted as three block records — thinking,
+    // tool_use, text — each carrying the IDENTICAL message.usage. A second
+    // message (id m2) is the final turn. Summing per record would triple m1;
+    // folding by message id counts each once, and context is m2's prompt alone.
+    const usage1 = { input_tokens: 100, output_tokens: 20, cache_read_input_tokens: 5000 }
+    const usage2 = {
+      input_tokens: 200,
+      output_tokens: 40,
+      cache_read_input_tokens: 6000,
+      cache_creation_input_tokens: 50,
+    }
+    const raw = [
+      record("2026-01-01T00:00:01.000Z", usage1, "m1"),
+      record("2026-01-01T00:00:01.100Z", usage1, "m1"),
+      record("2026-01-01T00:00:01.200Z", usage1, "m1"),
+      record("2026-01-01T00:00:02.000Z", usage2, "m2"),
+      record("2026-01-01T00:00:02.100Z", usage2, "m2"),
+    ].join("\n")
+    expect(await readUsageSnapshot("s1", fakeDeps("blocks", "s1", raw))).toEqual({
+      input_tokens: 300, // 100 + 200, not 3×100 + 2×200
+      output_tokens: 60,
+      cache_read_input_tokens: 11000,
+      cache_creation_input_tokens: 50,
+      // context = LAST message (m2) only: 200 + 6000 + 50
+      context_tokens: 6250,
       context_tokens_approximate: true,
     })
   })


### PR DESCRIPTION
## Direction
Bugs / correctness — surfaced by a code-health review of the engine usage/telemetry path (`packages/kobe/src/engine/claude-code-local`).

## The problem
`readUsageSnapshot` (the session-aggregate usage the daemon forwards onto the `usage.context` channel, feeding the footer's token chip and the settings usage dashboard) summed usage **once per transcript record**:

```ts
for (const message of messages) {
  const usage = message.usage
  if (!usage) continue
  input += usage.input_tokens
  ...
}
```

But Claude Code writes **one JSONL record per assistant content block** (thinking, tool_use, text) and stamps the **identical `message.usage`** on every record sharing a `message.id`. So an assistant reply split across three block-records had its input/output/cache tokens counted **3×**. A single-tool-call turn double-counts; a thinking + text + tool_use turn triples.

This is an already-documented vendor quirk: `claude-code-local/turns.ts` folds usage into a `usageByMessage` Map keyed by `message.id` **precisely to avoid this**, and its unit test pins "usage is counted once per message id, not once per record." The snapshot path just never got the same treatment — and `Message` (what `readHistory` yields) drops the `message.id`, so the snapshot had no id to dedup by.

`context_tokens` was already correct (it's an assignment of the last record's prompt, not a sum), and Codex is unaffected (it uses session-cumulative totals, not per-record sums).

## The fix
- New `foldSessionUsage(raw)` in `history-parse.ts` (co-located with the existing `extractUsage`, the single usage-extraction source) folds the raw JSONL into one usage per assistant `message.id`. Id-less legacy records each get a distinct key so they still count exactly once rather than collapsing together. It also tracks the newest record's usage (by timestamp, file order breaking ties) as the context prompt.
- `readUsageSnapshot` now sums those deduped per-message values instead of per-record. `context_tokens` semantics are unchanged (last message's fresh input + cache read + cache creation).
- Factored the `~/.claude/projects/<encoded-cwd>/<sessionId>.jsonl` discovery loop out of `readHistory` into a shared `findSessionRaw` helper so both the history read and the usage snapshot locate the transcript the same way (and the snapshot can operate on raw JSONL, where the ids live). `readHistory` behavior — first-readable-candidate, same append-cache key — is preserved.

## Verification
- Added a regression test: one assistant message persisted across three identical block-records plus a second message → totals count each message once (300 in, not 3×100 + 2×200) and context is the last message's prompt alone.
- `bun x vitest run test/engine` — 834 pass / 1 skipped, including the existing `claude-turns` "once per message id" test and the full history-read/append-cache/session-discovery suites (the `readHistory` refactor is covered).
- `bun run lint` and `bun run typecheck` both green. Both touched files stay under the file-size cap (history.ts 435 lines).

## Follow-ups deferred
- The secondary find from the review — Codex `token_count` records that land *after* `task_complete` would be dropped — is unconfirmed against a real codex-cli rollout, so I left it out of scope rather than guess at an ordering that may never occur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014nefqWgWv4KGY9ANBUV4JQ

---
_Generated by [Claude Code](https://claude.ai/code/session_014nefqWgWv4KGY9ANBUV4JQ)_