### PR TITLE
fix: wrapped engine presets read their declared protocol's adapter

### DIFF
--- a/.changeset/wrapped-preset-protocol-entry.md
+++ b/.changeset/wrapped-preset-protocol-entry.md
@@ -1,0 +1,7 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Wrapped engine presets now get the protocol's context usage, composer gate, turn detector and title hint
+
+A custom preset (`engineProtocol.<id>`) declares which built-in adapter Rove speaks to it with, but five reads still keyed off the raw preset id and so landed on the registry's EMPTY custom entry. On a `claudecpa` task that meant: no token/context chip in the footer, no per-turn telemetry, no composer-busy gate (so `rove api send` pasted over half-typed text instead of deferring), no turn detector, and a title hint that answered `null` forever — leaving the ESC interrupt observer unable to see working→rest.

--- a/packages/kobe/src/cli/api/pty-delivery.ts
+++ b/packages/kobe/src/cli/api/pty-delivery.ts
@@ -14,6 +14,7 @@
 
 import type { PtyOpenResult } from "@sma1lboy/kobe-daemon/daemon/protocol"
 import type { PtySessionInfo } from "@sma1lboy/kobe-daemon/daemon/pty-host"
+import { protocolEntry } from "../../engine/engine-presets.ts"
 import type { PsSnapshot } from "../../engine/foreground.ts"
 import {
   ComposerBusyError,
@@ -34,7 +35,6 @@ import {
   writeHostedPrompt,
   writeHostedPromptIfClear,
 } from "../../engine/hosted-session.ts"
-import { engineEntry } from "../../engine/registry.ts"
 import type { EngineScreenManifest } from "../../engine/screen-state.ts"
 import { enginePresence } from "../../engine/session-engine-presence.ts"
 import { type EngineSessionLaunch, initMarkerSaysFinished } from "../../engine/session-launch.ts"
@@ -362,8 +362,16 @@ export async function deliverHostedPrompt(
   }
 }
 
