### PR TITLE
perf(win): render at 60fps and coalesce PTY output per frame on Windows

### DIFF
--- a/.changeset/windows-60fps-input-latency.md
+++ b/.changeset/windows-60fps-input-latency.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Render at 60fps on Windows and coalesce terminal output every 16ms instead of 33ms. An engine tab on Windows sits behind two ConPTYs — the pty host's and Windows Terminal's — and the inner one already paces its output in 16–60ms batches, so Rove's own 33ms snapshot window plus a 33ms frame on top made typing feel a beat behind a native `claude` in the same terminal. Halving both takes about 33ms off the worst case. macOS and Linux keep 30fps. The snapshot window and the renderer's frame rate now come from one place, so they cannot drift apart.

--- a/packages/kobe/src/tui/lib/host-render-options.ts
+++ b/packages/kobe/src/tui/lib/host-render-options.ts
@@ -24,6 +24,23 @@
  */
 const KITTY_KEYBOARD = {} as const
 
+/**
+ * The runtime TUI's render cadence — also the PTY snapshot coalesce period
+ * (`SNAPSHOT_COALESCE_MS` derives from it, so the two cannot drift).
+ *
+ * 30 (opentui's default) everywhere except Windows, where it is 60. An engine
+ * tab there sits behind TWO ConPTYs — the pty host's and Windows Terminal's —
+ * and the inner one already paces output in ~16–60ms batches (measured echo
+ * p90 ≈ 63ms against p50 ≈ 1ms). Stacking a 33ms coalesce plus a 33ms frame
+ * on top is what made typing feel a beat behind a native `claude` in the same
+ * terminal; halving both takes ~33ms off the worst path. The cost is idle CPU
+ * on a platform where the frame is cheap, not extra work per keystroke — a
+ * snapshot is still built at most once per frame.
+ */
+export function hostTargetFps(platform: NodeJS.Platform = process.platform): number {
+  return platform === "win32" ? 60 : 30
+}
+
 export function hostRenderOptions(onDestroy?: () => void): Record<string, unknown> {
   const base = {
     backgroundColor: "transparent",
@@ -31,6 +48,7 @@ export function hostRenderOptions(onDestroy?: () => void): Record<string, unknow
     exitOnCtrlC: false,
     screenMode: "alternate-screen",
     useKittyKeyboard: KITTY_KEYBOARD,
+    targetFps: hostTargetFps(),
   }
   return onDestroy ? { ...base, onDestroy } : base
 }

--- a/packages/kobe/src/tui/panes/terminal/pty-xterm-base.ts
+++ b/packages/kobe/src/tui/panes/terminal/pty-xterm-base.ts
@@ -4,6 +4,7 @@
 import { Unicode11Addon } from "@xterm/addon-unicode11"
 import { Terminal as XtermHeadless } from "@xterm/headless"
 import { persistedScrollbackRows } from "../../../state/scrollback"
+import { hostTargetFps } from "../../lib/host-render-options"
 import { profileSpan, profileTick } from "../../lib/render-profile"
 import { type TerminalInputModes, encodeMouseButton, encodeWheel } from "./keys-pure"
 import { PtyListeners } from "./pty-listeners"
@@ -24,21 +25,22 @@ import { XtermRefreshTracker, wireXtermChannels, wireXtermDefaultColorQueries } 
 /**
  * How long a burst of PTY output is coalesced before one snapshot is built.
  *
- * This is the renderer's frame period, not a guess. `createCliRenderer` runs
- * at `targetFps` 30 (src/tui/lib/host-render-options.ts sets no override, and
- * `snapshot-coalesce.test.tsx` reads 30 off a live renderer), so a snapshot
- * produced more often than every 33ms is built, published, committed through
- * React and laid out by opentui for a frame that is then never drawn.
+ * This is the renderer's frame period, not a guess: it derives from the same
+ * `hostTargetFps()` that `hostRenderOptions` hands `createCliRenderer` (30 —
+ * 33ms — except Windows at 60 — 16ms; see host-render-options.ts for why). A
+ * snapshot produced more often than once per frame is built, published,
+ * committed through React and laid out by opentui for a frame that is then
+ * never drawn.
  *
- * It used to be 16ms — 62.5Hz against a 30Hz renderer. Measured on a pane
- * streaming 200 lines/s at 200x50: 49 refreshes/s where the renderer drew 30,
- * so ~40% of the whole snapshot→paint pass was discarded work.
+ * It used to be a flat 16ms — 62.5Hz against a 30Hz renderer. Measured on a
+ * pane streaming 200 lines/s at 200x50: 49 refreshes/s where the renderer
+ * drew 30, so ~40% of the whole snapshot→paint pass was discarded work.
  *
- * Raising it costs no visible latency: the extra snapshots were never on
- * screen. It must not exceed the frame period either, or output visibly lags
- * the renderer — hence the test that pins it to the live `targetFps`.
+ * Matching the frame costs no visible latency: the extra snapshots were never
+ * on screen. It must not exceed the frame period either, or output visibly
+ * lags the renderer — hence the test that pins it to `targetFps`.
  */
