### PR TITLE
fix: cycle the chime volume up by exactly one step from a between-step value

### DIFF
--- a/.changeset/sound-volume-cycle-between-steps.md
+++ b/.changeset/sound-volume-cycle-between-steps.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Fix the Chime volume setting skipping a level when the stored volume sat between two steps. The Settings → General → Chime volume row cycles through 10% / 25% / 40% / 60% / 80% / 100%, but its "next step" search anchored on the first step at or above the current value and then advanced once more, so a value that was not itself a step — a hand-edited `notifications.sound.volume`, say — jumped two steps at once: cycling from 0.5 landed on 80% and 60% could never be selected. It now anchors on the nearest step at or below the current value, so every press moves up exactly one step, and a sub-minimum or silent `0` cycles up to the quietest 10% step.

--- a/packages/kobe/src/state/sound-volume.ts
+++ b/packages/kobe/src/state/sound-volume.ts
@@ -33,10 +33,21 @@ export function normalizeSoundVolume(value: unknown): number {
   return Math.min(1, Math.max(0, n))
 }
 
-/** The step after `volume` — the nearest step at or below it, then one along, wrapping. */
+/**
+ * The step after `volume` — the nearest step at or BELOW it, then one along,
+ * wrapping.
+ *
+ * `findLastIndex(step <= current)`, not `findIndex(step >= current)`: a value
+ * that sits between steps (a hand-edited `0.5`, say) already makes the
+ * `>=` search land on the next step up, so the `+ 1` then advanced a second
+ * time and skipped a step — cycling from `0.5` jumped to `0.8`, and `0.6` was
+ * unreachable. Anchoring on the step at or below `current` advances by exactly
+ * one from every input. A `current` below the first step (or the silent `0`)
+ * finds nothing (`-1`) and the wrap lands on the quietest step.
+ */
 export function nextSoundVolume(volume: number): number {
   const current = normalizeSoundVolume(volume)
-  const at = SOUND_VOLUME_STEPS.findIndex((step) => step >= current - 1e-9)
+  const at = SOUND_VOLUME_STEPS.findLastIndex((step) => step <= current + 1e-9)
   return SOUND_VOLUME_STEPS[(at < 0 ? 0 : at + 1) % SOUND_VOLUME_STEPS.length] as number
 }
 

--- a/packages/kobe/test/state/sound-volume.test.ts
+++ b/packages/kobe/test/state/sound-volume.test.ts
@@ -47,10 +47,22 @@ describe("nextSoundVolume", () => {
     expect(SOUND_VOLUME_STEPS).toContain(DEFAULT_SOUND_VOLUME)
   })
 
-  it("lands on a step from a value between steps, never staying put", () => {
-    const off = nextSoundVolume(0.33)
-    expect(SOUND_VOLUME_STEPS).toContain(off)
-    expect(off).not.toBe(0.33)
+  it("advances by exactly one step from a value between steps, never skipping one", () => {
+    // A hand-edited state.json can hold a value that is not itself a step;
+    // cycling must land on the next step UP, not the one after it.
+    expect(nextSoundVolume(0.33)).toBe(0.4)
+    expect(nextSoundVolume(0.5)).toBe(0.6)
+    expect(nextSoundVolume(0.7)).toBe(0.8)
+  })
+
+  it("cycles up to the quietest step from a sub-minimum value, including the silent 0", () => {
+    expect(nextSoundVolume(0.05)).toBe(SOUND_VOLUME_STEPS[0])
+    expect(nextSoundVolume(0)).toBe(SOUND_VOLUME_STEPS[0])
+  })
+
+  it("advances by exactly one step from every on-step value, wrapping at the top", () => {
+    const advanced = SOUND_VOLUME_STEPS.map((step) => nextSoundVolume(step))
+    expect(advanced).toEqual([...SOUND_VOLUME_STEPS.slice(1), SOUND_VOLUME_STEPS[0]])
   })
 
   it("offers something quieter than the default to cycle down to", () => {


### PR DESCRIPTION
## Direction

Bug / correctness — found by review of the recently shipped Chime volume setting (0.9.181, #969).

## Problem

`nextSoundVolume` (`packages/kobe/src/state/sound-volume.ts`) powers the Settings → General → Chime volume row, which cycles through `[0.1, 0.25, 0.4, 0.6, 0.8, 1]`. It found the "current" position with `findIndex(step => step >= current - 1e-9)` — the first step **at or above** the current value — and then returned `steps[at + 1]`.

When `current` is exactly a step, that index *is* the current step, so `+ 1` correctly advances one. But when `current` sits **between** steps, `findIndex` already lands on the next step up, and the `+ 1` then advances a *second* time, skipping a step. This contradicts the function's own doc ("the nearest step at or below it, then one along").

`normalizeSoundVolume` does not snap to a step, so a between-step value is a supported, reachable input — a hand-edited `notifications.sound.volume` (the existing test already covers a hand-edited `state.json` reading `"0.6"`). Observed:

- `nextSoundVolume(0.5)` → `0.8` (should be `0.6`; `0.6` was unreachable)
- `nextSoundVolume(0.33)` → `0.6` (should be `0.4`)
- `nextSoundVolume(0.7)` → `1` (should be `0.8`)

On-step inputs were already correct.

## Fix

Anchor the search on the nearest step **at or below** `current` with `findLastIndex(step => step <= current + 1e-9)`, then advance one. Every input now moves up exactly one step; the existing `(at < 0 ? 0 : at + 1) % length` wrap already handles a `current` below the first step (or the silent `0`) by landing on the quietest step. On-step behaviour is unchanged, and the top still wraps to the bottom.

## Verification

- Strengthened `test/state/sound-volume.test.ts`: the old "between steps" test only asserted the result was *some* step ≠ the input, so it passed on the buggy `0.6`. It now pins exact results (`0.33 → 0.4`, `0.5 → 0.6`, `0.7 → 0.8`), adds sub-minimum/`0` cases, and asserts the full on-step walk with its wrap.
- `bun x vitest run packages/kobe/test/state/sound-volume.test.ts` — 10 passed.
- `bun run lint` (root, CI's command) and `bun run typecheck` — both green.
- Changeset added (`@sma1lboy/rove`, patch).

## Follow-ups (deferred, out of this slice)

- `packages/kobe/.changeset/p0-tui-c.md` is a stray changeset in the wrong directory (the tooling reads the repo-root `.changeset/`) and uses the pre-rename `"@sma1lboy/kobe"` package name. It is never consumed at release and is unrelated to this fix; flagging rather than touching it.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PFmAUjEujTtkJLB5tV9AXa)_