### PR TITLE
Atomic pidfile writes, and one owner for the owner-only file modes

### DIFF
--- a/.changeset/drop-web-exposure-metadata.md
+++ b/.changeset/drop-web-exposure-metadata.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Delete the last prose describing the web-RPC allowset. The `web` registry field and its derivation are already gone; four comments still called the allowlist a live security contract, and one told the next author which flag to flip to extend it. Nothing they describe exists.

--- a/.changeset/one-owner-for-owner-only-modes.md
+++ b/.changeset/one-owner-for-owner-only-modes.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+The owner-only file modes have one owner again. `web-token.ts` and `pty-freeze-store.ts` each kept a private `0o700`/`0o600` pair plus their own copy of the "mkdir's mode is a no-op on an existing path" reasoning, because `owner-only.ts` offered only async tighteners and both of them run synchronously; it now offers sync twins. Nine more bare octals became the named constants, and two exports whose only remaining line was their own declaration are gone.

--- a/.changeset/one-process-liveness-owner.md
+++ b/.changeset/one-process-liveness-owner.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Stop producing the torn pidfile that made `isProcessAlive`'s pid-`0` guard necessary. Both the daemon's and the PTY host's pidfiles were written with a plain `writeFile`, which truncates before it writes, so an interrupted write left an EMPTY file — and `Number("")` is `0`, the pid `kill` reads as the caller's own process group. They now go through tmp+rename like every other file-backed store in the daemon, `readPidFile` refuses any implausible pid instead of passing it on, and `stopDaemonProcess` has coverage proving it signals nothing for a torn pidfile.

--- a/packages/kobe-daemon/src/compat-env.ts
+++ b/packages/kobe-daemon/src/compat-env.ts
@@ -26,8 +26,6 @@ export const LEGACY_KOBE_CONFIG_DIR_BASENAME = "kobe" as const
 
 /** @deprecated Legacy runtime/plugin layout; prefer an explicit canonical or legacy constant. */
 export const COMPAT_STATE_DIR_BASENAME = ".kobe" as const
