### PR TITLE
fix: the Worktrees page can no longer delete a user's own directory

### DIFF
--- a/.changeset/worktree-remove-kind-guard.md
+++ b/.changeset/worktree-remove-kind-guard.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+The Worktrees page can no longer delete a directory Task's own directory, or a project's own checkout. Both appear on the page — it lists every registered worktree of a saved project — and deleting one removed files Rove never created, then skipped the pointer repair, leaving the Task aimed at a directory that no longer existed. `worktree.remove` now refuses both by task kind (`NOT_A_ROVE_WORKTREE`), matching every other destructive path.

--- a/docs/WORKTREES.md
+++ b/docs/WORKTREES.md
@@ -105,9 +105,16 @@ The row disappears while removal runs. If git refuses or the operation fails,
 the row returns. A successful removal deregisters and removes the working
 directory but keeps its git branch.
 
-For a worktree tracked by a Task, Rove clears that Task's worktree pointer. It
-does not delete the Task, its branch, or engine history. Opening the Task later
-may materialize a fresh worktree from the retained branch.
+The page lists every registered worktree of a saved project, including
+directories Rove did not create. Two of those it refuses to delete
+(`NOT_A_ROVE_WORKTREE`): the directory a directory Task pins, and a project's
+own checkout. Both are yours, not Rove's, and neither can be re-materialized
+from a branch.
+
+For a **Rove-created** worktree tracked by a Task, Rove clears that Task's
+worktree pointer. It does not delete the Task, its branch, or engine history.
+Opening the Task later may materialize a fresh worktree from the retained
+branch.
 
 `rove api remove-worktree --task-id ID [--force]` is the same operation from a
 shell, for scripting a reclaim of idle checkouts. It runs this path — session

--- a/packages/kobe-daemon/src/daemon/handlers-worktree.ts
+++ b/packages/kobe-daemon/src/daemon/handlers-worktree.ts
@@ -24,6 +24,15 @@ import { optionalString, optionalVendor, requireString } from "./handler-validat
 import type { DaemonRequestHandler } from "./handlers.ts"
 import { serializeTask } from "./protocol.ts"
 
