### PR TITLE
fix(skill): bump to v43 and make a missed bump a red build

### DIFF
--- a/.agents/skills/kobe/SKILL.md
+++ b/.agents/skills/kobe/SKILL.md
@@ -3,7 +3,7 @@ name: rove
 description: Use when controlling Rove tasks, parallel coding attempts, hosted agent sessions, task lifecycle, or the daemon-owned issue tracker from a shell. Also the ONLY channel for messaging another agent session on this machine — `rove api send`, never a peer/MCP side channel.
 ---
 
-<!-- rove-skill-version: 42 — bump in lockstep with KOBE_SKILL_VERSION (src/lib/skill-install.ts). -->
+<!-- rove-skill-version: 43 — bump in lockstep with KOBE_SKILL_VERSION (src/lib/skill-install.ts). -->
 
 # Rove shell control
 

--- a/.changeset/skill-version-bump-guard.md
+++ b/.changeset/skill-version-bump-guard.md
@@ -1,0 +1,11 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Bump the agent skill to v43, and make a missed bump a red build.
+
+Staleness compares marker numbers only, never content, so four PRs in a row (#868, #869, #959, #970) edited `SKILL.md` while it stayed stamped v42. Every machine that installed the skill kept the older text and `rove skill status` still reported `✓ v42` — Claude and Codex both read that copy, so both were following instructions for a `send` deferred-inbox flow that had already been deleted, and neither had the "Communicate at handoffs" guidance.
+
+`test/architecture/skill-version-bump.test.ts` now records a sha256 of each skill file alongside the version it belongs to. Editing the skill without bumping fails the build and prints the exact edit to make, including the replacement fingerprint. `rove skill status` also gained a second opinion for copies already in the field: when the installed text differs from the bundled one at the same version it says so, instead of a bare `✓`.
+
+If you installed the skill before this release, refresh it: `rove skill install`, or `rove --skill > ~/.agents/skills/rove/SKILL.md`.

--- a/claude-plugin/skills/rove/SKILL.md
+++ b/claude-plugin/skills/rove/SKILL.md
@@ -3,7 +3,7 @@ name: rove
 description: Use when controlling Rove tasks, parallel coding attempts, hosted agent sessions, task lifecycle, or the daemon-owned issue tracker from a shell. Also the ONLY channel for messaging another agent session on this machine — `rove api send`, never a peer/MCP side channel.
 ---
 
-<!-- rove-skill-version: 42 — bump in lockstep with KOBE_SKILL_VERSION (src/lib/skill-install.ts). -->
+<!-- rove-skill-version: 43 — bump in lockstep with KOBE_SKILL_VERSION (src/lib/skill-install.ts). -->
 
 # Rove shell control
 

--- a/packages/kobe/src/cli/skill-cmd.ts
+++ b/packages/kobe/src/cli/skill-cmd.ts
@@ -23,6 +23,7 @@ import { join } from "node:path"
 import {
   NPX_MISSING_EXIT,
   bundledSkillDir,
+  installedSkillDiffersFromBundled,
   kobeSkillPaths,
   kobeSkillState,
   npxSkillsCommand,
@@ -138,9 +139,20 @@ export async function runSkillSubcommand(argv: readonly string[]): Promise<void>
       : state.stale
         ? `⚠ out of date (installed ${state.installedVersion === null ? "unstamped" : `v${state.installedVersion}`}, this Rove wants v${state.currentVersion})`
         : `✓ installed (v${state.installedVersion})`
+    // Second opinion on a copy that LOOKS current: staleness only compares
+    // marker numbers, so a SKILL.md edited without a version bump installs
+    // as ✓ and keeps teaching the old flow. Diagnostic only — `stale` (which
+    // drives the startup prompt) deliberately stays version-based.
+    const contentDrift = state.installed && !state.stale && !!state.path && installedSkillDiffersFromBundled(state.path)
     process.stdout.write(
       [
         `${CLI_NAME} skill: ${head}`,
+        ...(contentDrift
+          ? [
+              "  ⚠ content differs from the copy bundled with this Rove at the same version —",
+              `    run \`${CLI_NAME} --skill > ${state.path}\` to refresh it`,
+            ]
+          : []),
         // A `kobe`-named copy beside the current one is not cosmetic: agents
         // load every skill dir they find, so it keeps handing them an old
         // `api` surface however green the line above is.

--- a/packages/kobe/src/lib/skill-install.ts
+++ b/packages/kobe/src/lib/skill-install.ts
@@ -43,8 +43,13 @@ import { getPersistedString, setPersistedString } from "../state/repos.ts"
  * marker is below this number is STALE: the binary moved on, the skill
  * didn't, so we prompt the developer to re-run the active CLI's
  * `skill install` command.
+ *
+ * Editing the skill's TEXT without bumping this is invisible at runtime —
+ * staleness compares markers, never content — so
+ * `test/architecture/skill-version-bump.test.ts` goes red on any content
+ * change that skips the bump, and prints the exact edit to make.
  */
-export const KOBE_SKILL_VERSION = 42
+export const KOBE_SKILL_VERSION = 43
 
 /**
  * Where an installed kobe skill can be FOUND, relative to a home/project
@@ -233,6 +238,8 @@ export interface SkillState {
    * first path found made the whole thing invisible.
    */
   readonly legacyCopies: readonly SkillCopy[]
+  /** Where the reported copy lives (null when nothing is installed). */
+  readonly path: string | null
 }
 
 /** One skill file on disk: where it is and which marker version it carries. */
@@ -313,6 +320,7 @@ export function kobeSkillState(opts: { home?: string; cwd?: string } = {}): Skil
       currentVersion: KOBE_SKILL_VERSION,
       stale: false,
       legacyCopies: [],
+      path: null,
     }
   }
   const stale = best.version === null || best.version < KOBE_SKILL_VERSION
@@ -322,6 +330,25 @@ export function kobeSkillState(opts: { home?: string; cwd?: string } = {}): Skil
     currentVersion: KOBE_SKILL_VERSION,
     stale,
     legacyCopies: legacy.filter((copy) => copy.path !== best.path),
+    path: best.path,
+  }
+}
+
+/**
+ * True when an installed SKILL.md's TEXT differs from the one bundled in this
+ * build. The marker version is the only thing staleness looks at, so a skill
+ * edited without a version bump installs as "current" and stays wrong
+ * forever; this is the second opinion `skill status` reports. Unknown
+ * (`false`) when there is no bundled copy to compare against — an unbuilt
+ * checkout must not manufacture a warning.
+ */
+export function installedSkillDiffersFromBundled(installedPath: string): boolean {
+  const bundled = bundledSkillDir()
+  if (!bundled) return false
+  try {
+    return readFileSync(join(bundled, "SKILL.md"), "utf8") !== readFileSync(installedPath, "utf8")
+  } catch {
+    return false
   }
 }
 

