### PR TITLE
fix(win): write engine hook commands as bare argv so Windows shells run them

### DIFF
--- a/.changeset/windows-hook-command-quoting.md
+++ b/.changeset/windows-hook-command-quoting.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Make engine hooks fire on Windows. The hook commands Rove writes into `~/.codex/hooks.json`, Claude's settings and kimi's config were POSIX single-quoted (`'kobe' 'hook' 'turn-complete' '--engine' 'codex'`), which cmd.exe and PowerShell cannot run — cmd looks for a program named `'kobe'`, PowerShell reads a string literal — so on Windows a codex tab never reported a turn, a badge, or an attention item. Hook commands are now written as bare tokens (`kobe hook turn-complete --engine codex`), which every shell on every platform runs the same way; a token that does need quoting gets the platform's own dialect. Existing installs are rewritten on the next hook install; codex may ask you to trust the changed hooks once.

--- a/packages/kobe/src/engine/json-hooks.ts
+++ b/packages/kobe/src/engine/json-hooks.ts
@@ -16,7 +16,7 @@
  */
 
 import { kobeHookInvocation } from "../cli/invocation.ts"
-import { quoteShellArgv } from "../lib/shell-command.ts"
+import { type QuoteShellArgvOptions, quoteShellArgv } from "../lib/shell-command.ts"
 import type { EngineActivityKind } from "./hook-events.ts"
 
 /** Verbs installed only while a plugin subscribes to tool.* hooks (volume gate).
@@ -158,6 +158,23 @@ export interface ActivityHookOpts {
   readonly buildFilter?: (spec: HookEventSpec) => boolean
 }
 
+/**
+ * How a persisted hook command line is quoted.
+ *
+ * Bare tokens wherever the argv allows it — `kobe hook turn-complete --engine
+ * codex` is one command in POSIX sh, cmd.exe AND PowerShell. The engines run
+ * their hooks through whatever shell the platform hands them, and on Windows
+ * that is not sh: the single-quoted form the conservative quoter emits
+ * (`'kobe' 'hook' …`) is a program named `'kobe'` to cmd and a string literal
+ * to PowerShell, so every codex hook fire on Windows failed without a trace
+ * and no badge, turn state or attention item ever came from a codex tab. A
+ * token that still needs quoting (a dev entry path with spaces) gets the
+ * platform's own dialect.
+ */
+export function hookCommandQuoting(platform: NodeJS.Platform = process.platform): QuoteShellArgvOptions {
+  return { bareSafe: true, windows: platform === "win32" }
+}
+
 /** Build the activity hook groups kobe installs, pointing each event at
  *  `kobe hook <verb>` (cwd-based; no task id). `inv` is injectable for tests. */
 export function buildActivityHooks(
@@ -166,10 +183,11 @@ export function buildActivityHooks(
   opts: ActivityHookOpts = {},
 ): Record<string, unknown> {
   const out: Record<string, unknown> = {}
+  const quoting = hookCommandQuoting()
   for (const spec of eventMap) {
     if (opts.buildFilter && !opts.buildFilter(spec)) continue
     const { event, matcher, verb } = spec
-    const command = quoteShellArgv([...inv, "hook", verb, ...(opts.extraArgs ?? [])])
+    const command = quoteShellArgv([...inv, "hook", verb, ...(opts.extraArgs ?? [])], quoting)
     const group: Record<string, unknown> = { hooks: [{ type: "command", command }] }
     if (matcher) group.matcher = matcher
     // Accumulate — one event may carry several matcher-scoped specs (e.g.

--- a/packages/kobe/src/engine/kimi-local/hook-adapter.ts
+++ b/packages/kobe/src/engine/kimi-local/hook-adapter.ts
@@ -36,7 +36,7 @@ import { kobeHookInvocation } from "../../cli/invocation.ts"
 import { quoteShellArgv } from "../../lib/shell-command.ts"
 import type { EngineHookAdapter, EngineSessionRef } from "../hook-adapter.ts"
 import type { EngineActivityDetail, EngineActivityKind } from "../hook-events.ts"
-import { GATED_TOOL_VERBS, type HookEditOutcome, type HookEventSpec } from "../json-hooks.ts"
+import { GATED_TOOL_VERBS, type HookEditOutcome, type HookEventSpec, hookCommandQuoting } from "../json-hooks.ts"
 import { vendorConfigHome } from "../vendor-home.ts"
 
 /** Kimi hook event → normalized kobe verb. The ONE place Kimi event names live. */
@@ -85,7 +85,7 @@ export function renderKimiHookBlock(
     if (!opts.toolEvents && GATED_TOOL_VERBS.has(spec.verb)) continue
     // JSON.stringify doubles as a TOML basic-string quoter (same trick as
     // codex-local/trust.ts).
-    const command = quoteShellArgv([...inv, "hook", spec.verb, "--engine", "kimi"])
+    const command = quoteShellArgv([...inv, "hook", spec.verb, "--engine", "kimi"], hookCommandQuoting())
     lines.push("[[hooks]]")
     lines.push(`event = ${JSON.stringify(spec.event)}`)
     if (spec.matcher) lines.push(`matcher = ${JSON.stringify(spec.matcher)}`)

--- a/packages/kobe/src/lib/shell-command.ts
+++ b/packages/kobe/src/lib/shell-command.ts
@@ -14,12 +14,48 @@ export interface QuoteShellArgvOptions {
    * to read while still quoting spaces, quotes, and shell metacharacters.
    */
   readonly bareSafe?: boolean
+  /**
+   * Quote for a Windows shell (cmd.exe / PowerShell) instead of POSIX sh: a
+   * token that needs quoting gets double quotes, with inner quotes
+   * backslash-escaped. A POSIX single-quoted token is not a quote there at
+   * all — cmd runs `'kobe'` as a program named `'kobe'` and PowerShell reads
+   * it as a string expression — so a command persisted for a Windows host
+   * (codex hooks) must never carry single quotes. Bare tokens are the
+   * portable subset and need no dialect.
+   */
+  readonly windows?: boolean
 }
 
 /** Quote one value as a POSIX single-quoted shell token. */
 export function quoteShellArg(value: string, opts: QuoteShellArgvOptions = {}): string {
   if (opts.bareSafe && SAFE_BARE_TOKEN.test(value)) return value
+  if (opts.windows) return quoteWindowsArg(value)
   return `'${value.replace(/'/g, "'\\''")}'`
+}
+
+/**
+ * MSVCRT argv quoting: wrap in double quotes; a quote inside is escaped and
+ * the backslashes immediately before it (or before the closing quote) are
+ * doubled. Every other backslash — the ones in a path — stays as it is, which
+ * is what cmd.exe and PowerShell both hand through unchanged.
+ */
+function quoteWindowsArg(value: string): string {
+  let out = '"'
+  let backslashes = 0
+  for (const ch of value) {
+    if (ch === "\\") {
+      backslashes++
+      continue
+    }
+    if (ch === '"') {
+      out += `${"\\".repeat(backslashes * 2 + 1)}"`
+      backslashes = 0
+      continue
+    }
+    out += "\\".repeat(backslashes) + ch
+    backslashes = 0
+  }
+  return `${out}${"\\".repeat(backslashes * 2)}"`
 }
 
 /** Quote argv values and join them into one shell command line. */

--- a/packages/kobe/test/engine/claude-hook-adapter.test.ts
+++ b/packages/kobe/test/engine/claude-hook-adapter.test.ts
@@ -24,11 +24,12 @@ describe("buildClaudeHooks", () => {
     }
   })
 
-  it("points each hook at `kobe hook <verb>` with NO task id (shell-quoted argv)", () => {
-    expect(hooks.Stop[0].hooks[0].command).toContain("'hook' 'turn-complete'")
+  it("points each hook at `kobe hook <verb>` with NO task id (bare argv — one command in sh, cmd and PowerShell)", () => {
+    expect(hooks.Stop[0].hooks[0].command).toContain("hook turn-complete")
+    expect(hooks.Stop[0].hooks[0].command).not.toContain("'")
     expect(hooks.Stop[0].hooks[0].command).not.toContain("--task-id")
-    expect(hooks.StopFailure[0].hooks[0].command).toContain("'hook' 'turn-failed'")
-    expect(hooks.SessionStart[0].hooks[0].command).toContain("'hook' 'session-start'")
+    expect(hooks.StopFailure[0].hooks[0].command).toContain("hook turn-failed")
+    expect(hooks.SessionStart[0].hooks[0].command).toContain("hook session-start")
   })
 
   it("scopes the Notification hook to permission prompts + question dialogs", () => {
@@ -38,7 +39,7 @@ describe("buildClaudeHooks", () => {
     // every idle session (turn_complete already covers "done, look at me").
     expect(hooks.Notification.map((g) => g.matcher)).toEqual(["permission_prompt", "elicitation_dialog"])
     for (const group of hooks.Notification) {
-      expect(group.hooks[0].command).toContain("'hook' 'awaiting-input'")
+      expect(group.hooks[0].command).toContain("hook awaiting-input")
     }
   })
 })
@@ -132,9 +133,12 @@ describe("mergeActivityHooks (global, cwd-based)", () => {
     const out = mergeActivityHooks(legacy, true, ["kobe"]) as SettingsShape
     expect(out.hooks?.Stop).toHaveLength(2) // fresh kobe entry + the user's, legacy dropped
     expect(JSON.stringify(out.hooks?.Stop)).toContain("user-old-stop")
-    expect(JSON.stringify(out.hooks?.Stop)).toContain("'hook' 'turn-complete'")
-    expect(JSON.stringify(out.hooks?.Stop)).not.toContain('"kobe hook turn-complete"')
-    expect(JSON.stringify(out.hooks)).not.toContain('"kobe hook awaiting-input"')
+    expect(JSON.stringify(out.hooks?.Stop)).toContain('"kobe hook turn-complete"')
+    // The legacy permission_prompt entry is REPLACED, not duplicated: exactly
+    // the two fresh matcher-scoped groups carry the command afterwards.
+    const notification = (out.hooks as Record<string, { matcher?: string }[] | undefined>).Notification
+    expect(notification?.map((g) => g.matcher)).toEqual(["permission_prompt", "elicitation_dialog"])
+    expect((JSON.stringify(out.hooks).match(/"kobe hook awaiting-input"/g) ?? []).length).toBe(2)
   })
 
   it("removes kobe's hooks while keeping the user's same-event hooks", () => {

--- a/packages/kobe/test/engine/hook-install-rejection.test.ts
+++ b/packages/kobe/test/engine/hook-install-rejection.test.ts
@@ -95,7 +95,7 @@ describe("installActivityHooks on a settings file it cannot parse", () => {
     // The user's own group survived and Rove's hooks landed beside it.
     const doc = JSON.parse(await readFile(file, "utf8")) as { hooks: Record<string, unknown[]> }
     expect(doc.hooks.PreToolUse).toContainEqual({ matcher: "Bash", hooks: [] })
-    expect(JSON.stringify(doc)).toContain("'rove' 'hook'")
+    expect(JSON.stringify(doc)).toContain('"rove hook ')
   })
 
   it("negative control: a missing file is a first launch, not a refusal", async () => {

--- a/packages/kobe/test/engine/hook-record-preservation.test.ts
+++ b/packages/kobe/test/engine/hook-record-preservation.test.ts
@@ -17,7 +17,8 @@ describe("shared hook groups", () => {
     const installed = mergeActivityHooks(current, true, events, ["kobe"])
     expect(installed).toMatchObject({
       extra: true,
-      hooks: { Stop: [kept, { hooks: [{ command: "'kobe' 'hook' 'turn-complete'" }] }] },
+      // The single-quoted legacy entry is recognized as ours and re-written bare.
+      hooks: { Stop: [kept, { hooks: [{ command: "kobe hook turn-complete" }] }] },
     })
     expect(mergeActivityHooks(installed, false, events, ["kobe"])).toEqual({ extra: true, hooks: { Stop: [kept] } })
     expect(current.hooks.Stop[0].hooks).toHaveLength(2)

--- a/packages/kobe/test/engine/kimi-hook-adapter.test.ts
+++ b/packages/kobe/test/engine/kimi-hook-adapter.test.ts
@@ -65,7 +65,7 @@ describe("mergeKimiHooks (pure TOML block merge)", () => {
     expect(out).toContain("# >>> rove hooks")
     expect(out).toContain("# <<< rove hooks")
     expect(out).toContain('event = "Interrupt"')
-    expect(out).toContain(`command = "'kobe' 'hook' 'turn-interrupted' '--engine' 'kimi'"`)
+    expect(out).toContain(`command = "kobe hook turn-interrupted --engine kimi"`)
     // Gated tool family is absent by default…
     expect(out).not.toContain('event = "PreToolUse"')
     // …and present when a plugin subscribes tool.* events.

--- a/packages/kobe/test/lib/shell-command.test.ts
+++ b/packages/kobe/test/lib/shell-command.test.ts
@@ -15,4 +15,16 @@ describe("shell-command quoting", () => {
   test("joins conservatively quoted argv values", () => {
     expect(quoteShellArgv(["sh", "-c", "echo a b"])).toBe("'sh' '-c' 'echo a b'")
   })
+
+  test("quotes for a Windows shell with double quotes, MSVCRT style", () => {
+    const win = { bareSafe: true, windows: true }
+    expect(quoteShellArgv(["kobe", "hook", "turn-complete", "--engine", "codex"], win)).toBe(
+      "kobe hook turn-complete --engine codex",
+    )
+    expect(quoteShellArgv(["C:\\Program Files\\rove\\rove.exe", "hook"], win)).toBe(
+      '"C:\\Program Files\\rove\\rove.exe" hook',
+    )
+    expect(quoteShellArg('say "hi"', { windows: true })).toBe('"say \\"hi\\""')
+    expect(quoteShellArg("C:\\dir\\", { windows: true })).toBe('"C:\\dir\\\\"')
+  })
 })


### PR DESCRIPTION
## Problem

On Windows, codex hooks never worked. `~/.codex/hooks.json` carried

```
'kobe' 'hook' 'session-start' '--engine' 'codex'
```

which is POSIX quoting. Run the way codex runs hooks on Windows it fails in both shells (verified on the affected machine):

```
cmd:        ''kobe'' is not recognized as an internal or external command
PowerShell: parse error at 'kobe' (a string literal, not a command)
```

The bare form `kobe hook session-start --engine codex` exits 0 in both — and in sh. Codex's own log showed `hook/started` / `hook/completed` events, but nothing ever reached Rove from a codex tab.

## Fix

- `hookCommandQuoting()` (json-hooks.ts): `{ bareSafe: true, windows: platform === "win32" }`. Every persisted hook command is now bare tokens; the existing recognizer already accepted that form, so old entries are replaced on the next install.
- `quoteShellArg` gains `windows`: a token that still needs quoting (a dev entry path with spaces) is double-quoted MSVCRT-style instead of single-quoted.
- kimi's TOML block uses the same quoting.

Verified locally: ran `ensureGlobalKobeHooks()` from source → `~/.codex/hooks.json` rewritten to `kobe hook <verb> --engine codex`; the command runs under cmd with exit 0. Codex will re-prompt to trust the changed hooks once (its per-hook `trusted_hash`).

Tests updated to the bare form; `test/engine` + `shell-command` pass (only the pre-existing `history-default-deps` mtime case fails locally on Windows); typecheck + biome clean.
