### PR TITLE
test: seven CI flakes, three mechanisms, no widened sleeps

### DIFF
--- a/packages/kobe/test/orchestrator/land-commit-failure.test.ts
+++ b/packages/kobe/test/orchestrator/land-commit-failure.test.ts
@@ -28,6 +28,28 @@ import type { WorktreeExecDeps } from "../../src/orchestrator/worktree/exec-deps
 import type { Task } from "../../src/types/task.ts"
 import { toTaskId } from "../../src/types/task.ts"
 
+/**
+ * Per-test budget for this file, replacing vitest's 5000ms default.
+ *
+ * Each case here runs twenty real `git` processes — counted with a PATH shim:
+ * fourteen through the fixture's synchronous helpers (repo setup, the diverged
+ * branch, the broken signing config, the closing `status`) and six through
+ * `landTask`'s own async `ExecHost`. There is nothing to wait on and no race;
+ * the cost is entirely process spawn, which on windows-latest (Git-for-Windows'
+ * fork emulation plus on-access scanning of every child) runs an order of
+ * magnitude above the ~25ms it costs here.
+ *
+ * The default is worse than just small — it measures the wrong subset. The
+ * fixture's `git()`/`gitOk()` are `spawnSync`, which pins the event loop, so
+ * vitest's timer cannot fire while they run. Measured with a shim that adds a
+ * fixed delay per spawn: at 600ms/spawn this file burns 43 SECONDS of wall
+ * clock and still reports green; at 900ms/spawn it fails `Test timed out in
+ * 5000ms`. Only the six async spawns are ever on a clock, so the threshold is
+ * really "an async git spawn costs more than ~830ms", which a loaded Windows
+ * runner sits right on. Budget the whole thing instead.
+ */
+const GIT_SPAWN_HEAVY_TIMEOUT_MS = 30_000
+
 let tmpRoot: string
 let repo: string
 
@@ -94,7 +116,7 @@ afterEach(() => {
   }
 })
 