--- a/packages/kobe/test/architecture/skill-version-bump.test.ts
+++ b/packages/kobe/test/architecture/skill-version-bump.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Guard: editing the agent skill's CONTENT must bump its version marker.
+ *
+ * `kobeSkillState` decides staleness by comparing marker numbers only
+ * (`best.version < KOBE_SKILL_VERSION`) — it never looks at what the file
+ * says. So a content edit that skips the bump ships silently: every machine
+ * that installed the previous version keeps the old text, and
+ * `rove skill status` reports ✓ current. That happened four times in a row
+ * (#868, #869, #959, #970 all edited SKILL.md at v42), leaving installed
+ * skills teaching a `send`/deferred flow that #959 had already deleted.
+ *
+ * The rule lived only in a comment. This pins it: the fingerprint below
+ * records the skill files' hashes AND the version they belong to, and both
+ * halves have to move together.
+ */
+
+import { createHash } from "node:crypto"
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+import { fileURLToPath } from "node:url"
+import { describe, expect, test } from "vitest"
+import { KOBE_SKILL_VERSION } from "../../src/lib/skill-install.ts"
+
+const ROOT = fileURLToPath(new URL("../../../../", import.meta.url))
+/** The canonical skill source. `claude-plugin/skills/rove` is a byte-identical
+ *  copy, held there by `claude-plugin.test.ts` — hashing one covers both. */
+const SKILL_DIR = join(ROOT, ".agents", "skills", "kobe")
+
+/**
+ * sha256 of every file in the skill, as of {@link KOBE_SKILL_VERSION}.
+ * Regenerate with the command the failure message prints.
+ */
+const FINGERPRINT = {
+  version: 43,
+  sha256: {
+    "SKILL.md": "07d271241d33921fcba1ae71c1186e8a3dcd0e99af0fd275ac81d7cff35eec41",
+    "references/api-flags.md": "596ed554d8dc1eadde254adb8d6fde87d8877c6f61904be2b218ccfb242b6004",
+  },
+} as const
+
+type SkillFile = keyof typeof FINGERPRINT.sha256
+
+function hashOf(file: SkillFile): string {
+  return createHash("sha256")
+    .update(readFileSync(join(SKILL_DIR, ...file.split("/"))))
+    .digest("hex")
+}
+
+/** The whole fix, spelled out — a red build here should cost one paste. */
+function howToFix(): string {
+  const next = KOBE_SKILL_VERSION + 1
+  const rows = (Object.keys(FINGERPRINT.sha256) as SkillFile[])
+    .map((f) => `      ${JSON.stringify(f)}: "${hashOf(f)}",`)
+    .join("\n")
+  return [
+    "",
+    `Bump KOBE_SKILL_VERSION to ${next} in src/lib/skill-install.ts, set the`,
+    `\`<!-- rove-skill-version: ${next} -->\` marker in BOTH .agents/skills/kobe/SKILL.md`,
+    "and claude-plugin/skills/rove/SKILL.md, then paste this into FINGERPRINT:",
+    "",
+    `    version: ${next},`,
+    "    sha256: {",
+    rows,
+    "    },",
+    "",
+  ].join("\n")
+}
+
+describe("agent skill content is versioned", () => {
+  test.each(Object.keys(FINGERPRINT.sha256) as SkillFile[])(
+    "%s matches the fingerprint recorded for this skill version",
+    (file) => {
+      expect(hashOf(file), `${file} changed without a skill-version bump.${howToFix()}`).toBe(FINGERPRINT.sha256[file])
+    },
+  )
+
+  // Without this the guard goes soft after the first bump: a stale record
+  // would let every later content edit at the new version slip through.
+  test("the fingerprint records the version this build ships", () => {
+    expect(FINGERPRINT.version, `FINGERPRINT.version must track KOBE_SKILL_VERSION.${howToFix()}`).toBe(
+      KOBE_SKILL_VERSION,
+    )
+  })
+
+  test("both SKILL.md copies carry the marker this build expects", () => {
+    for (const path of [join(SKILL_DIR, "SKILL.md"), join(ROOT, "claude-plugin", "skills", "rove", "SKILL.md")]) {
+      expect(readFileSync(path, "utf8"), path).toContain(`rove-skill-version: ${KOBE_SKILL_VERSION} `)
+    }
+  })
+})

--- a/packages/kobe/test/cli/skill-cmd.test.ts
+++ b/packages/kobe/test/cli/skill-cmd.test.ts
@@ -10,6 +10,7 @@ import { type MockInstance, afterEach, beforeEach, describe, expect, it, vi } fr
 const mocks = vi.hoisted(() => ({
   kobeSkillState: vi.fn(),
   kobeSkillPaths: vi.fn(() => ["/home/u/.claude/skills/kobe/SKILL.md", "/proj/.claude/skills/kobe/SKILL.md"]),
+  installedSkillDiffersFromBundled: vi.fn(() => false),
   bunSpawn: vi.fn(),
 }))
 
@@ -19,6 +20,7 @@ vi.mock("../../src/lib/skill-install.ts", async (importOriginal) => {
     ...actual,
     kobeSkillState: mocks.kobeSkillState,
     kobeSkillPaths: mocks.kobeSkillPaths,
+    installedSkillDiffersFromBundled: mocks.installedSkillDiffersFromBundled,
   }
 })
 
