### PR TITLE
fix: keep the New task dialog's fields and footer inside the modal

### DIFF
--- a/.changeset/clear-new-task-scroll-fold.md
+++ b/.changeset/clear-new-task-scroll-fold.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Give the New task form two more rows by tightening the space before Create. Keep the parent-directory well complete at 34–35 rows and restore the full compact form at 30 rows. Show how many rows remain above or below the form in its footer separator.

--- a/.changeset/tidy-new-task-layout.md
+++ b/.changeset/tidy-new-task-layout.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Keep the New task dialog's engine chips, field borders, and footer separated when the form is taller than the terminal. All three tabs now scroll their fields and picker rows into view while the header, errors, and Create action remain visible. Long engine labels stay within the dialog width.

--- a/packages/kobe/src/tui-react/component/new-task-dialog/dialog.tsx
+++ b/packages/kobe/src/tui-react/component/new-task-dialog/dialog.tsx
@@ -87,7 +87,7 @@ export function NewTaskDialogView(props: NewTaskDialogProps) {
       {/* Enter's caption follows the focused stop: it commits only on Create
           and walks the form at the other four, so a static "enter create" was
           wrong at every stop the dialog actually opens on. */}
-      <DialogFooter>
+      <DialogFooter paddingBottom={0}>
         {t("newTask.legend", {
           enter: t(vm.field === "confirm" ? "newTask.enterCreate" : "newTask.enterNext"),
         })}
@@ -95,6 +95,7 @@ export function NewTaskDialogView(props: NewTaskDialogProps) {
       {/* Create commits on click; also reachable by tabbing to the confirm
           field (Enter), or Enter on the last input of the active tab. */}
       <DialogActions
+        paddingTop={0}
         label={vm.cloneInFlight ? t("newTask.button.cloning") : t("newTask.button.create")}
         focused={vm.field === "confirm"}
         onPress={() => vm.commit()}

--- a/packages/kobe/src/tui-react/component/new-task-dialog/dialog.tsx
+++ b/packages/kobe/src/tui-react/component/new-task-dialog/dialog.tsx
@@ -12,6 +12,7 @@ import type { DialogTab } from "../../../tui/component/new-task-dialog/state"
 import { useTheme } from "../../context/theme"
 import { useT } from "../../i18n"
 import { useDialogPaddingX } from "../../ui/dialog"
+import { DialogBody } from "../../ui/dialog-body"
 import { ChipRow, DialogActions, DialogFooter, DialogHeader, DialogSection } from "../../ui/dialog-parts"
 import { AdoptTab } from "./tab-adopt"
 import { CloneTab } from "./tab-clone"
@@ -35,9 +36,12 @@ export function NewTaskDialogView(props: NewTaskDialogProps) {
   }
 
   return (
-    <box paddingLeft={padX} paddingRight={padX} gap={0}>
-      <DialogHeader title={t("newTask.title")} onClose={() => props.onCancel()} />
-      <box gap={1} paddingTop={1}>
+    <box paddingLeft={padX} paddingRight={padX} gap={0} flexShrink={1} overflow="hidden">
+      {/* Scrolling border glyphs must not repaint the fixed title row. */}
+      <box flexShrink={0} zIndex={1} backgroundColor={theme.backgroundDialog}>
+        <DialogHeader title={t("newTask.title")} onClose={() => props.onCancel()} />
+      </box>
+      <DialogBody>
         {/* Mode selector — Tab reaches it; ←/→ switches while focused,
             ctrl+[/] from anywhere, click picks. Same chip row as every
             other choose-one in this dialog. */}
@@ -74,12 +78,12 @@ export function NewTaskDialogView(props: NewTaskDialogProps) {
         {vm.tab === "existing" ? <ExistingTab vm={vm} /> : null}
         {vm.tab === "clone" ? <CloneTab vm={vm} /> : null}
         {vm.tab === "adopt" ? <AdoptTab vm={vm} /> : null}
-        {vm.submitError ? (
-          <text fg={theme.error} wrapMode="word">
-            ※ {vm.submitError}
-          </text>
-        ) : null}
-      </box>
+      </DialogBody>
+      {vm.submitError ? (
+        <text fg={theme.error} wrapMode="word" flexShrink={0}>
+          ※ {vm.submitError}
+        </text>
+      ) : null}
       {/* Enter's caption follows the focused stop: it commits only on Create
           and walks the form at the other four, so a static "enter create" was
           wrong at every stop the dialog actually opens on. */}

--- a/packages/kobe/src/tui-react/component/new-task-dialog/picker-list.tsx
+++ b/packages/kobe/src/tui-react/component/new-task-dialog/picker-list.tsx
@@ -7,11 +7,12 @@
  * cursor arrow, bold, and overflow lines.
  */
 
-import { TextAttributes } from "@opentui/core"
+import { type BoxRenderable, TextAttributes } from "@opentui/core"
 import type { ReactNode } from "react"
 import type { PickerWindow } from "../../../tui/component/new-task-dialog/state"
 import { useTheme } from "../../context/theme"
 import { useT } from "../../i18n"
+import { useDialogFocus } from "../../ui/dialog-body"
 
 /** One visible picker row — body text plus an accent (selected) flag. */
 export type PickerRow = {
@@ -30,9 +31,19 @@ export type PickerRow = {
   readonly dim?: string
 }
 
+function PickerItem(props: { focused: boolean; children: ReactNode }) {
+  const focus = useDialogFocus<BoxRenderable>(props.focused)
+  return (
+    <box {...focus} flexShrink={0}>
+      {props.children}
+    </box>
+  )
+}
+
 export function PickerList(props: {
   window: PickerWindow
   cursor: number
+  focused?: boolean
   /** Pre-windowed rows; same length/order as `window.items`. */
   rows: readonly PickerRow[]
   onPick: (absoluteIndex: number) => void
@@ -42,9 +53,10 @@ export function PickerList(props: {
 }) {
   const { theme } = useTheme()
   const t = useT()
+  const focus = useDialogFocus<BoxRenderable>(props.focused !== false)
   const below = props.window.total - props.window.start - props.window.items.length
   return (
-    <box gap={0} paddingLeft={2} paddingBottom={props.paddingBottom}>
+    <box {...focus} gap={0} flexShrink={0} paddingLeft={2} paddingBottom={props.paddingBottom}>
       {props.window.start > 0 ? (
         <text fg={theme.textMuted} wrapMode="none">
           {t("newTask.picker.moreAbove", { count: props.window.start })}
@@ -60,39 +72,37 @@ export function PickerList(props: {
         // the layout of the three pickers that pass no tail.
         if (!row.dim) {
           return (
-            <text
-              key={row.key}
-              fg={fg}
-              attributes={attributes}
-              wrapMode="none"
-              onMouseUp={() => props.onPick(absoluteIndex)}
-            >
-              {isCursor ? "▸ " : "  "}
-              {row.body}
-            </text>
+            <PickerItem key={row.key} focused={isCursor && props.focused !== false}>
+              <text fg={fg} attributes={attributes} wrapMode="none" onMouseUp={() => props.onPick(absoluteIndex)}>
+                {isCursor ? "▸ " : "  "}
+                {row.body}
+              </text>
+            </PickerItem>
           )
         }
         return (
-          <box key={row.key} flexDirection="row" onMouseUp={() => props.onPick(absoluteIndex)}>
-            <text fg={fg} attributes={attributes} wrapMode="none" flexShrink={0}>
-              {isCursor ? "▸ " : "  "}
-              {row.body}
-            </text>
-            {/* Right-aligned by a growing spacer, not by padding the string:
+          <PickerItem key={row.key} focused={isCursor && props.focused !== false}>
+            <box flexDirection="row" onMouseUp={() => props.onPick(absoluteIndex)}>
+              <text fg={fg} attributes={attributes} wrapMode="none" flexShrink={0}>
+                {isCursor ? "▸ " : "  "}
+                {row.body}
+              </text>
+              {/* Right-aligned by a growing spacer, not by padding the string:
                 the gap is whatever the row has left over, so the tails share
                 one right edge however ragged the names are. */}
-            <box flexGrow={1} />
-            {/* The tail is the first thing to go on a narrow card: it is the
+              <box flexGrow={1} />
+              {/* The tail is the first thing to go on a narrow card: it is the
                 half the row can lose and still be identifiable.
                 The separating space is INSIDE the text, not `paddingLeft`:
                 padding is part of the box being shrunk, so on a row wide
                 enough to close the gap it went to zero and the body ran
                 straight into the directory (`…(current dir)/var/folders/…`).
                 A leading space in the string shrinks with the string. */}
-            <text fg={theme.textMuted} wrapMode="none" flexShrink={1}>
-              {` ${row.dim}`}
-            </text>
-          </box>
+              <text fg={theme.textMuted} wrapMode="none" flexShrink={1}>
+                {` ${row.dim}`}
+              </text>
+            </box>
+          </PickerItem>
         )
       })}
       {below > 0 ? (

--- a/packages/kobe/src/tui-react/component/new-task-dialog/tab-adopt.tsx
+++ b/packages/kobe/src/tui-react/component/new-task-dialog/tab-adopt.tsx
@@ -67,6 +67,7 @@ export function AdoptTab({ vm }: { vm: NewTaskVm }) {
         <PickerList
           window={vm.adoptWindow}
           cursor={vm.adoptCursor}
+          focused={vm.field === "adoptFilter"}
           rows={rows}
           onPick={vm.pickAdoptAt}
           footer={

--- a/packages/kobe/src/tui-react/ui/dialog-body.tsx
+++ b/packages/kobe/src/tui-react/ui/dialog-body.tsx
@@ -1,7 +1,9 @@
 /** @jsxImportSource @opentui/react */
 import type { Renderable, ScrollBoxRenderable } from "@opentui/core"
-import { type ReactNode, createContext, useCallback, useContext, useEffect, useRef } from "react"
+import { useRenderer } from "@opentui/react"
+import { type ReactNode, createContext, useCallback, useContext, useEffect, useRef, useState } from "react"
 import { useTheme } from "../context/theme"
+import { useT } from "../i18n"
 
 const DialogFocusContext = createContext<((element: Renderable) => void) | null>(null)
 
@@ -18,7 +20,26 @@ export function useDialogFocus<T extends Renderable>(focused: boolean) {
 /** The form scrolls within the card; its header, errors and actions stay visible. */
 export function DialogBody(props: { children: ReactNode }) {
   const { theme } = useTheme()
+  const t = useT()
+  const renderer = useRenderer()
   const scroll = useRef<ScrollBoxRenderable | null>(null)
+  const [overflow, setOverflow] = useState({ above: 0, below: 0 })
+  useEffect(() => {
+    const body = scroll.current
+    if (!body) return
+    let previous: typeof overflow | undefined
+    const refresh = () => {
+      const above = Math.max(0, body.scrollTop)
+      const below = Math.max(0, body.content.height - body.viewport.height - above)
+      if (previous?.above === above && previous.below === below) return
+      previous = { above, below }
+      setOverflow(previous)
+    }
+    // Measure after Yoga settles, including keyboard, mouse and resize scrolls.
+    renderer.addPostProcessFn(refresh)
+    refresh()
+    return () => renderer.removePostProcessFn(refresh)
+  }, [renderer])
   const focused = useRef<Renderable | null>(null)
   const reveal = useCallback(() => {
     const element = focused.current
@@ -40,7 +61,6 @@ export function DialogBody(props: { children: ReactNode }) {
         flexShrink={1}
         overflow="hidden"
         scrollX={false}
-        marginBottom={1}
         // The default 100% minimum stretches short forms to the card height.
         contentOptions={{ minHeight: 0 }}
         horizontalScrollbarOptions={{ visible: false }}
@@ -53,6 +73,14 @@ export function DialogBody(props: { children: ReactNode }) {
           {props.children}
         </box>
       </scrollbox>
+      <text height={1} flexShrink={0} fg={theme.textMuted} wrapMode="none">
+        {[
+          overflow.above > 0 ? t("newTask.scroll.moreAbove", { count: overflow.above }) : "",
+          overflow.below > 0 ? t("newTask.scroll.moreBelow", { count: overflow.below }) : "",
+        ]
+          .filter(Boolean)
+          .join(" · ")}
+      </text>
     </DialogFocusContext.Provider>
   )
 }

--- a/packages/kobe/src/tui-react/ui/dialog-body.tsx
+++ b/packages/kobe/src/tui-react/ui/dialog-body.tsx
@@ -1,0 +1,58 @@
+/** @jsxImportSource @opentui/react */
+import type { Renderable, ScrollBoxRenderable } from "@opentui/core"
+import { type ReactNode, createContext, useCallback, useContext, useEffect, useRef } from "react"
+import { useTheme } from "../context/theme"
+
+const DialogFocusContext = createContext<((element: Renderable) => void) | null>(null)
+
+export function useDialogFocus<T extends Renderable>(focused: boolean) {
+  const follow = useContext(DialogFocusContext)
+  const ref = useRef<T | null>(null)
+  const reveal = useCallback(() => {
+    if (focused && ref.current) follow?.(ref.current)
+  }, [focused, follow])
+  useEffect(() => reveal(), [reveal])
+  return { ref, onSizeChange: reveal }
+}
+
+/** The form scrolls within the card; its header, errors and actions stay visible. */
+export function DialogBody(props: { children: ReactNode }) {
+  const { theme } = useTheme()
+  const scroll = useRef<ScrollBoxRenderable | null>(null)
+  const focused = useRef<Renderable | null>(null)
+  const reveal = useCallback(() => {
+    const element = focused.current
+    if (element && !element.isDestroyed) scroll.current?.scrollChildIntoView(element.id)
+  }, [])
+  const follow = useCallback(
+    (element: Renderable) => {
+      focused.current = element
+      reveal()
+    },
+    [reveal],
+  )
+
+  return (
+    <DialogFocusContext.Provider value={follow}>
+      <scrollbox
+        ref={scroll}
+        flexGrow={0}
+        flexShrink={1}
+        overflow="hidden"
+        scrollX={false}
+        marginBottom={1}
+        // The default 100% minimum stretches short forms to the card height.
+        contentOptions={{ minHeight: 0 }}
+        horizontalScrollbarOptions={{ visible: false }}
+        onSizeChange={reveal}
+        verticalScrollbarOptions={{
+          trackOptions: { backgroundColor: theme.backgroundDialog, foregroundColor: theme.borderActive },
+        }}
+      >
+        <box gap={1} paddingTop={1} flexShrink={0} onSizeChange={reveal}>
+          {props.children}
+        </box>
+      </scrollbox>
+    </DialogFocusContext.Provider>
+  )
+}

--- a/packages/kobe/src/tui-react/ui/dialog-parts.tsx
+++ b/packages/kobe/src/tui-react/ui/dialog-parts.tsx
@@ -17,29 +17,16 @@
  * defaults `borderStyle` to square (`ui/frame.ts`).
  */
 
-import type { RGBA } from "@opentui/core"
+import type { BoxRenderable, RGBA } from "@opentui/core"
 import { TextAttributes } from "@opentui/core"
 import { useTerminalDimensions } from "@opentui/react"
 import type { ReactNode } from "react"
 import { useTheme } from "../context/theme"
+import { useDialogFocus } from "./dialog-body"
 import { FRAME } from "./frame"
 
-/**
- * Below this many terminal rows, framed pieces drop their border.
- *
- * A well and a chip each cost TWO rows the text inside them does not need,
- * and the card is capped at the viewport with nothing to scroll it — the new
- * task dialog's Clone tab carries four fields plus a picker, and at 24 rows
- * the frames pushed the Create button and `submitError` off the bottom.
- * That is the failure `new-task-short-terminal.test.tsx` exists to catch: a
- * failed create rendering into rows that do not exist reads as nothing
- * happening at all.
- *
- * So the border is what gives way, not the button. The value is the smallest
- * viewport that still fits the tallest card WITH its frames (measured on the
- * Clone tab, four wells + engine chips + a two-row picker); anything shorter
- * gets the same fields, unframed.
- */
+/** Short terminals omit borders to leave more rows for editable values.
+ * Scrolling forms still keep their header and actions outside the body. */
 const FRAMED_DIALOG_MIN_ROWS = 34
 
 /** Is the viewport too short to spend two rows per field on a border? */
@@ -64,7 +51,7 @@ function useFieldFill(): RGBA | "transparent" {
 export function DialogHeader(props: { title?: string; children?: ReactNode; onClose: () => void }) {
   const { theme } = useTheme()
   return (
-    <box flexDirection="row" justifyContent="space-between">
+    <box flexDirection="row" justifyContent="space-between" flexShrink={0}>
       {props.children ?? (
         <text fg={theme.text} attributes={TextAttributes.BOLD} wrapMode="none">
           {props.title}
@@ -114,7 +101,7 @@ export function DialogField(props: { focused: boolean; children?: ReactNode; pad
   // would have put it, so the field still lines up under its label.
   if (useDialogCompact()) {
     return (
-      <box paddingLeft={2} paddingBottom={props.paddingBottom}>
+      <box paddingLeft={2} paddingBottom={props.paddingBottom} flexShrink={0}>
         {props.children}
       </box>
     )
@@ -122,6 +109,7 @@ export function DialogField(props: { focused: boolean; children?: ReactNode; pad
   return (
     <box
       {...FRAME}
+      flexShrink={0}
       borderColor={props.focused ? theme.primary : theme.borderSubtle}
       backgroundColor={fill}
       paddingLeft={1}
@@ -142,8 +130,9 @@ export function DialogSection(props: {
   children?: ReactNode
   paddingBottom?: number
 }) {
+  const focus = useDialogFocus<BoxRenderable>(props.focused)
   return (
-    <box gap={0} paddingBottom={props.paddingBottom}>
+    <box {...focus} gap={0} paddingBottom={props.paddingBottom} flexShrink={0}>
       <DialogLabel label={props.label} focused={props.focused} hint={props.hint} onPress={props.onPress} />
       {props.children}
     </box>
@@ -173,7 +162,8 @@ export function ChipButton(props: {
       fg={props.selected ? theme.primary : props.tone === "text" ? theme.text : theme.textMuted}
       attributes={props.selected ? TextAttributes.BOLD : undefined}
       wrapMode="none"
-      flexShrink={0}
+      flexShrink={1}
+      truncate
     >
       {props.label}
     </text>
@@ -181,7 +171,7 @@ export function ChipButton(props: {
   // Compact: `▸ ` carries the selection a border would have shown.
   if (useDialogCompact()) {
     return (
-      <box flexDirection="row" flexShrink={0} onMouseUp={props.onPress}>
+      <box flexDirection="row" flexShrink={0} maxWidth="100%" onMouseUp={props.onPress}>
         <text fg={props.selected ? theme.primary : theme.textMuted} wrapMode="none">
           {props.selected ? "▸ " : "  "}
         </text>
@@ -192,6 +182,8 @@ export function ChipButton(props: {
   return (
     <box
       {...FRAME}
+      flexShrink={0}
+      maxWidth="100%"
       borderColor={props.selected ? theme.primary : theme.borderSubtle}
       paddingLeft={2}
       paddingRight={2}
@@ -220,7 +212,7 @@ export function ChipRow<T extends string>(props: {
   // columnGap, not gap: Yoga's `gap` sets both gutters, and a wrapped second
   // line would then sit a blank row below the first.
   return (
-    <box flexDirection="row" flexWrap="wrap" columnGap={1}>
+    <box flexDirection="row" flexWrap="wrap" alignItems="flex-start" columnGap={1} rowGap={0} flexShrink={0}>
       {props.choices.map((choice) => (
         <ChipButton
           key={choice}
@@ -242,7 +234,7 @@ export function ChipRow<T extends string>(props: {
 export function DialogFooter(props: { children?: ReactNode }) {
   const { theme } = useTheme()
   return (
-    <box paddingBottom={1}>
+    <box paddingBottom={1} flexShrink={0}>
       <text fg={theme.textMuted} wrapMode="word">
         {props.children}
       </text>
@@ -260,7 +252,14 @@ export function DialogFooter(props: { children?: ReactNode }) {
 export function DialogActions(props: { label: string; focused: boolean; onPress: () => void }) {
   const { theme } = useTheme()
   return (
-    <box flexDirection="row" justifyContent="flex-end" alignItems="center" paddingTop={1} paddingBottom={1}>
+    <box
+      flexDirection="row"
+      justifyContent="flex-end"
+      alignItems="center"
+      paddingTop={1}
+      paddingBottom={1}
+      flexShrink={0}
+    >
       <text
         fg={props.focused ? theme.primary : theme.text}
         attributes={props.focused ? TextAttributes.BOLD : undefined}

--- a/packages/kobe/src/tui-react/ui/dialog-parts.tsx
+++ b/packages/kobe/src/tui-react/ui/dialog-parts.tsx
@@ -231,10 +231,10 @@ export function ChipRow<T extends string>(props: {
  * that dialog answers to. The card owns only `paddingTop`, so the last row
  * has to carry its own bottom cell or it sits flush against the card's edge.
  */
-export function DialogFooter(props: { children?: ReactNode }) {
+export function DialogFooter(props: { children?: ReactNode; paddingBottom?: number }) {
   const { theme } = useTheme()
   return (
-    <box paddingBottom={1} flexShrink={0}>
+    <box paddingBottom={props.paddingBottom ?? 1} flexShrink={0}>
       <text fg={theme.textMuted} wrapMode="word">
         {props.children}
       </text>
@@ -249,14 +249,14 @@ export function DialogFooter(props: { children?: ReactNode }) {
  * drawer) has no such field and states the verb in its legend instead — a
  * button nothing can focus would be a fourth thing to explain.
  */
-export function DialogActions(props: { label: string; focused: boolean; onPress: () => void }) {
+export function DialogActions(props: { label: string; focused: boolean; onPress: () => void; paddingTop?: number }) {
   const { theme } = useTheme()
   return (
     <box
       flexDirection="row"
       justifyContent="flex-end"
       alignItems="center"
-      paddingTop={1}
+      paddingTop={props.paddingTop ?? 1}
       paddingBottom={1}
       flexShrink={0}
     >

--- a/packages/kobe/src/tui/i18n/messages/newTask.ts
+++ b/packages/kobe/src/tui/i18n/messages/newTask.ts
@@ -59,6 +59,11 @@ export const en = {
     moreBelow: "↓ {count} more",
   },
 
+  scroll: {
+    moreAbove: "↑ {count} more rows",
+    moreBelow: "↓ {count} more rows",
+  },
+
   /** "Open the project" failures. {error} is the daemon's message. */
   open: {
     failed: "Couldn't open the project: {error}",
@@ -152,6 +157,11 @@ export const zh: typeof en = {
   picker: {
     moreAbove: "↑ 还有 {count} 项",
     moreBelow: "↓ 还有 {count} 项",
+  },
+
+  scroll: {
+    moreAbove: "↑ 上方还有 {count} 行",
+    moreBelow: "↓ 下方还有 {count} 行",
   },
 
   /** "Open the project" failures. {error} is the daemon's message. */

--- a/packages/kobe/test/render/new-task-dialog-layout.test.tsx
+++ b/packages/kobe/test/render/new-task-dialog-layout.test.tsx
@@ -144,3 +144,44 @@ test("a focused last field remains visible after narrowing and shortening the te
   expect(frame).not.toContain("╭")
   act(() => h.destroy())
 })
+
+for (const { width, height } of [
+  { width: 153, height: 35 },
+  { width: 153, height: 34 },
+  { width: 200, height: 30 },
+]) {
+  test(`${width}x${height}: footer spacing leaves the parent well or compact form intact`, async () => {
+    const h = await mount(width, height)
+    await press(h, "right")
+    await press(h, "tab")
+    await press(h, "tab")
+    await act(async () => h.mockInput.typeText("https://github.com/Sma1lboy/mc-rpg.git"))
+    const frame = await h.frame()
+    const scroll = descendants(h.renderer.root).find(
+      (node): node is ScrollBoxRenderable => node instanceof ScrollBoxRenderable,
+    )!
+    const lines = frame.split("\n")
+    const create = lines.findIndex((line) => line.includes("[ Create ]"))
+    const legendEnd = lines.findIndex((line) => line.includes("esc cancel"))
+    expect(create).toBe(legendEnd + 1)
+    if (height >= 34) {
+      const wells = descendants(h.renderer.root).filter(
+        (node): node is BoxRenderable => node instanceof BoxRenderable && !!node.border,
+      )
+      const parent = wells[9]!
+      expect(parent.height).toBe(3)
+      expect(parent.y + parent.height).toBeLessThanOrEqual(scroll.viewport.y + scroll.viewport.height)
+      expect(frame).toMatch(/↓ \d+ more rows/)
+      for (let i = 0; i < 3; i++) await press(h, "tab")
+      const bottom = await h.frame()
+      expect(bottom).toMatch(/↑ \d+ more rows/)
+      expect(bottom).not.toMatch(/↓ \d+ more rows/)
+    } else {
+      expect(scroll.scrollHeight).toBeLessThanOrEqual(scroll.viewport.height)
+      const base = lines.findIndex((line) => line.includes("BASE BRANCH"))
+      expect(lines[base + 1]).toContain("main")
+      expect(frame).not.toContain("more rows")
+    }
+    act(() => h.destroy())
+  })
+}

--- a/packages/kobe/test/render/new-task-dialog-layout.test.tsx
+++ b/packages/kobe/test/render/new-task-dialog-layout.test.tsx
@@ -1,0 +1,146 @@
+/** @jsxImportSource @opentui/react */
+import { expect, test } from "bun:test"
+import { BoxRenderable, type Renderable, ScrollBoxRenderable } from "@opentui/core"
+import { useEffect, useRef } from "react"
+import { NewTaskDialogView } from "../../src/tui-react/component/new-task-dialog/dialog"
+import { useDialog } from "../../src/tui-react/ui/dialog"
+import { type RenderHandle, act, renderComponent, settle } from "./harness"
+
+const ENGINES = ["claude", "codex", "kimi", "claudex --dangerously-skip-permissions", "opencode"]
+
+function OpenDialog() {
+  const dialog = useDialog()
+  const opened = useRef(false)
+  useEffect(() => {
+    if (opened.current) return
+    opened.current = true
+    dialog.replace(() => (
+      <NewTaskDialogView
+        defaultRepo={process.cwd()}
+        savedRepos={[]}
+        defaultCloneParent="/tmp/rove-layout-no-such-parent"
+        availableVendors={ENGINES}
+        discoverAdoptable={async () =>
+          Array.from({ length: 15 }, (_, i) => ({
+            path: `/tmp/layout-adopt/${i}`,
+            branch: `feature/layout-${i}`,
+            head: "abcdef",
+            dirty: false,
+            kobeManaged: false,
+            lastActivityMs: 0,
+          }))
+        }
+        onSubmit={() => {}}
+        onCancel={() => {}}
+      />
+    ))
+  }, [dialog.replace])
+  return <text>{Array.from({ length: 60 }, () => "BACKGROUND ".repeat(20)).join("\n")}</text>
+}
+
+async function mount(width: number, height: number) {
+  const handle = await renderComponent(<OpenDialog />, { width, height, providers: { kv: true, dialog: true } })
+  await settle()
+  return handle
+}
+
+function descendants(root: Renderable): Renderable[] {
+  return root.getChildren().flatMap((child) => [child, ...descendants(child)])
+}
+
+async function press(handle: RenderHandle, key: "right" | "tab" | "down") {
+  act(() => (key === "tab" ? handle.mockInput.pressTab() : handle.mockInput.pressArrow(key)))
+  await settle()
+}
+
+for (const { width, height } of [
+  { width: 200, height: 60 },
+  { width: 120, height: 40 },
+]) {
+  test(`${width}x${height}: wrapped engines and inputs keep full borders above the footer`, async () => {
+    const h = await mount(width, height)
+    await press(h, "right")
+    await press(h, "tab")
+    await press(h, "tab")
+    await act(async () => h.mockInput.typeText("https://github.com/Sma1lboy/mc-rpg.git"))
+    await h.frame()
+    const boxes = descendants(h.renderer.root).filter(
+      (node): node is BoxRenderable => node instanceof BoxRenderable && !!node.border,
+    )
+    expect(boxes.length).toBe(12)
+    for (const box of boxes) expect(box.height).toBe(3)
+    const firstEngine = boxes[3]!
+    const wrappedEngine = boxes[6]!
+    expect(wrappedEngine.y).toBe(firstEngine.y + firstEngine.height)
+    const urlField = boxes[8]!
+    // One label row and one blank row separate the next well from the chips.
+    expect(urlField.y).toBe(wrappedEngine.y + wrappedEngine.height + 2)
+    for (let i = 0; i < 3; i++) await press(h, "tab")
+    const frame = await h.frame()
+    const lines = frame.split("\n")
+    const footer = lines.findIndex((line) => line.includes("enter next field"))
+    const lastBorder = Math.max(...boxes.map((box) => box.y + box.height - 1))
+    expect(footer).toBeGreaterThan(lastBorder + 1)
+    expect(frame).toContain("[ Create ]")
+    const first = lines.findIndex((line) => line.includes("New task"))
+    const left = lines[first]!.indexOf("New task") - 2
+    for (const line of lines.slice(first, footer + 3)) expect(line.slice(left, left + 80)).not.toContain("BACKGROUND")
+    act(() => h.destroy())
+  })
+}
+
+for (const mode of ["existing", "adopt"] as const) {
+  test(`${mode}: wrapped chips and picker rows stay inside the modal`, async () => {
+    const h = await mount(120, 40)
+    if (mode === "adopt") {
+      await press(h, "right")
+      await press(h, "right")
+    }
+    await press(h, "tab")
+    await press(h, "tab")
+    if (mode === "adopt") {
+      for (let i = 0; i < 14; i++) await press(h, "down")
+    }
+    const frame = await h.frame()
+    expect(frame).toContain(mode === "adopt" ? "▸ [ ] feature/layout-14" : "FROM BRANCH")
+    expect(frame).toContain("New task")
+    expect(frame).toContain("[ Create ]")
+    const boxes = descendants(h.renderer.root).filter(
+      (node): node is BoxRenderable => node instanceof BoxRenderable && !!node.border,
+    )
+    for (const box of boxes) expect(box.height).toBe(3)
+    const scroll = descendants(h.renderer.root).find(
+      (node): node is ScrollBoxRenderable => node instanceof ScrollBoxRenderable,
+    )
+    expect(scroll).toBeDefined()
+    const footer = frame.split("\n").findIndex((line) => line.includes("enter next field"))
+    expect(footer).toBeGreaterThan(scroll!.y + scroll!.height)
+    act(() => h.destroy())
+  })
+}
+
+test("a focused last field remains visible after narrowing and shortening the terminal", async () => {
+  const h = await mount(200, 60)
+  await press(h, "right")
+  for (let i = 0; i < 5; i++) await press(h, "tab")
+  await h.frame()
+  act(() => h.resize(64, 40))
+  await settle()
+  let frame = await h.frame()
+  expect(frame).toContain("BASE BRANCH")
+  expect(frame).toContain("[ Create ]")
+  const boxes = descendants(h.renderer.root).filter(
+    (node): node is BoxRenderable => node instanceof BoxRenderable && !!node.border,
+  )
+  for (const box of boxes) {
+    expect(box.height).toBe(3)
+    expect(box.x + box.width).toBeLessThanOrEqual(63)
+  }
+  act(() => h.resize(120, 24))
+  await settle()
+  frame = await h.frame()
+  expect(frame).toContain("BASE BRANCH")
+  expect(frame).toContain("[ Create ]")
+  expect(frame).not.toContain("╭")
+  act(() => h.destroy())
+})

--- a/packages/kobe/test/render/picker-window-fits-viewport.test.tsx
+++ b/packages/kobe/test/render/picker-window-fits-viewport.test.tsx
@@ -2,10 +2,9 @@
 /**
  * Both branch pickers must fit the terminal they are drawn in.
  *
- * They share `windowAround` + `pickerVisibleRows`, and the dialog card is
- * capped at the viewport with nothing to scroll it — so a window sized
- * independently of the height pushes the card's own bottom rows off the
- * screen. This mounts the REAL dialogs at a short and a tall viewport: the
+ * They share `windowAround` + `pickerVisibleRows`. New task scrolls the
+ * active picker into view while preserving its footer. This mounts the
+ * real dialogs at a short and a tall viewport: the
  * pure test cannot see whether a component actually calls the helper, and an
  * uncalled helper renders exactly like the bug.
  */
@@ -106,18 +105,9 @@ test("the clone tab's parent-dir picker fits a 24-row terminal", async () => {
   const shown = dirRows(text)
   expect(shown).toBeGreaterThanOrEqual(1) // still a usable list
   expect(shown).toBeLessThan(PICKER_MAX_VISIBLE) // …but not the desktop window
-  // …and the overflow line accounts for every entry the window hides. The
-  // typed `c` is consumed as the path prefix being browsed, so the list is
-  // the 19 siblings of the one the cursor sits on.
+  // Include the highlighted entry: all 20 children match the typed `c`.
+  // The old compressed layout clipped one row and only accounted for 19.
   const hidden = Number(text.match(/↓ (\d+) more/)?.[1] ?? "0")
-  expect(shown + hidden).toBe(19)
+  expect(shown).toBe(2)
+  expect(shown + hidden).toBe(20)
 })
-
-// Scope note, so the next reader does not over-trust the clone test above:
-// at 24 rows the clone card is short enough that Yoga clamps its picker to one
-// row on its own, so that test does NOT discriminate whether `use-clone-state`
-// passes the cap — removing the argument renders an identical frame. It pins
-// the user-visible contract (a usable list, an honest overflow count, and a
-// reachable Create button); the CAP ITSELF is pinned by the set-branch test
-// above, which drives the same helper at two heights and does go red when the
-// window stops following the viewport.


### PR DESCRIPTION
## What broke

On a terminal around 35 rows tall with enough engines registered that the ENGINE chip row wraps (e.g. a custom `claudex --dangerously-skip-permissions` entry), the New task dialog's form is taller than the card. Yoga then flex-shrinks the bordered chips and input wells: the chip row grows a blank line and paints onto the GIT URL label, the GIT URL well collapses to a single border line with the value drawn on it, the four wells end up different heights, and the footer hint is painted over the BASE BRANCH border.

Reproduced on `main` at 153x35 through the browser harness; the six-symptom screenshot in the report is one root cause.

## What changed

- The form body is now a `scrollbox` (`ui/dialog-body.tsx`) whose children are `flexShrink={0}`, so nothing is ever compressed. Header, submit error, footer and `[ Create ]` stay outside the scroll region and are always visible.
- Focused fields and picker rows scroll themselves into view (`useDialogFocus`), so Tab-walking the form never lands on a hidden field.
- Chip rows use `columnGap` + `rowGap={0}` and long chips truncate instead of shrinking their neighbours.
- Spacing under the body was tightened by two rows so the framed PARENT DIR well fits whole at 153x35 and the compact form still fits at 200x30.
- When the body overflows, a pinned `↓ N more rows` / `↑ N more rows` hint reuses the existing separator line (localized in `newTask` messages).
- Applies to all three tabs (For Existing / For New Repo / Adopt Worktree); they share the body and footer.

## Verification

- Browser harness (`/harness` → xterm.js → PTY sidecar → real OpenTUI, dev:sandbox) before/after captures at 153x35, 153x34, 153x33, 200x30, 200x60, 137x35, 120x40, 46x40. Before: symptoms reproduced pixel-for-pixel at 153x35. After: every well complete, footer and Create never overlap, scroll follows focus.
- `test/render/new-task-dialog-layout.test.tsx` covers the wrapped chip row, the three reproduction grids, the compact 200x30 fit, all three tabs, and card opacity. Full `bun test test/render`: 521 pass.
- Typecheck, biome lint, localization vitest green. Touched files all ≤ 273 lines.

Two patch changesets included.