+/**
+ * The screen manifest the composer gate classifies with — the WRAPPED
+ * engine's, via {@link protocolEntry}. A screen manifest is protocol
+ * knowledge ("what does this engine's composer look like"), so keying it off
+ * the raw id would find the empty custom entry and leave the B-layer with
+ * nothing to classify: a `claudecpa` task would get no gate at all rather
+ * than a degraded one, and `send` would paste over half-typed text.
+ */
 export function resolveComposerManifest(vendor?: VendorId): EngineScreenManifest | undefined {
-  return vendor ? engineEntry(vendor).screenManifest : undefined
+  return vendor ? protocolEntry(vendor).screenManifest : undefined
 }
 
 /**

--- a/packages/kobe/src/core/daemon-runtime.ts
+++ b/packages/kobe/src/core/daemon-runtime.ts
@@ -3,7 +3,7 @@
 import type { DaemonRuntimeAdapter } from "@sma1lboy/kobe-daemon/daemon/runtime"
 import { parseAheadBehind } from "@sma1lboy/kobe-daemon/daemon/worktree-changes-collector"
 import { availableEngineIds } from "../engine/account-detect.ts"
-import { engineProtocolKey } from "../engine/engine-presets.ts"
+import { engineProtocolKey, protocolEntry, sessionProtocol } from "../engine/engine-presets.ts"
 import { foregroundEngineIn, parsePsSnapshot, psSnapshot } from "../engine/foreground.ts"
 import { affectsActivityState, isEngineActivityKind } from "../engine/hook-events.ts"
 import { engineDisplayName, kobeApiInvocation } from "../engine/interactive-command.ts"
@@ -79,18 +79,24 @@ export const daemonRuntime: DaemonRuntimeAdapter = {
     }
     return out
   },
-  titleTurnHint: engineTitleTurnHint,
+  // Protocol-keyed, like every other "how do we talk to it" read in this
+  // object: a `claudecpa` task's OSC title is claude's, and `registry.ts`
+  // stays state-free so it cannot resolve the preset itself. Keying off the
+  // raw id finds the empty custom entry, whose `terminalTitle` is undefined
+  // — `titleTurnHint` then answers null forever and the interrupt observer
+  // never sees working→rest on a wrapped tab.
+  titleTurnHint: (vendor, title) => engineTitleTurnHint(sessionProtocol(vendor), title),
   // Tier-(b) protocol sniff: the record upgrade for a generic
   // task identified by its live session, plus the preset write-back —
   // rules live with the sniffer.
   resolveProtocolUpgrade: resolveProtocolUpgradeAndLearnPreset,
   // Per-turn telemetry — delegated straight to the vendor's own
   // adapter; an engine without a turn reader simply reports none.
-  readEngineTurns: async (vendor, transcriptPath) => (await engineEntry(vendor).readTurns?.(transcriptPath)) ?? [],
+  readEngineTurns: async (vendor, transcriptPath) => (await protocolEntry(vendor).readTurns?.(transcriptPath)) ?? [],
   checkLatestVersion,
   latestTranscriptMtime,
   deriveTitleFromSession,
-  createEngineTurnDetector,
+  createEngineTurnDetector: (vendor) => createEngineTurnDetector(sessionProtocol(vendor)),
   async runWorktreeStatus(worktreePath, signal, baseRef) {
     const result = await spawnCapture("git", ["status", "--porcelain=v1"], {
       cwd: worktreePath,
@@ -155,7 +161,7 @@ export const daemonRuntime: DaemonRuntimeAdapter = {
   // when the adapter reported it; a missing field stays missing rather than
   // becoming a fabricated `0`.
   async readEngineContextUsage(vendor, sessionId) {
-    const read = engineEntry(vendor).history.readUsageSnapshot
+    const read = protocolEntry(vendor).history.readUsageSnapshot
     if (!read) return null
     const snapshot = await read(sessionId)
     if (snapshot?.context_tokens === undefined) return null

--- a/packages/kobe/src/core/daemon-session-adapter.ts
+++ b/packages/kobe/src/core/daemon-session-adapter.ts
@@ -1,7 +1,7 @@
 import type { DaemonRpcClient } from "@sma1lboy/kobe-daemon/client/rpc"
 import { resolveLoginShell } from "@sma1lboy/kobe-daemon/daemon/platform-shell"
 import type { SerializedTask } from "@sma1lboy/kobe-daemon/daemon/protocol"
-import { engineLaunchArgv } from "../engine/engine-presets.ts"
+import { engineLaunchArgv, protocolEntry } from "../engine/engine-presets.ts"
 import {
   ComposerBusyError,
   awaitEngineProcess,
@@ -16,7 +16,6 @@ import {
   openHostedSessionHost,
   pastePromptWhenEngineUp,
 } from "../engine/hosted-session.ts"
-import { engineEntry } from "../engine/registry.ts"
 import { sessionHasEngine } from "../engine/session-engine-presence.ts"
 import { buildEngineSessionLaunch } from "../engine/session-launch.ts"
 import { trustEngineWorktree } from "../engine/trust-worktree.ts"
@@ -197,7 +196,7 @@ export async function deliverPromptToLiveEngineAdapter(
     const key = findHostedEngineKey(sessions, task.id, engineArgv[0])
     if (!key) return false
     if (!(await sessionHasEngine(sessions.find((s) => s.key === key)?.pid, engineArgv))) return false
-    const manifest = task.vendor ? engineEntry(task.vendor).screenManifest : undefined
+    const manifest = task.vendor ? protocolEntry(task.vendor).screenManifest : undefined
     return (
       (await deliverToHostedKey(host.rpc, key, prompt, {
         screenManifest: manifest,
@@ -264,7 +263,7 @@ export async function deliverPromptToLiveEngineDetailedAdapter(
     if (!(await sessionHasEngine(sessions.find((s) => s.key === key)?.pid, engineArgv))) {
       return { outcome: "no-engine", tabId: tabIdFromHostedKey(key) }
     }
-    const manifest = task.vendor ? engineEntry(task.vendor).screenManifest : undefined
+    const manifest = task.vendor ? protocolEntry(task.vendor).screenManifest : undefined
     try {
       const delivered = await deliverToHostedKey(host.rpc, key, prompt, {
         screenManifest: manifest,
@@ -326,7 +325,7 @@ export async function deliverPromptToLiveEngineTabDetailedAdapter(
       vendor: target.vendor,
     })
     if (!(await sessionHasEngine(session.pid, engineArgv))) return { outcome: "no-engine", tabId: target.tabId }
-    const manifest = target.vendor ? engineEntry(target.vendor).screenManifest : undefined
+    const manifest = target.vendor ? protocolEntry(target.vendor).screenManifest : undefined
     try {
       const delivered = await deliverToHostedKey(host.rpc, key, prompt, {
         screenManifest: manifest,

--- a/packages/kobe/test/engine/wrapped-preset-protocol-reads.test.ts
+++ b/packages/kobe/test/engine/wrapped-preset-protocol-reads.test.ts
@@ -1,0 +1,112 @@
+/**
+ * The five "how do we talk to this engine" reads, on a task whose `vendor` is
+ * a RAW preset id.
+ *
+ * That shape is not hypothetical: the TUI's new-task dialog passes the picked
+ * engine id straight through as `vendor` with no `command`
+ * (`tui/lib/task-create-flow.ts`), and the change-engine picker offers every
+ * `customEngineIds` entry (`engine/account-detect.ts` →
+ * `engine-picker-dialog.tsx`). So a `claudecpa` preset declaring
+ * `engineProtocol.claudecpa = "claude"` reaches the daemon as
+ * `vendor: "claudecpa"`, and every read below used to key off that id — which
+ * `engineEntry` answers with the documented EMPTY custom entry.
+ *
+ * Each assertion pairs the preset with plain `claude`: the preset must resolve
+ * to the SAME adapter, which is the whole promise `engineProtocol.<id>` makes.
+ */
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { resolveComposerManifest } from "../../src/cli/api/pty-delivery.ts"
+import { protocolEntry, sessionProtocol } from "../../src/engine/engine-presets.ts"
+import { engineEntry } from "../../src/engine/registry.ts"
+
+let home: string
+let originalHome: string | undefined
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "kobe-wrapped-preset-"))
+  originalHome = process.env.KOBE_HOME_DIR
+  process.env.KOBE_HOME_DIR = home
+  const dir = join(home, ".config", "rove")
+  mkdirSync(dir, { recursive: true })
+  writeFileSync(
+    join(dir, "state.json"),
+    JSON.stringify({
+      customEngineIds: ["claudecpa"],
+      "engineCommand.claudecpa": "claude",
+      "engineProtocol.claudecpa": "claude",
+    }),
+    "utf8",
+  )
+})
+
+afterEach(() => {
+  if (originalHome === undefined) {
+    // biome-ignore lint/performance/noDelete: the var must be truly unset when it started unset.
+    delete process.env.KOBE_HOME_DIR
+  } else process.env.KOBE_HOME_DIR = originalHome
+  rmSync(home, { recursive: true, force: true })
+})
+
+describe("a wrapped preset resolves the protocol's adapter, not the empty custom entry", () => {
+  it("has an empty entry under its own id — the trap every read below fell into", () => {
+    const raw = engineEntry("claudecpa")
+    expect(raw.builtin).toBe(false)
+    expect(raw.history.readUsageSnapshot).toBeUndefined()
+    expect(raw.screenManifest).toBeUndefined()
+    expect(raw.terminalTitle).toBeUndefined()
+    expect(raw.readTurns).toBeUndefined()
+  })
+
+  it("reads context/token usage through claude's history reader", () => {
+    expect(protocolEntry("claudecpa").history.readUsageSnapshot).toBe(engineEntry("claude").history.readUsageSnapshot)
+  })
+
+  it("reads per-turn telemetry through claude's turn reader", () => {
+    expect(protocolEntry("claudecpa").readTurns).toBe(engineEntry("claude").readTurns)
+  })
+
+  it("classifies the composer with claude's screen manifest", () => {
+    expect(resolveComposerManifest("claudecpa")).toBe(engineEntry("claude").screenManifest)
+    expect(resolveComposerManifest("claudecpa")).toBeDefined()
+  })
+
+  it("reads the OSC title turn hint with claude's title rules", () => {
+    expect(protocolEntry("claudecpa").terminalTitle).toBe(engineEntry("claude").terminalTitle)
+  })
+
+  it("resolves claude's turn detector and session identity", () => {
+    expect(sessionProtocol("claudecpa")).toBe("claude")
+    expect(protocolEntry("claudecpa").sessionIdentity).toBe(engineEntry("claude").sessionIdentity)
+  })
+
+  it("leaves an unregistered id generic rather than guessing claude", () => {
+    expect(sessionProtocol("mystery-engine")).toBe("mystery-engine")
+    expect(resolveComposerManifest("mystery-engine")).toBeUndefined()
+  })
+})
+
+/**
+ * The same rule at the seam that actually consumes it. `registry.ts` is
+ * deliberately state-free (vitest and the daemon both import it), so it cannot
+ * resolve a preset itself — which is why the wiring, not the registry, is where
+ * these four reads have to be protocol-keyed.
+ */
+describe("daemonRuntime keys its engine reads on the protocol", () => {
+  it("reads the OSC title turn hint claude's glyphs imply", async () => {
+    const { daemonRuntime } = await import("../../src/core/daemon-runtime.ts")
+    const working = "⠹ Claude"
+    expect(daemonRuntime.titleTurnHint("claudecpa", working)).toBe(daemonRuntime.titleTurnHint("claude", working))
+    expect(daemonRuntime.titleTurnHint("claudecpa", working)).not.toBeNull()
+  })
+
+  it("builds claude's turn detector for a wrapped preset", async () => {
+    const { daemonRuntime } = await import("../../src/core/daemon-runtime.ts")
+    expect(daemonRuntime.createEngineTurnDetector("claudecpa").constructor).toBe(
+      daemonRuntime.createEngineTurnDetector("claude").constructor,
+    )
+  })
+})