@@ -36,7 +38,9 @@ beforeEach(() => {
     currentVersion: 2,
     stale: false,
     legacyCopies: [],
+    path: "/home/u/.claude/skills/kobe/SKILL.md",
   })
+  mocks.installedSkillDiffersFromBundled.mockReset().mockReturnValue(false)
   mocks.bunSpawn.mockReset().mockReturnValue({ exited: Promise.resolve(0) })
   vi.stubGlobal("Bun", { spawn: mocks.bunSpawn })
 
@@ -127,6 +131,23 @@ describe("kobe skill status", () => {
     })
     await runSkillSubcommand(["status"])
     expect(out()).toContain("out of date (installed unstamped, this Rove wants v2)")
+  })
+
+  // The failure mode that shipped four times: someone edits SKILL.md without
+  // bumping the marker, so every installed copy reports ✓ while teaching the
+  // old flow. Version parity can't see it; the text comparison can.
+  it("flags a copy whose TEXT drifted from the bundled skill at the same version", async () => {
+    mocks.installedSkillDiffersFromBundled.mockReturnValue(true)
+    await runSkillSubcommand(["status"])
+    const text = out()
+    expect(text).toContain("✓ installed (v2)")
+    expect(text).toContain("content differs from the copy bundled with this Rove at the same version")
+    expect(text).toContain("run `kobe --skill > /home/u/.claude/skills/kobe/SKILL.md`")
+  })
+
+  it("says nothing about content when the installed copy matches the bundle", async () => {
+    await runSkillSubcommand(["status"])
+    expect(out()).not.toContain("content differs")
   })
 })
 


### PR DESCRIPTION
## The bug

`kobeSkillState` decides staleness with `best.version < KOBE_SKILL_VERSION` — two numbers, never the file's text. `KOBE_SKILL_VERSION` has been 42 since #831; #868, #869, #959 and #970 each edited `.agents/skills/kobe/SKILL.md` afterwards and none of them bumped it.

