### PR TITLE
ci(render): run the PTY tests in their own bun process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,7 @@ packages/*/coverage-daemon/
 # `bun test test/render --coverage` output (the render-track sibling of the
 # vitest coverage/ above) — see docs/HARNESS.md "render track".
 packages/*/coverage-render/
+packages/*/coverage-render-pty/
 
 # Session handoff — local working state / scratchpad for the next agent in
 # THIS environment. Not shared history (the durable record lives in git

--- a/packages/kobe/package.json
+++ b/packages/kobe/package.json
@@ -57,7 +57,7 @@
     "test:socket": "KOBE_INCLUDE_SOCKET=1 vitest run test/daemon --pool forks --minWorkers=1 --maxWorkers=4 --passWithNoTests",
     "test:socket:coverage": "KOBE_INCLUDE_SOCKET=1 KOBE_COVERAGE_DAEMON=1 vitest run test/daemon --coverage --pool forks --minWorkers=1 --maxWorkers=4 --passWithNoTests",
     "test:behavior": "KOBE_INCLUDE_BEHAVIOR=1 vitest run test/behavior --pool forks --minWorkers=1 --maxWorkers=1 --retry=2 --passWithNoTests",
-    "test:render": "bun test test/render --coverage --coverage-reporter=text --coverage-reporter=lcov --coverage-dir=coverage-render",
+    "test:render": "bun scripts/render-track.mjs",
     "coverage": "vitest run --coverage --passWithNoTests",
     "bench": "vitest bench --run",
     "lint": "biome check .",

--- a/packages/kobe/scripts/render-track.mjs
+++ b/packages/kobe/scripts/render-track.mjs
@@ -1,0 +1,78 @@
+#!/usr/bin/env bun
+// The render track, run as TWO `bun test` processes instead of one.
+//
+// Why: a PTY child can enter a state it does not leave — `?NEs`, surviving
+// SIGKILL — and bun's main thread then blocks in a synchronous `wait4()` on
+// it. As one process that wedges the WHOLE track: on 2026-09-07 (Release
+// 0.9.175) and 2026-09-08 (main CI) the job printed its last `(pass)`, opened
+// `test/render/pty-hosted.test.ts` / `pty-host.test.ts`, and emitted nothing
+// for ~12m45s until `timeout-minutes: 15` cancelled it. No summary line, no
+// coverage — the other 114 files' results were lost along with it.
+//
+// Splitting does not stop a child from wedging. It bounds the blast radius:
+// the PTY files run LAST in their own process, so the other 114 have already
+// run, reported, and written their coverage before anything can wedge.
+//
+// Both halves always run — a failure in the first does not skip the second —
+// and the exit code is non-zero if either failed. Each writes its own lcov;
+// scripts/coverage-gate.mjs unions them per line (the PTY files re-report 142
+// sources the main half already covers, so a naive last-record-wins read
+// would replace real coverage with the thinner one).
+
+import { spawnSync } from "node:child_process"
+import { readdirSync } from "node:fs"
+import { join } from "node:path"
+
+const ROOT = "test/render"
+
+/** Every test file under `test/render`, repo-relative, one level of nesting. */
+function testFiles(dir) {
+  const found = []
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const path = join(dir, entry.name)
+    if (entry.isDirectory()) found.push(...testFiles(path))
+    else if (/\.test\.tsx?$/.test(entry.name)) found.push(path)
+  }
+  return found
+}
+
+const all = testFiles(ROOT).sort()
+// Basename, not path: the marker is the file's own name, so a `pty-*` file
+// added under a subdirectory later lands in the bounded half automatically.
+const isPty = (path) => /(^|\/)pty-[^/]*\.test\.tsx?$/.test(path)
+const pty = all.filter(isPty)
+const main = all.filter((path) => !isPty(path))
+
+if (pty.length === 0 || main.length === 0) {
+  console.error(`render-track: expected both halves to be non-empty (main=${main.length}, pty=${pty.length})`)
+  process.exit(2)
+}
+
+/** One `bun test` process over `files`, coverage into its own directory. */
+function run(label, files, coverageDir) {
+  console.log(`\n=== render track: ${label} (${files.length} files) → ${coverageDir} ===\n`)
+  const result = spawnSync(
+    "bun",
+    [
+      "test",
+      ...files,
+      "--coverage",
+      "--coverage-reporter=text",
+      "--coverage-reporter=lcov",
+      `--coverage-dir=${coverageDir}`,
+    ],
+    { stdio: "inherit" },
+  )
+  // A signalled process reports status null; that is a failure, not a pass.
+  return result.status === 0 && !result.signal
+}
+
+// PTY last, deliberately: whatever it does, the other half has already
+// reported by the time it starts.
+const mainOk = run("main", main, "coverage-render")
+const ptyOk = run("pty", pty, "coverage-render-pty")
+
+if (!mainOk || !ptyOk) {
+  console.error(`\nrender track failed (main=${mainOk ? "pass" : "FAIL"}, pty=${ptyOk ? "pass" : "FAIL"})`)
+  process.exit(1)
+}

