### PR TITLE
feat: add --effort, and stop set-effort rewriting a preset's identity

### DIFF
--- a/.agents/skills/kobe/references/api-flags.md
+++ b/.agents/skills/kobe/references/api-flags.md
@@ -166,7 +166,7 @@ clear the shared active task.
 
 <!-- generated:begin create,edit,lifecycle -->
 ```text
-add          --repo(REQ) --title --branch --base-branch --command --count
+add          --repo(REQ) --title --branch --base-branch --command --effort --count
              --agents <claude:2,codex:1>
              --status{backlog|in_progress|in_review|done|canceled|error}(backlog) --pin
              --activate(false) --prompt|--prompt-file

--- a/.changeset/add-effort-and-set-effort-identity.md
+++ b/.changeset/add-effort-and-set-effort-identity.md
@@ -1,0 +1,7 @@
+---
+"@sma1lboy/rove": patch
+---
+
+`rove api add --effort` sets a task's reasoning level on its FIRST session, and `set-effort` stops rewriting a wrapped preset's engine identity
+
+Scripting a codex task at `xhigh` used to take three steps — `add`, `set-effort`, then a session rebuild — so the opening session always ran at the engine default. `add --effort` validates the level through the same gate `set-effort` uses and carries it into the create. Two `set-effort` fixes ride along: it now resolves a task's engine through the preset's declared protocol (so a level was not refused outright on every preset task created from the TUI), and it leaves the task's own vendor alone instead of overwriting a `mycodex` preset with `codex`, which silently dropped the user's `engineName.mycodex` label from the footer.

--- a/claude-plugin/skills/rove/references/api-flags.md
+++ b/claude-plugin/skills/rove/references/api-flags.md
@@ -166,7 +166,7 @@ clear the shared active task.
 
 <!-- generated:begin create,edit,lifecycle -->
 ```text
-add          --repo(REQ) --title --branch --base-branch --command --count
+add          --repo(REQ) --title --branch --base-branch --command --effort --count
              --agents <claude:2,codex:1>
              --status{backlog|in_progress|in_review|done|canceled|error}(backlog) --pin
              --activate(false) --prompt|--prompt-file

--- a/docs/ENGINES.md
+++ b/docs/ENGINES.md
@@ -77,14 +77,16 @@ can drive; a selected effort is ignored there rather than passed through.
 
 Three places select one:
 
-- the web board's engine picker, when you start a task from an issue;
+- `rove api add --command codex --effort LEVEL`, which is the only one that
+  reaches the task's **first** session — the other two rebuild it;
 - the sidebar row menu's **Change engine** entry, whose second row lists the
   engine's levels (`←→` picks one, and "engine default" clears it). Engines
   that declare no levels show no row;
 - `rove api set-effort --task-id ID --level LEVEL` from a shell.
 
-All three take effect on the task's next session rebuild, not on the running
-one.
+The board's start-a-task-from-an-issue picker chooses an engine but not a
+level, so a task started that way runs its first session on the engine's
+default until you set one.
 
 ### Workspace trust
 

--- a/packages/kobe/src/cli/api/add-engine-fields.ts
+++ b/packages/kobe/src/cli/api/add-engine-fields.ts
@@ -1,0 +1,71 @@
+/**
+ * The ENGINE half of an `add`: which engine a new task launches, and at what
+ * reasoning level.
+ *
+ * Split from `handlers-add.ts`, which owns the create ORCHESTRATION — flag
+ * conflicts, the single-vs-parallel split, per-sibling failure rows, prompt
+ * delivery. This file owns one question instead: given the caller's
+ * `--command` / `--effort`, what engine fields does `task.create` carry? Both
+ * `addOne` and `addParallel` route through it, so the two paths cannot drift
+ * on the engine contract the way they once did on `--status`/`--pin`.
+ */
+
+import { resolveCommandProtocol } from "../../engine/engine-presets.ts"
+import type { VendorId } from "../../types/vendor.ts"
+import { assertEngineAcceptsEffort } from "./handlers-engines.ts"
+import type { VerbContext } from "./types.ts"
+
+/** The engine fields a create carries: the raw command + its resolved protocol. */
+export interface EngineChoice {
+  readonly command?: string
+  readonly vendor?: VendorId
+}
+
+/**
+ * Resolve `--command` into what a task record needs. A bare preset id stays
+ * verbatim in `command` (so a later `engineCommand.<id>` edit in Settings
+ * still reaches this task) with its declared protocol alongside; a full
+ * command line records both too. No `--command` = the repo's default engine,
+ * which is a preset id, so it goes in the same two fields.
+ */
+export async function engineChoice(ctx: VerbContext, repo: string): Promise<EngineChoice> {
+  const command = ctx.args.str("command")
+  if (command) return { command, vendor: resolveCommandProtocol(command) }
+  const fallback = await ctx.runtime.defaultVendor(repo)
+  return fallback ? { command: fallback, vendor: fallback } : {}
+}
+
+/** The engine fields as a flat `task.create` payload fragment. */
+export function enginePayload(choice: EngineChoice, effort?: string): Record<string, string> {
+  return {
+    ...(choice.command ? { command: choice.command } : {}),
+    ...(choice.vendor ? { vendor: choice.vendor } : {}),
+    // Wire key is `effort`; the daemon maps it to the record's `modelEffort`
+    // (`handlers-task.ts` task.create). Sending `modelEffort` here is silently
+    // dropped — the create succeeds and the level simply never lands.
+    ...(effort ? { effort } : {}),
+  }
+}
+
+/**
+ * `--effort`, validated against the engine(s) this create will actually
+ * launch — before anything is created, so a bad level costs no orphan task.
+ *
+ * Deliberately not an `enum` flag: levels are per-engine and a plugin engine
+ * may declare its own, so the closed list lives on the registry entry, not on
+ * the flag spec (the same reason `set-effort` takes a free string). It shares
+ * that verb's gate, so a level `add` accepts is one `set-effort` would accept
+ * too.
+ *
+ * A fan-out validates EVERY engine in the plan: `--agents claude:1,codex:1
+ * --effort xhigh` is rejected outright rather than applied to the codex
+ * sibling and silently dropped on the claude one.
+ */
+export function effortFor(ctx: VerbContext, engines: readonly VendorId[]): string | undefined {
+  const level = ctx.args.str("effort")?.trim()
+  if (!level) return undefined
+  for (const engine of new Set(engines)) {
+    assertEngineAcceptsEffort(engine, level, ["api", "engine-list"])
+  }
+  return level
+}

--- a/packages/kobe/src/cli/api/handlers-add.ts
+++ b/packages/kobe/src/cli/api/handlers-add.ts
@@ -27,6 +27,7 @@ import type { DaemonRpc } from "../daemon-session.ts"
 import { dispatcherEnvPayload, withPeerProvenance } from "./dispatcher.ts"
 import { FANOUT_CAP, buildCountPlan, parseAgentsSpec } from "./flags.ts"
 import { daemonOf } from "./handler-helpers.ts"
