### PR TITLE
fix(win): anchor the host cursor for the IME on Windows too

### DIFF
--- a/.changeset/windows-ime-cursor-anchor.md
+++ b/.changeset/windows-ime-cursor-anchor.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Put the IME composition window where you are typing on Windows. Windows Terminal draws the pinyin (and any other input-method) preedit and candidate list at the console cursor, and Rove left that cursor at the last cell it painted — the top of the sidebar — so the composition appeared far from the engine's input line. The cursor anchor that already fixed this on macOS now runs on Windows too: after every frame the hidden host cursor is parked on the focused terminal's cursor cell, so the IME window follows your typing.

--- a/packages/kobe/src/tui-react/panes/terminal/use-terminal-host-cursor.ts
+++ b/packages/kobe/src/tui-react/panes/terminal/use-terminal-host-cursor.ts
@@ -1,6 +1,7 @@
 /**
  * Host-side terminal output effects: push geometry changes to the PTY and
- * anchor the native host cursor to the visible terminal cell for macOS IME.
+ * anchor the native host cursor to the visible terminal cell for the IME
+ * (macOS input methods and Windows Terminal place the composition there).
  *
  * Its own hook because everything here is IMPERATIVE: renderer and PTY side
  * effects plus the retention objects that survive across output frames, none

--- a/packages/kobe/src/tui/lib/ime-anchor-output.ts
+++ b/packages/kobe/src/tui/lib/ime-anchor-output.ts
@@ -1,9 +1,10 @@
 /**
- * macOS IME cursor anchoring at the OpenTUI output boundary.
+ * IME cursor anchoring at the OpenTUI output boundary (macOS and Windows).
  *
  * OpenTUI restores a visible cursor after each diff frame, but a hidden
- * cursor is left at the last painted cell. macOS input methods use that real
- * terminal cursor for preedit/candidate placement. This adapter buffers each
+ * cursor is left at the last painted cell. macOS input methods and Windows
+ * Terminal's TSF composition use that real terminal cursor for
+ * preedit/candidate placement. This adapter buffers each
  * synchronized update as one transaction and inserts the focused embedded
  * terminal's hidden cursor position immediately before its terminator. A
  * truncated frame is therefore discarded before any partial paint can reach
@@ -212,14 +213,24 @@ export function createImeAnchoredOutput(
   }
 }
 
-/** Select the custom output path only for the affected fullscreen macOS TUI. */
+/**
+ * Platforms whose terminals place the IME preedit/candidate window at the
+ * REAL cursor: macOS terminals, and Windows Terminal / conhost (the TSF
+ * composition follows the console cursor). Without the anchor, Windows drew
+ * a pinyin composition at whatever cell OpenTUI painted last — the sidebar's
+ * top row — instead of at the engine's input line. Linux terminals vary;
+ * left on the direct path until one is shown to need it.
+ */
+const IME_ANCHOR_PLATFORMS: ReadonlySet<NodeJS.Platform> = new Set<NodeJS.Platform>(["darwin", "win32"])
+
+/** Select the custom output path only for fullscreen TUIs on an IME-anchoring platform. */
 export function createHostImeOutput(opts: {
   readonly platform: NodeJS.Platform
   readonly fullscreen: boolean
   readonly stdout: NodeJS.WriteStream
   readonly controller?: ImeAnchorController
 }): HostImeOutput {
-  if (opts.platform !== "darwin" || !opts.fullscreen) {
+  if (!IME_ANCHOR_PLATFORMS.has(opts.platform) || !opts.fullscreen) {
     return {
       active: false,
       rendererOptions: {},

--- a/packages/kobe/test/tui/host-render-options.test.ts
+++ b/packages/kobe/test/tui/host-render-options.test.ts
@@ -46,13 +46,14 @@ describe("hostRenderOptions", () => {
 })
 
 describe("createHostImeOutput", () => {
-  it("uses a local custom-output feed only for fullscreen macOS hosts", () => {
+  it("uses a local custom-output feed for fullscreen macOS and Windows hosts", () => {
     const stdout = fakeTty()
-    const mac = createHostImeOutput({ platform: "darwin", fullscreen: true, stdout })
-
-    expect(mac.rendererOptions.remote).toBe(false)
-    expect(mac.rendererOptions.stdout).not.toBe(stdout)
-    expect(mac.active).toBe(true)
+    for (const platform of ["darwin", "win32"] as const) {
+      const host = createHostImeOutput({ platform, fullscreen: true, stdout })
+      expect(host.rendererOptions.remote).toBe(false)
+      expect(host.rendererOptions.stdout).not.toBe(stdout)
+      expect(host.active).toBe(true)
+    }
   })
 
   it("leaves Linux and inline command hosts on the direct stdout path", () => {
@@ -60,6 +61,7 @@ describe("createHostImeOutput", () => {
 
     expect(createHostImeOutput({ platform: "linux", fullscreen: true, stdout }).rendererOptions).toEqual({})
     expect(createHostImeOutput({ platform: "darwin", fullscreen: false, stdout }).rendererOptions).toEqual({})
+    expect(createHostImeOutput({ platform: "win32", fullscreen: false, stdout }).rendererOptions).toEqual({})
   })
 })
 


### PR DESCRIPTION
## Problem

Typing Chinese (pinyin) in a Rove engine tab on Windows, the IME composition string and candidate list appear at the top-left of the screen (over the sidebar's first row) instead of at the input line — see the user's screenshot: `zi'fu` rendered into a sidebar row with the candidate bar under it.

Windows Terminal (and conhost) place the TSF composition at the **console cursor**. OpenTUI leaves the hidden cursor at the last cell it painted. `createHostImeOutput` — the adapter that re-parks the hidden host cursor on the focused terminal's cursor cell after each synchronized frame — was gated to `platform === "darwin"`.

## Fix

Enable the adapter on `win32` as well (fullscreen only, as before). The resize forwarder it installs uses SIGWINCH, which is what OpenTUI itself relies on for `process.stdout` on Windows, so resize behavior is unchanged. Linux stays on the direct path.

## Tests

`host-render-options.test.ts`: win32 fullscreen gets the custom feed; win32 inline stays direct. typecheck + biome clean.

Manual check after release: type pinyin in an engine tab — the candidate window should sit at the input cursor.
