### PR TITLE
fix: clip read-output strings on a character boundary

### DIFF
--- a/.changeset/read-output-clip-surrogate-safe.md
+++ b/.changeset/read-output-clip-surrogate-safe.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Clip oversized strings in `rove api read-output` on a character boundary instead of a UTF-16 one. A tool result long enough to be clipped could be cut through the middle of an emoji or other astral character, leaving an orphaned surrogate half that read back as a `�` replacement glyph in the JSON an agent consumes; the same cut now keeps whole characters, and the `[+N chars clipped]` tally counts characters rather than double-counting astral ones as two.

--- a/packages/kobe/src/cli/api/read-output-page.ts
+++ b/packages/kobe/src/cli/api/read-output-page.ts
@@ -120,8 +120,21 @@ export function decodeCursor(raw: string, taskId: string): Cursor {
  *  when a single tool result is huge). Messages are plain parsed JSON. */
 export function clipStrings(value: unknown): unknown {
   if (typeof value === "string") {
+    // Fast path by UTF-16 length: a string within the cap in code UNITS is
+    // also within it in code POINTS (points ≤ units always), so nothing needs
+    // clipping and we skip the spread below.
     if (value.length <= STRING_CLIP_CHARS) return value
-    return `${value.slice(0, STRING_CLIP_CHARS)}…[+${value.length - STRING_CLIP_CHARS} chars clipped]`
+    // Clip on a code-POINT boundary, not a UTF-16 code unit: a bare
+    // `value.slice(0, N)` can bisect a surrogate pair (emoji / astral char)
+    // straddling the boundary and leave an orphaned half that renders as
+    // U+FFFD in the JSON an agent reads back. `orchestrator/title.ts` guards
+    // the identical hazard the same way. Counting points also makes the
+    // `[+N chars clipped]` tally honest — one astral char is one char, not
+    // the two UTF-16 units a `.length` subtraction would report.
+    const points = [...value]
+    if (points.length <= STRING_CLIP_CHARS) return value
+    const kept = points.slice(0, STRING_CLIP_CHARS).join("")
+    return `${kept}…[+${points.length - STRING_CLIP_CHARS} chars clipped]`
   }
   if (Array.isArray(value)) return value.map(clipStrings)
   if (value !== null && typeof value === "object") {

--- a/packages/kobe/test/cli/api-read-output.test.ts
+++ b/packages/kobe/test/cli/api-read-output.test.ts
@@ -163,6 +163,39 @@ describe("read-output history paging", () => {
     expect(clipped.text.length).toBeLessThan(STRING_CLIP_CHARS + 100)
     expect(clipped.text).toContain("chars clipped]")
   })
+
+  it("clips on a code-point boundary so an astral char straddling the cut is not bisected", () => {
+    // The emoji is the last code point within the cap, but its two UTF-16
+    // units straddle the raw `STRING_CLIP_CHARS` index — a bare `.slice` would
+    // keep only its high surrogate and drop the low one, leaving an orphaned
+    // half that renders as U+FFFD in the JSON an agent reads back.
+    const value = `${"y".repeat(STRING_CLIP_CHARS - 1)}😀${"z".repeat(10)}`
+    const clipped = clipStrings({ text: value }) as { text: string }
+    // No lone surrogate survives: a UTF-8 round-trip is lossless only when
+    // every surrogate is paired, and there is no replacement glyph.
+    expect(Buffer.from(clipped.text, "utf8").toString("utf8")).toBe(clipped.text)
+    expect(clipped.text).not.toContain("�")
+    // The emoji is kept whole (it is the final in-cap code point); only the
+    // trailing `z`s past the cap are clipped.
+    expect(clipped.text).toBe(`${"y".repeat(STRING_CLIP_CHARS - 1)}😀…[+10 chars clipped]`)
+  })
+
+  it("counts clipped code points, not UTF-16 units, in the tally", () => {
+    // 300 astral chars past the cap is 300 clipped CHARS, even though they are
+    // 600 UTF-16 units — the label must not double-count them.
+    const value = `${"y".repeat(STRING_CLIP_CHARS)}${"😀".repeat(300)}`
+    const clipped = clipStrings({ text: value }) as { text: string }
+    expect(clipped.text).toContain("[+300 chars clipped]")
+  })
+
+  it("keeps a string whose code-point count is within the cap even when its UTF-16 length exceeds it", () => {
+    // All astral: STRING_CLIP_CHARS code points spelled with 2× that many
+    // UTF-16 units. It is within the cap by the "chars" the field name and
+    // clip label speak in, so it passes through unclipped.
+    const value = "😀".repeat(STRING_CLIP_CHARS)
+    const clipped = clipStrings({ text: value }) as { text: string }
+    expect(clipped.text).toBe(value)
+  })
 })
 
 describe("read-output fallback labeling", () => {


### PR DESCRIPTION
## Direction

Bugs / correctness — a self-found defect in agent-facing output shaping, surfaced while reviewing the pure-logic layer (`src/cli/api/**`). No open issue or open PR covers it.

## Problem

`clipStrings` in the `rove api read-output` pager (`packages/kobe/src/cli/api/read-output-page.ts`) clips any oversized string inside a message with `String.prototype.slice(0, STRING_CLIP_CHARS)`:

```ts
if (value.length <= STRING_CLIP_CHARS) return value
return `${value.slice(0, STRING_CLIP_CHARS)}…[+${value.length - STRING_CLIP_CHARS} chars clipped]`
```

`.slice` cuts on a **UTF-16 code-unit** boundary. When an emoji or other astral character straddles that boundary (its two surrogate units land on either side of `STRING_CLIP_CHARS`), the kept prefix ends in a **lone high surrogate** — an orphaned half that reads back as a `�` (U+FFFD) replacement glyph in the JSON an agent consumes via `read-output`. Secondarily, `value.length - STRING_CLIP_CHARS` reports UTF-16 units while the label says "chars", so a clipped tail of astral characters is double-counted.

The codebase already guards this exact hazard elsewhere: `orchestrator/title.ts`'s `deriveTitleFromPrompt` iterates `[...collapsed]` precisely so "a bare `.slice(0, CAP)` … [does not] bisect a surrogate pair … [and] leave an orphaned half that renders as a replacement glyph." `clipStrings` used the un-guarded form.

## Fix

Clip on a **code-point** boundary, matching the `title.ts` precedent:

- Keep the existing O(1) UTF-16-length fast path (points ≤ units, so a string within the cap in units is within it in points too — nothing to clip).
- Only when a string exceeds the cap do we spread to code points, slice, and re-join — so whole characters survive the cut and no lone surrogate is emitted.
- The `[+N chars clipped]` tally now counts code points, so it is honest for astral characters.

Scope is one file plus its test. No behavior change for the common (small-string / ASCII) path.

## Verification

- `bun x vitest run test/cli/api-read-output.test.ts` — 28 passed, including three new cases: an astral char straddling the cut is kept whole (round-trip lossless, no `�`); the clipped tally counts code points not UTF-16 units; and an all-astral string within the cap by code-point count passes through unclipped.
- `bun run lint` — clean.
- `bun run typecheck` — clean across all workspace packages.

## Follow-ups (deliberately deferred — out of this slice)

- `describePayload` in `src/client/remote-orchestrator-payloads.ts` truncates diagnostic text with the same `.slice(0, 120)` hazard. Lower value (it feeds only `client.log` drop-path diagnostics, not agent-facing output) and it lives in a different slice, so it is not bundled here.
- `buildHistoryPage`'s `PAGE_BYTE_BUDGET` and `boundedTail`'s `TERMINAL_TAIL_BYTES` measure "bytes" in UTF-16 units, so for CJK-heavy content the effective budget runs ~3× nominal. This may be an intentional soft-cap approximation; it needs an intent decision before changing, so it is left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013TsdptNkRnKVcEEvY9XkrQ

---
_Generated by [Claude Code](https://claude.ai/code/session_013TsdptNkRnKVcEEvY9XkrQ)_