### PR TITLE
fix: rove update runs on Windows

### DIFF
--- a/.changeset/windows-self-update.md
+++ b/.changeset/windows-self-update.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+`rove update` works on Windows. The updater spawned bare `sh`, which a default Git for Windows install does not put on `PATH` — only `…\Git\cmd` is added, while `sh.exe` lives in `…\Git\bin` — so both the CLI and the TUI's update chip died with a raw `spawn sh ENOENT`, leaving `npm install -g` by hand as the only route. The updater now runs the install script through the same Git Bash every engine and terminal tab already launches through, and a missing one is reported as "install Git for Windows" with the manual command, instead of an ENOENT naming a shell.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -58,6 +58,11 @@ rove updates using whichever package manager owns the `rove` on your `PATH`,
 so the new version can't land in a shadowed prefix. Manual fallback:
 `npm install -g @sma1lboy/rove@latest` (or `@nightly`).
 
+The update script is POSIX shell. On Windows, Rove runs it through Git for
+Windows' bash — the same shell every engine and terminal tab launches through
+— so `rove update` needs Git for Windows installed, exactly like the rest of
+the app. Without it the command says so and points at the manual fallback.
+
 Some versions are marked breaking. Installing across one prints a heads-up
 (`dry-run` included, so the rehearsal shows it too), and the next launch asks
 you to run `rove reset` first. Worktrees are never touched.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -56,8 +56,9 @@ Windows needs three separate runtimes:
 - **Node.js** runs the Windows Hosted PTY process. A Bun-only global install
   does not install Node for you.
 - **Git for Windows**, including its Git Bash, supplies the POSIX shell used by
-  every engine and terminal launch. Rove deliberately does not use the WSL
-  `bash.exe`, because it cannot address the Windows worktree correctly.
+  every engine and terminal launch — and by `rove update`, whose install
+  script is POSIX shell. Rove deliberately does not use the WSL `bash.exe`,
+  because it cannot address the Windows worktree correctly.
 
 Start with:
 

--- a/packages/kobe/src/cli/update.ts
+++ b/packages/kobe/src/cli/update.ts
@@ -16,6 +16,7 @@
  */
 
 import { spawnSync } from "node:child_process"
