### PR TITLE
fix: preserve conversations during Windows session recovery

### DIFF
--- a/.changeset/windows-resume-history.md
+++ b/.changeset/windows-resume-history.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Preserve engine conversations when restoring tabs after a reboot. A restored tab's saved engine identity no longer counts as a live process observation, so the shell startup window cannot erase its session ID and turn it into a plain shell. Codex, Copilot, and Kimi history lookup also matches Windows directories written with native backslashes or Git's forward slashes, keeping recorded conversations eligible for resume. Engines that generate their own session IDs rediscover their conversation when a saved ID is no longer valid, including an ID left over from another engine.

--- a/docs/SESSIONS.md
+++ b/docs/SESSIONS.md
@@ -6,6 +6,13 @@ their commands on attach. Closing a tab, deleting a managed/directory Task,
 resetting a terminal, or running `rove reset` is an intentional teardown
 instead.
 
+During recovery, an engine tab keeps its saved conversation while its shell
+starts. Rove converts it to a shell tab only after observing the engine run
+and then exit in the current TUI session. On Windows, engine history lookup
+accepts both native backslashes and Git's forward slashes for the same directory.
+For engines that generate their own session IDs, an invalid saved ID triggers
+discovery of an unclaimed conversation in that directory before relaunch.
+
 ## What survives
 
 | If you… | Running process | Scrollback | Tasks + worktrees | Conversation files |

--- a/packages/kobe/src/engine/codex-local/session-files.ts
+++ b/packages/kobe/src/engine/codex-local/session-files.ts
@@ -1,6 +1,7 @@
 import { readdir, stat } from "node:fs/promises"
 import path from "node:path"
 import { isJsonlLineWithinBound, readFirstLineBounded, readTextFileBounded } from "../file-bounds"
