### PR TITLE
fix(win): spawn the daemon and PTY host so they outlive the TUI

### DIFF
--- a/.changeset/windows-detached-spawn-survives-tui.md
+++ b/.changeset/windows-detached-spawn-survives-tui.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Keep the daemon and the PTY host alive when Rove quits on Windows. Quitting the TUI, closing its terminal tab, or letting a `rove daemon restart` finish used to take every engine tab with it: on Windows, Bun puts each spawned child in a kill-on-close job, so the daemon and the PTY host died the moment the process that started them exited, and with a log file on their stdio they were also left sharing the terminal's console, so a Ctrl+C or a closed tab reached them too. Both are now spawned through a small PowerShell launcher that creates the child broken away from the job, on its own hidden console, with stdout/stderr still appended to `daemon.log` / `pty.log`. Engine tabs survive quitting and restarting Rove on Windows the way they always have on macOS and Linux. If the launcher cannot run, the old direct spawn is used and the log says so.

--- a/packages/kobe-daemon/package.json
+++ b/packages/kobe-daemon/package.json
@@ -11,6 +11,7 @@
     "./client": "./src/client/index.ts",
     "./client/client-log": "./src/client/client-log.ts",
     "./client/daemon-process": "./src/client/daemon-process.ts",
+    "./client/detached-spawn": "./src/client/detached-spawn.ts",
     "./client/pty-process": "./src/client/pty-process.ts",
     "./client/rpc": "./src/client/rpc.ts",
     "./daemon/activity-arbitrate": "./src/daemon/activity-arbitrate.ts",

