### PR TITLE
fix: every worktree delete refusal can reach the force confirm

### DIFF
--- a/.changeset/worktree-force-refusal-parity.md
+++ b/.changeset/worktree-force-refusal-parity.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+The Worktrees page reaches the force-delete confirm for all three delete refusals, not just one. A worktree whose only work is gitignored — a `HANDOFF.md`, a `.scratch/` — refuses through a different message than a porcelain-dirty one, and the page matched that one message as prose, so two of the three refusals dead-ended in a red toast with no way to reach the two-stage force flow. The page now discriminates on `DIRTY_WORKTREE`, the same test the task-row delete uses, and the force confirm names the gitignored paths `git status` cannot show you.

--- a/docs/WORKTREES.md
+++ b/docs/WORKTREES.md
@@ -62,6 +62,14 @@ automatic cleanup decision:
 | `PR closed` | GitHub reports a closed, unmerged PR. |
 | `stale` | No stronger signal exists and the last activity is more than 14 days old. |
 
+`dirty` is `git status --porcelain` and nothing else, so a worktree whose only
+work is gitignored — a `HANDOFF.md`, a `.scratch/` — carries no `dirty` badge
+and can still read `in main`. Deletion checks more than the badge does
+(`git status --ignored` as well), so such a row looks safe to clean here and is
+still refused at the delete, offering the two-stage force flow below. That is
+the gate working: the badge reports what git reports, and the refusal names the
+paths git will not.
+
 The `rove` badge describes where the directory lives. **Adoption** describes
 whether Rove has a Task for that worktree. Either a Rove-managed or external
 worktree can be adopted through New task → Adopt Worktree or `rove adopt`.
@@ -90,9 +98,12 @@ manual conflict resolution to you.
 
 A successful land removes the worktree — it is spent once its branch is in —
 and the row leaves the page. The **branch survives**: git keeps the durable
-record. If removal is refused (the worktree is dirty, it is the base
-checkout, or it is the directory Rove itself is running from), the land still
-stands and the page reports why the worktree is still there. Deleting the
+record. Removal after a land is never forced, so it is refused by everything
+a plain delete is refused by: the worktree is dirty, it holds gitignored work
+`git status` cannot see (a `HANDOFF.md`, a `.scratch/`), that ignored listing
+could not run, it is the base checkout, or it is the directory Rove itself is
+running from. The land still stands and the page reports why the worktree is
+still there. Deleting the
 task and deleting the source branch remain separate lifecycle decisions;
 from the CLI, `rove api land --remove-worktree=false` keeps the worktree.
 
@@ -196,14 +207,21 @@ ordinary merge case, nor when no branch was deleted at all.
 The delete needs the worktree to be gone first: git refuses to delete a branch
 a live worktree has checked out. A land that kept the worktree — because you
 passed `--remove-worktree=false`, or because removal was refused (dirty tree,
-base checkout, the worktree you are running from) — keeps the branch too, and
-reports it as `branchKept` with the reason. Clear the worktree and re-run.
+gitignored work, an ignored listing that failed, base checkout, the worktree
+you are running from) — keeps the branch too, and reports it as `branchKept`
+with the reason. Clear the worktree and re-run.
 
 ### Recovering work a force delete destroyed
 
-Before any forced removal, Rove snapshots what the removal is about to
+Before a forced removal, Rove snapshots what the removal is about to
 destroy — modified tracked files and files you never `git add`ed — into a git
 ref in the owning repo.
+
+One force path takes no snapshot, because it cannot: a directory whose git
+repo is unreachable at all. Snapshotting runs `git` inside the worktree, and
+reaching that path means there is no repo to run it in. `--force` there is a
+plain delete of a directory under a Rove worktrees root, with nothing to
+recover afterwards.
 
 Files matched by `.gitignore` are included too, but only up to 64 MB per
 top-level entry. That threshold is the whole rule: a gitignored note or

