### PR TITLE
fix: rove update on Windows died with EBUSY on every second run

### DIFF
--- a/.changeset/windows-update-retire-dir.md
+++ b/.changeset/windows-update-retire-dir.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+**`rove update` on Windows no longer dies with `EBUSY` on `opentui.dll` every second time.** npm moves the old package to a sibling `.rove-<hash>` directory before unpacking the new one and deletes it afterwards, but Windows refuses to delete a DLL a running process has mapped — and a running Rove (the daemon, the PTY host, an open TUI) is the normal state during an update. npm swallowed that, reported success, and left the directory behind; since the hash comes from the path, the next update targeted the same directory, fell back to a file-by-file copy, and failed copying onto the still-mapped DLL. The update script now sweeps those leftovers before npm runs: it deletes what can be deleted (all of it, once the old build has exited) and moves what cannot out of npm's way, since Windows allows renaming a mapped file. When npm still reports `EBUSY`, the script now says a running Rove is holding files and names the remedy (quit Rove, `rove daemon stop`, retry) instead of leaving a bare errno.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -76,6 +76,34 @@ Windows executable path.
 Remote-project password auth is not available on Windows; use `--key` or
 ssh-agent. Only macOS has the keychain integration used by `--password`.
 
+## Windows: `rove update` fails with `EBUSY` on `opentui.dll`
+
+```text
+npm error code EBUSY
+npm error syscall copyfile
+npm error path ...\node_modules\@sma1lboy\rove\node_modules\@opentui\core-win32-x64\opentui.dll
+npm error dest ...\node_modules\@sma1lboy\.rove-xsdjqHxL\node_modules\@opentui\core-win32-x64\opentui.dll
+```
+
+npm moves the old package to a sibling `.rove-<hash>` directory before it
+unpacks the new one, and deletes that copy afterwards. Windows refuses to
+delete a DLL a running process has mapped — `opentui.dll` in the TUI and the
+daemon, `conpty.node` in the PTY host — and a running Rove is the normal state
+during an update, so the delete fails, npm swallows it, and the directory stays
+behind with the mapped files inside. The hash is derived from the path, so the
+*next* update targets the same directory, finds it occupied, falls back to a
+file-by-file copy, and dies copying onto the DLL that is still mapped.
+
+Current update scripts sweep those leftovers before npm runs (deleting what
+can be deleted, and renaming the rest out of npm's way — Windows allows
+renaming a mapped file), so simply running `rove update` again on a current
+build is the fix. If it still reports `EBUSY`, something is holding files in
+the old install in a way the sweep cannot get past — almost always a running
+Rove. Quit the TUI, run `rove daemon stop`, and retry; engine sessions live in
+the PTY host and survive both. A `.rove-<hash>.stale-<n>` directory next to
+the package is that leftover, parked; it is removed by a later update once
+the old build has exited.
+
 ## The Windows screen looks scrambled, and stays that way
 
 Rows overlapping each other, fragments of a pane you already left, patches of

--- a/packages/kobe/test/behavior/cli-update.test.ts
+++ b/packages/kobe/test/behavior/cli-update.test.ts
@@ -10,7 +10,8 @@
  */
 
 import { spawnSync } from "node:child_process"
