### PR TITLE
fix: a task's activity state now follows what its tabs are doing

### DIFF
--- a/.changeset/derived-activity-rollup.md
+++ b/.changeset/derived-activity-rollup.md
@@ -1,0 +1,15 @@
+---
+"@sma1lboy/rove": patch
+---
+
+A task's activity state now follows what its tabs are actually doing. It was a
+separate copy updated last-event-wins across every tab, so on a task with more
+than one tab a completion in one tab dimmed a live turn in another, and a tab
+whose engine died or went quiet without being the last to report left the task
+spinning with nothing running under it. The task state is now derived from the
+per-tab ledger: any working tab means the task is working, otherwise the newest
+state that wants a human (turn complete, permission needed, rate limited,
+error, dead) shows through.
+
+Closing a tab now clears its activity too — the running tab of a task could be
+closed and leave the task row spinning for the life of the daemon.

--- a/packages/kobe-daemon/src/daemon/activity-lapse.ts
+++ b/packages/kobe-daemon/src/daemon/activity-lapse.ts
@@ -1,0 +1,100 @@
+/**
+ * The activity lapse watchdog — the registry's only timer-and-probe concern,
+ * split out on that seam: everything else in `activity-registry.ts` is a
+ * synchronous ledger write, while this is a clock plus an async filesystem
+ * read, and mixing the two is what made the ledger hard to read.
+ *
+ * ONE implementation covers both scopes it polices — a task's tab-less hook
+ * entry and a per-tab hook slot. The policy is identical; the caller supplies
+ * how to read the policed entry and what "retire it" means at that scope.
+ */
+
+import {
+  type ActivityLiveness,
+  type ActivityLivenessProbe,
+  type EngineSessionInfo,
+  activityStillWorking,
+} from "./activity-reduce.ts"
+
+/** Scope key: a task's tab-less entry, or one of its tabs. */
+export interface LapseTarget {
+  readonly taskId: string
+  readonly tabId?: string
+}
+
+/** The subset of a hook entry the watchdog reads and writes. */
+export interface LapseEntry {
+  at: number
+  vendor?: string
+  session?: EngineSessionInfo
+  lapse?: ReturnType<typeof setTimeout>
+}
+
+export interface LapseDeps {
+  readonly staleMs: number
+  readonly now: () => number
+  readonly livenessAt: ActivityLivenessProbe
+  /** The hook entry this scope polices, or `undefined` once it is gone. */
+  readonly entryAt: (target: LapseTarget) => LapseEntry | undefined
+  /** Drop the silent claim at this scope and publish what follows from it. */
+  readonly retire: (target: LapseTarget) => void
+}
+
+export class ActivityLapseWatchdog {
+  constructor(private readonly deps: LapseDeps) {}
+
+  /**
+   * Arm (or re-arm) the watchdog for the entry stamped `at`. A long single
+   * turn emits only `turn-start` … `Stop` over many minutes — nothing in
+   * between — so a fixed timer would fire mid-turn and wrongly idle a working
+   * agent. Bumping the TTL only moves that cliff. Instead, when the timer
+   * fires we probe whether the engine is still writing its transcript: a write
+   * within the trailing `staleMs` window ⇒ the turn is alive, so we re-arm (a
+   * heartbeat) instead of retiring. Only a genuinely silent engine (no recent
+   * write ⇒ a missed Stop / hung process) lapses.
+   */
+  arm(target: LapseTarget, at: number): ReturnType<typeof setTimeout> {
+    const timer = setTimeout(() => {
+      void this.fire(target, at)
+    }, this.deps.staleMs)
+    timer.unref?.()
+    return timer
+  }
+
+  /** Probe wrapper: a best-effort filesystem read must never crash the daemon,
+   *  and a failed read of an identified session stays unknown. */
+  private async probe(taskId: string, vendor?: string, transcriptPath?: string): Promise<ActivityLiveness | undefined> {
+    try {
+      return await this.deps.livenessAt(taskId, vendor, transcriptPath)
+    } catch {
+      return transcriptPath ? { unknown: true } : undefined
+    }
+  }
+
+  /**
+   * Timer callback. Never throws. Guards against the entry changing across the
+   * async probe: a `report()` / `clearTask()` / `close()` that runs before OR
+   * during the probe supersedes this lapse (re-read the ledger and confirm the
+   * same entry identity after the await). A rescheduled lapse is stored back
+   * on the live entry, so a later event can cancel it.
+   */
+  private async fire(target: LapseTarget, at: number): Promise<void> {
+    // Superseded before we even probed (a fresh report swapped the entry).
+    const before = this.deps.entryAt(target)
+    if (!before || before.at !== at) return
+
+    const live = await this.probe(target.taskId, before.vendor, before.session?.transcriptPath)
+
+    // Re-read after the await: the entry may have been replaced or cleared
+    // while the probe was in flight. Acting on a stale `at` would clobber a
+    // newer state or resurrect a cleared task.
+    const cur = this.deps.entryAt(target)
+    if (cur !== before) return
+
+    if (activityStillWorking(live, at, this.deps.now(), this.deps.staleMs)) {
+      cur.lapse = this.arm(target, at)
+      return
+    }
+    this.deps.retire(target)
+  }
+}

--- a/packages/kobe-daemon/src/daemon/activity-registry.ts
+++ b/packages/kobe-daemon/src/daemon/activity-registry.ts
@@ -1,14 +1,14 @@
 import { type EffectiveActivity, type HookSlot, type ObservedSlot, recomputeTabActivity } from "./activity-arbitrate.ts"
 import { type ActivityDebugSnapshot, buildActivityDebugSnapshot } from "./activity-debug-dump.ts"
+import { ActivityLapseWatchdog, type LapseEntry, type LapseTarget } from "./activity-lapse.ts"
 import {
-  type ActivityLiveness,
   type ActivityLivenessProbe,
   type EngineSessionInfo,
   STICKY_STATES,
-  activityStillWorking,
   reduceActivity,
   resolveEngineStateTtlMs,
 } from "./activity-reduce.ts"
+import { type RollupCandidate, deriveTaskActivity, rollupCandidates } from "./activity-rollup.ts"
 import type { EngineActivityDetail, EngineActivityKind, TaskActivityState } from "./contracts.ts"
 import type { DaemonEventBus } from "./event-bus.ts"
 import type { ChannelPayloads } from "./protocol.ts"
@@ -30,8 +30,14 @@ export {
   type TabActivitySlots,
   recomputeTabActivity,
 } from "./activity-arbitrate.ts"
+export { type RollupCandidate, deriveTaskActivity, rollupCandidates } from "./activity-rollup.ts"
 