-export const SNAPSHOT_COALESCE_MS = 33
+export const SNAPSHOT_COALESCE_MS = Math.round(1000 / hostTargetFps())
 
 export abstract class XtermTaskPty implements TaskPtyLike {
   readonly taskId: string

--- a/packages/kobe/test/render/snapshot-coalesce.test.tsx
+++ b/packages/kobe/test/render/snapshot-coalesce.test.tsx
@@ -6,24 +6,39 @@
  * drawn (the state this test was written to stop returning to); too large and
  * terminal output visibly lags the renderer.
  *
- * `targetFps` is read off a LIVE renderer rather than asserted as a literal,
+ * Both now derive from `hostTargetFps()`; this test checks that the value the
+ * renderer is actually configured with (`hostRenderOptions().targetFps`) is
+ * the one the coalesce window was computed from, and — off Windows, where the
+ * cadence is opentui's own default — that a LIVE renderer still reports it,
  * so an opentui default change fails here instead of quietly re-inflating the
  * streaming path.
  */
 import { expect, test } from "bun:test"
 import { testRender } from "@opentui/react/test-utils"
+import { hostRenderOptions, hostTargetFps } from "../../src/tui/lib/host-render-options"
 import { SNAPSHOT_COALESCE_MS } from "../../src/tui/panes/terminal/pty-xterm-base"
 
 test("snapshot coalesce window matches the renderer's frame period", async () => {
+  const fps = hostTargetFps()
+  expect(fps).toBeGreaterThan(0)
+  expect(hostRenderOptions().targetFps).toBe(fps)
+  // Round, not equal: 1000/30 is 33.33 and the timer takes whole ms.
+  expect(SNAPSHOT_COALESCE_MS).toBe(Math.round(1000 / fps))
+
   const t = await testRender(
     <box>
       <text>fps</text>
     </box>,
     { width: 20, height: 5 },
   )
-  const targetFps = (t.renderer as unknown as { targetFps: number }).targetFps
-  expect(targetFps).toBeGreaterThan(0)
-  // Round, not equal: 1000/30 is 33.33 and the timer takes whole ms.
-  expect(SNAPSHOT_COALESCE_MS).toBe(Math.round(1000 / targetFps))
+  const liveFps = (t.renderer as unknown as { targetFps: number }).targetFps
+  expect(liveFps).toBeGreaterThan(0)
+  if (process.platform !== "win32") expect(liveFps).toBe(fps)
   await (t as unknown as { destroy?: () => Promise<void> }).destroy?.()
+})
+
+test("Windows renders at 60fps, everything else at opentui's 30", () => {
+  expect(hostTargetFps("win32")).toBe(60)
+  expect(hostTargetFps("darwin")).toBe(30)
+  expect(hostTargetFps("linux")).toBe(30)
 })


### PR DESCRIPTION
## Why

Typing in a Rove engine tab on Windows feels a beat behind a native `claude` in the same Windows Terminal. Measured on the affected machine:

- TUI → pty host RPC: ~1 ms (not it).
- Inner ConPTY echo (node-pty, default OS conpty): p50 1.2 ms, **p90 ≈ 63 ms** — ConPTY batches output on its own timer, and a Rove tab has two ConPTYs stacked (pty host's + Windows Terminal's) where a native `claude` has one.
- On top of that Rove adds a 33 ms snapshot coalesce window and a 33 ms frame (30 fps).

The ConPTY pacing is outside our control (node-pty's bundled `conpty.dll` did not produce output here, so `useConptyDll` is not a quick win). The two Rove-side numbers are ours: halving both takes ~33 ms off the worst path on Windows.

## Change

- `hostTargetFps(platform)` in `host-render-options.ts`: 60 on win32, 30 (opentui's default) elsewhere. `hostRenderOptions()` now passes `targetFps`.
- `SNAPSHOT_COALESCE_MS = round(1000 / hostTargetFps())` — the coalesce window and the frame rate come from one function, so they cannot drift (the concern the existing render test guards).
- `snapshot-coalesce.test.tsx` checks the configured `targetFps` matches the window; off Windows it still reads a live renderer to catch an opentui default change.

Cost: idle CPU on Windows only. Per-keystroke work is unchanged (still at most one snapshot per frame).

typecheck, biome, `bun test test/render/snapshot-coalesce.test.tsx`, `vitest test/tui` (1752) pass locally.