--- a/packages/kobe/src/orchestrator/errors.ts
+++ b/packages/kobe/src/orchestrator/errors.ts
@@ -57,19 +57,25 @@ export const DIRTY_WORKTREE_CODE = "DIRTY_WORKTREE"
  * can say whether this worktree holds such work. It refuses through the SAME
  * error on purpose — the UI already turns this one into a force-delete
  * re-prompt, which is exactly the choice an unverifiable worktree needs.
+ *
+ * The sentence itself is {@link describeDirtyWorktreeWork}, shared with
+ * `GitWorktreeManager.remove`'s own refusals — the same three states, and a
+ * caller across the daemon boundary sees only the message either way.
  */
+export function describeDirtyWorktreeWork(ignored: readonly string[] | "unknown"): string {
+  return ignored === "unknown"
+    ? "gitignored work this check could not read (git status --ignored failed) — nothing here can confirm it is empty"
+    : ignored.length > 0
+      ? `gitignored work git status cannot see: ${ignored.join(", ")}`
+      : "uncommitted or untracked changes"
+}
+
 export class DirtyWorktreeError extends Error {
   constructor(
     public readonly taskId: string,
     public readonly ignored: readonly string[] | "unknown" = [],
   ) {
-    const what =
-      ignored === "unknown"
-        ? "gitignored work this check could not read (git status --ignored failed) — nothing here can confirm it is empty"
-        : ignored.length > 0
-          ? `gitignored work git status cannot see: ${ignored.join(", ")}`
-          : "uncommitted or untracked changes"
-    super(`${DIRTY_WORKTREE_CODE}: task ${taskId} worktree has ${what}`)
+    super(`${DIRTY_WORKTREE_CODE}: task ${taskId} worktree has ${describeDirtyWorktreeWork(ignored)}`)
     this.name = "DirtyWorktreeError"
   }
 }

--- a/packages/kobe/src/orchestrator/worktree/manager-remove.ts
+++ b/packages/kobe/src/orchestrator/worktree/manager-remove.ts
@@ -30,6 +30,7 @@
 
 import path from "node:path"
 import type { ExecHost } from "../../exec/exec-host.ts"
+import { DIRTY_WORKTREE_CODE, describeDirtyWorktreeWork } from "../errors.ts"
 import { GitCommandError, type GitRunOpts, type GitRunResult } from "./git.ts"
 import { type BranchDeps, deleteBranchAnchored } from "./manager-branch.ts"
 import { canonicalize, isUnderManagedWorktreesRoot, requireAbsolute } from "./paths.ts"
@@ -174,6 +175,24 @@ async function deregisteredWorktreeResidue(exec: ExecHost, worktreePath: string)
   if (at < 0) return false
   // `<repo>/.git` — alive for a deregistered worktree, gone for an orphan.
   return await exec.exists(pointer.slice(0, at))