So a machine that installed the skill on 09-03 still has v42 text: it teaches that `send` returning deferred is a success you wait out in the Inbox (a mechanism #959 deleted) and is missing #970's "Communicate at handoffs" section. `rove skill status` reports `✓ v42` the whole time. Claude and Codex both read that one file, so both engines were following it.

The "bump when you edit" rule existed only as a comment on `KOBE_SKILL_VERSION`. Nothing enforced it.

## What's here

1. **Bump to 43** — `KOBE_SKILL_VERSION` plus the `rove-skill-version` marker in both `SKILL.md` copies. No substantive skill text changed. (`references/api-flags.md` carries no marker, so there was nothing to sync there.)
2. **`test/architecture/skill-version-bump.test.ts`** — records a sha256 of each skill file next to the version it belongs to. Editing the skill without bumping fails; the failure prints the new hashes and the exact `FINGERPRINT` block to paste.
3. **`skill status` content check** — for copies already in the field, it now compares the installed text against the bundled one and reports drift at the same version instead of a bare `✓`. `stale` (which drives the startup prompt) is untouched.

### One deviation from the brief

The brief asked for `hash == recorded || KOBE_SKILL_VERSION > recorded.version`. That disjunction goes soft after the first bump: once the record says 43 and the code says 44, *every* later edit at v44 satisfies the second half and the guard stops watching. Instead the record has to move with the version (`FINGERPRINT.version === KOBE_SKILL_VERSION`, its own one-line test) and hashes must match exactly. Same mechanism, no dead branch — and both requested mutations still behave as predicted below.

## Positive control

Appended one newline to `SKILL.md`, left the version alone:

```
 ❯ test/architecture/skill-version-bump.test.ts (4 tests | 1 failed) 6ms
   × agent skill content is versioned > SKILL.md is unchanged since the recorded version...
     → SKILL.md changed without a skill-version bump.
Bump KOBE_SKILL_VERSION to 44 in src/lib/skill-install.ts, set the
`<!-- rove-skill-version: 44 -->` marker in BOTH .agents/skills/kobe/SKILL.md
and claude-plugin/skills/rove/SKILL.md, then paste this into FINGERPRINT:

    version: 44,
    sha256: {
      "SKILL.md": "e86be2f3b41505ffc6a947e1b9691de79a736b8363b3c7dbdfded5aa726d2508",
      "references/api-flags.md": "596ed554d8dc1eadde254adb8d6fde87d8877c6f61904be2b218ccfb242b6004",
    },
: expected 'e86be2f3b41505ffc6a947e1b9691de79a736…' to be '07d271241d33921fcba1ae71c1186e8a3dcd0…'
```

Then followed those printed instructions verbatim (bump to 44, both markers, new fingerprint):

```
 ✓ test/architecture/skill-version-bump.test.ts (4 tests) 2ms
 Test Files  1 passed (1)
```

Temporary edit reverted; `git diff --stat` afterwards was the three intended one-line version changes and nothing else.

## Mutations

**1 — delete the non-hash half** (the version-lockstep test, this branch's stand-in for `|| version > record`). Current tree stays green, as predicted:

```
 Test Files  1 passed (1)
      Tests  3 passed (3)
```

**2 — corrupt one digit of the recorded `SKILL.md` hash** (`07d2712…` → `17d2712…`):

```
   × agent skill content is versioned > SKILL.md is unchanged since the recorded version...
: expected '07d271241d33921fcba1ae71c1186e8a3dcd0…' to be '17d271241d33921fcba1ae71c1186e8a3dcd0…'
      Tests  1 failed | 3 passed (4)
```

Both restored; suite back to 4 passed.

## Live check

Isolated home, `origin/main`'s v42 `SKILL.md` dropped in, running this branch's build:

```
=== CASE 1: installed v42, this build wants v43 ===
rove skill: ⚠ out of date (installed v42, this Rove wants v43)
  looked in: /tmp/rove-skillcheck-j6Ri8Q/.agents/skills/rove/SKILL.md
```

That is the line the affected machine never printed.

```
=== CASE 2: installed v43 but one character of content differs ===
rove skill: ✓ installed (v43)
  ⚠ content differs from the copy bundled with this Rove at the same version —
    run `rove --skill > /tmp/rove-skillcheck-j6Ri8Q/.agents/skills/rove/SKILL.md` to refresh it

=== CASE 3: byte-identical v43 → clean ✓, no drift line ===
rove skill: ✓ installed (v43)
  looked in: /tmp/rove-skillcheck-j6Ri8Q/.agents/skills/rove/SKILL.md
```

## Gates

| gate | result |
|---|---|
| `test:fast` (vitest) | 505 files, 5022 passed |
| `bun test test/render` | 523 pass, 0 fail |
| `test:socket` (daemon) | 114 files, 913 passed |
| `typecheck` | clean |
| root `bun run lint` | clean |
| `bun run build` | ok |
| `claude-plugin.test.ts` | green — both `SKILL.md` copies still byte-identical |

## For users on an older skill

`rove skill install`, or `rove --skill > ~/.agents/skills/rove/SKILL.md`.