--- a/scripts/coverage-gate.mjs
+++ b/scripts/coverage-gate.mjs
@@ -23,13 +23,17 @@
 // escape hatch, see the comment at its definition.
 
 import { execSync } from "node:child_process"
-import { readFileSync } from "node:fs"
+import { existsSync, readFileSync } from "node:fs"
 import { resolve } from "node:path"
 
 const MIN = Number(process.env.KOBE_COVERAGE_MIN ?? "50")
 const baseRef = process.env.BASE_REF
 const prBody = process.env.PR_BODY ?? ""
 const renderCoverage = process.env.KOBE_RENDER_COVERAGE === "1"
+// One per `bun test` process the render track splits into — see
+// packages/kobe/scripts/render-track.mjs. A missing dir is skipped so the
+// gate still reports on whichever halves produced coverage.
+const RENDER_COVERAGE_DIRS = ["coverage-render", "coverage-render-pty"]
 
 if (!baseRef) {
   console.error("coverage-gate: BASE_REF is required")
@@ -99,40 +103,75 @@ function isRenderTrackOnly(file) {
   }
 }
 
-function renderCoverageSummary(path) {
+/** Every `DA:` record for a source file, one entry per lcov that mentions it. */
+function renderRecords(paths) {
   const byRelative = new Map()
-  let source = null
-  let found = 0
-  let total = 0
-  const finish = () => {
-    if (source === null) return
-    const normal = source.replace(/\\/g, "/")
-    const index = normal.indexOf("packages/kobe/src/")
-    const relative = index >= 0 ? normal.slice(index) : normal.startsWith("src/") ? `packages/kobe/${normal}` : null
-    if (relative !== null) byRelative.set(relative, { lines: { pct: total === 0 ? 100 : (found / total) * 100 } })
-    source = null
-    found = 0
-    total = 0
-  }
-  for (const line of readFileSync(path, "utf8").split("\n")) {
-    if (line.startsWith("SF:")) {
-      finish()
-      source = line.slice(3)
-    } else if (line.startsWith("DA:")) {
-      const hits = Number(line.slice(3).split(",")[1])
-      total++
-      if (hits > 0) found++
-    } else if (line === "end_of_record") {
-      finish()
+  for (const path of paths) {
+    let relative = null
+    let lines = null
+    for (const line of readFileSync(path, "utf8").split("\n")) {
+      if (line.startsWith("SF:")) {
+        const normal = line.slice(3).replace(/\\/g, "/")
+        const index = normal.indexOf("packages/kobe/src/")
+        relative = index >= 0 ? normal.slice(index) : normal.startsWith("src/") ? `packages/kobe/${normal}` : null
+        lines = relative === null ? null : new Map()
+      } else if (line.startsWith("DA:") && lines) {
+        const [number, hits] = line.slice(3).split(",")
+        lines.set(number, Number(hits))
+      } else if (line === "end_of_record" && lines) {
+        const records = byRelative.get(relative) ?? []
+        records.push(lines)
+        byRelative.set(relative, records)
+        relative = null
+        lines = null
+      }
     }
   }
-  finish()
+  return byRelative
+}
+
+/**
+ * Line-% per source file, merged across the render track's several `bun test`
+ * processes (see packages/kobe/scripts/render-track.mjs).
+ *
+ * Two processes do NOT always agree on which lines of a file are executable:
+ * `src/engine/paste-readiness.ts` comes back with 25 lines from the main half
+ * and 15 from the PTY half. So the merge is two-stage — union the hit counts
+ * of records that report the SAME line set (that is a sound sum), and take
+ * the best percentage across line sets that differ (those denominators are
+ * not comparable, and unioning them counts one process's extra lines as
+ * misses: it read paste-readiness.ts as 60% where a single process read
+ * 100%).
+ *
+ * Letting the last record win — what this did when the track was one process
+ * and duplicate `SF:` blocks could not happen — silently replaces a
+ * well-covered file with whichever process touched it least.
+ */
+function renderCoverageSummary(paths) {
+  const byRelative = new Map()
+  for (const [relative, records] of renderRecords(paths)) {
+    const byLineSet = new Map()
+    for (const lines of records) {
+      const key = [...lines.keys()].sort().join(",")
+      const merged = byLineSet.get(key)
+      if (!merged) byLineSet.set(key, new Map(lines))
+      else for (const [number, hits] of lines) merged.set(number, Math.max(merged.get(number) ?? 0, hits))
+    }
+    let pct = 0
+    for (const lines of byLineSet.values()) {
+      const found = [...lines.values()].filter((hits) => hits > 0).length
+      pct = Math.max(pct, lines.size === 0 ? 100 : (found / lines.size) * 100)
+    }
+    byRelative.set(relative, { lines: { pct } })
+  }
   return byRelative
 }
 
 let byRelative
 if (renderCoverage) {
-  byRelative = renderCoverageSummary(resolve("packages/kobe/coverage-render/lcov.info"))
+  byRelative = renderCoverageSummary(
+    RENDER_COVERAGE_DIRS.map((dir) => resolve(`packages/kobe/${dir}/lcov.info`)).filter((path) => existsSync(path)),
+  )
 } else {
   const summaryPath = resolve("packages/kobe/coverage/coverage-summary.json")
   const summary = JSON.parse(readFileSync(summaryPath, "utf8"))

--- a/scripts/coverage-gate.mjs
+++ b/scripts/coverage-gate.mjs
@@ -134,18 +134,33 @@ function renderRecords(paths) {
  * Line-% per source file, merged across the render track's several `bun test`
  * processes (see packages/kobe/scripts/render-track.mjs).
  *
- * Two processes do NOT always agree on which lines of a file are executable:
- * `src/engine/paste-readiness.ts` comes back with 25 lines from the main half
- * and 15 from the PTY half. So the merge is two-stage — union the hit counts
- * of records that report the SAME line set (that is a sound sum), and take
- * the best percentage across line sets that differ (those denominators are
- * not comparable, and unioning them counts one process's extra lines as
- * misses: it read paste-readiness.ts as 60% where a single process read
- * 100%).
+ * THE TWO-STAGE GROUPING BELOW IS LOAD-BEARING. It reads like ceremony around
+ * what "should" be a per-line union, and both simpler shapes were measured
+ * against a single-process baseline before this one was written:
  *
- * Letting the last record win — what this did when the track was one process
- * and duplicate `SF:` blocks could not happen — silently replaces a
- * well-covered file with whichever process touched it least.
+ *   - Last record wins (what this did when the track was ONE process and
+ *     duplicate `SF:` blocks could not happen): the 7 PTY files re-report 142
+ *     sources the main half already covers, so a file's real coverage is
+ *     replaced by whichever process touched it least.
+ *
+ *   - Plain per-line union: WRONG, because two processes do not agree on
+ *     which lines of a file are executable. `src/engine/paste-readiness.ts`
+ *     comes back as 25 lines from the main half and 15 from the PTY half;
+ *     unioning counts the extra ten as misses and reads 60% where a single
+ *     process read 100%. Those denominators are not comparable.
+ *
+ * So: union the hit counts of records reporting the SAME line set (a sound
+ * sum), and take the best percentage across line sets that DIFFER. Measured
+ * across the whole tree, that reproduces the single-process numbers for every
+ * file the render gate enforces (128 same, 1 better, 0 worse).
+ *
+ * Three `src/tui/**` files do read lower than a single process did, and that
+ * is correct: e.g. `src/tui/panes/filetree/rows.ts` reports the same 102
+ * lines either way, but 12 of them were only ever hit because leaked
+ * module-level pollers from earlier files kept running during the PTY files
+ * in the shared process — the PTY half does not load rows.ts at all. That was
+ * accidental coverage, and losing it is the honest number. (None of the three
+ * is render-gated, so the gate itself is unaffected.)
  */
 function renderCoverageSummary(paths) {
   const byRelative = new Map()


### PR DESCRIPTION
`test:render` ran all 122 render files in one `bun test` process. A PTY child can enter a state it never leaves — `?NEs`, surviving SIGKILL — and bun's main thread then blocks in a synchronous `wait4()` on it, taking the whole track down.

Twice, on `main` and on a release:

| job | last `(pass)` before the wedge | group it stopped in | silence |
|---|---|---|---|
| [102239669167](https://github.com/Sma1lboy/rove/actions/runs/34279221240/attempts/1) (main CI) | `PtyHost > live sessions count toward liveCount, exited ones don't` | `test/render/pty-host.test.ts` | **12m39s** |
| [101642502243](https://github.com/Sma1lboy/rove/actions/runs/34090394709/attempts/1) (Release 0.9.175) | `HostedTaskPty … > a second viewer on the same key doesn't steal the stream…` | `test/render/pty-hosted.test.ts` | **12m50s** |

Neither log ever printed `Ran N tests across N files` — `grep -c` is 0 in both. Both end with the runner's own `The operation was canceled.` → `Terminate orphan process: pid (N) (bun)`. The other 115 files' results went with it.

(Both runs were later `gh run rerun --failed`, so this is invisible to `gh run list` / `gh run view`, which only report the newest attempt. `/attempts/1/jobs` is the only way to see it.)

## What this changes

`test:render` → `bun scripts/render-track.mjs`, which runs the 115 non-PTY files first and the 7 PTY files **last**, in separate processes. Both halves always run; the exit code fails if either does.

**This does not stop a child from wedging, and it does not by itself stop the 15-minute cancel.** It bounds the blast radius: the other 115 files have run, reported, and written coverage before anything can wedge, so the job fails with a diagnosis instead of a blank log. Bounding the PTY half's runtime is a separate decision and is deliberately not in this PR.

## Coverage: the gate survives the split

Each half writes its own lcov, so `scripts/coverage-gate.mjs` had to learn to merge. It previously keyed by file and let the **last** `SF:` record win — fine when duplicate records could not happen, silently destructive now: the 7 PTY files re-report **142** sources the main half already covers.

A plain per-line union is also wrong. The two processes disagree on which lines are executable — `src/engine/paste-readiness.ts` comes back as 25 lines from the main half and 15 from the PTY half — and unioning counts the extra ten as misses (100% → 60%). So the merge is two-stage: union hit counts across records reporting the **same** line set, take the **best** percentage across line sets that differ.

Verified by running this branch both ways and comparing per file:

- **531 pass / 0 fail both ways** (split: 486 + 45; unsplit: 531 across 122 files)
- **Files the render gate actually enforces** (`src/**/*.tsx`, plus `src/tui-react/**/*.ts` with a react value import): **128 same, 1 better, 0 worse**
- Non-gated files that appear in the lcov anyway: 344 same, 2 better, 3 worse

The 3 non-gated regressions are all `src/tui/**` and are the *disappearance of accidental coverage*: e.g. `src/tui/panes/filetree/rows.ts` reports the same 102 lines in both, but 12 of them were only ever hit because leaked module-level pollers from earlier files kept running during the PTY files in the shared process. `rows.ts` is not loaded by the PTY half at all. Its honest render coverage is the lower number.

## Verification

- `bun run test:render` — 486 + 45 = 531 pass, 0 fail
- `bun test test/render` (unsplit, same branch) — 531 pass, 0 fail
- `bun run lint` (repo root) — clean
- `BASE_REF=main KOBE_RENDER_COVERAGE=1 bun scripts/coverage-gate.mjs` — runs against the merged pair

`ci.yml` needs no change: it already calls `bun run test:render` and then the gate.

## Changeset

None. CI/test infrastructure only — no product code, and `test:render` is not shipped behavior.