-/** Task-level rollup entry — last-event-wins across the task's tabs. */
+/**
+ * A TAB-LESS hook entry: an engine the user started in a shell kobe did not
+ * spawn inherits no `KOBE_TAB_ID`, so its hooks report task-only (see
+ * `attention-inbox.ts`'s `record`). It is one more rollup candidate beside the
+ * task's tabs — NOT the rollup itself, which is derived (activity-rollup.ts).
+ */
 interface ActivityEntry {
   state: TaskActivityState
   detail?: EngineActivityDetail
@@ -42,8 +48,6 @@ interface ActivityEntry {
   /** The reporting engine's id (hook `--engine`) — what the liveness probe
    *  asks about. Carried forward like `session`. */
   vendor?: string
-  /** Exact tab report that owns this rollup; inherited session paths are not ownership. */
-  sourceHook?: TabHookEntry
   lapse?: ReturnType<typeof setTimeout>
 }
 
@@ -84,28 +88,29 @@ interface PayloadSource {
  * This is UI state, not task lifecycle: it is replayed to subscribers and the
  * web snapshot, but never persisted to tasks.json.
  *
- * Two levels: the task-level rollup (last-event-wins across tabs, every
- * existing consumer reads it) and the per-tab ledger (the F7 attention jump's
- * tab precision + the tab strip's chip). The per-tab ledger is where the
- * multi-source arbitration lives: hook events and observer facts occupy
- * separate slots and ONE pure function decides what subscribers see, instead
- * of each writer special-casing the other source's entries.
+ * The per-tab ledger is the ONLY thing written: hook events and observer facts
+ * occupy separate slots and ONE pure function decides what subscribers see
+ * (activity-arbitrate.ts), instead of each writer special-casing the other
+ * source's entries. The task-level rollup every consumer reads is DERIVED from
+ * that ledger on demand (activity-rollup.ts) rather than maintained as a
+ * second copy — see that file for why the copy could not be kept correct.
  */
-/** Scope key for the unified lapse watchdog — one abstraction covers both
- *  the task-level rollup and a per-tab hook slot. */
-interface LapseTarget {
-  readonly taskId: string
-  readonly tabId?: string
-}
-
-/** The subset of an entry the lapse-timer abstraction reads and writes. */
-type LapseEntry = Pick<ActivityEntry, "at" | "vendor" | "session" | "lapse">
-
 export class DaemonActivityRegistry {
+  /** Tab-less hook entries only (see {@link ActivityEntry}) — one rollup
+   *  candidate per task, not the rollup. */
   private readonly activity = new Map<string, ActivityEntry>()
   /** Per-tab records (taskId → tabId → entry) for events that carried a
    *  `tabId`. UI state like everything here — replayed, never persisted. */
   private readonly tabActivity = new Map<string, Map<string, TabEntry>>()
+  /**
+   * Per-tab REDUCER lineage (taskId → tabId → last reduced state), including
+   * idle. The ledger above drops an idle tab — a closed tab must not stay a
+   * rollup candidate — but {@link reduceActivity} still has to tell "this tab
+   * went quiet on the record" from "this daemon has never heard of it": a Stop
+   * on the first is an automated wake to swallow, on the second a turn that
+   * outlived a daemon restart, and its ● lamp is owed.
+   */
+  private readonly tabLineage = new Map<string, Map<string, TaskActivityState>>()
 
   constructor(
     private readonly bus: DaemonEventBus,
@@ -118,7 +123,25 @@ export class DaemonActivityRegistry {
      * whether the engine is still writing its transcript before idling.
      */
     private readonly livenessAt: ActivityLivenessProbe = () => Promise.resolve(undefined),
-  ) {}
+    /**
+     * Does this task still exist? The observer walks PTY sessions, which can
+     * outlive the task's removal from the index by a poll — without this a
+     * deleted task's observation re-created its ledger entry, resurrecting a
+     * badge for a task the UI had already dropped.
+     */
+    private readonly taskExists: (taskId: string) => boolean = () => true,
+  ) {
+    this.lapse = new ActivityLapseWatchdog({
+      staleMs: this.staleMs,
+      now: this.now,
+      livenessAt: (taskId, vendor, transcriptPath) => this.livenessAt(taskId, vendor, transcriptPath),
+      entryAt: (target) => this.lapseEntry(target),
+      retire: (target) => this.retireLapsed(target),
+    })
+  }
+
+  /** Safety net for a missed Stop/SessionEnd — see activity-lapse.ts. */
+  private readonly lapse: ActivityLapseWatchdog
 
   report(
     taskId: string,
@@ -128,51 +151,35 @@ export class DaemonActivityRegistry {
     session?: EngineSessionInfo,
     vendor?: string,
   ): void {
-    const prev = this.activity.get(taskId)
-    if (prev?.lapse) clearTimeout(prev.lapse)
-    const state = reduceActivity(prev?.state, kind, detail)
     const at = this.now()
-    const lineage = tabId ? this.tabActivity.get(taskId)?.get(tabId)?.hook : prev
-    const entry: ActivityEntry = {
-      state,
-      detail,
-      at,
-      session: session ?? lineage?.session,
-      vendor: vendor ?? lineage?.vendor,
-    }
-    // Safety net: only `running` is policed by the lapse watchdog — a missed
-    // Stop/SessionEnd must not pin it forever, so it lapses to idle once the
-    // engine genuinely goes silent (heartbeat probe below). Sticky states
-    // (turn_complete + the attention states a user walks away to handle) stay
-    // visible until the next real event clears them; see {@link STICKY_STATES}.
-    if (state !== "idle" && !STICKY_STATES.has(state)) {
-      entry.lapse = this.armLapse({ taskId }, at)
-    }
-    this.activity.set(taskId, entry)
-    // Per-tab ledger. A TAB-scoped publish must carry the TAB's session
-    // lineage only — the event's own id, or the same tab's previous one.
-    // Inheriting the task-level rollup here leaked another tab's (even
-    // another ENGINE's) session onto a fresh tab whose hooks don't pipe
-    // session ids. A hook event SUPERSEDES the observed slot for its tab:
-    // hooks are authoritative while the engine lives (see
-    // activity-arbitrate.ts), so the observation that filled the gap is
-    // dropped rather than left to age against the fresh claim.
-    let publishEntry: PayloadSource = entry
+    // The reduce's `previous` is PER SOURCE. Reading the task rollup here was
+    // the same conflation the rollup itself was: tab B's Stop reduced against
+    // tab A's turn-start, so one tab's completion state depended on another's.
     if (tabId) {
+      // A TAB-scoped publish must carry the TAB's session lineage only — the
+      // event's own id, or the same tab's previous one. Inheriting a
+      // task-level id here leaked another tab's (even another ENGINE's)
+      // session onto a fresh tab whose hooks don't pipe session ids. A hook
+      // event SUPERSEDES the observed slot for its tab: hooks are
+      // authoritative while the engine lives (see activity-arbitrate.ts), so
+      // the observation that filled the gap is dropped rather than left to
+      // age against the fresh claim.
       const tabs = this.tabActivity.get(taskId) ?? new Map<string, TabEntry>()
       const prevTab = tabs.get(tabId)
+      const lineage = this.tabLineage.get(taskId) ?? new Map<string, TaskActivityState>()
+      const state = reduceActivity(prevTab?.effective.state ?? lineage.get(tabId), kind, detail)
+      lineage.set(tabId, state)
+      this.tabLineage.set(taskId, lineage)
       if (prevTab?.hook?.lapse) clearTimeout(prevTab.hook.lapse)
       const tabSession = session ?? prevTab?.hook?.session
       const tabVendor = vendor ?? prevTab?.hook?.vendor
-      publishEntry = { state, detail, at, session: tabSession }
       if (state === "idle") {
         // A closed/ended tab must not linger as a candidate — idle CLEARS
         // the tab's record (both slots) rather than being stored.
         tabs.delete(tabId)
       } else {
         const hook: TabHookEntry = { state, detail, at, session: tabSession, vendor: tabVendor }
-        entry.sourceHook = hook
-        if (!STICKY_STATES.has(state)) hook.lapse = this.armLapse({ taskId, tabId }, at)
+        if (!STICKY_STATES.has(state)) hook.lapse = this.lapse.arm({ taskId, tabId }, at)
         tabs.set(tabId, {
           hook,
           effective: {
@@ -187,70 +194,76 @@ export class DaemonActivityRegistry {
       }
       if (tabs.size > 0) this.tabActivity.set(taskId, tabs)
       else this.tabActivity.delete(taskId)
-    }
-    this.bus.publish("engine-state", this.payload(taskId, publishEntry, tabId))
-  }
-
-  /** Probe wrapper: a best-effort filesystem read must never crash the daemon,
-   *  and a failed read of an identified session stays unknown. */
-  private async probe(taskId: string, vendor?: string, transcriptPath?: string): Promise<ActivityLiveness | undefined> {
-    try {
-      return await this.livenessAt(taskId, vendor, transcriptPath)
-    } catch {
-      return transcriptPath ? { unknown: true } : undefined
-    }
-  }
-
-  /**
-   * Arm (or re-arm) the lapse watchdog for the entry stamped `at`. A long
-   * single turn emits only `turn-start` … `Stop` over many minutes — nothing
-   * in between — so a fixed timer would fire mid-turn and wrongly idle a
-   * working agent. Bumping the TTL only moves that cliff. Instead, when the
-   * timer fires we probe whether the engine is still writing its transcript:
-   * a write within the trailing `staleMs` window ⇒ the turn is alive, so we
-   * re-arm (a heartbeat) instead of idling. Only a genuinely silent engine
-   * (no recent write ⇒ a missed Stop / hung process) lapses to idle.
-   *
-   * One helper covers both the task-level rollup and per-tab hook slots; the
-   * callback resolves the right ledger by the scope key.
-   */
-  private armLapse(target: LapseTarget, at: number): ReturnType<typeof setTimeout> {
-    const timer = setTimeout(() => {
-      void this.handleLapse(target, at)
-    }, this.staleMs)
-    timer.unref?.()
-    return timer
-  }
-
-  /**
-   * Lapse-timer callback. Never throws. Guards against the entry changing
-   * across the async probe: a `report()` / `clearTask()` / `close()` that runs
-   * before OR during the probe supersedes this lapse (re-read the map and
-   * confirm the same entry identity after the await). A rescheduled
-   * lapse is stored back on the live entry, so a later event can cancel it.
-   *
-   * One implementation covers both the task-level rollup and the per-tab hook
-   * slot — the policy (probe, supersede guard, heartbeat) is identical; only
-   * the idle cleanup differs.
-   */
-  private async handleLapse(target: LapseTarget, at: number): Promise<void> {
-    // Superseded before we even probed (a fresh report swapped the entry).
-    const before = this.lapseEntry(target)
-    if (!before || before.at !== at) return
-
-    const live = await this.probe(target.taskId, before.vendor, before.session?.transcriptPath)
-
-    // Re-read after the await: the entry may have been replaced or cleared
-    // while the probe was in flight. Acting on a stale `at` would clobber a
-    // newer state or resurrect a cleared task.
-    const cur = this.lapseEntry(target)
-    if (cur !== before) return
-
-    if (activityStillWorking(live, at, this.now(), this.staleMs)) {
-      cur.lapse = this.armLapse(target, at)
+      this.bus.publish("engine-state", this.payload(taskId, { state, detail, at, session: tabSession }, tabId))
+      this.publishRollup(taskId)
       return
     }
 
+    const prev = this.activity.get(taskId)
+    if (prev?.lapse) clearTimeout(prev.lapse)
+    const state = reduceActivity(prev?.state, kind, detail)
+    const entry: ActivityEntry = {
+      state,
+      detail,
+      at,
+      session: session ?? prev?.session,
+      vendor: vendor ?? prev?.vendor,
+    }
+    // Safety net: only `running` is policed by the lapse watchdog — a missed
+    // Stop/SessionEnd must not pin it forever, so it lapses to idle once the
+    // engine genuinely goes silent (heartbeat probe below). Sticky states
+    // (turn_complete + the attention states a user walks away to handle) stay
+    // visible until the next real event clears them; see {@link STICKY_STATES}.
+    if (state !== "idle" && !STICKY_STATES.has(state)) {
+      entry.lapse = this.lapse.arm({ taskId }, at)
+    }
+    this.activity.set(taskId, entry)
+    this.publishRollup(taskId)
+  }
+
+  /** The derived task-level state, or `undefined` when nothing ever reported. */
+  private rollup(taskId: string): RollupCandidate | undefined {
+    return deriveTaskActivity(rollupCandidates(this.activity.get(taskId), this.tabActivity.get(taskId)))
+  }
+
+  /**
+   * Publish the DERIVED task-level state. Every writer calls this after
+   * touching the ledger — that is what makes an engine death, an observer
+   * correction and a lapse all move the task row without any of them owning
+   * a copy of it. An empty ledger publishes an explicit idle so subscribers
+   * clear the badge rather than keeping the last non-idle one.
+   */
+  private publishRollup(taskId: string): void {
+    const derived = this.rollup(taskId)
+    this.bus.publish("engine-state", this.payload(taskId, derived ?? { state: "idle", at: this.now() }))
+  }
+
+  /**
+   * Drop a closed tab's ledger entry. A tab that is GONE has no state to
+   * arbitrate: leaving it behind kept its last claim in the rollup (and in
+   * every late subscriber's replay) for the life of the daemon, so closing
+   * the running tab of a task left the task row spinning.
+   */
+  clearTab(taskId: string, tabId: string): void {
+    const tabs = this.tabActivity.get(taskId)
+    const entry = tabs?.get(tabId)
+    if (!tabs || !entry) return
+    if (entry.hook?.lapse) clearTimeout(entry.hook.lapse)
+    tabs.delete(tabId)
+    if (tabs.size === 0) this.tabActivity.delete(taskId)
+    const lineage = this.tabLineage.get(taskId)
+    lineage?.delete(tabId)
+    if (lineage?.size === 0) this.tabLineage.delete(taskId)
+    this.bus.publish("engine-state", { taskId, tabId, state: "idle", at: this.now() })
+    this.publishRollup(taskId)
+  }
+
+  /**
+   * Retire a claim the watchdog found silent: drop it from the ledger and
+   * republish the task rollup, so the lapse moves the task row like every
+   * other writer does.
+   */
+  private retireLapsed(target: LapseTarget): void {
     if (target.tabId) {
       const tabs = this.tabActivity.get(target.taskId)
       if (tabs) {
@@ -259,11 +272,12 @@ export class DaemonActivityRegistry {
       }
       this.bus.publish("engine-state", { taskId: target.taskId, tabId: target.tabId, state: "idle", at: this.now() })
     } else {
-      this.publishIdle(target.taskId)
+      this.activity.delete(target.taskId)
     }
+    this.publishRollup(target.taskId)
   }
 
-  /** Read the hook entry that a lapse watchdog polices at a given scope. */
+  /** Read the hook entry the watchdog polices at a given scope. */
   private lapseEntry(target: LapseTarget): LapseEntry | undefined {
     if (target.tabId) {
       return this.tabActivity.get(target.taskId)?.get(target.tabId)?.hook
@@ -291,6 +305,9 @@ export class DaemonActivityRegistry {
     claim: "working" | "rest",
     opts: { vendor?: string; correctHookRunningAfterMs?: number } = {},
   ): ObserveTabOutcome {
+    // A PTY session outliving its task's deletion must not re-create a ledger
+    // entry for a task nothing can navigate to.
+    if (!this.taskExists(taskId)) return "noop"
     const tabs = this.tabActivity.get(taskId) ?? new Map<string, TabEntry>()
     const entry = tabs.get(tabId)
     const prev = entry?.effective
@@ -329,8 +346,8 @@ export class DaemonActivityRegistry {
     tabs.set(tabId, { ...(hook ? { hook } : {}), observed, effective })
     this.tabActivity.set(taskId, tabs)
     this.bus.publish("engine-state", this.payload(taskId, effective, tabId))
+    this.publishRollup(taskId)
 
-    if (effective.source === "observed" && effective.state === "idle") this.clearHookRollup(taskId, entry?.hook)
     if (effective.source === "hook") return "noop" // the observation lost arbitration
     if (effective.state === "running") return "observed-running"
     return prev?.source === "hook" ? "corrected-hook-running" : "observed-idle"
@@ -386,15 +403,8 @@ export class DaemonActivityRegistry {
     if (!effective) return
     tabs.set(tabId, { hook, ...(prev?.observed ? { observed: prev.observed } : {}), effective })
     this.tabActivity.set(taskId, tabs)
-    this.clearHookRollup(taskId, prev?.hook)
     this.bus.publish("engine-state", this.payload(taskId, effective, tabId))
-  }
-
-  private clearHookRollup(taskId: string, hook: TabHookEntry | undefined): void {
-    const current = this.activity.get(taskId)
-    if (current?.state === "running" && hook && current.sourceHook === hook) {
-      this.publishIdle(taskId)
-    }
+    this.publishRollup(taskId)
   }
 
   clearTask(taskId: string): void {
@@ -405,6 +415,7 @@ export class DaemonActivityRegistry {
     // subscriber drops its tab-level candidates too.
     const tabs = this.tabActivity.get(taskId)
     this.tabActivity.delete(taskId)
+    this.tabLineage.delete(taskId)
     if (tabs) {
       for (const [tabId, tabEntry] of tabs) {
         if (tabEntry.hook?.lapse) clearTimeout(tabEntry.hook.lapse)
@@ -413,20 +424,21 @@ export class DaemonActivityRegistry {
     }
     // Publish an explicit idle so every subscriber clears this task's badge.
     // The bus only caches one last value per channel, so this also prevents a
-    // stale per-task replay if the id is quickly recreated.
-    if (gone) this.bus.publish("engine-state", { taskId, state: "idle", at: this.now() })
+    // stale per-task replay if the id is quickly recreated. Gated on EITHER
+    // level having held something — most tasks only ever ledger per-tab.
+    if (gone || tabs) this.bus.publish("engine-state", { taskId, state: "idle", at: this.now() })
   }
 
-  snapshotByTask(): Record<string, EngineStatePayload> {
-    const out: Record<string, EngineStatePayload> = {}
-    for (const [taskId, entry] of this.activity) out[taskId] = this.payload(taskId, entry)
-    return out
+  /** Every task with a ledger entry at either level. */
+  private taskIds(): Set<string> {
+    return new Set([...this.activity.keys(), ...this.tabActivity.keys()])
   }
 
   currentNonIdle(): EngineStatePayload[] {
     const out: EngineStatePayload[] = []
-    for (const [taskId, entry] of this.activity) {
-      if (entry.state !== "idle") out.push(this.payload(taskId, entry))
+    for (const taskId of this.taskIds()) {
+      const derived = this.rollup(taskId)
+      if (derived && derived.state !== "idle") out.push(this.payload(taskId, derived))
     }
     // Tab entries ride the same replay so a late subscriber rebuilds its
     // per-tab map too. Hook-driven entries are only stored non-idle; the
@@ -444,7 +456,12 @@ export class DaemonActivityRegistry {
    * the wire payload.
    */
   debugSnapshot(): ActivityDebugSnapshot {
-    return buildActivityDebugSnapshot(this.activity, this.tabActivity)
+    const derived = new Map<string, RollupCandidate>()
+    for (const taskId of this.taskIds()) {
+      const entry = this.rollup(taskId)
+      if (entry) derived.set(taskId, entry)
+    }
+    return buildActivityDebugSnapshot(derived, this.tabActivity)
   }
 
   close(): void {
@@ -458,14 +475,7 @@ export class DaemonActivityRegistry {
     }
     this.activity.clear()
     this.tabActivity.clear()
-  }
-
-  private publishIdle(taskId: string): void {
-    const previous = this.activity.get(taskId)
-    if (previous?.lapse) clearTimeout(previous.lapse)
-    const entry: ActivityEntry = { state: "idle", at: this.now() }
-    this.activity.set(taskId, entry)
-    this.bus.publish("engine-state", this.payload(taskId, entry))
+    this.tabLineage.clear()
   }
 
   private payload(taskId: string, entry: PayloadSource, tabId?: string): EngineStatePayload {

--- a/packages/kobe-daemon/src/daemon/activity-rollup.ts
+++ b/packages/kobe-daemon/src/daemon/activity-rollup.ts
@@ -1,0 +1,96 @@
+/**
+ * Task-level activity rollup — DERIVED from the per-tab ledger, never stored.
+ *
+ * The registry used to keep a second, hand-maintained copy of the task state
+ * next to the per-tab records, updated last-event-wins across every tab. That
+ * shape cannot be right for a multi-tab task: tab A's `turn-start` and tab B's
+ * `turn-complete` are both true at once, and whichever landed last decided
+ * what the sidebar showed. It also had to be un-set by hand from three other
+ * places (engine death, an observer idle correction, the lapse watchdog),
+ * each with its own "was this MY entry?" ownership test — so a tab that died
+ * or went quiet without being the last writer left the task pinned `running`
+ * with no live tab under it.
+ *
+ * So: no second copy. One function folds the tab entries (plus the task's
+ * tab-less hook entry — an engine the user started in a shell kobe did not
+ * spawn reports with no `KOBE_TAB_ID`) into the state the task row shows.
+ *
+ * The order is by URGENCY, not recency:
+ *   - any candidate `running` ⇒ running (newest such `at`). Work in ANY tab
+ *     is work in the task; a completion elsewhere must not dim it.
+ *   - else the newest STICKY state (`turn_complete` / `permission_needed` /
+ *     `error` / `rate_limited` / `dead`) — the states that mean "a human
+ *     should look", which must survive a quiet sibling tab.
+ *   - else idle (or `undefined` when no source has ever reported: unknown).
+ *
+ * Pure: no timers, no bus, no I/O — the registry owns those.
+ */
+
+import type { EffectiveActivity } from "./activity-arbitrate.ts"
+import { type EngineSessionInfo, STICKY_STATES } from "./activity-reduce.ts"
+import type { EngineActivityDetail, TaskActivityState } from "./contracts.ts"
+
+/** One source's current claim about a task. Tab entries contribute their
+ *  arbitrated `effective`; a tab-less hook entry contributes itself. */
+export interface RollupCandidate {
+  readonly state: TaskActivityState
+  readonly at: number
+  readonly detail?: EngineActivityDetail
+  readonly vendor?: string
+  readonly session?: EngineSessionInfo
+  /** The winner's lapse watchdog, when it has one — carried so `kobe api
+   *  inspect` can still report `lapseArmed` for the derived rollup. */
+  readonly lapse?: unknown
+}
+
+/** Urgency tiers: running outranks every attention state, which outrank idle. */
+function urgency(state: TaskActivityState): number {
+  if (state === "running") return 2
+  return STICKY_STATES.has(state) ? 1 : 0
+}
+
+/**
+ * Fold every source's claim into the one the task row shows, or `undefined`
+ * when there is nothing to show. Highest urgency wins; newest `at` breaks a
+ * tie within a tier.
+ */
+export function deriveTaskActivity(candidates: Iterable<RollupCandidate>): RollupCandidate | undefined {
+  let best: RollupCandidate | undefined
+  let bestRank = -1
+  for (const candidate of candidates) {
+    const rank = urgency(candidate.state)
+    if (rank > bestRank || (rank === bestRank && best !== undefined && candidate.at > best.at)) {
+      best = candidate
+      bestRank = rank
+    }
+  }
+  return best
+}
+
+/** What {@link rollupCandidates} reads out of the per-tab ledger. */
+export interface RollupTabEntry {
+  readonly effective: EffectiveActivity
+  readonly hook?: { readonly lapse?: unknown }
+}
+
+/**
+ * Every candidate for one task: its tab-less hook entry plus each tab's
+ * arbitrated state. A hook-sourced tab carries its lapse handle along so
+ * `kobe api inspect` can still say whether the WINNING claim is policed.
+ */
+export function rollupCandidates(
+  tabless: RollupCandidate | undefined,
+  tabs: ReadonlyMap<string, RollupTabEntry> | undefined,
+): RollupCandidate[] {
+  const out: RollupCandidate[] = []
+  if (tabless) out.push(tabless)
+  if (tabs) {
+    for (const entry of tabs.values()) {
+      out.push({
+        ...entry.effective,
+        ...(entry.effective.source === "hook" && entry.hook?.lapse ? { lapse: entry.hook.lapse } : {}),
+      })
+    }
+  }
+  return out
+}

--- a/packages/kobe-daemon/src/daemon/handlers-ui.ts
+++ b/packages/kobe-daemon/src/daemon/handlers-ui.ts
@@ -127,6 +127,14 @@ export const UI_HANDLERS: readonly DaemonRequestHandler[] = [
       const detail = payload.detail
       const eventDetail =
         detail && typeof detail === "object" && !Array.isArray(detail) ? (detail as Record<string, unknown>) : undefined
+      // A closed tab has no activity to arbitrate. This is the ONE place every
+      // close funnels through — the TUI's own close path and the daemon's
+      // `terminalTab.close` (which drives that same path) both land here — so
+      // the ledger is swept without a second hook on the close broker.
+      if (kind === "tab.closed" && taskId) {
+        const closedTabId = eventDetail?.tabId
+        if (typeof closedTabId === "string" && closedTabId) ctx.activity.clearTab(taskId, closedTabId)
+      }
       ctx.plugins?.handleUiReport({
         kind: kind as import("../plugins/manifest.ts").PluginEventName,
         ...(taskId ? { taskId } : {}),

--- a/packages/kobe-daemon/src/daemon/stores.ts
+++ b/packages/kobe-daemon/src/daemon/stores.ts
@@ -53,7 +53,13 @@ export async function initDaemonStores(
   // for why it reads a completion marker and not just the transcript mtime.
   const livenessAt: ActivityLivenessProbe = (taskId, vendor, transcriptPath) =>
     readActivityLiveness(orch, runtime, taskId, vendor, transcriptPath)
-  const activity = new DaemonActivityRegistry(bus, undefined, undefined, livenessAt)
+  const activity = new DaemonActivityRegistry(
+    bus,
+    undefined,
+    undefined,
+    livenessAt,
+    (taskId) => orch.getTask(taskId) !== undefined,
+  )
   const inbox = new AttentionInboxStore(defaultAttentionInboxPath(homeDir), bus)
   await inbox.init().catch((err) => logDaemonError("attention-inbox-init", err))
   // Durable per-turn telemetry — written by the `turn-complete`

--- a/packages/kobe/src/client/remote-orchestrator-events.ts
+++ b/packages/kobe/src/client/remote-orchestrator-events.ts
@@ -177,20 +177,19 @@ export function handleOrchestratorEvent(name: string, payload: unknown, signals:
       ...(tabId ? { tabId } : {}),
       at: typeof p.at === "number" ? p.at : 0,
     }
-    // Accumulate per-task into a fresh Map (new ref → re-render). A tabId-
-    // carrying event updates BOTH levels: the daemon publishes one event per
-    // report, and the task entry is its last-event-wins rollup — EXCEPT that
-    // a tab-scoped idle only clears a rollup the SAME tab wrote: the activity
-    // observer publishes per-tab idles for quiet sessions, and letting any
-    // tab's idle delete the rollup blanks a task whose live work — another
-    // tab, or an untagged external session — is still going.
-    const prevTask = signals.engineStateAcc().get(p.taskId)
-    const prevTaskState = prevTask?.state
-    const next = new Map(signals.engineStateAcc())
-    if (p.state === "idle") {
-      if (!tabId || prevTask?.tabId === tabId) next.delete(p.taskId)
-    } else next.set(p.taskId, entry)
-    signals.setEngineStateSig(next)
+    // The task rollup comes from the daemon's TASK-level events only (no
+    // `tabId`). It used to be re-derived here from tab events too — a second
+    // copy of a rule the daemon already owns, and the two disagreed the moment
+    // a task had more than one tab. The daemon now publishes its derived
+    // rollup alongside every tab event (activity-rollup.ts), so this just
+    // records what it says.
+    const prevTaskState = signals.engineStateAcc().get(p.taskId)?.state
+    if (!tabId) {
+      const next = new Map(signals.engineStateAcc())
+      if (p.state === "idle") next.delete(p.taskId)
+      else next.set(p.taskId, entry)
+      signals.setEngineStateSig(next)
+    }
     // Transient lifecycle marks (subagent counts) must never outlive
     // the evidence: a turn ending clears them, and so does a FRESH running
     // edge — a cancelled compaction never sends post-compact, and an

--- a/packages/kobe/test/client/remote-orchestrator.test.ts
+++ b/packages/kobe/test/client/remote-orchestrator.test.ts
@@ -150,19 +150,16 @@ describe("RemoteOrchestrator channel handling", () => {
   // sessionId/transcriptPath ride the engine-state payload (additive
   // optional fields — an old daemon simply omits them). They land on both
   // the task-level entry and the per-tab map so "which engine session is
-  // live here" resolves at either granularity.
+  // live here" resolves at either granularity. The daemon publishes the pair
+  // — tab event, then the rollup it derives — and the client no longer
+  // re-derives the task level from the tab event (activity-rollup.ts).
   it("accumulates sessionId/transcriptPath from engine-state into both levels", () => {
     const { client, emit } = fakeClient()
     const orch = new RemoteOrchestrator(client)
 
-    emit("engine-state", {
-      taskId: "t1",
-      tabId: "tab-1",
-      state: "running",
-      sessionId: "sess-1",
-      transcriptPath: "/tmp/sess-1.jsonl",
-      at: 10,
-    })
+    const session = { sessionId: "sess-1", transcriptPath: "/tmp/sess-1.jsonl" }
+    emit("engine-state", { taskId: "t1", tabId: "tab-1", state: "running", ...session, at: 10 })
+    emit("engine-state", { taskId: "t1", state: "running", ...session, at: 10 })
     const taskEntry = orch.engineStateSignal()().get("t1")
     expect(taskEntry?.sessionId).toBe("sess-1")
     expect(taskEntry?.transcriptPath).toBe("/tmp/sess-1.jsonl")

--- a/packages/kobe/test/daemon/activity-liveness.test.ts
+++ b/packages/kobe/test/daemon/activity-liveness.test.ts
@@ -177,8 +177,9 @@ describe("activity registry liveness watchdog", () => {
     await vi.advanceTimersByTimeAsync(TTL)
 
     expect(probe).toHaveBeenCalledWith("t", "claude", undefined)
-    // Carried forward: a later event without the tag keeps the known vendor.
-    registry.report("t", "turn-start")
+    // Carried forward WITHIN the reporting source: a later event on the same
+    // tab without the tag keeps that tab's known vendor.
+    registry.report("t", "turn-start", undefined, "tab-1")
     await vi.advanceTimersByTimeAsync(TTL)
     expect(probe).toHaveBeenLastCalledWith("t", "claude", undefined)
   })
@@ -327,7 +328,7 @@ describe("activity registry liveness watchdog", () => {
     registry.report("t", "turn-start", undefined, "tab-2", { id: "two", transcriptPath: "/two" })
     registry.recordEngineDeath("t", "tab-1", { code: 1 }, Date.now())
     await vi.advanceTimersByTimeAsync(TTL)
-    expect(registry.snapshotByTask().t).toMatchObject({ state: "running", transcriptPath: "/two" })
+    expect(registry.currentNonIdle().find((p) => !p.tabId)).toMatchObject({ state: "running", transcriptPath: "/two" })
   })
 
   it("never idles after the entry was cleared during the probe await", async () => {

--- a/packages/kobe/test/daemon/activity-rollup-ownership.test.ts
+++ b/packages/kobe/test/daemon/activity-rollup-ownership.test.ts
@@ -2,7 +2,12 @@ import { DaemonActivityRegistry } from "@sma1lboy/kobe-daemon/daemon/activity-re
 import { DaemonEventBus } from "@sma1lboy/kobe-daemon/daemon/event-bus"
 import { describe, expect, it } from "vitest"
 
-describe("task rollup ownership", () => {
+/** The derived task-level rollup, as every production consumer reads it. */
+function rollup(registry: DaemonActivityRegistry) {
+  return registry.currentNonIdle().find((payload) => !payload.tabId)
+}
+
+describe("derived task rollup", () => {
   it.each([undefined, { id: "b", transcriptPath: "/a" }])("does not clear a sibling whose session is %j", (sibling) => {
     let now = 1
     const registry = new DaemonActivityRegistry(new DaemonEventBus(), 1000, () => now)
@@ -12,11 +17,13 @@ describe("task rollup ownership", () => {
       registry.report("t", "turn-start", undefined, "tab-2", sibling, "codex")
       now = 3
       registry.recordEngineDeath("t", "tab-1", { code: 1 }, now)
-      expect(registry.snapshotByTask().t).toMatchObject({ state: "running", at: 2 })
+      expect(rollup(registry)).toMatchObject({ state: "running", at: 2 })
       registry.observeTab("t", "tab-1", "rest", { correctHookRunningAfterMs: 0 })
-      expect(registry.snapshotByTask().t).toMatchObject({ state: "running", at: 2 })
+      expect(rollup(registry)).toMatchObject({ state: "running", at: 2 })
       registry.recordEngineDeath("t", "tab-2", { code: 1 }, now)
-      expect(registry.snapshotByTask().t.state).toBe("idle")
+      // Both engines are gone — the task reports the DEATH, not idle. A dead
+      // engine and a task nobody ever ran are different things to look at.
+      expect(rollup(registry)).toMatchObject({ state: "dead" })
     } finally {
       registry.close()
     }
@@ -30,7 +37,58 @@ describe("task rollup ownership", () => {
       now = 3
       registry.report("t", "turn-start", undefined, "tab-1", { id: "new", transcriptPath: "/same" })
       registry.recordEngineDeath("t", "tab-1", { code: 1 }, 2)
-      expect(registry.snapshotByTask().t).toMatchObject({ state: "running", sessionId: "new" })
+      expect(rollup(registry)).toMatchObject({ state: "running", sessionId: "new" })
+    } finally {
+      registry.close()
+    }
+  })
+
+  it("prefers a running tab over a completed one, whichever reported last", () => {
+    let now = 1
+    const registry = new DaemonActivityRegistry(new DaemonEventBus(), 1000, () => now)
+    try {
+      registry.report("t", "turn-start", undefined, "tab-1")
+      now = 2
+      registry.report("t", "turn-start", undefined, "tab-2")
+      now = 3
+      registry.report("t", "turn-complete", undefined, "tab-1")
+      // tab-1 finished LAST; tab-2 is still working, so the task is working.
+      expect(rollup(registry)).toMatchObject({ state: "running", at: 2 })
+      now = 4
+      registry.report("t", "turn-complete", undefined, "tab-2")
+      expect(rollup(registry)).toMatchObject({ state: "turn_complete", at: 4 })
+    } finally {
+      registry.close()
+    }
+  })
+
+  it("drops a closed tab's claim from the rollup", () => {
+    let now = 1
+    const registry = new DaemonActivityRegistry(new DaemonEventBus(), 1000, () => now)
+    try {
+      registry.report("t", "turn-start", undefined, "tab-1")
+      expect(rollup(registry)).toMatchObject({ state: "running" })
+      now = 2
+      registry.clearTab("t", "tab-1")
+      expect(rollup(registry)).toBeUndefined()
+      expect(registry.currentNonIdle()).toEqual([])
+    } finally {
+      registry.close()
+    }
+  })
+
+  it("ignores an observation for a task that no longer exists", () => {
+    const registry = new DaemonActivityRegistry(
+      new DaemonEventBus(),
+      1000,
+      () => 1,
+      () => Promise.resolve(undefined),
+      (taskId) => taskId === "alive",
+    )
+    try {
+      expect(registry.observeTab("gone", "tab-1", "working")).toBe("noop")
+      expect(registry.currentNonIdle()).toEqual([])
+      expect(registry.observeTab("alive", "tab-1", "working")).toBe("observed-running")
     } finally {
       registry.close()
     }

--- a/packages/kobe/test/daemon/activity-state.test.ts
+++ b/packages/kobe/test/daemon/activity-state.test.ts
@@ -164,7 +164,12 @@ describe("daemon activity state", () => {
     })
 
     registry.report("task-1", "awaiting-input", { waiting: "input" }, "tab-2")
-    expect(published).toEqual([{ taskId: "task-1", tabId: "tab-2", state: "permission_needed" }])
+    // Two publishes per tab report: the tab entry, then the DERIVED task
+    // rollup that follows from it (activity-rollup.ts).
+    expect(published).toEqual([
+      { taskId: "task-1", tabId: "tab-2", state: "permission_needed" },
+      { taskId: "task-1", tabId: undefined, state: "permission_needed" },
+    ])
     // Replay carries the task rollup AND the tab entry.
     expect(registry.currentNonIdle().map((p) => [p.taskId, p.tabId, p.state])).toEqual([
       ["task-1", undefined, "permission_needed"],
@@ -210,9 +215,10 @@ describe("daemon activity state", () => {
     expect(published[0]).toEqual({ state: "running", sessionId: "sess-abc", transcriptPath: "/tmp/sess-abc.jsonl" })
 
     // An event WITHOUT session info keeps the latest-known id (carry-forward)
-    // on both the task rollup and the tab entry.
+    // on both the tab entry and the rollup derived from it. `published[2]` is
+    // the tab publish — index 1 is the task rollup that followed the first.
     registry.report("task-1", "turn-complete", undefined, "tab-1")
-    expect(published[1]).toEqual({
+    expect(published[2]).toEqual({
       state: "turn_complete",
       sessionId: "sess-abc",
       transcriptPath: "/tmp/sess-abc.jsonl",
@@ -247,7 +253,7 @@ describe("daemon activity state", () => {
     // A different engine boots in tab-b; its hooks pipe NO session id.
     registry.report("task-1", "session-start", undefined, "tab-b")
 
-    const last = published.at(-1)
+    const last = published.filter((p) => p.tabId).at(-1)
     expect(last?.tabId).toBe("tab-b")
     expect(last?.sessionId).toBeUndefined()
     registry.close()

--- a/packages/kobe/test/daemon/handlers.test.ts
+++ b/packages/kobe/test/daemon/handlers.test.ts
@@ -1,4 +1,6 @@
+import { DaemonActivityRegistry } from "@sma1lboy/kobe-daemon/daemon/activity-registry"
 import { EngineEventLog } from "@sma1lboy/kobe-daemon/daemon/engine-events-log"
+import { DaemonEventBus } from "@sma1lboy/kobe-daemon/daemon/event-bus"
 import { PromptBroker } from "@sma1lboy/kobe-daemon/daemon/prompt-broker"
 import type { DaemonRequestName } from "@sma1lboy/kobe-daemon/daemon/protocol"
 import { type DaemonHandlerContext, createDaemonHandlerRegistry } from "@sma1lboy/kobe-daemon/daemon/server"
@@ -112,6 +114,30 @@ describe("daemon handler registry", () => {
       await dispatch("ui.reportEvent", { kind: "file.opened", taskId: "t1", detail: { path: "/x.mp4" } }, ctx)
       expect(seen).toEqual([{ kind: "file.opened", taskId: "t1", detail: { path: "/x.mp4" } }])
       await expect(dispatch("ui.reportEvent", { kind: "task.created" }, ctx)).rejects.toThrow(/unknown ui event/)
+    })
+
+    // `tab.closed` is the ONE place every terminal-tab close funnels through
+    // (the TUI's own path, and the daemon's `terminalTab.close`, which drives
+    // it). A real registry, not a spy: the assertion is that the LEDGER is
+    // swept, so cutting either the wiring here or `clearTab` itself fails.
+    it("sweeps the closed tab's activity ledger entry", async () => {
+      const { ctx } = fakeCtx({ getTask: () => TASK })
+      const bus = new DaemonEventBus()
+      const activity = new DaemonActivityRegistry(bus, 60_000)
+      ;(ctx as { activity: DaemonActivityRegistry }).activity = activity
+      ;(ctx as { plugins?: unknown }).plugins = { handleEngineReport: () => {}, handleUiReport: () => {} }
+      try {
+        activity.report("t1", "turn-start", undefined, "tab-1")
+        expect(activity.debugSnapshot().tabs.t1?.["tab-1"]?.state).toBe("running")
+
+        await dispatch("ui.reportEvent", { kind: "tab.closed", taskId: "t1", detail: { tabId: "tab-1" } }, ctx)
+
+        expect(activity.debugSnapshot().tabs.t1?.["tab-1"]).toBeUndefined()
+        // …and the task row follows: nothing is left to be running.
+        expect(activity.currentNonIdle()).toEqual([])
+      } finally {
+        activity.close()
+      }
     })
   })
 

--- a/packages/kobe/test/daemon/pty-exit-watch.test.ts
+++ b/packages/kobe/test/daemon/pty-exit-watch.test.ts
@@ -171,9 +171,12 @@ describe("startPtyExitWatch → activity registry", () => {
         path,
       )
       await waitFor(() => published.length > 0)
-      const payload = published.at(-1)
+      const payload = published.filter((p) => p.tabId).at(-1)
       expect(payload?.state).toBe("dead")
       expect(payload?.tabId).toBe("tab-1")
+      // The derived task rollup follows the death rather than being cleared
+      // to idle: the sidebar row shows the dead engine, not "nothing here".
+      expect(published.at(-1)).toMatchObject({ taskId: "task-1", state: "dead" })
       expect(payload?.detail?.exit?.code).toBe(143)
       // The error text was always on disk; this is the assertion that it now
       // travels with the state instead of dying in the file.

--- a/packages/kobe/test/engine/activity-pipeline.test.ts
+++ b/packages/kobe/test/engine/activity-pipeline.test.ts
@@ -67,12 +67,13 @@ function rowAfterClaudeHook(event: string, payload: Record<string, unknown>) {
     // wake (monitor stream ending), not a completion.
     if (verb !== "turn-start" && verb !== "session-start") registry.report("task-1", "turn-start")
     registry.report("task-1", verb, detail)
-    const published = registry.snapshotByTask()["task-1"]
-    expect(published).toBeDefined()
     // 5. Client side: RemoteOrchestrator accumulates non-idle states into
-    //    TaskEngineState (an `idle` publish deletes the entry → undefined).
-    const activity: TaskEngineState | undefined =
-      published.state === "idle" ? undefined : { state: published.state, detail: published.detail, at: published.at }
+    //    TaskEngineState — which is exactly what the registry's derived
+    //    rollup replays, so an idle task is simply absent here.
+    const published = registry.currentNonIdle().find((p) => p.taskId === "task-1" && !p.tabId)
+    const activity: TaskEngineState | undefined = published
+      ? { state: published.state, detail: published.detail, at: published.at }
+      : undefined
     // 6. Render: the sidebar badge.
     return buildSidebarRowView({
       task: task(),

--- a/packages/kobe/test/golden/running-status.test.ts
+++ b/packages/kobe/test/golden/running-status.test.ts
@@ -120,8 +120,10 @@ describe("golden: session events → sidebar running state", () => {
     const row = h.row("tab-1")
     expect(row.loading).toBe(true)
     expect(row.tone).toBe("primary")
-    const last = h.published.at(-1)
+    const last = h.published.filter((p) => p.tabId).at(-1)
     expect(last).toMatchObject({ taskId: TASK_ID, tabId: "tab-1", state: "running", sessionId: "s1" })
+    // …and the derived task rollup follows it, so the task row spins too.
+    expect(h.published.at(-1)).toMatchObject({ taskId: TASK_ID, state: "running", sessionId: "s1" })
   })
 
   it("a Stop after running lands the unseen ●, which digests once seen", () => {


### PR DESCRIPTION
## What

The task-level activity state was a second, hand-maintained copy of what the
per-tab ledger already knew — updated last-event-wins across every tab, and
un-set by hand from three other places (engine death, an observer idle
correction, the lapse watchdog), each with its own "was this MY entry?"
ownership test.

That shape cannot be correct for a multi-tab task. Tab A's `turn-start` and tab
B's `turn-complete` are both true at once, and whichever landed last decided
what the sidebar and the kanban card showed. A tab that died or went quiet
without being the last writer left the task pinned `running` with no live tab
under it. The client had a **third** copy of the same rule, folding tab events
into its own task rollup.

Now one pure function (`activity-rollup.ts`) folds the tab entries plus the
task's tab-less hook entry into the state consumers read. The order is by
urgency, not recency: any `running` wins, else the newest sticky attention
state, else idle. Every writer republishes the derived value, so an engine
death, an observer correction and a lapse all move the task row without any of
them owning a copy of it.

Also here:

- **A closed tab is swept from the ledger** (`clearTab`, hung on `tab.closed` —
  the one path every close funnels through). Its last claim used to stay in the
  rollup, and in every late subscriber's replay, for the life of the daemon.
- **An observation for a deleted task is ignored** (`taskExists` predicate). The
  observer walks PTY sessions that can outlive a task's removal from the index.
- **The reducer's `previous` is now per source.** Reading the task rollup there
  was the same conflation: tab B's Stop reduced against tab A's turn-start.
- `snapshotByTask()` is deleted (zero production callers); the lapse watchdog
  moves to `activity-lapse.ts` on the timer/probe seam, which is what keeps
  `activity-registry.ts` under the size cap (492 lines).

Verified on an isolated daemon + isolated pty paths throughout
(`KOBE_HOME_DIR=/tmp/mammoth-rollup-home`, socket/pid inlined per command); the
real `~/.rove` was never touched.

---

## A — a multi-tab completion no longer stalls the task

`tab-1 turn-start`, `tab-2 turn-start`, `tab-1 turn-complete`.

**BEFORE** — the task says `turn_complete` while tab-2 is still `running`. This
is the reported symptom:

```json
"task": { "state": "turn_complete", "at": 1788940047864, "vendor": "claude", "lapseArmed": false }
"tabs": {
  "tab-1": { "state": "turn_complete", "at": 1788940047864, "lapseArmed": false },
  "tab-2": { "state": "running",       "at": 1788940047633, "lapseArmed": true  }
}
```

**AFTER** — `running`, carrying tab-2's `at`:

```json
"task": { "state": "running", "at": 1788939814314, "vendor": "claude", "lapseArmed": true }
"tabs": {
  "tab-1": { "state": "turn_complete", "at": 1788939814451, "lapseArmed": false },
  "tab-2": { "state": "running",       "at": 1788939814314, "lapseArmed": true  }
}
```

Then `tab-2 turn-complete` — AFTER settles to `turn_complete` at **tab-2's**
timestamp (`1788939814727`, the tab-2 entry), not tab-1's:

```json
"task": { "state": "turn_complete", "at": 1788939814727, "lapseArmed": false }
"tabs": { "tab-1": { "at": 1788939814451 }, "tab-2": { "at": 1788939814727 } }
```

## B — a dead engine no longer leaves the task asking for a human

`awaiting-input` on tab-1, then a non-zero exit record for `T::tab-1` appended
to `pty-exits.json` and picked up by `pty-exit-watch`.

**BEFORE** — the tab is `dead`, the task still says `permission_needed`. The
engine died on the permission prompt and the task row asks for a human forever:

```json
"task": { "state": "permission_needed", "at": 1788940056185, "lapseArmed": false }
"tabs": { "tab-1": { "state": "dead", "at": 1788940200000,
                     "exit": { "code": 143, "signal": null, "lastLine": "zsh: terminated claude" } } }
```

**AFTER** — both `dead`:

```json
"task": { "state": "dead", "at": 1788940200000, "vendor": "claude", "lapseArmed": false }
"tabs": { "tab-1": { "state": "dead", "at": 1788940200000,
                     "exit": { "code": 143, "signal": null, "lastLine": "zsh: terminated claude" } } }
```

(Note this lands on `dead` rather than idle — a dead engine and a task nobody
ever ran are different things to look at.)

## D — closing a tab clears its claim

`tab-1 turn-start`, `tab-2 turn-complete`, then `ui.reportEvent
{kind:"tab.closed", detail:{tabId:"tab-2"…}}` over `KobeDaemonClient`.

**BEFORE** — the closed tab is still in the ledger, still `running`, still with
its lapse watchdog armed, and still replayed to every new subscriber:

```json
"tabs": {
  "tab-1": { "state": "running",       "at": 1788940059478, "lapseArmed": true  },
  "tab-2": { "state": "turn_complete", "at": 1788940059612, "lapseArmed": false }
}
```

**AFTER** — gone, and the rollup follows the surviving tab:

```json
"task": { "state": "turn_complete", "at": 1788939911294, "lapseArmed": false }
"tabs": { "tab-2": { "state": "turn_complete", "at": 1788939911294, "lapseArmed": false } }
```

## E — screenshots

Captured through the ground-truth path (fixed-viewport Chromium → `/harness` →
xterm.js → PTY sidecar → real OpenTUI), FRESH fixture for each side, reports
driven inside the shot's window because the fixture daemon is refcounted on the
attached GUI.

**Correction to the brief's expected surface.** The sidebar worktree row
deliberately carries no engine glyph — `WorktreeTreeRow`'s own doc says the
session state belongs to the tab row below it — and the fixture task has no tab
rows. I verified that first (a tab-less `running` renders no glyph there either,
on both sides), so the sidebar was never going to show this. The task rollup's
visible surface is the **kanban card badge**, which is also what the report
named. That is what these capture.

| beat | BEFORE | AFTER |
| --- | --- | --- |
| tab-1 done, tab-2 running | `turn done` ❌ | `working` ✅ |
| both done | `turn done` | `turn done` |

Daemon state at each capture:

```
BEFORE mixed  rollup: turn_complete   tabs: {tab-1: turn_complete, tab-2: running}
AFTER  mixed  rollup: running         tabs: {tab-1: turn_complete, tab-2: running}
BEFORE done   rollup: turn_complete   tabs: {tab-1: turn_complete, tab-2: turn_complete}
AFTER  done   rollup: turn_complete   tabs: {tab-1: turn_complete, tab-2: turn_complete}
```

Shots are in the worktree's `.scratch/rollup-shots/` (`E-before-1-mixed.png`,
`E-after-1-mixed.png`, `E-before-2-done.png`, `E-after-2-done.png`, plus `-zoom`
crops of the card).

## F — mutation

**1. Drop the "any running wins" tier** from `urgency()` so recency alone
decides:

```
× derived task rollup > does not clear a sibling whose session is undefined
× derived task rollup > does not clear a sibling whose session is {"id":"b",…}
× derived task rollup > prefers a running tab over a completed one, whichever reported last
AssertionError: expected { taskId: 't', state: 'dead', … } to match object { state: 'running', at: 2 }
AssertionError: expected { taskId: 't', … }              to match object { state: 'running', at: 2 }
  Tests  3 failed | 3 passed (6)
```

**2. Remove the `clearTab` call** from the `tab.closed` handler. First run this
mutation **survived** — every suite stayed green (916 passed), because the unit
test called `clearTab` directly and nothing covered the wiring. That is a real
gap, so I added a test that drives a real registry through `ui.reportEvent`
dispatch. Re-run:

```
× daemon handler registry > ui.reportEvent > sweeps the closed tab's activity ledger entry
  → expected { state: 'running', …(3) } to be undefined
  Tests  1 failed | 28 passed (29)
```

## C — not covered, and why

The hook-less-engine case needs a live PTY session whose foreground walk
resolves to a contrib vendor: a real pty host, an attached TUI, and a
plugin-contributed engine in the isolated home. `api pane-open` only broadcasts
to attached TUIs, so with none attached nothing spawns, and the visual fixture's
task deliberately has no chat tab (CI has no engine binary). I did not build
that stack.

What is covered of the same mechanism: the derivation reads each tab's
arbitrated `effective` regardless of which slot won, so an observed-only tab
contributes exactly like a hook one — and criterion B exercises a non-hook
writer (`recordEngineDeath`) moving the rollup end to end on a live daemon. The
`taskExists` predicate has a unit test. If you want C proven for real, it is its
own fixture task.

## Gates

`bun run test:fast` 5023 passed · `KOBE_INCLUDE_SOCKET=1 bun run test:socket`
917 passed · `bun test test/render` 523 passed · typecheck · build · root
`bun run lint` clean.

Note: `packages/kobe`'s own `bun run lint` is red on
`test/daemon/worktree-probe.test.ts` and `test/engine/ps-probe-deadline.test.ts`
— both pre-existing from #939, neither in this diff. The repo-root lint that CI
runs is clean.