-import { chmod, mkdir, readFile, realpath, symlink, writeFile } from "node:fs/promises"
+import { existsSync } from "node:fs"
+import { chmod, mkdir, readFile, readdir, realpath, symlink, writeFile } from "node:fs/promises"
 import { dirname, join, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
 import { afterAll, beforeAll, describe, expect, it } from "vitest"
@@ -272,5 +273,136 @@ describe("scripts/update.sh manager detection", () => {
     })
     expect(r.status).toBe(1)
     expect(r.stderr).toContain("shadowing")
+  })
+})
+
+/**
+ * Windows leaves npm's retire dir behind. npm moves the old package dir to
+ * a sibling `.rove-<hash>` before unpacking the new one and deletes it after;
+ * a DLL a running Rove has mapped cannot be deleted on Windows, so the dir
+ * survives — and the hash is path-derived, so the NEXT update finds the same
+ * dir already there, falls back to a file-by-file copy, and dies with EBUSY
+ * on the mapped DLL. The script sweeps those leftovers before npm runs.
+ */
+describe("scripts/update.sh stale npm retire dirs", () => {
+  let env: BehaviorEnv
+  beforeAll(async () => {
+    env = await makeBehaviorEnv()
+  })
+  afterAll(async () => {
+    await env.dispose()
+  })
+
+  /** A Windows-style npm global: shims at the prefix root, node_modules beside them. */
+  async function windowsLayout(base: string): Promise<{ binDir: string; scope: string; entry: string }> {
+    const binDir = join(base, "npm-global")
+    const scope = join(binDir, "node_modules", "@sma1lboy")
+    const pkgDir = join(scope, "rove", "dist", "cli")
+    await mkdir(pkgDir, { recursive: true })
+    const entry = join(pkgDir, "rove.js")
+    await writeFile(entry, "// bundle\n")
+    return { binDir, scope, entry }
+  }
+
+  async function plantRetireDir(scope: string, name: string): Promise<string> {
+    const dll = join(scope, name, "node_modules", "@opentui", "core-win32-x64")
+    await mkdir(dll, { recursive: true })
+    await writeFile(join(dll, "opentui.dll"), "MZ")
+    return join(scope, name)
+  }
+
+  it("deletes a leftover retire dir before installing (Windows layout, no lib/)", async () => {
+    const base = join(env.home, "case-retire-win")
+    const { binDir, scope } = await windowsLayout(base)
+    const retired = await plantRetireDir(scope, ".rove-xsdjqHxL")
+    const legacy = await plantRetireDir(scope, ".kobe-gcMdoyQi")
+
+    const r = await runUpdateScript(base, binDir)
+    expect(r.code).toBe(0)
+    expect(existsSync(retired)).toBe(false)
+    expect(existsSync(legacy)).toBe(false)
+    // The live package is untouched and the install still goes through npm.
+    expect(existsSync(join(scope, "rove", "dist", "cli", "rove.js"))).toBe(true)
+    expect(r.log).toContain("npm install -g @sma1lboy/rove@latest")
+  })
+
+  it("deletes a leftover retire dir under a lib/node_modules prefix too", async () => {
+    const base = join(env.home, "case-retire-unix")
+    const prefix = join(base, "owning-prefix")
+    const scope = join(prefix, "lib", "node_modules", "@sma1lboy")
+    const pkgDir = join(scope, "rove", "dist", "cli")
+    await mkdir(pkgDir, { recursive: true })
+    const entry = join(pkgDir, "rove.js")
+    await writeFile(entry, `#!/bin/sh\necho "rove 9.9.9"\n`)
+    await chmod(entry, 0o755)
+    const retired = await plantRetireDir(scope, ".rove-abc12345")
+
+    const r = await runUpdateScript(base, join(prefix, "bin"), entry)
+    expect(r.code).toBe(0)
+    expect(existsSync(retired)).toBe(false)
+    expect(existsSync(entry)).toBe(true)
+  })
+
+  // The mapped-DLL case: the delete fails (Windows refuses to unlink a file
+  // a process has loaded), so the dir must be moved out of npm's way
+  // instead — a rename of a mapped file is allowed, and npm's deterministic
+  // retire path is free again.
+  it("moves a retire dir aside when it cannot be deleted", async () => {
+    const base = join(env.home, "case-retire-mapped")
+    const { binDir, scope } = await windowsLayout(base)
+    const retired = await plantRetireDir(scope, ".rove-xsdjqHxL")
+    // `rm` refuses anything under a retire dir; everything else (the
+    // script's own log cleanup) goes to the real rm.
+    const shims = join(base, "rm-shim")
+    await mkdir(shims, { recursive: true })
+    await writeFile(
+      join(shims, "rm"),
+      `#!/bin/sh\nfor a in "$@"; do case "$a" in *.rove-*) exit 1 ;; esac; done\nexec /bin/rm "$@"\n`,
+    )
+    await chmod(join(shims, "rm"), 0o755)
+
+    const r = await runUpdateScript(base, binDir, undefined, undefined, [shims])
+    expect(r.code).toBe(0)
+    expect(existsSync(retired)).toBe(false)
+    const aside = (await readdir(scope)).filter((name) => name.startsWith(".rove-xsdjqHxL.stale-"))
+    expect(aside).toHaveLength(1)
+    expect(existsSync(join(scope, aside[0] as string, "node_modules/@opentui/core-win32-x64/opentui.dll"))).toBe(true)
+    expect(r.log).toContain("npm install -g @sma1lboy/rove@latest")
+  })
+
+  it("a dir already moved aside is left alone when it still cannot be deleted", async () => {
+    const base = join(env.home, "case-retire-aside")
+    const { binDir, scope } = await windowsLayout(base)
+    const aside = await plantRetireDir(scope, ".rove-xsdjqHxL.stale-4242")
+    const shims = join(base, "rm-shim")
+    await mkdir(shims, { recursive: true })
+    await writeFile(
+      join(shims, "rm"),
+      `#!/bin/sh\nfor a in "$@"; do case "$a" in *.rove-*) exit 1 ;; esac; done\nexec /bin/rm "$@"\n`,
+    )
+    await chmod(join(shims, "rm"), 0o755)
+
+    const r = await runUpdateScript(base, binDir, undefined, undefined, [shims])
+    expect(r.code).toBe(0)
+    expect(existsSync(aside)).toBe(true)
+    expect((await readdir(scope)).filter((name) => name.startsWith(".rove-"))).toEqual([".rove-xsdjqHxL.stale-4242"])
+  })
+
+  it("names the running-Rove remedy when npm still dies with EBUSY", async () => {
+    const base = join(env.home, "case-ebusy")
+    const { binDir } = await windowsLayout(base)
+    const shims = join(base, "npm-shim")
+    await mkdir(shims, { recursive: true })
+    await writeFile(
+      join(shims, "npm"),
+      `#!/bin/sh\nif [ "$1" = "view" ]; then echo "9.9.9"; exit 0; fi\necho "npm error code EBUSY" >&2\necho "npm error EBUSY: resource busy or locked, copyfile 'opentui.dll'" >&2\nexit 1\n`,
+    )
+    await chmod(join(shims, "npm"), 0o755)
+
+    const r = await runUpdateScript(base, binDir, undefined, undefined, [shims])
+    expect(r.code).toBe(1)
+    expect(r.out).toContain("npm install failed")
+    expect(r.out).toContain("A running Rove is holding files in the old install")
+    expect(r.out).toContain("rove daemon stop")
   })
 })

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -210,6 +210,50 @@ if [ "$MIGRATING" = "1" ]; then
   "$MANAGER" uninstall -g $NPM_PREFIX_ARGS "$LEGACY_PACKAGE" >>"$LOG" 2>&1 || true
 fi
 