-/** @deprecated Legacy config layout; canonical product data uses `rove`. */
-export const COMPAT_CONFIG_DIR_BASENAME = "kobe" as const
 
 export function legacyKobeEnvKey(roveKey: string): string | undefined {
   if (!roveKey.startsWith(ROVE_ENV_PREFIX)) return undefined

--- a/packages/kobe-daemon/src/daemon/agent-turns-store.ts
+++ b/packages/kobe-daemon/src/daemon/agent-turns-store.ts
@@ -20,6 +20,7 @@ import { ROVE_STATE_DIR_BASENAME, readRoveHomeDirEnv } from "../compat-env.ts"
 import type { AgentTurnRecord } from "./contracts.ts"
 import { logDaemonError } from "./crash-log.ts"
 import { serialized, writeJsonAtomic } from "./json-file.ts"
+import { OWNER_ONLY_FILE_MODE } from "./owner-only.ts"
 
 interface AgentTurnsFile {
   readonly version: 1
@@ -164,7 +165,7 @@ export class AgentTurnsStore {
     try {
       // 0600: no credentials here, but the records do name every repo you work
       // in and when — defense in depth, and free.
-      await writeJsonAtomic(this.path, body, { mode: 0o600, compact: true })
+      await writeJsonAtomic(this.path, body, { mode: OWNER_ONLY_FILE_MODE, compact: true })
     } catch (err) {
       logDaemonError("agent-turns-write", err)
     }

--- a/packages/kobe-daemon/src/daemon/handlers-pr.ts
+++ b/packages/kobe-daemon/src/daemon/handlers-pr.ts
@@ -6,9 +6,6 @@
  * `handlers-worktree.ts` — the registry is grouped by RPC-name prefix — and
  * because the work itself (two `gh` spawns) lives in `pr-failing-checks.ts`,
  * leaving only the task lookup here.
- *
- * Not web-exposed: it shells `gh` in a worktree on this machine, and the web
- * allowlist is a security contract, not a convenience list.
  */
 
 import { requireString } from "./handler-validators.ts"

--- a/packages/kobe-daemon/src/daemon/handlers-task.ts
+++ b/packages/kobe-daemon/src/daemon/handlers-task.ts
@@ -87,11 +87,6 @@ export const TASK_HANDLERS: readonly DaemonRequestHandler[] = [
   },
   {
     name: "task.observeLanguage",
-    // NOT web-exposed: the only callers are Rove's own creation paths (CLI
-    // add, daemon automation/work-item start), which reach the daemon over
-    // the socket. The browser has no reason to write another task's
-    // observed language, and the web allowlist is a security contract —
-    // adding to it should be a deliberate act, not a reflex.
     async handle(payload, ctx) {
       // Observation, not configuration: the caller hands over the user's own
       // prompt text and the orchestrator decides what (if anything) it says
@@ -352,12 +347,12 @@ export const TASK_HANDLERS: readonly DaemonRequestHandler[] = [
     },
   },
   {
-    // NOT web-exposed. Two writers, both on a path where the prompt is already
-    // on its way to an engine: the CLI `add` path records the brief AFTER
-    // delivery confirms, and the TUI's "Run again" copies a task's existing
-    // brief onto the fork it just created for it. The field means "this is the
-    // prompt the engine was given" in both cases — an agent reading `get-task`
-    // never sees a brief that was merely composed.
+    // Two writers, both on a path where the prompt is already on its way to
+    // an engine: the CLI `add` path records the brief AFTER delivery
+    // confirms, and the TUI's "Run again" copies a task's existing brief onto
+    // the fork it just created for it. The field means "this is the prompt
+    // the engine was given" in both cases — an agent reading `get-task` never
+    // sees a brief that was merely composed.
     name: "task.setPrompt",
     async handle(payload, ctx) {
       const taskId = requireString(payload, "taskId")

--- a/packages/kobe-daemon/src/daemon/home-owner.ts
+++ b/packages/kobe-daemon/src/daemon/home-owner.ts
@@ -4,7 +4,7 @@ import { join } from "node:path"
 import { type DaemonSocketState, probeDaemonSocket } from "../client/daemon-process.ts"
 import { ROVE_STATE_DIR_BASENAME } from "../compat-env.ts"
 import { isProcessAlive } from "./lifecycle.ts"
-import { ensureOwnerOnlyStateDir } from "./owner-only.ts"
+import { OWNER_ONLY_FILE_MODE, ensureOwnerOnlyStateDir } from "./owner-only.ts"
 
 export interface HomeOwnerClaim {
   readonly pid: number
@@ -97,7 +97,7 @@ export async function acquireHomeClaim(options: {
       throw new Error(`rove daemon: another daemon is already serving ${socketPath}; refusing to replace it`)
     }
     const staging = `${path}.${process.pid}.tmp`
-    await writeFile(staging, `${process.pid}:${socketPath}\n`, { encoding: "utf8", mode: 0o600 })
+    await writeFile(staging, `${process.pid}:${socketPath}\n`, { encoding: "utf8", mode: OWNER_ONLY_FILE_MODE })
     await rename(staging, path)
   } catch (err) {
     database.close()

--- a/packages/kobe-daemon/src/daemon/json-file.ts
+++ b/packages/kobe-daemon/src/daemon/json-file.ts
@@ -24,16 +24,30 @@ export interface WriteJsonAtomicOptions {
   compact?: boolean
 }
 
+/**
+ * The tmp+rename on its own, for the runtime files that are not JSON: the
+ * daemon and PTY-host pidfiles.
+ *
+ * `writeFile` truncates before it writes, so an interrupted write leaves an
+ * EMPTY file — and an empty pidfile is not merely unreadable, it parses as
+ * pid `0`, which `kill` reads as the caller's own process group. Every other
+ * file-backed store here already renames into place; the pidfile was the
+ * exception, and the one whose torn state is dangerous rather than annoying.
+ */
+export async function writeTextAtomic(path: string, text: string, mode?: number): Promise<void> {
+  await mkdir(dirname(path), { recursive: true })
+  const tmp = `${path}.tmp-${process.pid}-${randomUUID()}`
+  await writeFile(tmp, text, { encoding: "utf8", mode })
+  await rename(tmp, path)
+}
+
 export async function writeJsonAtomic(
   path: string,
   body: unknown,
   { mode, compact = false }: WriteJsonAtomicOptions = {},
 ): Promise<void> {
-  await mkdir(dirname(path), { recursive: true })
-  const tmp = `${path}.tmp-${process.pid}-${randomUUID()}`
   const text = compact ? JSON.stringify(body) : JSON.stringify(body, null, 2)
-  await writeFile(tmp, `${text}\n`, { encoding: "utf8", mode })
-  await rename(tmp, path)
+  await writeTextAtomic(path, `${text}\n`, mode)
 }
 
 const locks = new Map<string, Promise<unknown>>()

--- a/packages/kobe-daemon/src/daemon/owner-only.ts
+++ b/packages/kobe-daemon/src/daemon/owner-only.ts
@@ -24,6 +24,7 @@
  * daemon that will not start.
  */
 
+import { chmodSync } from "node:fs"
 import { chmod, mkdir } from "node:fs/promises"
 import { join } from "node:path"
 import { ROVE_STATE_DIR_BASENAME } from "../compat-env.ts"
@@ -50,6 +51,30 @@ export function tightenDirPermissions(dir: string): Promise<void> {
 /** Re-`chmod` an existing file to 0600. Safe on an absent path. */
 export function tightenFilePermissions(file: string): Promise<void> {
   return tighten(file, OWNER_ONLY_FILE_MODE)
+}
+
+/**
+ * Sync twins, for the two modules that must tighten on a synchronous path:
+ * the token minter (`web-token.ts`) and the freeze-record store
+ * (`pty-freeze-store.ts`). Same swallow-everything contract as above —
+ * having only the async form is what made both of them fork these modes and
+ * re-explain the `mkdirSync`-mode-is-a-no-op reasoning in the header.
+ */
+export function tightenDirPermissionsSync(dir: string): void {
+  try {
+    chmodSync(dir, OWNER_ONLY_DIR_MODE)
+  } catch {
+    /* absent, not ours, or a filesystem without modes */
+  }
+}
+
+/** Re-`chmod` an existing file to 0600, synchronously. Safe on an absent path. */
+export function tightenFilePermissionsSync(file: string): void {
+  try {
+    chmodSync(file, OWNER_ONLY_FILE_MODE)
+  } catch {
+    /* absent, not ours, or a filesystem without modes */
+  }
 }
 
 /**

--- a/packages/kobe-daemon/src/daemon/protocol.ts
+++ b/packages/kobe-daemon/src/daemon/protocol.ts
@@ -106,8 +106,6 @@ export type DaemonRequestName =
   // Record the task brief on the task row AFTER the prompt was confirmed
   // delivered into the engine — the engine's own transcript is not durable,
   // and this field is the copy that survives a dead engine/context loss.
-  // Deliberately NOT web-exposed: the browser has no reason to write another
-  // task's brief, and the web allowlist is a security contract.
   | "task.setPrompt"
   | "task.ensureMain"
   // Open an existing directory as a standalone `kind:"dir"` task (`kobe .`).

--- a/packages/kobe-daemon/src/daemon/pty-exit-store.ts
+++ b/packages/kobe-daemon/src/daemon/pty-exit-store.ts
@@ -26,6 +26,7 @@
 import { randomUUID } from "node:crypto"
 import { mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs"
 import { dirname } from "node:path"
+import { OWNER_ONLY_FILE_MODE } from "./owner-only.ts"
 import { defaultPtyExitsPath } from "./paths.ts"
 import type { PtySessionEndInfo } from "./pty-observability.ts"
 import { stripTerminalControls, terminalRows } from "./terminal-rows.ts"
@@ -299,6 +300,9 @@ function writeRecord(storeKey: string, record: PtyExitRecord, path: string): voi
   const tmp = `${path}.tmp-${process.pid}-${randomUUID()}`
   // 0600: every record carries `plainTail` — the dying process's last output,
   // same class of content as the scrollback in pty-freeze-store.
-  writeFileSync(tmp, JSON.stringify(Object.fromEntries(newest), null, 2), { encoding: "utf8", mode: 0o600 })
+  writeFileSync(tmp, JSON.stringify(Object.fromEntries(newest), null, 2), {
+    encoding: "utf8",
+    mode: OWNER_ONLY_FILE_MODE,
+  })
   renameSync(tmp, path)
 }

--- a/packages/kobe-daemon/src/daemon/pty-freeze-store.ts
+++ b/packages/kobe-daemon/src/daemon/pty-freeze-store.ts
@@ -31,6 +31,12 @@ import { randomUUID } from "node:crypto"
 import { chmodSync, mkdirSync, readFileSync, readdirSync, renameSync, rmSync, statSync, writeFileSync } from "node:fs"
 import { join } from "node:path"
 import { StringDecoder } from "node:string_decoder"
+import {
+  OWNER_ONLY_DIR_MODE,
+  OWNER_ONLY_FILE_MODE,
+  tightenDirPermissionsSync,
+  tightenFilePermissionsSync,
+} from "./owner-only.ts"
 import { defaultPtyFreezeDir } from "./paths.ts"
 import type { PtySessionExit } from "./protocol.ts"
 import type { PtySessionState } from "./pty-host-types.ts"
@@ -300,32 +306,16 @@ export function loadFrozenSessions(
   return kept
 }
 
-/** Owner-only. See {@link tightenExistingPermissions} for why the mode
- *  arguments on mkdir/write are not enough on their own. */
-const DIR_MODE = 0o700
-const FILE_MODE = 0o600
-
 /**
  * Re-`chmod` the freeze directory and every record already in it.
  *
- * The `mode` options on `mkdirSync` / `writeFileSync` apply ONLY when the
- * path is created — for a path that already exists they are a silent no-op.
- * So an install whose freeze directory was created with a laxer umask keeps
- * its 0755 directory and its 0644 records forever: the directory stays
- * traversable by every local user, and any session not re-frozen since keeps
- * world-readable scrollback. Closing that takes a remediation pass over the
- * existing paths, not just correct modes on files created from here on.
- *
- * Best-effort and idempotent, like every other write in this module: a
- * chmod that fails (foreign owner, read-only mount) must never take the
- * terminal down.
+ * The SWEEP is what is specific to this module — a record not re-frozen
+ * since the laxer-umask days keeps world-readable scrollback, so the repair
+ * has to walk what is already on disk. Why a repair pass is needed at all is
+ * the shared reasoning in `owner-only.ts`.
  */
 export function tightenExistingPermissions(dir: string): void {
-  try {
-    chmodSync(dir, DIR_MODE)
-  } catch {
-    /* absent, or not ours to chmod — the mkdir below still creates it 0700 */
-  }
+  tightenDirPermissionsSync(dir)
   let names: string[]
   try {
     names = readdirSync(dir)
@@ -333,12 +323,7 @@ export function tightenExistingPermissions(dir: string): void {
     return // no directory yet: nothing pre-existing to tighten
   }
   for (const name of names) {
-    if (!name.endsWith(".json")) continue
-    try {
-      chmodSync(join(dir, name), FILE_MODE)
-    } catch {
-      /* one stubborn file must not cost the rest */
-    }
+    if (name.endsWith(".json")) tightenFilePermissionsSync(join(dir, name))
   }
 }
 
@@ -354,10 +339,10 @@ export function fileFreezeSink(dir = defaultPtyFreezeDir()): PtyFreezeSink {
         // 0700/0600: `ringB64` is the session's whole scrollback, so this file
         // holds every byte the agent printed — `env` output, `cat`ed credential
         // files, a git remote carrying a PAT. Owner-only, like a private key.
-        mkdirSync(dir, { recursive: true, mode: DIR_MODE })
+        mkdirSync(dir, { recursive: true, mode: OWNER_ONLY_DIR_MODE })
         const target = recordFile(dir, record.key)
         const staging = `${target}.${process.pid}.tmp`
-        writeFileSync(staging, JSON.stringify(record), { encoding: "utf8", mode: FILE_MODE })
+        writeFileSync(staging, JSON.stringify(record), { encoding: "utf8", mode: OWNER_ONLY_FILE_MODE })
         renameSync(staging, target)
       } catch {
         /* best-effort by contract — a freeze hiccup never kills the terminal */

--- a/packages/kobe-daemon/src/daemon/pty-server.ts
+++ b/packages/kobe-daemon/src/daemon/pty-server.ts
@@ -22,13 +22,14 @@
  */
 
 import { readFileSync } from "node:fs"
-import { mkdir, unlink, writeFile } from "node:fs/promises"
+import { mkdir, unlink } from "node:fs/promises"
 import { type Server, type Socket, createServer } from "node:net"
 import { dirname } from "node:path"
 import { ClientWriter } from "./client-writer.ts"
 import { linkLegacyRuntimePath } from "./compat-link.ts"
 import { logDaemonError } from "./crash-log.ts"
 import { objectPayload, requireString } from "./handler-validators.ts"
+import { writeTextAtomic } from "./json-file.ts"
 import { LineReceiver } from "./line-receiver.ts"
 import { ensureOwnerOnlyStateDir } from "./owner-only.ts"
 import {
@@ -458,7 +459,8 @@ export async function startPtyHostServer(options: PtyHostServerOptions = {}): Pr
   // same post-listen chmod — `listen()` applies the umask, so an unchmod'd
   // node lands world-connectable.
   await listenOnUnixSocket(server, socketPath)
-  await writeFile(pidPath, `${process.pid}\n`, "utf8")
+  // tmp+rename: a torn pidfile is EMPTY, and empty parses as pid 0.
+  await writeTextAtomic(pidPath, `${process.pid}\n`)
   // Same reason as the daemon's: a pre-rename TUI that can't see this host
   // starts a SECOND one, and the engine tabs split across the pair.
   if (!pipeSocket) {

--- a/packages/kobe-daemon/src/daemon/server.ts
+++ b/packages/kobe-daemon/src/daemon/server.ts
@@ -4,7 +4,7 @@
  * surface: hello / daemon.status / daemon.stop + handlers.ts + subscribe.
  */
 
-import { mkdir, unlink, writeFile } from "node:fs/promises"
+import { mkdir, unlink } from "node:fs/promises"
 import { type Server, createServer } from "node:net"
 import { dirname } from "node:path"
 import { ptyHostHasLiveSessions, sweepPtyHostSessions } from "../client/pty-process.ts"
@@ -27,6 +27,7 @@ import {
 } from "./handlers.ts"
 import { acquireHomeClaim } from "./home-owner.ts"
 import { IssuesStore, defaultIssuesStorePath } from "./issues-store.ts"
+import { writeTextAtomic } from "./json-file.ts"
 import { DaemonLifetime, FIRST_GUI_GRACE_MS, resolveIdleGraceMs } from "./lifetime.ts"
 import { LineReceiver } from "./line-receiver.ts"
 import { NotesStore, defaultNotesStorePath } from "./notes-store.ts"
@@ -441,7 +442,8 @@ async function startOwnedServer(
   // arm is a window in which a usurper can unlink+rebind the path; arming
   // late meant either no stamp at all or a stamp of the usurper's inode.
   await sockGuard.arm()
-  await writeFile(pidPath, `${process.pid}\n`, "utf8")
+  // tmp+rename: a torn pidfile is EMPTY, and empty parses as pid 0.
+  await writeTextAtomic(pidPath, `${process.pid}\n`)
   // A pre-rename binary only knows `.kobe`; without these it starts a second
   // daemon on the same task index. See compat-link.ts.
   await linkLegacyRuntimePath(socketPath, legacyDaemonSocketPath(homeDir))

--- a/packages/kobe-daemon/src/daemon/socket-guard.ts
+++ b/packages/kobe-daemon/src/daemon/socket-guard.ts
@@ -93,11 +93,24 @@ export function isProcessAlive(pid: number): boolean {
   }
 }
 
+/**
+ * The pid in `pidPath`, or `null` when the file cannot be trusted.
+ *
+ * `Number("")` is `0`, so a pidfile truncated mid-write parses as pid `0` —
+ * the value {@link isProcessAlive} guards against precisely because
+ * `kill(0, …)` targets the caller's own process group. This is the second
+ * layer: the predicate stops the signal, and this stops the bad pid from
+ * being carried any further, so a torn pidfile reads as "no pidfile" rather
+ * than as pid `0` in `stopDaemonProcess`'s reported result.
+ *
+ * Neither layer is the root fix. That is writing the file with tmp+rename
+ * (see `writeTextAtomic`) so a torn pidfile stops being produced at all.
+ */
 export async function readPidFile(pidPath: string): Promise<number | null> {
   try {
     const raw = await readFile(pidPath, "utf8")
     const pid = Number(raw.trim())
-    return Number.isFinite(pid) ? pid : null
+    return Number.isInteger(pid) && pid > 1 ? pid : null
   } catch {
     return null
   }

--- a/packages/kobe-daemon/src/daemon/socket-guard.ts
+++ b/packages/kobe-daemon/src/daemon/socket-guard.ts
@@ -63,10 +63,6 @@ export async function listenOnUnixSocket(server: Server, socketPath: string): Pr
   if (!isWindowsPipePath(socketPath)) await tightenFilePermissions(socketPath)
 }
 
-/** The mode a bound socket is left at — exported so a test can assert the
- *  intent rather than restate the octal. */
-export const SOCKET_MODE = OWNER_ONLY_FILE_MODE
-
 /**
  * Whether a process exists. `process.kill(pid, 0)` sends no signal — it only
  * runs the permission/existence check — so it answers in three ways:

--- a/packages/kobe-daemon/src/daemon/web-token.ts
+++ b/packages/kobe-daemon/src/daemon/web-token.ts
@@ -22,13 +22,14 @@
  */
 
 import { randomBytes } from "node:crypto"
-import { chmodSync, existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs"
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs"
 import { dirname } from "node:path"
-
-/** Owner-only, for the same reason `pty-freeze-store.ts` is: this file is a
- *  credential, and the mode arguments below only bind at creation time. */
-const DIR_MODE = 0o700
-const FILE_MODE = 0o600
+import {
+  OWNER_ONLY_DIR_MODE,
+  OWNER_ONLY_FILE_MODE,
+  tightenDirPermissionsSync,
+  tightenFilePermissionsSync,
+} from "./owner-only.ts"
 
 /** 32 bytes ≈ 256 bits, base64url so it survives a header and a query string. */
 function mintToken(): string {
@@ -38,28 +39,14 @@ function mintToken(): string {
 /**
  * Re-`chmod` an existing token file and its directory.
  *
- * `mkdirSync`/`writeFileSync`'s `mode` option applies ONLY when the path is
- * created — for a path that already exists it is a silent no-op. An install
- * whose `.rove` directory predates this module keeps its 0755 mode, and a
- * token file written by a build without the mode argument keeps 0644, leaving
- * the credential world-readable forever. Remediating only on creation would
- * therefore fix every install except the ones that are actually exposed.
- *
- * Best-effort: a chmod that fails (foreign owner, read-only mount) must not
- * take the web transport down — the token still works, it is just not as
- * tight as we would like.
+ * The dir+file PAIR is what is specific to this module; why a repair pass is
+ * needed at all (mkdir/write modes bind only at creation, so the loose
+ * installs are exactly the ones creation-time modes cannot reach) is the
+ * shared reasoning in `owner-only.ts`.
  */
 export function tightenTokenPermissions(file: string): void {
-  try {
-    chmodSync(dirname(file), DIR_MODE)
-  } catch {
-    /* absent, or not ours — the mkdir below still creates it 0700 */
-  }
-  try {
-    chmodSync(file, FILE_MODE)
-  } catch {
-    /* absent, or not ours to chmod */
-  }
+  tightenDirPermissionsSync(dirname(file))
+  tightenFilePermissionsSync(file)
 }
 
 /**
@@ -80,9 +67,9 @@ export function ensureWebToken(file: string): string {
     }
   }
   const token = mintToken()
-  mkdirSync(dirname(file), { recursive: true, mode: DIR_MODE })
+  mkdirSync(dirname(file), { recursive: true, mode: OWNER_ONLY_DIR_MODE })
   const staging = `${file}.${process.pid}.tmp`
-  writeFileSync(staging, token, { encoding: "utf8", mode: FILE_MODE })
+  writeFileSync(staging, token, { encoding: "utf8", mode: OWNER_ONLY_FILE_MODE })
   renameSync(staging, file)
   tightenTokenPermissions(file)
   return token

--- a/packages/kobe-daemon/src/plugins/hook-run.ts
+++ b/packages/kobe-daemon/src/plugins/hook-run.ts
@@ -23,6 +23,7 @@
 import { spawn } from "node:child_process"
 import { appendFileSync, mkdirSync } from "node:fs"
 import { rotateLogIfNeeded } from "../daemon/log-rotate.ts"
+import { OWNER_ONLY_DIR_MODE, OWNER_ONLY_FILE_MODE } from "../daemon/owner-only.ts"
 import { buildPluginEnv } from "./env.ts"
 import type { PluginCommandSpec } from "./manifest.ts"
 import { pluginConfigDir, pluginLogPath, pluginStateDir } from "./plugin-paths.ts"
@@ -81,7 +82,7 @@ function appendRecord(pluginId: string, homeDir: string | undefined, record: Rec
     // that prints its own token on failure writes it here — 0600, and
     // capped like daemon.log so a per-tool-call hook can't fill the disk.
     rotateLogIfNeeded(logPath, PLUGIN_LOG_CAP_BYTES)
-    appendFileSync(logPath, `${JSON.stringify(record)}\n`, { mode: 0o600 })
+    appendFileSync(logPath, `${JSON.stringify(record)}\n`, { mode: OWNER_ONLY_FILE_MODE })
   } catch {
     // Log write failure must never take the daemon down.
   }
@@ -103,8 +104,8 @@ export async function runPluginHook(opts: HookRunOptions): Promise<void> {
   // honour the ROVE_PLUGIN_*_DIR contract, so record the failure and skip the
   // spawn rather than launching a hook into a broken environment.
   try {
-    mkdirSync(pluginConfigDir(pluginId, homeDir), { recursive: true, mode: 0o700 })
-    mkdirSync(pluginStateDir(pluginId, homeDir), { recursive: true, mode: 0o700 })
+    mkdirSync(pluginConfigDir(pluginId, homeDir), { recursive: true, mode: OWNER_ONLY_DIR_MODE })
+    mkdirSync(pluginStateDir(pluginId, homeDir), { recursive: true, mode: OWNER_ONLY_DIR_MODE })
   } catch (err) {
     appendRecord(pluginId, homeDir, {
       at: startedAt,

--- a/packages/kobe-daemon/src/plugins/registry.ts
+++ b/packages/kobe-daemon/src/plugins/registry.ts
@@ -8,6 +8,7 @@
 
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs"
 import { dirname, join, relative } from "node:path"
+import { OWNER_ONLY_FILE_MODE } from "../daemon/owner-only.ts"
 import { legacyPluginsRootDir, pluginRegistryPath, pluginsRootDir } from "./plugin-paths.ts"
 
 export interface PluginRegistryEntry {
@@ -83,7 +84,7 @@ export function savePluginRegistry(registry: PluginRegistry, homeDir?: string): 
   const path = pluginRegistryPath(homeDir)
   mkdirSync(dirname(path), { recursive: true })
   // 0600: the registry names every installed plugin and its checkout path.
-  writeFileSync(path, `${JSON.stringify(registry, null, 2)}\n`, { mode: 0o600 })
+  writeFileSync(path, `${JSON.stringify(registry, null, 2)}\n`, { mode: OWNER_ONLY_FILE_MODE })
 }
 
 /** Insert or replace the entry with the same id. */

--- a/packages/kobe-daemon/src/plugins/settings-env.ts
+++ b/packages/kobe-daemon/src/plugins/settings-env.ts
@@ -7,6 +7,7 @@
 
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs"
 import { join } from "node:path"
+import { OWNER_ONLY_DIR_MODE, OWNER_ONLY_FILE_MODE } from "../daemon/owner-only.ts"
 import { type PluginManifest, qualifiedActionId, readPluginManifest } from "./manifest.ts"
 import { tightenPluginPermissions } from "./permissions.ts"
 import { pluginConfigDir } from "./plugin-paths.ts"
@@ -79,8 +80,8 @@ export function writePluginSettings(pluginId: string, values: Record<string, str
   // `mode` arguments only cover a FRESH path — this is a rewrite-in-place, so
   // an existing 0644 .env keeps 0644 through every save. Hence the repair
   // afterwards, which is what actually closes an old install.
-  mkdirSync(pluginConfigDir(pluginId, homeDir), { recursive: true, mode: 0o700 })
-  writeFileSync(path, next.length > 0 ? `${next.join("\n")}\n` : "", { mode: 0o600 })
+  mkdirSync(pluginConfigDir(pluginId, homeDir), { recursive: true, mode: OWNER_ONLY_DIR_MODE })
+  writeFileSync(path, next.length > 0 ? `${next.join("\n")}\n` : "", { mode: OWNER_ONLY_FILE_MODE })
   tightenPluginPermissions(pluginId, homeDir)
 }
 

--- a/packages/kobe/test/daemon/lifecycle.test.ts
+++ b/packages/kobe/test/daemon/lifecycle.test.ts
@@ -3,7 +3,7 @@ import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { stopDaemonProcess } from "@sma1lboy/kobe-daemon/daemon/lifecycle"
-import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 type EventedChild = {
   readonly pid?: number
@@ -73,5 +73,64 @@ describe("stopDaemonProcess", () => {
     const result = await stopDaemonProcess(socketPath, pidPath)
     expect(result.pid).toBeNull()
     expect(result.method).toBe("absent")
+  })
+
+  /**
+   * An untrustworthy pidfile is not a pid.
+   *
+   * `Number("")` is `0`, so a pidfile truncated mid-write parses as `0` —
+   * the value `kill` reads as the caller's own process group. Two separate
+   * things are pinned here, and only one of them is this file's guard:
+   *
+   * - `pid: null` is what `readPidFile`'s range check adds. Without it the
+   *   result reports pid `0` as the daemon that was found.
+   * - `kill` never being called is currently owned by `isProcessAlive`,
+   *   which refuses `<= 0` before any signal goes out. The assertion is here
+   *   anyway because it is the property that actually matters, and it should
+   *   fail if EITHER layer regresses — not only the one below it.
+   */
+  it.each(["", " ", "0", "-1", "1.5", "abc"])("never signals for a pidfile of %j", async (body) => {
+    writeFileSync(pidPath, body)
+    const kill = vi.spyOn(process, "kill")
+    try {
+      const result = await stopDaemonProcess(socketPath, pidPath)
+      expect(result).toEqual({ pid: null, method: "absent" })
+      expect(kill).not.toHaveBeenCalled()
+    } finally {
+      kill.mockRestore()
+    }
+  })
+
+  /**
+   * Negative control for the guard above: a real pid still goes through.
+   *
+   * Without this, a guard that rejected everything would pass every
+   * assertion in this file — each daemon would silently read as "absent",
+   * and `daemon restart` would leave the old one running and race the new
+   * one onto its socket. The child is killed ~100ms in, well inside the 2s
+   * before `stopDaemonProcess` escalates, so the graceful path is what gets
+   * recorded.
+   */
+  it("still stops a daemon whose pidfile holds a live pid", async () => {
+    const child = spawn("sleep", ["30"], { stdio: "ignore" }) as unknown as EventedChild
+    const livePid = child.pid as number
+    writeFileSync(pidPath, `${livePid}\n`)
+
+    const kill = vi.spyOn(process, "kill")
+    try {
+      const stopping = stopDaemonProcess(socketPath, pidPath)
+      setTimeout(() => child.kill("SIGKILL"), 100)
+      const result = await stopping
+
+      expect(result.pid).toBe(livePid)
+      expect(result.method).toBe("graceful")
+      // Positive control for the spy in the case above: a real pid DOES
+      // reach `process.kill` (the liveness probe at minimum), so "never
+      // called" there is a fact about the guards, not about a spy that
+      // never fires. Assert before `mockRestore`, which clears the history.
+      expect(kill).toHaveBeenCalled()
+    } finally {
+      kill.mockRestore()
+    }
   })
 })


### PR DESCRIPTION
Three daemon-side cleanups: one comment-only deletion, one correctness fix on the pidfile write path, and one dedupe of the owner-only file modes. One commit each.

Rebased twice while in flight — `#951`/`#95x` landed a large part of what this branch originally carried, so bundles 1 and 2 are narrower than they started. What upstream took over is called out below rather than re-claimed.

---

## 1. `chore:` delete the last prose describing the web-RPC allowset

The `web?: boolean` registry field, `webExposedRpcNames`, all 21 `web: true` entries and the three dead `kobe-daemon` exports **were removed upstream while this branch was open**. What survived is the prose: three modules still explain why a verb is "NOT web-exposed" and call the allowlist a live security contract, and one told the next author which flag to flip to extend it.

**Before (on my original base) — candidate vs control:**

```
$ grep -rn 'webExposedRpcNames' packages --include='*.ts'
packages/kobe-daemon/src/daemon/handlers.ts:170:   * {@link webExposedRpcNames}), so a new verb is not browser-reachable
packages/kobe-daemon/src/daemon/handlers.ts:188:export function webExposedRpcNames(
                       # 2 hits, both inside the file that declares it

$ grep -rn 'blockingRpcNames' packages --include='*.ts'        # CONTROL — the sibling mechanism
packages/kobe-daemon/src/daemon/handlers.ts:197:export function blockingRpcNames(
packages/kobe-daemon/src/daemon/server.ts:56:  blockingRpcNames,
packages/kobe/test/daemon/rpc-deadline.test.ts:2:import { blockingRpcNames, createDaemonHandlerRegistry } from ...
packages/kobe/test/daemon/rpc-deadline.test.ts:47:    expect([...blockingRpcNames(createDaemonHandlerRegistry())]...
                       # 4 hits across 3 files — a real reader and a real assertion
```

`blocking` / `blockingRpcNames` are untouched, and `test/daemon/rpc-deadline.test.ts` still passes.

**After:** `grep -rn 'web: true\|webExposedRpcNames\|web?: boolean' packages --include='*.ts'` → no matches. Exports resolve 90/90.

---

## 2. `fix:` write both pidfiles atomically, and stop passing on an untrusted pid

**Upstream already landed the guarded `isProcessAlive`** (one owner in `socket-guard.ts`, `<= 0` refused, non-ESRCH counted as alive), so the pid-`0`-kills-your-own-process-group path is closed. It closed it at the *reader*. This closes it at the *writer*, which is where it comes from:

`server.ts` and `pty-server.ts` wrote their pidfiles with a bare `writeFile`, which truncates before it writes. An interrupted write leaves an **empty** file, and `Number("")` is `0` — the pid `kill` reads as the caller's own process group. Every other file-backed store in the daemon already renames into place; the pidfile was the exception, and the one whose torn state is dangerous rather than annoying. `writeJsonAtomic`'s tmp+rename is now factored out as `writeTextAtomic` and both pidfiles go through it.

`readPidFile` additionally refuses an implausible pid instead of reporting it. **This is a second layer, not the fix** — see the mutation result below.

**Boundary table (current predicate — upstream's, unchanged by this PR):**

| pid | alive |
|---|---|
| `0` | false |
| `-1` | false |
| `NaN` | false |
| `1.5` | false |
| `999999` (unused high) | false |
| `1` (init, EPERM) | **true** |
| `process.pid` | true |

**`readPidFile` after this PR:**

```
""      => null      "0"    => null      "1.5"  => null      "<real pid>" => <real pid>
" "     => null      "-1"   => null      "abc"  => null
```

**Mutation — revert the `readPidFile` guard only:**

```
× stopDaemonProcess > never signals for a pidfile of ""     × ... of "-1"
× ... of " "        × ... of "0"                            × ... of "1.5"
      Tests  5 failed | 6 passed (11)
```

The failing assertion is worth reading precisely, because it is what stops this PR overclaiming:

```
AssertionError: expected { pid: +0, method: 'absent' } to deeply equal { pid: null, method: 'absent' }
```

`method` stays `absent` and `process.kill` is **still never called** — upstream's predicate already refuses `0`. So the guard's contribution is that a torn pidfile stops being reported as "the daemon I found, pid 0". The `expect(kill).not.toHaveBeenCalled()` assertion is kept anyway as a regression guard on the invariant that actually matters, so it fails if *either* layer regresses; the test comment says exactly this rather than implying the spy is what catches the bug. That spy has a **positive control** in the live-pid case (`expect(kill).toHaveBeenCalled()`), so "never called" is a fact about the guards and not about a spy that never fires.

**Second mutation, different site — `writeTextAtomic` never renames:**

```
 Test Files  21 failed | 102 passed (123)
      Tests  88 failed | 882 passed (970)
```

Both callers (the JSON stores via `writeJsonAtomic`, and the two pidfiles) really do route through it.

**Isolated daemon** (whole env inlined; `~/.rove` never touched). `lifecycle.ts`'s graceful-vs-absent discrimination is the thing that must not break, so it is probed directly:

```
RESOLVED: /tmp/curlew-final-probe/.rove/daemon.pid
live daemon pid: 91822
A. live daemon   -> {"pid":91822,"method":"graceful"}
B. stale pidfile -> {"pid":91822,"method":"absent"}
C. EMPTY pidfile -> {"pid":null,"method":"absent"}      # was pid 0 before

pidfile contents: 94096
leftover .tmp- files: 0
```

---

## 3. `chore:` one owner for the owner-only file modes

`web-token.ts` and `pty-freeze-store.ts` each kept a private `DIR_MODE`/`FILE_MODE` pair and re-explained the same "mkdir's `mode` is a silent no-op on an existing path" reasoning — because `owner-only.ts` only offered async tighteners and both of them run synchronously. Adding `tightenDirPermissionsSync` / `tightenFilePermissionsSync` lets each keep only the part that is genuinely theirs: the token's dir+file pair, the freeze store's `*.json` sweep.

Nine bare octals became the named constants (`plugins/hook-run.ts`, `plugins/registry.ts`, `plugins/settings-env.ts`, `daemon/pty-exit-store.ts`, `daemon/home-owner.ts`, `daemon/agent-turns-store.ts`), and two exports whose only remaining line was their own declaration are gone:

```
$ grep -rn 'SOCKET_MODE' packages --include='*.ts'
packages/kobe-daemon/src/daemon/socket-guard.ts:68:export const SOCKET_MODE = OWNER_ONLY_FILE_MODE
                       # 1 hit — and its JSDoc claims a test asserts on it; that test is gone
$ grep -rn 'OWNER_ONLY_FILE_MODE' packages --include='*.ts' | wc -l
                    10          # CONTROL

$ grep -rn 'COMPAT_CONFIG_DIR_BASENAME' packages --include='*.ts'
packages/kobe-daemon/src/compat-env.ts:30:export const COMPAT_CONFIG_DIR_BASENAME = "kobe" as const
                       # 1 hit, already @deprecated
$ grep -rln 'LEGACY_KOBE_CONFIG_DIR_BASENAME' packages --include='*.ts' | wc -l
                     4          # CONTROL
```

`test/daemon/secret-file-modes.test.ts` still passes. It does not cover the *repair* path, so that was probed separately — pre-create the loose paths, then run the tighteners:

```
BEFORE  freezedir=755  record=644  token=644
AFTER   freezedir=700  record=600  token=600
```

---

## Deviation from the brief

The brief asked for the shared `isProcessAlive` to live in `lifecycle.ts`. Upstream put it in `socket-guard.ts` first, so this PR adopts that placement rather than re-litigating it.

`paths.ts`'s `pidIsLive` therefore stays a private copy: `socket-guard.ts` imports `isWindowsPipePath` from `paths.ts`, so deduping it would close a `socket-guard → paths → socket-guard` cycle. Its guard (`pid <= 1`) is strictly tighter than the shared one anyway. Flagging it rather than silently dropping it from scope.

## Gates

`typecheck` · root `lint` · `build` · `test:fast` 4945 · `test:socket` 970 · `test/render` 519 — all green. No touched file is over the 500-line cap (largest: `server.ts` at 499, unchanged in length by this PR).
