### PR TITLE
fix(win): verify the CLI's tab identity through its own console

### DIFF
--- a/.changeset/windows-cli-console-identity.md
+++ b/.changeset/windows-cli-console-identity.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Fix `rove api send` replying to the wrong tab on Windows. A `rove api` call made from an engine's Bash tool runs through the npm `sh` shim, and Git-Bash's fork exits the moment it execs `sh.exe`, so the CLI's parent chain reached a dead process before it reached the tab. Every task created that way recorded no dispatcher, and every bare `send` fell back to the active task — whatever tab you happened to be looking at. The console-membership repair that already re-links the engine to its tab shell now also runs on the CLI's own console, so the walk reaches the shell, `add` records the dispatcher, and `send` replies to the tab that dispatched the work. Process rows are now emitted in creation order so a console's root is chosen deterministically.

--- a/packages/kobe/src/cli/api/dispatcher.ts
+++ b/packages/kobe/src/cli/api/dispatcher.ts
@@ -24,7 +24,7 @@ export type Dispatcher = NonNullable<SerializedTask["dispatcher"]>
 export interface SelfSessionProbe {
   /** Live pty-host inventory (`pty.list`) — `[]` when the host is gone. */
   sessions(): Promise<readonly { key: string; pid: number | null; alive: boolean }[]>
-  /** Snapshot text, given the shell pids the walk anchors on (see `PsSnapshot`). */
+  /** Snapshot text, given the pids whose consoles the walk runs through — the tab's shell and this CLI (see `PsSnapshot`). */
   ps(anchors?: readonly number[]): Promise<string>
   /** This process's pid — the far end of the lineage walk. */
   pid: number
@@ -110,7 +110,11 @@ async function resolveSelfSession(env: NodeJS.ProcessEnv, probe?: SelfSessionPro
     const session = (await p.sessions()).find((s) => s.key === key && s.alive)
     if (session?.pid) {
       const { hasAncestor, parsePsSnapshot } = await import("../../engine/foreground.ts")
-      if (hasAncestor(parsePsSnapshot(await p.ps([session.pid])), p.pid, session.pid)) {
+      // Both ends of the walk are anchors: the tab's shell, whose console
+      // re-links the engine to it, and this CLI, whose console re-links it
+      // to the engine's Bash tool — Windows severs the chain at both places
+      // (win-process-snapshot.ts). POSIX ignores the list.
+      if (hasAncestor(parsePsSnapshot(await p.ps([session.pid, p.pid])), p.pid, session.pid)) {
         // A verified resolution clears any warning a previous one left. The
         // memo makes that a single resolution per process today; this keeps
         // the pair honest if the memo is ever relaxed.

--- a/packages/kobe/src/engine/foreground.ts
+++ b/packages/kobe/src/engine/foreground.ts
@@ -180,12 +180,14 @@ export function engineProcessIn(
 /**
  * Injectable so tests never shell out.
  *
- * `anchors` are the shell pids the caller is about to walk. POSIX ignores
- * them — a `ps` forest already carries every parent link there is. Windows
- * needs them: an npm-shim `cmd.exe` exits mid-chain and takes the link to the
- * engine with it, so the snapshot has to ask each tab's CONSOLE who is on it
- * before the tree is walkable (see `win-process-snapshot.ts`). Optional so
- * every existing zero-argument stub still satisfies the type.
+ * `anchors` are the pids whose consoles the caller's walk runs through: each
+ * tab shell it descends from, plus the caller itself when it is checking its
+ * own ancestry. POSIX ignores them — a `ps` forest already carries every
+ * parent link there is. Windows needs them: an npm shim exits mid-chain and
+ * takes a link with it (the engine's `cmd.exe`, the CLI's forked bash), so
+ * the snapshot has to ask each CONSOLE who is on it before the tree is
+ * walkable (see `win-process-snapshot.ts`). Optional so every existing
+ * zero-argument stub still satisfies the type.
  */
 export type PsSnapshot = (anchors?: readonly number[]) => Promise<string>
 

--- a/packages/kobe/src/engine/win-process-snapshot.ts
+++ b/packages/kobe/src/engine/win-process-snapshot.ts
@@ -33,6 +33,18 @@
  *    membership and re-attaches each cohort member whose parent is missing to
  *    the tab's shell, rebuilding a walkable tree.
  *
+ *    The same break happens on the OTHER end of the identity walk. A `rove
+ *    api` call from an engine's Bash tool runs through the npm `sh` shim:
+ *    Git-Bash forks, the fork execs `sh.exe`, and — `sh.exe` being an MSYS
+ *    program whose parent is another MSYS process — the forked bash's Windows
+ *    process exits instead of lingering as an exec stub. `sh.exe`'s
+ *    ParentProcessId is dead, and `hasAncestor(cli, tabShell)` was false for
+ *    every call made that way: no task recorded its dispatcher, and every
+ *    bare `send` fell back to the ACTIVE task — whichever tab the user was
+ *    looking at. The CLI's own console (the hidden one the Bash tool runs
+ *    in) still names its whole chain, so the same repair, anchored on the
+ *    CLI itself, re-attaches the orphan to that console's root.
+ *
  * Nothing here runs off win32: `psSnapshot` branches on the platform, and the
  * POSIX `ps` path is untouched.
  */
@@ -45,17 +57,21 @@ import { type ProcRow, PsProbeUnavailableError, serializeProcRows } from "./proc
 /**
  * `Get-CimInstance Win32_Process` rendered as `pid ppid commandline`.
  *
- * `-Property` narrows the CIM fetch to the four fields the walk reads.
+ * `-Property` narrows the CIM fetch to the five fields the walk reads.
  * `CommandLine` is null for processes this user may not open (and for the
  * kernel's own), so `Name` stands in: a row with no text at all would be
  * dropped by the parser and could break a chain that runs THROUGH it.
  * Command lines are flattened because a Windows command line may contain
  * literal newlines — Rove's own launch script does — and the snapshot format
- * is one process per line.
+ * is one process per line. Rows come out in creation order: when a console
+ * cohort holds several processes whose parents are off the console,
+ * {@link repairConsoleParentage} takes the OLDEST as that console's root, and
+ * row order is how it knows which one that is.
  */
 export const WIN_PROCESS_LIST_COMMAND =
   "[Console]::OutputEncoding=[System.Text.Encoding]::UTF8; " +
-  "Get-CimInstance -ClassName Win32_Process -Property ProcessId,ParentProcessId,CommandLine,Name | " +
+  "Get-CimInstance -ClassName Win32_Process -Property ProcessId,ParentProcessId,CommandLine,Name,CreationDate | " +
+  "Sort-Object CreationDate | " +
   "ForEach-Object { $c = $_.CommandLine; if (-not $c) { $c = $_.Name }; " +
   "\"$($_.ProcessId) $($_.ParentProcessId) $($c -replace '[\\r\\n\\t]+', ' ')\" }"
 
@@ -100,20 +116,28 @@ export function parseWinProcessList(text: string): ProcRow[] {
 }
 
 /**
- * Re-attach each console cohort's orphans to the shell that console belongs
- * to, so the tree is walkable again.
+ * Re-attach each console cohort's orphans to the root of that console, so the
+ * tree is walkable again.
  *
- * `cohorts` maps a tab's shell pid to every pid attached to its console
- * (`null` = the console could not be read, e.g. the shell already exited —
- * that anchor is left alone rather than guessed at). Membership is the
- * authority: a process on this console really is running inside this tab.
- * So a cohort member whose parent is ALSO in the cohort keeps its real
- * parent — depth is preserved, and the shallowest-engine walk still prefers
- * a wrapper's engine child over that engine's own helpers — while a member
- * whose parent is dead or off-console hangs off the shell directly.
+ * `cohorts` maps an anchor pid to every pid attached to its console (`null` =
+ * the console could not be read, e.g. the shell already exited — that anchor
+ * is left alone rather than guessed at). Membership is the authority: a
+ * process on this console really is running inside whatever that console
+ * belongs to. So a cohort member whose parent is ALSO in the cohort keeps its
+ * real parent — depth is preserved, and the shallowest-engine walk still
+ * prefers a wrapper's engine child over that engine's own helpers — while a
+ * member whose parent is dead or off-console hangs off the root directly.
  *
- * The shell itself is never reparented (its parent is the PTY host, which is
- * not attached to the console), so the repair cannot build a cycle.
+ * The root is the anchor when the anchor is where the console begins — a
+ * tab's shell, whose parent is the PTY host and not on the console. An anchor
+ * can also be a LEAF: the `rove api` CLI asking about its own console, which
+ * Git-Bash's `fork` + `exec` of the npm `sh` shim breaks the same way the
+ * shim's `cmd.exe` breaks the engine's (the forked bash's Windows process
+ * exits the moment it execs `sh.exe`, so the CLI's parent chain reaches a
+ * dead pid before it reaches the tab). There the root is the oldest member
+ * whose parent is alive and off the console — the process that brought the
+ * console into the tree — and the leaf itself is never a target, so the
+ * repair cannot build a cycle.
  */
 export function repairConsoleParentage(
   rows: readonly ProcRow[],
@@ -124,11 +148,13 @@ export function repairConsoleParentage(
   for (const [anchor, members] of cohorts) {
     if (!members || !byPid.has(anchor)) continue
     const cohort = new Set(members.filter((pid) => byPid.has(pid)))
+    const root = cohortRoot(rows, byPid, cohort, anchor)
+    if (root === undefined) continue
     for (const pid of cohort) {
-      if (pid === anchor || reparent.has(pid)) continue
+      if (pid === root || reparent.has(pid)) continue
       const row = byPid.get(pid)
       if (!row || cohort.has(row.ppid)) continue
-      reparent.set(pid, anchor)
+      reparent.set(pid, root)
     }
   }
   if (reparent.size === 0) return [...rows]
@@ -136,6 +162,31 @@ export function repairConsoleParentage(
     const ppid = reparent.get(row.pid)
     return ppid === undefined || ppid === row.ppid ? row : { ...row, ppid }
   })
+}
+
+/**
+ * The member a console's orphans hang off: the anchor when its own parent is
+ * off the console (a tab's shell), else the oldest member whose parent is
+ * alive and off the console, else the oldest whose parent is merely off it.
+ * `rows` are in creation order (see {@link WIN_PROCESS_LIST_COMMAND}), so
+ * "first" is "oldest". `undefined` when every member's parent is also a
+ * member — a cycle, which a real process table cannot hold.
+ */
+function cohortRoot(
+  rows: readonly ProcRow[],
+  byPid: ReadonlyMap<number, ProcRow>,
+  cohort: ReadonlySet<number>,
+  anchor: number,
+): number | undefined {
+  const anchorRow = byPid.get(anchor)
+  if (anchorRow && !cohort.has(anchorRow.ppid)) return anchor
+  let orphanRoot: number | undefined
+  for (const row of rows) {
+    if (!cohort.has(row.pid) || cohort.has(row.ppid)) continue
+    if (byPid.has(row.ppid)) return row.pid
+    orphanRoot ??= row.pid
+  }
+  return orphanRoot
 }
 
 /** The two Windows reads, injectable so tests never spawn anything. */
@@ -287,10 +338,12 @@ export function defaultWinProcessProbe(budgetMs: number = WIN_PROBE_TIMEOUT_MS):
  * The win32 replacement for one `ps -A -o pid=,ppid=,args=` run, in the same
  * text shape.
  *
- * `anchors` are the shell pids about to be walked. They are what the console
- * repair needs — and the reason {@link import("./foreground.ts").PsSnapshot}
- * takes them at all; the POSIX branch ignores them, because a POSIX parent
- * chain is already intact.
+ * `anchors` are the pids whose consoles the walk runs through: the shell of
+ * every tab about to be walked, plus the caller itself when the walk is an
+ * ancestry check on the caller. They are what the console repair needs — and
+ * the reason {@link import("./foreground.ts").PsSnapshot} takes them at all;
+ * the POSIX branch ignores them, because a POSIX parent chain is already
+ * intact.
  *
  * Failure is a THROW, never a thin snapshot: with the parent chain severed,
  * rows we could not repair would answer "no engine" for a tab whose engine is

--- a/packages/kobe/test/cli/api-dispatcher.test.ts
+++ b/packages/kobe/test/cli/api-dispatcher.test.ts
@@ -72,6 +72,23 @@ describe("verifiedSelfSession (env identity is inheritable, so it must be proven
     })
   })
 
+  it("anchors the snapshot on BOTH ends of the walk — the tab's shell and this CLI", async () => {
+    // Windows severs the chain at both: the engine shim's cmd.exe under the
+    // shell, and the forked bash that exec'd the npm sh shim above the CLI.
+    // Each console re-links its own side (win-process-snapshot.ts).
+    const base = probeFor("d1::tab-4", { shellPid: 100 })
+    let anchors: readonly number[] | undefined
+    const probe: SelfSessionProbe = {
+      ...base,
+      ps: async (a) => {
+        anchors = a
+        return base.ps()
+      },
+    }
+    await verifiedSelfSession({ KOBE_TASK_ID: "d1", KOBE_TAB_ID: "tab-4" }, probe)
+    expect(anchors).toEqual([100, 500])
+  })
+
   it("floors a missing tab id to the canonical tab-1 and verifies THAT", async () => {
     expect(await verifiedSelfSession({ KOBE_TASK_ID: "d1" }, probeFor("d1::tab-1"))).toEqual({
       taskId: "d1",

--- a/packages/kobe/test/engine/win-process-snapshot.test.ts
+++ b/packages/kobe/test/engine/win-process-snapshot.test.ts
@@ -9,7 +9,7 @@
  */
 
 import { describe, expect, it } from "vitest"
-import { engineProcessIn, foregroundEngineIn, parsePsSnapshot } from "../../src/engine/foreground.ts"
+import { engineProcessIn, foregroundEngineIn, hasAncestor, parsePsSnapshot } from "../../src/engine/foreground.ts"
 import { PsProbeUnavailableError } from "../../src/engine/process-rows.ts"
 import {
   WIN_PROBE_TIMEOUT_MS,
@@ -125,6 +125,84 @@ describe("repairConsoleParentage (the npm shim's cmd.exe took the chain with it)
       ]),
     )
     expect(fixed.find((r) => r.pid === 39384)?.ppid).toBe(39308)
+  })
+})
+
+/**
+ * The other end of the identity walk, transcribed from a machine where every
+ * `rove api add` made from an engine's Bash tool recorded no dispatcher.
+ * 12504's parent 32224 is the Git-Bash fork that exec'd the npm `sh` shim
+ * and exited on the spot; 30956's parent 26980 is the engine shim's `cmd.exe`.
+ * 7504 (the Bash tool's root bash) has no console; 20368 is the first process
+ * on the hidden console the rest of the chain shares. Rows are in creation
+ * order, as the CIM command emits them.
+ */
+const CIM_CLI = [
+  '5664 26696 "C:\\Program Files\\nodejs\\node.EXE" C:\\Users\\me\\AppData\\Roaming\\npm\\node_modules\\@sma1lboy\\rove\\dist\\cli\\pty-host-node.mjs',
+  "31768 5664 \"C:\\Program Files\\Git\\bin\\bash.exe\" -ilc \"export ROVE_TASK_ID='01M1V8' ROVE_TAB_ID='tab-4' claude\"",
+  '30956 26980 "C:\\Program Files\\Git\\usr\\bin\\sh.exe" /c/Users/me/AppData/Roaming/npm/claude --dangerously-skip-permissions',
+  "31188 30956 C:\\Users\\me\\AppData\\Roaming\\npm\\node_modules\\@anthropic-ai\\claude-code\\bin\\claude.exe --dangerously-skip-permissions",
+  '7504 31188 "C:\\Program Files\\Git\\bin\\bash.exe" -c "source /c/Users/me/.claude/shell-snapshots/snapshot-bash-1.sh"',
+  '20368 7504 "C:\\Program Files\\Git\\bin\\..\\usr\\bin\\bash.exe" -c "source /c/Users/me/.claude/shell-snapshots/snapshot-bash-1.sh"',
+  '24956 20368 "C:\\Program Files\\Git\\bin\\..\\usr\\bin\\bash.exe" -c "source /c/Users/me/.claude/shell-snapshots/snapshot-bash-1.sh"',
+  '12504 32224 "C:\\Program Files\\Git\\usr\\bin\\sh.exe" /c/Users/me/AppData/Roaming/npm/rove api add --repo . --title x',
+  '19248 12504 "C:\\Program Files\\nodejs\\node.exe" C:\\Users\\me\\AppData\\Roaming\\npm/node_modules/@sma1lboy/rove/dist/cli/rove.js api add --repo . --title x',
+  "29612 19248 C:\\Users\\me\\.bun\\bin\\bun.exe C:\\Users\\me\\AppData\\Roaming\\npm\\node_modules\\@sma1lboy\\rove\\dist\\cli\\rove-run.js api add --repo . --title x",
+].join("\n")
+
+const TAB_31768 = [31188, 30956, 31768]
+/** `GetConsoleProcessList` order is not creation order — the repair must not lean on it. */
+const CLI_29612 = [29612, 12504, 24956, 19248, 20368]
+
+describe("repairConsoleParentage anchored on the CLI itself (Git-Bash's fork exec'd the npm sh shim and died)", () => {
+  const raw = parseWinProcessList(CIM_CLI)
+  const both = new Map([
+    [31768, TAB_31768],
+    [29612, CLI_29612],
+  ])
+
+  it("cannot reach the tab's shell from the CLI before the repair — the bug, reproduced", () => {
+    expect(hasAncestor(raw, 29612, 31768)).toBe(false)
+  })
+
+  it("the tab-shell repair alone is not enough: the break is on the CLI's side of the engine", () => {
+    const fixed = repairConsoleParentage(raw, new Map([[31768, TAB_31768]]))
+    expect(hasAncestor(fixed, 31188, 31768)).toBe(true)
+    expect(hasAncestor(fixed, 29612, 31768)).toBe(false)
+  })
+
+  it("re-attaches the orphaned sh.exe to the CLI console's root, and the walk reaches the shell", () => {
+    const fixed = repairConsoleParentage(raw, both)
+    expect(fixed.find((r) => r.pid === 12504)?.ppid).toBe(20368)
+    expect(hasAncestor(fixed, 29612, 31768)).toBe(true)
+  })
+
+  it("the root is the oldest member whose parent is alive and off the console, and it keeps that parent", () => {
+    const fixed = repairConsoleParentage(raw, both)
+    expect(fixed.find((r) => r.pid === 20368)?.ppid).toBe(7504)
+  })
+
+  it("never reparents onto a leaf anchor, so the CLI keeps its real parent and no cycle forms", () => {
+    const fixed = repairConsoleParentage(raw, both)
+    expect(fixed.find((r) => r.pid === 29612)?.ppid).toBe(19248)
+    expect(fixed.find((r) => r.pid === 19248)?.ppid).toBe(12504)
+  })
+
+  it("prefers the older of two members with alive off-console parents, by row order", () => {
+    // A younger cohort member the engine itself spawned onto this console.
+    const younger = '40000 31188 "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe" -NoProfile -Command x'
+    const rows = parseWinProcessList(`${CIM_CLI}\n${younger}`)
+    const fixed = repairConsoleParentage(rows, new Map([[29612, [...CLI_29612, 40000]]]))
+    expect(fixed.find((r) => r.pid === 12504)?.ppid).toBe(20368)
+    expect(fixed.find((r) => r.pid === 40000)?.ppid).toBe(20368)
+  })
+
+  it("falls back to the oldest orphan when no member's parent is alive", () => {
+    // The console's own first process lost its parent too.
+    const rows = raw.map((r) => (r.pid === 20368 ? { ...r, ppid: 777777 } : r))
+    const fixed = repairConsoleParentage(rows, new Map([[29612, CLI_29612]]))
+    expect(fixed.find((r) => r.pid === 12504)?.ppid).toBe(20368)
+    expect(fixed.find((r) => r.pid === 20368)?.ppid).toBe(777777)
   })
 })
 


### PR DESCRIPTION
## Problem

On Windows, `rove api send` from a dispatched task replied to the **wrong tab** — a `succeeded:` report landed in a Codex chat tab the user happened to be looking at, and the next one in an unrelated Claude tab.

Root cause: every `rove api add` made from an engine's Bash tool recorded **no dispatcher** (the `identityWarning` "not running inside that tab" was in each result). The Git-Bash `fork` that execs the npm `sh` shim exits immediately (an MSYS process exec'ing an MSYS program under an MSYS parent keeps no exec stub), so `sh.exe`'s `ParentProcessId` is dead and `hasAncestor(cli, tabShell)` is false. With no dispatcher, a bare `send` falls back to the active task.

Verified on the affected machine: the installed CLI via the shim fails the check; `node rove.js` / `bun rove-run.js` directly (no MSYS fork+exec) pass; the same shell shape against this branch passes and records `dispatcher`.

## Fix

- `repairConsoleParentage` now takes the CLI's own pid as an anchor too. When the anchor is a leaf (its parent is on the console), the console's root is the oldest member whose parent is alive and off the console; orphans hang off that root. The tab-shell case is unchanged (anchor is the root).
- `WIN_PROCESS_LIST_COMMAND` sorts by `CreationDate` so "oldest" is deterministic.
- `verifiedSelfSession` passes `[shellPid, process.pid]` as anchors (POSIX ignores them).

## Tests

- `test/engine/win-process-snapshot.test.ts`: fixture transcribed from the affected machine; reproduces the break, shows the tab-side repair alone is insufficient, and covers root selection / leaf anchor / fallback.
- `test/cli/api-dispatcher.test.ts`: asserts both anchors reach the probe (file is on the Windows known-failing list locally; runs on CI).

Local: engine + cli vitest dirs pass except `history-default-deps.test.ts` (mtime ordering, pre-existing on this machine, unrelated). typecheck + biome clean.
