### PR TITLE
fix: four silent failures — the UI said it worked, or said nothing

### DIFF
--- a/.changeset/hook-install-rejection-reported.md
+++ b/.changeset/hook-install-rejection-reported.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+a settings file the hook installer cannot parse is now named on stderr and in `rove doctor`, instead of silently disabling every badge

--- a/.changeset/kv-write-error-toast.md
+++ b/.changeset/kv-write-error-toast.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+a settings write that never reaches disk now raises an error toast instead of vanishing into the alternate screen

--- a/.changeset/pty-kill-honest-reply.md
+++ b/.changeset/pty-kill-honest-reply.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+`pty.kill` answers `accepted` for the removal it actually completed, and a failed teardown reaches daemon.log under a tag

--- a/.changeset/silent-index-remove-rollback.md
+++ b/.changeset/silent-index-remove-rollback.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+a delete whose index write fails no longer removes the row, and no later save quietly completes it

--- a/packages/kobe-daemon/src/daemon/pty-host.ts
+++ b/packages/kobe-daemon/src/daemon/pty-host.ts
@@ -35,6 +35,7 @@
  * store) forgets a session for good.
  */
 
+import { logDaemonError } from "./crash-log.ts"
 import type { DaemonFrame, PtyPeekResult } from "./protocol.ts"
 import { PtyChildController } from "./pty-child-controller.ts"
 import { shouldFreeze } from "./pty-freeze-policy.ts"
@@ -290,16 +291,23 @@ export class PtyHost {
     }
   }
 
-  /** Compare and remove synchronously, so a reopened key cannot inherit an old kill. */
+  /**
+   * Compare and remove synchronously, so a reopened key cannot inherit an old
+   * kill. The CHILD's teardown is asynchronous (SIGTERM, up to 500ms grace,
+   * then SIGKILL), so the answer is `accepted`, not `killed`: the compare-and-
+   * remove is what this call actually completed. It said `killed: true` before
+   * the signal had been sent, which is how `rove api tab-close` reported a
+   * successful close over a PTY that was still running.
+   */
   killIfGeneration(
     key: string,
     expectedGeneration: string,
-  ): { killed: true } | { killed: false; reason: "missing-session" | "generation-mismatch" } {
+  ): { accepted: true } | { accepted: false; reason: "missing-session" | "generation-mismatch" } {
     const session = this.sessions.get(key)
-    if (!session) return { killed: false, reason: "missing-session" }
-    if (session.generation !== expectedGeneration) return { killed: false, reason: "generation-mismatch" }
-    void this.kill(key)
-    return { killed: true }
+    if (!session) return { accepted: false, reason: "missing-session" }
+    if (session.generation !== expectedGeneration) return { accepted: false, reason: "generation-mismatch" }
+    void this.kill(key).catch((err) => logDaemonError("pty-kill", err))
+    return { accepted: true }
   }
 
   /** End the child AND forget the session (explicit close / task deletion). */

--- a/packages/kobe-daemon/src/daemon/pty-server.ts
+++ b/packages/kobe-daemon/src/daemon/pty-server.ts
@@ -367,8 +367,13 @@ export async function startPtyHostServer(options: PtyHostServerOptions = {}): Pr
         const key = requireString(payload, "key")
         if ("expectedGeneration" in payload)
           return ptys.killIfGeneration(key, requireString(payload, "expectedGeneration"))