### PR DESCRIPTION
## What was broken

`engineProtocol.<id>` is the promise that a custom preset speaks a built-in
engine's protocol — `protocolEntry()` / `sessionProtocol()` exist to answer
"how do we TALK to this engine" while `engineEntry()` answers "what IS it".
Five reads still passed the task's raw `vendor` to `engineEntry()`, which
answers any unknown id with the documented EMPTY custom entry
(`registry.ts` `customEngineEntry`): no history reader, no screen manifest,
no terminal-title rules, no turn reader.

| Read | Was | Now |
|---|---|---|
| `daemon-runtime.ts` `readEngineContextUsage` | `engineEntry` | `protocolEntry` |
| `daemon-runtime.ts` `readEngineTurns` | `engineEntry` | `protocolEntry` |
| `daemon-runtime.ts` `titleTurnHint` | `engineTitleTurnHint(vendor, …)` | `engineTitleTurnHint(sessionProtocol(vendor), …)` |
| `daemon-runtime.ts` `createEngineTurnDetector` | raw id | `sessionProtocol(vendor)` |
| `pty-delivery.ts` `resolveComposerManifest` + the 3 `daemon-session-adapter.ts` manifest reads | `engineEntry` | `protocolEntry` |

The two `sessionProtocol` wrappings sit at the daemon-runtime seam rather
than in `registry.ts` / `turn-detector.ts` on purpose: those modules are
deliberately state-free (vitest and the daemon both import them), so they
cannot resolve a preset. `daemon-runtime.ts` is already the state-reading
adapter — `deriveTitleFromSession` and `latestTranscriptMtime` next to these
lines have gone through `protocolEntry` for a while, which is what makes the
change safe in the daemon process.