+import { assertEngineAcceptsEffort } from "./handlers-engines.ts"
 import { ApiError, type VerbContext, helpStep } from "./types.ts"
 
 /** The engine fields a create carries: the raw command + its resolved protocol. */
@@ -50,8 +51,38 @@ async function engineChoice(ctx: VerbContext, repo: string): Promise<EngineChoic
 }
 
 /** The engine fields as a flat `task.create` payload fragment. */
-function enginePayload(choice: EngineChoice): Record<string, string> {
-  return { ...(choice.command ? { command: choice.command } : {}), ...(choice.vendor ? { vendor: choice.vendor } : {}) }
+function enginePayload(choice: EngineChoice, effort?: string): Record<string, string> {
+  return {
+    ...(choice.command ? { command: choice.command } : {}),
+    ...(choice.vendor ? { vendor: choice.vendor } : {}),
+    // Wire key is `effort`; the daemon maps it to the record's `modelEffort`
+    // (`handlers-task.ts` task.create). Sending `modelEffort` here is silently
+    // dropped — the create succeeds and the level simply never lands.
+    ...(effort ? { effort } : {}),
+  }
+}
+
+/**
+ * `--effort`, validated against the engine(s) this create will actually
+ * launch — before anything is created, so a bad level costs no orphan task.
+ *
+ * Deliberately not an `enum` flag: levels are per-engine and a plugin engine
+ * may declare its own, so the closed list lives on the registry entry, not on
+ * the flag spec (the same reason `set-effort` takes a free string). It shares
+ * that verb's gate, so a level `add` accepts is one `set-effort` would accept
+ * too.
+ *
+ * A fan-out validates EVERY engine in the plan: `--agents claude:1,codex:1
+ * --effort xhigh` is rejected outright rather than applied to the codex
+ * sibling and silently dropped on the claude one.
+ */
+function effortFor(ctx: VerbContext, engines: readonly VendorId[]): string | undefined {
+  const level = ctx.args.str("effort")?.trim()
+  if (!level) return undefined
+  for (const engine of new Set(engines)) {
+    assertEngineAcceptsEffort(engine, level, ["api", "engine-list"])
+  }
+  return level
 }
 
 /**
@@ -138,7 +169,8 @@ async function addOne(ctx: VerbContext, repo: string): Promise<unknown> {
   // Record who dispatched this create — the reply address a
   // sub-task's bare `send` routes its outcome back to.
   const choice = await engineChoice(ctx, repo)
-  const payload: Record<string, string> = { repo, ...(await dispatcherEnvPayload()), ...enginePayload(choice) }
+  const effort = effortFor(ctx, choice.vendor ? [choice.vendor] : [])
+  const payload: Record<string, string> = { repo, ...(await dispatcherEnvPayload()), ...enginePayload(choice, effort) }
   const title = args.str("title") || (prompt ? deriveTitleFromPrompt(prompt) : "")
   if (title) payload.title = title
   const branch = args.str("branch")
@@ -317,6 +349,7 @@ async function addParallel(
       "BAD_FLAG",
     )
   }
+  const effort = effortFor(ctx, plan)
   const groupId = ulid()
 
   // Create serially — task.create is a pure store write (worktrees are lazy,
@@ -335,7 +368,7 @@ async function addParallel(
     // `--agents` picks each sibling's engine BY ID, so its command is that
     // id; a `--count` round reuses the caller's own `--command` verbatim.
     const engine: EngineChoice = agentsSpec ? { command: vendor, vendor } : { ...choice, vendor }
-    const payload: Record<string, string> = { repo, groupId, ...dispatcher, ...enginePayload(engine) }
+    const payload: Record<string, string> = { repo, groupId, ...dispatcher, ...enginePayload(engine, effort) }
     if (title) payload.title = plan.length > 1 ? `${title} #${i + 1}/${plan.length}` : title
     if (baseRef) payload.baseRef = baseRef
     try {

--- a/packages/kobe/src/cli/api/handlers-add.ts
+++ b/packages/kobe/src/cli/api/handlers-add.ts
@@ -17,73 +17,17 @@
  */
 
 import type { SerializedTask } from "@sma1lboy/kobe-daemon/daemon/protocol"
-import { resolveCommandProtocol } from "../../engine/engine-presets.ts"
 import { homeDir } from "../../env.ts"
 import { ulid } from "../../orchestrator/index/ulid.ts"
 import { deriveTitleFromPrompt } from "../../orchestrator/title.ts"
 import type { TaskStatus } from "../../types/task.ts"
 import { DEFAULT_VENDOR, type VendorId } from "../../types/vendor.ts"
 import type { DaemonRpc } from "../daemon-session.ts"
+import { type EngineChoice, effortFor, engineChoice, enginePayload } from "./add-engine-fields.ts"
 import { dispatcherEnvPayload, withPeerProvenance } from "./dispatcher.ts"
 import { FANOUT_CAP, buildCountPlan, parseAgentsSpec } from "./flags.ts"
 import { daemonOf } from "./handler-helpers.ts"
-import { assertEngineAcceptsEffort } from "./handlers-engines.ts"
 import { ApiError, type VerbContext, helpStep } from "./types.ts"
-
-/** The engine fields a create carries: the raw command + its resolved protocol. */
-interface EngineChoice {
-  readonly command?: string
-  readonly vendor?: VendorId
-}
-
-/**
- * Resolve `--command` into what a task record needs. A bare preset id stays
- * verbatim in `command` (so a later `engineCommand.<id>` edit in Settings
- * still reaches this task) with its declared protocol alongside; a full
- * command line records both too. No `--command` = the repo's default engine,
- * which is a preset id, so it goes in the same two fields.
- */
-async function engineChoice(ctx: VerbContext, repo: string): Promise<EngineChoice> {
-  const command = ctx.args.str("command")
-  if (command) return { command, vendor: resolveCommandProtocol(command) }
-  const fallback = await ctx.runtime.defaultVendor(repo)
-  return fallback ? { command: fallback, vendor: fallback } : {}
-}
-
-/** The engine fields as a flat `task.create` payload fragment. */
-function enginePayload(choice: EngineChoice, effort?: string): Record<string, string> {
-  return {
-    ...(choice.command ? { command: choice.command } : {}),
-    ...(choice.vendor ? { vendor: choice.vendor } : {}),
-    // Wire key is `effort`; the daemon maps it to the record's `modelEffort`
-    // (`handlers-task.ts` task.create). Sending `modelEffort` here is silently
-    // dropped — the create succeeds and the level simply never lands.
-    ...(effort ? { effort } : {}),
-  }
-}
-
-/**
- * `--effort`, validated against the engine(s) this create will actually
- * launch — before anything is created, so a bad level costs no orphan task.
- *
- * Deliberately not an `enum` flag: levels are per-engine and a plugin engine
- * may declare its own, so the closed list lives on the registry entry, not on
- * the flag spec (the same reason `set-effort` takes a free string). It shares
- * that verb's gate, so a level `add` accepts is one `set-effort` would accept
- * too.
- *
- * A fan-out validates EVERY engine in the plan: `--agents claude:1,codex:1
- * --effort xhigh` is rejected outright rather than applied to the codex
- * sibling and silently dropped on the claude one.
- */
-function effortFor(ctx: VerbContext, engines: readonly VendorId[]): string | undefined {
-  const level = ctx.args.str("effort")?.trim()
-  if (!level) return undefined
-  for (const engine of new Set(engines)) {
-    assertEngineAcceptsEffort(engine, level, ["api", "engine-list"])
-  }
-  return level
-}
 
 /**
  * `--status` / `--pin` aren't create-time fields on the RPC — apply them as

--- a/packages/kobe/src/cli/api/handlers-engines.ts
+++ b/packages/kobe/src/cli/api/handlers-engines.ts
@@ -24,6 +24,7 @@ import {
   describePreset,
   listEnginePresets,
   resolveCommandProtocol,
+  sessionProtocol,
 } from "../../engine/engine-presets.ts"
 import { ensurePluginEnginesLoaded } from "../../engine/plugin-engines.ts"
 import { engineEntry } from "../../engine/registry.ts"
@@ -92,9 +93,16 @@ export const SET_COMMAND_VERB: VerbSpec = {
 
 /**
  * The engine whose effort levels govern a task: its PINNED command when it
- * has one, else its recorded protocol — the same resolution
+ * has one, else its `vendor`'s PROTOCOL — the same resolution
  * `engineLaunchArgv` performs, so the level this verb accepts is the level
  * the launch actually carries.
+ *
+ * `sessionProtocol`, not the raw `vendor`: a task created from the TUI's
+ * new-task dialog records the picked engine id in `vendor` with no `command`
+ * (`tui/lib/task-create-flow.ts`), so a `mycodex` preset declaring the codex
+ * protocol arrived here as `mycodex`, found the registry's empty custom entry,
+ * and had every level rejected — `set-effort` could not set one at all on the
+ * tasks most likely to want one. A built-in id resolves to itself.
  */
 function taskEngine(task: Pick<SerializedTask, "command" | "vendor">): VendorId {
   const command = task.command?.trim()
@@ -102,24 +110,29 @@ function taskEngine(task: Pick<SerializedTask, "command" | "vendor">): VendorId 
     const resolved = resolveCommandProtocol(command)
     if (resolved !== GENERIC_PROTOCOL) return resolved
   }
-  return coerceVendorId(task.vendor)
+  return sessionProtocol(coerceVendorId(task.vendor))
 }
 
