### PR TITLE
fix(api): send presses Tab when the engine is mid-turn and asks for it

### DIFF
--- a/.changeset/send-queues-behind-running-turn.md
+++ b/.changeset/send-queues-behind-running-turn.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+`rove api send` now gets through to an engine that is mid-turn. Claude Code, while a turn is running, no longer submits on Enter: its footer says "tab to queue message" and the text just sits in the composer — which is where every dispatched `succeeded:` report landed while the coordinator was busy. Delivery now reads that hint off the screen after pasting and presses Tab instead, so the prompt is queued and runs when the turn ends; a late footer redraw is caught by one re-check after Enter. The result reports `queued: true` when that happened, so a dispatcher knows the report is waiting behind a turn rather than being processed now.

--- a/docs/API.md
+++ b/docs/API.md
@@ -586,6 +586,10 @@ branch included, live in the Rove agent skill. Prompts into existing sessions
     engines that collapse a large paste into a `[Pasted text #1]` placeholder
     never echo the text, so a positive proves delivery while a negative
     merely fails to.
+  - `queued` — `true` when the engine was mid-turn and asked for Tab (Claude
+    Code's "tab to queue message" footer): the prompt was queued behind the
+    running turn instead of submitted, and runs when that turn ends. Absent
+    when Enter submitted it immediately.
   - `reason` — why nothing was confirmed. Present only with
     `engineReady: false`.
 

--- a/packages/kobe/src/cli/api/pty-delivery.ts
+++ b/packages/kobe/src/cli/api/pty-delivery.ts
@@ -115,6 +115,8 @@ export function outcomeFields(outcome: PromptWriteOutcome | null): {
   delivered: boolean
   bytes?: number
   promptEcho?: "confirmed" | "unconfirmed"
+  /** The engine was mid-turn: the prompt is QUEUED behind it (Tab), not running yet. */
+  queued?: true
 } {
   if (!outcome) return { engineReady: false, delivered: false }
   return {
@@ -122,6 +124,7 @@ export function outcomeFields(outcome: PromptWriteOutcome | null): {
     delivered: true,
     bytes: outcome.bytes,
     promptEcho: outcome.confirmed ? "confirmed" : "unconfirmed",
+    ...(outcome.queued ? { queued: true as const } : {}),
   }
 }
 

--- a/packages/kobe/src/engine/hosted-session.ts
+++ b/packages/kobe/src/engine/hosted-session.ts
@@ -9,7 +9,13 @@ import type { TerminalDefaultColors } from "@sma1lboy/kobe-daemon/daemon/termina
 import { readPersistedTerminalDefaultColors } from "../tui/lib/terminal-colors.ts"
 import { BUILTIN_VENDORS } from "../types/vendor.ts"
 import { type PsSnapshot, engineProcessIn, parsePsSnapshot, psSnapshot } from "./foreground.ts"
-import { PASTE_READY_POLL_MS, PASTE_READY_TIMEOUT_MS, bracketedPasteActive, encodePaste } from "./paste-readiness.ts"
+import {
+  PASTE_READY_POLL_MS,
+  PASTE_READY_TIMEOUT_MS,
+  bracketedPasteActive,
+  encodePaste,
+  submitKeyFor,
+} from "./paste-readiness.ts"
 import { engineEntry } from "./registry.ts"
 import { ENGINE_EXIT_BANNER, type EngineSessionLaunch, REPO_INIT_TIMEOUT_SECONDS } from "./session-launch.ts"
 
@@ -197,6 +203,10 @@ export interface PromptWriteOutcome {
   /** The engine echoed the prompt's tail back — the only positive proof it
    *  landed. `false` means unconfirmed, NOT necessarily lost. */
   readonly confirmed: boolean
+  /** The engine was mid-turn and asked for TAB, so the prompt was QUEUED
+   *  behind the running turn rather than submitted now — it runs when that
+   *  turn ends. See `submitKeyFor`. */
+  readonly queued: boolean
 }
 
 /** Trailing slice of the prompt used as the echo marker. Long enough not to
@@ -255,9 +265,9 @@ async function writeAndConfirm(
   opts?: HostedPromptDeliveryOpts,
 ): Promise<PromptWriteOutcome> {
   const ready = await awaitPasteReady(rpc, key, { timeoutMs: opts?.pasteReadyTimeoutMs })
-  const bytes = await writeHostedPrompt(rpc, key, prompt, { ready })
+  const { bytes, queued } = await writeHostedPrompt(rpc, key, prompt, { ready })
   const confirmed = await confirmPromptLanded(rpc, key, prompt, sinceOffset)
-  return { bytes, ready, confirmed }
+  return { bytes, ready, confirmed, queued }
 }
 
 export async function writeHostedPromptIfLive(
@@ -313,13 +323,41 @@ export async function writeHostedPrompt(
   key: string,
   prompt: string,
   opts?: { readonly ready?: boolean },
-): Promise<number> {
+): Promise<{ readonly bytes: number; readonly queued: boolean }> {
   const bracketed = opts?.ready ?? (await awaitPasteReady(rpc, key))
   const data = encodePaste(prompt, bracketed)
+  const before = await rpc.request<PtyPeekResult>("pty.peek", { key })
   await rpc.request("pty.write", { key, data })
   await new Promise((resolve) => setTimeout(resolve, SUBMIT_DELAY_MS))
-  await rpc.request("pty.write", { key, data: "\r" })
-  return Buffer.byteLength(data, "utf8")
+  // The submit key is READ off the screen, not assumed: an engine mid-turn
+  // (Claude Code: "tab to queue message" in the footer once the composer
+  // holds text) ignores Enter and wants Tab. Checked after the paste — the
+  // hint only appears once there is text to queue — and once more after
+  // Enter, for a footer that redrew a frame late.
+  let submit = await submitKeyAfter(rpc, key, before.offset)
+  await rpc.request("pty.write", { key, data: submit })
+  if (submit === "\r") {
+    await new Promise((resolve) => setTimeout(resolve, QUEUE_HINT_RECHECK_MS))
+    const again = await submitKeyAfter(rpc, key, before.offset)
+    if (again === "\t") {
+      await rpc.request("pty.write", { key, data: again })
+      submit = again
+    }
+  }
+  return { bytes: Buffer.byteLength(data, "utf8"), queued: submit === "\t" }
+}
+
+/** How long Enter gets to take effect before the footer is read again. */
+const QUEUE_HINT_RECHECK_MS = 300
+
+/** Enter or Tab, per what the engine has drawn since `sinceOffset`. */
+async function submitKeyAfter(rpc: HostedSessionRpc, key: string, sinceOffset: number): Promise<"\r" | "\t"> {
+  try {
+    const peek = await rpc.request<PtyPeekResult>("pty.peek", { key, sinceOffset })
+    return submitKeyFor(Buffer.from(peek.data, "base64").toString("utf8"))
+  } catch {
+    return "\r"
+  }
 }
 
 /**

--- a/packages/kobe/src/engine/paste-readiness.ts
+++ b/packages/kobe/src/engine/paste-readiness.ts
@@ -50,6 +50,28 @@ export function bracketedPasteActive(output: string): boolean {
   return on > output.lastIndexOf(BRACKETED_PASTE_OFF)
 }
 
+/**
+ * The composer hint an engine shows while a turn is RUNNING and the input box
+ * holds text: Claude Code prints `tab to queue message` in its footer, and in
+ * that state Enter no longer submits — the text just sits there. Tab queues
+ * it behind the running turn. A `send` that pressed Enter regardless left
+ * every dispatched `succeeded:` report parked in the coordinator's input box
+ * until a human noticed. Matched loosely (whitespace collapsed by the caller,
+ * case-insensitive) so a footer that wraps or restyles still counts.
+ */
+const QUEUE_HINT = /tab to queue message/i
+
+/** Whether the engine's output says the composer wants TAB to queue, not Enter to submit. */
+export function queueHintVisible(output: string): boolean {
+  return QUEUE_HINT.test(output.replace(/\s+/g, " "))
+}
+
+/** The key that hands the composer's text to the engine: Enter normally, Tab
+ *  while a turn is running and the engine says so. */
+export function submitKeyFor(output: string): "\r" | "\t" {
+  return queueHintVisible(output) ? "\t" : "\r"
+}
+
 /** Wrap `prompt` for an engine that asked for bracketed paste; send it bare
  *  otherwise. Mirrors the interactive backend's conditional wrapping — an
  *  engine that never enabled DECSET 2004 would render `\x1b[200~` as text. */

--- a/packages/kobe/test/cli/pty-delivery.test.ts
+++ b/packages/kobe/test/cli/pty-delivery.test.ts
@@ -69,12 +69,23 @@ describe("deliverToKey", () => {
     // pty.peek, NOT pty.open: an open would last-attach-wins resize the
     // live session away from its attached TUI — delivery must
     // be indistinguishable from keyboard input (pure pty.write).
-    // Peeks (gate, readiness, confirm) then two writes — still no open/resize.
-    expect(calls.map((c) => c.name)).toEqual(["pty.peek", "pty.peek", "pty.write", "pty.write", "pty.peek"])
+    // Peeks (gate, readiness, pre-paste offset) then the paste, a peek for
+    // the submit key, the CR, a peek re-checking the footer, and the echo
+    // confirm — still no open/resize.
+    expect(calls.map((c) => c.name)).toEqual([
+      "pty.peek",
+      "pty.peek",
+      "pty.peek",
+      "pty.write",
+      "pty.peek",
+      "pty.write",
+      "pty.peek",
+      "pty.peek",
+    ])
     expect(calls[0].payload).toEqual({ key: "t1::tab-1" })
     // Bracketed paste markers wrap the prompt; the CR is a SEPARATE write.
-    expect(calls[2].payload).toEqual({ key: "t1::tab-1", data: "\x1b[200~do the thing\x1b[201~" })
-    expect(calls[3].payload).toEqual({ key: "t1::tab-1", data: "\r" })
+    expect(calls[3].payload).toEqual({ key: "t1::tab-1", data: "\x1b[200~do the thing\x1b[201~" })
+    expect(calls[5].payload).toEqual({ key: "t1::tab-1", data: "\r" })
   })
 
   it("returns false without writing when the session is dead", async () => {
@@ -191,8 +202,11 @@ describe("deliverHostedPrompt", () => {
       "pty.open",
       "pty.peek",
       "pty.peek",
+      "pty.peek",
       "pty.write",
+      "pty.peek",
       "pty.write",
+      "pty.peek",
       "pty.peek",
       "pty.detach",
     ])

--- a/packages/kobe/test/engine/hosted-session.test.ts
+++ b/packages/kobe/test/engine/hosted-session.test.ts
@@ -180,8 +180,41 @@ describe("deliverToHostedKey", () => {
   it("delivers into a live session", async () => {
     const { rpc, writes } = echoingRpc("\u276f")
     const outcome = await deliverToHostedKey(rpc, "t1::tab-1", "go")
-    expect(outcome).toMatchObject({ ready: true, confirmed: true })
+    expect(outcome).toMatchObject({ ready: true, confirmed: true, queued: false })
     expect(writes).toEqual(["pty.write", "pty.write"])
+  })
+
+  it("presses TAB, not Enter, when the engine is mid-turn and says 'tab to queue message'", async () => {
+    // Claude Code with a turn running: Enter leaves the text in the composer;
+    // the footer asks for Tab. A `send` that pressed Enter parked every
+    // dispatched report in the coordinator's input box.
+    const sent: string[] = []
+    let written = ""
+    const rpc: HostedSessionRpc = {
+      request: async <T>(name: string, payload?: unknown): Promise<T> => {
+        if (name === "pty.peek") {
+          const footer = written.length > 0 ? "\n  tab to queue message" : ""
+          return {
+            exists: true,
+            alive: true,
+            pid: 42,
+            offset: 0,
+            data: Buffer.from(`\x1b[?2004h\u276f ${written}${footer}`, "utf8").toString("base64"),
+            sinceValid: false,
+            exit: null,
+          } as T
+        }
+        if (name === "pty.write") {
+          const data = (payload as { data?: string })?.data ?? ""
+          written += data
+          sent.push(data)
+        }
+        return {} as T
+      },
+    }
+    const outcome = await deliverToHostedKey(rpc, "t1::tab-1", "report: done")
+    expect(outcome).toMatchObject({ confirmed: true, queued: true })
+    expect(sent).toEqual(["\x1b[200~report: done\x1b[201~", "\t"])
   })
 
   it("delivers even when the composer already holds text", async () => {

--- a/packages/kobe/test/render/pty-large-prompt.test.ts
+++ b/packages/kobe/test/render/pty-large-prompt.test.ts
@@ -102,7 +102,7 @@ describe("large prompt delivery into a cold engine", () => {
     // Cold for 1.6s: past a 1500ms fixed settle, like kimi.
     spawnFakeEngine(host, "t1::tab-1", sink, 1_600)
 
-    const bytes = await writeHostedPrompt(deliveryRpc(host), "t1::tab-1", BIG_PROMPT)
+    const { bytes } = await writeHostedPrompt(deliveryRpc(host), "t1::tab-1", BIG_PROMPT)
     await settle(1_500)
 
     const got = received(sink)


### PR DESCRIPTION
## Problem

`rove api send` into a Claude Code tab whose turn is still running leaves the prompt sitting in the composer, unsent. Current Claude Code shows `tab to queue message` in the footer in that state and ignores Enter; `send` pasted and pressed Enter regardless. Every `succeeded:` report a dispatched task sent while the coordinator was mid-turn parked there until a human noticed (owner screenshot: the `[ROVE PEER] …` report in the input box under "Working (6m 58s • esc to interrupt)").

Sending into an idle tab was fine (verified live on both a claude and a codex tab), so this is specifically the mid-turn path.

## Fix

- `submitKeyFor(output)` (paste-readiness.ts): Tab when the engine's recent output contains `tab to queue message`, Enter otherwise.
- `writeHostedPrompt`: peek the ring before pasting, paste, wait the existing 150 ms, read what the engine drew since, and press the key it asks for. If Enter was pressed, re-check once 300 ms later for a footer drawn late and press Tab if it appeared.
- `PromptWriteOutcome.queued` / `send` result `queued: true` when the prompt was queued rather than submitted; `docs/API.md` updated.

## Tests

`hosted-session.test.ts`: a fake pty that grows the "tab to queue message" footer once the composer holds text → exactly `[paste, "\t"]` is written and `queued: true`; the idle path still writes `[paste, "\r"]` with `queued: false`. Delivery/adapter suites pass; typecheck + biome clean.