+# npm retires the old package dir to a sibling `.rove-<hash>` before it
+# unpacks the new one, then deletes the retired copy. On Windows that delete
+# cannot finish while a Rove is running: a DLL a process has mapped
+# (opentui.dll in the TUI and daemon, conpty.node in the PTY host) is
+# undeletable, and a running Rove is the NORMAL state during an update —
+# the daemon and the PTY host are long-lived by design. npm swallows the
+# failure, reports success, and leaves the retire dir behind with the
+# mapped files in it. The hash is derived from the package path, so the
+# NEXT update targets the very same retire dir: `rename` fails because the
+# destination exists, npm falls back to a file-by-file copy, and copying
+# onto the still-mapped DLL dies with EBUSY. Every second update on Windows
+# failed this way while Rove was open.
+#
+# Clear the leftovers before npm runs: delete what can be deleted (Git
+# Bash's rm uses POSIX delete semantics and usually manages even a mapped
+# file; everything goes once the old build has exited) and move the rest
+# out of npm's way — Windows allows renaming a mapped file even when it
+# refuses to delete it. Anything moved aside is caught by the same glob on
+# a later run and deleted then. Only npm has retire dirs; a bun install
+# never enters this block.
+clear_retired_installs() {
+  scope="$1"
+  [ -d "$scope" ] || return 0
+  for retired in "$scope"/.rove-* "$scope"/.kobe-*; do
+    [ -d "$retired" ] || continue
+    rm -rf "$retired" 2>/dev/null || true
+    [ -d "$retired" ] || continue
+    case "$retired" in
+      *.stale-*) continue ;;
+    esac
+    mv "$retired" "${retired}.stale-$$" 2>/dev/null || true
+  done
+}
+
+if [ "$MANAGER" = "npm" ] && [ -n "$BIN" ]; then
+  if [ -n "$PREFIX" ]; then
+    clear_retired_installs "$PREFIX/lib/node_modules/@sma1lboy"
+  fi
+  # npm on Windows keeps no `lib/` and its bins are shims, not symlinks, so
+  # PREFIX stays empty there: the shims sit at the prefix root with
+  # node_modules beside them. A no-op wherever that layout does not exist.
+  clear_retired_installs "$(dirname "$BIN")/node_modules/@sma1lboy"
+fi
+
 # bun caches the package manifest, so a version published minutes ago is
 # "not found" until that cache expires — `bun add` reports it as
 # `No version matching "X" found ... (but package exists)`, which names
