### PR TITLE
fix: install Codex's SessionEnd and Subagent hooks, and correct the engine docs

### DIFF
--- a/.changeset/codex-session-end-and-subagent-hooks.md
+++ b/.changeset/codex-session-end-and-subagent-hooks.md
@@ -1,0 +1,7 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Codex now delivers session-end and subagent hook events, and ENGINES.md stops crediting Codex with hooks it never had
+
+`SessionEnd`, `SubagentStart` and `SubagentStop` are in codex-cli's hook event enum but were never installed, so a cleanly-quit Codex task kept whatever state its last hook set and a Codex row never showed the `◇N` subagent marker. The adapter's own comments disagreed with each other about whether those events existed; they now say what the binary says. `docs/ENGINES.md` no longer claims Codex reports the full needs-input vocabulary through hooks (its only waiting event is a permission decision hook Rove deliberately leaves alone), and now documents Codex's quota probe alongside Claude's.

--- a/docs/ENGINES.md
+++ b/docs/ENGINES.md
@@ -31,6 +31,13 @@ engine does, on its own launch command.
 **Claude Code is the default** and the most complete: its quota probe drives
 rate-limit auto-resume and the Settings usage dashboard.
 
+Codex has a quota probe too, and it works differently. There is no endpoint to
+call — the Codex CLI writes the server's `rate_limits` block into its rollout
+JSONL, so Rove reads the newest rollouts off disk. That makes it a snapshot of
+the last response Codex received: a window whose reset time has already passed
+is dropped, and an account that hasn't run Codex recently publishes nothing at
+all rather than a stale number.
+
 **Contrib engines are launch + badge only.** Rove ships a catalog of
 well-known coding CLIs (`gemini`, `opencode`, `cursor`, `grok`, `droid`,
 `amp`) so they appear in the engine selector whenever the binary is on your
@@ -154,12 +161,16 @@ The sidebar shows what each session is doing: **working**, **done**, or
 hook events, falling back to its transcript when hooks aren't available.
 
 One thing worth knowing: **the depth of the badge depends on the engine**.
-Claude, codex, and kimi report through hooks: the full working / done /
-needs-input vocabulary, sub-second. Engines without hooks or a readable
-transcript (copilot today) fall back to screen reading: Rove classifies the
-visible terminal against engine-declared rules, which still distinguishes
-working from waiting-on-you but can't see a completed turn the way a
-transcript marker can. Rove labels the gap honestly rather than guessing.
+Claude and kimi report the full working / done / needs-input vocabulary
+through hooks, sub-second. Codex reports working and done through hooks, but
+not needs-input: its only "waiting" event is a permission decision hook, and
+Rove will not install an observer on a hook that gates approvals. Codex's
+needs-input therefore comes from screen reading, one layer down. Engines
+without hooks or a readable transcript (copilot today) rely on screen reading
+for everything: Rove classifies the visible terminal against engine-declared
+rules, which still distinguishes working from waiting-on-you but can't see a
+completed turn the way a transcript marker can. Rove labels the gap honestly
+rather than guessing.
 
 Codex won't run Rove's hooks until you trust them once via `/hooks`, so Codex
 badges stay dark until you approve. That's by design: Rove writes the hook

--- a/packages/kobe/src/engine/codex-local/hook-adapter.ts
+++ b/packages/kobe/src/engine/codex-local/hook-adapter.ts
@@ -13,14 +13,14 @@
  *   - `SessionStart`     → session-start
  *   - `UserPromptSubmit` → turn-start
  *   - `Stop`             → turn-complete
+ *   - `SessionEnd`       → session-end
  *   - `PostToolUse`(Bash)→ worktree-created (inherited worktree-watch observer)
  * NOT wired: `turn-failed` (Codex's hook enum has no failure event at all —
- * see `activityDetailFromPayload`), `session-end`
- * (no SessionEnd), `awaiting-input` (Codex's only "waiting" event is
- * `PermissionRequest`, an allow/deny DECISION hook — installing kobe's observer
- * on it could interfere with Codex's approval flow, the same provider-hook trap
- * that broke `claude --worktree`, so we leave it alone). The polling fallback
- * still covers those states.
+ * see `activityDetailFromPayload`) and `awaiting-input` (Codex's only "waiting"
+ * event is `PermissionRequest`, an allow/deny DECISION hook — installing kobe's
+ * observer on it could interfere with Codex's approval flow, the same
+ * provider-hook trap that broke `claude --worktree`, so we leave it alone).
+ * The polling fallback and `CODEX_SCREEN_MANIFEST` still cover those states.
  *
  * Trust model: Codex won't RUN a non-managed command hook until the user trusts
  * it once via `/hooks` (or launches with `--dangerously-bypass-hook-trust`).