+import { updaterShell, updaterShellFailureHint } from "../lib/updater-shell.ts"
 import {
   BREAKING_VERSIONS,
   CURRENT_VERSION,
@@ -55,7 +56,8 @@ type RunDeps = {
 export function updatePlan(target?: string): UpdatePlan {
   const shell = target === undefined ? UPDATE_COMMAND : `${UPDATE_COMMAND} -s -- ${target}`
   return {
-    command: "sh",
+    // Not bare `sh`: Windows has none on PATH. See lib/updater-shell.ts.
+    command: updaterShell(),
     args: ["-c", shell],
     display: shell,
   }
@@ -292,6 +294,8 @@ export async function runUpdateSubcommand(args: readonly string[], deps?: Partia
   const result = io.spawn(plan.command, plan.args, { stdio: "inherit" })
   if (result.error) {
     io.stderr.write(`${CLI_NAME} update: failed to run ${plan.command}: ${result.error.message}\n`)
+    const hint = updaterShellFailureHint()
+    if (hint) io.stderr.write(hint)
     io.exit(1)
   }
   if (result.status === 0) io.stdout.write(FOLLOW_UP_NOTE)

--- a/packages/kobe/src/lib/updater-shell.ts
+++ b/packages/kobe/src/lib/updater-shell.ts
@@ -1,0 +1,58 @@
+/**
+ * Which shell runs the GitHub-hosted update script, and what to say when it
+ * is missing.
+ *
+ * `scripts/update.sh` is POSIX shell, and every caller used to spawn it as
+ * bare `sh`. Windows has no `sh` on PATH: a default Git for Windows install
+ * adds only `…\Git\cmd` (git.exe and friends), while `sh.exe`/`bash.exe`
+ * live in `…\Git\bin`. So `rove update` — and the TUI's update chip, which
+ * spawns the same way — died with a raw `spawn sh ENOENT` on a platform Rove
+ * otherwise supports, leaving `npm install -g` by hand as the only route.
+ *
+ * The fix is not a second Windows dialect of the script: Rove already runs
+ * every engine and terminal tab through Git for Windows' bash, and
+ * {@link resolveLoginShell} is the one module that knows how to find it
+ * (including why System32's `bash.exe` — the WSL launcher — must never be
+ * used). This just points the updater at the same shell. `update.sh` itself
+ * needs no changes: under Git Bash `command -v rove` lands on npm's shell
+ * shim, the `lib/node_modules` prefix derivation finds nothing and falls
+ * back to a plain `npm install -g`, which is the correct install on Windows.
+ *
+ * POSIX behaviour is deliberately unchanged — still bare `sh`, never `$SHELL`,
+ * because a login fish/zsh is not the dialect the script is written in.
+ */
+
+import { resolveLoginShell } from "@sma1lboy/kobe-daemon/daemon/platform-shell"
+import { recommendedGlobalInstallCommand } from "../version.ts"
+
+type ShellDeps = {
+  platform?: NodeJS.Platform
+  env?: Readonly<Record<string, string | undefined>>
+  /** Filesystem probe; injected so a `win32` resolution can be tested on POSIX. */
+  exists?: (path: string) => boolean
+}
+
+/** The shell to spawn `update.sh` through: `sh` on POSIX, Git Bash on Windows. */
+export function updaterShell(deps: ShellDeps = {}): string {
+  const platform = deps.platform ?? process.platform
+  if (platform !== "win32") return "sh"
+  return resolveLoginShell({ fallback: "/bin/sh", platform, env: deps.env, exists: deps.exists })
+}
+
+/**
+ * Extra lines for a spawn failure. `spawn … ENOENT` names the shell but not
+ * the missing dependency, and on Windows the dependency is a whole product —
+ * so say which one, and hand over the manual route in the same breath.
+ */
+export function updaterShellFailureHint(deps: ShellDeps = {}): string | null {
+  const platform = deps.platform ?? process.platform
+  if (platform !== "win32") return null
+  return [
+    "The update script is POSIX shell. Rove runs it through Git for Windows'",
+    "bash — the same shell every engine and terminal tab launches through.",
+    "Install Git for Windows (https://git-scm.com/download/win), or update",
+    "by hand:",
+    `  ${recommendedGlobalInstallCommand()}`,
+    "",
+  ].join("\n")
+}

--- a/packages/kobe/src/tui-react/component/run-updater.ts
+++ b/packages/kobe/src/tui-react/component/run-updater.ts
@@ -7,6 +7,7 @@
  */
 
 import { spawnSync } from "node:child_process"
+import { updaterShell, updaterShellFailureHint } from "../../lib/updater-shell.ts"
 import { CURRENT_VERSION } from "../../version.ts"
 
 type UpdaterT = (key: string, params?: Record<string, string>) => string
@@ -38,9 +39,16 @@ export async function runShellUpdater(opts: {
   opts.renderer?.destroy()
   process.stdout.write(`\nrove ${CURRENT_VERSION} -> ${opts.targetLabel}\n`)
   process.stdout.write(`running: ${opts.command}\n\n`)
-  const result = spawnSync("sh", ["-c", opts.command], { stdio: "inherit" })
+  // Bare `sh` exists on POSIX only; Windows resolves to Git Bash. The chip
+  // and `rove update` must agree — see lib/updater-shell.ts.
+  const shell = updaterShell()
+  const result = spawnSync(shell, ["-c", opts.command], { stdio: "inherit" })
   const code = result.status ?? (result.error ? 1 : 0)
-  if (result.error) process.stderr.write(`\nrove update: failed to start updater: ${result.error.message}\n`)
+  if (result.error) {
+    process.stderr.write(`\nrove update: failed to start updater (${shell}): ${result.error.message}\n`)
+    const hint = updaterShellFailureHint()
+    if (hint) process.stderr.write(hint)
+  }
   process.stdout.write(
     code === 0
       ? `\n${opts.t("update.updateComplete")}\n`

--- a/packages/kobe/test/cli/update.test.ts
+++ b/packages/kobe/test/cli/update.test.ts
@@ -1,11 +1,12 @@
 import { describe, expect, it, vi } from "vitest"
 import { parseUpdateArgs, runUpdateSubcommand, updatePlan } from "../../src/cli/update.ts"
+import { updaterShell } from "../../src/lib/updater-shell.ts"
 import { PACKAGE_NAME, UPDATE_COMMAND, UPDATE_SCRIPT_URL, recommendedGlobalInstallCommand } from "../../src/version.ts"
 
 describe("updatePlan", () => {
   it("delegates to the GitHub-hosted update script", () => {
     expect(updatePlan()).toEqual({
-      command: "sh",
+      command: updaterShell(),
       args: ["-c", UPDATE_COMMAND],
       display: UPDATE_COMMAND,
     })
@@ -17,7 +18,7 @@ describe("updatePlan", () => {
     // npm makes no distinction between a version and a dist-tag in
     // `pkg@<arg>`, so the channel needs no separate flag downstream.
     expect(updatePlan("nightly")).toEqual({
-      command: "sh",
+      command: updaterShell(),
       args: ["-c", `${UPDATE_COMMAND} -s -- nightly`],
       display: `${UPDATE_COMMAND} -s -- nightly`,
     })
@@ -25,7 +26,7 @@ describe("updatePlan", () => {
 
   it("a pinned version rides into the script as `sh -s -- <version>`", () => {
     expect(updatePlan("0.7.90")).toEqual({
-      command: "sh",
+      command: updaterShell(),
       args: ["-c", `${UPDATE_COMMAND} -s -- 0.7.90`],
       display: `${UPDATE_COMMAND} -s -- 0.7.90`,
     })
@@ -236,7 +237,7 @@ describe("runUpdateSubcommand", () => {
       expect((err as Error).message).toBe("exit")
     })
 
-    expect(spawn).toHaveBeenCalledWith("sh", ["-c", UPDATE_COMMAND], { stdio: "inherit" })
+    expect(spawn).toHaveBeenCalledWith(updaterShell(), ["-c", UPDATE_COMMAND], { stdio: "inherit" })
     expect(exits).toEqual([7])
   })
 
@@ -262,7 +263,7 @@ describe("runUpdateSubcommand", () => {
     expect(exit).not.toHaveBeenCalled()
   })
 
-  it("a spawn failure (e.g. sh missing) reports the cause and exits 1", async () => {
+  it("a spawn failure (e.g. no POSIX shell) reports the cause and exits 1", async () => {
     const err: string[] = []
     const exits: number[] = []
     const spawn = vi.fn(() => ({ error: new Error("ENOENT") }))
@@ -282,7 +283,7 @@ describe("runUpdateSubcommand", () => {
     }).catch((e) => {
       expect((e as Error).message).toBe("exit")
     })
-    expect(err.join("")).toContain("kobe update: failed to run sh: ENOENT")
+    expect(err.join("")).toContain(`kobe update: failed to run ${updaterShell()}: ENOENT`)
     expect(exits).toEqual([1])
   })
 

--- a/packages/kobe/test/lib/updater-shell.test.ts
+++ b/packages/kobe/test/lib/updater-shell.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest"
+import { updaterShell, updaterShellFailureHint } from "../../src/lib/updater-shell.ts"
+
+describe("updaterShell", () => {
+  it("stays bare `sh` on POSIX — never $SHELL", () => {
+    // The update script is written in POSIX sh; a login fish/zsh is not that
+    // dialect, so the resolver must not reach for $SHELL here.
+    expect(updaterShell({ platform: "darwin", env: { SHELL: "/usr/local/bin/fish" } })).toBe("sh")
+    expect(updaterShell({ platform: "linux", env: {} })).toBe("sh")
+  })
+
+  it("resolves Git for Windows' bash on win32, where `sh` is not on PATH", () => {
+    const shell = updaterShell({
+      platform: "win32",
+      env: { ProgramFiles: "C:\\Program Files" },
+      exists: (p) => p === "C:\\Program Files\\Git\\bin\\bash.exe",
+    })
+    expect(shell).toBe("C:\\Program Files\\Git\\bin\\bash.exe")
+  })
+
+  it("names the real path when Git for Windows is missing, so the spawn error says so", () => {
+    // Deliberately not bare `bash.exe`: System32's is the WSL launcher, which
+    // would install into a Linux prefix the Windows PATH never sees.
+    const shell = updaterShell({ platform: "win32", env: {}, exists: () => false })
+    expect(shell).toBe("C:\\Program Files\\Git\\bin\\bash.exe")
+    expect(shell).not.toBe("bash.exe")
+  })
+})
+
+describe("updaterShellFailureHint", () => {
+  it("names the missing dependency on win32 and hands over the manual route", () => {
+    const hint = updaterShellFailureHint({ platform: "win32" })
+    expect(hint).toContain("Git for Windows")
+    expect(hint).toContain("npm install -g")
+  })
+
+  it("adds nothing on POSIX, where a missing `sh` is not a known story", () => {
+    expect(updaterShellFailureHint({ platform: "darwin" })).toBeNull()
+    expect(updaterShellFailureHint({ platform: "linux" })).toBeNull()
+  })
+})


### PR DESCRIPTION
## The bug

`rove update` — and the TUI's update chip (`U` on the update page, and the versions browser) — spawned bare `sh`:

- `src/cli/update.ts` → `updatePlan()` returned `{ command: "sh", args: ["-c", "curl -fsSL … | sh"] }`
- `src/tui-react/component/run-updater.ts` → `spawnSync("sh", ["-c", command])`

Windows has no `sh` on `PATH`. A default Git for Windows install adds only `…\Git\cmd` (git.exe and friends); `sh.exe`/`bash.exe` live in `…\Git\bin`. So a Windows user got:

```
rove update: failed to run sh: spawn sh ENOENT
```

on a platform Rove otherwise supports (Windows PTY host, CIM process walk, Git Bash engine launches are all wired). The only route left was `npm install -g @sma1lboy/rove@latest` by hand, which nothing told them about.

## The fix

Not a second Windows dialect of the script — `scripts/update.sh` needs no changes at all. Under Git Bash `command -v rove` lands on npm's shell shim, the `lib/node_modules` prefix derivation finds nothing and falls back to a plain `npm install -g`, which is the correct install on Windows.

New `src/lib/updater-shell.ts` points the updater at the shell Rove already uses everywhere else:

- `updaterShell()` — bare `sh` on POSIX (deliberately **not** `$SHELL`: a login fish/zsh is not the dialect the script is written in), and on win32 delegates to `resolveLoginShell()` from `kobe-daemon/daemon/platform-shell`, the one module that knows where Git for Windows puts bash and why System32's `bash.exe` (the WSL launcher) must never be used.
- `updaterShellFailureHint()` — on win32, turns a raw ENOENT into "install Git for Windows" + the manual `npm install -g` command.

Both call sites use it, so the chip and the CLI can't drift apart.

## Not changed (surfacing, not fixing)

`src/tui/lib/editor-launch.ts`, `src/tui-react/workspace/use-file-open-actions.ts` and `src/cli/config-cmd.ts` also hardcode `sh` for editor/diff/config launches. Same class of Windows bug, different slice — say the word and I'll take it in a follow-up.

`rove doctor`'s win32 block checks for Node but not for Git Bash; adding that check is also a reasonable follow-up.

## Test

- `test/lib/updater-shell.test.ts` (new) — POSIX stays `sh` even with `$SHELL=fish`; win32 resolves `C:\Program Files\Git\bin\bash.exe` with an injected `exists`; missing Git for Windows still names the real path rather than bare `bash.exe`; the hint is win32-only.
- `test/cli/update.test.ts` — expectations now go through `updaterShell()` so the Windows CI job passes too.
- `bun run test:fast`: 500 files / 4946 passed. typecheck + biome clean.