-describe("a git commit that fails mid-land", () => {
+describe("a git commit that fails mid-land", { timeout: GIT_SPAWN_HEAVY_TIMEOUT_MS }, () => {
   test("squash surfaces git's own error and does NOT reset the staged merge away", async () => {
     branchAheadOfMovedMain()
     breakCommitting()

--- a/packages/kobe/test/orchestrator/task-deletion.test.ts
+++ b/packages/kobe/test/orchestrator/task-deletion.test.ts
@@ -7,6 +7,27 @@ import { DirtyWorktreeError, TaskDeletingError, WorktreeRemoveFailedError } from
 import { TaskIndexStore } from "../../src/orchestrator/index/store.ts"
 import type { GitWorktreeManager } from "../../src/orchestrator/worktree/manager.ts"
 
+/**
+ * Per-test budget for this file, replacing vitest's 5000ms default.
+ *
+ * Nothing here waits on an event — every case is a straight line of
+ * `TaskIndexStore.save()` calls, and each save is a full durable write:
+ * lockfile acquire (mkdir + write sidecar + link + unlink), read-merge, then
+ * open + write + **fsync** + close + rename, then release (read + unlink).
+ * Roughly eleven filesystem syscalls and one fsync apiece. The two cases that
+ * timed out on the Windows runner are exactly the two heaviest — 10 saves and
+ * 8 saves; every case at 3-5 saves stayed green in the same run. That is a
+ * volume-vs-budget ratio, not a race, and 5000ms is a vitest default nobody
+ * sized against ten fsyncs on a filesystem with on-access virus scanning.
+ *
+ * The default is also actively misleading here: the store's own lock wait is
+ * `LOCK_MAX_WAIT_MS = 5_000` (index/store-codec.ts), the same number, so a
+ * genuinely contended index could never report itself — vitest would kill the
+ * test first and the `LockfileError` naming the holding pid would never throw.
+ * Any budget for this file has to clear that deadline to stay diagnosable.
+ */
+const DURABLE_WRITE_TIMEOUT_MS = 30_000
+
 let home: string
 let store: TaskIndexStore
 let orch: Orchestrator
@@ -39,7 +60,7 @@ async function makeTask(worktreePath = "/wt/task") {
   return orch.getTask(task.id)!
 }
 
-describe("durable background task deletion", () => {
+describe("durable background task deletion", { timeout: DURABLE_WRITE_TIMEOUT_MS }, () => {
   it("persists queued/running before physical cleanup and removes the task only on success", async () => {
     const task = await makeTask()
 
@@ -273,7 +294,7 @@ describe("durable background task deletion", () => {
   })
 })
 
-describe("dir tasks on the daemon's prepare→begin→finish path", () => {
+describe("dir tasks on the daemon's prepare→begin→finish path", { timeout: DURABLE_WRITE_TIMEOUT_MS }, () => {
   it("NEVER removes the user's own directory, and never probes it for dirt", async () => {
     // This is the path `rove api delete` takes. `finish()` has its OWN
     // `kind !== "dir"` guard, separate from the one `deleteNow()` reaches

--- a/packages/kobe/test/render/diff-review-send-guard.test.tsx
+++ b/packages/kobe/test/render/diff-review-send-guard.test.tsx
@@ -31,7 +31,7 @@ import {
   diffCommentsKey,
   unsentComments,
 } from "../../src/tui/ops/diff-comments"
-import { renderComponent, settle, waitForFrameText } from "./harness"
+import { act, renderComponent, settle, waitForFrameText } from "./harness"
 
 const DIFF = ["--- a/a.ts", "+++ b/a.ts", "@@ -1,1 +1,3 @@", " const a = 1", "+const b = 2", "+const c = 3"].join("\n")
 const REL = "a.ts"
@@ -102,12 +102,22 @@ async function writeNote(
   body: string,
   location: string,
 ): Promise<void> {
-  handle.mockInput.typeText("c")
+  await act(async () => {
+    await handle.mockInput.typeText("c")
+  })
   await waitForFrameText(handle.frame, location)
-  handle.mockInput.typeText(body)
+  await act(async () => {
+    await handle.mockInput.typeText(body)
+  })
+  // The dialog commits its submit through a state update outside React's event
+  // system, so the old `settle(150)` was a bet on when that landed. When it lost,
+  // the next frame still showed the OPEN note dialog and a `notes: 0` footer —
+  // the CI failure. `act` flushes the commit; the closed prompt is then the
+  // observable proof it happened, not the clock.
+  await act(async () => {
+    handle.mockInput.pressEnter()
+  })
   await settle(60)
-  handle.mockInput.pressEnter()
-  await settle(150)
 }
 
 test("s keeps the notes unsent and says why when there is no engine session", async () => {
@@ -121,14 +131,16 @@ test("s keeps the notes unsent and says why when there is no engine session", as
   await writeNote(handle, "please rename this", "Review note")
   expect(await handle.frame()).toContain("notes: 1 · 1 unsent")
 
-  handle.mockInput.typeText("s")
-  await settle(200)
-
+  await act(async () => {
+    await handle.mockInput.typeText("s")
+  })
+  // Wait for the refusal to paint, THEN assert the count. Asserting the
+  // unchanged count first would pass on a frame where `s` had not been
+  // handled at all — the same clock bet, silently inverted into a false green.
+  expect(await waitForFrameText(handle.frame, "No engine session")).toContain("No engine session")
   // The note survived and is still pending — the count is the whole assertion.
   expect(await handle.frame()).toContain("notes: 1 · 1 unsent")
   expect(unsentComments(kv.read())).toHaveLength(1)
-  // …and the refusal is on screen rather than in a log nobody can read.
-  expect(await handle.frame()).toContain("No engine session")
 })
 
 test("s still marks them sent once delivery answers", async () => {
@@ -140,10 +152,10 @@ test("s still marks them sent once delivery answers", async () => {
   })
   await settle(120)
   await writeNote(handle, "please rename this", "Review note")
-  handle.mockInput.typeText("s")
-  await settle(200)
-
-  expect(await handle.frame()).toContain("notes: 1 · 0 unsent")
+  await act(async () => {
+    await handle.mockInput.typeText("s")
+  })
+  expect(await waitForFrameText(handle.frame, "notes: 1 · 0 unsent")).toContain("notes: 1 · 0 unsent")
   expect(unsentComments(kv.read())).toHaveLength(0)
 })
 
@@ -158,10 +170,10 @@ test("x drops the note under the cursor", async () => {
   await writeNote(handle, "typo", "Review note")
   expect(await handle.frame()).toContain("notes: 1")
 
-  handle.mockInput.typeText("x")
-  await settle(200)
-
-  expect(await handle.frame()).toContain("notes: 0 · 0 unsent")
+  await act(async () => {
+    await handle.mockInput.typeText("x")
+  })
+  expect(await waitForFrameText(handle.frame, "notes: 0 · 0 unsent")).toContain("notes: 0 · 0 unsent")
   expect(kv.read()).toHaveLength(0)
 })
 

--- a/packages/kobe/test/render/golden/sidebar-frames.test.tsx
+++ b/packages/kobe/test/render/golden/sidebar-frames.test.tsx
@@ -23,7 +23,7 @@ import { afterAll, beforeAll, expect, test } from "bun:test"
 import { DEFAULT_SPINNER_FRAMES } from "@/engine/spinner-frames"
 import { currentLang, setLocaleLang } from "@/tui/i18n"
 import { goldenPath, matchGolden } from "../../golden/golden-file"
-import { renderComponent, settle } from "../harness"
+import { act, renderComponent, settle } from "../harness"
 import { SCENES, SCENE_HEIGHT, SCENE_WIDTH, type Scene } from "./sidebar-scenes"
 
 /** Let opentui's mount, the tree's follow effect, and the layout pass settle
@@ -93,7 +93,17 @@ for (const scene of SCENES) {
     })
     await settle(SETTLE_MS)
     for (const key of scene.keys ?? []) {
-      mockInput.typeText(key)
+      // `act` is what makes the keyed scenes deterministic, not the sleep.
+      // The sidebar's search box captures keys on a RAW renderer listener and
+      // calls `setQuery` from it (use-tree-search.ts), outside React's event
+      // system and outside `flushSync` — so the commit rides the concurrent
+      // scheduler and a fixed sleep is a bet on when it lands. Losing that bet
+      // captures the frame BEFORE the query renders, which is the `/ █ fuzzy
+      // filter` vs `/review█ 2/5` golden diff seen on CI. Awaiting `act` flushes
+      // the pending work instead of waiting for it.
+      await act(async () => {
+        await mockInput.typeText(key)
+      })
       await settle(SETTLE_MS)
     }
     const captured = scene.animated ? maskSpinner(await frame()) : await frame()

--- a/packages/kobe/test/render/keyboard-hints.test.tsx
+++ b/packages/kobe/test/render/keyboard-hints.test.tsx
@@ -271,8 +271,9 @@ describe("footer hint clicks", () => {
     )
     await settle()
     const spot = locate(await frame(), "[settings]")
-    await mockMouse.click(spot.x + 1, spot.y)
-    await settle()
+    await act(async () => {
+      await mockMouse.click(spot.x + 1, spot.y)
+    })
     expect(settingsOpened.length).toBe(1)
   })
 
@@ -285,9 +286,16 @@ describe("footer hint clicks", () => {
     )
     await settle()
     const spot = locate(await frame(), "F1 help")
-    await mockMouse.click(spot.x + 1, spot.y)
-    await settle()
-    expect(await frame()).toContain("Rove — keybindings")
+    // The click opens the dialog through a React state update that is neither
+    // inside React's event system nor inside `flushSync`, so its commit rides
+    // the concurrent scheduler. `settle()` + one `frame()` was a bet on that
+    // landing inside 60ms; when it did not, the captured frame was the footer
+    // with no dialog over it — the CI failure. `act` flushes the commit and
+    // `waitForFrameText` waits for the paint instead of guessing at it.
+    await act(async () => {
+      await mockMouse.click(spot.x + 1, spot.y)
+    })
+    expect(await waitForFrameText(frame, "Rove — keybindings")).toContain("Rove — keybindings")
   })
 
   it("clicking the commands caption arms the real prefix and shows the which-key guide", async () => {

--- a/packages/kobe/test/render/kitty-input-paths.test.tsx
+++ b/packages/kobe/test/render/kitty-input-paths.test.tsx
@@ -7,6 +7,24 @@ import { Terminal } from "../../src/tui-react/panes/terminal/Terminal"
 import { createScriptedPtyRegistry } from "../../src/tui/panes/terminal/pty-scripted"
 import { act, renderComponent, settle } from "./harness"
 
+/**
+ * Wait until `<Terminal>` has actually taken a pty out of the registry.
+ *
+ * One `await frame()` flushes a render pass, which is not the same thing: the
+ * acquire happens in a mount effect, so a loaded machine can paint the first
+ * frame with the registry still empty and `harness.last()` throws "scripted pty
+ * registry: nothing acquired yet" — an error that reads like a broken fixture
+ * rather than a race. Seen once in ten soak runs of the render track.
+ */
+async function acquiredPty(harness: ReturnType<typeof createScriptedPtyRegistry>, timeoutMs = 2_000) {
+  const deadline = Date.now() + timeoutMs
+  while (harness.ptys.length === 0) {
+    if (Date.now() >= deadline) throw new Error(`no pty acquired within ${timeoutMs}ms`)
+    await settle(10)
+  }
+  return harness.last()
+}
+
 function ComposerProbe() {
   const [value, setValue] = useState("")
   useBindings(() => ({ bindings: [] }))
@@ -28,11 +46,11 @@ test("kitty all-keys-as-escapes input still types into a composer", async () => 
 
 test("kitty modifier, text, keypad, and navigation events are re-encoded for the embedded PTY", async () => {
   const harness = createScriptedPtyRegistry()
-  const { mockInput, frame } = await renderComponent(
+  const { mockInput } = await renderComponent(
     <Terminal cwd="/wt" taskId="kitty-wire" focused registry={harness.registry} />,
     { width: 60, height: 12, providers: { dialog: true } },
   )
-  await frame()
+  await acquiredPty(harness)
 
   const wireEvents = [
     "\x1b[57442;5u",
@@ -78,13 +96,11 @@ test("kitty modifier, text, keypad, and navigation events are re-encoded for the
 
 test("kitty navigation follows the child PTY application cursor and keypad modes", async () => {
   const harness = createScriptedPtyRegistry()
-  const { mockInput, frame } = await renderComponent(
+  const { mockInput } = await renderComponent(
     <Terminal cwd="/wt" taskId="kitty-application-modes" focused registry={harness.registry} />,
     { width: 60, height: 12, providers: { dialog: true } },
   )
-  await frame()
-
-  harness.last().modes = { applicationCursorKeys: true, applicationKeypad: true }
+  ;(await acquiredPty(harness)).modes = { applicationCursorKeys: true, applicationKeypad: true }
   act(() => {
     mockInput.pressKey("\x1b[1;1:1A")
     mockInput.pressKey("\x1b[1;1:1H")

--- a/packages/kobe/test/tui/pty-fake.ts
+++ b/packages/kobe/test/tui/pty-fake.ts
@@ -1,0 +1,52 @@
+/**
+ * Shared fake-transport PTY + the settle barrier its snapshot tests need.
+ *
+ * The barrier is the point. `XtermTaskPty` publishes a snapshot two hops
+ * after output arrives: xterm parses the chunk and fires the write callback
+ * asynchronously, and that callback arms a `setTimeout(SNAPSHOT_COALESCE_MS)`
+ * (pty-xterm-base.ts `queueRefresh`). The tests used to wait out both hops
+ * with one hard-coded `settle(60)`.
+ *
+ * That sleep was written when the coalesce period was 16ms. PR #878 raised it
+ * to 33ms and left the 60 alone, so the margin covering an xterm parse plus
+ * TWO timer dispatches fell to 27ms — fine on an idle laptop, not on a shared
+ * CI runner. It showed up as `expected false to be true` (a publish that had
+ * not arrived yet) and as `spy ... been called 1 times` (the PREVIOUS step's
+ * publish arriving after `mockClear`, attributed to the wrong pump).
+ * Shrinking the sleep to 34ms reproduces both, every run.
+ *
+ * `pump()` splits the two hops. xterm runs write callbacks in FIFO order, so
+ * a follow-up empty write resolves strictly after the fed chunk's parse — the
+ * unbounded half is now awaited, not slept through. Only the coalesce timer
+ * is left, and {@link REFRESH_WINDOW_MS} budgets that one alone, anchored to
+ * the product constant so raising it can't silently eat the margin again.
+ */
+
+import type { TerminalRow } from "../../src/tui/panes/terminal/pty-types"
+import { SNAPSHOT_COALESCE_MS, XtermTaskPty } from "../../src/tui/panes/terminal/pty-xterm-base"
+
+/** One coalesce period plus 3x headroom for the single timer dispatch left
+ *  after `pump()` has already awaited the parse. */
+export const REFRESH_WINDOW_MS = SNAPSHOT_COALESCE_MS * 4
+
+export class FakeTransportPty extends XtermTaskPty {
+  protected transportWrite(_data: string): void {}
+  protected transportResize(_cols: number, _rows: number): void {}
+  protected transportKill(): void {}
+
+  /** Feed `data` and resolve once xterm has finished parsing it. The queued
+   *  snapshot refresh is still one timer away — follow with {@link settleRefresh}. */
+  async pump(data: string): Promise<void> {
+    this.feed(data)
+    await new Promise<void>((resolve) => this.term.write("", () => resolve()))
+  }
+}
+
+/** Wait out the coalesced snapshot refresh armed by the last {@link FakeTransportPty.pump}. */
+export function settleRefresh(ms = REFRESH_WINDOW_MS): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+export function rowsText(rows: readonly TerminalRow[]): string {
+  return rows.map((row) => row.map((chunk) => chunk.text).join("")).join("\n")
+}

--- a/packages/kobe/test/tui/terminal-pty-lazy-snapshot.test.ts
+++ b/packages/kobe/test/tui/terminal-pty-lazy-snapshot.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it, vi } from "vitest"
-import type { TerminalRow } from "../../src/tui/panes/terminal/pty-types"
-import { XtermTaskPty } from "../../src/tui/panes/terminal/pty-xterm-base"
+import { FakeTransportPty, rowsText, settleRefresh } from "./pty-fake"
 
 /**
  * Lazy snapshot rebuild for unwatched PTYs.
@@ -15,32 +14,14 @@ import { XtermTaskPty } from "../../src/tui/panes/terminal/pty-xterm-base"
  * `onData` subscribe still always see fresh content.
  */
 
-class FakeTransportPty extends XtermTaskPty {
-  protected transportWrite(_data: string): void {}
-  protected transportResize(_cols: number, _rows: number): void {}
-  protected transportKill(): void {}
-  pump(data: string): void {
-    this.feed(data)
-  }
-}
-
-function rowsText(rows: readonly TerminalRow[]): string {
-  return rows.map((row) => row.map((chunk) => chunk.text).join("")).join("\n")
-}
-
-/** Let xterm's async write callback + the 16ms refresh debounce drain. */
-function settle(ms = 60): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms))
-}
-
 describe("XtermTaskPty lazy snapshot (no subscribers)", () => {
   it("defers the rebuild until capture(), then serves it without re-converting", async () => {
     const pty = new FakeTransportPty({ taskId: "t1", cwd: "/wt" })
     // biome-ignore lint/suspicious/noExplicitAny: reaching a private method to observe laziness
     const refresh = vi.spyOn(pty as any, "refreshSnapshot")
 
-    pty.pump("hello from background\r\n")
-    await settle()
+    await pty.pump("hello from background\r\n")
+    await settleRefresh()
     // Output landed but nobody is watching — no conversion ran.
     expect(refresh).not.toHaveBeenCalled()
 
@@ -58,8 +39,8 @@ describe("XtermTaskPty lazy snapshot (no subscribers)", () => {
 
   it("primes a late onData subscriber with fresh content, not the stale snapshot", async () => {
     const pty = new FakeTransportPty({ taskId: "t1", cwd: "/wt" })
-    pty.pump("first output\r\n")
-    await settle()
+    await pty.pump("first output\r\n")
+    await settleRefresh()
 
     const primed: string[] = []
     pty.onData((snap) => primed.push(rowsText(snap)))
@@ -74,8 +55,8 @@ describe("XtermTaskPty lazy snapshot (no subscribers)", () => {
     const seen: string[] = []
     pty.onData((snap) => seen.push(rowsText(snap)))
 
-    pty.pump("streamed line\r\n")
-    await settle()
+    await pty.pump("streamed line\r\n")
+    await settleRefresh()
     // No capture() needed — the subscriber was pushed the fresh snapshot.
     expect(seen.some((s) => s.includes("streamed line"))).toBe(true)
 

--- a/packages/kobe/test/tui/terminal-pty-redraw-budget.test.ts
+++ b/packages/kobe/test/tui/terminal-pty-redraw-budget.test.ts
@@ -1,26 +1,12 @@
 import { describe, expect, it, vi } from "vitest"
 import type { CursorPos, TerminalRow } from "../../src/tui/panes/terminal/pty-types"
-import { XtermTaskPty } from "../../src/tui/panes/terminal/pty-xterm-base"
 import { xtermLineToChunks } from "../../src/tui/panes/terminal/xterm-chunks"
+import { FakeTransportPty, settleRefresh } from "./pty-fake"
 
 vi.mock("../../src/tui/panes/terminal/xterm-chunks", async (importOriginal) => {
   const mod = await importOriginal<typeof import("../../src/tui/panes/terminal/xterm-chunks")>()
   return { ...mod, xtermLineToChunks: vi.fn(mod.xtermLineToChunks) }
 })
-
-class FakeTransportPty extends XtermTaskPty {
-  protected transportWrite(_data: string): void {}
-  protected transportResize(_cols: number, _rows: number): void {}
-  protected transportKill(): void {}
-
-  pump(data: string): void {
-    this.feed(data)
-  }
-}
-
-function settle(ms = 60): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms))
-}
 
 function makePty(): FakeTransportPty {
   return new FakeTransportPty({ taskId: "t1", cwd: "/wt", cols: 40, rows: 10, scrollback: 20 })
@@ -35,26 +21,26 @@ describe("XtermTaskPty redraw budget", () => {
     pty.onData(onData)
     pty.onTitleChange(onTitle)
 
-    pty.pump("seed")
-    await settle()
+    await pty.pump("seed")
+    await settleRefresh()
     const before = pty.capture()
     onData.mockClear()
     onTitle.mockClear()
     vi.mocked(xtermLineToChunks).mockClear()
 
-    pty.pump("\x1b]2;vim\x07")
-    await settle()
+    await pty.pump("\x1b]2;vim\x07")
+    await settleRefresh()
     expect(onTitle).toHaveBeenCalledWith("vim")
     expect(onData).not.toHaveBeenCalled()
     expect(pty.capture()).toBe(before)
 
-    pty.pump("\x1b[1;5H")
-    await settle()
+    await pty.pump("\x1b[1;5H")
+    await settleRefresh()
     expect(onData).not.toHaveBeenCalled()
     expect(pty.capture()).toBe(before)
 
-    pty.pump("\x1b[?2026h\x1b[1;5H\x1b[?2026l")
-    await settle()
+    await pty.pump("\x1b[?2026h\x1b[1;5H\x1b[?2026l")
+    await settleRefresh()
     expect(onData).not.toHaveBeenCalled()
     expect(pty.capture()).toBe(before)
     expect(xtermLineToChunks).not.toHaveBeenCalled()
@@ -75,16 +61,16 @@ describe("XtermTaskPty redraw budget", () => {
     const pty = makePty() // rows 10 + scrollback 20 -> saturates at 30 lines
     const text = (rows: readonly TerminalRow[]) => rows.map((r) => r.map((c) => c.text).join("")).join("\n")
 
-    for (let i = 0; i < 60; i++) pty.pump(`line-${i}\r\n`)
-    await settle()
+    for (let i = 0; i < 60; i++) await pty.pump(`line-${i}\r\n`)
+    await settleRefresh()
     const saturated = pty.capture()
     expect(text(saturated)).toContain("line-59")
     const topBefore = text(saturated).split("\n")[0]
 
     // A sync-marked frame, which is what forces dirty={kind:"all"} — exactly
     // the case the fast path short-circuits.
-    pty.pump("\x1b[?2026hline-60\r\n\x1b[?2026l")
-    await settle()
+    await pty.pump("\x1b[?2026hline-60\r\n\x1b[?2026l")
+    await settleRefresh()
 
     const shifted = pty.capture()
     expect(shifted).not.toBe(saturated)
@@ -98,13 +84,13 @@ describe("XtermTaskPty redraw budget", () => {
     const onData = vi.fn<(rows: readonly TerminalRow[], cursor: CursorPos | null) => void>()
     pty.onData(onData)
 
-    pty.pump("seed")
-    await settle()
+    await pty.pump("seed")
+    await settleRefresh()
     const before = pty.capture()
     onData.mockClear()
 
-    pty.pump("!")
-    await settle()
+    await pty.pump("!")
+    await settleRefresh()
 
     expect(onData).toHaveBeenCalledTimes(1)
     expect(pty.capture()).not.toBe(before)
@@ -116,13 +102,13 @@ describe("XtermTaskPty redraw budget", () => {
     const onData = vi.fn()
     pty.onData(onData)
 
-    pty.pump("A")
-    await settle()
+    await pty.pump("A")
+    await settleRefresh()
     const before = pty.capture()
     onData.mockClear()
 
-    pty.pump("\r\x1b[31mA")
-    await settle()
+    await pty.pump("\r\x1b[31mA")
+    await settleRefresh()
 
     expect(onData).toHaveBeenCalledTimes(1)
     expect(pty.capture()).not.toBe(before)
@@ -143,17 +129,17 @@ describe("XtermTaskPty redraw budget", () => {
     })
     pty.onData(() => {})
 
-    pty.pump("\x1b[48;2;48;48;47mcomposer")
-    await settle()
+    await pty.pump("\x1b[48;2;48;48;47mcomposer")
+    await settleRefresh()
     expect(pty.capture()[0]?.[0]?.fg).toBeUndefined()
     expect(pty.capture()[0]?.[0]?.bg).toEqual([48, 48, 47])
 
-    pty.pump("\x1b[?1049h\x1b[0m\x1b[48;2;48;48;47mtranscript")
-    await settle()
+    await pty.pump("\x1b[?1049h\x1b[0m\x1b[48;2;48;48;47mtranscript")
+    await settleRefresh()
     expect(pty.capture()[0]?.[0]).toMatchObject({ fg: [20, 20, 19], bg: [234, 231, 223] })
 
-    pty.pump("\x1b[?1049l")
-    await settle()
+    await pty.pump("\x1b[?1049l")
+    await settleRefresh()
     expect(pty.capture()[0]?.[0]?.fg).toBeUndefined()
     expect(pty.capture()[0]?.[0]?.bg).toEqual([48, 48, 47])
     pty.kill()
@@ -164,13 +150,13 @@ describe("XtermTaskPty redraw budget", () => {
     const seen: Array<{ rows: readonly TerminalRow[]; cursor: CursorPos | null }> = []
     pty.onData((rows, cursor) => seen.push({ rows, cursor }))
 
-    pty.pump("seed")
-    await settle()
+    await pty.pump("seed")
+    await settleRefresh()
     const before = pty.capture()
     seen.length = 0
 
-    pty.pump("\x1b[D")
-    await settle()
+    await pty.pump("\x1b[D")
+    await settleRefresh()
 
     expect(seen).toHaveLength(1)
     expect(seen[0]?.rows).toBe(before)
@@ -183,24 +169,24 @@ describe("XtermTaskPty redraw budget", () => {
     const seen: Array<{ rows: readonly TerminalRow[]; cursor: CursorPos | null }> = []
     pty.onData((rows, cursor) => seen.push({ rows, cursor }))
 
-    pty.pump("seed")
-    await settle()
+    await pty.pump("seed")
+    await settleRefresh()
     const before = pty.capture()
     seen.length = 0
 
-    pty.pump("\x1b[?25l")
-    await settle()
+    await pty.pump("\x1b[?25l")
+    await settleRefresh()
     expect(seen).toEqual([{ rows: before, cursor: null }])
 
     const hiddenRows = pty.capture()
     seen.length = 0
-    pty.pump("\x1b[10C")
-    await settle()
+    await pty.pump("\x1b[10C")
+    await settleRefresh()
     expect(seen).toHaveLength(0)
     expect(pty.capture()).toBe(hiddenRows)
 
-    pty.pump("\x1b[?25h")
-    await settle()
+    await pty.pump("\x1b[?25h")
+    await settleRefresh()
     expect(seen).toHaveLength(1)
     expect(seen[0]?.cursor).toEqual({ x: 14, y: 0 })
     pty.kill()
@@ -211,14 +197,14 @@ describe("XtermTaskPty redraw budget", () => {
     const seen: Array<CursorPos | null> = []
     pty.onData((_rows, cursor) => seen.push(cursor))
 
-    pty.pump("input")
-    await settle()
-    pty.pump("\x1b[?1049h\x1b[?25lpager")
-    await settle()
+    await pty.pump("input")
+    await settleRefresh()
+    await pty.pump("\x1b[?1049h\x1b[?25lpager")
+    await settleRefresh()
     expect(seen.at(-1)).toBeNull()
 
-    pty.pump("\x1b[?1049l\x1b[?25h")
-    await settle()
+    await pty.pump("\x1b[?1049l\x1b[?25h")
+    await settleRefresh()
     expect(seen.at(-1)).toEqual({ x: 5, y: 0 })
     pty.kill()
   })


### PR DESCRIPTION
Seven tests went red on CI on 2026-09-06 across the `windows`, `render-track` and Release `publish` jobs, all green on rerun. Each one here gets a named mechanism, a knob that reproduces it locally at 100%, and a fix that removes the guess rather than widening it. No bare sleeps were lengthened.

## The three mechanisms

**1. A fixed sleep that a product constant outgrew** — `terminal-pty-lazy-snapshot`, `terminal-pty-redraw-budget`

`XtermTaskPty` publishes a snapshot two hops after output arrives: xterm parses the chunk asynchronously and fires a write callback, and that callback arms a `setTimeout(SNAPSHOT_COALESCE_MS)` (`pty-xterm-base.ts:386`). Both tests waited out both hops with one hard-coded `settle(60)`, written when the coalesce period was 16ms. PR #878 raised it to 33ms and left the 60 alone, so the margin covering a parse plus two timer dispatches fell from 44ms to 27ms.

That is exactly both reported failures. `expected false to be true` is a publish that had not landed; `spy … been called 1 times` is the *previous* pump's publish arriving after `mockClear` and being charged to the wrong step.

`pump()` now awaits the parse instead of sleeping through it — xterm runs write callbacks in FIFO order, so a follow-up empty write resolves strictly after the fed chunk — and `settleRefresh()` budgets the one remaining timer, anchored to the product constant so raising it cannot silently eat the margin again.

**2. Vitest's default 5000ms applied to I/O-bound integration tests** — `land-commit-failure`, `task-deletion`

Neither waits on an event and neither has a race. Each does a fixed, bounded amount of syscall work; 5000ms is vitest's default for CPU-bound unit tests.

- `task-deletion`: every case is a straight line of `TaskIndexStore.save()`, and a save is a durable write — lockfile acquire, read-merge, `open + write + fsync + rename`, release: ~11 syscalls and one fsync each. Counted per test, the two that timed out on CI are exactly the two heaviest (10 saves and 8 saves); every case at 3–5 saves stayed green in the same run. The default is also self-defeating here: the store's own lock wait is `LOCK_MAX_WAIT_MS = 5_000`, the same number, so a genuinely contended index could never report itself — vitest kills the test before the `LockfileError` naming the holding pid can throw.
- `land-commit-failure`: 20 real `git` spawns per case, counted with a PATH shim. Fourteen go through the fixture's `spawnSync` helpers, which pin the event loop so vitest's timer cannot fire while they run. Measured with a delay shim: at 600ms/spawn the file burns **43 seconds** of wall clock and still reports GREEN, then times out at 900ms/spawn — only `landTask`'s six async spawns are ever on a clock. The default was thresholding a third of the work at ~830ms per async spawn, which a loaded Windows runner sits on.

Both get a 30s budget with the reasoning in the file. A ceiling, not a wait: a real hang still fails and both files stay at ~0.5s locally.

**3. Synthetic input whose React commit was never flushed** — `keyboard-hints`, `sidebar-frames` golden, `diff-review-send-guard`

One mechanism, three failures. Each drives the UI with synthetic input whose React state update is neither inside React's event system nor inside `flushSync`, so the commit rides the concurrent scheduler. The tests then captured a frame after a fixed `settle()`. Losing that bet does not error — it captures the *previous* frame, so the failure reads as wrong content:

- sidebar golden `search-tab-title`: the query row painted before `setQuery` committed → golden diff `/ █ fuzzy filter` vs `/review█ 2/5`. The keystrokes land on a **raw renderer listener** (`use-tree-search.ts:58-70`), which is why nothing flushed them.
- `clicking the help caption opens the F1 reference`: the captured frame was the bare footer, dialog not committed.
- `x drops the note under the cursor`: the note dialog was still open with the body typed into it, footer still `notes: 0`.

`act` flushes the pending commit rather than waiting for it, and where the assertion is positive `waitForFrameText` waits for the paint instead of guessing. The `s`-refusal case additionally now waits for the refusal toast **before** asserting the unchanged count — asserting an unchanged value first would have passed on a frame where the key was never handled.

## Evidence

Every mechanism has a knob that reproduces it at 100% locally; `nice`+CPU load alone never reproduced any of them on this hardware (20/20 green), so the knobs target the actual failure mode instead.

| # | Test | Knob | Before | After |
|---|---|---|---|---|
| 1, 7 | `terminal-pty-{lazy-snapshot,redraw-budget}` | 40ms event-loop blocks | 20/20 fail | 20/20 pass |
| 1, 7 | same | budget shrunk to 34ms (1 tick over coalesce) | 7/11 fail, both CI assertions verbatim | 11/11 pass |
| 2 | `land-commit-failure` | 900ms/git-spawn shim | 20/20 fail | 20/20 pass |
| 3 | `task-deletion` | 40ms event-loop blocks | 20/20 fail | 20/20 pass |
| 4, 5, 6 | render trio in one bun process | 30ms event-loop blocks | 20/20 fail | 20/20 pass |
| 4, 6 | whole render track under CPU load | 10 full-suite runs | 2 red — run 3 was exactly these two | — |

Headroom check on the one budget that is a number rather than a barrier: under the 40ms blocker the heaviest `task-deletion` case takes 9653ms — already 2x the old 5000ms default, and 32% of the new 30s. A real hang still fails.

Gates: `test:fast` 3x 4915/4915, `bun test test/render` 3x 513/513, root lint + typecheck clean.

## Also fixed (not on the list)

Soaking the whole render track turned up a second red: `kitty navigation follows the child PTY application cursor and keypad modes` throws `scripted pty registry: nothing acquired yet`. Same class — `<Terminal>` takes its pty in a mount effect, and one `await frame()` flushes a render pass, not that effect. It now polls the registry. Reporting it rather than leaving a 1-in-10 red on a job this PR has to get green.

Tests only — no changeset.