## This is not a hypothetical record shape

A task reaches the daemon with a RAW preset id in `vendor` by the product's
main path, not a legacy one:

- `tui/lib/task-create-flow.ts:161,181` passes the picked engine id straight
  into `createTask` as `vendor`, with no `command`.
- `engine/account-detect.ts` `installedEngineIds` folds `getCustomEngineIds()`
  into the picker list, so `engine-picker-dialog.tsx` offers `claudecpa` and
  `host-task-actions.ts:191` persists it via `setVendor`.

(`rove api add --command claudecpa` does resolve the protocol at creation —
`handlers-add.ts:47` — so the CLI path was already fine. The TUI path is the
one that was broken.)

## Evidence — footer usage chip, `readEngineContextUsage`

Isolated harness fixture (own `KOBE_HOME_DIR` + full socket/pid/port set,
port base 5473), `engineProtocol.claudecpa = claude`,
`engineCommand.claudecpa` = a sentinel script, task record
`vendor: "claudecpa"` with no `command` (the TUI shape above), a seeded
claude transcript with usage under the fixture's `~/.claude/projects/…`, and
`engine.reportEvent` driving tab-1 non-idle with that session id.
**Each shot rebuilt `dist` and ran against its own FRESH fixture.**

- BEFORE (`HEAD~1`): `.scratch/pigeon-evidence/before-ctx.png` — footer is empty.
- AFTER: `.scratch/pigeon-evidence/after-ctx.png` — footer reads `Σ 12k`.