+import { sameHistoryWorktree } from "../history-worktree"
 import { vendorConfigHome } from "../vendor-home"
 
 export interface HistoryDeps {
@@ -210,7 +211,7 @@ export async function listSessionIdsForWorktree(
 ): Promise<string[]> {
   if (!worktree) return []
   return (await catalog(deps).sessions())
-    .filter((file) => file.cwd === worktree)
+    .filter((file) => sameHistoryWorktree(file.cwd, worktree))
     .map((file) => file.sessionId)
     .reverse()
 }
@@ -222,7 +223,7 @@ export async function findLatestRolloutForWorktree(
   if (!worktree) return null
   let best: { path: string; mtimeMs: number } | null = null
   for (const file of await catalog(deps).sessions()) {
-    if (file.cwd === worktree && (!best || file.stamp.mtimeMs > best.mtimeMs))
+    if (sameHistoryWorktree(file.cwd, worktree) && (!best || file.stamp.mtimeMs > best.mtimeMs))
       best = { path: file.path, mtimeMs: file.stamp.mtimeMs }
   }
   return best

--- a/packages/kobe/src/engine/copilot-local/history.ts
+++ b/packages/kobe/src/engine/copilot-local/history.ts
@@ -5,6 +5,7 @@ import type { ContentBlock } from "@/types/content"
 import type { EngineHistory, EngineUsageSnapshot, Message } from "@/types/engine"
 import { isJsonlLineWithinBound, readTextFileBounded } from "../file-bounds"
 import { createAppendParseCache } from "../history-cache"
+import { sameHistoryWorktree } from "../history-worktree"
 import { vendorConfigHome } from "../vendor-home"
 import { copilotUsageToSnapshot } from "./usage"
 
@@ -63,7 +64,7 @@ export async function listSessionIdsForWorktree(
   const matches: { id: string; updatedAt: string }[] = []
   for (const dir of await listSessionDirs(deps)) {
     const workspace = await readWorkspace(dir, deps)
-    if (workspace.cwd !== worktree) continue
+    if (!sameHistoryWorktree(workspace.cwd, worktree)) continue
     matches.push({ id: workspace.id ?? path.basename(dir), updatedAt: workspace.updatedAt ?? "" })
   }
   return matches.sort((a, b) => a.updatedAt.localeCompare(b.updatedAt)).map((m) => m.id)
@@ -84,7 +85,7 @@ export async function latestTranscriptMtimeForWorktree(
   let newest = 0
   for (const dir of await listSessionDirs(deps)) {
     const workspace = await readWorkspace(dir, deps)
-    if (workspace.cwd !== worktree) continue
+    if (!sameHistoryWorktree(workspace.cwd, worktree)) continue
     try {
       const { mtimeMs } = await deps.stat(path.join(dir, "events.jsonl"))
       if (mtimeMs > newest) newest = mtimeMs

--- a/packages/kobe/src/engine/history-worktree.ts
+++ b/packages/kobe/src/engine/history-worktree.ts
@@ -1,0 +1,8 @@
+import path from "node:path"
+
+export function sameHistoryWorktree(recorded: string | undefined, worktree: string): boolean {
+  if (!recorded || !worktree) return false
+  const windows = [recorded, worktree].some((cwd) => /^[a-z]:[\\/]/i.test(cwd) || cwd.startsWith("\\\\"))
+  const normalize = windows ? path.win32.normalize : path.posix.normalize
+  return normalize(recorded) === normalize(worktree)
+}

--- a/packages/kobe/src/engine/kimi-local/history.ts
+++ b/packages/kobe/src/engine/kimi-local/history.ts
@@ -23,6 +23,7 @@ import { stat } from "node:fs/promises"
 import { homedir } from "node:os"
 import path from "node:path"
 import { isJsonlLineWithinBound, readTextFileBounded } from "../file-bounds"
+import { sameHistoryWorktree } from "../history-worktree"
 import { vendorConfigHome } from "../vendor-home"
 
 export interface KimiHistoryDeps {
@@ -101,7 +102,7 @@ async function worktreeSessionFiles(
   if (!worktree) return []
   const matches: { id: string; mtimeMs: number }[] = []
   for (const entry of await sessionIndex(deps)) {
-    if (entry.workDir !== worktree) continue
+    if (!sameHistoryWorktree(entry.workDir, worktree)) continue
     const file = wirePath(entry.sessionDir)
     const info = await deps.stat(file).catch(() => null)
     if (info) matches.push({ id: entry.sessionId, mtimeMs: info.mtimeMs })

--- a/packages/kobe/src/tui-react/workspace/use-tab-lifecycle.ts
+++ b/packages/kobe/src/tui-react/workspace/use-tab-lifecycle.ts
@@ -9,6 +9,7 @@
  * synchronously). See the TerminalTabs file header for why refs.
  */
 
+import { protocolEntry } from "@/engine/engine-presets"
 import { engineSessionIdFromTitle } from "@/engine/registry"
 import { discoverSessionId, engineSessionExists } from "@/engine/session-discovery"
 import { deriveTitleFromSessionId } from "@/monitor/auto-title"
@@ -69,33 +70,26 @@ export function useTabHydration(rehydrated: boolean, io: TabLifecycleIO): boolea
         // list. Two live engines then write one transcript, which is exactly
         // the collision `session-identity.ts` says claim-tracking prevents.
         for (const tab of engines) {
-          if (tab.sessionId) continue
+          const vendor = vendorOfTab(tab)
+          if (tab.sessionId) {
+            const exists = await engineSessionExists(vendor, worktree, tab.sessionId)
+            if (cancelled) return
+            io.update(setTabSpawned(io.stateRef.current, tab.id, exists))
+            // A caller-pinned id may belong to a fresh, still-empty tab.
+            // Engine-generated ids must name a recorded conversation.
+            if (exists || protocolEntry(vendor).sessionIdentity?.pinFlag) continue
+          }
           // No recorded id: this engine mints its own and reports it
           // nowhere (kimi), so ASK ITS STORE which session this worktree
           // has. It has to happen here rather than in the naming poll —
           // `hydrating` is what holds the spawn back, and a tab that
           // respawns before its id is known opens a blank conversation,
           // which is the whole bug.
-          const found = await discoverSessionId(vendorOfTab(tab), worktree, claimedIds(io))
+          const found = await discoverSessionId(vendor, worktree, claimedIds(io))
           if (cancelled) return
           if (!found) continue
           io.update(setTabSpawned(setTabSessionId(io.stateRef.current, tab.id, found), tab.id, true))
         }
-
-        // Re-verification stays concurrent: it claims nothing, it only asks
-        // whether an id a tab ALREADY holds is still on disk.
-        await Promise.all(
-          engines.map(async (tab) => {
-            if (!tab.sessionId) return
-            // Ask whether the session is RECORDED, not whether kobe can
-            // parse its messages: `readHistory` is empty for engines that
-            // ship no message parser (kimi), so a parse-based check reports
-            // every kimi session as absent and the tab respawns blank.
-            const exists = await engineSessionExists(vendorOfTab(tab), worktree, tab.sessionId)
-            if (cancelled) return
-            io.update(setTabSpawned(io.stateRef.current, tab.id, exists))
-          }),
-        )
       } finally {
         if (!cancelled) setHydrating(false)
       }

--- a/packages/kobe/src/tui-react/workspace/use-tab-turn-state.ts
+++ b/packages/kobe/src/tui-react/workspace/use-tab-turn-state.ts
@@ -27,7 +27,8 @@ import type { ChatTabTurnState } from "../../engine/turn-detector"
 import { attentionEdges, chipAttentionKind } from "../../tui/lib/notify-state"
 import { defaultShell } from "../../tui/panes/terminal/pty-types"
 import { InterruptObserver } from "../../tui/workspace/interrupt-observer"
-import { demoteExitedEngine } from "../../tui/workspace/terminal-tab-identity"
+import { getDefaultLiveEngines } from "../../tui/workspace/live-engine"
+import { createTabIdentityObserver } from "../../tui/workspace/terminal-tab-identity"
 import {
   type TabsState,
   type TerminalTab,
@@ -35,6 +36,7 @@ import {
   setTabLiveVendor,
 } from "../../tui/workspace/terminal-tabs-core"
 import { type HookTabState, mergeTurnStates } from "../../tui/workspace/turn-state-merge"
+import { soloKey } from "../../tui/workspace/turn-target"
 import type { VendorId } from "../../types/vendor"
 import { useOptionalKV } from "../context/kv"
 import type { NotificationsContext } from "../context/notifications"
@@ -105,41 +107,37 @@ export function useTabTurnState(deps: {
   }, [deps.hookTabStates, rawTitles, turnVendors])
   useEffect(() => () => observerRef.current?.dispose(), [])
 
-  // Record the live titles AND live engine identity onto the tabs
-  // themselves. Only THIS component sees the OSC stream / turn targets, and
-  // only for the task it hosts — so a surface rendering someone else's tab
-  // (the Inbox, the sidebar tree) would otherwise fall back to `autoTitle`
-  // and, after a restart, demote a shell-turned-agent to a plain shell (the
-  // fresh process's registry has no PTY to probe until the tab mounts).
-  // Both setters return the same state when nothing changed, so repeated
-  // pushes never churn the persisted snapshot. Identity writes only cover
-  // tabs WITH a live title — that means an attached PTY, where a missing
-  // vendor genuinely means "no engine running" rather than "not probed yet".
+  // A restored title can arrive before the engine starts. Only process
+  // observations from this mount can establish an engine-exit edge.
   const updateRef = useLatest(deps.update)
   const titleStateRef = useLatest(deps.state)
+  const identityObserver = useRef<ReturnType<typeof createTabIdentityObserver> | null>(null)
+  if (!identityObserver.current) identityObserver.current = createTabIdentityObserver()
   useEffect(() => {
     const apply = updateRef.current
     if (!apply) return
-    const current = titleStateRef.current
-    let next = current
-    for (const [tabId, title] of liveTitles) {
-      const live = turnVendors.get(tabId) ?? null
-      // The engine this tab was running is gone (vendor → confirmed null):
-      // reset the tab to the shell it always was, BEFORE recording the new
-      // identity. `kind` describes what runs here now — leaving it at
-      // "engine" keeps a dot on the sidebar row and makes every keystroke
-      // mark an optimistic turn for a session that has exited.
-      const tab = next.tabs.find((t) => t.id === tabId)
-      const demoted = tab ? demoteExitedEngine(tab, tab.liveVendor, live, [defaultShell()]) : undefined
-      if (tab && demoted && demoted !== tab) {
-        next = { ...next, tabs: next.tabs.map((t) => (t.id === tabId ? demoted : t)) }
-        continue // the reset already cleared lastTitle/liveVendor
+    const engines = getDefaultLiveEngines()
+    const record = () => {
+      const current = titleStateRef.current
+      let next = current
+      for (const [tabId, title] of liveTitles) {
+        const tab = next.tabs.find((t) => t.id === tabId)
+        if (!tab) continue
+        const key = soloKey(deps.taskId, tab)
+        const live = key ? engines.resolve(key) : undefined
+        const demoted = identityObserver.current?.(tab, live, [defaultShell()])
+        if (demoted && demoted !== tab) {
+          next = { ...next, tabs: next.tabs.map((t) => (t.id === tabId ? demoted : t)) }
+          continue // the reset already cleared lastTitle/liveVendor
+        }
+        next = setTabLastTitle(next, tabId, title)
+        if (live !== undefined) next = setTabLiveVendor(next, tabId, live)
       }
-      next = setTabLastTitle(next, tabId, title)
-      next = setTabLiveVendor(next, tabId, live)
+      if (next !== current) apply(next)
     }
-    if (next !== current) apply(next)
-  }, [liveTitles, turnVendors])
+    record()
+    return engines.subscribe(record)
+  }, [liveTitles, deps.taskId])
 
   // Rising-edge notify for background tabs. `prev === null` until the first
   // observation lands (attentionEdges' seed rule). Refs for values the

--- a/packages/kobe/src/tui/workspace/terminal-tab-identity.ts
+++ b/packages/kobe/src/tui/workspace/terminal-tab-identity.ts
@@ -27,6 +27,16 @@
 import type { VendorId } from "../../types/vendor"
 import type { TerminalTab } from "./terminal-tabs-core"
 
+export function createTabIdentityObserver() {
+  const observed = new Map<string, VendorId>()
+  return (tab: TerminalTab, live: VendorId | null | undefined, shell: readonly string[]): TerminalTab => {
+    const previous = observed.get(tab.id)
+    if (live) observed.set(tab.id, live)
+    else observed.delete(tab.id)
+    return demoteExitedEngine(tab, previous, live, shell)
+  }
+}
+
 /**
  * The engine in this tab exited: reset it to the shell it always was.
  *

--- a/packages/kobe/test/engine/codex-history-windows-paths.test.ts
+++ b/packages/kobe/test/engine/codex-history-windows-paths.test.ts
@@ -1,0 +1,27 @@
+import { mkdir, mkdtemp, readFile, readdir, stat, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import path from "node:path"
+import { expect, it } from "vitest"
+import {
+  type HistoryDeps,
+  findLatestRolloutForWorktree,
+  listSessionIdsForWorktree,
+} from "../../src/engine/codex-local/session-files"
+
+it("finds the same Windows conversation through Git and native cwd spellings", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "rove-resume-path-"))
+  const dir = path.join(root, "2026", "09", "06")
+  await mkdir(dir, { recursive: true })
+  const id = "aaaaaaaa-1111-2222-3333-444444444444"
+  const file = path.join(dir, `rollout-2026-09-06T18-37-00-${id}.jsonl`)
+  await writeFile(file, JSON.stringify({ type: "session_meta", payload: { cwd: "C:\\Users\\jackson\\repo" } }))
+  const deps: HistoryDeps = {
+    sessionsDir: () => root,
+    readdir,
+    readFile: (name) => readFile(name, "utf8"),
+    stat,
+  }
+  expect(await listSessionIdsForWorktree("C:/Users/jackson/repo", deps)).toEqual([id])
+  expect(await findLatestRolloutForWorktree("C:/Users/jackson/repo", deps)).toMatchObject({ path: file })
+  expect(await listSessionIdsForWorktree("C:/Users/jackson/other", deps)).toEqual([])
+})

--- a/packages/kobe/test/engine/history-worktree.test.ts
+++ b/packages/kobe/test/engine/history-worktree.test.ts
@@ -1,0 +1,14 @@
+import { expect, it } from "vitest"
+import { sameHistoryWorktree } from "../../src/engine/history-worktree"
+
+it.each([
+  ["C:\\Users\\jackson\\repo", "C:/Users/jackson/repo", true],
+  ["\\\\server\\share\\repo", "//server/share/repo", true],
+  ["C:\\Users\\jackson\\repo", "C:/Users/jackson/other", false],
+  ["/repo/a", "/repo/A", false],
+  ["/repo/a\\b", "/repo/a/b", false],
+  [undefined, "/repo", false],
+  ["", "", false],
+])("compares history cwd %s with %s", (recorded, worktree, expected) => {
+  expect(sameHistoryWorktree(recorded, worktree)).toBe(expected)
+})

--- a/packages/kobe/test/render/tab-naming-codex-title.test.tsx
+++ b/packages/kobe/test/render/tab-naming-codex-title.test.tsx
@@ -23,7 +23,7 @@ import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import path from "node:path"
 import type { ReactNode } from "react"
-import { type TabLifecycleIO, useTabNaming } from "../../src/tui-react/workspace/use-tab-lifecycle"
+import { type TabLifecycleIO, useTabHydration, useTabNaming } from "../../src/tui-react/workspace/use-tab-lifecycle"
 import type { EngineTab, TabsState } from "../../src/tui/workspace/terminal-tabs-core"
 import { renderComponent } from "./harness"
 
@@ -43,12 +43,12 @@ afterEach(async () => {
 })
 
 /** A real `~/.codex` tree holding one rollout for THREAD_ID. */
-async function seedCodexRollout(): Promise<void> {
+async function seedCodexRollout(cwd = "/wt"): Promise<void> {
   codexHome = await mkdtemp(path.join(tmpdir(), "rove-codex-home-"))
   const day = path.join(codexHome, "sessions", "2026", "08", "18")
   await mkdir(day, { recursive: true })
   const lines = [
-    JSON.stringify({ type: "session_meta", payload: { id: THREAD_ID, cwd: "/wt" } }),
+    JSON.stringify({ type: "session_meta", payload: { id: THREAD_ID, cwd } }),
     JSON.stringify({
       type: "response_item",
       timestamp: "2026-08-18T00:00:01Z",
@@ -105,6 +105,19 @@ function Naming({ io }: { io: TabLifecycleIO }): ReactNode {
   useTabNaming(io)
   return <text>naming</text>
 }
+
+test("Windows restart recovers a Codex conversation when the tab still records another engine's id", async () => {
+  await seedCodexRollout("C:\\Users\\jackson\\repo")
+  const io = lifecycleIO(codexTabs({ sessionId: "stale-claude-id", spawned: true }), "codex", "C:/Users/jackson/repo")
+  let hydrating = true
+  function Hydrating(): ReactNode {
+    hydrating = useTabHydration(true, io)
+    return <text>hydrating</text>
+  }
+  await renderComponent(<Hydrating />)
+  await until(() => !hydrating)
+  expect(engineTab(io.state())).toMatchObject({ sessionId: THREAD_ID, spawned: true })
+})
 
 test("names a codex tab from the thread id in its own OSC title", async () => {
   await seedCodexRollout()

--- a/packages/kobe/test/render/tab-resume-identity.test.tsx
+++ b/packages/kobe/test/render/tab-resume-identity.test.tsx
@@ -1,0 +1,74 @@
+/** @jsxImportSource @opentui/react */
+import { afterEach, expect, spyOn, test } from "bun:test"
+import { useState } from "react"
+import { useTabTurnState } from "../../src/tui-react/workspace/use-tab-turn-state"
+import { MockTaskPty } from "../../src/tui/panes/terminal/pty-mock"
+import { getDefaultPtyRegistry } from "../../src/tui/panes/terminal/registry"
+import { getDefaultLiveEngines } from "../../src/tui/workspace/live-engine"
+import type { TabsState } from "../../src/tui/workspace/terminal-tabs-core"
+import type { VendorId } from "../../src/types/vendor"
+import { act, renderComponent } from "./harness"
+
+const restore: (() => void)[] = []
+afterEach(() => {
+  for (const run of restore.splice(0)) run()
+})
+
+test("a restored tab keeps its session through shell startup and demotes only after a live engine exits", async () => {
+  const pty = new MockTaskPty({ taskId: "resume::tab-1", cwd: "/wt" })
+  pty.feed("\x1b]0;restored title\x07")
+  const registry = getDefaultPtyRegistry()
+  const get = spyOn(registry, "get").mockImplementation((key) => (key === pty.taskId ? pty : null))
+  const has = spyOn(registry, "has").mockImplementation((key) => key === pty.taskId)
+  let live: VendorId | null | undefined
+  const listeners = new Set<() => void>()
+  const engines = getDefaultLiveEngines()
+  const resolve = spyOn(engines, "resolve").mockImplementation(() => live)
+  const subscribe = spyOn(engines, "subscribe").mockImplementation((listener) => {
+    listeners.add(listener)
+    return () => {
+      listeners.delete(listener)
+    }
+  })
+  restore.push(() => {
+    get.mockRestore()
+    has.mockRestore()
+    resolve.mockRestore()
+    subscribe.mockRestore()
+  })
+  let state: TabsState = {
+    tabs: [
+      { kind: "engine", id: "tab-1", ordinal: 1, title: null, spawned: true, sessionId: "saved", liveVendor: "claude" },
+    ],
+    activeId: "tab-1",
+    nextOrdinal: 2,
+  }
+  function Probe() {
+    const [current, update] = useState(state)
+    state = current
+    useTabTurnState({
+      taskId: "resume",
+      worktree: "/wt",
+      vendor: "claude",
+      state: current,
+      update,
+      notif: { toasts: [], unread: new Map(), notify() {}, dismiss() {}, markRead() {} },
+    })
+    return <text>resume</text>
+  }
+  const rendered = await renderComponent(<Probe />)
+  const observe = async (vendor: VendorId | null | undefined) => {
+    await act(async () => {
+      live = vendor
+      for (const listener of [...listeners]) listener()
+    })
+    await rendered.rerender()
+  }
+  await observe(null)
+  expect(state.tabs[0]).toMatchObject({ kind: "engine", sessionId: "saved", spawned: true })
+  await observe("claude")
+  expect(state.tabs[0]?.kind).toBe("engine")
+  await observe(null)
+  expect(state.tabs[0]?.kind).toBe("command")
+  rendered.destroy()
+})

--- a/packages/kobe/test/render/tab-session-discovery.test.tsx
+++ b/packages/kobe/test/render/tab-session-discovery.test.tsx
@@ -120,6 +120,36 @@ test("a rehydrated kimi tab adopts the session its worktree already has", async 
 
 const SECOND_SESSION_ID = "session_fc747c28-84ge-56d3-a8g5-5cd5g4346cgg"
 
+test("a stale id from another engine does not prevent discovery of the current engine's conversation", async () => {
+  await seedKimiSession()
+  const io = lifecycleIO(
+    {
+      tabs: [
+        {
+          kind: "engine",
+          id: "tab-1",
+          title: null,
+          ordinal: 1,
+          vendor: "kimi",
+          sessionId: "old-engine-id",
+          spawned: true,
+        },
+      ],
+      activeId: "tab-1",
+      nextOrdinal: 2,
+    },
+    worktree as string,
+  )
+  let hydrating = true
+  function Probe(): ReactNode {
+    hydrating = useTabHydration(true, io)
+    return <text>probe</text>
+  }
+  await renderComponent(<Probe />)
+  await until(() => !hydrating)
+  expect(io.state().tabs[0]).toMatchObject({ sessionId: SESSION_ID, spawned: true })
+})
+
 /**
  * Two engine tabs in one task share ONE worktree (`session-launch.ts:290-292`),
  * so "two tabs, one worktree" is the ordinary case, not an edge one — and the

--- a/packages/kobe/test/tui/terminal-tab-identity.test.ts
+++ b/packages/kobe/test/tui/terminal-tab-identity.test.ts
@@ -9,12 +9,29 @@
  */
 
 import { describe, expect, it } from "vitest"
-import { demoteExitedEngine } from "../../src/tui/workspace/terminal-tab-identity"
+import { createTabIdentityObserver, demoteExitedEngine } from "../../src/tui/workspace/terminal-tab-identity"
 import type { TerminalTab } from "../../src/tui/workspace/terminal-tabs-core"
 
 const SHELL = ["/bin/zsh"]
 const engineTab = (over: Partial<TerminalTab> = {}): TerminalTab =>
   ({ kind: "engine", id: "tab-1", title: null, ordinal: 1, sessionId: "s1", spawned: true, ...over }) as TerminalTab
+
+it("keeps a restored conversation through the shell startup window, then observes a real exit", () => {
+  const observe = createTabIdentityObserver()
+  const tab = engineTab({ liveVendor: "claude" })
+  expect(observe(tab, undefined, SHELL)).toBe(tab)
+  expect(observe(tab, null, SHELL)).toBe(tab)
+  expect(observe(tab, "claude", SHELL)).toBe(tab)
+  expect(observe(tab, null, SHELL).kind).toBe("command")
+})
+
+it("does not carry an observed engine exit across a detached or replaced PTY", () => {
+  const observe = createTabIdentityObserver()
+  const tab = engineTab({ liveVendor: "claude" })
+  observe(tab, "claude", SHELL)
+  expect(observe(tab, undefined, SHELL)).toBe(tab)
+  expect(observe(tab, null, SHELL)).toBe(tab)
+})
 
 describe("demoteExitedEngine", () => {
   it("resets an exited engine tab to a shell — kind, session pin and status title", () => {


### PR DESCRIPTION
After a Windows reboot, saved engine tabs could reopen as empty shells or fresh conversations. Replayed titles and persisted `liveVendor` were mistaken for a current process exit, erasing the tab's session ID during shell startup. History readers also compared Git's forward-slash worktree paths with native backslash paths literally, and a stale ID from a previous engine prevented discovery of the current conversation.

This change records exit edges from current process observations, shares Windows-aware worktree matching across Codex/Copilot/Kimi history, and retries discovery for invalid engine-generated IDs while retaining caller-pinned IDs for conversations that have not started. Existing IDs remain intact when discovery finds no replacement. The session documentation and patch changeset describe the recovery behavior.

Validation: lint and typecheck pass. Regression tests reproduce the old shell demotion and path mismatch, then pass with the fix; real React hooks cover startup, engine exit, stale-ID recovery and sibling claim isolation. A read-only check against the affected machine's real Codex history confirms both path spellings return the same conversations. The full local fast suite passed 3,970 tests with three Windows symlink-permission failures and one concurrency failure that passed on isolated retry. The socket/behavior/render/visual suites were also attempted; their Windows host limitations and results are retained locally. All required cross-platform CI jobs remain the merge gate.
