### PR TITLE
fix: repo init runs once per worktree, and tabs stop sharing a session

### DIFF
--- a/.changeset/repo-init-once-per-worktree.md
+++ b/.changeset/repo-init-once-per-worktree.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+`.rove/init.sh` now really does run once per worktree. Its marker is a receipt, deleted for the whole run and keyed by worktree — which every tab of a task shares — so two tabs opening before the first init finished, or any worktree whose last init exited non-zero, both passed the gate and both ran the script. Two installs in one directory, and the shared env dump they raced over could reach the engine truncated or missing, leaving it without the PATH, venv, or API keys init exported. A `set -C` lock now admits one run; the other waits for its marker and sources a complete dump.

--- a/.changeset/tab-session-claim-race.md
+++ b/.changeset/tab-session-claim-race.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Two engine tabs in one task no longer adopt the same session on restart. All tabs of a task share one worktree, and an engine that mints its own session id (kimi) is discovered by asking its store — which answers per-worktree. The restart pass ran every tab's discovery concurrently, so each computed the claimed-id set before any sibling had recorded one and all of them were handed the same newest session: two live engines writing one transcript. Discovery is now sequential and re-reads the claim set per tab, matching what the tab-naming poll already did.

--- a/packages/kobe/src/engine/session-launch.ts
+++ b/packages/kobe/src/engine/session-launch.ts
@@ -146,6 +146,12 @@ export function engineLaunchLine(engineCommand: string, init?: EngineInitLaunch)
   }
   const marker = quoteShellArg(markerPath)
   const markerDir = quoteShellArg(markerDirOf(markerPath))