-async function setEffort(ctx: VerbContext): Promise<unknown> {
-  const taskId = ctx.args.require("task-id")
-  const level = ctx.args.require("level").trim()
-  const daemon = daemonOf(ctx)
-  const { task } = await daemon.request<{ task: SerializedTask }>("task.get", { taskId })
-  const engine = taskEngine(task)
-  // Validated HERE rather than passed through: `withEngineEffort` drops a
-  // level the engine never declared, silently — which is how a user picks
-  // "high" and gets the default with no error anywhere.
+/**
+ * Reject `level` unless `engine` declares it. Exported because `add --effort`
+ * must refuse exactly what `set-effort` refuses — one gate, two entry points,
+ * so a level accepted at create time cannot be one `set-effort` would have
+ * rejected.
+ *
+ * Validated HERE rather than passed through: `withEngineEffort` drops a level
+ * the engine never declared, silently — which is how a user picks "high" and
+ * gets the default with no error anywhere.
+ *
+ * `recover` is the argv the error's `nextCommandArgs` offers: `get-task` when
+ * the task already exists, `engine-list` when it does not yet.
+ */
+export function assertEngineAcceptsEffort(engine: VendorId, level: string, recover: readonly string[]): void {
   const levels = engineEntry(engine).effortLevels ?? []
   if (levels.length === 0) {
     throw new ApiError(`engine ${engine} declares no reasoning effort levels`, "BAD_EFFORT", {
       engine,
       hint: `Only engines with declared levels accept one (codex today). Check the task's engine with \`get-task\`.`,
-      nextCommandArgs: ["api", "get-task", "--task-id", taskId],
+      nextCommandArgs: [...recover],
     })
   }
   if (!levels.includes(level)) {
@@ -130,11 +143,35 @@ async function setEffort(ctx: VerbContext): Promise<unknown> {
         engine,
         levels,
         hint: `Pass one of: ${levels.join(", ")}.`,
-        nextCommandArgs: ["api", "get-task", "--task-id", taskId],
+        nextCommandArgs: [...recover],
       },
     )
   }
-  await simpleRpc(ctx, "task.setVendor", { taskId, vendor: engine, effort: level })
+}
+
+async function setEffort(ctx: VerbContext): Promise<unknown> {
+  const taskId = ctx.args.require("task-id")
+  const level = ctx.args.require("level").trim()
+  const daemon = daemonOf(ctx)
+  const { task } = await daemon.request<{ task: SerializedTask }>("task.get", { taskId })
+  const engine = taskEngine(task)
+  assertEngineAcceptsEffort(engine, level, ["api", "get-task", "--task-id", taskId])
+  // Which vendor to write back. `taskEngine` resolved the PROTOCOL — the right
+  // thing to validate a level against, and the wrong thing to persist when the
+  // record already spells that protocol as a preset id: a `mycodex` task
+  // silently became `codex`, so the footer stopped rendering the user's
+  // `engineName.mycodex` label. Launch never depended on the write
+  // (`engineLaunchArgv` prefers the pinned command), so the label was the only
+  // casualty.
+  //
+  // A record whose vendor does NOT resolve to the engine is a different case:
+  // that is a stale or generic vendor next to a command naming a real one, and
+  // naming it is a genuine upgrade (the same one `resolveProtocolUpgrade`
+  // performs). So: keep the id when it already means this engine, correct it
+  // when it does not.
+  const recorded = coerceVendorId(task.vendor)
+  const vendor = sessionProtocol(recorded) === engine ? recorded : engine
+  await simpleRpc(ctx, "task.setVendor", { taskId, vendor, effort: level })
   return { ok: true, taskId, engine, effort: level }
 }
 