Everything else in the two frames is byte-identical, tab label `claudecpa 1`
included.

One correction to the brief's expectation: on claude the chip that appears is
`Σ 12k`, not `ctx N%`. `contextChip` needs `contextWindowTokens`
(`usage-core.ts:209`) and claude's `readUsageSnapshot` never reports a window.
Both chips are rendered from the same `readEngineContextUsage` return, so
`Σ 12k` is the same proof: BEFORE that call returned `null` because
`EMPTY_HISTORY` has no `readUsageSnapshot`.

**A false start worth recording**: the first BEFORE/AFTER pair BOTH showed
`Σ 12k`. The seed script edited `tasks.json` while the daemon was running, and
the daemon holds the task index in memory — so both runs measured
`vendor: "claude"` (what `add` had written) and neither exercised the preset
path at all. `seed.sh` now restarts the daemon after the edit and asserts
`get-task` reports `claudecpa None` before any shot is taken.

## Evidence — the other four reads

`test/engine/wrapped-preset-protocol-reads.test.ts` (9 tests). It first pins
the trap — `engineEntry("claudecpa")` really does return an entry whose
`readUsageSnapshot` / `screenManifest` / `terminalTitle` / `readTurns` are all
undefined — then asserts each read resolves to the same adapter object plain
`claude` gets.

**Negative control**: `sessionProtocol("mystery-engine")` stays
`"mystery-engine"` and `resolveComposerManifest("mystery-engine")` stays
`undefined` — an unregistered id must not be guessed into claude.

**Mutation verification** (per-file revert to `HEAD~1`, both re-run):

```
$ git show HEAD~1:…/pty-delivery.ts > …/pty-delivery.ts && bun x vitest run …
   × classifies the composer with claude's screen manifest
     Received: undefined
 Tests  1 failed | 6 passed

$ git show HEAD~1:…/daemon-runtime.ts > …/daemon-runtime.ts && bun x vitest run …
   × reads the OSC title turn hint claude's glyphs imply
   × builds claude's turn detector for a wrapped preset
 Tests  2 failed | 7 passed
```

## What the composer gap meant

`docs/CONFIGURATION.md:198` promises `delivery.composerGate` protects
half-typed text. The B-layer classifies the pane capture against the engine's
`screenManifest`; with `undefined` there is nothing to classify, so on a
preset task the gate was **absent**, not degraded — `rove api send` pasted its
prompt on top of whatever the user had typed. (The A-layer recent-human-write
check still fired, which is why this reads as intermittent rather than always.)

## Scope notes

- **`hook-adapter.ts:114` deliberately unchanged.** `createEngineHookAdapter`
  is only ever called with `ALL_VENDORS` (`cli/hook-cmd.ts:168,173`) — hook
  installation is driven by recognisable engine ids, never by a task's vendor —
  so the preset id cannot reach it. Changing it for symmetry would add a state
  read on a path that never has a preset to resolve.
- **`readEngineTurns` was not in the brief.** It is the same one-word bug in the
  same object literal, two lines from `readEngineContextUsage`, and per-turn
  telemetry is protocol knowledge by the same argument. Left alone it would
  have been the one remaining `engineEntry` in that group.
- **`engineEntry` at `daemon-runtime.ts:149`** stays as-is: the daemon declares
  it (`runtime.ts:233`, for `effortLevels`) but never calls it. Dead field,
  separate cleanup.
- One commit rather than three. The change is one word in five call sites that
  share an import; splitting it would produce commits that each leave the
  object half-converted.

## Checks

`bun run test:fast` 4924 pass · `bun test test/render` 513 pass · root
`bun run lint` clean · `tsc --noEmit` clean.