@@ -249,6 +293,16 @@ if ! wait "$PID"; then
     printf '%bThat version IS published — this is a stale package-manager cache.%b\n' "$DIM" "$RESET" >&2
     printf '%bTry: rm -rf ~/.bun/install/cache && %s install -g %s@%s%b\n' \
       "$DIM" "$MANAGER" "$PACKAGE" "${VERSION:-latest}" "$RESET" >&2
+  fi
+  # EBUSY is npm's spelling of Windows' sharing violation: something has a
+  # file in the old install open in a way the install cannot get past.
+  # After the retire-dir sweep above that is a running Rove itself — name
+  # the remedy rather than leaving an errno the user cannot act on.
+  if grep -q 'EBUSY' "$LOG" 2>/dev/null; then
+    printf '%bA running Rove is holding files in the old install (Windows cannot replace a file a process has loaded).%b\n' \
+      "$DIM" "$RESET" >&2
+    printf '%bQuit Rove, run `rove daemon stop`, then retry. Engine sessions live in the PTY host and survive both.%b\n' \
+      "$DIM" "$RESET" >&2
   fi
   # We removed the legacy package to free the bin names, so a failed
   # install would otherwise leave the user with no kobe at all. Put it


### PR DESCRIPTION
## What

`rove update` on Windows failed with `EBUSY: resource busy or locked, copyfile ...\opentui.dll -> ...\.rove-xsdjqHxL\...\opentui.dll` on every second update while Rove was open.

## Why

npm moves the old package dir to a sibling `.rove-<hash>` before unpacking the new one and deletes that copy afterwards. Windows refuses to delete a DLL a running process has mapped (`opentui.dll` in the TUI and daemon, `conpty.node` in the PTY host), and a running Rove is the normal state during an update. npm swallows the failure, reports success, and leaves the retire dir behind. The hash is derived from the path, so the *next* update targets the same dir: `rename` fails because it exists, npm falls back to a file-by-file copy, and the copy onto the still-mapped DLL dies with EBUSY.

Reproduced and isolated on Windows 11 / npm 11.16.0:
- no Rove processes → update OK
- daemon running, no leftover retire dir → update OK (a mapped DLL alone is not the problem)
- TUI + daemon running **and** the leftover retire dir from the previous update → EBUSY, deterministic
- same, after the process mapping the retire dir's DLL exits → update OK

## Fix

`scripts/update.sh` (fetched over curl by `rove update` and the TUI chip, so old installs get it immediately):
- before `npm install`, sweep `.rove-*` / `.kobe-*` under the `@sma1lboy` scope dir: `rm -rf` (Git Bash's POSIX delete semantics usually manage even a mapped file), and whatever survives is renamed aside to `<name>.stale-<pid>` — Windows allows renaming a mapped file — so npm's deterministic retire path is free. Parked dirs are caught by the same glob and deleted on a later run.
- the scope dir is derived from `$PREFIX/lib/node_modules` (macOS/Linux) and from `$(dirname "$BIN")/node_modules` (npm on Windows keeps no `lib/`, and its bins are shims rather than symlinks so `PREFIX` stays empty there).
- when npm still reports `EBUSY`, print the remedy (quit Rove, `rove daemon stop`, retry) instead of a bare errno.

Verified end-to-end on the real install with the TUI and daemon open and the retire dir mapped: downgrade 0.9.172 → 0.9.171 and back both succeed, no leftover dir.

## Tests

`test/behavior/cli-update.test.ts` gains a "stale npm retire dirs" block that runs the real script with PATH shims: leftover deleted (Windows layout and `lib/node_modules` layout), moved aside when `rm` refuses, an already-parked dir left alone, and the EBUSY hint. The behavior suite cannot run natively on Windows (it spawns `sh` with a POSIX-only PATH and needs symlinks), so the same scenarios were exercised by hand in Git Bash; the vitest run is on CI.

Docs: new TROUBLESHOOTING section for the error. Changeset: patch.