--- a/packages/kobe/src/cli/api/verbs-create.ts
+++ b/packages/kobe/src/cli/api/verbs-create.ts
@@ -28,6 +28,13 @@ export const CREATE_VERBS: readonly VerbSpec[] = [
       { name: "base-branch", type: "string", placeholder: "B", description: "Base ref the worktree branches from." },
       F.command(),
       {
+        name: "effort",
+        type: "string",
+        placeholder: "LEVEL",
+        description:
+          "Reasoning effort for the FIRST session, not just later ones. Validated against the engine's declared levels (codex: none/low/medium/high/xhigh/max; claude declares none) — free-form, since a plugin engine may declare its own. With --agents, every engine in the plan must declare it.",
+      },
+      {
         name: "count",
         type: "int",
         placeholder: "N",

--- a/packages/kobe/src/tui-react/component/engine-picker-dialog.tsx
+++ b/packages/kobe/src/tui-react/component/engine-picker-dialog.tsx
@@ -9,10 +9,10 @@
  *
  * Engines that DECLARE reasoning levels (`EngineRegistryEntry.effortLevels` —
  * codex today) get a second row under the list, so the level is settable on a
- * task that already exists — otherwise the web board's create-time picker is
- * the only surface that can set one, and a codex task is stuck on whatever it
- * launched with. Engines with no declared levels render no row at all,
- * matching the web picker's rule.
+ * task that already exists. Engines with no declared levels render no row at
+ * all. The board's start-from-an-issue picker sets an engine but no level, so
+ * this and `rove api set-effort` are the two ways to change one after the
+ * fact; only `rove api add --effort` reaches the FIRST session.
  *
  * Picking persists the task's vendor (and level) and nothing else; like `v`,
  * it takes effect on the task's next enter (`applyVendorChange` says so in

--- a/packages/kobe/test/cli/api-add-effort.test.ts
+++ b/packages/kobe/test/cli/api-add-effort.test.ts
@@ -36,28 +36,31 @@ function createClient(): FakeClient {
 }
 
 describe("add --effort", () => {
+  // These assert the ENGINE fields, never the whole payload: `--repo` is
+  // absolutized against the runner's cwd, so `/repo/x` arrives as `D:\repo\x`
+  // on the windows job and a whole-payload equality fails there while passing
+  // everywhere else.
   it("rides on task.create as `effort`, so the first session carries it", async () => {
     const client = createClient()
     await invokeVerb("add", ["--repo", "/repo/x", "--command", "codex", "--effort", "xhigh"], {
       client,
       runtime: stubRuntime(),
     })
-    // `effort` is the WIRE key the daemon maps onto the record's
-    // `modelEffort`; sending `modelEffort` here is dropped without a word, and
-    // the create still succeeds — so the payload name is the assertion.
-    expect(client.requests[0]).toEqual({
-      name: "task.create",
-      payload: { repo: "/repo/x", command: "codex", vendor: "codex", effort: "xhigh" },
-    })
+    expect(client.requests[0]?.name).toBe("task.create")
+    expect(client.requests[0]?.payload).toMatchObject({ command: "codex", vendor: "codex", effort: "xhigh" })
+    // `effort` is the WIRE key the daemon maps onto the record's `modelEffort`
+    // (`handlers-task.ts` task.create). Sending `modelEffort` instead is
+    // dropped without a word and the create still succeeds, so the key's NAME
+    // is the whole assertion — hence the negative half.
+    expect(client.requests[0]?.payload).not.toHaveProperty("modelEffort")
   })
 
   it("is optional — an add without it sends no effort at all", async () => {
     const client = createClient()
     await invokeVerb("add", ["--repo", "/repo/x", "--command", "codex"], { client, runtime: stubRuntime() })
-    expect(client.requests[0]).toEqual({
-      name: "task.create",
-      payload: { repo: "/repo/x", command: "codex", vendor: "codex" },
-    })
+    expect(client.requests[0]?.name).toBe("task.create")
+    expect(client.requests[0]?.payload).toMatchObject({ command: "codex", vendor: "codex" })
+    expect(client.requests[0]?.payload).not.toHaveProperty("effort")
   })
 
   it("refuses a level the engine does not declare, before creating anything", async () => {

--- a/packages/kobe/test/cli/api-add-effort.test.ts
+++ b/packages/kobe/test/cli/api-add-effort.test.ts
@@ -1,0 +1,127 @@
+/**
+ * `add --effort` — the level a task's FIRST session launches with.
+ *
+ * Before this flag existed, scripting a codex task at `xhigh` took three
+ * steps: `add`, then `set-effort`, then a session rebuild — so the first
+ * session, the one that does the opening work, always ran at the engine's
+ * default. These pin the payload the level rides on and the gate it must pass,
+ * which is deliberately the SAME gate `set-effort` uses
+ * (`assertEngineAcceptsEffort`): a level accepted here can never be one
+ * `set-effort` would have rejected.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { type ApiRuntime, invokeVerb } from "../../src/cli/api-cmd.ts"
+import { FakeClient, expectApiError, recordingDelivery, stubRuntime, taskFixture } from "./api-handler-fixtures.ts"
+
+const savedEnv = { taskId: process.env.KOBE_TASK_ID, tabId: process.env.KOBE_TAB_ID }
+beforeEach(() => {
+  // biome-ignore lint/performance/noDelete: env must fully unset (assigning undefined leaves the string "undefined").
+  delete process.env.KOBE_TASK_ID
+  // biome-ignore lint/performance/noDelete: env must fully unset (assigning undefined leaves the string "undefined").
+  delete process.env.KOBE_TAB_ID
+})
+afterEach(() => {
+  for (const [name, value] of [
+    ["KOBE_TASK_ID", savedEnv.taskId],
+    ["KOBE_TAB_ID", savedEnv.tabId],
+  ] as const) {
+    if (value === undefined) delete process.env[name]
+    else process.env[name] = value
+  }
+})
+
+function createClient(): FakeClient {
+  return new FakeClient({ "task.create": () => ({ taskId: "t1", task: taskFixture() }) })
+}
+
+describe("add --effort", () => {
+  it("rides on task.create as `effort`, so the first session carries it", async () => {
+    const client = createClient()
+    await invokeVerb("add", ["--repo", "/repo/x", "--command", "codex", "--effort", "xhigh"], {
+      client,
+      runtime: stubRuntime(),
+    })
+    // `effort` is the WIRE key the daemon maps onto the record's
+    // `modelEffort`; sending `modelEffort` here is dropped without a word, and
+    // the create still succeeds — so the payload name is the assertion.
+    expect(client.requests[0]).toEqual({
+      name: "task.create",
+      payload: { repo: "/repo/x", command: "codex", vendor: "codex", effort: "xhigh" },
+    })
+  })
+
+  it("is optional — an add without it sends no effort at all", async () => {
+    const client = createClient()
+    await invokeVerb("add", ["--repo", "/repo/x", "--command", "codex"], { client, runtime: stubRuntime() })
+    expect(client.requests[0]).toEqual({
+      name: "task.create",
+      payload: { repo: "/repo/x", command: "codex", vendor: "codex" },
+    })
+  })
+
+  it("refuses a level the engine does not declare, before creating anything", async () => {
+    const client = createClient()
+    await expectApiError(
+      () =>
+        invokeVerb("add", ["--repo", "/repo/x", "--command", "codex", "--effort", "bogus"], {
+          client,
+          runtime: stubRuntime(),
+        }),
+      "BAD_EFFORT",
+      /none, low, medium, high, xhigh/,
+    )
+    // The whole point of validating up front: a rejected level must not leave
+    // an orphan task behind an error that carries no taskId.
+    expect(client.requests).toEqual([])
+  })
+
+  it("refuses any level on an engine that declares none", async () => {
+    const client = createClient()
+    await expectApiError(
+      () =>
+        invokeVerb("add", ["--repo", "/repo/x", "--command", "claude", "--effort", "xhigh"], {
+          client,
+          runtime: stubRuntime(),
+        }),
+      "BAD_EFFORT",
+      /declares no reasoning effort levels/,
+    )
+    expect(client.requests).toEqual([])
+  })
+
+  it("applies the level to every sibling of a --count round", async () => {
+    const client = createClient()
+    const runtime: ApiRuntime = { ...stubRuntime(), deliverPrompt: recordingDelivery().deliver }
+    await invokeVerb(
+      "add",
+      ["--repo", "/repo/x", "--command", "codex", "--effort", "high", "--count", "2", "--prompt", "go"],
+      { client, runtime },
+    )
+    const creates = client.requests.filter((r) => r.name === "task.create")
+    expect(creates).toHaveLength(2)
+    for (const create of creates) {
+      expect((create.payload as { effort?: string }).effort).toBe("high")
+    }
+  })
+
+  // `--agents` names a different engine per sibling, so one shared level has
+  // to hold for all of them. Applying it to the codex sibling and dropping it
+  // on the claude one is exactly the silent half-application this gate exists
+  // to prevent.
+  it("refuses a level no engine in an --agents plan declares", async () => {
+    const client = createClient()
+    const runtime: ApiRuntime = { ...stubRuntime(), deliverPrompt: recordingDelivery().deliver }
+    await expectApiError(
+      () =>
+        invokeVerb(
+          "add",
+          ["--repo", "/repo/x", "--agents", "codex:1,claude:1", "--effort", "xhigh", "--prompt", "go"],
+          { client, runtime },
+        ),
+      "BAD_EFFORT",
+      /engine claude declares no reasoning effort levels/,
+    )
+    expect(client.requests).toEqual([])
+  })
+})

--- a/packages/kobe/test/cli/api-handlers-more.test.ts
+++ b/packages/kobe/test/cli/api-handlers-more.test.ts
@@ -8,10 +8,7 @@
  * request traffic; these pin RPC names + payloads scripts depend on.
  */
 
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
-import { tmpdir } from "node:os"
-import { join } from "node:path"
-import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { describe, expect, it } from "vitest"
 import {
   API_SCHEMA_VERSION,
   ApiError,
@@ -63,42 +60,6 @@ function stubRuntime(): ApiRuntime {
     tearDownSession: async () => {},
   }
 }
-
-/**
- * Register a `mycodex` preset declaring the codex protocol, in a throwaway
- * KOBE_HOME_DIR. `engine-presets.ts` reads state.json per call, so writing the
- * file is the whole registration.
- */
-function withPreset(): void {
-  const home = mkdtempSync(join(tmpdir(), "kobe-api-effort-"))
-  presetHomes.push(home)
-  const dir = join(home, ".config", "rove")
-  mkdirSync(dir, { recursive: true })
-  writeFileSync(
-    join(dir, "state.json"),
-    JSON.stringify({
-      customEngineIds: ["mycodex"],
-      "engineCommand.mycodex": "codex",
-      "engineProtocol.mycodex": "codex",
-      "engineName.mycodex": "My Codex",
-    }),
-    "utf8",
-  )
-  process.env.KOBE_HOME_DIR = home
-}
-
-const presetHomes: string[] = []
-let homeBeforePreset: string | undefined
-beforeEach(() => {
-  homeBeforePreset = process.env.KOBE_HOME_DIR
-})
-afterEach(() => {
-  if (homeBeforePreset === undefined) {
-    // biome-ignore lint/performance/noDelete: the var must be truly unset when it started unset.
-    delete process.env.KOBE_HOME_DIR
-  } else process.env.KOBE_HOME_DIR = homeBeforePreset
-  for (const home of presetHomes.splice(0)) rmSync(home, { recursive: true, force: true })
-})
 
 async function expectApiError(run: () => Promise<unknown>, code: string, message?: string | RegExp): Promise<void> {
   try {
@@ -265,91 +226,6 @@ describe("edit verbs — RPC name + payload", () => {
     expect(client.requests).toEqual([
       { name: "task.setCommand", payload: { taskId: "t1", command: "codex --search", vendor: "codex" } },
     ])
-  })
-
-  describe("set-effort", () => {
-    /** A task.get responder — the verb reads the task to learn its engine. */
-    const taskOf = (task: Record<string, unknown>) => ({ "task.get": () => ({ task: { id: "t1", ...task } }) })
-
-    it("sends the level on task.setVendor once the task's engine declares it", async () => {
-      const client = new FakeClient({ ...taskOf({ vendor: "codex" }), "task.setVendor": () => ({}) })
-      const out = await invokeVerb("set-effort", ["--task-id", "t1", "--level", "xhigh"], {
-        client,
-        runtime: stubRuntime(),
-      })
-      expect(out).toEqual({ ok: true, taskId: "t1", engine: "codex", effort: "xhigh" })
-      expect(client.requests.at(-1)).toEqual({
-        name: "task.setVendor",
-        payload: { taskId: "t1", vendor: "codex", effort: "xhigh" },
-      })
-    })
-
-    it("resolves the engine from a PINNED command, not just the recorded vendor", async () => {
-      // A task launched with `--command "codex --search"` is a codex launch;
-      // reading `vendor` alone would judge the level against the wrong engine.
-      const client = new FakeClient({
-        ...taskOf({ vendor: "generic", command: "codex --search" }),
-        "task.setVendor": () => ({}),
-      })
-      await invokeVerb("set-effort", ["--task-id", "t1", "--level", "high"], { client, runtime: stubRuntime() })
-      expect(client.requests.at(-1)).toEqual({
-        name: "task.setVendor",
-        payload: { taskId: "t1", vendor: "codex", effort: "high" },
-      })
-    })
-
-    it("refuses a level the engine does not declare, naming the ones it does", async () => {
-      // The whole point of the verb: `withEngineEffort` DROPS an unknown
-      // level at launch, so passing it through would look like success and
-      // run at the default.
-      const client = new FakeClient(taskOf({ vendor: "codex" }))
-      await expectApiError(
-        () => invokeVerb("set-effort", ["--task-id", "t1", "--level", "turbo"], { client, runtime: stubRuntime() }),
-        "BAD_EFFORT",
-        /none, low, medium, high, xhigh/,
-      )
-      expect(client.requests.map((r) => r.name)).toEqual(["task.get"])
-    })
-
-    it("refuses any level on an engine with no declared levels", async () => {
-      const client = new FakeClient(taskOf({ vendor: "claude" }))
-      await expectApiError(
-        () => invokeVerb("set-effort", ["--task-id", "t1", "--level", "xhigh"], { client, runtime: stubRuntime() }),
-        "BAD_EFFORT",
-        /declares no reasoning effort levels/,
-      )
-      expect(client.requests.map((r) => r.name)).toEqual(["task.get"])
-    })
-
-    // A preset declaring the codex protocol IS a codex launch, and the TUI
-    // records the preset id in `vendor`. Reading that id raw found the
-    // registry's empty custom entry, so every level was refused — set-effort
-    // could not set one at all on the tasks most likely to want one.
-    it("accepts a level on a wrapped preset that declares the engine's protocol", async () => {
-      withPreset()
-      const client = new FakeClient({ ...taskOf({ vendor: "mycodex" }), "task.setVendor": () => ({}) })
-      const out = await invokeVerb("set-effort", ["--task-id", "t1", "--level", "high"], {
-        client,
-        runtime: stubRuntime(),
-      })
-      expect(out).toEqual({ ok: true, taskId: "t1", engine: "codex", effort: "high" })
-    })
-
-    // Setting a level must not change WHICH engine the task says it is: the
-    // footer labels a task from `engineName.<vendor>`, so rewriting `mycodex`
-    // to `codex` silently dropped the user's own name for it.
-    it("leaves a wrapped preset's own id on the task", async () => {
-      withPreset()
-      const client = new FakeClient({
-        ...taskOf({ vendor: "mycodex", command: "codex" }),
-        "task.setVendor": () => ({}),
-      })
-      await invokeVerb("set-effort", ["--task-id", "t1", "--level", "high"], { client, runtime: stubRuntime() })
-      expect(client.requests.at(-1)).toEqual({
-        name: "task.setVendor",
-        payload: { taskId: "t1", vendor: "mycodex", effort: "high" },
-      })
-    })
   })
 
   it("set-status → task.status with a validated status", async () => {

--- a/packages/kobe/test/cli/api-handlers-more.test.ts
+++ b/packages/kobe/test/cli/api-handlers-more.test.ts
@@ -8,7 +8,10 @@
  * request traffic; these pin RPC names + payloads scripts depend on.
  */
 
-import { describe, expect, it } from "vitest"
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
 import {
   API_SCHEMA_VERSION,
   ApiError,
@@ -60,6 +63,42 @@ function stubRuntime(): ApiRuntime {
     tearDownSession: async () => {},
   }
 }
+
+/**
+ * Register a `mycodex` preset declaring the codex protocol, in a throwaway
+ * KOBE_HOME_DIR. `engine-presets.ts` reads state.json per call, so writing the
+ * file is the whole registration.
+ */
+function withPreset(): void {
+  const home = mkdtempSync(join(tmpdir(), "kobe-api-effort-"))
+  presetHomes.push(home)
+  const dir = join(home, ".config", "rove")
+  mkdirSync(dir, { recursive: true })
+  writeFileSync(
+    join(dir, "state.json"),
+    JSON.stringify({
+      customEngineIds: ["mycodex"],
+      "engineCommand.mycodex": "codex",
+      "engineProtocol.mycodex": "codex",
+      "engineName.mycodex": "My Codex",
+    }),
+    "utf8",
+  )
+  process.env.KOBE_HOME_DIR = home
+}
+
+const presetHomes: string[] = []
+let homeBeforePreset: string | undefined
+beforeEach(() => {
+  homeBeforePreset = process.env.KOBE_HOME_DIR
+})
+afterEach(() => {
+  if (homeBeforePreset === undefined) {
+    // biome-ignore lint/performance/noDelete: the var must be truly unset when it started unset.
+    delete process.env.KOBE_HOME_DIR
+  } else process.env.KOBE_HOME_DIR = homeBeforePreset
+  for (const home of presetHomes.splice(0)) rmSync(home, { recursive: true, force: true })
+})
 
 async function expectApiError(run: () => Promise<unknown>, code: string, message?: string | RegExp): Promise<void> {
   try {
@@ -280,6 +319,36 @@ describe("edit verbs — RPC name + payload", () => {
         /declares no reasoning effort levels/,
       )
       expect(client.requests.map((r) => r.name)).toEqual(["task.get"])
+    })
+
+    // A preset declaring the codex protocol IS a codex launch, and the TUI
+    // records the preset id in `vendor`. Reading that id raw found the
+    // registry's empty custom entry, so every level was refused — set-effort
+    // could not set one at all on the tasks most likely to want one.
+    it("accepts a level on a wrapped preset that declares the engine's protocol", async () => {
+      withPreset()
+      const client = new FakeClient({ ...taskOf({ vendor: "mycodex" }), "task.setVendor": () => ({}) })
+      const out = await invokeVerb("set-effort", ["--task-id", "t1", "--level", "high"], {
+        client,
+        runtime: stubRuntime(),
+      })
+      expect(out).toEqual({ ok: true, taskId: "t1", engine: "codex", effort: "high" })
+    })
+
+    // Setting a level must not change WHICH engine the task says it is: the
+    // footer labels a task from `engineName.<vendor>`, so rewriting `mycodex`
+    // to `codex` silently dropped the user's own name for it.
+    it("leaves a wrapped preset's own id on the task", async () => {
+      withPreset()
+      const client = new FakeClient({
+        ...taskOf({ vendor: "mycodex", command: "codex" }),
+        "task.setVendor": () => ({}),
+      })
+      await invokeVerb("set-effort", ["--task-id", "t1", "--level", "high"], { client, runtime: stubRuntime() })
+      expect(client.requests.at(-1)).toEqual({
+        name: "task.setVendor",
+        payload: { taskId: "t1", vendor: "mycodex", effort: "high" },
+      })
     })
   })
 

--- a/packages/kobe/test/cli/api-set-effort.test.ts
+++ b/packages/kobe/test/cli/api-set-effort.test.ts
@@ -1,0 +1,139 @@
+/**
+ * `set-effort` — which engine's levels govern a task, and what the verb is
+ * allowed to write back.
+ *
+ * Split out of `api-handlers-more.test.ts` (file-size cap) along its own seam:
+ * those pin the generic simple-RPC edit verbs, where the payload IS the
+ * behaviour. This one is about ENGINE RESOLUTION — `taskEngine` picking the
+ * right levels to validate against, and the write-back deliberately not
+ * changing which engine a task says it is. Its sibling `api-add-effort.test.ts`
+ * covers the same gate on the create side.
+ */
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { invokeVerb } from "../../src/cli/api-cmd.ts"
+import { FakeClient, expectApiError, stubRuntime } from "./api-handler-fixtures.ts"
+
+/**
+ * Register a `mycodex` preset declaring the codex protocol, in a throwaway
+ * KOBE_HOME_DIR. `engine-presets.ts` reads state.json per call, so writing the
+ * file is the whole registration.
+ */
+function withPreset(): void {
+  const home = mkdtempSync(join(tmpdir(), "kobe-api-effort-"))
+  presetHomes.push(home)
+  const dir = join(home, ".config", "rove")
+  mkdirSync(dir, { recursive: true })
+  writeFileSync(
+    join(dir, "state.json"),
+    JSON.stringify({
+      customEngineIds: ["mycodex"],
+      "engineCommand.mycodex": "codex",
+      "engineProtocol.mycodex": "codex",
+      "engineName.mycodex": "My Codex",
+    }),
+    "utf8",
+  )
+  process.env.KOBE_HOME_DIR = home
+}
+
+const presetHomes: string[] = []
+let homeBeforePreset: string | undefined
+beforeEach(() => {
+  homeBeforePreset = process.env.KOBE_HOME_DIR
+})
+afterEach(() => {
+  if (homeBeforePreset === undefined) {
+    // biome-ignore lint/performance/noDelete: the var must be truly unset when it started unset.
+    delete process.env.KOBE_HOME_DIR
+  } else process.env.KOBE_HOME_DIR = homeBeforePreset
+  for (const home of presetHomes.splice(0)) rmSync(home, { recursive: true, force: true })
+})
+
+describe("set-effort", () => {
+  /** A task.get responder — the verb reads the task to learn its engine. */
+  const taskOf = (task: Record<string, unknown>) => ({ "task.get": () => ({ task: { id: "t1", ...task } }) })
+
+  it("sends the level on task.setVendor once the task's engine declares it", async () => {
+    const client = new FakeClient({ ...taskOf({ vendor: "codex" }), "task.setVendor": () => ({}) })
+    const out = await invokeVerb("set-effort", ["--task-id", "t1", "--level", "xhigh"], {
+      client,
+      runtime: stubRuntime(),
+    })
+    expect(out).toEqual({ ok: true, taskId: "t1", engine: "codex", effort: "xhigh" })
+    expect(client.requests.at(-1)).toEqual({
+      name: "task.setVendor",
+      payload: { taskId: "t1", vendor: "codex", effort: "xhigh" },
+    })
+  })
+
+  it("resolves the engine from a PINNED command, not just the recorded vendor", async () => {
+    // A task launched with `--command "codex --search"` is a codex launch;
+    // reading `vendor` alone would judge the level against the wrong engine.
+    const client = new FakeClient({
+      ...taskOf({ vendor: "generic", command: "codex --search" }),
+      "task.setVendor": () => ({}),
+    })
+    await invokeVerb("set-effort", ["--task-id", "t1", "--level", "high"], { client, runtime: stubRuntime() })
+    expect(client.requests.at(-1)).toEqual({
+      name: "task.setVendor",
+      payload: { taskId: "t1", vendor: "codex", effort: "high" },
+    })
+  })
+
+  it("refuses a level the engine does not declare, naming the ones it does", async () => {
+    // The whole point of the verb: `withEngineEffort` DROPS an unknown
+    // level at launch, so passing it through would look like success and
+    // run at the default.
+    const client = new FakeClient(taskOf({ vendor: "codex" }))
+    await expectApiError(
+      () => invokeVerb("set-effort", ["--task-id", "t1", "--level", "turbo"], { client, runtime: stubRuntime() }),
+      "BAD_EFFORT",
+      /none, low, medium, high, xhigh/,
+    )
+    expect(client.requests.map((r) => r.name)).toEqual(["task.get"])
+  })
+
+  it("refuses any level on an engine with no declared levels", async () => {
+    const client = new FakeClient(taskOf({ vendor: "claude" }))
+    await expectApiError(
+      () => invokeVerb("set-effort", ["--task-id", "t1", "--level", "xhigh"], { client, runtime: stubRuntime() }),
+      "BAD_EFFORT",
+      /declares no reasoning effort levels/,
+    )
+    expect(client.requests.map((r) => r.name)).toEqual(["task.get"])
+  })
+
+  // A preset declaring the codex protocol IS a codex launch, and the TUI
+  // records the preset id in `vendor`. Reading that id raw found the
+  // registry's empty custom entry, so every level was refused — set-effort
+  // could not set one at all on the tasks most likely to want one.
+  it("accepts a level on a wrapped preset that declares the engine's protocol", async () => {
+    withPreset()
+    const client = new FakeClient({ ...taskOf({ vendor: "mycodex" }), "task.setVendor": () => ({}) })
+    const out = await invokeVerb("set-effort", ["--task-id", "t1", "--level", "high"], {
+      client,
+      runtime: stubRuntime(),
+    })
+    expect(out).toEqual({ ok: true, taskId: "t1", engine: "codex", effort: "high" })
+  })
+
+  // Setting a level must not change WHICH engine the task says it is: the
+  // footer labels a task from `engineName.<vendor>`, so rewriting `mycodex`
+  // to `codex` silently dropped the user's own name for it.
+  it("leaves a wrapped preset's own id on the task", async () => {
+    withPreset()
+    const client = new FakeClient({
+      ...taskOf({ vendor: "mycodex", command: "codex" }),
+      "task.setVendor": () => ({}),
+    })
+    await invokeVerb("set-effort", ["--task-id", "t1", "--level", "high"], { client, runtime: stubRuntime() })
+    expect(client.requests.at(-1)).toEqual({
+      name: "task.setVendor",
+      payload: { taskId: "t1", vendor: "mycodex", effort: "high" },
+    })
+  })
+})


### PR DESCRIPTION
Three fixes around reasoning effort. They share a file and a root cause — the
gate that decides which engine's levels apply to a task — so they ship together.

## 1. `rove api add --effort` (new)

`--effort` reaches a task's **first** session; nothing else does. The row menu
and `set-effort` both take effect on the next session rebuild, so scripting a
codex task at `xhigh` was `add` → `set-effort` → rebuild, and the opening
session — the one that does the work — always ran at the engine default.

Every layer below `add` already carried the level: `CreateTaskInput.modelEffort`,
`core-create.ts` persistence, `handlers-add.ts`'s echo. Only the flag was
missing.

Deliberately `type: "string"`, not `enum`: levels are per-engine and a plugin
engine may declare its own, so the closed list stays on the registry entry —
the same reason `set-effort` takes a free string. Validation happens **before**
`task.create`, so a rejected level leaves no orphan task.

The gate is literally `set-effort`'s, extracted as `assertEngineAcceptsEffort`
and called from both. A level `add` accepts can therefore never be one
`set-effort` would have rejected.

**Evidence** — isolated fixture (own `KOBE_HOME_DIR` + full socket/pid/port
set), rebuilt `dist`:

```
$ rove api add --command codex --effort xhigh --title "codex xhigh"
  created vendor='codex' command='codex' modelEffort='xhigh'

  task record:        {"vendor":"codex","command":"codex","modelEffort":"xhigh"}
  first-session argv: ["codex","-c","model_reasoning_effort=xhigh",
                       "-c","tui.terminal_title=[\"activity\",\"thread-title\"]"]
```

No `set-effort`, no rebuild. **Both positive controls:**

```
$ rove api add --command claude --effort xhigh
{"error":{"message":"engine claude declares no reasoning effort levels","code":"BAD_EFFORT",…}}

$ rove api add --command codex --effort bogus
{"error":{"message":"engine codex does not accept effort level \"bogus\" — it declares
 none, low, medium, high, xhigh, max","code":"BAD_EFFORT","levels":[…],…}}
```

BEFORE, same commands: `{"error":{"message":"unknown flag --effort for \"add\"","code":"BAD_FLAG"}}`.

`--count` applies the level to every sibling. `--agents` validates **every**
engine in the plan and rejects up front, rather than applying it to the codex
sibling and dropping it on the claude one.

## 2. `set-effort` refused every level on a preset task created from the TUI

`taskEngine()` fell back to `coerceVendorId(task.vendor)` — the RAW id. The
TUI's new-task dialog records the picked engine id in `vendor` with no
`command` (`tui/lib/task-create-flow.ts`), so a `mycodex` preset declaring the
codex protocol arrived as `mycodex`, hit the registry's empty custom entry, and
was told it declares no levels. `set-effort` could not set one **at all** on
exactly the tasks most likely to want one.

Now `sessionProtocol(coerceVendorId(task.vendor))` — the Bundle-1 rule, one
layer up. A built-in id resolves to itself.

```
                     BEFORE                                  AFTER
record   vendor='mycodex' command=None            vendor='mycodex' command=None
$ set-effort --level high
         {"error":…"engine mycodex declares         {"ok":true,"engine":"codex",
          no reasoning effort levels"…}              "effort":"high"}
after    modelEffort=None                          modelEffort='high'
```

## 3. `set-effort` renamed the user's engine

`taskEngine()` returns the PROTOCOL — correct for validating a level, wrong to
persist. It was sent straight to `task.setVendor`, so a `mycodex` task became
`codex`. Launch was unaffected (`engineLaunchArgv` prefers the pinned command);
the casualty was the label, since the footer reads
`engineDisplayName(task.vendor)` → the user's `engineName.mycodex`.

Reproduced through a real path: `rove api add --command codex` (vendor=codex,
command=codex), then the TUI row menu's **Change engine** → "My Codex", which
is `task.setVendor(id, "mycodex")` and leaves `command` alone
(`task-editor.ts` `setVendor` writes only vendor+effort).

```
                     BEFORE                                  AFTER
before   vendor='mycodex' label="My Codex"        vendor='mycodex' label="My Codex"
$ set-effort --level high  →  {"ok":true,"engine":"codex","effort":"high"}
after    vendor='codex'   label="Codex"    ←BUG   vendor='mycodex' label="My Codex"
         argv: […model_reasoning_effort=high…]    argv: […model_reasoning_effort=high…]
```

**Not a blanket "always keep the recorded vendor".** An existing test pins a
genuine case: `{vendor: "generic", command: "codex --search"}` SHOULD be
corrected to `codex` — that is a stale vendor next to a command naming a real
engine, the same upgrade `resolveProtocolUpgrade` performs. So the rule is:
keep the id when it already resolves to this engine, correct it when it does
not. My first attempt was the blanket version; that test caught it.

## 4. `docs/ENGINES.md` listed an effort entry point that does not exist

"the web board's engine picker, when you start a task from an issue" — `effort`
has **zero hits** across `issue-detail-{contract,dialog,parts}`, and
`IssueDetailOutcome`'s `start`/`create` arms carry only `vendor`. (There is also
no web board in this checkout; the board is the TUI kanban page.) The negative
control is the second bullet, the sidebar row menu, which does exist —
`engine-picker-dialog.tsx:48` + `host-task-actions.ts:191`.

**I did the docs fix, not the feature, and that is a deviation from the brief**,
which preferred adding the effort row to the issue-detail picker. Reason:
`issue-detail-dialog.tsx` is 472 lines and the change extends its field-focus
ring — a real feature with its own keyboard-navigation review, landing next to
three CLI fixes. Filed as **issue #103** with the concrete shape (reuse
`EnginePickerDialogView`'s second row, `tasks.footerEffort` already exists,
extend the outcome with `effort?: string`) so it is tracked rather than lost.

The docs now list the three entry points that exist, lead with `add --effort`
as the only one reaching the first session, and say plainly that a task started
from an issue runs its first session at the engine default. The stale
"web board's create-time picker" comment in `engine-picker-dialog.tsx` is
corrected too.

## Tests

- `test/cli/api-add-effort.test.ts` (new, 6): the wire key (`effort`, not
  `modelEffort` — the daemon maps it, and sending the wrong one is dropped
  silently while the create still succeeds), both refusals with **no** create
  request issued, `--count` fan-out, and the `--agents` mixed-engine refusal.
- `test/cli/api-handlers-more.test.ts` (+2): a level accepted on a wrapped
  preset, and the preset's id surviving on the task.

**Mutation verification** — all three src files reverted to `origin/main`:

```
× add --effort > rides on task.create as `effort`, so the first session carries it
× add --effort > refuses a level the engine does not declare, before creating anything
× add --effort > refuses any level on an engine that declares none
× add --effort > applies the level to every sibling of a --count round
× add --effort > refuses a level no engine in an --agents plan declares
× set-effort > accepts a level on a wrapped preset that declares the engine's protocol
× set-effort > leaves a wrapped preset's own id on the task
Tests  7 failed | 38 passed
```

`.agents/skills/kobe/references/api-flags.md` and its `claude-plugin` twin are
regenerated (`bun scripts/gen-skill-api-flags.ts`) — the drift guard in
`test/architecture/skill-api-reference.test.ts` fails otherwise.

`bun run test:fast` 4932 pass · `bun test test/render` 513 pass · root
`bun run lint` clean · `tsc --noEmit` clean.

## File-size follow-up (second commit)

`file-size-cap` failed the first push: `api-handlers-more.test.ts` reached 553
lines. No exemption — both files had a real seam.

- **`api-handlers-more.test.ts` 553 → 429.** That file pins the generic
  simple-RPC edit verbs, where the payload IS the behaviour. The `set-effort`
  cases are about engine RESOLUTION instead — which levels apply, and what the
  write-back may change. They move to **`api-set-effort.test.ts`**, next to
  `api-add-effort.test.ts`, which covers the same gate on the create side.
- **`handlers-add.ts` 473 → 417.** Optional (it was a warning, not a failure),
  done because this branch is what pushed it there. The engine half — which
  command, which protocol, which level — moves to **`add-engine-fields.ts`**
  (71 lines); `handlers-add.ts` keeps the create orchestration: flag conflicts,
  single-vs-parallel, per-sibling failure rows, prompt delivery. Both `addOne`
  and `addParallel` route through the new module, so the two paths cannot drift
  on the engine contract the way they once did on `--status`/`--pin`. Happy to
  drop this half if you'd rather keep the diff to the tests.