+  // Beside the marker, so it inherits the same per-worktree keying and the
+  // same `mkdir -p` above.
+  const lock = quoteShellArg(`${markerPath}.lock`)
+  // The winner's own ceiling plus slack for the shell around it: a loser that
+  // gave up earlier would start its engine while init was still writing.
+  const waitSeconds = String(resolveRepoInitTimeoutSeconds(init?.timeoutSeconds) + 5)
   return (
     SIGINT_GUARD +
     [
@@ -161,6 +167,21 @@ export function engineLaunchLine(engineCommand: string, init?: EngineInitLaunch)
       // code retries, exactly as a missing marker did.
       `if [ ! -f ${marker} ] || [ "$(cat ${marker} 2>/dev/null)" != "0" ]; then`,
       `mkdir -p ${markerDir} 2>/dev/null`,
+      // The marker is a RECEIPT, not a lock: it is deleted for the whole run
+      // (below), so between the test above and the write below it does not
+      // exist — and it is keyed by WORKTREE, which every tab of a task
+      // shares. Two tabs opening before the first init finished, or any
+      // worktree whose last init exited non-zero, therefore both passed the
+      // test and both ran `.rove/init.sh` — two `bun install`s in one
+      // directory, against a contract that says "once per worktree"
+      // (`state/repo-init.ts`, `docs/CONFIGURATION.md`).
+      //
+      // `set -C` makes `> file` fail when the file exists, which is POSIX
+      // sh's atomic create-or-fail — no `flock`, which not every target
+      // platform ships. The winner runs; the loser waits for the winner's
+      // marker rather than racing it, so it also sources a COMPLETE env dump
+      // (the dump is written inside the group, before the marker).
+      `if (set -C; : > ${lock}) 2>/dev/null; then`,
       // This run owns the marker while it runs: absent means "init is still
       // going", which is the question the spawner is asking. Without the
       // delete a retry would leave the previous run's code on disk and the
@@ -168,6 +189,23 @@ export function engineLaunchLine(engineCommand: string, init?: EngineInitLaunch)
       `rm -f ${marker} 2>/dev/null`,
       group,
       `printf '%s' "$__kobe_init_rc" > ${marker}`,
+      `rm -f ${lock} 2>/dev/null`,
+      "else",
+      // Wait on the LOCK, not on the marker. The winner deletes the marker as
+      // its first act, so a loser polling for the marker can still see the
+      // PREVIOUS run's one in the instant before that delete and walk on while
+      // init is running. The lock has no such window: it exists from before
+      // the marker is deleted until after the new one is written.
+      //
+      // Bounded by the same budget the init itself gets, so a crashed winner
+      // costs one wait and not a permanent stall. Falling through is the
+      // honest outcome then: the engine starts without the exports, exactly as
+      // it would have if init had failed, and clearing the stale lock lets the
+      // next launch try again.
+      "__kobe_init_w=0",
+      `while [ -f ${lock} ] && [ "$__kobe_init_w" -lt ${waitSeconds} ]; do sleep 1; __kobe_init_w=$((__kobe_init_w+1)); done`,
+      `rm -f ${lock} 2>/dev/null`,
+      "fi",
       "fi",
       restore,
       tail,
@@ -269,12 +307,7 @@ export function buildEngineSessionLaunch(input: EngineSessionLaunchInput): Engin
   const protocolTaskId = input.task.kind === "main" ? undefined : input.task.id
   const dispatcherTaskId = input.task.kind === "main" ? input.task.id : undefined
   const gates = input.protocolGates
-  const launchInit = resolveEngineLaunchInit(
-    input.task.repo ?? "",
-    input.worktreePath,
-    input.promptIntent,
-    input.task.id,
-  )
+  const launchInit = resolveEngineLaunchInit(input.task.repo ?? "", input.worktreePath, input.promptIntent)
   // The repo's accumulated field notes ride along in the same
   // --append-system-prompt as the filing protocol, so a fresh worktree
   // session starts with what earlier sessions already learned. Read only for

--- a/packages/kobe/src/state/repo-init.ts
+++ b/packages/kobe/src/state/repo-init.ts
@@ -189,7 +189,6 @@ function firstMessageFor(
   intent: PromptDeliveryIntent,
   init: ResolvedRepoInit,
   worktreePath: string,
-  taskId?: string,
 ): FirstEngineMessage | undefined {
   if (intent.kind === "none") return undefined
   if (intent.kind === "explicit") return { source: "explicit", text: intent.prompt }
@@ -218,11 +217,10 @@ export function resolveEngineLaunchInit(
   repoRoot: string,
   worktreePath: string,
   intent: PromptDeliveryIntent = { kind: "repo-init" },
-  taskId?: string,
 ): EngineLaunchInit {
   const init = resolveRepoInit(repoRoot, worktreePath)
   return {
     initScript: init.initScript,
-    firstMessage: firstMessageFor(intent, init, worktreePath, taskId),
+    firstMessage: firstMessageFor(intent, init, worktreePath),
   }
 }

--- a/packages/kobe/src/tui-react/workspace/use-tab-lifecycle.ts
+++ b/packages/kobe/src/tui-react/workspace/use-tab-lifecycle.ts
@@ -54,28 +54,44 @@ export function useTabHydration(rehydrated: boolean, io: TabLifecycleIO): boolea
     let cancelled = false
     void (async () => {
       try {
+        const engines = io.stateRef.current.tabs.filter((tab): tab is EngineTab => tab.kind === "engine")
+        const worktree = io.propsRef.current.worktree
+        const vendorOfTab = (tab: EngineTab): VendorId => tab.vendor ?? io.propsRef.current.vendor
+
+        // SEQUENTIALLY, and re-reading the claim set each time — the same
+        // shape `useTabNaming` below uses for the same discovery.
+        //
+        // A tab's claim only exists once `io.update` has written its
+        // sessionId back. Run these concurrently and every undiscovered tab
+        // computes `claimedIds` before any sibling has recorded anything, so
+        // `pickUnclaimedSessionId` hands them all the SAME newest id — and
+        // the store answers per-WORKTREE, so all tabs of one task see one
+        // list. Two live engines then write one transcript, which is exactly
+        // the collision `session-identity.ts` says claim-tracking prevents.
+        for (const tab of engines) {
+          if (tab.sessionId) continue
+          // No recorded id: this engine mints its own and reports it
+          // nowhere (kimi), so ASK ITS STORE which session this worktree
+          // has. It has to happen here rather than in the naming poll —
+          // `hydrating` is what holds the spawn back, and a tab that
+          // respawns before its id is known opens a blank conversation,
+          // which is the whole bug.
+          const found = await discoverSessionId(vendorOfTab(tab), worktree, claimedIds(io))
+          if (cancelled) return
+          if (!found) continue
+          io.update(setTabSpawned(setTabSessionId(io.stateRef.current, tab.id, found), tab.id, true))
+        }
+
+        // Re-verification stays concurrent: it claims nothing, it only asks
+        // whether an id a tab ALREADY holds is still on disk.
         await Promise.all(
-          io.stateRef.current.tabs.map(async (tab) => {
-            if (tab.kind !== "engine") return
-            const vendor = tab.vendor ?? io.propsRef.current.vendor
-            const worktree = io.propsRef.current.worktree
-            // No recorded id: this engine mints its own and reports it
-            // nowhere (kimi), so ASK ITS STORE which session this worktree
-            // has. It has to happen here rather than in the naming poll —
-            // `hydrating` is what holds the spawn back, and a tab that
-            // respawns before its id is known opens a blank conversation,
-            // which is the whole bug.
-            if (!tab.sessionId) {
-              const found = await discoverSessionId(vendor, worktree, claimedIds(io))
-              if (cancelled || !found) return
-              io.update(setTabSpawned(setTabSessionId(io.stateRef.current, tab.id, found), tab.id, true))
-              return
-            }
+          engines.map(async (tab) => {
+            if (!tab.sessionId) return
             // Ask whether the session is RECORDED, not whether kobe can
             // parse its messages: `readHistory` is empty for engines that
             // ship no message parser (kimi), so a parse-based check reports
             // every kimi session as absent and the tab respawns blank.
-            const exists = await engineSessionExists(vendor, worktree, tab.sessionId)
+            const exists = await engineSessionExists(vendorOfTab(tab), worktree, tab.sessionId)
             if (cancelled) return
             io.update(setTabSpawned(io.stateRef.current, tab.id, exists))
           }),

--- a/packages/kobe/test/engine/session-launch.test.ts
+++ b/packages/kobe/test/engine/session-launch.test.ts
@@ -235,6 +235,44 @@ describe("hosted engine session launch", () => {
       expect(runLaunch(dir, script).trim()).toBe("1")
     })
 
+    /**
+     * C2: the marker is a RECEIPT, not a lock. It is deleted for the whole run
+     * ("absent means init is still going", which the paste spawner depends on)
+     * and it is keyed by WORKTREE — which every tab of a task shares
+     * (`session-launch.ts` gives one task one worktree). So two tabs opening
+     * before the first init finished both passed `[ ! -f marker ]` and both
+     * ran the script: two `bun install`s in one directory, against a contract
+     * that says once per worktree.
+     *
+     * Executed, not asserted on the script text: only running two shells at
+     * once can answer how many times the script actually ran. Sequential runs
+     * are already covered above and would pass either way.
+     */
+    test("two shells racing one worktree run init exactly once", () => {
+      const { dir, marker } = scratch()
+      const counter = path.join(dir, "runs")
+      // Long enough that the second shell is provably inside the window while
+      // the first is still working, short enough to stay a unit test.
+      const script = launchScript(
+        `printf x >> ${JSON.stringify(counter)}; export ROVE_INIT_PROBE=racewinner; sleep 1`,
+        marker,
+      )
+      const out = path.join(dir, "race")
+      execFileSync("/bin/sh", [
+        "-c",
+        `{ ${script}\n} > ${JSON.stringify(`${out}-a.log`)} 2>&1 & ` +
+          `{ ${script}\n} > ${JSON.stringify(`${out}-b.log`)} 2>&1 & wait`,
+      ])
+
+      expect(fs.readFileSync(counter, "utf8").length).toBe(1)
+      expect(fs.readFileSync(marker, "utf8")).toBe("0")
+      // C3: the loser waits for the marker rather than racing the dump, so it
+      // sources a COMPLETE one — the dump is written inside the run, before
+      // the marker. Both engines start with what init exported.
+      expect(fs.readFileSync(`${out}-a.log`, "utf8").trim()).toBe("racewinner")
+      expect(fs.readFileSync(`${out}-b.log`, "utf8").trim()).toBe("racewinner")
+    })
+
     test("keeps the env dump 0600 — an init script's exports are where a key would be", () => {
       const { dir, marker } = scratch()
       runLaunch(dir, launchScript("export ROVE_INIT_PROBE=1", marker))

--- a/packages/kobe/test/render/tab-session-discovery.test.tsx
+++ b/packages/kobe/test/render/tab-session-discovery.test.tsx
@@ -19,7 +19,7 @@
  */
 
 import { afterEach, expect, test } from "bun:test"
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
+import { appendFile, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import path from "node:path"
 import type { ReactNode } from "react"
@@ -82,6 +82,19 @@ function lifecycleIO(state: TabsState, wt: string): TabLifecycleIO & { state: ()
   }
 }
 
+/** Add another session for the SAME worktree — the store answers per-worktree,
+ *  so both tabs of one task see both of these. `newer` sorts last, which is
+ *  what `pickUnclaimedSessionId` reaches for first. */
+async function seedSecondKimiSession(id: string): Promise<void> {
+  const dir = path.join(kimiHome as string, "sessions", `wd_${id}`)
+  await mkdir(path.join(dir, "agents", "main"), { recursive: true })
+  await writeFile(path.join(dir, "agents", "main", "wire.jsonl"), '{"type":"protocol-frame"}\n')
+  await appendFile(
+    path.join(kimiHome as string, "session_index.jsonl"),
+    `${JSON.stringify({ sessionId: id, sessionDir: dir, workDir: worktree })}\n`,
+  )
+}
+
 test("a rehydrated kimi tab adopts the session its worktree already has", async () => {
   await seedKimiSession()
   const state: TabsState = {
@@ -103,4 +116,47 @@ test("a rehydrated kimi tab adopts the session its worktree already has", async 
   // `spawned` rides along: a session on disk IS a conversation, and it is what
   // makes the next launch take the engine's resume verb instead of a blank one.
   expect(tab.spawned).toBe(true)
+})
+
+const SECOND_SESSION_ID = "session_fc747c28-84ge-56d3-a8g5-5cd5g4346cgg"
+
+/**
+ * Two engine tabs in one task share ONE worktree (`session-launch.ts:290-292`),
+ * so "two tabs, one worktree" is the ordinary case, not an edge one — and the
+ * kimi session store answers per-WORKTREE, so both tabs see the same list.
+ *
+ * A tab's claim exists only once `io.update` has written its sessionId back.
+ * The hydration pass used to run every tab's discovery inside one
+ * `Promise.all`, so both computed their claim set before either had recorded
+ * anything and `pickUnclaimedSessionId` handed both the same newest id — two
+ * live engines writing one transcript, the exact collision claim-tracking
+ * exists to prevent (`engine/session-identity.ts:145-152`).
+ *
+ * `useTabNaming` in the same file already did this sequentially; this is the
+ * hydration pass catching up.
+ */
+test("two rehydrated tabs in one worktree take different sessions", async () => {
+  await seedKimiSession()
+  await seedSecondKimiSession(SECOND_SESSION_ID)
+  const state: TabsState = {
+    tabs: [
+      { kind: "engine", id: "tab-1", title: null, ordinal: 1, vendor: "kimi" },
+      { kind: "engine", id: "tab-2", title: null, ordinal: 2, vendor: "kimi" },
+    ],
+    activeId: "tab-1",
+    nextOrdinal: 3,
+  }
+  const io = lifecycleIO(state, worktree as string)
+  function Probe(): ReactNode {
+    useTabHydration(true, io)
+    return <text>probe</text>
+  }
+  await renderComponent(<Probe />)
+  await until(() => io.state().tabs.every((t) => (t as EngineTab).sessionId != null))
+
+  const ids = io.state().tabs.map((t) => (t as EngineTab).sessionId)
+  expect(ids.filter(Boolean)).toHaveLength(2)
+  // The assertion is DISTINCTNESS. Asserting which tab got which id would pin
+  // the store's ordering rather than the invariant that is actually at stake.
+  expect(new Set(ids).size).toBe(2)
 })

--- a/packages/kobe/test/state/repo-init.test.ts
+++ b/packages/kobe/test/state/repo-init.test.ts
@@ -159,7 +159,7 @@ describe("resolveEngineLaunchInit", () => {
   // along, because no skill can know them.
   test("new-task delivers the user's prompt verbatim — no appended instructions", () => {
     const wt = makeWorktree()
-    const msg = resolveEngineLaunchInit(wt, wt, { kind: "new-task", prompt: "fix the bug" }, "task-9").firstMessage
+    const msg = resolveEngineLaunchInit(wt, wt, { kind: "new-task", prompt: "fix the bug" }).firstMessage
     expect(msg?.source).toBe("explicit")
     expect(msg?.text).toBe("fix the bug")
   })
@@ -168,7 +168,7 @@ describe("resolveEngineLaunchInit", () => {
     // Pins the deletion: these strings coming back means the coda returned,
     // and the user's prompt is once again trailed by English boilerplate.
     const wt = makeWorktree()
-    const msg = resolveEngineLaunchInit(wt, wt, { kind: "new-task", prompt: "修一下这个 bug" }, "task-9").firstMessage
+    const msg = resolveEngineLaunchInit(wt, wt, { kind: "new-task", prompt: "修一下这个 bug" }).firstMessage
     expect(msg?.text).not.toContain("set-branch")
     expect(msg?.text).not.toContain("spawned by Rove task")
     expect(msg?.text).toBe("修一下这个 bug")
@@ -183,39 +183,39 @@ describe("resolveEngineLaunchInit", () => {
 describe("missing-dependency coda (new-task only)", () => {
   test("lockfile present, dependency dir missing, no init script → warns", () => {
     const wt = makeWorktree({ "bun.lock": "{}" })
-    const msg = resolveEngineLaunchInit(wt, wt, { kind: "new-task", prompt: "fix it" }, "task-1").firstMessage
+    const msg = resolveEngineLaunchInit(wt, wt, { kind: "new-task", prompt: "fix it" }).firstMessage
     expect(msg?.text).toContain("no installed dependencies")
     expect(msg?.text).toContain("node_modules")
   })
 
   test("dependency dir already installed → silent", () => {
     const wt = makeWorktree({ "bun.lock": "{}", "node_modules/.keep": "" })
-    const msg = resolveEngineLaunchInit(wt, wt, { kind: "new-task", prompt: "fix it" }, "task-1").firstMessage
+    const msg = resolveEngineLaunchInit(wt, wt, { kind: "new-task", prompt: "fix it" }).firstMessage
     expect(msg?.text).not.toContain("no installed dependencies")
   })
 
   test("no lockfile → silent", () => {
     const wt = makeWorktree()
-    const msg = resolveEngineLaunchInit(wt, wt, { kind: "new-task", prompt: "fix it" }, "task-1").firstMessage
+    const msg = resolveEngineLaunchInit(wt, wt, { kind: "new-task", prompt: "fix it" }).firstMessage
     expect(msg?.text).not.toContain("no installed dependencies")
   })
 
   test("repo init script configured → silent (install is init.sh's job)", () => {
     const wt = makeWorktree({ "bun.lock": "{}", ".rove/init.sh": "bun install" })
-    const msg = resolveEngineLaunchInit(wt, wt, { kind: "new-task", prompt: "fix it" }, "task-1").firstMessage
+    const msg = resolveEngineLaunchInit(wt, wt, { kind: "new-task", prompt: "fix it" }).firstMessage
     expect(msg?.text).not.toContain("no installed dependencies")
   })
 
   test("per-user init-script override also silences it", () => {
     const wt = makeWorktree({ "Cargo.lock": "" })
     setRepoInitOverride(wt, { initScript: "cargo fetch" })
-    const msg = resolveEngineLaunchInit(wt, wt, { kind: "new-task", prompt: "fix it" }, "task-1").firstMessage
+    const msg = resolveEngineLaunchInit(wt, wt, { kind: "new-task", prompt: "fix it" }).firstMessage
     expect(msg?.text).not.toContain("no installed dependencies")
   })
 
   test("non-node ecosystems map to their own dependency dir", () => {
     const wt = makeWorktree({ "Cargo.lock": "" })
-    const msg = resolveEngineLaunchInit(wt, wt, { kind: "new-task", prompt: "fix it" }, "task-1").firstMessage
+    const msg = resolveEngineLaunchInit(wt, wt, { kind: "new-task", prompt: "fix it" }).firstMessage
     expect(msg?.text).toContain("target")
   })
 


### PR DESCRIPTION
Two races on state keyed by **worktree** rather than by tab. All tabs of a task share one worktree (`session-launch.ts:290-292`), so "two tabs, one worktree" is the ordinary case — which is what makes both of these reachable rather than exotic.

## C1 — two engine tabs adopt the same session

`use-tab-lifecycle.ts:57-81` ran every tab's hydration inside one `Promise.all`. Each branch computes `claimedIds(io)` at `:69` but only writes its claim back at `:71`, *after* the `await` — so every tab with no recorded sessionId computed its claim set before any sibling had recorded one, and `pickUnclaimedSessionId` handed them all the same newest id. Two live engines, one transcript.

The store answers per-**worktree**, which is why one task's tabs all see one list. `engine/session-identity.ts:145-152` spells out the invariant this broke:

> Claim-tracking is what makes discovery safe with more than one tab per worktree. […] taking the newest unclaimed one gives the second tab the second-newest session instead of both tabs fighting over one conversation.

The positive control is 60 lines below in the same file: `useTabNaming` (`:131-138`) does the *same* discovery with a sequential `for…of`, recomputing `claimedIds` after each `io.update`. Hydration now matches it. The `engineSessionExists` re-verification stays concurrent — it claims nothing, it only asks whether an id a tab already holds is still on disk.

**BEFORE / AFTER** — the new render test against each version of the file (two kimi tabs, two sessions seeded in one worktree's store):

```
BEFORE (origin/main, Promise.all)   Expected: 2   Received: 1   ← one id, taken twice
AFTER                               2 pass 0 fail
```

**Mutation** — `claimedIds` forced to return an empty set: `Expected: 2, Received: 1`. The assertion is *distinctness*, not which tab won; pinning the winner would pin the store's ordering instead of the invariant.

## C2 / C3 — two tabs run `.rove/init.sh` concurrently

`session-launch.ts:137-146`. The gate is `[ ! -f marker ] || [ "$(cat marker)" != "0" ]`, and the first thing inside it is `rm -f marker` (`:143`) — deliberately, because "absent means init is still going" is the question the paste spawner asks. So for the entire run the marker does not exist, and the marker path (`env.ts:146-149`) is keyed by worktree only.

Two tabs opening before the first init finishes — a fresh fan-out — both pass the test and both run the script. So does **any** worktree whose last init exited non-zero (`:134-136` retries by design). `docs/CONFIGURATION.md:349-350`, `docs/ORCHESTRATION.md:174` and `state/repo-init.ts:19-20` all say init runs *once per worktree*.

C3 rides along: `__kobe_init_env` (`:130`) is one durable per-worktree path that each run `rm -f`s at `:72` and truncates with `>` at `:80`, and the engine sources it at `:112`. Two concurrent runs are two writers and a deleter on one file — the engine can exec with none of init's PATH/venv/API-key exports and no banner saying why, which is the failure `:105-111` exists to fix.

**Fix:** `set -C; : > "$marker.lock"` — noclobber is POSIX sh's atomic create-or-fail, so no `flock` (not every target platform ships it). The winner runs; the loser waits, bounded by the init budget + 5s, and clears a stale lock on the way out so a crashed winner costs one wait rather than a permanent stall.

The loser waits on the **lock**, not on the marker. The winner deletes the marker as its first act, so a loser polling for the marker could still catch the *previous* run's one in the instant before that delete and walk on while init was running. The lock has no such window — it exists from before the marker is deleted until after the new one is written. Because the env dump is written *inside* the run and the marker *after* it, waiting on the marker is also what makes the loser source a complete dump — C3 closed by the same lock.

**BEFORE / AFTER** — two shells racing one generated launch line, identical script both sides (`.scratch/init-race.ts`):

```
BEFORE (origin/main), 3 rounds:        AFTER:
  init.sh runs: 2                        init.sh runs: 1
  init.sh runs: 2                        a: ENGINE_ENV_MARK=53964
  init.sh runs: 2                        b: ENGINE_ENV_MARK=53964
```

Deterministic, not probabilistic — every round.

**Mutation** — lock removed, same suite: `expected 2 to be 1`, and only the new test fails; the 25 existing sequential ones stay green (they pass either way, which is why the test executes two shells instead of asserting on script text).

Honest scope on C3: the double-run is reproduced deterministically. A *corrupted* dump I did not reproduce — its window is the milliseconds between one run's dump write and its marker write. The lock removes the second writer structurally; I am not claiming a measured before/after for the truncation itself.

## C4 — no change needed

`hosted-session-readiness.ts:90-96` breaks on `initMarkerSaysFinished`, i.e. on marker existence. That was wrong while a *sibling* tab's run could write the marker; with C2 there is only ever one run per worktree, and its marker is written after its own dump, so "marker present" now means exactly "this worktree's init finished" — which is what the wait wanted. Left untouched deliberately: zorilla has that file on `fix/api-dispatcher-gaps`.

## C5 — a parameter nothing reads

`repo-init.ts:192,221,226` threaded `taskId` two levels down to `firstMessageFor`, which never uses it. The positive control is in the same file: `worktreePath` has 15 hits including real reads. Dropped, along with the argument at `session-launch.ts:252`.

```
$ grep -n taskId packages/kobe/src/state/repo-init.ts
(no output)
$ grep -c worktreePath packages/kobe/src/state/repo-init.ts
15
```

## Tests

`test:fast` 499 files / 4945 ✓ · `test:socket` 123 files / 962 ✓ · `bun test test/render` 122 files / 519 ✓ · typecheck ✓ · root lint ✓.

The race test lands in `session-launch.test.ts`, which is already on `windows-known-failing.txt` — it drives `/bin/sh` and `sleep`, neither of which the Windows job can run.

## Not screenshotted

C2/C3/C5 are not UI-visible — the evidence is the executed race above.

For C1 I went looking for the harness shot and found the proposed observable does not exist. The suggested symptom was two tabs auto-titling from the same conversation, but a kimi tab never auto-titles at all:

```
kimi   supportsStructuredHistory: false
kimi   deriveTitleFromSessionId : ""
claude supportsStructuredHistory: true    <- positive control
```

`kimi-local/history.ts:1-6` says why: its wire format is a protocol stream Rove deliberately does not parse, so `readHistory` is empty and `deriveTitleFromSessionId` returns `""` for every kimi session. Both tabs render the placeholder either way — identical before and after, and not because the bug is absent.

The symptom that IS real is that both tabs resume one conversation. Capturing that on screen needs two genuine kimi sessions, and kimi on this machine cannot make them:

```
$ /Users/jacksonc/.kimi-code/bin/kimi --version
0.40.1
$ kimi -p "reply with exactly: PROBE_OK"
kimi version 0.40.1
error: failed to run prompt: internal: The provided authorization grant is invalid
```

The binary is installed and runs — it is the authorization that is dead, so no session can be created to photograph.

So the closest thing to the screen, and what I have instead: the actual launch commands, produced by the real discovery against a real on-disk kimi session store (two sessions, one worktree) and the real `engineResumeArgv`:

```
BEFORE (origin/main, Promise.all)      AFTER (this PR, sequential)
  tab-1 launches: kimi -S session_newer   tab-1 launches: kimi -S session_newer
  tab-2 launches: kimi -S session_newer   tab-2 launches: kimi -S session_older
  => BOTH TABS RESUME ONE CONVERSATION    => each tab resumes its own
```

`kimi -S <id>` is kimi's real resume verb (`engineResumeArgv(["kimi"], "kimi", id)`), so those are the two commands two live engines would be started with.

Probes, both runnable: `packages/kobe/.scratch/c1-resume-argv.ts` (the table above; takes `concurrent` or `sequential`) and `packages/kobe/.scratch/init-race.ts` (the C2 race). The committed evidence is `test/render/tab-session-discovery.test.tsx` — real hook, real on-disk kimi store — which is red against `origin/main`'s file and green against this one.
