### PR TITLE
fix: a PR check we cannot read no longer reads as passing

### DIFF
--- a/.changeset/pr-check-rollup-unknown-not-passing.md
+++ b/.changeset/pr-check-rollup-unknown-not-passing.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+The per-task PR badge no longer reports a branch's checks as passing when one of them is unreadable. The status rollup that condenses a PR's check runs into a single headline treated any entry it could not classify as if it were absent, so a mix of one green check and one unreadable entry surfaced as a clean "passing" — telling you CI was clear when a check's state was actually unknown. It now reports "passing" only when every check that is not failing or pending is genuinely green, and pulls the headline to "unknown" otherwise; a failing check still wins, a pending one still beats an unknown sibling, and a well-formed all-green PR is unaffected.

--- a/packages/kobe/src/monitor/pr-status.ts
+++ b/packages/kobe/src/monitor/pr-status.ts
@@ -84,22 +84,31 @@ function entryCheckState(entry: GhCheckEntry): PRCheckState {
 /**
  * Roll the per-check states up to the PR headline. Precedence is the same
  * mental model GitHub's own badge uses: **any** failing → failing; else any
- * pending → pending; else all-passing → passing; an empty rollup is `none`
- * (no checks configured); anything we can't read is `unknown`.
+ * pending → pending; else `passing` ONLY when every remaining entry passed;
+ * an empty rollup is `none` (no checks configured); an unreadable entry
+ * mixed in (`unknown`) pulls the headline to `unknown`.
+ *
+ * `passing` reports "all checks are green", so a single entry we could not
+ * classify must not be swept under a green headline — that would tell the
+ * user CI is clear when one check's state is actually unknown. Real
+ * `gh pr view` output never produces an `unknown` entry ({@link
+ * entryCheckState} covers every CheckRun status/conclusion and StatusContext
+ * state), so this only hardens the malformed / partial-payload case; a
+ * well-formed all-green rollup still reports `passing`.
  */
 export function checkStateFromRollup(rollup: readonly GhCheckEntry[] | undefined): PRCheckState {
   if (!rollup || rollup.length === 0) return "none"
   let sawPending = false
-  let sawPassing = false
+  let sawUnknown = false
   for (const entry of rollup) {
     const s = entryCheckState(entry)
     if (s === "failing") return "failing"
     if (s === "pending") sawPending = true
-    else if (s === "passing") sawPassing = true
+    else if (s === "unknown") sawUnknown = true
   }
   if (sawPending) return "pending"
-  if (sawPassing) return "passing"
-  return "unknown"
+  if (sawUnknown) return "unknown"
+  return "passing"
 }
 
 /**

--- a/packages/kobe/test/monitor/pr-status.test.ts
+++ b/packages/kobe/test/monitor/pr-status.test.ts
@@ -64,6 +64,17 @@ describe("checkStateFromRollup", () => {
       "failing",
     )
   })
+  test("a passing check mixed with an unreadable entry is unknown, not a false green", () => {
+    // A single entry we cannot classify must not be swept under a "passing"
+    // headline — that would tell the user CI is clear when one check's state
+    // is actually unknown. `passing` requires every remaining entry to pass.
+    expect(checkStateFromRollup([{ __typename: "CheckRun", status: "COMPLETED", conclusion: "SUCCESS" }, {}])).toBe(
+      "unknown",
+    )
+  })
+  test("pending precedence beats an unreadable sibling", () => {
+    expect(checkStateFromRollup([{ __typename: "CheckRun", status: "IN_PROGRESS" }, {}])).toBe("pending")
+  })
 })
 
 describe("mapGhPrView", () => {


### PR DESCRIPTION
## Direction

Bugs / correctness — surfaced by a code-health review of the PR-status poller (`src/monitor/pr-status.ts`), the pure mapping that turns `gh pr view --json statusCheckRollup` into the per-task PR badge the sidebar renders.

## Problem

`checkStateFromRollup` reduces a PR's individual check entries to one headline (`failing` / `pending` / `passing` / `unknown` / `none`). Its documented contract is: *"any failing → failing; else any pending → pending; else all-passing → passing; … anything we can't read is `unknown`."*

The implementation diverged from that: it tracked only `sawPassing`/`sawPending` and **silently ignored** any entry that classified as `unknown`. So a rollup mixing one green check with one entry it could not read returned `passing` — a false green that tells the user CI is clear when a check's state is actually unknown. `passing` is supposed to mean *every* check is green; an unreadable check must not be swept under it.

```ts
// before: [ {…SUCCESS}, {} ]  →  "passing"   (the {} entry is unknown, and dropped)
// after:  [ {…SUCCESS}, {} ]  →  "unknown"
```

## Fix

Track `sawUnknown` instead of `sawPassing`. After the failing/pending precedence checks, return `passing` only when nothing unreadable was seen, else `unknown`. Precedence is unchanged and still matches the doc: a failing check wins, a pending check beats an unknown sibling, and `passing` now requires every non-failing/non-pending entry to be genuinely green. The doc comment was tightened to state this explicitly.

**No behavior change for real `gh` output.** `entryCheckState` already classifies every real CheckRun `status`/`conclusion` and every StatusContext `state`, so an `unknown` entry only arises from a malformed / partial payload. A well-formed all-green rollup still reports `passing` — this strictly hardens the unreadable-entry case.

## Verification

- `bun x vitest run test/monitor/pr-status.test.ts` — 27 passed, including two new cases: a passing check mixed with an unreadable entry → `unknown`, and pending precedence beating an unreadable sibling.
- `bun run lint` — clean.
- `bun run typecheck` — clean across all workspaces.
- `bun run changeset:check` — passes (patch changeset added).

## Follow-ups / deliberately deferred

- `docs/CLI.md` / `docs/API.md` and the rest of the pure-logic layer were audited alongside this and found accurate/robust — nothing else to ship in this slice.
- Not changed: the daemon-side `pr-status-collector` that feeds this mapping (it only passes the parsed JSON through, so the fix takes effect there automatically).


---
_Generated by [Claude Code](https://claude.ai/code/session_01P6bHPfzQeAGrd4s8X3VMcG)_