--- a/packages/kobe-daemon/src/client/daemon-process.ts
+++ b/packages/kobe-daemon/src/client/daemon-process.ts
@@ -1,4 +1,3 @@
-import { type StdioOptions, spawn } from "node:child_process"
 import { closeSync, existsSync, mkdirSync, openSync, statSync, unlinkSync } from "node:fs"
 import { dirname, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
@@ -7,6 +6,7 @@ import { isProcessAlive, stopDaemonProcess } from "../daemon/lifecycle.ts"
 import { defaultDaemonLogPath, defaultDaemonPidPath, defaultDaemonSocketPath } from "../daemon/paths.ts"
 import { DAEMON_PROTOCOL_VERSION } from "../daemon/protocol.ts"
 import { readPidFile } from "../daemon/socket-guard.ts"
+import { spawnDetachedDaemon } from "./detached-spawn.ts"
 import { KobeDaemonClient } from "./index.ts"
 
 const DAEMON_START_ARGS = ["daemon", "start"] as const
@@ -28,57 +28,6 @@ const DAEMON_HELLO_TIMEOUT_MS = 3000
  * task creation.
  */
 const BUSY_DAEMON_GRACE_MS = 15_000
-
-/**
- * How a background child is cut loose from this process.
- *
- * On Windows `detached: true` means DETACHED_PROCESS: the child gets its OWN
- * console, which the OS renders as a stray terminal window next to the TUI,
- * retitling itself after whatever the hosted PTY happens to be running. libuv
- * gives DETACHED_PROCESS precedence over CREATE_NO_WINDOW, so `windowsHide`
- * cannot suppress it — on Windows the flag must be absent. Nothing is lost:
- * `detached` only buys POSIX setsid, and an unref'd Windows child already
- * outlives its parent.
- */
-export function detachOptions(
-  platform: NodeJS.Platform = process.platform,
-): { windowsHide: true } | { detached: true } {
-  return platform === "win32" ? { windowsHide: true } : { detached: true }
-}
-
-/**
- * Spawn the detached daemon child with stdout/stderr appended to
- * `logPath`, so a crash leaves a trace. Falls back to `"ignore"` if the
- * log file can't be opened (never block the daemon from starting over a
- * log file).
- * The parent closes its copy of the fd after the fork; the child keeps
- * its own.
- */
-export function spawnDetachedDaemon(
-  command: string,
-  args: readonly string[],
-  env: NodeJS.ProcessEnv,
-  logPath: string,
-): void {
-  let stdio: StdioOptions = "ignore"
-  let logFd: number | undefined
-  try {
-    mkdirSync(dirname(logPath), { recursive: true })
-    logFd = openSync(logPath, "a")
-    stdio = ["ignore", logFd, logFd]
-  } catch {
-    stdio = "ignore"
-  }
-  const child = spawn(command, [...args], { ...detachOptions(), stdio, env })
-  child.unref()
-  if (logFd !== undefined) {
-    try {
-      closeSync(logFd)
-    } catch {
-      /* parent's copy only — child holds its own dup */
-    }
-  }
-}
 
 /**
  * True when this process runs INSIDE a kobe engine session — the launch

--- a/packages/kobe-daemon/src/client/detached-spawn.ts
+++ b/packages/kobe-daemon/src/client/detached-spawn.ts
@@ -1,0 +1,108 @@
+/**
+ * Spawning a background child that must OUTLIVE this process — the daemon
+ * (`rove daemon start`) and the PTY host (`rove pty-host`). Owns the
+ * platform split: POSIX detaches with setsid and hands the log fd down;
+ * Windows goes through the PowerShell launcher in win-detached-launch.ts,
+ * falling back to a plain spawn (that dies with us) only when the launcher
+ * itself cannot run. Reachability, probing and the spawn+poll loops stay in
+ * daemon-process.ts / pty-process.ts.
+ */
+
+import { type StdioOptions, spawn } from "node:child_process"
+import { appendFileSync, closeSync, mkdirSync, openSync } from "node:fs"
+import { dirname } from "node:path"
+import { spawnWindowsDetached } from "./win-detached-launch.ts"
+
+/**
+ * How a background child is cut loose from this process by a plain
+ * `child_process.spawn`.
+ *
+ * POSIX: `detached` (setsid) is the whole answer. Windows: this is only the
+ * FALLBACK shape, used when the real launcher (win-detached-launch.ts)
+ * could not run. `detached: true` there means DETACHED_PROCESS — no console
+ * at all, so every console child the daemon spawns (git, gh, PowerShell
+ * probes) pops a visible window — and it would not save the child anyway:
+ * Bun's job object kills it when this process exits. `windowsHide` keeps
+ * the windows away; the child then shares this console and dies with it.
+ */
+export function detachOptions(
+  platform: NodeJS.Platform = process.platform,
+): { windowsHide: true } | { detached: true } {
+  return platform === "win32" ? { windowsHide: true } : { detached: true }
+}
+
+/**
+ * Spawn the detached daemon child with stdout/stderr appended to
+ * `logPath`, so a crash leaves a trace.
+ *
+ * Windows goes through the PowerShell launcher in win-detached-launch.ts —
+ * the only way the child survives this process's exit (Bun's kill-on-close
+ * job) and this terminal's close (its own hidden console); see that file.
+ * Should the launcher itself fail, the child is spawned directly instead,
+ * with a line in the log saying it will not outlive this process: a daemon
+ * that dies with its TUI beats no daemon.
+ *
+ * POSIX: the parent opens the log and hands the fd down, closing its own
+ * copy after the fork; falls back to `"ignore"` if the log file can't be
+ * opened (never block the daemon from starting over a log file).
+ */
+export function spawnDetachedDaemon(
+  command: string,
+  args: readonly string[],
+  env: NodeJS.ProcessEnv,
+  logPath: string,
+  platform: NodeJS.Platform = process.platform,
+): void {
+  try {
+    mkdirSync(dirname(logPath), { recursive: true })
+  } catch {
+    /* the direct spawn below copes with a missing log dir */
+  }
+  if (platform === "win32") {
+    const launcher = spawnWindowsDetached(command, args, env, logPath)
+    const fallback = (reason: string) => {
+      try {
+        appendFileSync(
+          logPath,
+          `[${new Date().toISOString()}] rove: detached launcher ${reason} — spawning directly; this process will not outlive its parent\n`,
+        )
+      } catch {
+        /* log is best-effort */
+      }
+      spawnDirect(command, args, env, logPath, platform)
+    }
+    launcher.once("error", (err) => fallback(`could not start (${err.message})`))
+    launcher.once("exit", (code, signal) => {
+      if (code !== 0) fallback(`exited ${code ?? signal}`)
+    })
+    return
+  }
+  spawnDirect(command, args, env, logPath, platform)
+}
+
+function spawnDirect(
+  command: string,
+  args: readonly string[],
+  env: NodeJS.ProcessEnv,
+  logPath: string,
+  platform: NodeJS.Platform,
+): void {
+  let stdio: StdioOptions = "ignore"
+  let logFd: number | undefined
+  try {
+    mkdirSync(dirname(logPath), { recursive: true })
+    logFd = openSync(logPath, "a")
+    stdio = ["ignore", logFd, logFd]
+  } catch {
+    stdio = "ignore"
+  }
+  const child = spawn(command, [...args], { ...detachOptions(platform), stdio, env })
+  child.unref()
+  if (logFd !== undefined) {
+    try {
+      closeSync(logFd)
+    } catch {
+      /* parent's copy only — child holds its own dup */
+    }
+  }
+}

--- a/packages/kobe-daemon/src/client/pty-process.ts
+++ b/packages/kobe-daemon/src/client/pty-process.ts
@@ -16,7 +16,8 @@ import { isProcessAlive, stopDaemonProcess } from "../daemon/lifecycle.ts"
 import { defaultPtyHostLogPath, defaultPtyHostPidPath, defaultPtyHostSocketPath } from "../daemon/paths.ts"
 import type { PtySessionInfo } from "../daemon/pty-observability.ts"
 import { readPidFile } from "../daemon/socket-guard.ts"
-import { resolveKobeSpawn, spawnDetachedDaemon, testDaemonResponds } from "./daemon-process.ts"
+import { resolveKobeSpawn, testDaemonResponds } from "./daemon-process.ts"
+import { spawnDetachedDaemon } from "./detached-spawn.ts"
 import { KobeDaemonClient } from "./index.ts"
 
 const PTY_HOST_START_ARGS = ["pty-host"] as const

--- a/packages/kobe-daemon/src/client/win-detached-launch.ts
+++ b/packages/kobe-daemon/src/client/win-detached-launch.ts
@@ -1,0 +1,163 @@
+/**
+ * How a background child escapes its parent on Windows.
+ *
+ * `spawnDetachedDaemon` (daemon-process.ts) spawns the daemon and the PTY
+ * host as children that must OUTLIVE the process that started them — the
+ * TUI, a `rove daemon restart`, an agent's `rove api` call. On POSIX
+ * `detached: true` (setsid) is the whole answer. On Windows, under Bun,
+ * two things kill such a child that no spawn option can prevent:
+ *
+ *  1. **Bun puts every child in a job object with KILL_ON_JOB_CLOSE.** The
+ *     moment the spawning Bun process exits, the job closes and every
+ *     process in it is terminated — `unref()`, `detached: true`, and
+ *     `windowsHide` change nothing. The job does allow breakaway
+ *     (`BREAKAWAY_OK | SILENT_BREAKAWAY_OK`), so a process created with
+ *     `CREATE_BREAKAWAY_FROM_JOB` is spared.
+ *  2. **`windowsHide` is dropped when stdio carries file handles.** With
+ *     `stdio: ["ignore", logFd, logFd]` the child lands on the PARENT'S
+ *     console instead of a hidden one of its own, and a console close /
+ *     Ctrl+C on the terminal running the TUI ends every process attached
+ *     to it — the PTY host included, which is how "quit Rove and every
+ *     engine tab died with it" happened on Windows while macOS kept them.
+ *
+ * Neither flag is reachable through `child_process`, so the child is
+ * created by a small PowerShell launcher that calls `CreateProcess`
+ * directly: `CREATE_BREAKAWAY_FROM_JOB | CREATE_NEW_CONSOLE` with the
+ * window hidden, and stdout/stderr pointed at the log file with an
+ * inheritable append handle — the same "append fd" contract the log
+ * rotation in daemon-cmd.ts / pty-host-cmd.ts relies on. The launcher's own
+ * parameters travel in environment variables (never on a command line, so
+ * there is nothing to quote twice) and are removed before the child is
+ * created, so the daemon does not inherit them.
+ */
+
+import { type ChildProcess, spawn } from "node:child_process"
+import { existsSync } from "node:fs"
+import { join } from "node:path"
+
+/** The launcher reads these; it strips them before the child is created. */
+export const LAUNCH_CMD_ENV = "ROVE_LAUNCH_CMD"
+export const LAUNCH_LOG_ENV = "ROVE_LAUNCH_LOG"
+
+/**
+ * The launcher. Plain Windows PowerShell 5.1 (always present) plus one
+ * `Add-Type` for the three kernel32 calls. Exit code 1 with the error on
+ * stderr when the child could not be created, so the caller can fall back.
+ */
+export const WIN_DETACHED_LAUNCHER_PS = `
+$ErrorActionPreference = 'Stop'
+$cmd = $env:${LAUNCH_CMD_ENV}
+$log = $env:${LAUNCH_LOG_ENV}
+if (-not $cmd -or -not $log) { [Console]::Error.WriteLine('rove launcher: ${LAUNCH_CMD_ENV}/${LAUNCH_LOG_ENV} not set'); exit 1 }
+Remove-Item Env:${LAUNCH_CMD_ENV}, Env:${LAUNCH_LOG_ENV}
+Add-Type -TypeDefinition @'
+using System;
+using System.Runtime.InteropServices;
+public static class RoveDetachedLaunch {
+  [StructLayout(LayoutKind.Sequential)] public struct SA { public int nLength; public IntPtr lpSecurityDescriptor; public bool bInheritHandle; }
+  [StructLayout(LayoutKind.Sequential, CharSet=CharSet.Unicode)] public struct SI { public int cb; public string lpReserved; public string lpDesktop; public string lpTitle; public int dwX, dwY, dwXSize, dwYSize, dwXCountChars, dwYCountChars, dwFillAttribute, dwFlags; public short wShowWindow, cbReserved2; public IntPtr lpReserved2, hStdInput, hStdOutput, hStdError; }
+  [StructLayout(LayoutKind.Sequential)] public struct PI { public IntPtr hProcess, hThread; public int dwProcessId, dwThreadId; }
+  [DllImport("kernel32.dll", CharSet=CharSet.Unicode, SetLastError=true)] static extern IntPtr CreateFile(string name, uint access, uint share, ref SA sa, uint disposition, uint flags, IntPtr template);
+  [DllImport("kernel32.dll", CharSet=CharSet.Unicode, SetLastError=true)] static extern bool CreateProcess(string app, string cmd, IntPtr pa, IntPtr ta, bool inherit, uint flags, IntPtr env, string cwd, ref SI si, out PI pi);
+  [DllImport("kernel32.dll")] static extern bool CloseHandle(IntPtr h);
+  public static int Launch(string cmd, string log) {
+    SA sa = new SA(); sa.nLength = Marshal.SizeOf(sa); sa.bInheritHandle = true;
+    // FILE_APPEND_DATA | GENERIC_READ, shared read/write, OPEN_ALWAYS, FILE_ATTRIBUTE_NORMAL
+    IntPtr h = CreateFile(log, 0x0004 | 0x80000000, 0x1 | 0x2, ref sa, 4, 0x80, IntPtr.Zero);
+    if (h == (IntPtr)(-1)) throw new Exception("CreateFile(" + log + ") failed: " + Marshal.GetLastWin32Error());
+    IntPtr nul = CreateFile("NUL", 0x80000000, 0x1 | 0x2, ref sa, 3, 0x80, IntPtr.Zero);
+    SI si = new SI(); si.cb = Marshal.SizeOf(si);
+    si.dwFlags = 0x100 | 0x1; // STARTF_USESTDHANDLES | STARTF_USESHOWWINDOW
+    si.wShowWindow = 0;       // SW_HIDE
+    si.hStdInput = nul; si.hStdOutput = h; si.hStdError = h;
+    PI pi;
+    uint flags = 0x00000010 | 0x01000000 | 0x00000200; // CREATE_NEW_CONSOLE | CREATE_BREAKAWAY_FROM_JOB | CREATE_NEW_PROCESS_GROUP
+    if (!CreateProcess(null, cmd, IntPtr.Zero, IntPtr.Zero, true, flags, IntPtr.Zero, null, ref si, out pi)) throw new Exception("CreateProcess failed: " + Marshal.GetLastWin32Error());
+    CloseHandle(h); CloseHandle(nul); CloseHandle(pi.hThread); CloseHandle(pi.hProcess);
+    return pi.dwProcessId;
+  }
+}
+'@
+[RoveDetachedLaunch]::Launch($cmd, $log) | Out-Null
+`
+
+/**
+ * One argv rendered as the command line `CreateProcess` hands the child —
+ * the quoting MSVCRT's argv parser undoes: an argument with a space, tab or
+ * quote is wrapped in quotes, a quote inside is escaped, and backslashes
+ * are doubled ONLY where they precede a quote (a trailing run before the
+ * closing quote included). A plain path with backslashes passes verbatim.
+ */
+export function windowsCommandLine(argv: readonly string[]): string {
+  return argv.map(quoteWindowsArg).join(" ")
+}
+
+function quoteWindowsArg(arg: string): string {
+  if (arg !== "" && !/[\s"]/.test(arg)) return arg
+  let out = '"'
+  let backslashes = 0
+  for (const ch of arg) {
+    if (ch === "\\") {
+      backslashes++
+      continue
+    }
+    if (ch === '"') {
+      out += `${"\\".repeat(backslashes * 2 + 1)}"`
+      backslashes = 0
+      continue
+    }
+    out += "\\".repeat(backslashes) + ch
+    backslashes = 0
+  }
+  return `${out}${"\\".repeat(backslashes * 2)}"`
+}
+
+/** `powershell.exe` by absolute path — PATH is not guaranteed under a PTY. */
+export function windowsPowershellPath(env: NodeJS.ProcessEnv = process.env): string {
+  const root = env.SystemRoot || env.windir || "C:\\Windows"
+  const absolute = join(root, "System32", "WindowsPowerShell", "v1.0", "powershell.exe")
+  return existsSync(absolute) ? absolute : "powershell.exe"
+}
+
+/** PowerShell's `-EncodedCommand` wants the script as base64 UTF-16LE. */
+export function encodePowershellCommand(script: string): string {
+  return Buffer.from(script, "utf16le").toString("base64")
+}
+
+/** The launcher's argv, for callers and tests that inspect the spawn. */
+export function windowsDetachedLauncherArgs(): string[] {
+  return [
+    "-NoProfile",
+    "-NonInteractive",
+    "-ExecutionPolicy",
+    "Bypass",
+    "-EncodedCommand",
+    encodePowershellCommand(WIN_DETACHED_LAUNCHER_PS),
+  ]
+}
+
+/**
+ * Spawn `command args` on Windows so that it outlives this process and its
+ * console, with stdout/stderr appended to `logPath`. Returns the LAUNCHER
+ * child: it exits 0 once the real child exists, non-zero when it could not
+ * be created — the caller decides what to do then.
+ *
+ * The launcher itself gets `windowsHide` + `stdio: "ignore"`, the one
+ * combination Bun honours; the real child never sees the launcher's
+ * console anyway (it gets its own), and never sees `LAUNCH_*` (stripped).
+ */
+export function spawnWindowsDetached(
+  command: string,
+  args: readonly string[],
+  env: NodeJS.ProcessEnv,
+  logPath: string,
+  spawnImpl: typeof spawn = spawn,
+): ChildProcess {
+  const child = spawnImpl(windowsPowershellPath(env), windowsDetachedLauncherArgs(), {
+    windowsHide: true,
+    stdio: "ignore",
+    env: { ...env, [LAUNCH_CMD_ENV]: windowsCommandLine([command, ...args]), [LAUNCH_LOG_ENV]: logPath },
+  })
+  child.unref()
+  return child
+}

--- a/packages/kobe/test/client/win-detached-launch.test.ts
+++ b/packages/kobe/test/client/win-detached-launch.test.ts
@@ -1,0 +1,91 @@
+/**
+ * The Windows detached launcher — the shape of the spawn, never a real
+ * PowerShell. What it must get right: the child's command line survives
+ * MSVCRT's argv parser, the launcher's parameters ride the env (nothing to
+ * quote twice), and the launcher itself is spawned in the one shape Bun
+ * honours on Windows (`windowsHide` + `stdio: "ignore"`).
+ */
+
+import type { ChildProcess } from "node:child_process"
+import { EventEmitter } from "node:events"
+import { describe, expect, it } from "vitest"
+import {
+  LAUNCH_CMD_ENV,
+  LAUNCH_LOG_ENV,
+  WIN_DETACHED_LAUNCHER_PS,
+  encodePowershellCommand,
+  spawnWindowsDetached,
+  windowsCommandLine,
+} from "../../../kobe-daemon/src/client/win-detached-launch.ts"
+
+describe("windowsCommandLine (MSVCRT argv quoting)", () => {
+  it("passes plain arguments and backslash paths verbatim", () => {
+    expect(windowsCommandLine(["C:\\Users\\me\\.bun\\bin\\bun.exe", "daemon", "start"])).toBe(
+      "C:\\Users\\me\\.bun\\bin\\bun.exe daemon start",
+    )
+  })
+
+  it("quotes an argument with a space and doubles only the backslashes before the closing quote", () => {
+    expect(windowsCommandLine(["C:\\Program Files\\Git\\bin\\bash.exe"])).toBe(
+      '"C:\\Program Files\\Git\\bin\\bash.exe"',
+    )
+    expect(windowsCommandLine(["C:\\Program Files\\"])).toBe('"C:\\Program Files\\\\"')
+  })
+
+  it("escapes an embedded quote and the backslashes in front of it", () => {
+    expect(windowsCommandLine(['say "hi"'])).toBe('"say \\"hi\\""')
+    expect(windowsCommandLine(['a\\"b'])).toBe('"a\\\\\\"b"')
+  })
+
+  it("renders an empty argument as an empty pair of quotes", () => {
+    expect(windowsCommandLine(["x", "", "y"])).toBe('x "" y')
+  })
+})
+
+describe("the launcher script", () => {
+  it("reads its parameters from the env, strips them, and breaks away from the job with its own hidden console", () => {
+    expect(WIN_DETACHED_LAUNCHER_PS).toContain(`$env:${LAUNCH_CMD_ENV}`)
+    expect(WIN_DETACHED_LAUNCHER_PS).toContain(`$env:${LAUNCH_LOG_ENV}`)
+    expect(WIN_DETACHED_LAUNCHER_PS).toContain(`Remove-Item Env:${LAUNCH_CMD_ENV}, Env:${LAUNCH_LOG_ENV}`)
+    // CREATE_NEW_CONSOLE | CREATE_BREAKAWAY_FROM_JOB | CREATE_NEW_PROCESS_GROUP, SW_HIDE
+    expect(WIN_DETACHED_LAUNCHER_PS).toContain("0x00000010 | 0x01000000 | 0x00000200")
+    expect(WIN_DETACHED_LAUNCHER_PS).toContain("si.wShowWindow = 0;")
+  })
+
+  it("is handed to PowerShell as base64 UTF-16LE", () => {
+    const encoded = encodePowershellCommand("Write-Output hi")
+    expect(Buffer.from(encoded, "base64").toString("utf16le")).toBe("Write-Output hi")
+  })
+})
+
+describe("spawnWindowsDetached", () => {
+  it("spawns powershell hidden with stdio ignored, the command line and log path in the env", () => {
+    const calls: { file: string; args: readonly string[]; options: Record<string, unknown> }[] = []
+    const fakeSpawn = ((file: string, args: readonly string[], options: Record<string, unknown>) => {
+      calls.push({ file, args, options })
+      const child = new EventEmitter() as ChildProcess
+      child.unref = () => {}
+      return child
+    }) as unknown as typeof import("node:child_process").spawn
+
+    spawnWindowsDetached(
+      "C:\\bun\\bun.exe",
+      ["C:\\Program Files\\rove\\rove-run.js", "daemon", "start"],
+      { PATH: "x", SystemRoot: "C:\\Windows" },
+      "C:\\Users\\me\\.rove\\daemon.log",
+      fakeSpawn,
+    )
+
+    expect(calls).toHaveLength(1)
+    const [{ file, args, options }] = calls
+    expect(file.toLowerCase()).toContain("powershell.exe")
+    expect(args.slice(0, 5)).toEqual(["-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-EncodedCommand"])
+    expect(Buffer.from(args[5] as string, "base64").toString("utf16le")).toBe(WIN_DETACHED_LAUNCHER_PS)
+    expect(options.windowsHide).toBe(true)
+    expect(options.stdio).toBe("ignore")
+    const env = options.env as Record<string, string>
+    expect(env.PATH).toBe("x")
+    expect(env[LAUNCH_CMD_ENV]).toBe('C:\\bun\\bun.exe "C:\\Program Files\\rove\\rove-run.js" daemon start')
+    expect(env[LAUNCH_LOG_ENV]).toBe("C:\\Users\\me\\.rove\\daemon.log")
+  })
+})

--- a/packages/kobe/test/daemon/node-pty-host-spawn.test.ts
+++ b/packages/kobe/test/daemon/node-pty-host-spawn.test.ts
@@ -1,5 +1,5 @@
 import { delimiter } from "node:path"
-import { detachOptions } from "@sma1lboy/kobe-daemon/client/daemon-process"
+import { detachOptions } from "@sma1lboy/kobe-daemon/client/detached-spawn"
 import {
   type NodePtyHostResolution,
   bundleWithBun,
@@ -211,7 +211,7 @@ describe("defaultPtyHostSocketPath", () => {
 })
 
 describe("detachOptions", () => {
-  test("POSIX detaches; Windows only hides, so no stray console window appears", () => {
+  test("POSIX detaches; Windows only hides (the fallback shape — the real spawn goes through win-detached-launch.ts)", () => {
     expect(detachOptions("darwin")).toEqual({ detached: true })
     expect(detachOptions("linux")).toEqual({ detached: true })
     expect(detachOptions("win32")).toEqual({ windowsHide: true })


### PR DESCRIPTION
## Problem

On Windows, quitting Rove (or `rove daemon restart`, or closing the terminal tab) killed the daemon **and the PTY host**, so every engine tab died with the TUI. macOS/Linux keep them (setsid).

Two independent causes, both measured on the affected machine (Bun 1.4.2):

1. **Bun's job object.** Every child Bun spawns on Windows is in a job with `KILL_ON_JOB_CLOSE` (`limitFlags=0x3c00`: kill-on-close + breakaway-ok + silent-breakaway-ok). When the spawning process exits, the job closes and the child is terminated — `unref()`, `detached: true`, `windowsHide` make no difference. Direct children died at parent exit in every combination tested.
2. **`windowsHide` is dropped with file stdio.** `spawn(..., { windowsHide: true, stdio: ["ignore", logFd, logFd] })` (the shape `spawnDetachedDaemon` used) put the child on the *parent's* console; only `stdio: "ignore"` got a hidden console of its own. `GetConsoleProcessList` on the running system showed TUI, daemon and PTY host all on the Windows Terminal console — a Ctrl+C / closed tab reaches all three.

## Fix

`spawnDetachedDaemon` on win32 now runs a small PowerShell launcher (`win-detached-launch.ts`, passed via `-EncodedCommand`, parameters in env vars — nothing to quote twice) that calls `CreateProcess` with `CREATE_BREAKAWAY_FROM_JOB | CREATE_NEW_CONSOLE | CREATE_NEW_PROCESS_GROUP`, window hidden, stdout/stderr = an inheritable `FILE_APPEND_DATA` handle on the log (same append-fd contract the boot-time log rotation relies on). The launcher strips its env vars before creating the child. If the launcher fails (non-zero exit / spawn error), the old direct spawn runs and a line in the log says the child will not outlive its parent.

POSIX path unchanged. The spawn helpers moved from `daemon-process.ts` (over the 500-line cap after the change) into `detached-spawn.ts`; `win-detached-launch.ts` owns the Windows mechanism.

## Verified

- Launcher experiment: child survives the Bun parent's exit, `GetConsoleProcessList` shows it alone on its console, stdout+stderr land in the log.
- Source e2e under an isolated `ROVE_HOME_DIR`: `rove daemon restart` → daemon alive after the CLI exited, parent gone, console `[pid]` only, `daemon.log` has the boot lines; `daemon stop` cleans up. Restart round-trip ≈2.2s (PowerShell + `Add-Type`).
- Unit tests: `windowsCommandLine` (MSVCRT quoting), launcher script invariants, spawn shape (`windowsHide` + `stdio: "ignore"` + env). `test/client`, `daemon-cmd`, `pty-host-cmd`, `node-pty-host-spawn` pass locally; typecheck + biome clean.