-        void ptys.kill(key)
-        return {}
+        // Same as `killIfGeneration`: the session is dropped synchronously,
+        // the child's teardown is not. `accepted` says the request was taken,
+        // which is all this reply can honestly claim — and the rejection now
+        // reaches `daemon.log` under a tag instead of an anonymous
+        // unhandledRejection (see crash-log.ts).
+        void ptys.kill(key).catch((err) => logDaemonError("pty-kill", err))
+        return { accepted: true }
       }
       case "pty.rename": {
         const payload = objectPayload(req.payload)

--- a/packages/kobe/src/cli/doctor-cmd.ts
+++ b/packages/kobe/src/cli/doctor-cmd.ts
@@ -15,6 +15,7 @@ import {
 } from "@sma1lboy/kobe-daemon/daemon/paths"
 import { isForeignDaemonHome } from "@sma1lboy/kobe-daemon/daemon/protocol"
 import { readPidFile } from "@sma1lboy/kobe-daemon/daemon/server"
+import { hookConfigIssues } from "../engine/hook-config-check.ts"
 import { homeDir, kvStatePath, roveStateDir } from "../env.ts"
 import { formatBytes } from "../lib/format-bytes.ts"
 import { kobeSkillState, skillInstallCommand } from "../lib/skill-install.ts"
@@ -252,7 +253,9 @@ async function collectDoctor(): Promise<{ lines: string[]; fixes: DoctorFix[]; o
     const snapshot = await requestIfReachable<InspectSnapshot>(daemonSocket, "debug.inspect")
     const tabs = snapshot?.activity?.tabs
     if (tabs) {
-      const hookInput = { socketPath: daemonSocket }
+      // The second way the channel dies (see doctor-hook-channel.ts): the
+      // install was refused, so the hooks were never written at all.
+      const hookInput = { socketPath: daemonSocket, configIssues: hookConfigIssues() }
       const verdict = classifyHookChannel({ tabs, ...hookInput })
       out.push("", ...hookChannelDoctorLines(verdict, hookInput, CLI_NAME))
       if (verdict.kind === "down") fixes.push(daemonRestartFix(CLI_NAME, "hooksDown"), engineTabsManualFix())

--- a/packages/kobe/src/cli/doctor-hook-channel.ts
+++ b/packages/kobe/src/cli/doctor-hook-channel.ts
@@ -19,6 +19,8 @@
  * hook entry yet and is perfectly healthy.
  */
 
+import type { HookConfigIssue } from "../engine/hook-config-check.ts"
+
 /** The one field of a `debug.inspect` tab entry this check reads. */
 interface InspectTabEntry {
   readonly source?: string
@@ -38,6 +40,14 @@ export interface HookChannelInput {
    * branch), so any such comparison is unreachable by construction.
    */
   readonly socketPath: string
+  /**
+   * Engine settings files whose hook install was refused (see
+   * `engine/json-hooks.ts#parseHookSettings`). The SECOND way the channel
+   * dies, and the one nothing used to diagnose: a stale socket at least
+   * leaves live tabs behind, whereas a `hooks` shape Rove cannot parse means
+   * the install never ran and nothing on the machine says so.
+   */
+  readonly configIssues?: readonly HookConfigIssue[]
 }
 
 export type HookChannelVerdict =
@@ -72,17 +82,28 @@ export function classifyHookChannel(input: HookChannelInput): HookChannelVerdict
  */
 export function hookChannelDoctorLines(
   verdict: HookChannelVerdict,
-  input: Pick<HookChannelInput, "socketPath">,
+  input: Pick<HookChannelInput, "socketPath" | "configIssues">,
   cliName: string,
 ): string[] {
-  if (verdict.kind === "no-tabs") return ["hooks:   — no engine tabs yet (nothing to check)"]
+  // A refused settings file is worth reporting whatever the tab verdict says:
+  // one engine's hooks can be live while another's install has been skipped on
+  // every launch since the file was hand-edited.
+  const configLines = (input.configIssues ?? []).flatMap((issue) => [
+    `         ⚠ hook install skipped: ${issue.file}`,
+    `           ${issue.reason} — fix the file, then relaunch Rove`,
+  ])
+  if (verdict.kind === "no-tabs") return ["hooks:   — no engine tabs yet (nothing to check)", ...configLines]
   if (verdict.kind === "live") {
-    return [`hooks:   ✓ engine hook channel live (${verdict.hookTabs}/${verdict.totalTabs} tab(s) hook-sourced)`]
+    return [
+      `hooks:   ✓ engine hook channel live (${verdict.hookTabs}/${verdict.totalTabs} tab(s) hook-sourced)`,
+      ...configLines,
+    ]
   }
   const out = [
     `hooks:   ✗ NO hook events reaching the daemon (0/${verdict.totalTabs} tab(s) hook-sourced)`,
     "         badges fall back to a ~10s poll, so activity looks seconds late",
     `         daemon socket: ${input.socketPath}`,
+    ...configLines,
   ]
   // The failure this names: an engine (and every hook it forks) inherits a
   // `*_DAEMON_SOCKET_PATH` pointing at a socket that is gone, so every hook

--- a/packages/kobe/src/engine/hook-adapter.ts
+++ b/packages/kobe/src/engine/hook-adapter.ts
@@ -21,6 +21,7 @@
 
 import type { VendorId } from "../types/vendor.ts"
 import type { EngineActivityDetail, EngineActivityKind } from "./hook-events.ts"
+import type { HookEditOutcome } from "./json-hooks.ts"
 import { engineEntry } from "./registry.ts"
 
 /** An engine session's own identity, as reported by its hook payload. */
@@ -72,8 +73,13 @@ export interface EngineHookAdapter {
    * a task). Must be IDEMPOTENT (safe on every launch; skips the write when
    * already in place), merge-safe (preserves the user's own hooks), and must
    * never throw fatally.
+   *
+   * Returns whether the merge actually reached the file. A refusal (a
+   * settings document this adapter cannot understand) is not an error the
+   * launch may fail on, but it is not nothing either: hooks stay uninstalled
+   * for good and every badge falls back to the daemon's ~10s poll.
    */
-  installActivityHooks(settingsFilePath: string, opts?: { toolEvents?: boolean }): Promise<void>
+  installActivityHooks(settingsFilePath: string, opts?: { toolEvents?: boolean }): Promise<HookEditOutcome>
   /** Remove the activity hooks this adapter installed. Idempotent. */
   removeActivityHooks(settingsFilePath: string): Promise<void>
 
@@ -129,8 +135,9 @@ export class NoopHookAdapter implements EngineHookAdapter {
   sessionFromPayload(): EngineSessionRef | undefined {
     return undefined // no wired hooks → no payload this adapter understands
   }
-  async installActivityHooks(): Promise<void> {
+  async installActivityHooks(): Promise<HookEditOutcome> {
     /* no-op until this engine's hook format is implemented */
+    return { ok: true }
   }
   async removeActivityHooks(): Promise<void> {
     /* no-op */

--- a/packages/kobe/src/engine/hook-config-check.ts
+++ b/packages/kobe/src/engine/hook-config-check.ts
@@ -1,0 +1,52 @@
+/**
+ * Read-only counterpart to the hook installer: which engine settings files
+ * would have their hook merge REFUSED right now, and why.
+ *
+ * The installer abandons a document it cannot understand
+ * (`json-hooks.ts#parseHookSettings`) so a best-effort write never clobbers an
+ * engine configuration — correct, but it means a hand-edited
+ * `~/.claude/settings.json` permanently stops receiving hooks. The only
+ * symptom is latency: every badge falls back to the daemon's ~10s activity
+ * poll. This is the module that lets `rove doctor` name the file instead.
+ *
+ * Its own file rather than `cli/hook-cmd.ts` so `doctor-cmd` does not take a
+ * runtime edge on another CLI verb's module — that class of import lands as a
+ * bundle-only TDZ crash in a neighbouring verb, invisible to tsc and unit
+ * tests.
+ */
+
+import { readFileSync } from "node:fs"
+import { ALL_VENDORS } from "../types/vendor.ts"
+import { createEngineHookAdapter } from "./hook-adapter.ts"
+import { parseHookSettings } from "./json-hooks.ts"
+
+/** A settings file the hook installer refused, and why. */
+export interface HookConfigIssue {
+  readonly file: string
+  readonly reason: string
+}
+
+/**
+ * Only JSON-shaped settings are checked: `parseHookSettings` is that format's
+ * validator, and the TOML adapter (Kimi) carries its own. A missing file is
+ * the first-launch case, and one that cannot be read at all is a permissions
+ * problem the install reports itself — neither is an issue here.
+ */
+export function hookConfigIssues(): HookConfigIssue[] {
+  const issues: HookConfigIssue[] = []
+  for (const vendor of ALL_VENDORS) {
+    const adapter = createEngineHookAdapter(vendor)
+    if (!adapter.supportsHooks()) continue
+    const file = adapter.globalSettingsPath()
+    if (!file || !file.endsWith(".json")) continue
+    let raw: string
+    try {
+      raw = readFileSync(file, "utf8")
+    } catch {
+      continue
+    }
+    const parsed = parseHookSettings(raw)
+    if (!parsed.ok) issues.push({ file, reason: parsed.reason })
+  }
+  return issues
+}

--- a/packages/kobe/src/engine/json-hook-adapter.ts
+++ b/packages/kobe/src/engine/json-hook-adapter.ts
@@ -17,10 +17,11 @@ import type { EngineHookAdapter, EngineSessionRef } from "./hook-adapter.ts"
 import type { EngineActivityDetail, EngineActivityKind } from "./hook-events.ts"
 import {
   GATED_TOOL_VERBS,
+  type HookEditOutcome,
   type HookEventSpec,
   removeWorktreeWatchHook as dropWorktreeWatchHook,
-  isObject,
   mergeActivityHooks,
+  parseHookSettings,
 } from "./json-hooks.ts"
 import { updateSharedJson } from "./shared-config-write.ts"
 
@@ -35,34 +36,31 @@ import { updateSharedJson } from "./shared-config-write.ts"
  * design) and lands via tmp+rename, never a write straight onto the live file a
  * starting session may be reading.
  *
- * Best-effort: a failure to read/parse/write must never block a launch.
+ * Best-effort: a failure to read/parse/write must never block a launch — it is
+ * REPORTED rather than thrown ({@link HookEditOutcome}). Reporting is the
+ * caller's job so the noise lands once: `ensureGlobalKobeHooks` runs an
+ * install and two removals over the same file on every launch, and three
+ * lines about one file is how a real signal gets read as boilerplate.
  */
 export async function editJsonSettings(
   settingsFilePath: string,
   transform: (current: Record<string, unknown>) => Record<string, unknown>,
-): Promise<void> {
+): Promise<HookEditOutcome> {
+  // Set by the loader when it refuses the document. The loader signals refusal
+  // to `updateSharedJson` with `undefined` — the same value it returns for
+  // "nothing to do" — so the reason has to come back out of band.
+  let rejected: string | undefined
   try {
     await updateSharedJson(
       settingsFilePath,
       (raw) => {
-        // A missing file starts empty; any other read or parse failure abandons
-        // the write so a best-effort install cannot clobber an existing engine
-        // configuration it could not understand.
-        if (raw === undefined) return {}
-        try {
-          const parsed: unknown = JSON.parse(raw)
-          if (!isObject(parsed)) return undefined
-          if (parsed.hooks !== undefined) {
-            if (!isObject(parsed.hooks)) return undefined
-            for (const groups of Object.values(parsed.hooks)) {
-              if (!Array.isArray(groups)) return undefined
-              if (groups.some((group) => !isObject(group) || !Array.isArray(group.hooks))) return undefined
-            }
-          }
-          return parsed
-        } catch {
-          return undefined
-        }
+        // A missing file starts empty; a document we cannot understand abandons
+        // the write so a best-effort install never clobbers an existing engine
+        // configuration.
+        const parsed = parseHookSettings(raw)
+        if (parsed.ok) return parsed.doc
+        rejected = parsed.reason
+        return undefined
       },
       (current) => {
         const next = transform(current)
@@ -70,9 +68,11 @@ export async function editJsonSettings(
         return json === JSON.stringify(current, null, 2) ? undefined : `${json}\n`
       },
     )
-  } catch {
-    /* best-effort — never block launch */
+  } catch (err) {
+    return { ok: false, file: settingsFilePath, reason: err instanceof Error ? err.message : String(err) }
   }
+  if (rejected !== undefined) return { ok: false, file: settingsFilePath, reason: rejected }
+  return { ok: true }
 }
 
 export abstract class JsonHookAdapter implements EngineHookAdapter {
@@ -118,9 +118,9 @@ export abstract class JsonHookAdapter implements EngineHookAdapter {
     return GATED_TOOL_VERBS
   }
 
-  async installActivityHooks(settingsFilePath: string, opts: { toolEvents?: boolean } = {}): Promise<void> {
+  async installActivityHooks(settingsFilePath: string, opts: { toolEvents?: boolean } = {}): Promise<HookEditOutcome> {
     const gated = this.gatedVerbs()
-    await editJsonSettings(settingsFilePath, (cur) =>
+    const outcome = await editJsonSettings(settingsFilePath, (cur) =>
       mergeActivityHooks(cur, true, this.eventMap, undefined, {
         // Phase 0 (docs/design/plugin-events.md): tag the report with the
         // vendor so `kobe hook` decodes with the right adapter, not a guess.
@@ -128,6 +128,11 @@ export abstract class JsonHookAdapter implements EngineHookAdapter {
         buildFilter: (spec) => opts.toolEvents === true || !gated.has(spec.verb),
       }),
     )
+    // stderr, not a throw: under `rove daemon` this lands in daemon.log, which
+    // is where `rove doctor` sends a reader whose hook channel is dead. The
+    // removals stay silent — this is the write whose absence costs the badges.
+    if (!outcome.ok) process.stderr.write(`[rove hooks] ${this.vendor}: skipped ${outcome.file}: ${outcome.reason}\n`)
+    return outcome
   }
 
   async removeActivityHooks(settingsFilePath: string): Promise<void> {

--- a/packages/kobe/src/engine/json-hooks.ts
+++ b/packages/kobe/src/engine/json-hooks.ts
@@ -36,6 +36,61 @@ export function isObject(v: unknown): v is Record<string, unknown> {
   return !!v && typeof v === "object" && !Array.isArray(v)
 }
 
+/**
+ * Whether a hook merge reached the settings file.
+ *
+ * Returned rather than thrown: every caller is on a best-effort launch path
+ * and must continue either way. What changed is that "continue" no longer
+ * means "say nothing" — a permanently skipped install used to leave the
+ * product looking merely slow (every badge back on the daemon's ~10s activity
+ * poll) with not one line naming the file responsible.
+ */
+export type HookEditOutcome =
+  | { readonly ok: true }
+  | { readonly ok: false; readonly file: string; readonly reason: string }
+
+/**
+ * A settings document the hook merge may run on, or the reason it may not.
+ *
+ * Rejecting is deliberate: a best-effort install must never clobber an engine
+ * configuration it could not understand. But abandoning the write and
+ * abandoning it SILENTLY are different things — a hand-edited
+ * `~/.claude/settings.json` whose `hooks` fails this check means Rove
+ * permanently stops installing hooks, every badge falls back to the ~10s
+ * activity poll, and the product reads as slow rather than misconfigured.
+ * Hence a reason string that names the offending path inside the document.
+ */
+export type HookSettingsParse =
+  | { readonly ok: true; readonly doc: Record<string, unknown> }
+  | { readonly ok: false; readonly reason: string }
+
+/**
+ * Validate the bytes of a shared settings file for the hook merge. A missing
+ * file (`undefined`) is an EMPTY document, not a rejection — that is the
+ * first-launch case the install exists to serve.
+ *
+ * Shared with `cli/doctor-hook-channel.ts` so doctor reports the same verdict
+ * on the same file rather than re-deriving a second opinion.
+ */
+export function parseHookSettings(raw: string | undefined): HookSettingsParse {
+  if (raw === undefined) return { ok: true, doc: {} }
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch (err) {
+    return { ok: false, reason: `not valid JSON (${err instanceof Error ? err.message : String(err)})` }
+  }
+  if (!isObject(parsed)) return { ok: false, reason: "top level is not a JSON object" }
+  if (parsed.hooks === undefined) return { ok: true, doc: parsed }
+  if (!isObject(parsed.hooks)) return { ok: false, reason: '"hooks" is not an object' }
+  for (const [event, groups] of Object.entries(parsed.hooks)) {
+    if (!Array.isArray(groups)) return { ok: false, reason: `"hooks.${event}" is not an array` }
+    const bad = groups.findIndex((group) => !isObject(group) || !Array.isArray(group.hooks))
+    if (bad >= 0) return { ok: false, reason: `"hooks.${event}[${bad}]" is not an object with a "hooks" array` }
+  }
+  return { ok: true, doc: parsed }
+}
+
 // Accept literal argv from the current quoter and older bare/double-quoted
 // installs. Shell operators, expansions and wrappers are not ours to remove.
 const HOOK_WORD = String.raw`(?:'(?:[^']|'\\'')*'|"[^"$\x60\\]*"|[A-Za-z0-9_./:=+-]+)`

--- a/packages/kobe/src/engine/kimi-local/hook-adapter.ts
+++ b/packages/kobe/src/engine/kimi-local/hook-adapter.ts
@@ -36,7 +36,7 @@ import { kobeHookInvocation } from "../../cli/invocation.ts"
 import { quoteShellArgv } from "../../lib/shell-command.ts"
 import type { EngineHookAdapter, EngineSessionRef } from "../hook-adapter.ts"
 import type { EngineActivityDetail, EngineActivityKind } from "../hook-events.ts"
-import { GATED_TOOL_VERBS, type HookEventSpec } from "../json-hooks.ts"
+import { GATED_TOOL_VERBS, type HookEditOutcome, type HookEventSpec } from "../json-hooks.ts"
 import { vendorConfigHome } from "../vendor-home.ts"
 
 /** Kimi hook event → normalized kobe verb. The ONE place Kimi event names live. */
@@ -214,11 +214,13 @@ export class KimiHookAdapter implements EngineHookAdapter {
     return { sessionId: payload.session_id }
   }
 
-  async installActivityHooks(settingsFilePath: string, opts: { toolEvents?: boolean } = {}): Promise<void> {
+  async installActivityHooks(settingsFilePath: string, opts: { toolEvents?: boolean } = {}): Promise<HookEditOutcome> {
     // Don't materialize ~/.kimi-code for a user who never installed Kimi —
-    // no config dir means no Kimi to read the hooks anyway.
-    if (!existsSync(dirname(settingsFilePath))) return
+    // no config dir means no Kimi to read the hooks anyway. Not a refusal:
+    // there is no engine here whose badges could go missing.
+    if (!existsSync(dirname(settingsFilePath))) return { ok: true }
     await editTomlConfig(settingsFilePath, (cur) => mergeKimiHooks(cur, true, undefined, opts))
+    return { ok: true }
   }
 
   async removeActivityHooks(settingsFilePath: string): Promise<void> {

--- a/packages/kobe/src/orchestrator/index/store.ts
+++ b/packages/kobe/src/orchestrator/index/store.ts
@@ -398,11 +398,20 @@ export class TaskIndexStore {
    * `void` made "deleted" and "there was nothing here" the same answer — a
    * caller working from a cache that never saw the task (a peer created it)
    * got a silent no-op indistinguishable from a deletion. Hence the boolean.
+   *
+   * Rolls back like its siblings when the write does not land. Without that,
+   * a failed delete was the worst of both: the row left the sidebar while the
+   * caller was told the delete failed, the task stayed on disk with its
+   * `deletion.phase` still `running` (so the next launch restored a row whose
+   * worktree `task-deletion.finish` had already removed), and the tombstone
+   * stayed in `removedIds` for the next UNRELATED successful save to flush —
+   * completing the deletion minutes later, silently.
    */
   async remove(id: TaskId | string): Promise<boolean> {
     this.assertLoaded()
     const idx = this.cache.tasks.findIndex((t) => t.id === id)
-    if (idx < 0) return false
+    const removed = this.cache.tasks[idx]
+    if (idx < 0 || !removed) return false
     this.cache.tasks.splice(idx, 1)
     // Record the deletion so the read-merge-write doesn't resurrect this task
     // from a stale on-disk copy, and stop treating it as a pending edit. The
@@ -410,7 +419,18 @@ export class TaskIndexStore {
     // task dirty in memory don't write it back either.
     this.dirtyIds.delete(String(id))
     this.removedIds.set(String(id), new Date().toISOString())
-    await this.save()
+    await this.saveOrRollback(String(id), () => {
+      // By object identity, like the other undos: if anything put this id back
+      // while we were writing, that mutation owns it and carries its own save.
+      if (this.cache.tasks.some((t) => t.id === removed.id)) return false
+      // The tombstone is the half that outlives the cache: leaving it behind
+      // is what let a later save finish the rejected deletion.
+      this.removedIds.delete(String(id))
+      // Clamp: a concurrent create can have shifted the tail. Position is
+      // best-effort, the restored entry is not.
+      this.cache.tasks.splice(Math.min(idx, this.cache.tasks.length), 0, removed)
+      return true
+    })
     this.notifyListeners()
     return true
   }

--- a/packages/kobe/src/tui-react/context/kv-core.ts
+++ b/packages/kobe/src/tui-react/context/kv-core.ts
@@ -19,10 +19,22 @@
  *     including keys other processes wrote after we loaded.
  */
 
+import { kvStatePath } from "../../env.ts"
 import { createStateCell } from "../../lib/external-store"
 import { loadStateFile, patchStateFile, replaceStateFile } from "../../state/store.ts"
 
 const WRITE_DEBOUNCE_MS = 250
+
+/** A debounced or exit flush that did not reach disk. */
+export interface KvWriteFailure {
+  /** The keys still unwritten — deduped, so a repeat failure on the same key is silent. */
+  readonly keys: readonly string[]
+  /** The file that could not be written, so the toast can name it. */
+  readonly file: string
+  readonly error: unknown
+}
+
+export type KvWriteErrorListener = (failure: KvWriteFailure) => void
 
 export interface KvCore {
   /** Current in-memory snapshot (immutable per change; React-safe). */
@@ -42,6 +54,17 @@ export interface KvCore {
   flush(): boolean
   /** Wipe every persisted key; false preserves the snapshot and pending edits. */
   clear(): boolean
+  /**
+   * Subscribe to flushes that did not reach disk; returns the unsubscribe.
+   *
+   * The debounced write is fire-and-forget — nothing awaits it and `set()`
+   * has already updated the snapshot, so a rejected write used to be
+   * invisible: the UI showed the new theme/toggle/width all session and
+   * silently reverted at the next launch. `console.error` alone does not
+   * count as surfacing under an alternate screen (see
+   * `workspace/use-host-notifiers.ts`), so the on-screen half needs a sink.
+   */
+  onWriteError(listener: KvWriteErrorListener): () => void
 }
 
 export function createKvCore(): KvCore {
@@ -50,6 +73,22 @@ export function createKvCore(): KvCore {
   /** Keys this process has `set()` since the last successful flush. */
   const dirtyKeys = new Set<string>()
   let writeTimer: ReturnType<typeof setTimeout> | null = null
+  const errorListeners = new Set<KvWriteErrorListener>()
+  /**
+   * Keys already reported as unwritten. A read-only state dir fails EVERY
+   * 250ms flush, and dirty keys survive a failed write, so without this the
+   * same key raises a toast on every keystroke that touches it. Cleared on
+   * the next write that lands, so a failure that comes back is reported again.
+   */
+  const reportedKeys = new Set<string>()
+
+  function reportWriteError(err: unknown): void {
+    const fresh = [...dirtyKeys].filter((key) => !reportedKeys.has(key))
+    if (fresh.length === 0) return
+    for (const key of fresh) reportedKeys.add(key)
+    const failure: KvWriteFailure = { keys: fresh, file: kvStatePath(), error: err }
+    for (const listener of errorListeners) listener(failure)
+  }
 
   function writeNow(label: string): boolean {
     if (dirtyKeys.size === 0) return true // nothing of ours to merge
@@ -62,9 +101,12 @@ export function createKvCore(): KvCore {
       for (const key of dirtyKeys) patch[key] = snap[key]
       patchStateFile(patch)
       dirtyKeys.clear()
+      reportedKeys.clear()
       return true
     } catch (err) {
+      // Kept for log forensics; `reportWriteError` is the on-screen half.
       console.error(`[rove] kv ${label} failed:`, err)
+      reportWriteError(err)
       return false
     }
   }
@@ -125,8 +167,15 @@ export function createKvCore(): KvCore {
       }
       cancelTimer()
       dirtyKeys.clear()
+      reportedKeys.clear()
       store.set({})
       return true
+    },
+    onWriteError(listener) {
+      errorListeners.add(listener)
+      return () => {
+        errorListeners.delete(listener)
+      }
     },
   }
 }

--- a/packages/kobe/src/tui-react/context/kv-write-error-toasts.tsx
+++ b/packages/kobe/src/tui-react/context/kv-write-error-toasts.tsx
@@ -1,0 +1,47 @@
+/** @jsxImportSource @opentui/react */
+/**
+ * The on-screen half of a failed `state.json` write.
+ *
+ * `kv.set` updates the snapshot immediately and schedules a 250ms debounced
+ * flush that nobody awaits. When that flush throws (a read-only state dir, a
+ * lock path something else owns, a full disk) the only trace used to be a
+ * `console.error` the alternate screen swallows — so a theme change, a
+ * settings toggle or a sidebar resize looked saved for the whole session and
+ * silently reverted at the next launch, `seen` marks included.
+ *
+ * Lives in its own file rather than in `kv.tsx` because `notifications.tsx`
+ * imports `useOptionalKV` from there; wiring the toast inside `kv.tsx` would
+ * close that import cycle. Mounted by `lib/host-boot.tsx` inside the
+ * notifications provider — KV sits ABOVE it in the fixed nesting order, so
+ * the provider itself cannot raise a toast.
+ */
+
+import { useEffect } from "react"
+import { tildify } from "../../lib/path-home"
+import { t } from "../i18n"
+import { useOptionalKV } from "./kv"
+import { useOptionalNotifications } from "./notifications"
+
+export function KvWriteErrorToasts() {
+  const kv = useOptionalKV()
+  const notifications = useOptionalNotifications()
+  useEffect(() => {
+    if (!kv || !notifications) return
+    return kv.onWriteError((failure) => {
+      notifications.notify({
+        taskId: "",
+        tabId: "",
+        kind: "error",
+        title: t("settings.stateWrite.failedTitle"),
+        // A toast body is one truncated line, so the file leads: `tildify`
+        // buys back the ~15 cells the home prefix costs, which is the
+        // difference between reading the filename and reading "/Users/…".
+        body: t("settings.stateWrite.failedBody", {
+          file: tildify(failure.file),
+          keys: failure.keys.join(", "),
+        }),
+      })
+    })
+  }, [kv, notifications])
+  return null
+}

--- a/packages/kobe/src/tui-react/context/kv.tsx
+++ b/packages/kobe/src/tui-react/context/kv.tsx
@@ -12,7 +12,7 @@
  */
 
 import { type ReactNode, createContext, useContext, useEffect, useMemo, useState, useSyncExternalStore } from "react"
-import { type KvCore, createKvCore } from "./kv-core"
+import { type KvCore, type KvWriteErrorListener, createKvCore } from "./kv-core"
 
 export type KVContext = {
   readonly ready: boolean
@@ -24,6 +24,15 @@ export type KVContext = {
   flush(): boolean
   /** Wipe every persisted key; false leaves state and pending edits intact. */
   clear(): boolean
+  /**
+   * Subscribe to writes that did not reach disk; returns the unsubscribe.
+   *
+   * Exposed as a subscription rather than a constructor callback because the
+   * sink is BELOW this provider: the fixed nesting order is Theme > KV >
+   * Focus > Dialog > Notifications (see `lib/host-boot.tsx`), so the toast
+   * context does not exist yet when the core is created.
+   */
+  onWriteError(listener: KvWriteErrorListener): () => void
 }
 
 const Ctx = createContext<KVContext | null>(null)
@@ -66,6 +75,7 @@ export function KVProvider(props: { children?: ReactNode }) {
       set: core.set,
       flush: core.flush,
       clear: core.clear,
+      onWriteError: core.onWriteError,
     }),
     [core, snapshot],
   )

--- a/packages/kobe/src/tui-react/lib/host-boot.tsx
+++ b/packages/kobe/src/tui-react/lib/host-boot.tsx
@@ -48,6 +48,7 @@ import { type PersistedUiPrefs, readPersistedUiPrefs } from "../../tui/lib/persi
 import { installScreenSelfHeal } from "../../tui/lib/screen-refresh"
 import { FocusProvider } from "../context/focus"
 import { KVProvider } from "../context/kv"
+import { KvWriteErrorToasts } from "../context/kv-write-error-toasts"
 import { NotificationsProvider } from "../context/notifications"
 import {
   ThemeProvider,
@@ -265,6 +266,7 @@ export async function bootPaneHost(opts: BootPaneHostOpts): Promise<void> {
   const body = (
     <>
       <UiPrefsSync />
+      <KvWriteErrorToasts />
       <PaneErrorBoundary>{screen.root()}</PaneErrorBoundary>
     </>
   )

--- a/packages/kobe/src/tui/i18n/messages/settings.ts
+++ b/packages/kobe/src/tui/i18n/messages/settings.ts
@@ -134,6 +134,13 @@ export const en = {
     failedTitle: "Deferred prompts were not flushed",
     failedBody: "{message}. Restart or update the daemon, then retry.",
   },
+  /** Error toast when the debounced `state.json` write throws. Nothing awaits
+   *  that write, so without the toast a settings change looks saved for the
+   *  whole session and reverts at the next launch. */
+  stateWrite: {
+    failedTitle: "Settings were not saved",
+    failedBody: "{file} could not be written ({keys}) — the change applies to this session only.",
+  },
   engines: {
     title: "Engines",
     hint: "Every engine Rove can launch, with what detection found under each one: where its binary is, and for the engines with an account detector whether you are logged in. [x] = offered when picking an engine for a task; (●) = the global default (per-project picks, e.g. Ctrl+Shift+T, override it) — click either, or use the keys below. Override a launch command when the binary isn't on PATH or to pass default flags. space on/off · enter edit command · r rename · x reset/remove · d set default.",
@@ -361,6 +368,11 @@ export const zh: typeof en = {
   deferredFlush: {
     failedTitle: "排队的提示词未能放行",
     failedBody: "{message}。请重启或升级 daemon 后重试。",
+  },
+  /** 防抖写入 `state.json` 抛错时的错误 toast。 */
+  stateWrite: {
+    failedTitle: "设置未能保存",
+    failedBody: "{file} 写入失败（{keys}）—— 改动只在本次会话生效。",
   },
   engines: {
     title: "引擎",

--- a/packages/kobe/test/cli/doctor-hook-channel.test.ts
+++ b/packages/kobe/test/cli/doctor-hook-channel.test.ts
@@ -48,4 +48,24 @@ describe("hookChannelDoctorLines", () => {
     expect(lines[0]).toContain("✓")
     expect(lines[0]).toContain("2/4")
   })
+
+  it("names a refused settings file — the SECOND way the channel dies", () => {
+    // A stale socket at least leaves live tabs behind. A `hooks` shape the
+    // installer cannot parse means the install never ran, and until now
+    // nothing in doctor could say so.
+    const configIssues = [{ file: "/home/u/.claude/settings.json", reason: '"hooks.PreToolUse" is not an array' }]
+    const text = hookChannelDoctorLines({ kind: "down", totalTabs: 3 }, { socketPath, configIssues }, "rove").join("\n")
+    expect(text).toContain("hook install skipped: /home/u/.claude/settings.json")
+    expect(text).toContain('"hooks.PreToolUse" is not an array')
+  })
+
+  it("reports a refused file even when another engine's hooks are live", () => {
+    const configIssues = [{ file: "/home/u/.codex/hooks.json", reason: "top level is not a JSON object" }]
+    const lines = hookChannelDoctorLines(
+      { kind: "live", hookTabs: 2, totalTabs: 4 },
+      { socketPath, configIssues },
+      "rove",
+    )
+    expect(lines.join("\n")).toContain("/home/u/.codex/hooks.json")
+  })
 })

--- a/packages/kobe/test/daemon/pty-kill-rejection.test.ts
+++ b/packages/kobe/test/daemon/pty-kill-rejection.test.ts
@@ -1,0 +1,102 @@
+/**
+ * `killIfGeneration` dispatches the child's teardown and answers immediately.
+ * Two things had to be true about that answer and were not:
+ *
+ *   - it said `killed: true` before any signal had been sent, so
+ *     `rove api tab-close` and every pane teardown reported a successful kill
+ *     over a PTY that might still be running;
+ *   - the dispatched promise was a bare `void`, so a teardown that threw
+ *     surfaced as an anonymous `unhandledRejection` — the one thing
+ *     `daemon/crash-log.ts` exists to stop.
+ *
+ * The reachable throw: `onExit` fans the `pty.exit` frame out to every
+ * attached sink without a guard, so a sink whose socket blew up rejects
+ * `endChild`.
+ */
+
+import type { PtyChild, PtyDriver, PtyExit } from "@sma1lboy/kobe-daemon/daemon/pty-driver"
+import { PtyHost } from "@sma1lboy/kobe-daemon/daemon/pty-host"
+import { describe, expect, it, vi } from "vitest"
+
+const SPEC = { cwd: "/wt/t1", command: ["/bin/cat"], cols: 80, rows: 24 }
+const KEY = "t1::tab-1"
+
+/**
+ * `pid = 1` on purpose: `signalProcessGroup` only reaches for
+ * `process.kill(-pid)` when `pid > 1`, so a fake child can never signal a
+ * real process group that happens to share its made-up pid.
+ */
+class FakeChild {
+  readonly pid = 1
+  private settle!: (exit: PtyExit) => void
+  readonly exited = new Promise<PtyExit>((resolve) => {
+    this.settle = resolve
+  })
+  constructor(private readonly settleOnKill: boolean) {}
+  write(): void {}
+  resize(): void {}
+  close(): void {}
+  kill(signal: NodeJS.Signals): void {
+    if (this.settleOnKill) this.settle({ code: null, signal })
+  }
+}
+
+function hostWithChild(settleOnKill = true): { host: PtyHost; generation: () => string } {
+  const driver: PtyDriver = () => new FakeChild(settleOnKill) as unknown as PtyChild
+  const host = new PtyHost({ driver })
+  return {
+    host,
+    generation: () => {
+      const info = host.list().find((s) => s.key === KEY)
+      if (!info?.generation) throw new Error("no session generation")
+      return info.generation
+    },
+  }
+}
+
+describe("PtyHost.killIfGeneration", () => {
+  it("reports the compare-and-remove it completed, not a kill it only dispatched", () => {
+    const { host, generation } = hostWithChild()
+    host.open(KEY, SPEC, {}, () => {})
+    expect(host.killIfGeneration(KEY, generation())).toEqual({ accepted: true })
+    // Idempotent, and still discriminated on the two checked refusals.
+    expect(host.killIfGeneration(KEY, "whatever")).toEqual({ accepted: false, reason: "missing-session" })
+  })
+
+  it("refuses a stale generation without touching the live session", () => {
+    const { host, generation } = hostWithChild()
+    host.open(KEY, SPEC, {}, () => {})
+    expect(host.killIfGeneration(KEY, "an-older-generation")).toEqual({
+      accepted: false,
+      reason: "generation-mismatch",
+    })
+    expect(generation()).toEqual(expect.any(String))
+  })
+
+  it("routes a failed teardown to daemon.log under a tag", async () => {
+    // A child that ignores both signals: the teardown reaches `onSettled` only
+    // after the SIGTERM + SIGKILL grace elapses, which is what puts the sink
+    // throw inside `endChild`'s own promise rather than the child's natural
+    // exit handler.
+    const { host, generation } = hostWithChild(false)
+    const stderr = vi.spyOn(process.stderr, "write").mockReturnValue(true)
+    try {
+      host.open(KEY, SPEC, {}, () => {
+        throw new Error("client socket is gone")
+      })
+      expect(host.killIfGeneration(KEY, generation())).toEqual({ accepted: true })
+      // The tag is what a post-mortem greps; without the `.catch` this same
+      // rejection reaches the process as an anonymous unhandledRejection.
+      await vi.waitFor(
+        () => {
+          const written = stderr.mock.calls.map((call) => String(call[0])).join("")
+          expect(written).toContain("daemon error [pty-kill]")
+          expect(written).toContain("client socket is gone")
+        },
+        { timeout: 5000 },
+      )
+    } finally {
+      stderr.mockRestore()
+    }
+  })
+})

--- a/packages/kobe/test/daemon/pty-server-restart.test.ts
+++ b/packages/kobe/test/daemon/pty-server-restart.test.ts
@@ -137,7 +137,7 @@ describe("pty-host server freeze/restore across a restart", () => {
     const second = await generation(a)
     expect(second).not.toBe(first)
     expect(await a.request("pty.kill", { key, expectedGeneration: first })).toEqual({
-      killed: false,
+      accepted: false,
       reason: "generation-mismatch",
     })
     expect(await generation(a)).toBe(second)
@@ -151,12 +151,12 @@ describe("pty-host server freeze/restore across a restart", () => {
     const respawned = await generation(b)
     expect(respawned).not.toBe(restored)
     expect(await b.request("pty.kill", { key, expectedGeneration: restored })).toEqual({
-      killed: false,
+      accepted: false,
       reason: "generation-mismatch",
     })
-    expect(await b.request("pty.kill", { key, expectedGeneration: respawned })).toEqual({ killed: true })
+    expect(await b.request("pty.kill", { key, expectedGeneration: respawned })).toEqual({ accepted: true })
     expect(await b.request("pty.kill", { key, expectedGeneration: respawned })).toEqual({
-      killed: false,
+      accepted: false,
       reason: "missing-session",
     })
   })

--- a/packages/kobe/test/daemon/pty-sweep-race.test.ts
+++ b/packages/kobe/test/daemon/pty-sweep-race.test.ts
@@ -59,7 +59,7 @@ describe("PTY observation before destructive cleanup", () => {
         }
       kills.push(payload)
       tasks.push("restored")
-      return { killed: true }
+      return { accepted: true }
     })
     await sweepPtyHostSessions(() => tasks, home)
     expect(kills).toEqual([{ key: "gone::tab-1", expectedGeneration: "first" }])

--- a/packages/kobe/test/engine/hook-adapter.test.ts
+++ b/packages/kobe/test/engine/hook-adapter.test.ts
@@ -40,7 +40,7 @@ describe("NoopHookAdapter", () => {
   })
 
   it("every install/remove is a resolved no-op (never throws into the launch path)", async () => {
-    await expect(noop.installActivityHooks()).resolves.toBeUndefined()
+    await expect(noop.installActivityHooks()).resolves.toEqual({ ok: true })
     await expect(noop.removeActivityHooks()).resolves.toBeUndefined()
     await expect(noop.removeWorktreeSyncHook()).resolves.toBeUndefined()
     await expect(noop.removeWorktreeWatchHook()).resolves.toBeUndefined()

--- a/packages/kobe/test/engine/hook-install-rejection.test.ts
+++ b/packages/kobe/test/engine/hook-install-rejection.test.ts
@@ -1,0 +1,105 @@
+/**
+ * What happens when the hook installer will not touch a settings file.
+ *
+ * Refusing is right — a best-effort install must never clobber an engine
+ * configuration it cannot parse. Refusing SILENTLY was not: a hand-edited
+ * `~/.claude/settings.json` whose `hooks` fails the check means Rove stops
+ * installing hooks for good, every badge falls back to the daemon's ~10s
+ * activity poll, and nothing on the machine names the file. The install
+ * abandoned the write through the same `undefined` the loader returns for
+ * "nothing to do", so not even the outer catch ran.
+ *
+ * Pinned here: the reason survives to the caller, exactly ONE tagged line is
+ * written, and a legal file still installs in silence (the negative control —
+ * without it this only proves the code got louder).
+ */
+
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { type MockInstance, afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { CodexHookAdapter } from "../../src/engine/codex-local/hook-adapter.ts"
+import { parseHookSettings } from "../../src/engine/json-hooks.ts"
+
+vi.mock("../../src/cli/invocation.ts", () => ({
+  roveCliInvocation: () => ["rove"],
+  kobeHookInvocation: () => ["rove"],
+}))
+
+describe("parseHookSettings", () => {
+  it("treats a missing file as an empty document, not a refusal", () => {
+    expect(parseHookSettings(undefined)).toEqual({ ok: true, doc: {} })
+  })
+
+  it("accepts a document with no hooks key and a well-formed one", () => {
+    expect(parseHookSettings('{"model":"opus"}')).toEqual({ ok: true, doc: { model: "opus" } })
+    const ok = parseHookSettings('{"hooks":{"PreToolUse":[{"hooks":[]}]}}')
+    expect(ok.ok).toBe(true)
+  })
+
+  it("names what it refused, down to the offending group index", () => {
+    expect(parseHookSettings("{oops")).toMatchObject({ ok: false })
+    expect(parseHookSettings("[]")).toEqual({ ok: false, reason: "top level is not a JSON object" })
+    expect(parseHookSettings('{"hooks":[]}')).toEqual({ ok: false, reason: '"hooks" is not an object' })
+    expect(parseHookSettings('{"hooks":{"PreToolUse":"not-an-array"}}')).toEqual({
+      ok: false,
+      reason: '"hooks.PreToolUse" is not an array',
+    })
+    expect(parseHookSettings('{"hooks":{"Stop":[{"hooks":[]},{"matcher":"x"}]}}')).toEqual({
+      ok: false,
+      reason: '"hooks.Stop[1]" is not an object with a "hooks" array',
+    })
+  })
+})
+
+describe("installActivityHooks on a settings file it cannot parse", () => {
+  let dir: string
+  let file: string
+  let stderr: MockInstance<typeof process.stderr.write>
+  const adapter = new CodexHookAdapter()
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "rove-hook-reject-"))
+    file = join(dir, "hooks.json")
+    stderr = vi.spyOn(process.stderr, "write").mockReturnValue(true)
+  })
+
+  afterEach(async () => {
+    stderr.mockRestore()
+    await rm(dir, { recursive: true, force: true })
+  })
+
+  const written = (): string => stderr.mock.calls.map((call) => String(call[0])).join("")
+
+  it("returns the reason, says it once, and leaves the file untouched", async () => {
+    const before = '{"hooks":{"PreToolUse":"not-an-array"}}'
+    await writeFile(file, before, "utf8")
+
+    const outcome = await adapter.installActivityHooks(file)
+
+    expect(outcome).toEqual({ ok: false, file, reason: '"hooks.PreToolUse" is not an array' })
+    expect(await readFile(file, "utf8")).toBe(before)
+    const lines = written().trimEnd().split("\n")
+    expect(lines).toHaveLength(1)
+    expect(lines[0]).toContain("[rove hooks]")
+    expect(lines[0]).toContain(file)
+    expect(lines[0]).toContain('"hooks.PreToolUse" is not an array')
+  })
+
+  it("negative control: a legal settings file still installs, and says nothing", async () => {
+    await writeFile(file, '{"hooks":{"PreToolUse":[{"matcher":"Bash","hooks":[]}]}}', "utf8")
+
+    expect(await adapter.installActivityHooks(file)).toEqual({ ok: true })
+
+    expect(written()).toBe("")
+    // The user's own group survived and Rove's hooks landed beside it.
+    const doc = JSON.parse(await readFile(file, "utf8")) as { hooks: Record<string, unknown[]> }
+    expect(doc.hooks.PreToolUse).toContainEqual({ matcher: "Bash", hooks: [] })
+    expect(JSON.stringify(doc)).toContain("'rove' 'hook'")
+  })
+
+  it("negative control: a missing file is a first launch, not a refusal", async () => {
+    expect(await adapter.installActivityHooks(join(dir, "absent", "hooks.json"))).toEqual({ ok: true })
+    expect(written()).toBe("")
+  })
+})

--- a/packages/kobe/test/orchestrator/store-rollback.test.ts
+++ b/packages/kobe/test/orchestrator/store-rollback.test.ts
@@ -102,6 +102,24 @@ describe("TaskIndexStore rollback on a failed save", () => {
     expect(await diskTitles()).toEqual(["a", "b", "c"])
   })
 
+  it("keeps a task whose delete failed, and no later save completes the deletion", async () => {
+    const store = new TaskIndexStore({ homeDir: home })
+    await store.load()
+    const task = await store.create(input("doomed"))
+
+    await breakSaves()
+    await expect(store.remove(task.id)).rejects.toThrow()
+    // The caller was told the delete failed; the sidebar must agree — the row
+    // vanishing next to a "delete failed" toast is the reported symptom.
+    expect(store.list().map((t) => t.title)).toEqual(["doomed"])
+
+    // The durable half: the tombstone must be gone too, or the next unrelated
+    // save carries the rejected deletion to disk minutes later.
+    await healSaves()
+    await store.create(input("unrelated"))
+    expect((await diskTitles()).sort()).toEqual(["doomed", "unrelated"])
+  })
+
   it("never lets two failed updates on one id reach disk, whichever rolls back first", async () => {
     const store = new TaskIndexStore({ homeDir: home })
     await store.load()

--- a/packages/kobe/test/render/attention-deferred-toast.test.tsx
+++ b/packages/kobe/test/render/attention-deferred-toast.test.tsx
@@ -33,6 +33,7 @@ function stubKv(): KVContext {
     },
     flush: () => true,
     clear: () => true,
+    onWriteError: () => () => {},
   }
 }
 

--- a/packages/kobe/test/render/attention-linear-lookups.test.tsx
+++ b/packages/kobe/test/render/attention-linear-lookups.test.tsx
@@ -38,6 +38,7 @@ function stubKv(): KVContext {
     },
     flush: () => true,
     clear: () => true,
+    onWriteError: () => () => {},
   }
 }
 

--- a/packages/kobe/test/render/host-pages.test.tsx
+++ b/packages/kobe/test/render/host-pages.test.tsx
@@ -231,6 +231,7 @@ function mockKv(): KVContext {
     set: () => {},
     flush: () => true,
     clear: () => true,
+    onWriteError: () => () => {},
   }
 }
 

--- a/packages/kobe/test/render/inbox-deferred-exit.test.tsx
+++ b/packages/kobe/test/render/inbox-deferred-exit.test.tsx
@@ -41,6 +41,7 @@ function stubKv(): KVContext {
     },
     flush: () => true,
     clear: () => true,
+    onWriteError: () => () => {},
   }
 }
 

--- a/packages/kobe/test/render/inbox-glyph-width.test.tsx
+++ b/packages/kobe/test/render/inbox-glyph-width.test.tsx
@@ -83,6 +83,7 @@ function stubKv(): KVContext {
     },
     flush: () => true,
     clear: () => true,
+    onWriteError: () => () => {},
   }
 }
 

--- a/packages/kobe/test/render/inbox-window.test.tsx
+++ b/packages/kobe/test/render/inbox-window.test.tsx
@@ -57,6 +57,7 @@ function stubKv(): KVContext {
     },
     flush: () => true,
     clear: () => true,
+    onWriteError: () => () => {},
   }
 }
 

--- a/packages/kobe/test/render/kv-write-error-toast.test.tsx
+++ b/packages/kobe/test/render/kv-write-error-toast.test.tsx
@@ -1,0 +1,75 @@
+/** @jsxImportSource @opentui/react */
+/**
+ * The on-screen half of a failed `state.json` write.
+ *
+ * `kv.set` returns after updating the snapshot and scheduling a flush nobody
+ * awaits, so a rejected write left only a `console.error` the alternate screen
+ * swallows: a theme change or a toggle looked saved for the session and
+ * reverted at the next launch. This drives the REAL provider stack — the same
+ * KV-above-notifications nesting `lib/host-boot.tsx` builds — because the
+ * point of the wiring is that the KV provider sits ABOVE the toast context and
+ * structurally cannot raise one; the sink has to be a subscriber below it.
+ */
+
+import { afterAll, beforeAll, expect, test } from "bun:test"
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { useKV } from "../../src/tui-react/context/kv"
+import { KvWriteErrorToasts } from "../../src/tui-react/context/kv-write-error-toasts"
+import { useNotifications } from "../../src/tui-react/context/notifications"
+import { act, renderComponent } from "./harness"
+
+let home: string
+let savedHome: string | undefined
+
+beforeAll(() => {
+  savedHome = process.env.KOBE_HOME_DIR
+  home = mkdtempSync(join(tmpdir(), "kobe-kv-toast-"))
+  process.env.KOBE_HOME_DIR = home
+  // Break the write deterministically: a DIRECTORY where the lockfile goes
+  // makes `acquireSync`'s link fail EEXIST, and reading the holder then fails
+  // EISDIR — not a contention error, so it propagates immediately.
+  mkdirSync(join(home, ".config", "rove", "state.json.lock"), { recursive: true })
+})
+
+afterAll(() => {
+  if (savedHome === undefined) Reflect.deleteProperty(process.env, "KOBE_HOME_DIR")
+  else process.env.KOBE_HOME_DIR = savedHome
+  rmSync(home, { recursive: true, force: true })
+})
+
+let failWrite: () => void = () => {}
+
+function Probe() {
+  const kv = useKV()
+  const { toasts } = useNotifications()
+  failWrite = () => {
+    kv.set("activeTheme", "tokyonight")
+    kv.flush()
+  }
+  const toast = toasts[0]
+  return <text>{toast ? `${toast.kind}|${toast.title}|${toast.body ?? ""}` : "no-toast"}</text>
+}
+
+test("a flush that cannot reach state.json surfaces as an error toast naming the file", async () => {
+  const { frame } = await renderComponent(
+    <>
+      <KvWriteErrorToasts />
+      <Probe />
+    </>,
+    { width: 100, height: 6, providers: { kv: true, notifications: true } },
+  )
+  expect(await frame()).toContain("no-toast")
+
+  await act(async () => {
+    failWrite()
+  })
+
+  const text = await frame()
+  expect(text).toContain("error|Settings were not saved")
+  // The path leads the body: a toast is one truncated line, and the home
+  // prefix is the part of it that carries no information.
+  expect(text).toContain("state.json")
+  expect(text).toContain("activeTheme")
+})

--- a/packages/kobe/test/tui-react/kv-core.test.ts
+++ b/packages/kobe/test/tui-react/kv-core.test.ts
@@ -12,11 +12,11 @@
  *   - Writes are debounced (250ms) — no disk write before the window.
  */
 
-import { mkdirSync, mkdtempSync, readFileSync, renameSync, writeFileSync } from "node:fs"
+import { mkdirSync, mkdtempSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
-import { createKvCore } from "../../src/tui-react/context/kv-core"
+import { type KvWriteFailure, createKvCore } from "../../src/tui-react/context/kv-core"
 import {
   type TabsSnapshotKv,
   sweepOrphanTabsSnapshots,
@@ -243,6 +243,59 @@ describe("createKvCore", () => {
     // Round-tripping through parse must reproduce the exact bytes.
     const raw = readFileSync(statePath(home), "utf8")
     expect(raw).toBe(JSON.stringify(JSON.parse(raw)))
+  })
+
+  it("reports a failed flush to onWriteError subscribers, once per key", () => {
+    const home = isolatedHome({})
+    // Break the write deterministically: a DIRECTORY where the lockfile goes
+    // makes `acquireSync`'s link fail EEXIST, then reading the holder fails
+    // EISDIR — which is not contention, so it propagates immediately.
+    mkdirSync(`${statePath(home)}.lock`, { recursive: true })
+    const kv = createKvCore()
+    const failures: KvWriteFailure[] = []
+    const off = kv.onWriteError((failure) => failures.push(failure))
+
+    kv.set("activeTheme", "tokyonight")
+    expect(kv.flush()).toBe(false)
+    expect(failures).toHaveLength(1)
+    expect(failures[0]?.keys).toEqual(["activeTheme"])
+    expect(failures[0]?.file).toBe(statePath(home))
+
+    // A read-only state dir fails EVERY 250ms flush and dirty keys survive a
+    // failure, so the same key must not raise a toast per keystroke.
+    kv.set("activeTheme", "gruvbox")
+    expect(kv.flush()).toBe(false)
+    expect(failures).toHaveLength(1)
+
+    // A NEW key is still worth saying out loud.
+    kv.set("sidebar.width", 40)
+    expect(kv.flush()).toBe(false)
+    expect(failures).toHaveLength(2)
+    expect(failures[1]?.keys).toEqual(["sidebar.width"])
+
+    off()
+    kv.set("another", 1)
+    expect(kv.flush()).toBe(false)
+    expect(failures).toHaveLength(2)
+  })
+
+  it("re-reports a key after a write lands in between", () => {
+    const home = isolatedHome({})
+    const lock = `${statePath(home)}.lock`
+    mkdirSync(lock, { recursive: true })
+    const kv = createKvCore()
+    const failures: KvWriteFailure[] = []
+    kv.onWriteError((failure) => failures.push(failure))
+
+    kv.set("activeTheme", "tokyonight")
+    expect(kv.flush()).toBe(false)
+    rmSync(lock, { recursive: true, force: true })
+    expect(kv.flush()).toBe(true)
+
+    mkdirSync(lock, { recursive: true })
+    kv.set("activeTheme", "gruvbox")
+    expect(kv.flush()).toBe(false)
+    expect(failures).toHaveLength(2)
   })
 
   it("notifies subscribers on set and supports unsubscribe", () => {


### PR DESCRIPTION
Four places where an operation failed and the interface said otherwise — or said nothing. Each is one commit; the fix in each case is to route the failure somewhere a person looks, not to make the code noisier.

coverage-exemption: packages/kobe/src/tui-react/lib/host-boot.tsx — boot wiring; measured 32.57% (57/175) on origin/main in a pristine worktree BEFORE this PR and 32.77% (58/177) after, i.e. already far under the 50% floor and nudged up, not down. The two added lines (one import, one `<KvWriteErrorToasts />` element) are covered by the new `test/render/kv-write-error-toast.test.tsx` (which the gate reports at 100%); the rest of the file is renderer/PTY bootstrap that cannot mount under the render harness.

---

## 1. `store.remove()` was the one mutator that skipped `saveOrRollback`

**Mechanism.** `packages/kobe/src/orchestrator/index/store.ts` — `remove()` spliced the cache, set the `removedIds` tombstone, then awaited a bare `save()`. Its three siblings (`create`, `update`, `move`) all route through `saveOrRollback(id, undo)`. A rejected write therefore left three things behind: the task gone from the cache, the task still on disk with `deletion.phase: "running"` (so the next launch restores a row whose worktree `task-deletion.finish` already removed), and the tombstone still in `removedIds` — where the **next unrelated successful save flushes it**, completing the rejected deletion with nobody watching. `remove()` now takes the same `saveOrRollback` path, and its undo restores the entry by object identity *and* drops the tombstone.

**Injection.** A directory at `<home>/.rove/tasks.json.lock`: `acquire`'s `link` fails EEXIST, reading the holder then fails EISDIR, which is not a contention error so it propagates immediately — no retry deadline, no timing, no chmod. Same recipe `store-rollback.test.ts` already used.

**Harness BEFORE/AFTER** (`/harness` → xterm → PTY sidecar → real OpenTUI, private port base 5673, isolated `.scratch/opentui-visual-5673/home`, rebuilt between the two frames):

Seeded a `kind: "dir"` task carrying `deletion: {phase: "running"}` so the daemon's boot-time `deletions.resume()` replays it — with the phase already `running` neither `begin()` nor `finish()` writes to the index before `remove()`, so the failed save is deterministically the *first* one, no race to win. Two seconds later the lock directory is removed and an unrelated `rove api add` runs against the same live daemon: that is the "next successful save".

| | sidebar rows | `tasks.json` afterwards |
|---|---|---|
| BEFORE | `Visual Fixture`, `Unrelated Later Task` | `['Visual Fixture', 'Unrelated Later Task']` |
| AFTER | `Visual Fixture`, `main  deleting`, `Unrelated Later Task` | `['Visual Fixture', 'Doomed Task', 'Unrelated Later Task']` |

The doomed row and its on-disk record are gone in BEFORE — deleted by a save that had nothing to do with it. In AFTER the row survives and still shows `deleting`, which is the truth: the delete was accepted and could not be persisted. Frames: `.scratch/finch/del-BEFORE2.png`, `.scratch/finch/del-AFTER2.png` (the two differ by exactly that row).

Positive control that the injection bit, from the fixture's `daemon.log` on **both** runs:

```
daemon error [task-deletion-audit]: Error: failed task 01M1W6C2ZYXQ3SXMQC7S0BRPZZ title="Doomed Task" kind=dir …
  Reason: EISDIR: illegal operation on a directory, read
    at async doSave (…/orchestrator/index/store.ts:168:29)
    at async remove (…/orchestrator/index/store.ts:413:16)
    at async finish (…/orchestrator/task-deletion.ts:170:22)
```

**Test + mutation.** `test/orchestrator/store-rollback.test.ts` gains "keeps a task whose delete failed, and no later save completes the deletion". Two mutations, two different sites:
- `saveOrRollback(…)` → `save()`: `expected [] to deeply equal [ 'doomed' ]` (the cache half).
- drop only `this.removedIds.delete(String(id))` from the undo: `expected [ 'unrelated' ] to deeply equal [ 'doomed', 'unrelated' ]` (the durable half).

---

## 2. A settings write that never reached disk went into the void

**Mechanism.** `tui-react/context/kv-core.ts` — `writeNow` caught, `console.error`'d and returned false; the debounced path and the exit flush both discarded that boolean. Under an alternate screen `console.error` is invisible (the repo says so itself in `workspace/use-host-notifiers.ts`), so a theme change, a toggle or a sidebar resize applied instantly, failed to persist 250ms later, looked saved for the whole session and reverted at the next launch — `seen` marks included. The positive control that this was an oversight rather than a policy: `clear()` in the same file already returns false and `settings-dialog/actions.ts` already raises a dialog on it.

The core now publishes failures to subscribers, **deduped per key** (a read-only state dir fails every 250ms flush and dirty keys survive a failure, so an undeduped version would toast on every keystroke) and re-armed after any write that lands. The sink is a subscription rather than a constructor callback because the nesting order is fixed as Theme > KV > Focus > Dialog > Notifications — the KV provider sits *above* the toast context and structurally cannot raise one. `KvWriteErrorToasts` mounts inside the notifications provider and does it there. `console.error` is retained for log forensics.

**Injection.** `mkdir <home>/.config/rove/state.json.lock` — same EISDIR trick, immediate.

**Harness BEFORE/AFTER** (`.scratch/finch/kv-BEFORE.png`, `.scratch/finch/kv-AFTER.png`; identical builds except the two lines in `host-boot.tsx` that mount the sink; same key sequence `s l j j enter esc`, which applies the tokyonight theme):

- BEFORE: the whole UI recolours to tokyonight, and nothing else happens. The change looks saved.
- AFTER: same recolour, plus a red toast bottom-right — `✗ Settings were not saved` / `~/.config/rove/state.json could not be…`.

`state.json`'s mtime is byte-identical before and after each run (`mtime_before=1788726390` / `mtime_after=1788726390` on both), so the injection really did stop the write in both builds — the two frames differ only in whether anyone was told.

**Tests + mutation.** `test/tui-react/kv-core.test.ts` gains two cases (report once per key; re-report after a write lands in between) and `test/render/kv-write-error-toast.test.tsx` drives the sink on the render track. Mutations:
- delete `reportWriteError(err)`: 2 failures, `expected [] to have a length of 1`.
- delete `reportedKeys.clear()` from the success path: 1 failure, `expected [ { keys: [ 'activeTheme' ], …(2) } ] to have a length of 2`.

---

## 3. A settings file the hook installer refused was never named

**Mechanism.** `engine/json-hook-adapter.ts`'s loader returned `undefined` for a document it could not parse — the same value `updateSharedJson` reads as "nothing to do" — so the write was abandoned normally and the outer `catch` never ran. A hand-edited `~/.claude/settings.json` whose `hooks` fails the shape check therefore stopped receiving hooks permanently, every badge fell back to the daemon's ~10s activity poll, and the product read as *slow* rather than *misconfigured*. `installActivityHooks` returned `Promise<void>`, so there was structurally nowhere to report it, and `doctor-hook-channel.ts` only ever diagnosed the stale-socket cause.

Refusing is still right (a best-effort install must not clobber a config it cannot understand). What changed: the validator is now `parseHookSettings` returning a reason that names the offending path inside the document, `installActivityHooks` resolves a `HookEditOutcome`, the install site — and only the install site, so the two removals that run over the same file on every launch stay quiet — writes one tagged stderr line, and `rove doctor` reports it as the second cause.

**Injection.** An isolated `HOME` with `{"hooks":{"PreToolUse":"not-an-array"}}` in `.claude/settings.json` and `{"hooks":{"Stop":[{"matcher":"x"}]}}` in `.codex/hooks.json`, then a real `ensureGlobalKobeHooks()` — the same call `src/tui/index.tsx:30` makes at boot.

**BEFORE** (only the four engine files reverted to their pre-fix state):

```
exit=0  bytes=       0  lines naming either file: 0
--- files still untouched (the refusal itself was always right) ---
{"hooks":{"PreToolUse":"not-an-array"}}
{"hooks":{"Stop":[{"matcher":"x"}]}}
```

**AFTER** — exactly two lines, one per refused file, each naming the path and the reason:

```
[rove hooks] claude: skipped /tmp/finch/hookhome/.claude/settings.json: "hooks.PreToolUse" is not an array
[rove hooks] codex: skipped /tmp/finch/hookhome/.codex/hooks.json: "hooks.Stop[0]" is not an object with a "hooks" array
```

and both files still byte-identical.

**`rove doctor`, AFTER**, against a live daemon in that same home:

```
hooks:   — no engine tabs yet (nothing to check)
         ⚠ hook install skipped: /tmp/finch/hookhome/.claude/settings.json
           "hooks.PreToolUse" is not an array — fix the file, then relaunch Rove
         ⚠ hook install skipped: /tmp/finch/hookhome/.codex/hooks.json
           "hooks.Stop[0]" is not an object with a "hooks" array — fix the file, then relaunch Rove
```

BEFORE, that block was its first line alone — `configIssues` did not exist. That half is a pure function change and is pinned by two new cases in `test/cli/doctor-hook-channel.test.ts` rather than a second rebuild.

**Negative control, same run shape, a LEGAL `settings.json`:**

```
bytes of output = 0
hooks actually installed = 11
events now: ['Notification', 'PostCompact', 'PreCompact', 'PreToolUse', 'SessionEnd', 'SessionStart',
             'Stop', 'StopFailure', 'SubagentStart', 'SubagentStop', 'UserPromptSubmit']
user group survived: True
```

So the change is not "the code got louder": a healthy install is still silent, still idempotent, and still preserves the user's own hook group.

**Tests.** `test/engine/hook-install-rejection.test.ts` — the validator's reasons, the one-line-and-untouched-file assertion, and both negative controls (legal file installs silently; a missing file is a first launch, not a refusal).

---

## 4. `pty.kill` reported a kill it had only dispatched

**Mechanism.** `pty-host.ts#killIfGeneration` did `void this.kill(key)` and returned `{ killed: true }`; `pty-server.ts`'s `pty.kill` did the same and returned `{}`. The child's teardown is asynchronous — SIGTERM, up to 500ms grace, SIGKILL, another 500ms (`pty-termination.ts`) — so `killed: true` was a claim about something that had not started. And the bare `void` on a promise that can reject is exactly what `crash-log.ts:65-71` documents `logDaemonError` to prevent; every other fire-and-forget in the daemon (`server.ts:131`, `handlers-engine-report.ts:147`, `collectors.ts:188`, …) already carries the `.catch`.

The reply is now `accepted` — the compare-and-remove *is* what the call completes, and it stays synchronous so a reopened key still cannot inherit an old kill — and the rejection reaches `daemon.log` under `[pty-kill]`.

**Why not await the real result.** The request path is synchronous (`handleLine` writes the response frame from `dispatch()`'s return value), and awaiting the teardown would make every tab close wait up to 2× `TERMINATION_GRACE_MS` on a child that ignores SIGTERM. The escape hatch in the brief — `.catch(logDaemonError)` plus an honest field name — is what landed.

**Injection.** `onExit` fans the `pty.exit` frame out to every attached sink without a guard, so a sink whose socket blew up rejects `endChild`. The fake child ignores both signals so the throw lands inside `endChild`'s own promise rather than the child's natural exit handler, and carries `pid = 1` on purpose — `signalProcessGroup` only reaches for `process.kill(-pid)` when `pid > 1`, so a made-up pid can never signal a real process group.

**BEFORE** (only the `.catch` reverted, so the assertion under test is the log line and not the field rename):

```
AssertionError: expected '' to contain 'daemon error [pty-kill]'
⎯⎯⎯⎯⎯⎯ Unhandled Errors ⎯⎯⎯⎯⎯⎯
⎯⎯⎯⎯ Unhandled Rejection ⎯⎯⎯⎯⎯
Error: client socket is gone
      Tests  1 failed | 2 passed (3)
     Errors  1 error
```

**AFTER**: `Tests  3 passed (3)`, no unhandled rejection, and the tagged line present.

With `pty-host.ts` fully reverted to origin/main the same file reports the rename too — `expected { killed: true } to deeply equal { accepted: true }` ×2 and one for the `killed: false` union — so both halves of the commit are load-bearing.

**Wire change.** `killed` → `accepted` on `pty.kill`'s reply. Nothing branches on it: the only client, `client/pty-process.ts:271`, discards the result; the assertions in `pty-server-restart.test.ts` and `pty-sweep-race.test.ts` are updated. The plain (ungenerational) `pty.kill` now returns `{ accepted: true }` instead of `{}`.

---

## Checks

| runner | result |
|---|---|
| `bun run typecheck` (kobe + kobe-daemon) | clean |
| root `bun run lint` | clean |
| `bun run check-i18n` | 947 keys × 2 locales in sync |
| `bun run test:fast` | 4926 passed (496 files) |
| `bun run test:socket` | 959 passed (123 files) |
| `bun test test/render` | 514 passed (121 files) |

Rebased onto `origin/main@227ad1418`. Touched-file line counts all ≤ 500 (largest: `pty-host.ts` 494).
