### PR TITLE
fix(skill,api): refer to a task by its title and branch, not its worktree directory

### DIFF
--- a/.agents/skills/kobe/SKILL.md
+++ b/.agents/skills/kobe/SKILL.md
@@ -3,7 +3,7 @@ name: rove
 description: Use when controlling Rove tasks, parallel coding attempts, hosted agent sessions, task lifecycle, or the daemon-owned issue tracker from a shell. Also the ONLY channel for messaging another agent session on this machine — `rove api send`, never a peer/MCP side channel.
 ---
 
-<!-- rove-skill-version: 43 — bump in lockstep with KOBE_SKILL_VERSION (src/lib/skill-install.ts). -->
+<!-- rove-skill-version: 44 — bump in lockstep with KOBE_SKILL_VERSION (src/lib/skill-install.ts). -->
 
 # Rove shell control
 
@@ -79,7 +79,7 @@ user asks for Rove by name.
 | Term | What it is | Isolation it gives | Users also say |
 |---|---|---|---|
 | **Task** | one tracked workspace record — managed worktree, saved-project main, or existing directory | managed Tasks own files + branch; main/directory Tasks reuse files | "a task", "a new one", "a separate attempt" |
-| **Worktree** | the isolated git working tree a managed Task owns (`.task.worktreePath`) | — | "workspace", "this checkout", "this branch", "here" |
+| **Worktree** | the isolated git working tree a managed Task owns (`.task.worktreePath`) — a filesystem address, never shown in the UI | — | "workspace", "this checkout", "this branch", "here" |
 | **Terminal Tab** | one engine, shell, command, or content surface inside a Task | an engine tab has its own conversation, but every tab uses the SAME Task files | "tab", "chattab", "another chat", "a second agent on this" |
 | **Split** | the tree that divides ONE Terminal Tab into several regions (the `pane-open` verb's unit; a leaf is not called a pane) | none — same session's screen, same files | "split it", "side by side", "put the logs next to it" |
 
@@ -145,7 +145,8 @@ a tab to, so `add` (single or `--count`) is the only routing available.
 
 ```bash
 echo "$ROVE_TASK_ID / $ROVE_TAB_ID"          # who you are (empty = not a Rove session)
-rove api get-task --task-id "$ROVE_TASK_ID"  # .task.worktreePath, .task.branch, .running, .tabs[]
+rove api get-task --task-id "$ROVE_TASK_ID"  # .task.title, .task.branch, .task.id, .running, .tabs[]
+                                             # .task.worktreePath too — only if you are about to read/write its files
 ```
 
 `get-task` is the per-task read that answers "what is my worktree, my
@@ -153,6 +154,24 @@ branch, and which sibling tabs exist" — `.tabs[]` carries each tab's `id`, `ki
 `vendor`, `liveVendor`, `lastTitle` and `alive`, which is exactly the target list for
 `send --tab`. A tab flagged `unregistered: true` is a live session the tab
 snapshot lost; it is addressable like any other.
+
+### Refer to a task the way the user sees it
+
+The sidebar row is the task's **title**; the line under it is its **branch**.
+Nothing in Rove's UI ever renders `worktreePath`, so the directory name in it
+(`~/.rove/worktrees/<repo>/marlin`) is a filesystem address the daemon picked
+from an animal pool — the user has never read that word and cannot find it on
+screen. **Never name a task by its directory** to a user or in a report.
+
+Use the **title** when a human reads it, the **task id** (or its last six
+characters) when you need it to be unique, and both when you need both:
+
+- ❌ `marlin opened a PR` · `landed in zorilla` · `see mammoth's branch`
+- ✅ `"Skill version guard…" (task …CWWA) opened PR #972`
+- ✅ `succeeded: guard now fails the build (branch fix/skill-version-bump)`
+
+`worktreePath` earns a mention only when the sentence is about files on disk —
+`cd`, a path in a command, a file you edited.
 
 ## Found a defect in ANOTHER project? File a request, don't work around
 

--- a/.changeset/task-identity-title-not-directory.md
+++ b/.changeset/task-identity-title-not-directory.md
@@ -1,0 +1,12 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Agent skill v44: name a task by its title and branch, not its worktree directory.
+
+The sidebar renders a task's title and, under it, its branch — `worktreePath`
+appears nowhere in the UI. Agents reached for the directory name anyway
+(`marlin`, `zorilla`), leaving the user with a word they cannot find on screen.
+The skill now says which fields the user actually sees, `rove api schema` says
+it on `add` and `get-task`, and each `--count` / `--agents` sibling's result row
+carries its `title` and `branch` instead of only an id.

--- a/claude-plugin/skills/rove/SKILL.md
+++ b/claude-plugin/skills/rove/SKILL.md
@@ -3,7 +3,7 @@ name: rove
 description: Use when controlling Rove tasks, parallel coding attempts, hosted agent sessions, task lifecycle, or the daemon-owned issue tracker from a shell. Also the ONLY channel for messaging another agent session on this machine — `rove api send`, never a peer/MCP side channel.
 ---
 
-<!-- rove-skill-version: 43 — bump in lockstep with KOBE_SKILL_VERSION (src/lib/skill-install.ts). -->
+<!-- rove-skill-version: 44 — bump in lockstep with KOBE_SKILL_VERSION (src/lib/skill-install.ts). -->
 
 # Rove shell control
 
@@ -79,7 +79,7 @@ user asks for Rove by name.
 | Term | What it is | Isolation it gives | Users also say |
 |---|---|---|---|
 | **Task** | one tracked workspace record — managed worktree, saved-project main, or existing directory | managed Tasks own files + branch; main/directory Tasks reuse files | "a task", "a new one", "a separate attempt" |
-| **Worktree** | the isolated git working tree a managed Task owns (`.task.worktreePath`) | — | "workspace", "this checkout", "this branch", "here" |
+| **Worktree** | the isolated git working tree a managed Task owns (`.task.worktreePath`) — a filesystem address, never shown in the UI | — | "workspace", "this checkout", "this branch", "here" |
 | **Terminal Tab** | one engine, shell, command, or content surface inside a Task | an engine tab has its own conversation, but every tab uses the SAME Task files | "tab", "chattab", "another chat", "a second agent on this" |
 | **Split** | the tree that divides ONE Terminal Tab into several regions (the `pane-open` verb's unit; a leaf is not called a pane) | none — same session's screen, same files | "split it", "side by side", "put the logs next to it" |
 
@@ -145,7 +145,8 @@ a tab to, so `add` (single or `--count`) is the only routing available.
 
 ```bash
 echo "$ROVE_TASK_ID / $ROVE_TAB_ID"          # who you are (empty = not a Rove session)
-rove api get-task --task-id "$ROVE_TASK_ID"  # .task.worktreePath, .task.branch, .running, .tabs[]
+rove api get-task --task-id "$ROVE_TASK_ID"  # .task.title, .task.branch, .task.id, .running, .tabs[]
+                                             # .task.worktreePath too — only if you are about to read/write its files
 ```
 
 `get-task` is the per-task read that answers "what is my worktree, my
@@ -153,6 +154,24 @@ branch, and which sibling tabs exist" — `.tabs[]` carries each tab's `id`, `ki
 `vendor`, `liveVendor`, `lastTitle` and `alive`, which is exactly the target list for
 `send --tab`. A tab flagged `unregistered: true` is a live session the tab
 snapshot lost; it is addressable like any other.
+
+### Refer to a task the way the user sees it
+
+The sidebar row is the task's **title**; the line under it is its **branch**.
+Nothing in Rove's UI ever renders `worktreePath`, so the directory name in it
+(`~/.rove/worktrees/<repo>/marlin`) is a filesystem address the daemon picked
+from an animal pool — the user has never read that word and cannot find it on
+screen. **Never name a task by its directory** to a user or in a report.
+
+Use the **title** when a human reads it, the **task id** (or its last six
+characters) when you need it to be unique, and both when you need both:
+
+- ❌ `marlin opened a PR` · `landed in zorilla` · `see mammoth's branch`
+- ✅ `"Skill version guard…" (task …CWWA) opened PR #972`
+- ✅ `succeeded: guard now fails the build (branch fix/skill-version-bump)`
+
+`worktreePath` earns a mention only when the sentence is about files on disk —
+`cd`, a path in a command, a file you edited.
 
 ## Found a defect in ANOTHER project? File a request, don't work around
 

--- a/packages/kobe/src/cli/api/handlers-add.ts
+++ b/packages/kobe/src/cli/api/handlers-add.ts
@@ -367,11 +367,17 @@ async function addParallel(
   // delivered sibling into a failure row: the engine already has the prompt.
   const persistedPrompts: Promise<unknown>[] = []
   settled.forEach((r, i) => {
-    const { taskId, vendor } = created[i]
+    const { taskId, vendor, task } = created[i]
     if (r.status === "fulfilled" && r.value.delivered) {
+      // `title` and `branch` before the rest: they are what the sidebar shows,
+      // so they are the only handles the spawner can use to name a sibling to
+      // the user. A row of bare taskIds pushes the caller toward the worktree
+      // directory name (`marlin`), which appears nowhere in the UI.
       const row: Record<string, unknown> = {
         ok: true,
         taskId,
+        title: task.title,
+        branch: task.branch,
         vendor,
         started: r.value.started,
         engineReady: r.value.engineReady,

--- a/packages/kobe/src/cli/api/verbs-create.ts
+++ b/packages/kobe/src/cli/api/verbs-create.ts
@@ -15,7 +15,7 @@ export const CREATE_VERBS: readonly VerbSpec[] = [
   {
     name: "add",
     group: "create",
-    summary: `Create a task (shows in the sidebar immediately). With --prompt it also starts the engine and delivers it. PARALLEL ATTEMPTS: --count N spawns N sibling tasks of the SAME prompt, each in its own worktree/branch (--agents claude:2,codex:1 for a mixed fleet); capped at ${FANOUT_CAP}, prefer 3-4. Does NOT steal focus — pass --activate to make it the active task. Alias: spawn-task.`,
+    summary: `Create a task (shows in the sidebar immediately). With --prompt it also starts the engine and delivers it. PARALLEL ATTEMPTS: --count N spawns N sibling tasks of the SAME prompt, each in its own worktree/branch (--agents claude:2,codex:1 for a mixed fleet); capped at ${FANOUT_CAP}, prefer 3-4. Does NOT steal focus — pass --activate to make it the active task. The sidebar shows .task.title and .task.branch — name a task by those (or its id), never by the directory in .task.worktreePath, which the UI never renders. Alias: spawn-task.`,
     flags: [
       F.repo(),
       F.title(),

--- a/packages/kobe/src/cli/api/verbs-read.ts
+++ b/packages/kobe/src/cli/api/verbs-read.ts
@@ -36,7 +36,7 @@ export const READ_VERBS: readonly VerbSpec[] = [
     name: "get-task",
     group: "read",
     summary:
-      "Read one task's metadata + terminal tabs. `.running` = any hosted engine tab is live; `.tabs[]` (id/kind/vendor/liveVendor/lastTitle/alive) is the discovery read for `send --tab tab-N`; `.task.dispatcher` = the Rove session (task+tab) that created it, when one did; `.task.prStatus.checkState` (none|pending|passing|failing|unknown) is Rove's OWN CI truth for the branch's PR — `passing` is what \"CI is green\" means, never a local test run.",
+      "Read one task's metadata + terminal tabs. `.running` = any hosted engine tab is live; `.tabs[]` (id/kind/vendor/liveVendor/lastTitle/alive) is the discovery read for `send --tab tab-N`; `.task.dispatcher` = the Rove session (task+tab) that created it, when one did; `.task.prStatus.checkState` (none|pending|passing|failing|unknown) is Rove's OWN CI truth for the branch's PR — `passing` is what \"CI is green\" means, never a local test run. `.task.worktreePath` is where the files live; the user only ever sees `.task.title` and `.task.branch`, so refer to the task by those.",
     flags: [F.taskId()],
     handler: getTask,
   },

--- a/packages/kobe/src/lib/skill-install.ts
+++ b/packages/kobe/src/lib/skill-install.ts
@@ -49,7 +49,7 @@ import { getPersistedString, setPersistedString } from "../state/repos.ts"
  * `test/architecture/skill-version-bump.test.ts` goes red on any content
  * change that skips the bump, and prints the exact edit to make.
  */
-export const KOBE_SKILL_VERSION = 43
+export const KOBE_SKILL_VERSION = 44
 
 /**
  * Where an installed kobe skill can be FOUND, relative to a home/project

--- a/packages/kobe/test/architecture/skill-version-bump.test.ts
+++ b/packages/kobe/test/architecture/skill-version-bump.test.ts
@@ -31,9 +31,9 @@ const SKILL_DIR = join(ROOT, ".agents", "skills", "kobe")
  * Regenerate with the command the failure message prints.
  */
 const FINGERPRINT = {
-  version: 43,
+  version: 44,
   sha256: {
-    "SKILL.md": "07d271241d33921fcba1ae71c1186e8a3dcd0e99af0fd275ac81d7cff35eec41",
+    "SKILL.md": "5bbb0ffb067d546923d7bd44de29fca5dbdfef5ba4cc520618a4f866d2360339",
     "references/api-flags.md": "596ed554d8dc1eadde254adb8d6fde87d8877c6f61904be2b218ccfb242b6004",
   },
 } as const
@@ -48,7 +48,8 @@ function hashOf(file: SkillFile): string {
 
 /** The whole fix, spelled out — a red build here should cost one paste. */
 function howToFix(): string {
-  const next = KOBE_SKILL_VERSION + 1
+  // Already bumped the constant? Then `next` is that number, not one past it.
+  const next = Math.max(KOBE_SKILL_VERSION, FINGERPRINT.version + 1)
   const rows = (Object.keys(FINGERPRINT.sha256) as SkillFile[])
     .map((f) => `      ${JSON.stringify(f)}: "${hashOf(f)}",`)
     .join("\n")

--- a/packages/kobe/test/cli/api-add-parallel.test.ts
+++ b/packages/kobe/test/cli/api-add-parallel.test.ts
@@ -90,6 +90,21 @@ describe("add --count (parallel round)", () => {
     expect(calls.every((call) => call.target.newTask === true)).toBe(true)
   })
 
+  it("names each sibling the way the sidebar does — title and branch, ahead of the rest", async () => {
+    const client = fanClient()
+    const result = (await invokeVerb("add", ["--repo", "/repo/x", "--prompt", "go", "--count", "2"], {
+      client,
+      runtime: stubRuntime({ deliverPrompt: recordingDelivery().deliver }),
+    })) as { tasks: Array<Record<string, unknown>> }
+    // Without these the spawner has only opaque ids and reaches for the
+    // worktree directory name, which appears nowhere in the UI.
+    expect(result.tasks.map((t) => [t.title, t.branch])).toEqual([
+      ["T", "kobe/t-t1"],
+      ["T", "kobe/t-t1"],
+    ])
+    expect(Object.keys(result.tasks[0]).slice(0, 4)).toEqual(["ok", "taskId", "title", "branch"])
+  })
+
   it("applies --status and --pin to every sibling, not just a single add", async () => {
     const client = new FakeClient({
       "task.create": (_payload, index) => ({ taskId: `t${index + 1}`, task: taskFixture({ id: `t${index + 1}` }) }),


### PR DESCRIPTION
Agents kept naming tasks by their worktree directory — `marlin`, `mammoth`,
`zorilla`. The sidebar renders `task.title` (`row-view.ts:321`) and `task.branch`
underneath it (`:251`); `git grep -E 'basename\(.*worktreePath|worktreePath.*split\("/"\)' -- packages/kobe/src/tui packages/kobe/src/tui-react`
returns nothing. The directory name is a daemon-assigned animal-pool path and
appears nowhere on screen, so the user cannot find the task being described.

The skill never said which fields the user can see, while handing the agent
`.task.worktreePath` on every `add` and `get-task` — the shortest unique word
won.

## 1. Skill (v43 → v44, both copies byte-identical)

New section after "Know where you are before you route":

> ### Refer to a task the way the user sees it
>
> The sidebar row is the task's **title**; the line under it is its **branch**.
> Nothing in Rove's UI ever renders `worktreePath`, so the directory name in it
> (`~/.rove/worktrees/<repo>/marlin`) is a filesystem address the daemon picked
> from an animal pool — the user has never read that word and cannot find it on
> screen. **Never name a task by its directory** to a user or in a report.
>
> Use the **title** when a human reads it, the **task id** (or its last six
> characters) when you need it to be unique, and both when you need both:
>
> - ❌ `marlin opened a PR` · `landed in zorilla` · `see mammoth's branch`
> - ✅ `"Skill version guard…" (task …CWWA) opened PR #972`
> - ✅ `succeeded: guard now fails the build (branch fix/skill-version-bump)`
>
> `worktreePath` earns a mention only when the sentence is about files on disk —
> `cd`, a path in a command, a file you edited.

Plus: the glossary's Worktree row now ends "— a filesystem address, never shown
in the UI", and the `get-task` example leads with `.task.title, .task.branch,
.task.id, .running, .tabs[]`, with `worktreePath` moved to a second line marked
"only if you are about to read/write its files".

The existing `succeeded: … (branch <final branch>)` report format was already
correct — it names the branch, not the directory. Left alone.

Every remaining `worktreePath` mention is in the filesystem-address framing:

```
$ grep -n "worktreePath\|marlin\|Refer to a task" .agents/skills/kobe/SKILL.md
82:| **Worktree** | the isolated git working tree a managed Task owns (`.task.worktreePath`) — a filesystem address, never shown in the UI | — | "workspace", "this checkout", "this branch", "here" |
149:                                             # .task.worktreePath too — only if you are about to read/write its files
158:### Refer to a task the way the user sees it
161:Nothing in Rove's UI ever renders `worktreePath`, so the directory name in it
162:(`~/.rove/worktrees/<repo>/marlin`) is a filesystem address the daemon picked
169:- ❌ `marlin opened a PR` · `landed in zorilla` · `see mammoth's branch`
173:`worktreePath` earns a mention only when the sentence is about files on disk —
```

## 2. API result shape

**The `task` object was already correct.** `serializeTask` (`protocol.ts:412`)
emits `id, title, repo, branch, worktreePath, …`, so BEFORE and AFTER are
identical for `add` / `get-task` / `list` — nothing to reorder. Isolated daemon
(`KOBE_HOME_DIR` / `ROVE_HOME_DIR` / `*_SOCKET_PATH` inlined), tmp git repo:

```
BEFORE (origin/main @ 978c02f61)          AFTER (this branch)
--- add .task keys                        --- add .task keys
["id","title","repo","branch",            ["id","title","repo","branch",
 "worktreePath","kind","status",           "worktreePath","kind","status",
 "pinned","vendor","createdAt",            "pinned","vendor","createdAt",
 "updatedAt"]                              "updatedAt"]
--- get-task .task keys   → same          --- get-task .task keys   → same
--- list .tasks[0] keys   → same          --- list .tasks[0] keys   → same
```

The real gap was one level down: a `--count` / `--agents` round returned rows of
`{ ok, taskId, vendor, started, … }` — no title, no branch at all, so a
dispatcher that just spawned four siblings had nothing user-visible to call them
by. The rows now carry `title` and `branch` (already in hand from `task.create`;
no extra RPC), ahead of the rest:

```
BEFORE: ["ok","taskId","vendor","started","engineReady","session"]
AFTER:  ["ok","taskId","title","branch","vendor","started","engineReady","session"]
```

Guarded by a new case in `test/cli/api-add-parallel.test.ts` (asserted through
the fake daemon client — a live probe would have to boot real engines).

## 3. `rove api schema`

```
$ rove api schema --verb add | jq -r .summary | tail -c 200
…pass --activate to make it the active task. The sidebar shows .task.title and
.task.branch — name a task by those (or its id), never by the directory in
.task.worktreePath, which the UI never renders. Alias: spawn-task.

$ rove api schema --verb get-task | jq -r .summary | tail -c 200
…never a local test run. `.task.worktreePath` is where the files live; the user
only ever sees `.task.title` and `.task.branch`, so refer to the task by those.
```

## 4. `--title` fallback — checked, no change

`deriveTitleFromPrompt` (`orchestrator/title.ts`) slices the prompt text. It has
no access to the worktree name and cannot degrade into a directory name.

## Unasked-for extra (one line, flagged)

`skill-version-bump.test.ts`'s `howToFix()` printed `KOBE_SKILL_VERSION + 1`
unconditionally, so re-running it *after* bumping the constant told you to jump
to 45 when 44 was correct. Now `Math.max(KOBE_SKILL_VERSION, FINGERPRINT.version + 1)`.
Say the word and I'll drop it.

## Mutation proof

| Mutation | Result |
|---|---|
| append a comment to `SKILL.md`, leave version at 44 | ✗ `SKILL.md changed without a skill-version bump.` + pasteable FINGERPRINT |
| revert `KOBE_SKILL_VERSION` to 43 | ✗ 2 failed — fingerprint-version and both-markers cases |
| restore both | ✓ 4 passed |
| delete `title: task.title` from the fan-out row | ✗ `expected [ [ undefined, 'kobe/t-t1' ], …(1) ] to deeply equal [ [ 'T', 'kobe/t-t1' ], …(1) ]` |
| restore | ✓ 14 passed |

`test/architecture/claude-plugin.test.ts` green (both `SKILL.md` copies byte-identical).

## Gates

- `bun run test:fast` — 505 files, 5023 passed
- `bun run test:socket` — 114 files, 913 passed
- `bun test test/render` — 523 passed, 0 fail
- `bun x tsc --noEmit`, repo-root `bun run lint`, `bun run build` — green

No UI change (the sidebar already showed title/branch), so no screenshots.
One changeset, `"@sma1lboy/rove": patch`.