+/**
+ * Stable sentinel embedded in `worktree.remove`'s kind refusal.
+ *
+ * The RPC layer rebuilds a thrown error as `new Error(message)` — `name` does
+ * not survive the wire — so callers can only discriminate on the MESSAGE.
+ * The `CODE: rest` shape is what `splitDaemonCode` in the CLI already parses.
+ */
+export const NOT_A_ROVE_WORKTREE_CODE = "NOT_A_ROVE_WORKTREE"
+
 export const WORKTREE_HANDLERS: readonly DaemonRequestHandler[] = [
   {
     name: "worktree.discoverAdoptable",
@@ -87,7 +96,25 @@ export const WORKTREE_HANDLERS: readonly DaemonRequestHandler[] = [
       // is already gone from their screen), and a dead/absent session throws
       // the same way a stuck one does, which would strand every already-dead
       // task's worktree. Logged, then the removal proceeds.
-      const taskId = ctx.orch ? matchTaskByWorktreePath(ctx.orch.listTasks(), path) : undefined
+      const tasks = ctx.orch ? ctx.orch.listTasks() : []
+      const taskId = matchTaskByWorktreePath(tasks, path)
+      // `kind` gates the DESTRUCTION, not the bookkeeping. A `dir` task's
+      // path IS the user's own directory and a `main` task's is the project
+      // checkout — neither is a Rove-created worktree, so removing one
+      // `rm -rf`s files Rove never made. Every sibling destructive path
+      // refuses these two by kind (`deleteTask`, `ensureWorktree`, `land`);
+      // this one addresses worktrees by PATH, so it never asked — and
+      // `clearWorktreePath` below early-returns for exactly these kinds, so
+      // the destructive half ran while the repair half was skipped, leaving
+      // the task pointed at a directory that no longer exists.
+      const kind = taskId ? tasks.find((t) => t.id === taskId)?.kind : undefined
+      if (kind === "dir" || kind === "main") {
+        throw new Error(
+          `${NOT_A_ROVE_WORKTREE_CODE}: ${path} is ${
+            kind === "dir" ? "a directory task's own directory" : "the project's own checkout"
+          }, not a Rove-created worktree — refusing to delete it`,
+        )
+      }
       if (taskId) {
         await ctx.runtime
           .tearDownTaskSession(taskId)

--- a/packages/kobe/test/daemon/worktree-list-handler.test.ts
+++ b/packages/kobe/test/daemon/worktree-list-handler.test.ts
@@ -23,6 +23,14 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest"
 import { daemonRuntime } from "../../src/core/daemon-runtime.ts"
 import { addSavedRepo } from "../../src/state/repos.ts"
 
+/**
+ * The wire contract, spelled out rather than imported: the RPC layer rebuilds
+ * a thrown error as `new Error(message)`, so this prefix is all a caller across
+ * the daemon boundary ever sees. Importing the daemon-side constant would let a
+ * rename of both sides pass while every existing caller broke.
+ */
+const NOT_A_ROVE_WORKTREE = "NOT_A_ROVE_WORKTREE"
+
 const gitEnv = {
   ...process.env,
   GIT_AUTHOR_NAME: "t",
@@ -176,6 +184,74 @@ describe("worktree.remove", () => {
 
     await expect(
       dispatchDaemonRequest(createDaemonHandlerRegistry(), "worktree.remove", { path: wt }, ctx),
+    ).resolves.toEqual({ removed: true })
+    expect(existsSync(wt)).toBe(false)
+  })
+
+  /**
+   * `worktree.remove` is the only destructive path that addresses a worktree
+   * by PATH rather than by task id, and it was the only one that never asked
+   * what KIND of task owns it. A `dir` task's path is the user's own
+   * directory, a `main` task's is the project checkout — neither is a
+   * Rove-created worktree, and both can reach this handler because
+   * `worktree.list` enumerates every registered worktree of a saved project.
+   *
+   * The assertion is that the DIRECTORY survives, not just that the call
+   * threw: the pre-fix bug removed the files and then skipped the repair
+   * (`clearWorktreePath` early-returns for these two kinds), so the task was
+   * left pointing at a path that no longer existed.
+   */
+  function ctxWithTask(task: { id: string; worktreePath: string; kind?: string }): DaemonHandlerContext {
+    return {
+      runtime: { ...daemonRuntime, tearDownTaskSession: async () => {} },
+      orch: { listTasks: () => [task], clearWorktreePath: async () => {} },
+    } as unknown as DaemonHandlerContext
+  }
+
+  it("refuses to delete a dir task's own directory, and leaves it on disk", async () => {
+    const wt = join(root, "user-directory")
+    execSync(`git worktree add -b feature/dir-task ${JSON.stringify(wt)}`, { cwd: repo, env: gitEnv })
+
+    await expect(
+      dispatchDaemonRequest(
+        createDaemonHandlerRegistry(),
+        "worktree.remove",
+        { path: wt },
+        ctxWithTask({ id: "task-dir", worktreePath: wt, kind: "dir" }),
+      ),
+    ).rejects.toThrow(new RegExp(`^${NOT_A_ROVE_WORKTREE}: `))
+    expect(existsSync(wt)).toBe(true)
+  })
+
+  it("refuses to delete a main task's project checkout, and leaves it on disk", async () => {
+    const wt = join(root, "project-checkout")
+    execSync(`git worktree add -b feature/main-task ${JSON.stringify(wt)}`, { cwd: repo, env: gitEnv })
+
+    await expect(
+      dispatchDaemonRequest(
+        createDaemonHandlerRegistry(),
+        "worktree.remove",
+        { path: wt },
+        ctxWithTask({ id: "task-main", worktreePath: wt, kind: "main" }),
+      ),
+    ).rejects.toThrow(new RegExp(`^${NOT_A_ROVE_WORKTREE}: `))
+    expect(existsSync(wt)).toBe(true)
+  })
+
+  // Positive control: the guard reads `kind`, not "this path owns a task".
+  // Without this, a guard that refused every tracked worktree would pass the
+  // two tests above while breaking the handler's entire purpose.
+  it("still removes a managed task's worktree", async () => {
+    const wt = join(root, "managed-worktree")
+    execSync(`git worktree add -b feature/managed ${JSON.stringify(wt)}`, { cwd: repo, env: gitEnv })
+
+    await expect(
+      dispatchDaemonRequest(
+        createDaemonHandlerRegistry(),
+        "worktree.remove",
+        { path: wt },
+        ctxWithTask({ id: "task-managed", worktreePath: wt, kind: "task" }),
+      ),
     ).resolves.toEqual({ removed: true })
     expect(existsSync(wt)).toBe(false)
   })


### PR DESCRIPTION
## Mechanism

`worktree.remove` (`packages/kobe-daemon/src/daemon/handlers-worktree.ts`) is the only destructive worktree path addressed by **path** rather than by task id — and it was the only one that never checked the owning task's `kind`. Its five siblings all refuse `dir`/`main`: `task-deletion.ts:54,121`, `core.ts:264-266` (`ensureWorktree`), `core.ts:292` (`clearWorktreePath`), `land.ts:93-94` / `core.ts:364-365`.

A `dir` task's `worktreePath` **is** the user's own directory (`core-create.ts:107` `openDirectoryTaskRow` never requires it to be a repo root), and `manager-list.ts` enumerates *every* registered worktree of a saved project — so that directory shows up as a row on the Worktrees page, and `d` deletes it.

The two halves came apart. The destructive half (`removeWorktree`) ran; the repair half (`clearWorktreePath`) early-returns for exactly these kinds, so the task was left pointing at a directory that no longer exists — after which every `ensureWorktree` hands the engine a nonexistent cwd, which is the failure `handlers-worktree.ts:99-102` says it exists to prevent.

The guard now sits on the removal, before session teardown, at the one point the page and `rove api remove-worktree` both pass through. `clearWorktreePath`'s early return is unchanged.

`rove api remove-worktree` was only accidentally safe: a dir task has `repo === worktreePath`, so `handlers-lifecycle.ts:276`'s `BASE_CHECKOUT` comparison happened to fire. Nothing about `kind`.

## Repro (isolated home, inlined env)

```sh
H=/tmp/wt-safety-A3; mkdir -p "$H/home" "$H/repo"
git -C "$H/repo" init -q -b main && git -C "$H/repo" commit -q --allow-empty -m base
git -C "$H/repo" worktree add -q "$H/side" -b side
# … rove api add --repo $H/repo … then task.openDir { dir: $H/side }
# then the RPC the page sends, with the path worktree.list reports:
worktree.remove { path: "/private/tmp/wt-safety-A3/side" }
```

**BEFORE**

```
worktree.list → /private/tmp/wt-safety-A/repo -> ['/private/tmp/wt-safety-A/side']
worktree.remove  → {"removed":true}
ls $H/side       → ls: No such file or directory
get-task         → kind= dir worktreePath= /private/tmp/wt-safety-A/side     ← still pointing at it
```

**AFTER**

```
worktree.remove  → {"error":"Error: NOT_A_ROVE_WORKTREE: /private/tmp/wt-safety-A3/side is a
                    directory task's own directory, not a Rove-created worktree — refusing to delete it"}
ls $H/side       → (present)
git worktree list→ /private/tmp/wt-safety-A3/side  112bf4e [side]
get-task         → kind= dir worktreePath= /private/tmp/wt-safety-A3/side
```

## Harness BEFORE/AFTER

Real OpenTUI through `/harness` → xterm → PTY sidecar, own port base (`KOBE_VISUAL_PORT_BASE`), a FRESH fixture per side, `dist` rebuilt between them. Same gesture both times: `x` (Worktrees) → `d` → confirm **Delete**.

The confirm dialog offered on a directory Rove never created:

> **Delete worktree?** Delete the worktree for "my-notes"? This removes the working directory; the branch itself is kept.

| | Row after confirm | Directory on disk |
|---|---|---|
| BEFORE (`origin/main`) | `No worktrees.` | **deleted** |
| AFTER | `my-notes` still listed | present |

And in the BEFORE fixture, the orphaned pointer: `kind= dir worktreePath= …/my-notes exists= False`.

Scope of what the AFTER shot proves: the **row survives and the directory survives**. It does not show the refusal toast — the Worktrees page is a full-window swap and the toast layer lives on the workspace host, so it is not in the page's frames at any wait (700ms and 2500ms both tried). The refusal text itself is proven by the raw RPC output above (`NOT_A_ROVE_WORKTREE: … refusing to delete it`), which is the same string the toast renders via `String(err)`.

## Positive control + mutation

- **Positive control** (`still removes a managed task's worktree`): the guard reads `kind`, not "this path owns a task". Without it, a guard that refused every *tracked* worktree would pass both refusal tests while breaking the handler's purpose.
- **Mutation** — replaced `if (kind === "dir" || kind === "main")` with `if (false)`:

```
× refuses to delete a dir task's own directory, and leaves it on disk
× refuses to delete a main task's project checkout, and leaves it on disk
✓ still removes a managed task's worktree
  Tests  2 failed | 8 passed (10)
```

The refusal tests assert the **directory survives**, not merely that the call threw — the pre-fix bug removed the files and then skipped the repair.

## Tests

`bun run typecheck` clean · root `bun run lint` clean · `test:fast` 485 files / 4789 tests green · `worktree-list-handler.test.ts` 10/10.

## Docs

`docs/WORKTREES.md` — the delete section promised "clears that Task's worktree pointer … may materialize a fresh worktree", which is untrue for `dir`/`main`. Now states what the page refuses and scopes the pointer repair to Rove-created worktrees.