@@ -41,11 +41,18 @@ const EVENT_MAP: readonly HookEventSpec[] = [
   { event: "SessionStart", verb: "session-start" },
   { event: "UserPromptSubmit", verb: "turn-start" },
   { event: "Stop", verb: "turn-complete" },
-  // Lifecycle-only verbs (docs/design/plugin-events.md). Codex ships both
-  // compact hooks natively; SessionEnd/Subagent* are documented upstream but
-  // absent from the pinned protocol — left out until verified.
+  // `SessionEnd` closes the session out. Without it a cleanly-quit codex task
+  // kept whatever state its last hook set — only the pty-exit record could
+  // move the badge, so `/quit` left the row lit.
+  { event: "SessionEnd", verb: "session-end" },
+  // Lifecycle-only verbs (docs/design/plugin-events.md). All four verified
+  // present in codex-cli 0.153.4's hook event enum (see the note on
+  // `activityDetailFromPayload`); Subagent* is what puts the `◇N` marker on a
+  // codex sidebar row.
   { event: "PreCompact", verb: "pre-compact" },
   { event: "PostCompact", verb: "post-compact" },
+  { event: "SubagentStart", verb: "subagent-start" },
+  { event: "SubagentStop", verb: "subagent-stop" },
   // Tool family: gated (see JsonHookAdapter.gatedVerbs) + behind Codex's own
   // hook trust prompt. Failures arrive folded into tool_response, so there is
   // no tool-failed row.
@@ -73,15 +80,24 @@ export class CodexHookAdapter extends JsonHookAdapter {
    *  carries the same `trigger` values as Claude.
    *
    *  No `turn-failed` branch, and that is not an oversight: Codex's hook
-   *  event enum (verified against codex-cli 0.149.1's binary) is PreToolUse /
-   *  PermissionRequest / PostToolUse / PreCompact / PostCompact / SessionStart
-   *  / SessionEnd / UserPromptSubmit / SubagentStart / SubagentStop / Stop —
-   *  there is no failure event to classify. `TurnFailed` exists in the binary
-   *  but is an app-server THREAD event (`turn.failed`), not a hook, so it
-   *  never reaches a `kobe hook` invocation. Codex therefore cannot reach
-   *  `rate_limited` through hooks at all; its quota probe
-   *  (`vendorsWithQuotaProbe`) is the only path, and adding a classifier here
-   *  would be dead code pretending otherwise. */
+   *  event enum (re-verified against codex-cli 0.153.4's binary) is PreToolUse
+   *  / PermissionRequest / PostToolUse / PreCompact / PostCompact /
+   *  SessionStart / SessionEnd / UserPromptSubmit / SubagentStart /
+   *  SubagentStop / Stop — there is no failure event to classify. `TurnFailed`
+   *  does not appear in that binary at all; the failure signal is the
+   *  app-server THREAD event (`turn.failed`), not a hook, so it never reaches
+   *  a `kobe hook` invocation. Codex therefore cannot reach `rate_limited`
+   *  through hooks at all; its quota probe (`vendorsWithQuotaProbe`) is the
+   *  only path, and adding a classifier here would be dead code pretending
+   *  otherwise.
+   *
+   *  No `subagent-*` branch either, for a narrower reason: the EVENT names are
+   *  verified, the PAYLOAD field names are not. Claude spells them
+   *  `agent_type`/`agent_id`; both strings exist in the codex binary, but
+   *  nothing proves they belong to ITS Subagent hook payloads. Detail feeds
+   *  the plugin event stream, not the `◇N` sidebar marker (which counts
+   *  `engine.lifecycle` events), so leaving it absent costs the badge nothing
+   *  and beats shipping a guessed field name. */
   override activityDetailFromPayload(
     kind: EngineActivityKind,
     payload: Record<string, unknown>,

--- a/packages/kobe/src/engine/registry.ts
+++ b/packages/kobe/src/engine/registry.ts
@@ -228,11 +228,17 @@ export interface EngineRegistryEntry {
    */
   readonly readTurns?: EngineTurnReader
   /**
-   * Declarative screen-state rules for engines WITHOUT persisted completion
-   * markers (see `engine/screen-state.ts`): the quiescence poll classifies
-   * each pane capture into working/blocked/idle instead of "unknown".
-   * Engines with markers don't declare one — the transcript is the better
-   * authority, and hooks supersede both (`turn-state-merge.ts`).
+   * Declarative screen-state rules (see `engine/screen-state.ts`): the
+   * quiescence poll classifies each pane capture into working/blocked/idle
+   * instead of publishing "unknown".
+   *
+   * It is the BOTTOM of a three-layer ladder — hooks > transcript markers >
+   * screen — not an alternative to the top two. Marker-carrying engines
+   * declare one too (claude and codex both do, `builtin-engines.ts`), because
+   * the layers cover different gaps: hooks need the user to trust them once,
+   * markers land only after a turn ends, and neither can see a modal the
+   * engine is currently blocked on. `turn-state-merge.ts` owns the precedence;
+   * `use-turn-polls.ts` passes this through when the entry has one.
    */
   readonly screenManifest?: EngineScreenManifest
 }

--- a/packages/kobe/test/engine/codex-hook-adapter.test.ts
+++ b/packages/kobe/test/engine/codex-hook-adapter.test.ts
@@ -60,12 +60,23 @@ describe("CodexHookAdapter", () => {
 
   it("owns exactly the events Codex can deliver safely", () => {
     expect([...KOBE_CODEX_HOOK_EVENTS].sort()).toEqual(
-      ["SessionStart", "Stop", "UserPromptSubmit", "PreCompact", "PostCompact", "PreToolUse", "PostToolUse"].sort(),
+      [
+        "SessionStart",
+        "SessionEnd",
+        "Stop",
+        "UserPromptSubmit",
+        "PreCompact",
+        "PostCompact",
+        "SubagentStart",
+        "SubagentStop",
+        "PreToolUse",
+        "PostToolUse",
+      ].sort(),
     )
-    // The verbs with no clean Codex signal are NOT installed: no StopFailure
-    // equivalent, no Notification, and SessionEnd/Subagent* are documented
-    // upstream but absent from the pinned protocol.
-    for (const absent of ["StopFailure", "Notification", "SessionEnd", "SubagentStart", "PostToolUseFailure"]) {
+    // The verbs with no clean Codex signal stay OUT: Codex's enum has no
+    // failure event at all, and its only "waiting" event is PermissionRequest
+    // — an allow/deny DECISION hook Rove must not observe.
+    for (const absent of ["StopFailure", "PostToolUseFailure", "Notification", "PermissionRequest", "TurnFailed"]) {
       expect(KOBE_CODEX_HOOK_EVENTS).not.toContain(absent)
     }
   })
@@ -107,7 +118,7 @@ describe("CodexHookAdapter install/remove roundtrip (real file)", () => {
     expect(await readFile(file, "utf8")).toBe(malformed)
   })
 
-  it("installs SessionStart/UserPromptSubmit/Stop, preserving the user's hooks", async () => {
+  it("installs the session, turn, compaction and subagent events, preserving the user's hooks", async () => {
     // Seed a user-authored hook that must survive kobe's merge.
     await writeFile(file, JSON.stringify({ hooks: { Stop: [{ hooks: [{ type: "command", command: "user-stop" }] }] } }))
 
@@ -117,10 +128,15 @@ describe("CodexHookAdapter install/remove roundtrip (real file)", () => {
     expect(hooks.SessionStart).toBeDefined()
     expect(hooks.UserPromptSubmit).toBeDefined()
     expect(hooks.Stop).toBeDefined()
+    // SessionEnd closes the session out — without it a cleanly-quit codex task
+    // keeps whatever state its last hook set.
+    expect(JSON.stringify(hooks.SessionEnd)).toContain("session-end")
+    expect(JSON.stringify(hooks.SubagentStart)).toContain("subagent-start")
+    expect(JSON.stringify(hooks.SubagentStop)).toContain("subagent-stop")
     // Codex never delivers these → kobe must not install them.
     expect(hooks.StopFailure).toBeUndefined()
     expect(hooks.Notification).toBeUndefined()
-    expect(hooks.SessionEnd).toBeUndefined()
+    expect(hooks.PermissionRequest).toBeUndefined()
     // kobe's Stop coexists with the user's Stop hook.
     expect(JSON.stringify(hooks.Stop)).toContain("turn-complete")
     expect(JSON.stringify(hooks.Stop)).toContain("user-stop")


### PR DESCRIPTION
## 1. Codex never delivered `session-end` / `subagent-start` / `subagent-stop`

`codex-local/hook-adapter.ts` contradicted itself in three places: the module
doc said "no SessionEnd", the `EVENT_MAP` comment said SessionEnd/Subagent*
were "documented upstream but absent from the pinned protocol — left out until
verified", and `activityDetailFromPayload`'s doc listed an enum "verified
against codex-cli 0.149.1's binary" that **includes** all three. Claude and
kimi install all three; Codex installed none.

User-visible: a Codex row never showed the `◇N` subagent marker
(`row-view.ts:288`, counted from `engine.lifecycle` in
`remote-orchestrator-events.ts:405`), and after `/quit` the badge kept
whatever state the last hook set — only the pty-exit record could move it.

### Verifying the enum (never by driving Codex's TUI)

Read out of the installed binary. A bare Enter into Codex's TUI can hit its
update prompt and upgrade the machine's codex, so this touches no process:

```
codex --version: codex-cli 0.153.4
binary: …/@openai/codex-darwin-arm64/vendor/aarch64-apple-darwin/bin/codex

EVENT                occurrences in binary
SessionStart         55      PreCompact           29
SessionEnd           32      PostCompact          29
UserPromptSubmit     18      SubagentStart        35
Stop                 97      SubagentStop         30
PreToolUse           54      PermissionRequest    54
PostToolUse          41
--- negative controls ---
TurnFailed            0      StopFailure           0
PostToolUseFailure    0      BogusHookEventXyz     0
```

The three newly-wired events sit in the same band as the ones already
installed. The four zeros include a synthetic name, so the probe is proven to
be able to answer "absent".

This also settles the other half: `TurnFailed` is genuinely not in the binary,
so the "no `turn-failed` branch" comment was right — it just cited a stale
version and an enum it then contradicted.

### `~/.codex/hooks.json`, before and after

Same adapter, same isolated `CODEX_HOME`:

```
BEFORE (origin/main)                      AFTER
 SessionStart      'session-start'         SessionStart      'session-start'
 SessionEnd        — NOT INSTALLED         SessionEnd        'session-end'
 Stop              'turn-complete'         Stop              'turn-complete'
 UserPromptSubmit  'turn-start'            UserPromptSubmit  'turn-start'
 SubagentStart     — NOT INSTALLED         SubagentStart     'subagent-start'
 SubagentStop      — NOT INSTALLED         SubagentStop      'subagent-stop'
 PreCompact        'pre-compact'           PreCompact        'pre-compact'
 PostCompact       'post-compact'          PostCompact       'post-compact'
```

### The chain end to end

Running the **exact command strings** the adapter writes into `hooks.json`,
against an isolated daemon (own `KOBE_HOME_DIR` + full socket/pid/port set),
payload on stdin:

```
-> kobe hook turn-start     --engine codex   activity: {"…": {"state": "running", "vendor": "codex"}}
-> kobe hook subagent-start --engine codex   activity: {"…": {"state": "running", "vendor": "codex"}}
-> kobe hook subagent-stop  --engine codex   activity: {"…": {"state": "running", "vendor": "codex"}}
-> kobe hook session-end    --engine codex   activity: {"…": {"state": "idle",    "vendor": "codex"}}
```

`session-end` is the transition that did not exist before. Subagent events
correctly leave the badge alone — they are lifecycle-only — and land on the
channel the `◇N` marker is accumulated from, confirmed by subscribing to it:

```
engine.lifecycle {"taskId":"01M1W5RXJ…","kind":"subagent-start","tabId":"tab-1","at":1788726816940}
engine.lifecycle {"taskId":"01M1W5RXJ…","kind":"subagent-start","tabId":"tab-1","at":1788726836190}
engine.lifecycle {"taskId":"01M1W5RXJ…","kind":"subagent-stop","tabId":"tab-1","at":1788726837239}
```

**Not screenshotted, and why**: the last hop (Codex itself invoking the hook)
needs a logged-in Codex, and the isolated fixture has no `~/.codex/auth.json`
— copying the operator's credentials into a fixture home is not something I
will do for a screenshot. The enum table covers the half Codex owns; the
`hooks.json` diff and the trace above cover the half Rove owns. What the two
do not jointly prove is only that codex-cli fires these hooks at the moments
its enum implies.

### `activityDetailFromPayload` deliberately gains no `subagent-*` branch

The EVENT names are verified; the PAYLOAD field names are not. Claude spells
them `agent_type`/`agent_id` and both strings exist in the codex binary — but
nothing proves they belong to *its* Subagent hook payloads. That detail feeds
the plugin event stream, not the `◇N` marker (which counts events), so leaving
it absent costs the badge nothing and beats shipping a guessed field name. The
comment says so.

## 2. `docs/ENGINES.md` credited Codex with hooks it never had

- **Line 159-162** said "Claude, codex, and kimi report through hooks: the full
  working / done / needs-input vocabulary". Codex has no `awaiting-input` hook
  — its only waiting event is `PermissionRequest`, an allow/deny decision hook
  the adapter deliberately avoids — and no `turn-failed`. Its needs-input comes
  from `CODEX_SCREEN_MANIFEST`, one layer down. Split into: Claude/Kimi full
  vocabulary; Codex working/done via hooks, needs-input via screen reading.
- **Line 31-32** credited only Claude with a quota probe.
  `vendorsWithQuotaProbe()` has always returned `["claude", "codex"]`
  (`builtin-engines.ts:100,167`).

**Evidence for the quota claim** — the harness fixture with a seeded rollout
and **no Codex task at all** (`rove api list` → only a `claude` and a
`claudecpa` task). The footer renders the Codex quota row:

```
CODEX 5h 41% → 16:25 · 7d 12% → 9/10 13:25
```

`.scratch/pigeon-evidence/codex-quota-footer.png`. Probed through the real
reader in that home:

```
vendorsWithQuotaProbe(): [ "claude", "codex" ]
fetchCodexQuotaUsage(): { "windows": [ {"kind":"primary","label":"5h","percent":41,…},
                                       {"kind":"secondary","label":"7d","percent":12,…} ] }
```

The new paragraph keeps the honest caveat the reader's own doc-comment makes:
it is a snapshot of the last response Codex received, windows past their reset
are dropped, and an idle account publishes nothing.

I checked the brief's stated failure mode before writing — a missing Codex row
would have been a second bug, not something to paper over in prose. The row is
there.

## 3. `registry.ts` `screenManifest` comment was contradicted by two engines

"Engines with markers don't declare one" — but `builtin-engines.ts:102`
(claude) and `:128` (codex) both carry markers *and* a manifest. Rewritten as
the actual three-layer ladder (hooks > transcript markers > screen), with why
the layers are not alternatives: hooks need one-time trust, markers land only
after a turn ends, and neither sees a modal the engine is blocked on.
`turn-state-merge.ts` owns precedence, `use-turn-polls.ts:172` passes it
through.

## Tests

`test/engine/codex-hook-adapter.test.ts` had encoded the wrong belief
(`expect(hooks.SessionEnd).toBeUndefined()`), so it failed the moment the fix
landed — which is the regression proof. Updated to assert the three events are
installed with the right verbs, and the true negatives kept and widened:
`StopFailure`, `PostToolUseFailure`, `Notification`, `PermissionRequest`,
`TurnFailed` must all stay out.

`bun run test:fast` 4924 pass · root `bun run lint` clean · `tsc --noEmit`
clean.