+}
+
+/**
+ * The refusal message every non-force `remove()` gate throws.
+ *
+ * `DIRTY_WORKTREE_CODE` first so a caller across the daemon boundary can
+ * discriminate on it (the only field that survives the wire), then the same
+ * sentence {@link DirtyWorktreeError} produces, so the three states read
+ * identically whichever path refused. Named paths matter most in the ignored
+ * case: `git status` cannot see those, so a user told only "it has work" would
+ * go looking with a command that reports nothing.
+ *
+ * No `{ force: true }` in the text. Every surface already offers the remedy in
+ * its own vocabulary — the worktrees page as a force-delete re-prompt, the CLI
+ * as `--force` — and API syntax read badly in the dialog that IS the override.
+ */
+function dirtyRefusal(worktreePath: string, ignored: IgnoredWorkProbe): string {
+  return `${DIRTY_WORKTREE_CODE}: ${worktreePath} has ${describeDirtyWorktreeWork(ignored)} — forcing the removal salvages it to a ref first`
 }
 
 /**
@@ -332,10 +351,15 @@ export async function removeWorktree(deps: RemoveDeps, worktreePath: string, opt
     const salvaged = await salvageWorktree({ runGit: (e, a, o) => deps.runGit(e, a, o) }, exec, worktreePath)
     opts?.onSalvage?.(salvaged)
   } else {
+    // All three refusals below lead the message with DIRTY_WORKTREE_CODE and
+    // phrase the reason with the SAME sentence `DirtyWorktreeError` uses. The
+    // RPC layer rebuilds a thrown error as `new Error(message)`, so the
+    // message is the only thing a caller across the daemon boundary can
+    // discriminate on — and the worktrees page used to match prose that only
+    // the first of the three produced, dropping the other two into a dead-end
+    // error toast with no force-delete re-prompt.
     if (await deps.isDirty(worktreePath)) {
-      throw new Error(
-        `remove(): refusing to remove dirty worktree at ${worktreePath} (pass { force: true } to override)`,
-      )
+      throw new Error(dirtyRefusal(worktreePath, []))
     }
     // `status --porcelain` is blind to `.gitignore`d entries, so a worktree
     // whose only work is `HANDOFF.md` or `.scratch/` reads clean and the
@@ -349,15 +373,8 @@ export async function removeWorktree(deps: RemoveDeps, worktreePath: string, opt
     // throw (`daemon-worktree-adapter.ts` names that as why a destructive path
     // may not read an unverified verdict).
     const ignored = await deps.ignoredWork(worktreePath)
-    if (ignored === "unknown") {
-      throw new Error(
-        `remove(): refusing to remove worktree at ${worktreePath} — git status --ignored failed, so nothing can confirm it holds no gitignored work (pass { force: true } to override, which salvages first)`,
-      )
-    }
-    if (ignored.length > 0) {
-      throw new Error(
-        `remove(): refusing to remove worktree at ${worktreePath} — it holds gitignored work git status cannot see: ${ignored.join(", ")} (pass { force: true } to override)`,
-      )
+    if (ignored === "unknown" || ignored.length > 0) {
+      throw new Error(dirtyRefusal(worktreePath, ignored))
     }
   }
 

--- a/packages/kobe/src/tui-react/component/worktrees-page.tsx
+++ b/packages/kobe/src/tui-react/component/worktrees-page.tsx
@@ -30,6 +30,7 @@ import { TextAttributes } from "@opentui/core"
 import { type ReactNode, useEffect, useState } from "react"
 import type { RemoteOrchestrator } from "../../client/remote-orchestrator"
 import { relativeAge } from "../../lib/relative-time"
+import { DIRTY_WORKTREE_CODE } from "../../orchestrator/errors"
 import { clampCursor } from "../../tui/component/new-task-dialog/state"
 import type { WorktreeAuditRow, WorktreeProject } from "../../types/worktree"
 import { useNotifications } from "../context/notifications"
@@ -46,7 +47,27 @@ function flattenRows(projects: readonly WorktreeProject[]): readonly WorktreeAud
   return projects.flatMap((p) => p.worktrees)
 }
 
-const DIRTY_REFUSAL_RE = /refusing to remove dirty worktree/
+/**
+ * Read a dirty refusal out of a daemon error, or `null` when it is something
+ * else. The RPC layer rebuilds a thrown error as `new Error(message)`, so the
+ * message is all that survives — the same test `tui/lib/task-actions.ts` uses
+ * for the task-row delete, which is the other half of this one event.
+ *
+ * Matching the CODE and not prose is the point: `GitWorktreeManager.remove`
+ * refuses in three ways (porcelain-dirty, `git status --ignored` failed,
+ * gitignored work present) and the old regex recognised only the first, so the
+ * other two never reached the force re-prompt at all.
+ *
+ * The returned reason is what follows the code — it names the gitignored paths
+ * in the case where that is what refused, which is the only way that refusal is
+ * actionable: `git status` cannot see them.
+ */
+function dirtyRefusalReason(err: unknown): string | null {
+  if (!(err instanceof Error)) return null
+  const at = err.message.indexOf(DIRTY_WORKTREE_CODE)
+  if (at < 0) return null
+  return err.message.slice(at + DIRTY_WORKTREE_CODE.length).replace(/^:\s*/, "")
+}
 
 /** Match a worktree row's path to a tracked task id (loose realpath tolerance). */
 function taskIdForPath(orch: RemoteOrchestrator, wtPath: string): string | undefined {
@@ -160,11 +181,12 @@ export function WorktreesPage(props: { orchestrator: RemoteOrchestrator | null; 
       refetch()
     } catch (err) {
       setRemovingPaths((paths) => paths.filter((p) => p !== row.path))
-      if (!force && err instanceof Error && DIRTY_REFUSAL_RE.test(err.message)) {
+      const reason = force ? null : dirtyRefusalReason(err)
+      if (reason !== null) {
         const confirmed = await DialogConfirm.show(
           dialog,
           t("worktrees.delete.forceTitle"),
-          t("worktrees.delete.forceBody", { branch: row.branch || row.path }),
+          `${t("worktrees.delete.forceBody", { branch: row.branch || row.path })}\n\n${t("worktrees.delete.forceReason", { reason })}`,
           t("common.cancel"),
           t("worktrees.delete.button"),
           { danger: true },

--- a/packages/kobe/src/tui/i18n/messages/worktrees.ts
+++ b/packages/kobe/src/tui/i18n/messages/worktrees.ts
@@ -45,6 +45,10 @@ export const en = {
         overstating the danger pushes people to cancel a safe operation. */
     forceBody:
       '"{branch}" has uncommitted, untracked, or gitignored work. Force delete removes the worktree, but the work is snapshotted first to a salvage ref — list them with `git for-each-ref refs/rove/salvage`. Force delete anyway?',
+    /** The daemon's own words for WHICH of the three refusals fired. Only that
+        message names the gitignored paths, and `git status` cannot see those —
+        without them the user goes looking with a command that reports nothing. */
+    forceReason: "Refused because: {reason}",
     failed: "Failed to delete worktree: {error}",
     residue:
       "Git deregistered the worktree, but couldn't delete {path} ({reason}). Rove is done with it — retrying won't help; delete the directory by hand if you want the space.",
@@ -115,6 +119,7 @@ export const zh: typeof en = {
     forceTitle: "强制删除 worktree？",
     forceBody:
       '"{branch}" 存在未提交、未跟踪或被 gitignore 的改动。强制删除会移除 worktree，但这些改动会先被快照到一个 salvage ref——用 `git for-each-ref refs/rove/salvage` 可以列出它们。仍要强制删除吗？',
+    forceReason: "拒绝原因：{reason}",
     failed: "删除 worktree 失败：{error}",
     residue:
       "Git 已注销该 worktree，但没能删掉 {path}（{reason}）。Rove 这边已经处理完了——重试没有用；想要回磁盘空间请手动删除该目录。",

--- a/packages/kobe/test/daemon/worktree-list-handler.test.ts
+++ b/packages/kobe/test/daemon/worktree-list-handler.test.ts
@@ -110,8 +110,41 @@ describe("worktree.remove", () => {
     execSync(`git worktree add -b feature/dirty ${JSON.stringify(wt)}`, { cwd: repo, env: gitEnv })
     writeFileSync(join(wt, "untracked.txt"), "uncommitted")
 
-    await expect(dispatch("worktree.remove", { path: wt })).rejects.toThrow(/refusing to remove dirty worktree/)
+    // The CODE, not the prose: the message is all that survives the RPC, and
+    // the worktrees page discriminates on exactly this prefix.
+    await expect(dispatch("worktree.remove", { path: wt })).rejects.toThrow(/^DIRTY_WORKTREE: /)
     await expect(dispatch("worktree.remove", { path: wt, force: true })).resolves.toEqual({ removed: true })
+  })
+
+  /**
+   * The refusal the worktrees page could not see. `status --porcelain` is
+   * blind to gitignored entries, so a worktree whose only work is a
+   * `HANDOFF.md` reads clean and refuses through a DIFFERENT message than the
+   * porcelain-dirty one — which is why the page's old prose match dropped it
+   * into a dead-end error toast instead of the force re-prompt.
+   *
+   * Two assertions, both load-bearing: the CODE (what the page discriminates
+   * on) and the PATH (what makes the refusal actionable — `git status` will
+   * never name it, so a user told only "it has work" searches with a command
+   * that reports nothing).
+   */
+  it("refuses gitignored-only work with the same code, naming the path", async () => {
+    const wt = join(root, "ignored-only-worktree")
+    writeFileSync(join(repo, ".gitignore"), "HANDOFF.md\n")
+    execSync("git add .gitignore && git commit -q -m ignore", { cwd: repo, env: gitEnv })
+    execSync(`git worktree add -b feature/ignored ${JSON.stringify(wt)}`, { cwd: repo, env: gitEnv })
+    writeFileSync(join(wt, "HANDOFF.md"), "session notes")
+
+    // Not dirty by the badge's own measure — that is the whole trap.
+    expect(execSync("git status --porcelain", { cwd: wt, env: gitEnv }).toString()).toBe("")
+
+    await expect(dispatch("worktree.remove", { path: wt })).rejects.toThrow(/^DIRTY_WORKTREE: /)
+    await expect(dispatch("worktree.remove", { path: wt })).rejects.toThrow(/HANDOFF\.md/)
+    expect(existsSync(join(wt, "HANDOFF.md"))).toBe(true)
+
+    // And force still gets through, which is what the second confirm authorizes.
+    await expect(dispatch("worktree.remove", { path: wt, force: true })).resolves.toEqual({ removed: true })
+    expect(existsSync(wt)).toBe(false)
   })
 
   it("rejects a missing path", async () => {

--- a/packages/kobe/test/orchestrator/land.test.ts
+++ b/packages/kobe/test/orchestrator/land.test.ts
@@ -310,7 +310,9 @@ describe("landTaskWithCleanup worktree cleanup", () => {
     const { deps: d, cleared } = deps()
     const res = await landTaskWithCleanup({ ...task("feat"), worktreePath: wt }, {}, d)
     expect(res.worktree?.removed).toBe(false)
-    expect(res.worktree?.reason).toMatch(/dirty/)
+    // The code, not the prose: it is the only part of a refusal that survives
+    // the daemon wire, so it is what every caller discriminates on.
+    expect(res.worktree?.reason).toMatch(/DIRTY_WORKTREE: /)
     expect(fs.existsSync(path.join(wt, "wip.txt"))).toBe(true)
     expect(cleared).toEqual([])
     expect(fs.existsSync(path.join(repo, "b.txt"))).toBe(true)
@@ -447,7 +449,7 @@ describe("landTaskWithCleanup worktree cleanup", () => {
     const res = await landTaskWithCleanup({ ...task("feat"), worktreePath: wt }, { deleteBranch: true }, d)
     expect(res.worktree?.removed).toBe(false)
     expect(branchExists("feat")).toBe(true)
-    expect(res.branchKept?.reason).toMatch(/dirty/)
+    expect(res.branchKept?.reason).toMatch(/DIRTY_WORKTREE: /)
   })
 
   test("the worktree going lets --delete-branch through", async () => {

--- a/packages/kobe/test/render/worktrees-page-delete.test.tsx
+++ b/packages/kobe/test/render/worktrees-page-delete.test.tsx
@@ -77,3 +77,47 @@ test("a failed delete puts the row back", async () => {
   await settle()
   expect(await frame()).toContain("feature-a")
 })
+
+/**
+ * `GitWorktreeManager.remove` refuses in three ways, and only ONE of them said
+ * "refusing to remove dirty worktree" — the prose the page used to match. A
+ * worktree whose only work is gitignored (a `HANDOFF.md`, a `.scratch/`) hits
+ * the other refusal, so it never reached the force re-prompt: red toast, row
+ * back, and no way to get to the two-stage flow `docs/WORKTREES.md` documents.
+ *
+ * The page now discriminates on `DIRTY_WORKTREE`, the same test the task-row
+ * delete uses (`tui/lib/task-actions.ts`) for the other half of this one event.
+ */
+test("a gitignored-work refusal opens the force re-prompt, naming the paths", async () => {
+  const calls: boolean[] = []
+  const remove = (_path: string, force: boolean): Promise<void> => {
+    calls.push(force)
+    return force
+      ? Promise.resolve()
+      : Promise.reject(
+          new Error("DIRTY_WORKTREE: /x/wt/feature-a has gitignored work git status cannot see: HANDOFF.md"),
+        )
+  }
+  const { frame, mockInput } = await renderComponent(
+    <WorktreesPage orchestrator={orchestrator(remove)} onClose={() => {}} />,
+    { width: 70, height: 24, providers: { dialog: true, notifications: true } },
+  )
+  await settle()
+  mockInput.typeText("d")
+  await settle()
+  mockInput.pressArrow("right")
+  await settle()
+  mockInput.pressEnter() // confirm the ordinary delete
+  await settle()
+
+  // The second, more severe confirm — and it names what `git status` cannot.
+  const forcePrompt = await frame()
+  expect(forcePrompt).toContain("Force delete")
+  expect(forcePrompt).toContain("HANDOFF.md")
+
+  mockInput.pressArrow("right")
+  await settle()
+  mockInput.pressEnter() // authorize the force
+  await settle()
+  expect(calls).toEqual([false, true])
+})


### PR DESCRIPTION
## Mechanism

`GitWorktreeManager.remove`'s non-force gate throws **three** different refusals:

| `manager-remove.ts` | Cause |
|---|---|
| `:337` | `git status --porcelain` is dirty |
| `:354` | `git status --ignored` failed — nothing can confirm the worktree is empty |
| `:359` | gitignored work is present (a `HANDOFF.md`, a `.scratch/`) |

The Worktrees page recognised **one**: `worktrees-page.tsx:49` `DIRTY_REFUSAL_RE = /refusing to remove dirty worktree/`, used at `:163`. The other two fell through to `:175`, which renders `String(err)` as a red toast and puts the row back — a dead end. The two-stage force flow `docs/WORKTREES.md:136-165` documents was unreachable for them.

That is not a hypothetical row. A worktree whose only work is a gitignored `HANDOFF.md` reads **clean** to `git status --porcelain`, so it carries no `dirty` badge and can still read `in main` — and `HANDOFF.md` / `.scratch/` are gitignored in this very repo.

The positive control lives 60 lines away in a sibling: the task-row delete matches `message.includes(DIRTY_WORKTREE_CODE)` (`tui/lib/task-actions.ts:217`), because `errors.ts:36-42` says outright that the message is the only thing that survives the RPC wire — `new Error(frame.error.message)` at `client/index.ts:353`. The two flows even share the confirm copy (`worktrees.delete.forceBody`). One half discriminated on a stable marker; the other on prose.

**B1** — all three refusals now go through one `dirtyRefusal()` helper that leads with `DIRTY_WORKTREE_CODE`; the page uses the same `includes` test as `task-actions.ts`. No second regex.

**B2** — the reason phrase is now `describeDirtyWorktreeWork()`, extracted from `DirtyWorktreeError` so both paths describe the same three states identically. The force confirm renders it (`worktrees.delete.forceReason`), which is what puts the **paths** in front of the user — `errors.ts:51-54` already argues why that matters: `git status` cannot show a gitignored file, so a user told only "it has work" goes looking with a command that reports nothing.

The messages drop their `remove():` prefix and their `(pass { force: true } …)` tail. The prefix was a function name leaking into a dialog; the tail is API syntax offered inside the dialog that *is* the override. Every surface states the remedy in its own vocabulary already.

**B3** — took the docs option. Adding an `ignoredWork` signal to `judgeWorktree` costs a `du` per row on the list's hot path, which the brief gates on "only if acceptable"; it isn't obviously so. `docs/WORKTREES.md` now states that `dirty` is porcelain-only while the delete gate also runs `git status --ignored`, so an `in main` row can still be refused — and that this is the gate working.

**B4** — `land.ts:206` calls `remove()` without `force`, so a land inherits all three refusals; the docs listed only three of the five reasons a post-land removal can be refused. Both lists updated (`:92-93`, `:191-192`). And `docs/WORKTREES.md:201` promised "Before **any** forced removal, Rove snapshots" — false for the unreachable-repo force path, which takes `onSalvage(null)` at `manager-remove.ts:305` because snapshotting needs a git repo to run in. Now stated as the exception it is.

## Harness BEFORE/AFTER

Real OpenTUI through `/harness` → xterm → PTY sidecar. Own port base, a FRESH fixture per side, `dist` rebuilt between them. Identical seed both sides — a worktree whose ONLY content is a gitignored `HANDOFF.md`:

```
$ git -C wt-notes status --porcelain
                            ← empty: reads clean, no `dirty` badge
$ git -C wt-notes status --ignored --porcelain
!! HANDOFF.md
```

Identical gesture both sides: `x` (Worktrees) → `d` → confirm **Delete**.

| | Result |
|---|---|
| **BEFORE** (`origin/main`) — `.scratch/wt-safety/B-BEFORE-toast.png` | row returns, **no second dialog**. Dead end: the force flow is unreachable. |
| **AFTER** — `.scratch/wt-safety/B-AFTER-force.png` | **Force delete worktree?** opens, body reads `Refused because: …/wt-notes has gitignored work git status cannot see: HANDOFF.md — forcing the removal salvages it to a ref first` |

Then authorizing that force (`.scratch/wt-safety/B-AFTER-forced.png`) completes the documented chain:

```
worktree     → gone
salvage ref  → refs/rove/salvage/feat-notes-20260906T222347Z
git show <ref>:HANDOFF.md → session notes worth keeping
```

Same caveat as #950: the *refusal toast* is not in these frames — the Worktrees page is a full-window swap and the toast layer lives on the workspace host. What the pair shows is the decisive difference, the presence or absence of the force dialog, which is the bug itself.

## Positive control + mutation

- **Positive control**: `worktree-list-handler.test.ts` asserts the porcelain-dirty refusal still carries the code and that `force: true` still removes — a guard that refused everything, or a code that only the new branch emits, fails here.
- **Mutation** — restored the old prose match in `dirtyRefusalReason`:

```
[rove worktrees] delete failed: DIRTY_WORKTREE: /x/wt/feature-a has gitignored work
                               git status cannot see: HANDOFF.md
(fail) a gitignored-work refusal opens the force re-prompt, naming the paths
 2 pass  1 fail
```

The render test lands in the error-toast branch — the bug, reproduced.

## Tests

`test:fast` 499 files / 4944 ✓ · `test:socket` 123 files / 963 ✓ · `bun test test/render` 122 files / 519 ✓ · typecheck ✓ · root lint ✓ · `check-i18n` 949 keys × 2 locales in sync.

Two `land.test.ts` assertions pinned `res.worktree?.reason` to `/dirty/` — the word this change removes. They now pin `/DIRTY_WORKTREE: /`, the marker that survives the wire, which is what a caller can actually discriminate on.

## One mismatch surfaced, not fixed

`docs/WORKTREES.md:141-142` says the force confirm warns "modified and untracked files will be **permanently lost**". The dialog it describes says the opposite and is correct — every force path salvages first. Pre-existing and outside this slice, so flagging rather than widening.
