### PR TITLE
Machines: see every computer you code on in one sidebar

### DIFF
--- a/.changeset/machines-pr1.md
+++ b/.changeset/machines-pr1.md
@@ -1,0 +1,7 @@
+---
+"@sma1lboy/rove": patch
+---
+
+See every machine you code on in one sidebar. `rove machine add <ssh-target>` registers another computer running Rove; its tasks appear under a row of their own, and a repo you have on both machines reads `kobe` here and `narwhal:kobe` there. A machine that goes offline keeps its rows — greyed, not gone — and reconnects on its own.
+
+Read-only in this release: opening a remote session, and `rove api` verbs aimed at a remote task, arrive next. Those verbs refuse with `NOT_YET_SUPPORTED_REMOTE` rather than quietly running against your local daemon. See `docs/MACHINES.md`.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -233,6 +233,20 @@ as `activeSortMode` and read back on startup. Older state files may contain
 `tasksPane.projectFilter`; the daemon still mirrors that compatibility value
 for background consumers, but the current PureTUI tree does not consume it.
 
+### Machines
+
+`machines` maps a local alias to another computer running Rove. Written by
+[`rove machine add`](./MACHINES.md); nothing here needs hand-editing.
+
+| Field | What |
+|---|---|
+| `host` | SSH host as typed — usually an `ssh_config` `Host` alias, not a DNS name |
+| `user` | Login user, or absent to let `ssh_config` decide |
+| `port` | SSH port, or absent for the `ssh_config` default |
+| `auth` | `{"kind":"key"}` (agent / default identities), `{"kind":"key","keyPath":"…"}`, or `{"kind":"password","keychainRef":{…}}` — a password is never stored here, only a pointer to it |
+| `identity` | `{hostname, homeDir, daemonPid}` learned from the machine's last handshake. Two aliases whose triples match are one machine |
+| `addedAt` | ISO timestamp of registration |
+
 ### Experimental
 
 Off by default. These can change without notice.

--- a/docs/MACHINES.md
+++ b/docs/MACHINES.md
@@ -40,16 +40,19 @@ Rove never guesses a remote socket path — the remote home may be a different
 user, and the path may have been shortened to fit the platform's socket-name
 limit.
 
-The alias defaults to the machine's own hostname, and it is what the sidebar
-shows — so give it a short one when the hostname isn't:
+The alias is what the sidebar shows. It defaults to the target you typed —
+`rove machine add narwhal` gives you a machine called `narwhal`, because that
+is the name you already chose for it. A target that is addressing rather than a
+name (`user@host`, an explicit port, a bare IP) takes the machine's own
+hostname instead. Override either with `--alias`:
 
 ```console
-$ rove machine add narwhal --alias narwhal
+$ rove machine add nahuel@mac-mini.local --alias narwhal
 ```
 
 | Option | What it does |
 | --- | --- |
-| `--alias <name>` | Local name for the machine. Default: its hostname. |
+| `--alias <name>` | Local name for the machine. Default: the target you typed, or the machine's hostname when the target is `user@host` / has a port / is an IP. |
 | `--port <n>` | SSH port. Default: whatever `ssh_config` says. |
 | `--identity <file>` | SSH private key. Default: ssh-agent / `ssh_config`. |
 

--- a/docs/MACHINES.md
+++ b/docs/MACHINES.md
@@ -1,0 +1,126 @@
+# Machines
+
+One Rove watching every computer you code on.
+
+Install Rove on each machine, register the others with `rove machine add`, and
+their tasks appear in your sidebar under a row of their own. There is no
+"switch to that machine" step — every machine is connected at once, and the
+tree is the answer to what is running where.
+
+## What this needs
+
+- Rove installed on **both** machines (`npm i -g @sma1lboy/rove`).
+- SSH access to the remote one, working non-interactively — `ssh narwhal true`
+  must succeed without a prompt. A `Host` block in `~/.ssh/config` is the
+  usual way; Rove reads it rather than replacing it.
+
+Nothing else. Rove opens no ports and adds no authentication of its own: the
+remote daemon keeps listening on its private unix socket, and SSH forwards that
+socket to yours. SSH *is* the transport and the authentication.
+
+## Add a machine
+
+```console
+$ rove machine add narwhal
+rove machine: contacting narwhal…
+rove machine: Nahuels-Mac-mini → narwhal (rove 0.9.185 on Nahuels-Mac-mini.local)
+```
+
+`add` verifies before it saves: it asks the machine where its daemon listens
+(`rove daemon status --json`, starting one there if none is up) and refuses if
+the host is unreachable, Rove is not installed, or no daemon can be started.
+Rove never guesses a remote socket path — the remote home may be a different
+user, and the path may have been shortened to fit the platform's socket-name
+limit.
+
+The alias defaults to the machine's own hostname. Give it a shorter one:
+
+```console
+$ rove machine add narwhal --alias narwhal
+```
+
+| Option | What it does |
+| --- | --- |
+| `--alias <name>` | Local name for the machine. Default: its hostname. |
+| `--port <n>` | SSH port. Default: whatever `ssh_config` says. |
+| `--identity <file>` | SSH private key. Default: ssh-agent / `ssh_config`. |
+
+The target is `[user@]host[:port]`, usually just an `ssh_config` `Host` alias.
+An IPv6 address with a port needs brackets, exactly as `ssh` requires:
+`[fe80::1]:2222`.
+
+Nothing secret is written to `state.json`. A key is stored as a path; a
+password is stored as a keychain reference, never as a password.
+
+## What you see
+
+```
+kobe                          ← your projects, exactly where they were
+  main
+  fix/machines
+narwhal · v0.9.185            ← a machine
+  narwhal:kobe                ← its checkout of a repo you also have
+    remote probe
+```
+
+- **Two machines, one repo name.** A repo called `kobe` on both machines shows
+  as `kobe` here and `narwhal:kobe` there. The local one keeps the bare name —
+  it is the one you are sitting at.
+- **Offline machines keep their rows.** A laptop whose lid closed has not
+  stopped having those tasks, so the row stays and greys out instead of
+  vanishing. Rove reconnects in the background and the rows come back to life.
+- **Version skew is on the row.** `narwhal · v0.9.180` next to your own build
+  explains most of what otherwise looks like a bug. A machine whose Rove is too
+  old to talk to yours reads `⚠ v0.9.100 (protocol mismatch)` and is the only
+  row affected.
+
+## List and remove
+
+```console
+$ rove machine list
+narwhal  narwhal  Nahuels-Mac-mini.local
+
+$ rove machine remove narwhal
+rove machine: removed narwhal. Nothing on that machine was changed — its daemon, tasks and worktrees are untouched.
+```
+
+Registering one machine under two aliases is recognized and reported: Rove
+compares the remote daemon's hostname, state root and pid, and renders one row
+either way.
+
+## What this release does not do yet
+
+This is the first of three. Today machines are **read-only**:
+
+- Opening a remote task's session is not wired up yet — you can see it, not
+  enter it.
+- `rove api` verbs aimed at a remote task refuse with
+  `NOT_YET_SUPPORTED_REMOTE` rather than quietly running against your local
+  daemon, where that task id does not exist. Run the command on that machine
+  instead.
+- The file tree and diff panes show `on <host>` for a remote task. Its worktree
+  path means nothing on your filesystem, and reading it would list whatever
+  happens to sit at the same path here.
+
+Windows can register and list machines, but cannot open the tunnel: OpenSSH on
+Windows has no unix-socket forwarding. Such a machine's row reads
+`unsupported`.
+
+## Where things live
+
+| Path | What |
+| --- | --- |
+| `state.json` → `machines` | The registry: host, user, port, auth, learned identity |
+| `<home>/.rove/machines/<alias>/daemon.sock` | Local end of the forwarded daemon socket |
+| `<home>/.rove/machines/<alias>/pty.sock` | Local end of the forwarded PTY-host socket |
+| `<home>/.rove/machines/<alias>/cm` | The shared SSH connection (ControlMaster) |
+
+The directory is owner-only (`0700`); so are the sockets in it. They reach a
+daemon that runs commands as its owner.
+
+## Not the same as `rove add --remote`
+
+`rove add --remote` registers a remote *project* and drives git and the engine
+over SSH from **your** daemon — it assumes the far side has no Rove. Machines
+assume the far side runs Rove and speaks the daemon protocol. Both still exist;
+they answer different questions.

--- a/docs/MACHINES.md
+++ b/docs/MACHINES.md
@@ -18,6 +18,13 @@ Nothing else. Rove opens no ports and adds no authentication of its own: the
 remote daemon keeps listening on its private unix socket, and SSH forwards that
 socket to yours. SSH *is* the transport and the authentication.
 
+Both machines need a Rove new enough to have machines — an older one reports no
+PTY socket in `rove daemon status`, and `machine add` says so rather than
+half-connecting.
+
+While a machine's rows are on screen, Rove counts as one attached window on
+that machine, so its daemon stays up for as long as you are looking at it.
+
 ## Add a machine
 
 ```console
@@ -33,7 +40,8 @@ Rove never guesses a remote socket path — the remote home may be a different
 user, and the path may have been shortened to fit the platform's socket-name
 limit.
 
-The alias defaults to the machine's own hostname. Give it a shorter one:
+The alias defaults to the machine's own hostname, and it is what the sidebar
+shows — so give it a short one when the hostname isn't:
 
 ```console
 $ rove machine add narwhal --alias narwhal
@@ -65,7 +73,9 @@ narwhal · v0.9.185            ← a machine
 
 - **Two machines, one repo name.** A repo called `kobe` on both machines shows
   as `kobe` here and `narwhal:kobe` there. The local one keeps the bare name —
-  it is the one you are sitting at.
+  it is the one you are sitting at. Two checkouts of `kobe` on the *same*
+  machine take the path instead (`gihub/kobe`, `i/kobe`): there the machine
+  name would say nothing.
 - **Offline machines keep their rows.** A laptop whose lid closed has not
   stopped having those tasks, so the row stays and greys out instead of
   vanishing. Rove reconnects in the background and the rows come back to life.
@@ -114,6 +124,11 @@ Windows has no unix-socket forwarding. Such a machine's row reads
 | `<home>/.rove/machines/<alias>/daemon.sock` | Local end of the forwarded daemon socket |
 | `<home>/.rove/machines/<alias>/pty.sock` | Local end of the forwarded PTY-host socket |
 | `<home>/.rove/machines/<alias>/cm` | The shared SSH connection (ControlMaster) |
+
+Under a deeply-nested home these move to a short `$TMPDIR/rove-m-…` directory:
+a unix socket path cannot exceed ~104 bytes, and `<home>/.rove/machines/…`
+overruns that before it starts. The fallback is derived from the home and the
+alias, so it is the same path every time.
 
 The directory is owner-only (`0700`); so are the sockets in it. They reach a
 daemon that runs commands as its owner.

--- a/packages/kobe-daemon/src/daemon/handlers.ts
+++ b/packages/kobe-daemon/src/daemon/handlers.ts
@@ -28,6 +28,7 @@
  * `packages/kobe/test/daemon/handlers.test.ts`).
  */
 
+import { hostname } from "node:os"
 import type { DaemonRpcClient } from "../client/rpc.ts"
 import type { DaemonActivityRegistry } from "./activity-registry.ts"
 import type { AgentTurnsStore } from "./agent-turns-store.ts"
@@ -50,6 +51,7 @@ import { WORK_ITEM_HANDLERS } from "./handlers-work-items.ts"
 import { WORKTREE_HANDLERS } from "./handlers-worktree.ts"
 import type { IssuesStore } from "./issues-store.ts"
 import type { NotesStore } from "./notes-store.ts"
+import { defaultPtyHostSocketPath } from "./paths.ts"
 import {
   CHANNEL_NAMES,
   DAEMON_PROTOCOL_VERSION,
@@ -269,6 +271,12 @@ export function createDaemonHandlerRegistry(): ReadonlyMap<DaemonRequestName, Da
           // inherited the production socket path) and must reject the list
           // instead of rendering an empty sidebar — protocol.isForeignDaemonHome.
           homeDir: ctx.daemon.homeDir,
+          // The host this daemon runs on. A client reaching it through an SSH
+          // tunnel sees only a local socket path, so this is the only thing
+          // that says WHICH machine answered — and, with `homeDir` +
+          // `daemonPid` above, the triple that recognizes two machine aliases
+          // as one machine (`machines/registry.ts` duplicateAliasOf).
+          hostname: hostname(),
           tasks: ctx.orch.listTasks().map(serializeTask),
         }
       },
@@ -298,6 +306,13 @@ export function createDaemonHandlerRegistry(): ReadonlyMap<DaemonRequestName, Da
           // which otherwise reads as "my tasks vanished".
           homeDir: ctx.daemon.homeDir,
           socketPath: ctx.daemon.socketPath,
+          // The PTY host's socket, and this daemon's host. `rove machine add`
+          // reads both over SSH (`rove daemon status --json`) so the local side
+          // never has to GUESS a remote socket path — the remote home may be a
+          // different user, and `fitSocketPath` can shorten either path to fit
+          // the platform's sun_path limit, so neither is derivable from here.
+          ptySocketPath: defaultPtyHostSocketPath(ctx.daemon.homeDir),
+          hostname: hostname(),
         }
       },
     },

--- a/packages/kobe-daemon/src/daemon/protocol.ts
+++ b/packages/kobe-daemon/src/daemon/protocol.ts
@@ -392,6 +392,13 @@ export interface SerializedTask {
   /** The worker's own outcome claim (`set-status --report-*`) — a CLAIM,
    *  where `prStatus` is the daemon's own observation of the forge. */
   readonly report?: DaemonTask["report"]
+  /**
+   * Which machine served this task. NEVER set by a daemon — the merging
+   * client stamps it after deserializing, and `rove api list` passes it
+   * through. Declared here so the CLI's wire type and the client's `Task`
+   * agree on the field rather than each widening the other with a cast.
+   */
+  readonly origin?: { readonly machineId: string; readonly hostLabel: string }
   readonly createdAt: string
   readonly updatedAt: string
 }

--- a/packages/kobe-docs/scripts/sync-docs.mjs
+++ b/packages/kobe-docs/scripts/sync-docs.mjs
@@ -93,6 +93,7 @@ const MODULES = [
           ["CONFIGURATION.md", "rove/configuration"],
           ["ENGINES.md", "rove/engines"],
           ["WORKTREES.md", "rove/worktrees"],
+          ["MACHINES.md", "rove/machines"],
           ["themes.md", "rove/themes"],
           ["SESSIONS.md", "rove/sessions"],
         ],

--- a/packages/kobe/src/cli/api-cmd.ts
+++ b/packages/kobe/src/cli/api-cmd.ts
@@ -242,6 +242,12 @@ export async function runApiSubcommand(argv: readonly string[]): Promise<void> {
   }
 
   try {
+    // A `--task-id` naming a task on ANOTHER machine must be refused here, not
+    // forwarded: the local daemon has never heard of that id, so every verb
+    // would answer TASK_NOT_FOUND for a task the user can see in the sidebar.
+    // Costs nothing — and opens no socket — when no machine is registered.
+    const { assertLocalTask } = await import("../machines/api-merge.ts")
+    await assertLocalTask(parsed.flags.get("task-id"))
     const result = await verb.handler(makeContext(verb, parsed.flags, session?.client ?? null, defaultApiRuntime))
     emit(result, parsed.pretty)
   } catch (err) {

--- a/packages/kobe/src/cli/api/handlers-tasks.ts
+++ b/packages/kobe/src/cli/api/handlers-tasks.ts
@@ -319,7 +319,12 @@ export async function getTask(ctx: VerbContext): Promise<unknown> {
 }
 
 export async function list(ctx: VerbContext): Promise<unknown> {
-  return daemonOf(ctx).request<{ tasks: SerializedTask[] }>("task.list")
+  const local = await daemonOf(ctx).request<{ tasks: SerializedTask[] }>("task.list")
+  // With no machine registered this hands back the daemon's own response
+  // object untouched, so the single-machine payload is byte-identical to what
+  // it was before machines existed.
+  const { mergeTaskList } = await import("../../machines/api-merge.ts")
+  return await mergeTaskList(local)
 }
 
 export async function setActive(ctx: VerbContext): Promise<unknown> {

--- a/packages/kobe/src/cli/index-commands.ts
+++ b/packages/kobe/src/cli/index-commands.ts
@@ -71,6 +71,13 @@ export const DYNAMIC_COMMANDS = new Map<string, CommandHandler>([
     },
   ],
   [
+    "machine",
+    async (args) => {
+      const { runMachineSubcommand } = await import("./machine-cmd.ts")
+      await runMachineSubcommand(args)
+    },
+  ],
+  [
     "doctor",
     async (args) => {
       const { runDoctorSubcommand } = await import("./doctor-cmd.ts")

--- a/packages/kobe/src/cli/machine-cmd.ts
+++ b/packages/kobe/src/cli/machine-cmd.ts
@@ -1,0 +1,206 @@
+/**
+ * `rove machine <add|remove|list>` — register the other computers running Rove.
+ *
+ * A machine is reached by forwarding its daemon's unix socket over SSH; nothing
+ * here opens a port and nothing here invents an auth scheme. That means `add`
+ * has exactly two jobs: remember how to `ssh` there, and ask that machine where
+ * its daemon listens (`machines/discover.ts` — Rove never guesses a remote
+ * socket path).
+ *
+ * `add` VERIFIES before it saves. A registration that silently fails at first
+ * connect is worse than a refusal: the machine sits in the sidebar as an
+ * offline row and nothing says whether the host, the install or the daemon is
+ * the problem. So the discovery probe runs first and its failure is the
+ * command's failure, with the specific remedy in the message.
+ */
+
+import { discoverMachine } from "../machines/discover.ts"
+import {
+  type MachineConfig,
+  addMachine,
+  duplicateAliasOf,
+  getMachine,
+  isValidMachineAlias,
+  listMachines,
+  parseSshTarget,
+  removeMachine,
+  setMachineIdentity,
+  sshTargetOf,
+} from "../machines/registry.ts"
+import { readMachines } from "../machines/registry.ts"
+import { machineSocketDir } from "../machines/ssh-args.ts"
+import { loadStateFile } from "../state/store.ts"
+import { activeCliName } from "./rename-compat.ts"
+
+const CLI_NAME = activeCliName()
+
+const MACHINE_USAGE = [
+  `Usage: ${CLI_NAME} machine <add|remove|list> [options]`,
+  "",
+  "Manage the other computers running Rove. Each one is reached over SSH;",
+  "its tasks appear in the sidebar under a row of its own.",
+  "",
+  "Commands:",
+  "  add <ssh-target>        Register a machine (verifies it before saving)",
+  "  remove <alias>          Forget a machine (nothing on it is touched)",
+  "  list                    Show registered machines",
+  "",
+  "Add options:",
+  "  --alias <name>          Local name for the machine (default: its hostname)",
+  "  --port <n>              SSH port (default: whatever ssh_config says)",
+  "  --identity <file>       SSH private key (default: ssh-agent / ssh_config)",
+  "",
+  "  <ssh-target> is [user@]host[:port] — usually just an ssh_config Host alias.",
+  "  The machine must already have Rove installed (`npm i -g @sma1lboy/rove`).",
+  "",
+].join("\n")
+
+function usageError(message: string): never {
+  process.stderr.write(`${CLI_NAME} machine: ${message}\n\n${MACHINE_USAGE}\n`)
+  process.exit(2)
+}
+
+function fail(message: string): never {
+  process.stderr.write(`${CLI_NAME} machine: ${message}\n`)
+  process.exit(1)
+}
+
+/** `--name value` and `--name=value` both. Missing a value is a usage error,
+ *  not a silently-absent flag. */
+function flagValue(argv: readonly string[], name: string): string | undefined {
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i]
+    if (arg === undefined) continue
+    if (arg.startsWith(`--${name}=`)) return arg.slice(name.length + 3)
+    if (arg !== `--${name}`) continue
+    const value = argv[i + 1]
+    if (value === undefined || value.startsWith("--")) usageError(`--${name} needs a value`)
+    return value
+  }
+  return undefined
+}
+
+export async function runMachineSubcommand(argv: readonly string[]): Promise<void> {
+  const [verb, ...rest] = argv
+  if (!verb || verb === "--help" || verb === "-h" || verb === "help") {
+    process.stdout.write(`${MACHINE_USAGE}\n`)
+    return
+  }
+  if (verb === "list") return list()
+  if (verb === "add") return await add(rest)
+  if (verb === "remove") return remove(rest)
+  usageError(`unknown verb "${verb}"`)
+}
+
+async function add(argv: readonly string[]): Promise<void> {
+  const target = positionalOf(argv)
+  if (!target) usageError("add needs an ssh target, e.g. `machine add narwhal`")
+  const parsed = parseSshTarget(target)
+  if (!parsed) usageError(`"${target}" is not a valid ssh target ([user@]host[:port])`)
+  const portFlag = flagValue(argv, "port")
+  const port = portFlag ? Number(portFlag) : parsed.port
+  if (port !== undefined && (!Number.isInteger(port) || port < 1 || port > 65535)) usageError("--port must be 1-65535")
+  const identity = flagValue(argv, "identity")
+
+  // The alias defaults to the machine's own hostname, which is only knowable
+  // AFTER the probe — so probe under a provisional alias (the target text),
+  // then rename. The provisional alias only names a ControlMaster socket.
+  const requested = flagValue(argv, "alias")
+  if (requested && !isValidMachineAlias(requested)) {
+    usageError(`--alias must be letters/digits/._- and cannot be "local" (got "${requested}")`)
+  }
+  const probeAlias = requested ?? sanitizeAlias(parsed.host)
+  const config: MachineConfig = {
+    host: parsed.host,
+    ...(parsed.user ? { user: parsed.user } : {}),
+    ...(port ? { port } : {}),
+    auth: identity ? { kind: "key", keyPath: identity } : { kind: "key" },
+  }
+
+  process.stderr.write(`${CLI_NAME} machine: contacting ${sshTargetOf(config)}…\n`)
+  const found = await discoverMachine(probeAlias, config)
+  if (!found.ok) fail(found.message)
+
+  const alias = requested ?? sanitizeAlias(found.status.hostname || parsed.host)
+  if (!isValidMachineAlias(alias))
+    fail(`could not derive a usable alias from "${found.status.hostname}" — pass --alias`)
+
+  const identityTriple = {
+    hostname: found.status.hostname,
+    homeDir: found.status.homeDir,
+    daemonPid: found.status.daemonPid,
+  }
+  const duplicate = duplicateAliasOf(readMachines(loadStateFile()), alias, identityTriple)
+
+  addMachine(alias, { ...config, identity: identityTriple })
+  setMachineIdentity(alias, identityTriple)
+
+  process.stdout.write(
+    `${CLI_NAME} machine: ${alias} → ${sshTargetOf(config)} (rove ${found.status.kobeVersion || "?"} on ${found.status.hostname || "?"})\n`,
+  )
+  if (duplicate) {
+    // Not an error: two names for one machine is a reasonable thing to do by
+    // accident, and the fix (pick one) is the user's. The sidebar renders one
+    // row either way — see `MachineHub.republishTasks`.
+    process.stdout.write(
+      `${CLI_NAME} machine: ${alias} is the same machine as ${duplicate} (hostname/homeDir/pid match) — the sidebar shows one row\n`,
+    )
+  }
+}
+
+function remove(argv: readonly string[]): void {
+  const alias = argv[0]
+  if (!alias) usageError("remove needs an alias, e.g. `machine remove narwhal`")
+  if (!getMachine(alias)) fail(`no machine named "${alias}" (see \`${CLI_NAME} machine list\`)`)
+  removeMachine(alias)
+  process.stdout.write(
+    `${CLI_NAME} machine: removed ${alias}. Nothing on that machine was changed — its daemon, tasks and worktrees are untouched.\n`,
+  )
+  process.stdout.write(`${CLI_NAME} machine: leftover sockets live in ${machineSocketDir(alias)}\n`)
+}
+
+function list(): void {
+  const machines = listMachines()
+  if (machines.length === 0) {
+    process.stdout.write(`No machines registered. Add one with \`${CLI_NAME} machine add <ssh-target>\`.\n`)
+    return
+  }
+  const all = readMachines(loadStateFile())
+  const rows = machines.map((entry) => {
+    const duplicate = entry.identity ? duplicateAliasOf(all, entry.alias, entry.identity) : null
+    return [
+      entry.alias,
+      sshTargetOf(entry),
+      entry.identity?.hostname ?? "—",
+      duplicate ? `same machine as ${duplicate}` : "",
+    ]
+  })
+  const widths = [0, 1, 2].map((i) => Math.max(...rows.map((row) => (row[i] ?? "").length), 0))
+  for (const row of rows) {
+    const line = [0, 1, 2].map((i) => (row[i] ?? "").padEnd(widths[i] ?? 0)).join("  ")
+    process.stdout.write(`${line}${row[3] ? `  ${row[3]}` : ""}\n`.replace(/\s+$/, "\n"))
+  }
+}
+
+/** The first argument that is neither a `--flag` nor a flag's value. Every
+ *  flag this command takes carries one, so skipping in pairs is exact. */
+function positionalOf(argv: readonly string[]): string | undefined {
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i]
+    if (arg === undefined) continue
+    if (arg.startsWith("--")) {
+      // `--flag=value` carries its value; `--flag value` eats the next token.
+      if (!arg.includes("=")) i++
+      continue
+    }
+    return arg
+  }
+  return undefined
+}
+
+/** An ssh target or hostname as a filesystem-safe alias: `Nahuels-Mac-mini.local`
+ *  keeps its dots and dashes, anything else collapses to `-`. */
+function sanitizeAlias(raw: string): string {
+  const base = raw.split(".")[0] ?? raw
+  return base.replace(/[^A-Za-z0-9._-]/g, "-").slice(0, 64)
+}

--- a/packages/kobe/src/cli/machine-cmd.ts
+++ b/packages/kobe/src/cli/machine-cmd.ts
@@ -132,12 +132,28 @@ async function add(argv: readonly string[]): Promise<void> {
   }
   const duplicate = duplicateAliasOf(readMachines(loadStateFile()), alias, identityTriple)
 
-  addMachine(alias, { ...config, identity: identityTriple })
+  const sockets = { daemon: found.status.socketPath, pty: found.status.ptySocketPath }
+  addMachine(alias, { ...config, identity: identityTriple, sockets })
   setMachineIdentity(alias, identityTriple)
+  // Bring the forward up now, on the connection the probe just opened. Without
+  // it the machine is registered but unreachable until a TUI starts one, and
+  // `rove machine list` would report a machine `rove api list` cannot see.
+  const { ensureForwards } = await import("../machines/tunnel.ts")
+  const up = await ensureForwards({
+    alias,
+    config,
+    remoteDaemonSocket: sockets.daemon,
+    remotePtySocket: sockets.pty,
+  })
 
   process.stdout.write(
     `${CLI_NAME} machine: ${alias} → ${sshTargetOf(config)} (rove ${found.status.kobeVersion || "?"} on ${found.status.hostname || "?"})\n`,
   )
+  if (!up) {
+    process.stderr.write(
+      `${CLI_NAME} machine: registered, but could not forward ${alias}'s socket yet — it will show as offline until the connection comes up\n`,
+    )
+  }
   if (duplicate) {
     // Not an error: two names for one machine is a reasonable thing to do by
     // accident, and the fix (pick one) is the user's. The sidebar renders one

--- a/packages/kobe/src/cli/machine-cmd.ts
+++ b/packages/kobe/src/cli/machine-cmd.ts
@@ -18,12 +18,14 @@ import { discoverMachine } from "../machines/discover.ts"
 import {
   type MachineConfig,
   addMachine,
+  defaultMachineAlias,
   duplicateAliasOf,
   getMachine,
   isValidMachineAlias,
   listMachines,
   parseSshTarget,
   removeMachine,
+  sanitizeAlias,
   setMachineIdentity,
   sshTargetOf,
 } from "../machines/registry.ts"
@@ -46,7 +48,7 @@ const MACHINE_USAGE = [
   "  list                    Show registered machines",
   "",
   "Add options:",
-  "  --alias <name>          Local name for the machine (default: its hostname)",
+  "  --alias <name>          Local name for the machine (default: the target you typed)",
   "  --port <n>              SSH port (default: whatever ssh_config says)",
   "  --identity <file>       SSH private key (default: ssh-agent / ssh_config)",
   "",
@@ -102,9 +104,10 @@ async function add(argv: readonly string[]): Promise<void> {
   if (port !== undefined && (!Number.isInteger(port) || port < 1 || port > 65535)) usageError("--port must be 1-65535")
   const identity = flagValue(argv, "identity")
 
-  // The alias defaults to the machine's own hostname, which is only knowable
-  // AFTER the probe — so probe under a provisional alias (the target text),
-  // then rename. The provisional alias only names a ControlMaster socket.
+  // The default alias may depend on the machine's own hostname, which is only
+  // knowable AFTER the probe — so probe under a provisional alias derived from
+  // the target text, then settle. The provisional alias only names a
+  // ControlMaster socket.
   const requested = flagValue(argv, "alias")
   if (requested && !isValidMachineAlias(requested)) {
     usageError(`--alias must be letters/digits/._- and cannot be "local" (got "${requested}")`)
@@ -121,7 +124,14 @@ async function add(argv: readonly string[]): Promise<void> {
   const found = await discoverMachine(probeAlias, config)
   if (!found.ok) fail(found.message)
 
-  const alias = requested ?? sanitizeAlias(found.status.hostname || parsed.host)
+  const alias =
+    requested ??
+    defaultMachineAlias({
+      typedHost: parsed.host,
+      typedUser: parsed.user,
+      port,
+      remoteHostname: found.status.hostname,
+    })
   if (!isValidMachineAlias(alias))
     fail(`could not derive a usable alias from "${found.status.hostname}" — pass --alias`)
 
@@ -212,11 +222,4 @@ function positionalOf(argv: readonly string[]): string | undefined {
     return arg
   }
   return undefined
-}
-
-/** An ssh target or hostname as a filesystem-safe alias: `Nahuels-Mac-mini.local`
- *  keeps its dots and dashes, anything else collapses to `-`. */
-function sanitizeAlias(raw: string): string {
-  const base = raw.split(".")[0] ?? raw
-  return base.replace(/[^A-Za-z0-9._-]/g, "-").slice(0, 64)
 }

--- a/packages/kobe/src/cli/subcommands.ts
+++ b/packages/kobe/src/cli/subcommands.ts
@@ -19,6 +19,7 @@ export const TOP_LEVEL_SUBCOMMANDS = [
   "repo",
   "api",
   "daemon",
+  "machine",
   "doctor",
   "config",
   "reset",
@@ -48,10 +49,11 @@ export const TOP_LEVEL_SUBCOMMANDS = [
  * Canonical spellings only. Aliases (`theme ls`/`rm`) stay in their command
  * module — completing both spellings is noise.
  */
-export type VerbedSubcommand = "daemon" | "plugin" | "repo" | "skill" | "theme"
+export type VerbedSubcommand = "daemon" | "machine" | "plugin" | "repo" | "skill" | "theme"
 
 export const SUBCOMMAND_VERBS: Readonly<Record<VerbedSubcommand, readonly string[]>> = {
   daemon: ["status", "start", "stop", "restart"],
+  machine: ["add", "remove", "list"],
   plugin: [
     "install",
     "link",

--- a/packages/kobe/src/cli/usage.ts
+++ b/packages/kobe/src/cli/usage.ts
@@ -29,6 +29,7 @@ export function topLevelUsage(cliName: ProductCliName = activeCliName()): string
     "  repo <verb>             Per-repo init script + first prompt (show|set|unset)",
     `  api <verb>              Scriptable RPC surface for agents (see \`${cliName} api --help\`)`,
     "  daemon <verb>           Manage the daemon (start|stop|status|restart)",
+    "  machine <verb>          Other computers running Rove (add|remove|list)",
     "  doctor [--report|--fix] Diagnose daemon/PTY/engines/git; --fix walks the remedies",
     `  config [--path]         Open ${cliName}'s config file (state.json) in your editor`,
     "  reset [--hard]          Stop runtimes; optionally wipe task/UI state",

--- a/packages/kobe/src/client/remote-orchestrator-connect.ts
+++ b/packages/kobe/src/client/remote-orchestrator-connect.ts
@@ -30,6 +30,21 @@ export interface PerformInitOptions {
   readonly channels?: readonly ChannelName[]
   /** `false` when a channel filter excludes `task.snapshot` — skip hello task hydration. */
   readonly subscribesTasks: boolean
+  /**
+   * True for a MACHINE connection (a remote daemon reached through an SSH
+   * tunnel). A different `homeDir` is then the expected answer, not the
+   * sandbox-squatting-the-socket accident the guard exists to catch — see the
+   * guard site below. Absent/false keeps the local behaviour byte-for-byte.
+   */
+  readonly expectForeignHome?: boolean
+  /** Called with the peer's identity once the handshake succeeds — how a
+   *  machine learns which host actually answered its forwarded socket. */
+  readonly onPeerIdentity?: (peer: {
+    hostname: string
+    homeDir: string
+    daemonPid: number
+    kobeVersion: string
+  }) => void
 }
 
 /**
@@ -115,6 +130,10 @@ export async function performInit(
     // The state root the daemon serves. Omitted by a daemon that predates
     // the field, in which case the ownership check below is skipped.
     homeDir?: string
+    // The host the daemon runs on. Omitted by a daemon that predates the
+    // field; a machine falls back to its alias then.
+    hostname?: string
+    daemonPid?: number
     // The daemon's channel/feature set. The client gates the
     // `worktree.changes` consumer on it (see below) — a capability list
     // is the honest rollout mechanism for an additive channel: an old
@@ -146,8 +165,13 @@ export async function performInit(
   // task sits intact on disk. Throwing keeps the caller's
   // reconnect loop running, so the moment the real daemon reclaims the socket
   // the client re-syncs on its own.
+  // A machine's daemon serves ITS OWN home by definition, so the ownership
+  // guard is scoped to local sockets. It is not weakened for them: the failure
+  // it catches — a sandbox daemon squatting the production socket — is a
+  // local-socket accident, and a tunnel that reaches the wrong machine is
+  // caught instead by the identity triple recorded below.
   const clientHome = homeDir()
-  if (isForeignDaemonHome(hello.homeDir, clientHome)) {
+  if (!opts.expectForeignHome && isForeignDaemonHome(hello.homeDir, clientHome)) {
     throw new Error(
       `Rove daemon on this socket serves ${hello.homeDir}, but this client uses ${clientHome}. A sandbox or dev daemon has taken the production socket — stop it (\`rove daemon stop\`), or unset ROVE_DAEMON_SOCKET_PATH / KOBE_DAEMON_SOCKET_PATH before starting it.`,
     )
@@ -160,6 +184,12 @@ export async function performInit(
   // Re-set on every init so a reconnect to a freshly-restarted daemon clears
   // the banner once versions match.
   signals.setDaemonVersionSig(typeof hello.kobeVersion === "string" ? hello.kobeVersion : null)
+  opts.onPeerIdentity?.({
+    hostname: typeof hello.hostname === "string" ? hello.hostname : "",
+    homeDir: typeof hello.homeDir === "string" ? hello.homeDir : "",
+    daemonPid: typeof hello.daemonPid === "number" ? hello.daemonPid : 0,
+    kobeVersion: typeof hello.kobeVersion === "string" ? hello.kobeVersion : "",
+  })
   // A daemon that announced `reason: "restart"` on its way out has now come
   // back and re-answered `hello`, so the swap is over: clear the flag and let
   // the version comparison above be the only thing that decides whether a

--- a/packages/kobe/src/client/remote-orchestrator-payloads.ts
+++ b/packages/kobe/src/client/remote-orchestrator-payloads.ts
@@ -347,6 +347,20 @@ export type DaemonConnectionState = "online" | "disconnected"
 
 export interface RemoteOrchestratorOptions {
   /**
+   * True for a MACHINE connection: the daemon on the far end of an SSH tunnel
+   * serves its OWN home, so the foreign-home guard must not fire. Defaults to
+   * false, which keeps every local connection's behaviour unchanged.
+   */
+  readonly expectForeignHome?: boolean
+  /** Told who answered the handshake — hostname / homeDir / daemonPid, the
+   *  triple that identifies a machine (`machines/registry.ts`). */
+  readonly onPeerIdentity?: (peer: {
+    hostname: string
+    homeDir: string
+    daemonPid: number
+    kobeVersion: string
+  }) => void
+  /**
    * Bring the daemon back on the socket this client already points
    * at. Shared mode uses the stable production socket; single/owned
    * mode injects a restart function for its per-TUI socket.

--- a/packages/kobe/src/client/remote-orchestrator.ts
+++ b/packages/kobe/src/client/remote-orchestrator.ts
@@ -115,6 +115,9 @@ export class RemoteOrchestrator {
   private readonly channels?: readonly ChannelName[]
   /** True when the filter excludes `task.snapshot` — skip hello task hydration. */
   private readonly subscribesTasks: boolean
+  /** Machine connection: the far daemon's own home is expected to differ. */
+  private readonly expectForeignHome: boolean
+  private readonly onPeerIdentity: RemoteOrchestratorOptions["onPeerIdentity"]
   /** One shared retry task: repeated close events and an explicit reconnect
    *  join the same loop instead of racing two hello/subscribe handshakes. */
   private reconnectTask: Promise<void> | null = null
@@ -129,6 +132,8 @@ export class RemoteOrchestrator {
     this.role = options.role ?? "pane"
     this.channels = options.channels
     this.subscribesTasks = !options.channels || options.channels.includes("task.snapshot")
+    this.expectForeignHome = options.expectForeignHome === true
+    this.onPeerIdentity = options.onPeerIdentity
     this.signals = {
       tasksAcc: this.tasksAcc,
       setTasks: this.tasksAcc.set,
@@ -220,7 +225,13 @@ export class RemoteOrchestrator {
   async init(): Promise<void> {
     await performInit(
       this.client,
-      { role: this.role, channels: this.channels, subscribesTasks: this.subscribesTasks },
+      {
+        role: this.role,
+        channels: this.channels,
+        subscribesTasks: this.subscribesTasks,
+        expectForeignHome: this.expectForeignHome,
+        onPeerIdentity: this.onPeerIdentity,
+      },
       this.signals,
     )
   }

--- a/packages/kobe/src/machines/api-merge.ts
+++ b/packages/kobe/src/machines/api-merge.ts
@@ -1,0 +1,99 @@
+/**
+ * `rove api` across machines, PR 1: merged READS, refused writes.
+ *
+ * Two entry points, both no-ops when no machine is registered — which is the
+ * regression guard the whole feature is built around. `mergeTaskList` hands
+ * back the daemon's own response OBJECT when there is nothing to merge, so
+ * `rove api list` on a single-machine install prints the bytes it always did.
+ *
+ * Reaching a machine from the CLI means dialing the forwarded socket that a
+ * TUI's {@link import("./hub").MachineHub} keeps alive. A CLI process does not
+ * start tunnels of its own: it is short-lived, and spawning an ssh master per
+ * `rove api list` would be a connection storm. So a machine whose socket is
+ * not there right now is simply reported as offline — the same thing the
+ * sidebar says.
+ */
+
+import { KobeDaemonClient } from "@sma1lboy/kobe-daemon/client"
+import type { SerializedTask } from "@sma1lboy/kobe-daemon/daemon/protocol"
+import { ApiError } from "../cli/api/types.ts"
+import { listMachines } from "./registry.ts"
+import { localDaemonSocketPath } from "./ssh-args.ts"
+
+/**
+ * Refusal for a verb aimed at a task on another machine.
+ *
+ * An {@link ApiError} so it travels in the same `{error:{message,code,…}}`
+ * envelope every other refusal uses, carrying the recovery command: the verb
+ * is not wrong, only its address is.
+ */
+export function remoteTaskUnsupported(taskId: string, machineId: string): ApiError {
+  return new ApiError(
+    `task ${taskId} lives on machine "${machineId}". Rove can list it, but acting on a remote task is not supported yet.`,
+    "NOT_YET_SUPPORTED_REMOTE",
+    {
+      taskId,
+      machineId,
+      hint: `run the command on ${machineId} itself; remote writes arrive in a later release`,
+      nextCommandArgs: ["machine", "list"],
+    },
+  )
+}
+
+async function tasksOf(socketPath: string): Promise<SerializedTask[] | null> {
+  const client = new KobeDaemonClient(socketPath)
+  try {
+    await client.request("hello", {})
+    const res = await client.request<{ tasks?: SerializedTask[] }>("task.list")
+    return res.tasks ?? []
+  } catch {
+    return null
+  } finally {
+    client.close()
+  }
+}
+
+/**
+ * Add every reachable machine's tasks to a local `task.list` response.
+ *
+ * Returns `local` UNCHANGED (same object) when no machine is registered.
+ * Otherwise every task — local ones included — carries an `origin`, so a
+ * consumer never has to read an absent field as "this one is local".
+ */
+export async function mergeTaskList(local: { tasks?: SerializedTask[] }): Promise<{ tasks: SerializedTask[] }> {
+  const machines = listMachines()
+  if (machines.length === 0) return local as { tasks: SerializedTask[] }
+  const tasks: SerializedTask[] = (local.tasks ?? []).map((task) => ({
+    ...task,
+    origin: { machineId: "local", hostLabel: "local" },
+  }))
+  for (const entry of machines) {
+    const remote = await tasksOf(localDaemonSocketPath(entry.alias))
+    if (!remote) continue
+    const hostLabel = entry.identity?.hostname || entry.alias
+    for (const task of remote) tasks.push({ ...task, origin: { machineId: entry.alias, hostLabel } })
+  }
+  return { tasks }
+}
+
+/**
+ * Refuse a verb aimed at a remote task instead of letting it land on the local
+ * daemon, where the id simply does not exist.
+ *
+ * The distinction matters: a bare `TASK_NOT_FOUND` for a task the user can SEE
+ * in the sidebar reads as data loss. Naming the machine says the task is fine
+ * and the command is early.
+ *
+ * No machines registered → returns immediately without opening a socket, so
+ * every existing verb pays nothing.
+ */
+export async function assertLocalTask(taskId: string | undefined): Promise<void> {
+  if (!taskId) return
+  const machines = listMachines()
+  if (machines.length === 0) return
+  for (const entry of machines) {
+    const remote = await tasksOf(localDaemonSocketPath(entry.alias))
+    if (!remote) continue
+    if (remote.some((task) => task.id === taskId)) throw remoteTaskUnsupported(taskId, entry.alias)
+  }
+}

--- a/packages/kobe/src/machines/api-merge.ts
+++ b/packages/kobe/src/machines/api-merge.ts
@@ -17,7 +17,7 @@
 import { KobeDaemonClient } from "@sma1lboy/kobe-daemon/client"
 import type { SerializedTask } from "@sma1lboy/kobe-daemon/daemon/protocol"
 import { ApiError } from "../cli/api/types.ts"
-import { type MachineEntry, listMachines } from "./registry.ts"
+import { type MachineEntry, dedupeMachines, listMachines } from "./registry.ts"
 import { localDaemonSocketPath } from "./ssh-args.ts"
 import { ensureForwards } from "./tunnel.ts"
 
@@ -85,7 +85,10 @@ async function tasksOf(socketPath: string): Promise<SerializedTask[] | null> {
  * consumer never has to read an absent field as "this one is local".
  */
 export async function mergeTaskList(local: { tasks?: SerializedTask[] }): Promise<{ tasks: SerializedTask[] }> {
-  const machines = listMachines()
+  // Two aliases for one machine list its tasks ONCE — the same rule the
+  // sidebar renders by, so the two surfaces can never disagree about how many
+  // machines there are.
+  const machines = dedupeMachines(listMachines())
   if (machines.length === 0) return local as { tasks: SerializedTask[] }
   const tasks: SerializedTask[] = (local.tasks ?? []).map((task) => ({
     ...task,
@@ -113,7 +116,7 @@ export async function mergeTaskList(local: { tasks?: SerializedTask[] }): Promis
  */
 export async function assertLocalTask(taskId: string | undefined): Promise<void> {
   if (!taskId) return
-  const machines = listMachines()
+  const machines = dedupeMachines(listMachines())
   if (machines.length === 0) return
   for (const entry of machines) {
     const remote = await machineTasks(entry)

--- a/packages/kobe/src/machines/api-merge.ts
+++ b/packages/kobe/src/machines/api-merge.ts
@@ -17,8 +17,9 @@
 import { KobeDaemonClient } from "@sma1lboy/kobe-daemon/client"
 import type { SerializedTask } from "@sma1lboy/kobe-daemon/daemon/protocol"
 import { ApiError } from "../cli/api/types.ts"
-import { listMachines } from "./registry.ts"
+import { type MachineEntry, listMachines } from "./registry.ts"
 import { localDaemonSocketPath } from "./ssh-args.ts"
+import { ensureForwards } from "./tunnel.ts"
 
 /**
  * Refusal for a verb aimed at a task on another machine.
@@ -38,6 +39,29 @@ export function remoteTaskUnsupported(taskId: string, machineId: string): ApiErr
       nextCommandArgs: ["machine", "list"],
     },
   )
+}
+
+/**
+ * A machine's tasks, opening its forwarded socket first if nothing is
+ * listening there yet.
+ *
+ * The forward rides the shared ssh connection (`ensureForwards`), so the first
+ * CLI call after a quiet period pays one connect and the next few minutes of
+ * calls find it already up. A machine that cannot be reached answers null —
+ * the caller reports it as offline rather than failing the whole command.
+ */
+async function machineTasks(entry: MachineEntry): Promise<SerializedTask[] | null> {
+  const socketPath = localDaemonSocketPath(entry.alias)
+  const direct = await tasksOf(socketPath)
+  if (direct) return direct
+  if (!entry.sockets) return null
+  const up = await ensureForwards({
+    alias: entry.alias,
+    config: entry,
+    remoteDaemonSocket: entry.sockets.daemon,
+    remotePtySocket: entry.sockets.pty,
+  })
+  return up ? await tasksOf(socketPath) : null
 }
 
 async function tasksOf(socketPath: string): Promise<SerializedTask[] | null> {
@@ -68,7 +92,7 @@ export async function mergeTaskList(local: { tasks?: SerializedTask[] }): Promis
     origin: { machineId: "local", hostLabel: "local" },
   }))
   for (const entry of machines) {
-    const remote = await tasksOf(localDaemonSocketPath(entry.alias))
+    const remote = await machineTasks(entry)
     if (!remote) continue
     const hostLabel = entry.identity?.hostname || entry.alias
     for (const task of remote) tasks.push({ ...task, origin: { machineId: entry.alias, hostLabel } })
@@ -92,7 +116,7 @@ export async function assertLocalTask(taskId: string | undefined): Promise<void>
   const machines = listMachines()
   if (machines.length === 0) return
   for (const entry of machines) {
-    const remote = await tasksOf(localDaemonSocketPath(entry.alias))
+    const remote = await machineTasks(entry)
     if (!remote) continue
     if (remote.some((task) => task.id === taskId)) throw remoteTaskUnsupported(taskId, entry.alias)
   }

--- a/packages/kobe/src/machines/api-merge.ts
+++ b/packages/kobe/src/machines/api-merge.ts
@@ -97,7 +97,8 @@ export async function mergeTaskList(local: { tasks?: SerializedTask[] }): Promis
   for (const entry of machines) {
     const remote = await machineTasks(entry)
     if (!remote) continue
-    const hostLabel = entry.identity?.hostname || entry.alias
+    // The alias, not the hostname — see `MachineStatus.hostLabel`.
+    const hostLabel = entry.alias
     for (const task of remote) tasks.push({ ...task, origin: { machineId: entry.alias, hostLabel } })
   }
   return { tasks }

--- a/packages/kobe/src/machines/discover.ts
+++ b/packages/kobe/src/machines/discover.ts
@@ -1,0 +1,143 @@
+/**
+ * Ask a machine where its daemon listens.
+ *
+ * `ssh <target> 'rove daemon status --json'` — and, when nothing is running
+ * there, `rove daemon start` first. The answer carries the remote socket paths
+ * verbatim, which is the whole point: the remote home may belong to a
+ * different user, and `fitSocketPath` may have SHORTENED either path to fit
+ * the platform's `sun_path` limit, so a path derived locally would be wrong in
+ * two independent ways. Rove never guesses a remote socket path.
+ */
+
+import { spawn } from "node:child_process"
+import type { MachineConfig } from "./registry.ts"
+import { machineSshArgs } from "./ssh-args.ts"
+
+export interface RemoteDaemonStatus {
+  readonly socketPath: string
+  readonly ptySocketPath: string
+  readonly homeDir: string
+  readonly hostname: string
+  readonly kobeVersion: string
+  readonly daemonPid: number
+}
+
+export interface DiscoverResult {
+  readonly ok: true
+  readonly status: RemoteDaemonStatus
+}
+export interface DiscoverFailure {
+  readonly ok: false
+  readonly code: "SSH_FAILED" | "NO_ROVE" | "NO_DAEMON" | "BAD_STATUS"
+  readonly message: string
+}
+
+/** Run one command on the machine. Never throws; a spawn failure is exit -1. */
+export async function runOnMachine(
+  alias: string,
+  config: MachineConfig,
+  command: string,
+  opts: { readonly home?: string; readonly timeoutMs?: number } = {},
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  const argv = [...machineSshArgs(alias, config, { home: opts.home }), command]
+  return await new Promise((resolve) => {
+    let stdout = ""
+    let stderr = ""
+    let settled = false
+    const done = (exitCode: number): void => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
+      resolve({ stdout, stderr, exitCode })
+    }
+    const child = spawn(argv[0] ?? "ssh", argv.slice(1), { stdio: ["ignore", "pipe", "pipe"] })
+    const timer = setTimeout(() => {
+      child.kill("SIGKILL")
+      stderr += "\ntimed out"
+      done(-1)
+    }, opts.timeoutMs ?? 30_000)
+    child.stdout?.on("data", (c: Buffer) => {
+      stdout += c.toString()
+    })
+    child.stderr?.on("data", (c: Buffer) => {
+      stderr += c.toString()
+    })
+    child.on("error", () => done(-1))
+    child.on("close", (code) => done(code ?? -1))
+  })
+}
+
+/**
+ * `rove daemon status --json`, starting the remote daemon once if none is up.
+ *
+ * Starting it is not overreach: a machine the user just registered is a
+ * machine they want to see, and the remote daemon idle-stops on its own once
+ * nothing is attached. Failure is classified rather than thrown so `machine
+ * add` can say WHICH of the three things went wrong — unreachable host, Rove
+ * not installed, daemon refused to start.
+ */
+export async function discoverMachine(
+  alias: string,
+  config: MachineConfig,
+  opts: { readonly home?: string } = {},
+): Promise<DiscoverResult | DiscoverFailure> {
+  const first = await runOnMachine(alias, config, "rove daemon status --json", opts)
+  const parsed = parseStatusJson(first.stdout)
+  if (parsed) return { ok: true, status: parsed }
+  const combined = `${first.stdout}\n${first.stderr}`.trim()
+  if (/command not found|not found: rove|No such file or directory/i.test(combined) && /rove/i.test(combined)) {
+    return {
+      ok: false,
+      code: "NO_ROVE",
+      message: `Rove is not installed on ${alias} (or not on the non-interactive PATH). Install it there with \`npm i -g @sma1lboy/rove\`, then re-run.`,
+    }
+  }
+  if (first.exitCode === 255 || first.exitCode === -1) {
+    return { ok: false, code: "SSH_FAILED", message: `ssh to ${alias} failed: ${combined || "no output"}` }
+  }
+  // No daemon over there yet — start one and ask again.
+  const started = await runOnMachine(alias, config, "rove daemon start", { ...opts, timeoutMs: 60_000 })
+  const second = await runOnMachine(alias, config, "rove daemon status --json", opts)
+  const retry = parseStatusJson(second.stdout)
+  if (retry) return { ok: true, status: retry }
+  return {
+    ok: false,
+    code: started.exitCode === 0 ? "BAD_STATUS" : "NO_DAEMON",
+    message: `could not read a daemon status from ${alias}: ${`${second.stdout}\n${second.stderr}\n${started.stderr}`.trim() || "no output"}`,
+  }
+}
+
+/**
+ * Pull the status object out of a command's stdout.
+ *
+ * Tolerant of leading noise (a login banner, an update notice) by scanning for
+ * the first `{` — a machine whose shell prints something on every
+ * non-interactive login is common enough that being strict here would read as
+ * "Rove is broken on that host". Returns null unless BOTH socket paths are
+ * present, so an older remote Rove — which reports `socketPath` but not
+ * `ptySocketPath` — is a clean "upgrade that machine" rather than a tunnel
+ * that half-forwards.
+ */
+export function parseStatusJson(stdout: string): RemoteDaemonStatus | null {
+  const at = stdout.indexOf("{")
+  if (at < 0) return null
+  let raw: unknown
+  try {
+    raw = JSON.parse(stdout.slice(at))
+  } catch {
+    return null
+  }
+  if (!raw || typeof raw !== "object") return null
+  const o = raw as Record<string, unknown>
+  const socketPath = typeof o.socketPath === "string" ? o.socketPath : ""
+  const ptySocketPath = typeof o.ptySocketPath === "string" ? o.ptySocketPath : ""
+  if (!socketPath || !ptySocketPath) return null
+  return {
+    socketPath,
+    ptySocketPath,
+    homeDir: typeof o.homeDir === "string" ? o.homeDir : "",
+    hostname: typeof o.hostname === "string" ? o.hostname : "",
+    kobeVersion: typeof o.kobeVersion === "string" ? o.kobeVersion : "",
+    daemonPid: typeof o.daemonPid === "number" ? o.daemonPid : 0,
+  }
+}

--- a/packages/kobe/src/machines/discover.ts
+++ b/packages/kobe/src/machines/discover.ts
@@ -10,8 +10,9 @@
  */
 
 import { spawn } from "node:child_process"
+import { mkdirSync } from "node:fs"
 import type { MachineConfig } from "./registry.ts"
-import { machineSshArgs } from "./ssh-args.ts"
+import { machineSocketDir, machineSshArgs } from "./ssh-args.ts"
 
 export interface RemoteDaemonStatus {
   readonly socketPath: string
@@ -39,6 +40,15 @@ export async function runOnMachine(
   command: string,
   opts: { readonly home?: string; readonly timeoutMs?: number } = {},
 ): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  // The ControlPath's directory must exist before ssh tries to bind there.
+  // Without it ssh reports `Control socket connect(...): No such file or
+  // directory` — a message that names the .rove path and reads like a missing
+  // Rove rather than a missing directory.
+  try {
+    mkdirSync(machineSocketDir(alias, opts.home), { recursive: true, mode: 0o700 })
+  } catch {
+    /* already there, or a filesystem without modes */
+  }
   const argv = [...machineSshArgs(alias, config, { home: opts.home }), command]
   return await new Promise((resolve) => {
     let stdout = ""
@@ -85,7 +95,10 @@ export async function discoverMachine(
   const parsed = parseStatusJson(first.stdout)
   if (parsed) return { ok: true, status: parsed }
   const combined = `${first.stdout}\n${first.stderr}`.trim()
-  if (/command not found|not found: rove|No such file or directory/i.test(combined) && /rove/i.test(combined)) {
+  // Match the SHELL's own "no such command" phrasings, anchored on the command
+  // name. A bare `No such file or directory` is not enough: ssh says exactly
+  // that about its own control socket, whose path contains `.rove`.
+  if (/(?:^|\W)rove:? (?:command not found|not found)|command not found:? rove/i.test(combined)) {
     return {
       ok: false,
       code: "NO_ROVE",
@@ -100,10 +113,32 @@ export async function discoverMachine(
   const second = await runOnMachine(alias, config, "rove daemon status --json", opts)
   const retry = parseStatusJson(second.stdout)
   if (retry) return { ok: true, status: retry }
+  // A remote Rove old enough to predate `ptySocketPath` answers `daemon
+  // status` perfectly and still cannot be tunnelled — say so, rather than
+  // reporting it as a daemon that would not start.
+  if (looksLikeOldStatus(second.stdout)) {
+    return {
+      ok: false,
+      code: "BAD_STATUS",
+      message: `${alias} runs a Rove too old for machines (its \`daemon status\` reports no pty socket). Upgrade it: \`ssh ${alias} npm i -g @sma1lboy/rove\`.`,
+    }
+  }
   return {
     ok: false,
     code: started.exitCode === 0 ? "BAD_STATUS" : "NO_DAEMON",
     message: `could not read a daemon status from ${alias}: ${`${second.stdout}\n${second.stderr}\n${started.stderr}`.trim() || "no output"}`,
+  }
+}
+
+/** A status payload that parses but predates `ptySocketPath`. */
+export function looksLikeOldStatus(stdout: string): boolean {
+  const at = stdout.indexOf("{")
+  if (at < 0) return false
+  try {
+    const raw = JSON.parse(stdout.slice(at)) as Record<string, unknown>
+    return typeof raw.socketPath === "string" && typeof raw.ptySocketPath !== "string"
+  } catch {
+    return false
   }
 }
 

--- a/packages/kobe/src/machines/hub-singleton.ts
+++ b/packages/kobe/src/machines/hub-singleton.ts
@@ -1,0 +1,55 @@
+/**
+ * The process's one {@link MachineHub}, and the hooks that read it.
+ *
+ * A module-level singleton, like `getDefaultPtyRegistry()`: the hub is a
+ * process-lifetime resource created during boot, and threading it as a prop
+ * would mean widening every component between the workspace root and the
+ * sidebar for something none of them use.
+ *
+ * Absent by default. Every read below answers "no machines" when nothing has
+ * been set, so a pane host, a test render and any process that never boots the
+ * workspace behave exactly as they did before machines existed.
+ */
+
+import { useSyncExternalStore } from "react"
+import type { RemoteOrchestrator } from "../client/remote-orchestrator.ts"
+import type { MachineLayerEntry } from "../tui/panes/sidebar/machine-layer.ts"
+import type { Task } from "../types/task.ts"
+import type { MachineHub } from "./hub.ts"
+
+let hub: MachineHub | null = null
+
+export function setMachineHub(next: MachineHub | null): void {
+  hub = next
+}
+
+export function machineHub(): MachineHub | null {
+  return hub
+}
+
+const NO_MACHINES: readonly MachineLayerEntry[] = []
+
+/**
+ * The task list to render: the hub's merged one when machines are registered,
+ * the orchestrator's own signal otherwise — the SAME cell, so nothing
+ * downstream can tell the hub exists.
+ */
+export function useMergedTasks(orchestrator: RemoteOrchestrator): readonly Task[] {
+  const state = hub ? hub.tasksSignal() : orchestrator.tasksSignal()
+  return useSyncExternalStore(state.subscribe, state.get, state.get)
+}
+
+/** Registered machines, for the sidebar's machine layer. */
+export function useMachineRows(): readonly MachineLayerEntry[] {
+  const state = hub?.machinesSignal()
+  const subscribe = state?.subscribe ?? noopSubscribe
+  const get = state?.get ?? emptyRows
+  return useSyncExternalStore(subscribe, get, get)
+}
+
+function noopSubscribe(): () => void {
+  return () => {}
+}
+function emptyRows(): readonly MachineLayerEntry[] {
+  return NO_MACHINES
+}

--- a/packages/kobe/src/machines/hub.ts
+++ b/packages/kobe/src/machines/hub.ts
@@ -1,0 +1,247 @@
+/**
+ * The machine hub: one `RemoteOrchestrator` per machine, one merged task list.
+ *
+ * Multiplexing, not switching. Every registered machine is connected at once
+ * and its tasks are merged into the list the sidebar renders, each stamped
+ * with a {@link TaskOrigin}. There is no "current machine" — the tree IS the
+ * answer to "what is running where".
+ *
+ * With NO machines registered, this module does nothing at all: `attach`
+ * returns early and the local orchestrator's task signal is handed back
+ * unchanged, object identity included. That is the regression guard — the
+ * zero-machine install must render and serialize byte-for-byte what it did
+ * before machines existed.
+ *
+ * PR 1 is READ-ONLY across the tunnel. Writes aimed at a remote task are
+ * refused by {@link guardRemoteTaskRequests} rather than silently landing on
+ * the local daemon, which is what would otherwise happen: the local daemon
+ * would simply not know that id.
+ */
+
+import { KobeDaemonClient } from "@sma1lboy/kobe-daemon/client"
+import { logClient, logClientError } from "@sma1lboy/kobe-daemon/client/client-log"
+import { RemoteOrchestrator } from "../client/remote-orchestrator.ts"
+import type { ReadableState } from "../lib/external-store.ts"
+import { createStateCell } from "../lib/external-store.ts"
+import { loadStateFile } from "../state/store.ts"
+import type { Task } from "../types/task.ts"
+import { discoverMachine } from "./discover.ts"
+import { type MachineEntry, duplicateAliasOf, listMachines, readMachines, setMachineIdentity } from "./registry.ts"
+import { type TunnelHandle, startTunnel } from "./tunnel.ts"
+
+/** What a machine row in the sidebar renders from. */
+export interface MachineStatus {
+  readonly alias: string
+  /** Remote hostname once known, else the alias. */
+  readonly hostLabel: string
+  readonly state: "connecting" | "online" | "offline" | "unsupported" | "mismatch"
+  /** Remote build version, once a handshake succeeded. */
+  readonly version?: string
+  /** Set when this alias turned out to be a machine already registered under
+   *  another name — the row is suppressed and `machine list` reports it. */
+  readonly duplicateOf?: string
+  /** Why the machine is not usable, for the row's tooltip / `machine list`. */
+  readonly error?: string
+}
+
+interface MachineSlot {
+  readonly entry: MachineEntry
+  tunnel?: TunnelHandle
+  orchestrator?: RemoteOrchestrator
+  unsubscribe?: () => void
+  tasks: readonly Task[]
+}
+
+export class MachineHub {
+  private readonly slots = new Map<string, MachineSlot>()
+  private readonly machinesAcc = createStateCell<readonly MachineStatus[]>([], "machines.status")
+  private readonly mergedAcc = createStateCell<Task[]>([], "machines.tasks")
+  private localUnsubscribe: (() => void) | null = null
+  private disposed = false
+
+  constructor(private readonly local: RemoteOrchestrator) {}
+
+  /** Registered machines and their live connection state. */
+  machinesSignal(): ReadableState<readonly MachineStatus[]> {
+    return this.machinesAcc
+  }
+
+  /**
+   * The task list the UI should render.
+   *
+   * Returns the LOCAL orchestrator's own signal when no machine is registered
+   * — same cell, same identity, so nothing downstream can tell this class
+   * exists. Only a real machine puts a merging cell in the path.
+   */
+  tasksSignal(): ReadableState<Task[]> {
+    if (this.slots.size === 0) return this.local.tasksSignal()
+    return this.mergedAcc
+  }
+
+  /** Task ids that live on a machine other than this one. */
+  remoteTaskIds(): ReadonlySet<string> {
+    const ids = new Set<string>()
+    for (const slot of this.slots.values()) for (const task of slot.tasks) ids.add(String(task.id))
+    return ids
+  }
+
+  /**
+   * Register every machine and start connecting.
+   *
+   * SYNCHRONOUS on purpose. The signals this returns to must be stable from
+   * the first render — `tasksSignal()` picks its cell by whether any machine
+   * exists — so the slots have to be in place before the UI mounts, while the
+   * SSH probe behind each of them may take a lidded laptop's worth of time. A
+   * machine that is asleep must never delay the ones that are awake, so each
+   * slot reports its own state as it settles and none of them are awaited.
+   */
+  attach(): void {
+    const entries = listMachines()
+    if (entries.length === 0) return
+    for (const entry of entries) {
+      this.slots.set(entry.alias, { entry, tasks: [] })
+    }
+    this.publishStatuses()
+    this.localUnsubscribe = this.local.tasksSignal().subscribe(() => this.republishTasks())
+    this.republishTasks()
+    for (const entry of entries) void this.connect(entry)
+  }
+
+  private async connect(entry: MachineEntry): Promise<void> {
+    const slot = this.slots.get(entry.alias)
+    if (!slot || this.disposed) return
+    const found = await discoverMachine(entry.alias, entry)
+    if (this.disposed) return
+    if (!found.ok) {
+      this.setStatus(entry.alias, { state: "offline", error: found.message })
+      return
+    }
+    const tunnel = startTunnel({
+      alias: entry.alias,
+      config: entry,
+      remoteDaemonSocket: found.status.socketPath,
+      remotePtySocket: found.status.ptySocketPath,
+    })
+    slot.tunnel = tunnel
+    if (tunnel.state() === "unsupported") {
+      this.setStatus(entry.alias, {
+        state: "unsupported",
+        error: "SSH unix-socket forwarding is not available on Windows",
+      })
+      return
+    }
+    tunnel.onState((state) => {
+      if (state === "online") void this.openOrchestrator(entry, tunnel)
+      // A dropped tunnel does NOT drop the machine's rows: the last snapshot
+      // stays on screen, greyed, because a laptop that closed its lid has not
+      // stopped having those tasks. See `docs/MACHINES.md`.
+      else if (state === "offline") {
+        this.setStatus(entry.alias, { state: "offline" })
+        this.republishTasks()
+      }
+    })
+    if (tunnel.state() === "online") await this.openOrchestrator(entry, tunnel)
+  }
+
+  private async openOrchestrator(entry: MachineEntry, tunnel: TunnelHandle): Promise<void> {
+    const slot = this.slots.get(entry.alias)
+    if (!slot || this.disposed || slot.orchestrator) return
+    const client = new KobeDaemonClient(tunnel.daemonSocketPath)
+    const orchestrator = new RemoteOrchestrator(client, {
+      // A machine's tasks are read-only in PR 1, and holding a remote daemon
+      // open from here would keep someone else's machine awake for a sidebar
+      // row. `pane` reads without taking the GUI refcount.
+      role: "pane",
+      expectForeignHome: true,
+      onPeerIdentity: (peer) => this.onPeerIdentity(entry.alias, peer),
+    })
+    slot.orchestrator = orchestrator
+    try {
+      await orchestrator.init()
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      // A protocol range mismatch is the machine's own problem and must not
+      // reach the top level: the other machines keep working, this row says
+      // what is wrong with this one.
+      const mismatch = /protocol v/i.test(message)
+      this.setStatus(entry.alias, { state: mismatch ? "mismatch" : "offline", error: message })
+      logClientError("machines", err)
+      return
+    }
+    slot.unsubscribe = orchestrator.tasksSignal().subscribe(() => {
+      slot.tasks = orchestrator.tasksSignal().get()
+      this.republishTasks()
+    })
+    slot.tasks = orchestrator.tasksSignal().get()
+    this.setStatus(entry.alias, { state: "online", version: orchestrator.daemonVersionSignal().get() ?? undefined })
+    this.republishTasks()
+    logClient("machines", `${entry.alias} online (${slot.tasks.length} tasks)`)
+  }
+
+  private onPeerIdentity(
+    alias: string,
+    peer: { hostname: string; homeDir: string; daemonPid: number; kobeVersion: string },
+  ): void {
+    if (!peer.hostname && !peer.homeDir) return
+    const identity = { hostname: peer.hostname, homeDir: peer.homeDir, daemonPid: peer.daemonPid }
+    setMachineIdentity(alias, identity)
+    const duplicate = duplicateAliasOf(readMachines(loadStateFile()), alias, identity)
+    this.setStatus(alias, {
+      hostLabel: peer.hostname || alias,
+      version: peer.kobeVersion || undefined,
+      ...(duplicate ? { duplicateOf: duplicate } : {}),
+    })
+  }
+
+  private setStatus(alias: string, patch: Partial<MachineStatus>): void {
+    const current = this.machinesAcc.get()
+    const next = current.map((row) => (row.alias === alias ? { ...row, ...patch } : row))
+    this.machinesAcc.set(next)
+  }
+
+  private publishStatuses(): void {
+    this.machinesAcc.set(
+      [...this.slots.values()].map((slot) => ({
+        alias: slot.entry.alias,
+        hostLabel: slot.entry.identity?.hostname || slot.entry.alias,
+        state: "connecting" as const,
+      })),
+    )
+  }
+
+  /**
+   * Rebuild the merged list: local tasks first (stamped `local`), then each
+   * machine's, in registration order. Stamping the LOCAL ones too is what
+   * makes `origin` answerable for every row rather than only the remote ones —
+   * a consumer should never have to read "absent" as "local".
+   */
+  private republishTasks(): void {
+    const merged: Task[] = this.local
+      .tasksSignal()
+      .get()
+      .map((task) => stampOrigin(task, "local", "local"))
+    for (const slot of this.slots.values()) {
+      const status = this.machinesAcc.get().find((row) => row.alias === slot.entry.alias)
+      if (status?.duplicateOf) continue
+      const hostLabel = status?.hostLabel || slot.entry.alias
+      const stale = status?.state !== "online"
+      for (const task of slot.tasks) merged.push(stampOrigin(task, slot.entry.alias, hostLabel, stale))
+    }
+    this.mergedAcc.set(merged)
+  }
+
+  dispose(): void {
+    this.disposed = true
+    this.localUnsubscribe?.()
+    for (const slot of this.slots.values()) {
+      slot.unsubscribe?.()
+      slot.orchestrator?.dispose()
+      slot.tunnel?.stop()
+    }
+    this.slots.clear()
+  }
+}
+
+export function stampOrigin(task: Task, machineId: string, hostLabel: string, stale = false): Task {
+  return { ...task, origin: { machineId, hostLabel, ...(stale ? { stale: true } : {}) } }
+}

--- a/packages/kobe/src/machines/hub.ts
+++ b/packages/kobe/src/machines/hub.ts
@@ -28,6 +28,7 @@ import type { Task } from "../types/task.ts"
 import { discoverMachine } from "./discover.ts"
 import {
   type MachineEntry,
+  dedupeMachines,
   duplicateAliasOf,
   listMachines,
   readMachines,
@@ -103,7 +104,7 @@ export class MachineHub {
    * slot reports its own state as it settles and none of them are awaited.
    */
   attach(): void {
-    const entries = listMachines()
+    const entries = dedupeMachines(listMachines())
     if (entries.length === 0) return
     for (const entry of entries) {
       this.slots.set(entry.alias, { entry, tasks: [] })
@@ -172,11 +173,7 @@ export class MachineHub {
       await orchestrator.init()
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err)
-      // A protocol range mismatch is the machine's own problem and must not
-      // reach the top level: the other machines keep working, this row says
-      // what is wrong with this one.
-      const mismatch = /protocol v/i.test(message)
-      this.setStatus(entry.alias, { state: mismatch ? "mismatch" : "offline", error: message })
+      this.setStatus(entry.alias, { state: classifyHandshakeFailure(message), error: message })
       logClientError("machines", err)
       return
     }
@@ -252,6 +249,23 @@ export class MachineHub {
     }
     this.slots.clear()
   }
+}
+
+/**
+ * What a failed handshake means for the machine's row.
+ *
+ * A protocol-range mismatch is that ONE machine's problem: the other machines
+ * keep working and its row says what is wrong with it, rather than the failure
+ * reaching the top level as if Rove were broken. `performInit` phrases that
+ * rejection as "Rove daemon is protocol vN (min vM)" on the client side and
+ * "daemon is protocol vN" on the daemon side — both name a protocol version,
+ * which nothing else in the handshake path does.
+ *
+ * Everything else is `offline`: unreachable, wedged, or gone. Pure, so the
+ * classification is tested without a daemon to be incompatible with.
+ */
+export function classifyHandshakeFailure(message: string): MachineStatus["state"] {
+  return /protocol v\d/i.test(message) ? "mismatch" : "offline"
 }
 
 export function stampOrigin(task: Task, machineId: string, hostLabel: string, stale = false): Task {

--- a/packages/kobe/src/machines/hub.ts
+++ b/packages/kobe/src/machines/hub.ts
@@ -26,7 +26,14 @@ import { createStateCell } from "../lib/external-store.ts"
 import { loadStateFile } from "../state/store.ts"
 import type { Task } from "../types/task.ts"
 import { discoverMachine } from "./discover.ts"
-import { type MachineEntry, duplicateAliasOf, listMachines, readMachines, setMachineIdentity } from "./registry.ts"
+import {
+  type MachineEntry,
+  duplicateAliasOf,
+  listMachines,
+  readMachines,
+  setMachineIdentity,
+  updateMachine,
+} from "./registry.ts"
 import { type TunnelHandle, startTunnel } from "./tunnel.ts"
 
 /** What a machine row in the sidebar renders from. */
@@ -112,15 +119,20 @@ export class MachineHub {
     if (!slot || this.disposed) return
     const found = await discoverMachine(entry.alias, entry)
     if (this.disposed) return
-    if (!found.ok) {
-      this.setStatus(entry.alias, { state: "offline", error: found.message })
+    // A probe that failed is not fatal when we already know where that machine
+    // listens: the paths do not move, and reusing them lets the tunnel's own
+    // backoff be what waits for a machine that is merely asleep.
+    const sockets = found.ok ? { daemon: found.status.socketPath, pty: found.status.ptySocketPath } : entry.sockets
+    if (!sockets) {
+      this.setStatus(entry.alias, { state: "offline", error: found.ok ? undefined : found.message })
       return
     }
+    if (found.ok) updateMachine(entry.alias, { sockets })
     const tunnel = startTunnel({
       alias: entry.alias,
       config: entry,
-      remoteDaemonSocket: found.status.socketPath,
-      remotePtySocket: found.status.ptySocketPath,
+      remoteDaemonSocket: sockets.daemon,
+      remotePtySocket: sockets.pty,
     })
     slot.tunnel = tunnel
     if (tunnel.state() === "unsupported") {

--- a/packages/kobe/src/machines/hub.ts
+++ b/packages/kobe/src/machines/hub.ts
@@ -40,8 +40,19 @@ import { type TunnelHandle, startTunnel } from "./tunnel.ts"
 /** What a machine row in the sidebar renders from. */
 export interface MachineStatus {
   readonly alias: string
-  /** Remote hostname once known, else the alias. */
+  /**
+   * What the machine is CALLED on screen — the alias, always.
+   *
+   * Not the remote hostname. The alias is the name the user chose for this
+   * machine, and they chose it because it is short: a real hostname
+   * (`Nahuels-Mac-mini.local`) fills the whole sidebar rail and turns a
+   * disambiguated repo into `Nahuels-Mac-mini.local:kobe`. The hostname stays
+   * where it answers a different question — `machine list`, and the identity
+   * triple that recognizes two aliases as one machine.
+   */
   readonly hostLabel: string
+  /** The machine's own hostname, once a handshake reported it. */
+  readonly hostname?: string
   readonly state: "connecting" | "online" | "offline" | "unsupported" | "mismatch"
   /** Remote build version, once a handshake succeeded. */
   readonly version?: string
@@ -161,10 +172,13 @@ export class MachineHub {
     if (!slot || this.disposed || slot.orchestrator) return
     const client = new KobeDaemonClient(tunnel.daemonSocketPath)
     const orchestrator = new RemoteOrchestrator(client, {
-      // A machine's tasks are read-only in PR 1, and holding a remote daemon
-      // open from here would keep someone else's machine awake for a sidebar
-      // row. `pane` reads without taking the GUI refcount.
-      role: "pane",
+      // `gui`, not `pane`: this connection holds the remote daemon open for as
+      // long as its rows are on screen. A pane-role watcher does not take that
+      // refcount, so the remote daemon idle-stopped three seconds after its
+      // own last window closed and the machine row flapped online → offline →
+      // online while somebody was looking straight at it. Someone IS looking
+      // at that machine, which is exactly what the refcount counts.
+      role: "gui",
       expectForeignHome: true,
       onPeerIdentity: (peer) => this.onPeerIdentity(entry.alias, peer),
     })
@@ -177,10 +191,26 @@ export class MachineHub {
       logClientError("machines", err)
       return
     }
-    slot.unsubscribe = orchestrator.tasksSignal().subscribe(() => {
+    const stopTasks = orchestrator.tasksSignal().subscribe(() => {
       slot.tasks = orchestrator.tasksSignal().get()
       this.republishTasks()
     })
+    // The daemon's own connection state, not just the tunnel's. A forwarded
+    // socket keeps ACCEPTING after the far daemon dies — ssh answers locally
+    // and only then discovers there is nothing behind it — so a liveness poll
+    // on the socket alone reports a machine as online while its Rove is gone.
+    // The orchestrator is the layer that actually talks to that daemon, so its
+    // verdict is the one the row shows.
+    const stopConnection = orchestrator.connectionStateSignal().subscribe(() => {
+      const connected = orchestrator.connectionStateSignal().get() === "online"
+      if (this.slots.get(entry.alias) !== slot) return
+      this.setStatus(entry.alias, { state: connected ? "online" : "offline" })
+      this.republishTasks()
+    })
+    slot.unsubscribe = () => {
+      stopTasks()
+      stopConnection()
+    }
     slot.tasks = orchestrator.tasksSignal().get()
     this.setStatus(entry.alias, { state: "online", version: orchestrator.daemonVersionSignal().get() ?? undefined })
     this.republishTasks()
@@ -196,7 +226,7 @@ export class MachineHub {
     setMachineIdentity(alias, identity)
     const duplicate = duplicateAliasOf(readMachines(loadStateFile()), alias, identity)
     this.setStatus(alias, {
-      hostLabel: peer.hostname || alias,
+      hostname: peer.hostname || undefined,
       version: peer.kobeVersion || undefined,
       ...(duplicate ? { duplicateOf: duplicate } : {}),
     })
@@ -212,7 +242,7 @@ export class MachineHub {
     this.machinesAcc.set(
       [...this.slots.values()].map((slot) => ({
         alias: slot.entry.alias,
-        hostLabel: slot.entry.identity?.hostname || slot.entry.alias,
+        hostLabel: slot.entry.alias,
         state: "connecting" as const,
       })),
     )

--- a/packages/kobe/src/machines/registry.ts
+++ b/packages/kobe/src/machines/registry.ts
@@ -1,0 +1,182 @@
+/**
+ * The machine registry: what `rove machine add|remove|list` persists, and the
+ * one place that parses an SSH target string.
+ *
+ * A "machine" is another computer running its own Rove daemon. Rove reaches it
+ * by forwarding that daemon's unix socket over SSH — no TCP listener, no
+ * auth protocol of Rove's own (`docs/MACHINES.md`). So everything stored here
+ * is addressing plus the same `RemoteAuthConfig` shape `remoteRepos` already
+ * uses: a key path, or a keychain POINTER. A password never lands in
+ * state.json.
+ *
+ * Distinct from `state/remote-repos.ts`, which registers a remote PROJECT for
+ * the experimental `rove add --remote` path — that one assumes the far side
+ * has no Rove and drives git over SSH itself. This module assumes the far side
+ * runs Rove and speaks the daemon protocol.
+ *
+ * Imports `store.ts` only (same cycle rule as `remote-repos.ts`).
+ */
+
+import type { RemoteAuthConfig } from "../state/remote-repos.ts"
+import { type StateSnapshot, loadStateFile, updateStateFile } from "../state/store.ts"
+
+/** The local machine's reserved id. Never registered, never removable. */
+export const LOCAL_MACHINE_ID = "local"
+
+export interface MachineConfig {
+  /** The SSH host as typed — an ssh_config `Host` alias is the common case,
+   *  so this is NOT necessarily a DNS name. */
+  readonly host: string
+  /** Login user, or "" to let ssh_config decide. */
+  readonly user?: string
+  readonly port?: number
+  readonly auth: RemoteAuthConfig
+  /**
+   * Identity learned from the remote daemon's `hello` — how two aliases are
+   * recognized as one machine. Absent until the first successful connect.
+   */
+  readonly identity?: MachineIdentity
+  /** ISO timestamp of registration, for `machine list` ordering. */
+  readonly addedAt?: string
+}
+
+/**
+ * What makes two aliases the SAME machine. All three must match: a hostname
+ * alone repeats across cloned VMs, a homeDir alone repeats across every mac,
+ * and a pid alone recycles. Together they name one running daemon serving one
+ * state root on one host, which is exactly the thing a machine row stands for.
+ */
+export interface MachineIdentity {
+  readonly hostname: string
+  readonly homeDir: string
+  readonly daemonPid: number
+}
+
+export type MachineEntry = { readonly alias: string } & MachineConfig
+
+/** Aliases must survive being a path segment (`machines/<alias>/daemon.sock`). */
+const ALIAS_RE = /^[A-Za-z0-9][A-Za-z0-9._-]*$/
+
+export function isValidMachineAlias(alias: string): boolean {
+  return alias !== LOCAL_MACHINE_ID && alias.length <= 64 && ALIAS_RE.test(alias)
+}
+
+/**
+ * Parse `[user@]host[:port]` as `rove machine add` accepts it.
+ *
+ * A bare `host` is the intended shape: it lets ssh_config own the user, the
+ * port and the identity file, which is what makes `rove machine add narwhal`
+ * work off an existing `Host narwhal` block with nothing else configured.
+ * Returns null for an empty or malformed target rather than guessing.
+ */
+export function parseSshTarget(target: string): { host: string; user?: string; port?: number } | null {
+  const trimmed = target.trim()
+  if (!trimmed) return null
+  const at = trimmed.lastIndexOf("@")
+  const user = at >= 0 ? trimmed.slice(0, at) : undefined
+  const rest = at >= 0 ? trimmed.slice(at + 1) : trimmed
+  if (at >= 0 && !user) return null
+  // Port parsing follows ssh's own rule rather than "split on the last colon":
+  // an IPv6 literal is colons all the way down, so `::1` would otherwise read
+  // as host `:` on port 1 — a silently WRONG target, which is worse than a
+  // refusal. So a bare address keeps every colon it has, and an IPv6 address
+  // that wants a port must be bracketed, exactly as `ssh [::1]:2222` requires.
+  const bracketed = /^\[([^\]]+)\](?::(\d{1,5}))?$/.exec(rest)
+  const portMatch = bracketed ? null : /^([^:]*):(\d{1,5})$/.exec(rest)
+  const host = bracketed ? (bracketed[1] ?? "") : portMatch ? (portMatch[1] ?? "") : rest
+  const rawPort = bracketed ? bracketed[2] : portMatch?.[2]
+  const port = rawPort ? Number(rawPort) : undefined
+  if (!host || /\s/.test(host)) return null
+  if (port !== undefined && (port < 1 || port > 65535)) return null
+  return { host, ...(user ? { user } : {}), ...(port ? { port } : {}) }
+}
+
+/** `user@host` (or bare `host`) — what goes on the ssh command line. */
+export function sshTargetOf(config: MachineConfig): string {
+  return config.user ? `${config.user}@${config.host}` : config.host
+}
+
+export function readMachines(state: StateSnapshot): Record<string, MachineConfig> {
+  const raw = state.machines
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return {}
+  return raw as Record<string, MachineConfig>
+}
+
+/** Every registered machine, in stored order. Never includes `local`. */
+export function listMachines(): MachineEntry[] {
+  const machines = readMachines(loadStateFile())
+  return Object.entries(machines).map(([alias, config]) => ({ alias, ...config }))
+}
+
+export function getMachine(alias: string): MachineConfig | null {
+  return readMachines(loadStateFile())[alias] ?? null
+}
+
+/**
+ * Register (or update) a machine. Overwrites an existing alias, which is how
+ * `machine add` doubles as "change the port / the identity file".
+ */
+export function addMachine(alias: string, config: MachineConfig): { added: boolean } {
+  let added = false
+  updateStateFile((state) => {
+    const machines = { ...readMachines(state) }
+    added = machines[alias] === undefined
+    machines[alias] = { ...config, addedAt: config.addedAt ?? machines[alias]?.addedAt ?? new Date().toISOString() }
+    state.machines = machines
+    return undefined
+  })
+  return { added }
+}
+
+/** Record the identity learned from a successful `hello`. */
+export function setMachineIdentity(alias: string, identity: MachineIdentity): void {
+  updateStateFile((state) => {
+    const machines = { ...readMachines(state) }
+    const existing = machines[alias]
+    if (!existing) return false
+    machines[alias] = { ...existing, identity }
+    state.machines = machines
+    return undefined
+  })
+}
+
+export function removeMachine(alias: string): boolean {
+  let removed = false
+  updateStateFile((state) => {
+    const machines = { ...readMachines(state) }
+    removed = machines[alias] !== undefined
+    if (!removed) return false
+    delete machines[alias]
+    state.machines = machines
+    return undefined
+  })
+  return removed
+}
+
+/**
+ * The already-registered alias that names the SAME machine as `identity`, or
+ * null. `self` is excluded so re-connecting an alias never reports itself as
+ * its own duplicate.
+ *
+ * Pure over an explicit map so the merge rule is unit-testable without a state
+ * file.
+ */
+export function duplicateAliasOf(
+  machines: Readonly<Record<string, MachineConfig>>,
+  self: string,
+  identity: MachineIdentity,
+): string | null {
+  for (const [alias, config] of Object.entries(machines)) {
+    if (alias === self) continue
+    const other = config.identity
+    if (!other) continue
+    if (
+      other.hostname === identity.hostname &&
+      other.homeDir === identity.homeDir &&
+      other.daemonPid === identity.daemonPid
+    ) {
+      return alias
+    }
+  }
+  return null
+}

--- a/packages/kobe/src/machines/registry.ts
+++ b/packages/kobe/src/machines/registry.ts
@@ -36,6 +36,12 @@ export interface MachineConfig {
    * recognized as one machine. Absent until the first successful connect.
    */
   readonly identity?: MachineIdentity
+  /**
+   * The remote socket paths, as that machine last reported them. Cached so a
+   * reconnect does not need a second SSH round-trip before it can forward
+   * anything — never derived locally (see `discover.ts`).
+   */
+  readonly sockets?: { readonly daemon: string; readonly pty: string }
   /** ISO timestamp of registration, for `machine list` ordering. */
   readonly addedAt?: string
 }
@@ -128,16 +134,21 @@ export function addMachine(alias: string, config: MachineConfig): { added: boole
   return { added }
 }
 
-/** Record the identity learned from a successful `hello`. */
-export function setMachineIdentity(alias: string, identity: MachineIdentity): void {
+/** Record what a successful handshake or probe taught us about a machine. */
+export function updateMachine(alias: string, patch: Partial<MachineConfig>): void {
   updateStateFile((state) => {
     const machines = { ...readMachines(state) }
     const existing = machines[alias]
     if (!existing) return false
-    machines[alias] = { ...existing, identity }
+    machines[alias] = { ...existing, ...patch }
     state.machines = machines
     return undefined
   })
+}
+
+/** Record the identity learned from a successful `hello`. */
+export function setMachineIdentity(alias: string, identity: MachineIdentity): void {
+  updateMachine(alias, { identity })
 }
 
 export function removeMachine(alias: string): boolean {

--- a/packages/kobe/src/machines/registry.ts
+++ b/packages/kobe/src/machines/registry.ts
@@ -165,6 +165,35 @@ export function removeMachine(alias: string): boolean {
 }
 
 /**
+ * Registered machines with the duplicates dropped: when two aliases name one
+ * machine, the FIRST in stored order survives.
+ *
+ * One rule, shared by the sidebar and by `rove api list`, because the two
+ * disagreeing is exactly the bug it exists to prevent — a machine that renders
+ * as one row while the CLI lists its tasks twice. An entry that has never
+ * connected has no identity to compare and is always kept: it may turn out to
+ * be a machine of its own.
+ */
+export function dedupeMachines(entries: readonly MachineEntry[]): MachineEntry[] {
+  const kept: MachineEntry[] = []
+  const seen: MachineIdentity[] = []
+  for (const entry of entries) {
+    const identity = entry.identity
+    if (identity) {
+      if (seen.some((other) => sameMachine(other, identity))) continue
+      seen.push(identity)
+    }
+    kept.push(entry)
+  }
+  return kept
+}
+
+/** All three parts must agree — see {@link duplicateAliasOf}. */
+function sameMachine(a: MachineIdentity, b: MachineIdentity): boolean {
+  return a.hostname === b.hostname && a.homeDir === b.homeDir && a.daemonPid === b.daemonPid
+}
+
+/**
  * The already-registered alias that names the SAME machine as `identity`, or
  * null. `self` is excluded so re-connecting an alias never reports itself as
  * its own duplicate.

--- a/packages/kobe/src/machines/registry.ts
+++ b/packages/kobe/src/machines/registry.ts
@@ -97,6 +97,49 @@ export function parseSshTarget(target: string): { host: string; user?: string; p
   return { host, ...(user ? { user } : {}), ...(port ? { port } : {}) }
 }
 
+/**
+ * What to call a machine when the user did not pass `--alias`.
+ *
+ * A BARE host — `rove machine add narwhal`, no user, no port — is already a
+ * name the user chose, almost always an `ssh_config` `Host` they picked
+ * precisely because it is short. Replacing it with the machine's own hostname
+ * overwrites a chosen name with one they never picked, and hostnames are long
+ * enough to fill the sidebar rail (`Nahuels-Mac-mini.local`).
+ *
+ * Anything else is addressing rather than a name — `user@host`, an explicit
+ * port, a bare IP — so the remote hostname is the better answer there, and an
+ * IP would in any case survive {@link sanitizeAlias} as its first octet.
+ *
+ * Pure: `remoteHostname` is passed in, because it is only knowable after the
+ * probe.
+ */
+export function defaultMachineAlias(args: {
+  readonly typedHost: string
+  readonly typedUser?: string
+  readonly port?: number
+  readonly remoteHostname?: string
+}): string {
+  const bare = !args.typedUser && args.port === undefined && !isIpLiteral(args.typedHost)
+  const source = bare ? args.typedHost : args.remoteHostname || args.typedHost
+  return sanitizeAlias(source)
+}
+
+/** An IPv4 dotted quad or an IPv6 literal — addressing, never a chosen name. */
+function isIpLiteral(host: string): boolean {
+  return host.includes(":") || /^\d{1,3}(\.\d{1,3}){3}$/.test(host)
+}
+
+/**
+ * A host or alias as a filesystem-safe alias: the leading label only
+ * (`Nahuels-Mac-mini.local` → `Nahuels-Mac-mini`), with anything outside
+ * `[A-Za-z0-9._-]` collapsed to `-`. The result names a directory under
+ * `<home>/.rove/machines/`, so it has to survive being a path segment.
+ */
+export function sanitizeAlias(raw: string): string {
+  const base = raw.split(".")[0] ?? raw
+  return base.replace(/[^A-Za-z0-9._-]/g, "-").slice(0, 64)
+}
+
 /** `user@host` (or bare `host`) — what goes on the ssh command line. */
 export function sshTargetOf(config: MachineConfig): string {
   return config.user ? `${config.user}@${config.host}` : config.host

--- a/packages/kobe/src/machines/ssh-args.ts
+++ b/packages/kobe/src/machines/ssh-args.ts
@@ -1,0 +1,108 @@
+/**
+ * The `ssh` argv a machine connection uses — one builder, so the discovery
+ * probe, the tunnel and any future call agree on the multiplexing options.
+ *
+ * Deliberately a sibling of `exec/exec-host.ts`'s `sshConnectArgs` rather than
+ * a call into it: that one takes a `RemoteSpec` built for remote PROJECTS
+ * (which carries a `basePath` and a lazily-fetched keychain password), and its
+ * ControlPath lives under the remote-project tree. The FLAGS below are
+ * deliberately the same set — `ControlMaster=auto` + `ControlPersist=300` +
+ * TOFU host keys — because they encode the same decision, and this file is
+ * where a machine's version of it is stated.
+ */
+
+import { join } from "node:path"
+import { homeDir } from "../env.ts"
+import type { MachineConfig } from "./registry.ts"
+import { sshTargetOf } from "./registry.ts"
+
+/** How long a shared master outlives its last channel, in seconds. */
+export const CONTROL_PERSIST_SECONDS = 300
+
+/** `<home>/.rove/machines/<alias>` — holds the control socket and both
+ *  forwarded sockets. Owner-only; created by the tunnel. */
+export function machineSocketDir(alias: string, home = homeDir()): string {
+  return join(home, ".rove", "machines", alias)
+}
+
+/** The local end of the forwarded DAEMON socket for a machine. */
+export function localDaemonSocketPath(alias: string, home = homeDir()): string {
+  return join(machineSocketDir(alias, home), "daemon.sock")
+}
+
+/** The local end of the forwarded PTY-HOST socket for a machine. */
+export function localPtySocketPath(alias: string, home = homeDir()): string {
+  return join(machineSocketDir(alias, home), "pty.sock")
+}
+
+/** ControlMaster socket. Kept beside the forwarded sockets so removing a
+ *  machine's directory tears down every file the connection owns. */
+export function controlPath(alias: string, home = homeDir()): string {
+  return join(machineSocketDir(alias, home), "cm")
+}
+
+/**
+ * Connection flags shared by every machine ssh invocation — no remote command,
+ * no target. `batch` (the default) fails fast instead of prompting, which is
+ * required for anything the daemon or a reconnect loop runs unattended.
+ */
+export function machineSshArgs(
+  alias: string,
+  config: MachineConfig,
+  opts: { readonly home?: string; readonly batch?: boolean } = {},
+): string[] {
+  const argv = ["ssh"]
+  if (opts.batch !== false) argv.push("-o", "BatchMode=yes")
+  argv.push(
+    "-o",
+    "ControlMaster=auto",
+    "-o",
+    `ControlPath=${controlPath(alias, opts.home)}`,
+    "-o",
+    `ControlPersist=${CONTROL_PERSIST_SECONDS}`,
+    // TOFU: accept an unknown host key on first connect, reject a CHANGED one.
+    "-o",
+    "StrictHostKeyChecking=accept-new",
+  )
+  if (config.port) argv.push("-p", String(config.port))
+  if (config.auth.kind === "key" && config.auth.keyPath) argv.push("-i", config.auth.keyPath)
+  argv.push(sshTargetOf(config))
+  return argv
+}
+
+/**
+ * The two `-L` forwards that make a remote daemon reachable as a local socket.
+ * Local-socket-to-remote-socket forwarding (`-L /local:/remote`) is an OpenSSH
+ * 6.7+ feature; it is what lets both ends stay unix sockets, so neither daemon
+ * ever opens a TCP port.
+ *
+ * `ExitOnForwardFailure=yes` is load-bearing: without it a forward that cannot
+ * bind leaves ssh running and healthy-looking while the socket it was supposed
+ * to create does not exist, and the machine reads as online forever.
+ */
+export function tunnelArgs(args: {
+  readonly alias: string
+  readonly config: MachineConfig
+  readonly remoteDaemonSocket: string
+  readonly remotePtySocket: string
+  readonly home?: string
+}): string[] {
+  const argv = machineSshArgs(args.alias, args.config, { home: args.home })
+  argv.splice(
+    1,
+    0,
+    "-N",
+    "-o",
+    "ExitOnForwardFailure=yes",
+    "-o",
+    "ServerAliveInterval=15",
+    "-o",
+    "ServerAliveCountMax=3",
+  )
+  const daemonLocal = localDaemonSocketPath(args.alias, args.home)
+  const ptyLocal = localPtySocketPath(args.alias, args.home)
+  // Insert the forwards before the target (the last element).
+  argv.splice(argv.length - 1, 0, "-L", `${daemonLocal}:${args.remoteDaemonSocket}`)
+  argv.splice(argv.length - 1, 0, "-L", `${ptyLocal}:${args.remotePtySocket}`)
+  return argv
+}

--- a/packages/kobe/src/machines/ssh-args.ts
+++ b/packages/kobe/src/machines/ssh-args.ts
@@ -11,7 +11,9 @@
  * where a machine's version of it is stated.
  */
 
+import { tmpdir } from "node:os"
 import { join } from "node:path"
+import { shortHomeTag } from "@sma1lboy/kobe-daemon/daemon/paths"
 import { homeDir } from "../env.ts"
 import type { MachineConfig } from "./registry.ts"
 import { sshTargetOf } from "./registry.ts"
@@ -19,11 +21,33 @@ import { sshTargetOf } from "./registry.ts"
 /** How long a shared master outlives its last channel, in seconds. */
 export const CONTROL_PERSIST_SECONDS = 300
 
-/** `<home>/.rove/machines/<alias>` — holds the control socket and both
- *  forwarded sockets. Owner-only; created by the tunnel. */
+/**
+ * `<home>/.rove/machines/<alias>` — holds the control socket and both
+ * forwarded sockets. Owner-only; created by the tunnel.
+ *
+ * Falls back to a short `$TMPDIR` directory when the natural path would put a
+ * socket past the kernel's `sun_path` limit — a real case, not a theoretical
+ * one: a Rove home inside a worktree (`~/.rove/worktrees/<name>/…`) already
+ * spends 60 of the ~104 bytes before `machines/<alias>/daemon.sock` starts,
+ * and ssh's own refusal reads `ControlPath too long`, which names neither the
+ * machine nor the remedy. Keyed on home + alias via the same
+ * {@link shortHomeTag} the daemon's sockets use, so the fallback path is the
+ * SAME string every time — a client that computed a different one would look
+ * for the forward in the wrong place.
+ */
 export function machineSocketDir(alias: string, home = homeDir()): string {
-  return join(home, ".rove", "machines", alias)
+  const natural = join(home, ".rove", "machines", alias)
+  // The longest name this directory has to hold. Measuring the DIRECTORY
+  // against the limit would pass and then fail on the socket inside it.
+  if (Buffer.byteLength(join(natural, "daemon.sock"), "utf8") <= SOCKET_PATH_LIMIT) return natural
+  return join(tmpdir(), `rove-m-${shortHomeTag(home)}-${shortHomeTag(alias)}`)
 }
+
+/**
+ * Budget for a unix socket path. `sun_path` is 104 bytes on macOS and 108 on
+ * Linux; the daemon's own paths use 100 as the safe floor and so does this.
+ */
+const SOCKET_PATH_LIMIT = 100
 
 /** The local end of the forwarded DAEMON socket for a machine. */
 export function localDaemonSocketPath(alias: string, home = homeDir()): string {
@@ -67,42 +91,5 @@ export function machineSshArgs(
   if (config.port) argv.push("-p", String(config.port))
   if (config.auth.kind === "key" && config.auth.keyPath) argv.push("-i", config.auth.keyPath)
   argv.push(sshTargetOf(config))
-  return argv
-}
-
-/**
- * The two `-L` forwards that make a remote daemon reachable as a local socket.
- * Local-socket-to-remote-socket forwarding (`-L /local:/remote`) is an OpenSSH
- * 6.7+ feature; it is what lets both ends stay unix sockets, so neither daemon
- * ever opens a TCP port.
- *
- * `ExitOnForwardFailure=yes` is load-bearing: without it a forward that cannot
- * bind leaves ssh running and healthy-looking while the socket it was supposed
- * to create does not exist, and the machine reads as online forever.
- */
-export function tunnelArgs(args: {
-  readonly alias: string
-  readonly config: MachineConfig
-  readonly remoteDaemonSocket: string
-  readonly remotePtySocket: string
-  readonly home?: string
-}): string[] {
-  const argv = machineSshArgs(args.alias, args.config, { home: args.home })
-  argv.splice(
-    1,
-    0,
-    "-N",
-    "-o",
-    "ExitOnForwardFailure=yes",
-    "-o",
-    "ServerAliveInterval=15",
-    "-o",
-    "ServerAliveCountMax=3",
-  )
-  const daemonLocal = localDaemonSocketPath(args.alias, args.home)
-  const ptyLocal = localPtySocketPath(args.alias, args.home)
-  // Insert the forwards before the target (the last element).
-  argv.splice(argv.length - 1, 0, "-L", `${daemonLocal}:${args.remoteDaemonSocket}`)
-  argv.splice(argv.length - 1, 0, "-L", `${ptyLocal}:${args.remotePtySocket}`)
   return argv
 }

--- a/packages/kobe/src/machines/tunnel.ts
+++ b/packages/kobe/src/machines/tunnel.ts
@@ -19,9 +19,10 @@
 
 import { type ChildProcess, spawn } from "node:child_process"
 import { mkdirSync, rmSync } from "node:fs"
+import { connect as netConnect } from "node:net"
 import { homeDir } from "../env.ts"
 import type { MachineConfig } from "./registry.ts"
-import { localDaemonSocketPath, localPtySocketPath, machineSocketDir, tunnelArgs } from "./ssh-args.ts"
+import { localDaemonSocketPath, localPtySocketPath, machineSocketDir, machineSshArgs, tunnelArgs } from "./ssh-args.ts"
 
 /** Owner-only, like every other directory under `<home>/.rove`: the sockets in
  *  here reach a daemon that runs commands as its owner. */
@@ -180,4 +181,83 @@ export function startTunnel(opts: StartTunnelOptions): TunnelHandle {
       setState("offline")
     },
   }
+}
+
+/**
+ * Install the two forwards onto the machine's SHARED ssh connection, without
+ * leaving a process behind — the CLI's way in.
+ *
+ * A `rove api` process lives for milliseconds, so it cannot hold an `ssh -N`
+ * open the way the TUI does. `ssh -O forward` adds a forward to a running
+ * ControlMaster instead, and the master outlives the client that created it by
+ * `ControlPersist` seconds. So the first CLI call that needs a machine pays
+ * one connect, and the next few minutes of calls find the socket already there.
+ *
+ * Best-effort: every failure answers `false`, and the caller reports the
+ * machine as offline. Returns true when the forwarded daemon socket exists
+ * afterwards, which is the only claim worth making.
+ */
+export async function ensureForwards(args: {
+  readonly alias: string
+  readonly config: MachineConfig
+  readonly remoteDaemonSocket: string
+  readonly remotePtySocket: string
+  readonly home?: string
+}): Promise<boolean> {
+  if (process.platform === "win32") return false
+  const home = args.home ?? homeDir()
+  const daemonLocal = localDaemonSocketPath(args.alias, home)
+  const ptyLocal = localPtySocketPath(args.alias, home)
+  try {
+    mkdirSync(machineSocketDir(args.alias, home), { recursive: true, mode: DIR_MODE })
+  } catch {
+    /* already there */
+  }
+  if (await socketAnswers(daemonLocal)) return true
+  // A leftover socket file from a dead master would make `-O forward` fail.
+  for (const path of [daemonLocal, ptyLocal]) {
+    try {
+      rmSync(path, { force: true })
+    } catch {
+      /* nothing there */
+    }
+  }
+  const base = machineSshArgs(args.alias, args.config, { home })
+  // `true` is the cheapest remote command that establishes the master.
+  if ((await runSsh([...base, "true"])) !== 0) return false
+  const target = base.at(-1) ?? args.alias
+  const flags = base.slice(0, -1)
+  const forwarded = await runSsh([
+    ...flags,
+    "-O",
+    "forward",
+    "-L",
+    `${daemonLocal}:${args.remoteDaemonSocket}`,
+    "-L",
+    `${ptyLocal}:${args.remotePtySocket}`,
+    target,
+  ])
+  return forwarded === 0 && (await socketAnswers(daemonLocal))
+}
+
+function runSsh(argv: readonly string[]): Promise<number> {
+  return new Promise((resolve) => {
+    const child = spawn(argv[0] ?? "ssh", argv.slice(1), { stdio: "ignore" })
+    child.on("error", () => resolve(-1))
+    child.on("close", (code) => resolve(code ?? -1))
+  })
+}
+
+/** Whether a unix socket at `path` accepts a connection right now. */
+function socketAnswers(path: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    const socket = netConnect(path)
+    const done = (answer: boolean): void => {
+      socket.destroy()
+      resolve(answer)
+    }
+    socket.once("connect", () => done(true))
+    socket.once("error", () => done(false))
+    socket.setTimeout(1500, () => done(false))
+  })
 }

--- a/packages/kobe/src/machines/tunnel.ts
+++ b/packages/kobe/src/machines/tunnel.ts
@@ -1,0 +1,183 @@
+/**
+ * One `ssh -N -L … -L …` process per machine, kept alive.
+ *
+ * The two forwards turn the remote daemon socket and the remote PTY-host
+ * socket into local unix sockets under `<home>/.rove/machines/<alias>/`. Every
+ * other layer then treats a machine exactly like the local daemon — a socket
+ * path — which is why nothing above this file knows SSH exists.
+ *
+ * Windows has no `AF_UNIX` forwarding in OpenSSH's `-L local-socket` form, so
+ * {@link startTunnel} reports `unsupported` there rather than spawning
+ * something that cannot work. The module still IMPORTS cleanly on Windows —
+ * `rove machine list` must run everywhere.
+ *
+ * Reconnect policy mirrors the daemon client's: exponential backoff capped at
+ * a few seconds, forever, because the far side coming back is the expected
+ * outcome and a machine the user registered should not need re-registering
+ * after a lid close.
+ */
+
+import { type ChildProcess, spawn } from "node:child_process"
+import { mkdirSync, rmSync } from "node:fs"
+import { homeDir } from "../env.ts"
+import type { MachineConfig } from "./registry.ts"
+import { localDaemonSocketPath, localPtySocketPath, machineSocketDir, tunnelArgs } from "./ssh-args.ts"
+
+/** Owner-only, like every other directory under `<home>/.rove`: the sockets in
+ *  here reach a daemon that runs commands as its owner. */
+const DIR_MODE = 0o700
+
+export type TunnelState = "connecting" | "online" | "offline" | "unsupported"
+
+export interface TunnelHandle {
+  readonly alias: string
+  /** Local socket the machine's daemon answers on. */
+  readonly daemonSocketPath: string
+  /** Local socket the machine's PTY host answers on (PR 2 attaches to it). */
+  readonly ptySocketPath: string
+  state(): TunnelState
+  /** Called on every state transition, including the initial connect. */
+  onState(listener: (state: TunnelState) => void): () => void
+  stop(): void
+}
+
+export interface StartTunnelOptions {
+  readonly alias: string
+  readonly config: MachineConfig
+  readonly remoteDaemonSocket: string
+  readonly remotePtySocket: string
+  readonly home?: string
+  /** Injected for tests: spawn the ssh child. */
+  readonly spawnFn?: (argv: readonly string[]) => ChildProcess
+  /** Injected for tests: schedule the next reconnect attempt. */
+  readonly setTimeoutFn?: (fn: () => void, ms: number) => unknown
+}
+
+const BACKOFF_START_MS = 500
+const BACKOFF_MAX_MS = 5_000
+
+/**
+ * Spawn (and re-spawn) the tunnel. Returns immediately with a handle whose
+ * state starts at `connecting`; callers watch {@link TunnelHandle.onState}
+ * rather than awaiting, because a machine that is down must not block the
+ * ones that are up.
+ */
+export function startTunnel(opts: StartTunnelOptions): TunnelHandle {
+  const home = opts.home ?? homeDir()
+  const dir = machineSocketDir(opts.alias, home)
+  const daemonSocketPath = localDaemonSocketPath(opts.alias, home)
+  const ptySocketPath = localPtySocketPath(opts.alias, home)
+  const listeners = new Set<(state: TunnelState) => void>()
+  let state: TunnelState = "connecting"
+  let child: ChildProcess | null = null
+  let stopped = false
+  let backoff = BACKOFF_START_MS
+
+  const setState = (next: TunnelState): void => {
+    if (state === next) return
+    state = next
+    for (const listener of listeners) listener(next)
+  }
+
+  if (process.platform === "win32") {
+    setState("unsupported")
+    return {
+      alias: opts.alias,
+      daemonSocketPath,
+      ptySocketPath,
+      state: () => state,
+      onState: (listener) => {
+        listeners.add(listener)
+        return () => listeners.delete(listener)
+      },
+      stop: () => {},
+    }
+  }
+
+  const connect = (): void => {
+    if (stopped) return
+    try {
+      mkdirSync(dir, { recursive: true, mode: DIR_MODE })
+    } catch {
+      /* a home on a filesystem without modes, or already there */
+    }
+    // ssh REFUSES to bind a local forward socket that already exists — a
+    // leftover from a killed tunnel would otherwise make every reconnect fail
+    // with `ExitOnForwardFailure` and read as "that machine is permanently
+    // down". Only our own two paths, only inside our own directory.
+    for (const path of [daemonSocketPath, ptySocketPath]) {
+      try {
+        rmSync(path, { force: true })
+      } catch {
+        /* nothing there */
+      }
+    }
+    const argv = tunnelArgs({
+      alias: opts.alias,
+      config: opts.config,
+      remoteDaemonSocket: opts.remoteDaemonSocket,
+      remotePtySocket: opts.remotePtySocket,
+      home,
+    })
+    const spawnFn = opts.spawnFn ?? ((a: readonly string[]) => spawn(a[0] ?? "ssh", a.slice(1), { stdio: "ignore" }))
+    let proc: ChildProcess
+    try {
+      proc = spawnFn(argv)
+    } catch {
+      scheduleRetry()
+      return
+    }
+    child = proc
+    // `ssh -N` prints nothing on success, so there is no "ready" line to wait
+    // for. Staying up past the moment ssh would have failed IS the readiness
+    // signal: `ExitOnForwardFailure=yes` makes a bind failure an immediate
+    // exit, so a process still alive after the grace window has both forwards.
+    const readyTimer = setTimeout(() => {
+      if (child === proc && !stopped) {
+        backoff = BACKOFF_START_MS
+        setState("online")
+      }
+    }, 700)
+    proc.on("exit", () => {
+      clearTimeout(readyTimer)
+      if (child !== proc || stopped) return
+      child = null
+      setState("offline")
+      scheduleRetry()
+    })
+    proc.on("error", () => {
+      clearTimeout(readyTimer)
+      if (child !== proc || stopped) return
+      child = null
+      setState("offline")
+      scheduleRetry()
+    })
+  }
+
+  const scheduleRetry = (): void => {
+    if (stopped) return
+    const wait = backoff
+    backoff = Math.min(backoff * 2, BACKOFF_MAX_MS)
+    const schedule = opts.setTimeoutFn ?? ((fn: () => void, ms: number) => setTimeout(fn, ms))
+    schedule(() => connect(), wait)
+  }
+
+  connect()
+
+  return {
+    alias: opts.alias,
+    daemonSocketPath,
+    ptySocketPath,
+    state: () => state,
+    onState: (listener) => {
+      listeners.add(listener)
+      return () => listeners.delete(listener)
+    },
+    stop: () => {
+      stopped = true
+      child?.kill("SIGTERM")
+      child = null
+      setState("offline")
+    },
+  }
+}

--- a/packages/kobe/src/machines/tunnel.ts
+++ b/packages/kobe/src/machines/tunnel.ts
@@ -1,28 +1,31 @@
 /**
- * One `ssh -N -L … -L …` process per machine, kept alive.
+ * The SSH forward that makes a machine's daemon reachable as a local socket.
  *
- * The two forwards turn the remote daemon socket and the remote PTY-host
- * socket into local unix sockets under `<home>/.rove/machines/<alias>/`. Every
- * other layer then treats a machine exactly like the local daemon — a socket
- * path — which is why nothing above this file knows SSH exists.
+ * Both forwards ride the machine's shared ControlMaster connection
+ * (`ssh -O forward`), which outlives the process that created it by
+ * `ControlPersist` seconds. That is what lets a millisecond-long `rove api`
+ * process and a day-long TUI use the SAME mechanism: neither has to hold an
+ * `ssh -N` open, and neither can knock the other's forward down by racing it
+ * for the same socket path — which is exactly what happened while the two were
+ * separate.
+ *
+ * So {@link ensureForwards} is the whole transport, and {@link startTunnel} is
+ * that plus a liveness poll: it re-establishes the forward when the socket
+ * stops answering, with exponential backoff, forever. The far side coming back
+ * is the expected outcome — a machine you registered should not need
+ * re-registering after a lid close.
  *
  * Windows has no `AF_UNIX` forwarding in OpenSSH's `-L local-socket` form, so
- * {@link startTunnel} reports `unsupported` there rather than spawning
- * something that cannot work. The module still IMPORTS cleanly on Windows —
- * `rove machine list` must run everywhere.
- *
- * Reconnect policy mirrors the daemon client's: exponential backoff capped at
- * a few seconds, forever, because the far side coming back is the expected
- * outcome and a machine the user registered should not need re-registering
- * after a lid close.
+ * both entry points report failure there rather than pretending. The module
+ * still IMPORTS cleanly on Windows — `rove machine list` must run everywhere.
  */
 
-import { type ChildProcess, spawn } from "node:child_process"
+import { spawn } from "node:child_process"
 import { mkdirSync, rmSync } from "node:fs"
 import { connect as netConnect } from "node:net"
 import { homeDir } from "../env.ts"
 import type { MachineConfig } from "./registry.ts"
-import { localDaemonSocketPath, localPtySocketPath, machineSocketDir, machineSshArgs, tunnelArgs } from "./ssh-args.ts"
+import { localDaemonSocketPath, localPtySocketPath, machineSocketDir, machineSshArgs } from "./ssh-args.ts"
 
 /** Owner-only, like every other directory under `<home>/.rove`: the sockets in
  *  here reach a daemon that runs commands as its owner. */
@@ -48,29 +51,32 @@ export interface StartTunnelOptions {
   readonly remoteDaemonSocket: string
   readonly remotePtySocket: string
   readonly home?: string
-  /** Injected for tests: spawn the ssh child. */
-  readonly spawnFn?: (argv: readonly string[]) => ChildProcess
-  /** Injected for tests: schedule the next reconnect attempt. */
+  /** Injected for tests: bring the forward up. Resolves true when it is up. */
+  readonly ensureFn?: () => Promise<boolean>
+  /** Injected for tests: whether the forwarded daemon socket answers. */
+  readonly checkFn?: () => Promise<boolean>
+  /** Injected for tests: schedule the next attempt / health check. */
   readonly setTimeoutFn?: (fn: () => void, ms: number) => unknown
 }
 
 const BACKOFF_START_MS = 500
 const BACKOFF_MAX_MS = 5_000
+/** How often a live forward is re-checked. Long enough to be free, short
+ *  enough that a closed lid greys its rows within one glance. */
+const HEALTH_INTERVAL_MS = 10_000
 
 /**
- * Spawn (and re-spawn) the tunnel. Returns immediately with a handle whose
- * state starts at `connecting`; callers watch {@link TunnelHandle.onState}
- * rather than awaiting, because a machine that is down must not block the
- * ones that are up.
+ * Keep a machine's forward up. Returns immediately with a handle whose state
+ * starts at `connecting`; callers watch {@link TunnelHandle.onState} rather
+ * than awaiting, because a machine that is down must not block the ones that
+ * are up.
  */
 export function startTunnel(opts: StartTunnelOptions): TunnelHandle {
   const home = opts.home ?? homeDir()
-  const dir = machineSocketDir(opts.alias, home)
   const daemonSocketPath = localDaemonSocketPath(opts.alias, home)
   const ptySocketPath = localPtySocketPath(opts.alias, home)
   const listeners = new Set<(state: TunnelState) => void>()
   let state: TunnelState = "connecting"
-  let child: ChildProcess | null = null
   let stopped = false
   let backoff = BACKOFF_START_MS
 
@@ -79,93 +85,7 @@ export function startTunnel(opts: StartTunnelOptions): TunnelHandle {
     state = next
     for (const listener of listeners) listener(next)
   }
-
-  if (process.platform === "win32") {
-    setState("unsupported")
-    return {
-      alias: opts.alias,
-      daemonSocketPath,
-      ptySocketPath,
-      state: () => state,
-      onState: (listener) => {
-        listeners.add(listener)
-        return () => listeners.delete(listener)
-      },
-      stop: () => {},
-    }
-  }
-
-  const connect = (): void => {
-    if (stopped) return
-    try {
-      mkdirSync(dir, { recursive: true, mode: DIR_MODE })
-    } catch {
-      /* a home on a filesystem without modes, or already there */
-    }
-    // ssh REFUSES to bind a local forward socket that already exists — a
-    // leftover from a killed tunnel would otherwise make every reconnect fail
-    // with `ExitOnForwardFailure` and read as "that machine is permanently
-    // down". Only our own two paths, only inside our own directory.
-    for (const path of [daemonSocketPath, ptySocketPath]) {
-      try {
-        rmSync(path, { force: true })
-      } catch {
-        /* nothing there */
-      }
-    }
-    const argv = tunnelArgs({
-      alias: opts.alias,
-      config: opts.config,
-      remoteDaemonSocket: opts.remoteDaemonSocket,
-      remotePtySocket: opts.remotePtySocket,
-      home,
-    })
-    const spawnFn = opts.spawnFn ?? ((a: readonly string[]) => spawn(a[0] ?? "ssh", a.slice(1), { stdio: "ignore" }))
-    let proc: ChildProcess
-    try {
-      proc = spawnFn(argv)
-    } catch {
-      scheduleRetry()
-      return
-    }
-    child = proc
-    // `ssh -N` prints nothing on success, so there is no "ready" line to wait
-    // for. Staying up past the moment ssh would have failed IS the readiness
-    // signal: `ExitOnForwardFailure=yes` makes a bind failure an immediate
-    // exit, so a process still alive after the grace window has both forwards.
-    const readyTimer = setTimeout(() => {
-      if (child === proc && !stopped) {
-        backoff = BACKOFF_START_MS
-        setState("online")
-      }
-    }, 700)
-    proc.on("exit", () => {
-      clearTimeout(readyTimer)
-      if (child !== proc || stopped) return
-      child = null
-      setState("offline")
-      scheduleRetry()
-    })
-    proc.on("error", () => {
-      clearTimeout(readyTimer)
-      if (child !== proc || stopped) return
-      child = null
-      setState("offline")
-      scheduleRetry()
-    })
-  }
-
-  const scheduleRetry = (): void => {
-    if (stopped) return
-    const wait = backoff
-    backoff = Math.min(backoff * 2, BACKOFF_MAX_MS)
-    const schedule = opts.setTimeoutFn ?? ((fn: () => void, ms: number) => setTimeout(fn, ms))
-    schedule(() => connect(), wait)
-  }
-
-  connect()
-
-  return {
+  const handle: TunnelHandle = {
     alias: opts.alias,
     daemonSocketPath,
     ptySocketPath,
@@ -176,26 +96,67 @@ export function startTunnel(opts: StartTunnelOptions): TunnelHandle {
     },
     stop: () => {
       stopped = true
-      child?.kill("SIGTERM")
-      child = null
-      setState("offline")
     },
   }
+
+  if (process.platform === "win32") {
+    setState("unsupported")
+    return handle
+  }
+
+  const schedule = opts.setTimeoutFn ?? ((fn: () => void, ms: number) => setTimeout(fn, ms))
+  const ensure =
+    opts.ensureFn ??
+    (() =>
+      ensureForwards({
+        alias: opts.alias,
+        config: opts.config,
+        remoteDaemonSocket: opts.remoteDaemonSocket,
+        remotePtySocket: opts.remotePtySocket,
+        home,
+      }))
+  const check = opts.checkFn ?? (() => socketAnswers(daemonSocketPath))
+
+  const attempt = async (): Promise<void> => {
+    if (stopped) return
+    const up = await ensure()
+    if (stopped) return
+    if (up) {
+      backoff = BACKOFF_START_MS
+      setState("online")
+      schedule(() => void health(), HEALTH_INTERVAL_MS)
+      return
+    }
+    setState("offline")
+    const wait = backoff
+    backoff = Math.min(backoff * 2, BACKOFF_MAX_MS)
+    schedule(() => void attempt(), wait)
+  }
+
+  const health = async (): Promise<void> => {
+    if (stopped) return
+    if (await check()) {
+      if (!stopped) schedule(() => void health(), HEALTH_INTERVAL_MS)
+      return
+    }
+    // The forward went away — the master timed out, the network dropped, or
+    // the machine went to sleep. Rows stay on screen and grey out; this side
+    // just starts trying again.
+    setState("offline")
+    void attempt()
+  }
+
+  void attempt()
+  return handle
 }
 
 /**
- * Install the two forwards onto the machine's SHARED ssh connection, without
- * leaving a process behind — the CLI's way in.
- *
- * A `rove api` process lives for milliseconds, so it cannot hold an `ssh -N`
- * open the way the TUI does. `ssh -O forward` adds a forward to a running
- * ControlMaster instead, and the master outlives the client that created it by
- * `ControlPersist` seconds. So the first CLI call that needs a machine pays
- * one connect, and the next few minutes of calls find the socket already there.
+ * Install both forwards onto the machine's shared ssh connection, leaving no
+ * process behind.
  *
  * Best-effort: every failure answers `false`, and the caller reports the
- * machine as offline. Returns true when the forwarded daemon socket exists
- * afterwards, which is the only claim worth making.
+ * machine as offline. Returns true only when the forwarded daemon socket
+ * actually answers afterwards, which is the only claim worth making.
  */
 export async function ensureForwards(args: {
   readonly alias: string
@@ -211,10 +172,14 @@ export async function ensureForwards(args: {
   try {
     mkdirSync(machineSocketDir(args.alias, home), { recursive: true, mode: DIR_MODE })
   } catch {
-    /* already there */
+    /* already there, or a filesystem without modes */
   }
+  // Already up — including when another Rove process on this machine put it
+  // up. Sharing the forward is the point: a second one on the same path is
+  // what `ExitOnForwardFailure` would refuse.
   if (await socketAnswers(daemonLocal)) return true
-  // A leftover socket file from a dead master would make `-O forward` fail.
+  // A socket FILE with nothing behind it is a leftover from a dead master;
+  // ssh refuses to bind over it. Only our own two paths, in our own directory.
   for (const path of [daemonLocal, ptyLocal]) {
     try {
       rmSync(path, { force: true })

--- a/packages/kobe/src/tui-react/panes/sidebar/SidebarTree.tsx
+++ b/packages/kobe/src/tui-react/panes/sidebar/SidebarTree.tsx
@@ -16,6 +16,7 @@ import type { Task } from "@/types/task"
 import type { BoxRenderable, ScrollBoxRenderable } from "@opentui/core"
 import { useTerminalDimensions } from "@opentui/react"
 import { type MutableRefObject, useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { useMachineRows } from "../../../machines/hub-singleton"
 import { createSidebarController } from "../../../tui/panes/sidebar/controller"
 import { RECENT_ROW_ID, type TreeRow, parseRowId } from "../../../tui/panes/sidebar/tree-core"
 import { MAIN_BRANCH_POLL_MS, SIDEBAR_WIDTH } from "../../../tui/panes/sidebar/view-core"
@@ -72,6 +73,7 @@ export function SidebarTree(props: SidebarTreeProps) {
     return () => clearInterval(timer)
   }, [])
 
+  const machines = useMachineRows()
   const search = useTreeSearch({ focused, onActiveChange: props.onSearchActiveChange })
   const tree = useTreeState({
     tasks: props.tasks,
@@ -82,6 +84,7 @@ export function SidebarTree(props: SidebarTreeProps) {
     recentTask: props.recentTask ?? null,
     sortMode: props.sortMode,
     branchTick,
+    machines,
   })
   const flatIndexOf = useMemo(() => {
     const map = new Map<string, number>()

--- a/packages/kobe/src/tui-react/panes/sidebar/chrome.tsx
+++ b/packages/kobe/src/tui-react/panes/sidebar/chrome.tsx
@@ -24,6 +24,9 @@ export function SectionHeader(props: {
   onPress?: () => void
   /** Right-click, with the click's screen cell (the tree's project menu). */
   onContextMenu?: (x: number, y: number) => void
+  /** Drop the label's BOLD — how an offline machine section reads as inactive
+   *  without inventing a colour the theme does not define. */
+  muted?: boolean
 }) {
   const { theme, transparentBackground } = useTheme()
   const dividerColor = transparentBackground ? theme.border : theme.borderSubtle
@@ -58,7 +61,12 @@ export function SectionHeader(props: {
             {props.prefix}
           </text>
         ) : null}
-        <text fg={theme.textMuted} attributes={TextAttributes.BOLD} wrapMode="none" flexShrink={0}>
+        <text
+          fg={theme.textMuted}
+          attributes={props.muted ? undefined : TextAttributes.BOLD}
+          wrapMode="none"
+          flexShrink={0}
+        >
           {props.label}
         </text>
         <text fg={dividerColor} wrapMode="none" flexBasis={0} flexGrow={1} flexShrink={1}>

--- a/packages/kobe/src/tui-react/panes/sidebar/chrome.tsx
+++ b/packages/kobe/src/tui-react/panes/sidebar/chrome.tsx
@@ -27,6 +27,9 @@ export function SectionHeader(props: {
   /** Drop the label's BOLD — how an offline machine section reads as inactive
    *  without inventing a colour the theme does not define. */
   muted?: boolean
+  /** Tree depth. Non-zero indents the header, so a project sitting under a
+   *  machine header reads as belonging to it. */
+  depth?: number
 }) {
   const { theme, transparentBackground } = useTheme()
   const dividerColor = transparentBackground ? theme.border : theme.borderSubtle
@@ -42,7 +45,7 @@ export function SectionHeader(props: {
         flexDirection="row"
         flexShrink={0}
         gap={1}
-        paddingLeft={1}
+        paddingLeft={1 + (props.depth ?? 0) * 2}
         paddingRight={1}
         onMouseUp={
           props.onPress || props.onContextMenu

--- a/packages/kobe/src/tui-react/panes/sidebar/tree-panel.tsx
+++ b/packages/kobe/src/tui-react/panes/sidebar/tree-panel.tsx
@@ -79,6 +79,7 @@ export function SidebarTreeBody(props: {
                 label={isScratch ? t("tasks.header.scratch") : row.label}
                 suffix={props.movingProjectId === row.id ? t("tasks.moveChip") : undefined}
                 topPad={i > 0}
+                depth={row.depth}
                 onContextMenu={
                   props.onProjectContextMenu && !isScratch
                     ? (x, y) => props.onProjectContextMenu?.(row.id, x, y)

--- a/packages/kobe/src/tui-react/panes/sidebar/tree-panel.tsx
+++ b/packages/kobe/src/tui-react/panes/sidebar/tree-panel.tsx
@@ -14,6 +14,7 @@
  */
 
 import type { ScrollBoxRenderable } from "@opentui/core"
+import { machineRowLabel } from "../../../tui/panes/sidebar/machine-layer"
 import { SCRATCH_SECTION_ID, type TreeRow } from "../../../tui/panes/sidebar/tree-core"
 import { sidebarEmptyStateKey } from "../../../tui/panes/sidebar/view-core"
 import { useTheme } from "../../context/theme"
@@ -49,6 +50,24 @@ export function SidebarTreeBody(props: {
     >
       <box flexShrink={0} gap={0}>
         {props.rows.map((row, i) => {
+          if (row.kind === "machine") {
+            // A machine header is a SectionHeader like a project's, one rung
+            // up: its whole content is the label `machine-layer.ts` composed
+            // (`narwhal · v0.9.185` / `narwhal · offline`). Offline and
+            // protocol-mismatch rows grey out, and so do the rows beneath
+            // them — a stale snapshot must not read as live.
+            return (
+              <SectionHeader
+                key={row.id}
+                label={machineRowLabel(
+                  { alias: row.alias, hostLabel: row.label, state: row.state, version: row.version },
+                  t,
+                )}
+                topPad={i > 0}
+                muted={row.state !== "online"}
+              />
+            )
+          }
           if (row.kind === "project") {
             // The Scratch header reuses the project-row shape but
             // is a fixed section, not a repo: translated label, no context
@@ -98,6 +117,7 @@ export function SidebarTreeBody(props: {
                 rowId={row.id}
                 flatIndex={props.flatIndexOf.get(row.id) ?? -1}
                 task={row.task}
+                depth={row.depth}
                 shared={props.shared}
               />
             )
@@ -109,6 +129,7 @@ export function SidebarTreeBody(props: {
               flatIndex={props.flatIndexOf.get(row.id) ?? -1}
               task={row.task}
               tab={row.tab}
+              depth={row.depth - 1}
               shared={props.shared}
             />
           )

--- a/packages/kobe/src/tui-react/panes/sidebar/tree-rows.tsx
+++ b/packages/kobe/src/tui-react/panes/sidebar/tree-rows.tsx
@@ -77,6 +77,8 @@ export function WorktreeTreeRow(props: {
   readonly rowId: string
   readonly flatIndex: number
   readonly task: Task
+  /** Tree depth — 1 at rest, one deeper under a machine header. */
+  readonly depth?: number
   readonly shared: TreeRowShared
 }) {
   const { theme } = useTheme()
@@ -134,7 +136,7 @@ export function WorktreeTreeRow(props: {
     ((changes?.behind ?? 0) > 0 ? clusterCells(`↓${changes?.behind}`) : 0) +
     (moving ? clusterCells(t("tasks.moveChip").trim()) : 0)
   return (
-    <RowShell rowId={props.rowId} flatIndex={props.flatIndex} depth={1} shared={shared}>
+    <RowShell rowId={props.rowId} flatIndex={props.flatIndex} depth={props.depth ?? 1} shared={shared}>
       {spinning ? (
         <text fg={theme.primary} wrapMode="none" width={2} flexShrink={0}>
           {`${IN_PROGRESS_SPINNER[frame % IN_PROGRESS_SPINNER.length] ?? IN_PROGRESS_SPINNER[0]} `}
@@ -145,7 +147,17 @@ export function WorktreeTreeRow(props: {
         </text>
       ) : null}
       <box flexDirection="row" flexGrow={1} paddingRight={1} gap={1}>
-        <text fg={theme.text} wrapMode="none" flexBasis={0} flexGrow={1} flexShrink={1}>
+        {/* A row from an unreachable machine is the LAST KNOWN state, not a
+            live one — it keeps its place and drops to muted rather than
+            disappearing, which would erase the only record of where the work
+            is. */}
+        <text
+          fg={task.origin?.stale ? theme.textMuted : theme.text}
+          wrapMode="none"
+          flexBasis={0}
+          flexGrow={1}
+          flexShrink={1}
+        >
           {truncateEndCells(label, treeLabelBudget(shared, reserved), charWidth)}
         </text>
         {task.pinned === true ? (
@@ -213,6 +225,8 @@ export function TabTreeRow(props: {
   readonly flatIndex: number
   readonly task: Task
   readonly tab: TreeTab
+  /** Tree depth — 1 at rest, one deeper under a machine header. */
+  readonly depth?: number
   readonly shared: TreeRowShared
 }) {
   const { theme } = useTheme()
@@ -294,7 +308,7 @@ export function TabTreeRow(props: {
   // worktree row — the circle status glyph carries the hierarchy, and the
   // extra indent cell wasted width the narrow rail doesn't have.
   return (
-    <RowShell rowId={props.rowId} flatIndex={props.flatIndex} depth={1} shared={props.shared}>
+    <RowShell rowId={props.rowId} flatIndex={props.flatIndex} depth={props.depth ?? 1} shared={props.shared}>
       <text
         fg={restored ? theme.error : carriesState ? toneColor(theme, rowView.tone) : theme.textMuted}
         wrapMode="none"

--- a/packages/kobe/src/tui-react/panes/sidebar/use-tree-menu.ts
+++ b/packages/kobe/src/tui-react/panes/sidebar/use-tree-menu.ts
@@ -104,7 +104,8 @@ export function useTreeMenu(deps: TreeMenuDeps): TreeMenu {
       const row = tree.rows.find((candidate) => candidate.id === rowId)
       // Neither the "↩ recent" jump row nor the routine count row has a menu:
       // both are shortcuts, not task rows, so there is no task to act on.
-      if (!row || row.kind === "project" || row.kind === "recent" || row.kind === "routines") return
+      if (!row || row.kind === "project" || row.kind === "machine" || row.kind === "recent" || row.kind === "routines")
+        return
       // Move the cursor too: the menu and the highlight must agree about which
       // row the next action lands on.
       setCursorIndex(flatIndex)
@@ -169,7 +170,7 @@ export function useTreeMenu(deps: TreeMenuDeps): TreeMenu {
       }
       // A routine count row never opens a menu (see the guard above), so it
       // can only arrive here through a stale `menu` — nothing to act on.
-      if (row.kind === "routines") return
+      if (row.kind === "routines" || row.kind === "machine") return
       const taskId = row.task.id
       switch (action) {
         case "open":

--- a/packages/kobe/src/tui-react/panes/sidebar/use-tree-state.ts
+++ b/packages/kobe/src/tui-react/panes/sidebar/use-tree-state.ts
@@ -26,7 +26,8 @@ import type { Task } from "@/types/task"
 import { DEFAULT_TASK_VENDOR } from "@/types/task"
 import { useCallback, useEffect, useMemo, useState } from "react"
 import { currentBranch } from "../../../tui/panes/sidebar/git-head"
-import { sidebarProjectKey } from "../../../tui/panes/sidebar/groups"
+import { sidebarProjectKeyOfTask } from "../../../tui/panes/sidebar/groups"
+import { type MachineLayerEntry, applyMachineLayer } from "../../../tui/panes/sidebar/machine-layer"
 import {
   type TreeRow,
   type TreeTab,
@@ -71,7 +72,14 @@ export interface TreeStateOpts {
    *  HEADs, so a `main` row becomes findable by its branch as soon as the
    *  poller answers rather than only on the next unrelated re-render. */
   readonly branchTick?: number
+  /** Registered machines. Absent/empty leaves the tree exactly as it was
+   *  before machines existed — no header row, no extra indent. */
+  readonly machines?: readonly MachineLayerEntry[]
 }
+
+/** One shared empty array, so an install with no machines never invalidates
+ *  the tree memo on a fresh literal. */
+const EMPTY_MACHINES: readonly MachineLayerEntry[] = []
 
 export interface TreeState {
   readonly rows: readonly TreeRow[]
@@ -259,6 +267,7 @@ export function useTreeState(opts: TreeStateOpts): TreeState {
 
   const recentTask = opts.recentTask ?? null
   const sortMode = opts.sortMode ?? "default"
+  const machines = opts.machines ?? EMPTY_MACHINES
   const { rows, totalCount } = useMemo(() => {
     // A SEARCH builds the tree fully expanded: folding the routine
     // sessions away at rest must not make them unfindable, and search is how
@@ -283,10 +292,16 @@ export function useTreeState(opts: TreeStateOpts): TreeState {
       return path ? currentBranch(path) : ""
     }
     return {
-      rows: searching ? filterTreeRows(all, query, liveBranch) : withRecentRow(all, recentTask),
+      // The machine layer runs LAST, over the finished tree: with no machine
+      // registered it returns the very array it was handed, so a zero-machine
+      // sidebar is byte-identical to what it was before machines existed.
+      rows: applyMachineLayer(
+        searching ? filterTreeRows(all, query, liveBranch) : withRecentRow(all, recentTask),
+        machines,
+      ),
       totalCount: total,
     }
-  }, [tasks, tabsByTask, searching, query, recentTask, sortMode, expandedRoutines, opts.branchTick])
+  }, [tasks, tabsByTask, searching, query, recentTask, sortMode, expandedRoutines, machines, opts.branchTick])
   const flatIds = useMemo(() => treeFlatIds(rows), [rows])
 
   // The active row is the selected task's ACTIVE TAB, else the worktree row
@@ -307,7 +322,7 @@ export function useTreeState(opts: TreeStateOpts): TreeState {
     (taskId: string): string | null => {
       const task = tasks.find((candidate) => candidate.id === taskId)
       if (!task || task.kind === "dir") return null
-      return sidebarProjectKey(task.repo)
+      return sidebarProjectKeyOfTask(task)
     },
     [tasks],
   )

--- a/packages/kobe/src/tui-react/workspace/host-files-pane.tsx
+++ b/packages/kobe/src/tui-react/workspace/host-files-pane.tsx
@@ -12,6 +12,7 @@ import { useTerminalDimensions } from "@opentui/react"
 import { sidebarWidthFor } from "../../tui/panes/sidebar/view-core"
 import { useFocus } from "../context/focus"
 import { useTheme } from "../context/theme"
+import { useT } from "../i18n"
 import { FileTree } from "../panes/filetree/FileTree"
 
 const WORKTREE_TOOLS_MIN_WIDTH = 22
@@ -35,8 +36,14 @@ export function HostFilesPane(props: {
    *  `"dir"` rows point at a directory whose branch Rove does not own, so they
    *  keep it. */
   readonly taskKind: "main" | "task" | "dir" | undefined
+  /** Host the selected task's worktree lives on, when that is not this
+   *  machine. A remote worktree path means nothing to the local filesystem —
+   *  reading it would list whatever happens to sit at the same path here — so
+   *  the pane names the machine instead of showing a tree. */
+  readonly remoteHost?: string
 }) {
   const { theme } = useTheme()
+  const t = useT()
   const focus = useFocus()
   const dims = useTerminalDimensions()
   const inactiveBorder = theme.borderActive
@@ -50,20 +57,31 @@ export function HostFilesPane(props: {
       borderColor={focus.focused === "files" ? theme.focusAccent : inactiveBorder}
       onMouseUp={() => focus.setFocused("files")}
     >
-      <FileTree
-        worktreePath={props.worktree}
-        paneWidth={width - 2 /* box border */}
-        prBaseRef={props.prBaseRef}
-        focused={props.focused}
-        onOpenFile={props.onOpenFile}
-        onOpenDiff={props.onOpenDiff}
-        onMention={props.onMention}
-        onZenToggle={props.onZenToggle}
-        // Withholding the chip is not withholding the action: `files.createPR`
-        // is a GLOBAL prefix binding, so prefix+P still fires on a main row and
-        // still explains itself with the toast.
-        onCreatePR={props.taskKind === "main" ? undefined : props.onCreatePR}
-      />
+      {props.remoteHost ? (
+        <box flexDirection="column" padding={1} gap={1}>
+          <text fg={theme.textMuted} wrapMode="word">
+            {t("tasks.machine.filesElsewhere", { host: props.remoteHost })}
+          </text>
+          <text fg={theme.textMuted} wrapMode="word">
+            {t("tasks.machine.filesHint", { host: props.remoteHost })}
+          </text>
+        </box>
+      ) : (
+        <FileTree
+          worktreePath={props.worktree}
+          paneWidth={width - 2 /* box border */}
+          prBaseRef={props.prBaseRef}
+          focused={props.focused}
+          onOpenFile={props.onOpenFile}
+          onOpenDiff={props.onOpenDiff}
+          onMention={props.onMention}
+          onZenToggle={props.onZenToggle}
+          // Withholding the chip is not withholding the action: `files.createPR`
+          // is a GLOBAL prefix binding, so prefix+P still fires on a main row and
+          // still explains itself with the toast.
+          onCreatePR={props.taskKind === "main" ? undefined : props.onCreatePR}
+        />
+      )}
     </box>
   )
 }

--- a/packages/kobe/src/tui-react/workspace/host.tsx
+++ b/packages/kobe/src/tui-react/workspace/host.tsx
@@ -443,6 +443,11 @@ export function WorkspaceRoot(props: { orchestrator: RemoteOrchestrator }) {
           onZenToggle={toggleZen}
           onCreatePR={() => void editor.onCreatePR()}
           taskKind={selectedTask?.kind}
+          remoteHost={
+            selectedTask?.origin && selectedTask.origin.machineId !== "local"
+              ? selectedTask.origin.hostLabel
+              : undefined
+          }
         />
       ) : null}
 
@@ -470,9 +475,19 @@ export async function startWorkspaceHost(): Promise<void> {
       const orchestrator = new RemoteOrchestrator(client, { role: "gui" })
       await orchestrator.init()
       process.env.KOBE_DAEMON_SOCKET_PATH = client.socketPath
+      // Other computers running Rove. `attach()` is synchronous and a no-op
+      // when none are registered, so an install without machines pays one map
+      // lookup and boots exactly as before.
+      const { MachineHub } = await import("../../machines/hub.ts")
+      const { setMachineHub } = await import("../../machines/hub-singleton.ts")
+      const machines = new MachineHub(orchestrator)
+      machines.attach()
+      setMachineHub(machines)
       return {
         root: () => <WorkspaceRoot orchestrator={orchestrator} />,
         onDestroy: () => {
+          setMachineHub(null)
+          machines.dispose()
           orchestrator.dispose()
           // Detach, don't kill: hosted PTYs (the `kobe pty-host` process)
           // keep their engine sessions RUNNING in the background and

--- a/packages/kobe/src/tui-react/workspace/host.tsx
+++ b/packages/kobe/src/tui-react/workspace/host.tsx
@@ -9,7 +9,7 @@
 import { useRenderer, useTerminalDimensions } from "@opentui/react"
 import { connectOrStartDaemon } from "@sma1lboy/kobe-daemon/client/daemon-process"
 import { useEffect, useRef, useState } from "react"
-import { RemoteOrchestrator } from "../../client/remote-orchestrator.ts"
+import type { RemoteOrchestrator } from "../../client/remote-orchestrator.ts"
 import { sidebarWidthFor } from "../../tui/panes/sidebar/view-core"
 import { getDefaultPtyRegistry } from "../../tui/panes/terminal/registry"
 import { PrefixHud } from "../component/prefix-hud"
@@ -464,38 +464,4 @@ export function WorkspaceRoot(props: { orchestrator: RemoteOrchestrator }) {
       <PrefixHud left={1} width={sidebarWidthFor(dims.width) - 2} />
     </WorkspaceFrame>
   )
-}
-
-export async function startWorkspaceHost(): Promise<void> {
-  await bootPaneHost({
-    logContext: "workspace",
-    providers: { kv: true, focus: true, notifications: true },
-    setup: async () => {
-      const client = await connectOrStartDaemon()
-      const orchestrator = new RemoteOrchestrator(client, { role: "gui" })
-      await orchestrator.init()
-      process.env.KOBE_DAEMON_SOCKET_PATH = client.socketPath
-      // Other computers running Rove. `attach()` is synchronous and a no-op
-      // when none are registered, so an install without machines pays one map
-      // lookup and boots exactly as before.
-      const { MachineHub } = await import("../../machines/hub.ts")
-      const { setMachineHub } = await import("../../machines/hub-singleton.ts")
-      const machines = new MachineHub(orchestrator)
-      machines.attach()
-      setMachineHub(machines)
-      return {
-        root: () => <WorkspaceRoot orchestrator={orchestrator} />,
-        onDestroy: () => {
-          setMachineHub(null)
-          machines.dispose()
-          orchestrator.dispose()
-          // Detach, don't kill: hosted PTYs (the `kobe pty-host` process)
-          // keep their engine sessions RUNNING in the background and
-          // reattach on next boot. Local-backend PTYs (no detach()) are
-          // still killed — a child of this process can't outlive it usefully.
-          getDefaultPtyRegistry().detachAll()
-        },
-      }
-    },
-  })
 }

--- a/packages/kobe/src/tui-react/workspace/start-workspace.tsx
+++ b/packages/kobe/src/tui-react/workspace/start-workspace.tsx
@@ -1,0 +1,50 @@
+/** @jsxImportSource @opentui/react */
+/**
+ * Booting the workspace: what has to exist before `WorkspaceRoot` can render,
+ * and what has to be let go of when it stops.
+ *
+ * Split from `host.tsx`, which owns the COMPONENT. The two jobs share only the
+ * orchestrator: this file has no JSX beyond handing the root back, and the
+ * component knows nothing about daemons, machines or PTY registries.
+ */
+
+import { connectOrStartDaemon } from "@sma1lboy/kobe-daemon/client/daemon-process"
+import { RemoteOrchestrator } from "../../client/remote-orchestrator"
+import { getDefaultPtyRegistry } from "../../tui/panes/terminal/registry"
+import { bootPaneHost } from "../lib/host-boot"
+import { WorkspaceRoot } from "./host"
+
+export async function startWorkspaceHost(): Promise<void> {
+  await bootPaneHost({
+    logContext: "workspace",
+    providers: { kv: true, focus: true, notifications: true },
+    setup: async () => {
+      const client = await connectOrStartDaemon()
+      const orchestrator = new RemoteOrchestrator(client, { role: "gui" })
+      await orchestrator.init()
+      process.env.KOBE_DAEMON_SOCKET_PATH = client.socketPath
+      // Other computers running Rove. `attach()` is synchronous and a no-op
+      // when none are registered, so an install without machines pays one map
+      // lookup and boots exactly as before. Imported lazily for the same
+      // reason: nothing about machines is loaded on a machine-free install.
+      const { MachineHub } = await import("../../machines/hub.ts")
+      const { setMachineHub } = await import("../../machines/hub-singleton.ts")
+      const machines = new MachineHub(orchestrator)
+      machines.attach()
+      setMachineHub(machines)
+      return {
+        root: () => <WorkspaceRoot orchestrator={orchestrator} />,
+        onDestroy: () => {
+          setMachineHub(null)
+          machines.dispose()
+          orchestrator.dispose()
+          // Detach, don't kill: hosted PTYs (the `kobe pty-host` process)
+          // keep their engine sessions RUNNING in the background and
+          // reattach on next boot. Local-backend PTYs (no detach()) are
+          // still killed — a child of this process can't outlive it usefully.
+          getDefaultPtyRegistry().detachAll()
+        },
+      }
+    },
+  })
+}

--- a/packages/kobe/src/tui-react/workspace/start-workspace.tsx
+++ b/packages/kobe/src/tui-react/workspace/start-workspace.tsx
@@ -6,6 +6,12 @@
  * Split from `host.tsx`, which owns the COMPONENT. The two jobs share only the
  * orchestrator: this file has no JSX beyond handing the root back, and the
  * component knows nothing about daemons, machines or PTY registries.
+ *
+ * Nothing here is reachable from a render test, and that is the point of the
+ * split rather than a gap in it: every line opens a real daemon socket, a real
+ * SSH tunnel or the PTY registry whose teardown it owns. `WorkspaceRoot` next
+ * door IS mountable and is covered as such; what is left over here is the
+ * process entry point (see `docs/HARNESS.md` on the coverage gate).
  */
 
 import { connectOrStartDaemon } from "@sma1lboy/kobe-daemon/client/daemon-process"

--- a/packages/kobe/src/tui-react/workspace/use-daemon-state.tsx
+++ b/packages/kobe/src/tui-react/workspace/use-daemon-state.tsx
@@ -16,6 +16,7 @@ import type {
   TranscriptActivityMap,
   WorktreeChangesMap,
 } from "../../client/remote-orchestrator-payloads"
+import { useMergedTasks } from "../../machines/hub-singleton"
 import type { Task } from "../../types/task"
 import { useAccessor } from "../lib/use-accessor"
 import { useAnsweredTabStates, useOptimisticEngineState } from "./use-optimistic-engine-state"
@@ -34,7 +35,9 @@ export interface UseDaemonStateResult {
 }
 
 export function useDaemonState(orchestrator: RemoteOrchestrator): UseDaemonStateResult {
-  const tasks = useAccessor(orchestrator.tasksSignal())
+  // Machines-aware: the merged list when any machine is registered, the
+  // orchestrator's own cell otherwise (`hub-singleton.ts`).
+  const tasks = useMergedTasks(orchestrator)
   const activeTaskId = useAccessor(orchestrator.activeTaskSignal())
   const engineState = useAccessor(orchestrator.engineStateSignal())
   const engineLifecycle = useAccessor(orchestrator.engineLifecycleSignal())

--- a/packages/kobe/src/tui-react/workspace/use-task-selection.ts
+++ b/packages/kobe/src/tui-react/workspace/use-task-selection.ts
@@ -49,6 +49,16 @@ export async function activateWorkspaceTask(opts: ActivateWorkspaceTaskOptions, 
     opts.reportError(new TaskDeletingError(id))
     return false
   }
+  // A task on ANOTHER machine has its worktree over there. Materializing is a
+  // write, and the only daemon this process can reach is the local one — which
+  // has never heard of that id, so the attempt fails as "task not found" for a
+  // task the user is looking at. Select it and stop: the row, the topbar and
+  // the files pane all still say what it is.
+  if (task?.origin && task.origin.machineId !== "local") {
+    opts.selectTask(id)
+    opts.focusWorkspace()
+    return true
+  }
   // A create RPC can resolve before the daemon's task snapshot causes the
   // workspace host to render. An unknown task is therefore not proof that the
   // id is invalid — materialize by the authoritative RPC id and let the daemon

--- a/packages/kobe/src/tui/i18n/messages/tasks.ts
+++ b/packages/kobe/src/tui/i18n/messages/tasks.ts
@@ -149,6 +149,16 @@ export const en = {
   recentJump: "Recent: {title}",
   /** The fold row standing in for a project's routine sessions */
   routinesRow: "{count} routine sessions",
+  /** Machine section headers — another computer running its own Rove daemon */
+  machine: {
+    connecting: "connecting…",
+    offline: "offline",
+    unsupported: "unsupported",
+    mismatch: "protocol mismatch",
+    /** Files/diff placeholder for a task whose worktree is on another machine */
+    filesElsewhere: "on {host}",
+    filesHint: "This task's worktree lives on {host}. Opening remote files arrives in a later release.",
+  },
   /** Empty-state messages */
   empty: {
     noMatchSearch: "No matching tasks — esc to clear.",
@@ -337,6 +347,14 @@ export const zh: typeof en = {
   moveChip: " 移动",
   recentJump: "最近:{title}",
   routinesRow: "{count} 个 routine 会话",
+  machine: {
+    connecting: "连接中…",
+    offline: "离线",
+    unsupported: "不支持",
+    mismatch: "协议不兼容",
+    filesElsewhere: "在 {host} 上",
+    filesHint: "这个任务的 worktree 在 {host} 上。读取远端文件会在后续版本提供。",
+  },
   empty: {
     noMatchSearch: "无匹配任务——按 esc 清除。",
     noActiveProject: "该项目暂无活跃任务。",

--- a/packages/kobe/src/tui/index.tsx
+++ b/packages/kobe/src/tui/index.tsx
@@ -35,6 +35,6 @@ export async function startTui(): Promise<void> {
   const { loadPluginEngines } = await import("../engine/plugin-engines.ts")
   loadPluginEngines()
 
-  const { startWorkspaceHost } = await import("../tui-react/workspace/host.tsx")
+  const { startWorkspaceHost } = await import("../tui-react/workspace/start-workspace.tsx")
   await startWorkspaceHost()
 }

--- a/packages/kobe/src/tui/panes/sidebar/groups.ts
+++ b/packages/kobe/src/tui/panes/sidebar/groups.ts
@@ -184,12 +184,22 @@ export interface LabelledRepo {
 /**
  * What a project header is CALLED.
  *
- * Three tiers, narrowest first:
- *   1. no collision → the bare basename (`kobe`);
- *   2. collides across MACHINES → `host:basename` (`narwhal:kobe`), because the
- *      machine is the thing that tells them apart and a path tail would not;
- *   3. collides on the SAME machine → the last two path segments (`work/api`),
- *      the rule that predates machines and still reads best there.
+ * Narrowest label that still tells this project apart from every other one on
+ * screen, resolved in that order:
+ *
+ *   1. nothing else shares the basename → the bare basename (`kobe`);
+ *   2. something on the SAME machine shares it → the last two path segments
+ *      (`gihub/kobe` vs `i/kobe`), because on one machine the path is what
+ *      differs and the machine name would say nothing;
+ *   3. only another MACHINE shares it → `host:basename` (`narwhal:kobe`).
+ *      The local machine keeps the bare name: it is the one you are sitting
+ *      at, and prefixing it makes the common case pay for the rare one.
+ *
+ * Step 2 runs before step 3 on purpose. Two checkouts of `kobe` on one remote
+ * machine both answered `narwhal:kobe` when the machine test came first — two
+ * headers reading as one project, which is the whole failure this function
+ * exists to prevent. When a same-machine tail is ITSELF ambiguous across
+ * machines, the host still goes in front of it.
  *
  * `repos` may be plain strings (every pre-machines caller) or
  * {@link LabelledRepo}s. With no host labels anywhere the function is exactly
@@ -201,18 +211,24 @@ export function sidebarProjectLabel(
   hostLabel?: string,
 ): string {
   const base = repoBasename(repo)
+  const host = hostLabel ?? ""
   const others = repos
     .map((entry) => (typeof entry === "string" ? { repo: entry } : entry))
-    .filter((entry) => entry.repo !== repo || (entry.hostLabel ?? "") !== (hostLabel ?? ""))
+    .filter((entry) => entry.repo !== repo || (entry.hostLabel ?? "") !== host)
   const collisions = others.filter((entry) => repoBasename(entry.repo) === base)
   if (collisions.length === 0) return base
-  // Some colliding repo is on a DIFFERENT host — name the host, which is the
-  // only thing that distinguishes two checkouts at the same path. THIS
-  // machine's row keeps the bare name: the local checkout is the one the user
-  // is sitting at, and prefixing it too would make the common case pay for the
-  // rare one. `kobe` and `narwhal:kobe` read correctly side by side.
-  const crossMachine = collisions.some((entry) => (entry.hostLabel ?? "") !== (hostLabel ?? ""))
-  if (crossMachine) return hostLabel ? `${hostLabel}:${base}` : base
+  if (collisions.some((entry) => (entry.hostLabel ?? "") === host)) {
+    const tail = pathTail(repo)
+    // The tail settles the same-machine collision; only a tail that ALSO
+    // repeats on another machine still needs the host in front of it.
+    const tailRepeats = collisions.some((entry) => (entry.hostLabel ?? "") !== host && pathTail(entry.repo) === tail)
+    return tailRepeats && host ? `${host}:${tail}` : tail
+  }
+  return host ? `${host}:${base}` : base
+}
+
+/** The last two path segments — `work/api`, `gihub/kobe`. */
+function pathTail(repo: string): string {
   const syntax = pathSyntax(repo)
   return syntax.normalize(repo).split(syntax.sep).filter(Boolean).slice(-2).join("/")
 }

--- a/packages/kobe/src/tui/panes/sidebar/groups.ts
+++ b/packages/kobe/src/tui/panes/sidebar/groups.ts
@@ -152,14 +152,67 @@ export function repoBasename(repo: string): string {
   return pathSyntax(repo).basename(repo) || repo
 }
 
-export function sidebarProjectKey(repo: string): string {
-  return pathIdentity(repo.trim()) || repo
+/**
+ * The identity of a project row.
+ *
+ * A path alone is NOT an identity once more than one machine is connected:
+ * `~/i/kobe` exists on the laptop and on the build box, and keying on the path
+ * merged the two into one row whose tasks came from both. So the key is
+ * `machineId + NUL + pathIdentity(repo)`, with the local machine's id fixed at
+ * `"local"`.
+ *
+ * `machineId` is OPTIONAL and defaults to `"local"`, which is what keeps the
+ * zero-machine install byte-identical: every existing caller passes one
+ * argument and gets exactly the string it got before.
+ */
+export function sidebarProjectKey(repo: string, machineId = "local"): string {
+  const path = pathIdentity(repo.trim()) || repo
+  return machineId === "local" ? path : `${machineId}\u0000${path}`
 }
 
-export function sidebarProjectLabel(repo: string, repos: readonly string[]): string {
+/** The project key for a task, honouring the machine it came from. */
+export function sidebarProjectKeyOfTask(task: Pick<Task, "repo" | "origin">): string {
+  return sidebarProjectKey(task.repo, task.origin?.machineId ?? "local")
+}
+
+/** A repo as the label rules see it: its path plus the host it lives on. */
+export interface LabelledRepo {
+  readonly repo: string
+  readonly hostLabel?: string
+}
+
+/**
+ * What a project header is CALLED.
+ *
+ * Three tiers, narrowest first:
+ *   1. no collision → the bare basename (`kobe`);
+ *   2. collides across MACHINES → `host:basename` (`narwhal:kobe`), because the
+ *      machine is the thing that tells them apart and a path tail would not;
+ *   3. collides on the SAME machine → the last two path segments (`work/api`),
+ *      the rule that predates machines and still reads best there.
+ *
+ * `repos` may be plain strings (every pre-machines caller) or
+ * {@link LabelledRepo}s. With no host labels anywhere the function is exactly
+ * the two-tier rule it always was.
+ */
+export function sidebarProjectLabel(
+  repo: string,
+  repos: readonly (string | LabelledRepo)[],
+  hostLabel?: string,
+): string {
   const base = repoBasename(repo)
-  const collides = repos.some((r) => r !== repo && repoBasename(r) === base)
-  if (!collides) return base
+  const others = repos
+    .map((entry) => (typeof entry === "string" ? { repo: entry } : entry))
+    .filter((entry) => entry.repo !== repo || (entry.hostLabel ?? "") !== (hostLabel ?? ""))
+  const collisions = others.filter((entry) => repoBasename(entry.repo) === base)
+  if (collisions.length === 0) return base
+  // Some colliding repo is on a DIFFERENT host — name the host, which is the
+  // only thing that distinguishes two checkouts at the same path. THIS
+  // machine's row keeps the bare name: the local checkout is the one the user
+  // is sitting at, and prefixing it too would make the common case pay for the
+  // rare one. `kobe` and `narwhal:kobe` read correctly side by side.
+  const crossMachine = collisions.some((entry) => (entry.hostLabel ?? "") !== (hostLabel ?? ""))
+  if (crossMachine) return hostLabel ? `${hostLabel}:${base}` : base
   const syntax = pathSyntax(repo)
   return syntax.normalize(repo).split(syntax.sep).filter(Boolean).slice(-2).join("/")
 }

--- a/packages/kobe/src/tui/panes/sidebar/machine-layer.ts
+++ b/packages/kobe/src/tui/panes/sidebar/machine-layer.ts
@@ -1,0 +1,126 @@
+/**
+ * The MACHINE layer of the sidebar tree.
+ *
+ * `buildTreeRows` already groups every task under its project, and a project's
+ * key now carries the machine it lives on — so all this pass has to do is
+ * gather each remote machine's project subtrees behind one header and indent
+ * them by one.
+ *
+ * Two rules the whole feature rests on:
+ *
+ *  1. **Zero machines changes nothing.** With no machines registered, this
+ *     returns the SAME array it was given — identity included — so a sidebar
+ *     golden recorded before machines existed still matches byte for byte.
+ *  2. **The local machine gets no header.** Its projects stay at depth 0 where
+ *     they have always been. Adding a `local` header would cost every row on
+ *     the machine everybody actually uses one level of indent to state
+ *     something the absence of a header already says.
+ *
+ * An OFFLINE machine keeps its rows. They grey out (the renderer's job), but
+ * they do not disappear: a laptop with a closed lid has not stopped having
+ * those tasks, and a row that vanishes takes with it the only record of where
+ * the work was.
+ */
+
+import { type MachineRowState, type TreeRow, machineRowId } from "./tree-core"
+
+/** One registered machine, as this layer needs it. */
+export interface MachineLayerEntry {
+  readonly alias: string
+  /** Remote hostname when known, else the alias. */
+  readonly hostLabel: string
+  readonly state: MachineRowState
+  readonly version?: string
+}
+
+/**
+ * The i18n key for a machine's state word, or null when the machine is up (an
+ * online machine says its VERSION, which needs no translation).
+ *
+ * A key rather than a rendered string: this module is pure and the renderer
+ * owns the translator, so composing English here would freeze the label in one
+ * language the way a module-level `t()` constant does.
+ */
+export function machineStateKey(state: MachineRowState): string | null {
+  switch (state) {
+    case "online":
+      return null
+    case "connecting":
+      return "tasks.machine.connecting"
+    case "unsupported":
+      return "tasks.machine.unsupported"
+    case "mismatch":
+      return "tasks.machine.mismatch"
+    default:
+      return "tasks.machine.offline"
+  }
+}
+
+/**
+ * What a machine header reads as, given a translator: `narwhal · v0.9.185`,
+ * `narwhal · offline`, or `narwhal · ⚠ v0.9.100 (protocol mismatch)`.
+ *
+ * The version is on the row deliberately. Two machines running different Rove
+ * builds is the normal state of a fleet, and it explains most of what looks
+ * like a bug across one — so it belongs where the machine is named rather than
+ * behind a command.
+ */
+export function machineRowLabel(entry: MachineLayerEntry, t: (key: string) => string): string {
+  const name = entry.hostLabel || entry.alias
+  const word = machineStateKey(entry.state)
+  if (!word) return entry.version ? `${name} · v${entry.version}` : name
+  if (entry.state === "mismatch") {
+    return entry.version ? `${name} · ⚠ v${entry.version} (${t(word)})` : `${name} · ⚠ ${t(word)}`
+  }
+  return `${name} · ${t(word)}`
+}
+
+/**
+ * Insert a header per remote machine and indent that machine's rows under it.
+ *
+ * `rows` is the flat list `buildTreeRows` produced from the MERGED task list,
+ * so every row already knows its machine (a project row states it; a worktree
+ * or tab row inherits it from the project header above). Rows of a machine
+ * with no registered entry are dropped rather than rendered loose — that is a
+ * machine mid-removal, and a headerless remote project reads as a local one.
+ */
+export function applyMachineLayer(
+  rows: readonly TreeRow[],
+  machines: readonly MachineLayerEntry[],
+): readonly TreeRow[] {
+  if (machines.length === 0) return rows
+  const byAlias = new Map(machines.map((entry) => [entry.alias, entry]))
+  const local: TreeRow[] = []
+  const remote = new Map<string, TreeRow[]>()
+  let current = "local"
+  for (const row of rows) {
+    if (row.kind === "machine") continue
+    if (row.kind === "project") current = row.machineId
+    if (current === "local") {
+      local.push(row)
+      continue
+    }
+    if (!byAlias.has(current)) continue
+    const bucket = remote.get(current) ?? []
+    bucket.push({ ...row, depth: row.depth + 1 } as TreeRow)
+    remote.set(current, bucket)
+  }
+  const out: TreeRow[] = [...local]
+  // Registration order, not connection order: a machine's place in the tree
+  // must not move because it woke up before another one.
+  for (const entry of machines) {
+    // A machine still handshaking contributes its header and no rows — the
+    // header's own label is what says so.
+    out.push({
+      kind: "machine",
+      id: machineRowId(entry.alias),
+      alias: entry.alias,
+      label: entry.hostLabel || entry.alias,
+      state: entry.state,
+      ...(entry.version ? { version: entry.version } : {}),
+      depth: 0,
+    })
+    for (const row of remote.get(entry.alias) ?? []) out.push(row)
+  }
+  return out
+}

--- a/packages/kobe/src/tui/panes/sidebar/tree-core.ts
+++ b/packages/kobe/src/tui/panes/sidebar/tree-core.ts
@@ -19,21 +19,28 @@
  * never disagree about what identifies a tab.
  */
 
-import { homedir } from "node:os"
 import type { Task } from "@/types/task"
-import { tildify } from "../../../lib/path-home"
-import { truncateStart } from "../../lib/truncate"
 import { fuzzyMatch } from "./fuzzy"
-import { compareRecent, repoBasename, sidebarProjectKey, sidebarProjectLabel } from "./groups"
+import { type LabelledRepo, compareRecent, repoBasename, sidebarProjectKeyOfTask, sidebarProjectLabel } from "./groups"
+import { RECENT_ROW_ID, SCRATCH_SECTION_ID, routinesRowId, tabRowId } from "./tree-ids"
 
 // Search lives in its own module — this file decides what rows EXIST, that one
 // decides which survive a query — but stays part of tree-core's public surface,
 // so every caller imports the tree's vocabulary from one place.
 export { filterTreeRows } from "./tree-search"
-
-/** Separator between a task id and a tab id in a tab row's id. Matches the
- *  PTY registry's key format so one parse rule covers both. */
-const TAB_ROW_SEPARATOR = "::"
+// The row-id vocabulary and the row-label rule live in their own modules —
+// both are read by code that never builds a tree (the PTY registry composes
+// the same tab key; the row renderer labels one task at a time). Re-exported
+// here so every caller still names them through the tree's vocabulary.
+export {
+  RECENT_ROW_ID,
+  SCRATCH_SECTION_ID,
+  machineRowId,
+  parseRowId,
+  projectKeyOfRoutinesRow,
+  tabRowId,
+} from "./tree-ids"
+export { rowLiveBranchPath, worktreeRowLabel } from "./tree-labels"
 
 /** A worktree row's tab, as the sidebar needs it (the tab module owns the
  *  real shape; this is the projection the tree renders). */
@@ -56,16 +63,38 @@ export interface TreeTab {
 }
 
 export type TreeRow =
-  | { readonly kind: "project"; readonly id: string; readonly repo: string; readonly label: string; readonly depth: 0 }
-  | { readonly kind: "worktree"; readonly id: string; readonly task: Task; readonly depth: 1 }
+  /**
+   * A MACHINE section header — another computer running its own Rove daemon.
+   * Emitted only when at least one machine is registered; with none, the tree
+   * has no machine rows at all and every depth below is what it always was.
+   */
+  | {
+      readonly kind: "machine"
+      readonly id: string
+      readonly alias: string
+      readonly label: string
+      readonly state: MachineRowState
+      readonly version?: string
+      readonly depth: 0
+    }
+  | {
+      readonly kind: "project"
+      readonly id: string
+      readonly repo: string
+      readonly label: string
+      /** Which machine's checkout this is; `"local"` for this computer. */
+      readonly machineId: string
+      readonly depth: number
+    }
+  | { readonly kind: "worktree"; readonly id: string; readonly task: Task; readonly depth: number }
   | {
       readonly kind: "tab"
       readonly id: string
       readonly task: Task
       readonly tab: TreeTab
-      readonly depth: 2
+      readonly depth: number
     }
-  | { readonly kind: "recent"; readonly id: typeof RECENT_ROW_ID; readonly task: Task; readonly depth: 1 }
+  | { readonly kind: "recent"; readonly id: typeof RECENT_ROW_ID; readonly task: Task; readonly depth: number }
   /**
    * The routine count row: one row standing in for a project's
    * routine session tasks, which are background noise beside the handful of
@@ -79,44 +108,13 @@ export type TreeRow =
       readonly projectKey: string
       readonly count: number
       readonly expanded: boolean
-      readonly depth: 1
+      readonly depth: number
     }
 
-/**
- * Navigation id of the narrow-mode "↩ recent" jump row.
- * Not a ULID and free of {@link TAB_ROW_SEPARATOR}, so `parseRowId` on it
- * yields a task id no task can have — cursor chords that don't special-case
- * it fall through to a lookup miss instead of acting on a real task.
- */
-export const RECENT_ROW_ID = "~recent"
-
-/**
- * Header id of the Scratch section. Like {@link RECENT_ROW_ID},
- * not a repo path and free of the separator, so project-header consumers
- * (move mode, context menu, `mainTaskIdOfProject`) that look it up simply
- * miss — a Scratch header has no main task to move and no repo to file into.
- */
-export const SCRATCH_SECTION_ID = "~scratch"
-
-/**
- * Navigation id of a project's routine count row. Prefixed like
- * the other sentinels so it can never collide with a ULID, and carrying the
- * project key so two projects' rows stay distinct.
- *
- * This row is the ONE fold in a tree that otherwise has none (see
- * `tree-panel.tsx`). It is scoped deliberately: it
- * folds only tasks a SCHEDULE created, never a task a human opened, so the
- * "everything under a project is always visible" promise still holds for
- * everything the user made themselves.
- */
-function routinesRowId(projectKey: string): string {
-  return `~routines:${projectKey}`
-}
-
-/** The project key a routines row id names, or null for any other id. */
-export function projectKeyOfRoutinesRow(id: string): string | null {
-  return id.startsWith("~routines:") ? id.slice("~routines:".length) : null
-}
+/** What a machine row says about its connection. `mismatch` is a remote Rove
+ *  whose protocol range this build cannot talk to — its own row's problem,
+ *  never the whole tree's. */
+export type MachineRowState = "connecting" | "online" | "offline" | "unsupported" | "mismatch"
 
 /** True for a task the sidebar folds behind a routine count row. */
 function isRoutineTask(task: Task): boolean {
@@ -131,79 +129,6 @@ function isRoutineTask(task: Task): boolean {
 export function withRecentRow(rows: readonly TreeRow[], recent: Task | null): TreeRow[] {
   if (!recent) return [...rows]
   return [{ kind: "recent", id: RECENT_ROW_ID, task: recent, depth: 1 }, ...rows]
-}
-
-/** Compose a tab row's navigation id. */
-export function tabRowId(taskId: string, tabId: string): string {
-  return `${taskId}${TAB_ROW_SEPARATOR}${tabId}`
-}
-
-/**
- * Split a row id back into its parts. A task row id has no separator and
- * yields `tabId: null` — callers switch on that rather than string-matching
- * the separator themselves.
- *
- * Task ids are ULIDs and tab ids are `tab-N`, so neither contains the
- * separator; splitting on the FIRST occurrence is unambiguous either way.
- */
-export function parseRowId(rowId: string): { taskId: string; tabId: string | null } {
-  const at = rowId.indexOf(TAB_ROW_SEPARATOR)
-  if (at < 0) return { taskId: rowId, tabId: null }
-  return { taskId: rowId.slice(0, at), tabId: rowId.slice(at + TAB_ROW_SEPARATOR.length) }
-}
-
-/** Widest path label a worktree row renders before tail-truncation — the
- *  default rail width minus row chrome. The row's flex still end-clips on
- *  narrower rails; pre-truncating from the START keeps the leaf visible at
- *  the default width, which is the half that disambiguates a path. */
-const PATH_LABEL_MAX = 24
-
-/**
- * What a worktree row is CALLED — the one derivation rule:
- * a task with a branch is named by it; a branchless `dir` task (plain
- * `rove .` opens and scratch shells alike) by its tail-truncated
- * directory — the stored title is deliberately ignored there, because
- * dir-task titles are auto-generated noise (`jacksonc-xxxx`) and existing
- * rows render by this rule with no data migration. A regular task
- * before its worktree materialises (no branch yet, path not its own)
- * keeps its title, else the label falls back to the path and finally
- * "scratch" so a row is never blank.
- *
- * `liveBranch` is the caller-resolved HEAD for the rows that own no branch of
- * their own (see {@link rowLiveBranchPath} and `git-head.ts`); `home` is
- * injectable so the tildification unit-tests without the real $HOME.
- */
-/**
- * The checkout whose LIVE HEAD names this row, or `""` when the row already
- * carries its own branch.
- *
- * Rove-created worktrees store `branch`, so their label is fixed. Two kinds
- * store none and move freely: `main` (its checkout is the user's to switch)
- * and `dir` — an arbitrary directory the user opened, which is what a scratch
- * shell becomes. A scratch shell opened inside a repo IS on a branch, so
- * labelling it with its path while every worktree row beside it showed a
- * branch made it read as a different species of row. Not-a-repo still falls
- * back to the path: the poller answers `""` for anything it can't resolve.
- */
-export function rowLiveBranchPath(task: Task): string {
-  if (task.kind !== "main" && task.kind !== "dir") return ""
-  return task.worktreePath || task.repo || ""
-}
-
-export function worktreeRowLabel(
-  task: Task,
-  opts: { readonly liveBranch?: string; readonly home?: string } = {},
-): string {
-  const branch = (opts.liveBranch ?? task.branch) || task.branch
-  if (branch) return branch
-  if (task.kind !== "dir" && task.title) return task.title
-  const path = task.worktreePath || task.repo
-  if (path) {
-    const home = opts.home ?? homedir()
-    const tildified = tildify(path, home)
-    return truncateStart(tildified, PATH_LABEL_MAX)
-  }
-  return task.title || "scratch"
 }
 
 export interface TreeInput {
@@ -297,7 +222,7 @@ export function buildTreeRows(input: TreeInput): TreeRow[] {
 
   for (const task of tasks) {
     if (task.kind === "dir" && task.scratch === true) continue
-    const key = sidebarProjectKey(task.repo)
+    const key = sidebarProjectKeyOfTask(task)
     const entry = byProject.get(key) ?? { repo: task.repo, tasks: [] }
     // The main task carries the canonical repo path — a regular task's
     // `repo` is the same value, but taking it from main keeps the header
@@ -319,7 +244,7 @@ export function buildTreeRows(input: TreeInput): TreeRow[] {
   const seen = new Set<string>()
   for (const task of tasks) {
     if (task.kind !== "main") continue
-    const key = sidebarProjectKey(task.repo)
+    const key = sidebarProjectKeyOfTask(task)
     if (!seen.has(key)) {
       seen.add(key)
       orderedKeys.push(key)
@@ -350,7 +275,7 @@ export function buildTreeRows(input: TreeInput): TreeRow[] {
   // The header reuses the project-row shape (id is a sentinel no repo path
   // can be — see SCRATCH_SECTION_ID); the renderer translates its label.
   if (scratchTasks.length > 0) {
-    rows.push({ kind: "project", id: SCRATCH_SECTION_ID, repo: "", label: "Scratch", depth: 0 })
+    rows.push({ kind: "project", id: SCRATCH_SECTION_ID, repo: "", label: "Scratch", machineId: "local", depth: 0 })
     // A scratch task renders NO worktree row of its own: its
     // auto-generated name is noise, and the shell IS the whole session — so
     // its tab rows hang directly under the section header. The task remains a
@@ -382,15 +307,20 @@ export function buildTreeRows(input: TreeInput): TreeRow[] {
     const entry = byProject.get(key)
     return entry ? !isClosedDownProject(entry.tasks, tabsByTask) : false
   })
-  const projectRepos = visibleKeys.map((key) => byProject.get(key)?.repo ?? "")
+  const projectRepos: LabelledRepo[] = visibleKeys.map((key) => {
+    const entry = byProject.get(key)
+    return { repo: entry?.repo ?? "", hostLabel: hostLabelOf(entry?.tasks[0]) }
+  })
   for (const key of visibleKeys) {
     const entry = byProject.get(key)
     if (!entry) continue
+    const hostLabel = hostLabelOf(entry.tasks[0])
     rows.push({
       kind: "project",
       id: key,
       repo: entry.repo,
-      label: sidebarProjectLabel(entry.repo, projectRepos),
+      label: sidebarProjectLabel(entry.repo, projectRepos, hostLabel),
+      machineId: entry.tasks[0]?.origin?.machineId ?? "local",
       depth: 0,
     })
     // Routine sessions sort to the END of their project, behind
@@ -418,6 +348,14 @@ export function buildTreeRows(input: TreeInput): TreeRow[] {
   return rows
 }
 
+/** The host a task's rows display under — undefined for the local machine, so
+ *  a machine-free tree carries no host anywhere in the label rules. */
+function hostLabelOf(task: Task | undefined): string | undefined {
+  const origin = task?.origin
+  if (!origin || origin.machineId === "local") return undefined
+  return origin.hostLabel || origin.machineId
+}
+
 function pushWorktree(rows: TreeRow[], task: Task, tabsByTask: ReadonlyMap<string, readonly TreeTab[]>): void {
   rows.push({ kind: "worktree", id: task.id, task, depth: 1 })
   for (const tab of tabsByTask.get(task.id) ?? []) {
@@ -439,7 +377,7 @@ export function treeFlatIds(rows: readonly TreeRow[]): string[] {
   for (const row of rows) {
     // The routines count row IS navigable, unlike a project header: opening
     // it is the whole point, so the cursor has to be able to land on it.
-    if (row.kind !== "project") ids.push(row.id)
+    if (row.kind !== "project" && row.kind !== "machine") ids.push(row.id)
   }
   return ids
 }
@@ -450,7 +388,7 @@ export function treeFlatIds(rows: readonly TreeRow[]): string[] {
  *  the same key `buildTreeRows` groups it under. */
 export function ownerProjectKey(task: Task): string | null {
   if (task.kind === "dir" && task.scratch === true) return SCRATCH_SECTION_ID
-  return sidebarProjectKey(task.repo)
+  return sidebarProjectKeyOfTask(task)
 }
 
 /**
@@ -485,7 +423,7 @@ export function projectKeysOf(tasks: readonly Task[]): string[] {
 export function mainTaskIdOfProject(tasks: readonly Task[], projectKey: string): string | null {
   for (const task of tasks) {
     if (task.kind !== "main") continue
-    if (sidebarProjectKey(task.repo) === projectKey) return String(task.id)
+    if (sidebarProjectKeyOfTask(task) === projectKey) return String(task.id)
   }
   return null
 }

--- a/packages/kobe/src/tui/panes/sidebar/tree-ids.ts
+++ b/packages/kobe/src/tui/panes/sidebar/tree-ids.ts
@@ -1,0 +1,69 @@
+/**
+ * The sidebar tree's ID VOCABULARY — what a row is called in the one flat
+ * array the cursor indexes into.
+ *
+ * Split from `tree-core.ts`, which decides what rows EXIST. These names are
+ * read by code that never builds a tree: the PTY registry composes the same
+ * `taskId::tabId` key, keyboard chords parse a row id back apart, and the
+ * context menu asks whether an id is a sentinel. Keeping them here means those
+ * callers do not pull in the tree builder to spell a string.
+ *
+ * Every sentinel below is deliberately un-ULID-like and free of
+ * {@link TAB_ROW_SEPARATOR}: `parseRowId` on one yields a task id no task can
+ * have, so a chord that does not special-case it falls through to a lookup
+ * miss instead of acting on a real task.
+ *
+ * `tree-core.ts` re-exports all of it, so importers keep their existing path.
+ */
+
+/** Separator between a task id and a tab id in a tab row's id. Matches the
+ *  PTY registry's key format so one parse rule covers both. */
+const TAB_ROW_SEPARATOR = "::"
+
+/** Navigation id of the narrow-mode "↩ recent" jump row. */
+export const RECENT_ROW_ID = "~recent"
+
+/**
+ * Header id of the Scratch section. Not a repo path, so project-header
+ * consumers (move mode, context menu, `mainTaskIdOfProject`) that look it up
+ * simply miss — a Scratch header has no main task to move and no repo to file
+ * into.
+ */
+export const SCRATCH_SECTION_ID = "~scratch"
+
+/** Navigation id of a machine section header. */
+export function machineRowId(alias: string): string {
+  return `~machine:${alias}`
+}
+
+/**
+ * Navigation id of a project's routine count row, carrying the project key so
+ * two projects' rows stay distinct.
+ */
+export function routinesRowId(projectKey: string): string {
+  return `~routines:${projectKey}`
+}
+
+/** The project key a routines row id names, or null for any other id. */
+export function projectKeyOfRoutinesRow(id: string): string | null {
+  return id.startsWith("~routines:") ? id.slice("~routines:".length) : null
+}
+
+/** Compose a tab row's navigation id. */
+export function tabRowId(taskId: string, tabId: string): string {
+  return `${taskId}${TAB_ROW_SEPARATOR}${tabId}`
+}
+
+/**
+ * Split a row id back into its parts. A task row id has no separator and
+ * yields `tabId: null` — callers switch on that rather than string-matching
+ * the separator themselves.
+ *
+ * Task ids are ULIDs and tab ids are `tab-N`, so neither contains the
+ * separator; splitting on the FIRST occurrence is unambiguous either way.
+ */
+export function parseRowId(rowId: string): { taskId: string; tabId: string | null } {
+  const at = rowId.indexOf(TAB_ROW_SEPARATOR)
+  if (at < 0) return { taskId: rowId, tabId: null }
+  return { taskId: rowId.slice(0, at), tabId: rowId.slice(at + TAB_ROW_SEPARATOR.length) }
+}

--- a/packages/kobe/src/tui/panes/sidebar/tree-labels.ts
+++ b/packages/kobe/src/tui/panes/sidebar/tree-labels.ts
@@ -1,0 +1,68 @@
+/**
+ * What a worktree row is CALLED.
+ *
+ * Split from `tree-core.ts` (which decides what rows exist) because this is a
+ * derivation over ONE task, with its own rule and its own edge cases — and
+ * because the row renderer calls it directly, per row, without wanting the
+ * tree builder in scope.
+ *
+ * `tree-core.ts` re-exports both functions, so importers keep their path.
+ */
+
+import { homedir } from "node:os"
+import type { Task } from "@/types/task"
+import { tildify } from "../../../lib/path-home"
+import { truncateStart } from "../../lib/truncate"
+
+/** Widest path label a worktree row renders before tail-truncation — the
+ *  default rail width minus row chrome. The row's flex still end-clips on
+ *  narrower rails; pre-truncating from the START keeps the leaf visible at
+ *  the default width, which is the half that disambiguates a path. */
+const PATH_LABEL_MAX = 24
+
+/**
+ * The checkout whose LIVE HEAD names this row, or `""` when the row already
+ * carries its own branch.
+ *
+ * Rove-created worktrees store `branch`, so their label is fixed. Two kinds
+ * store none and move freely: `main` (its checkout is the user's to switch)
+ * and `dir` — an arbitrary directory the user opened, which is what a scratch
+ * shell becomes. A scratch shell opened inside a repo IS on a branch, so
+ * labelling it with its path while every worktree row beside it showed a
+ * branch made it read as a different species of row. Not-a-repo still falls
+ * back to the path: the poller answers `""` for anything it can't resolve.
+ */
+export function rowLiveBranchPath(task: Task): string {
+  if (task.kind !== "main" && task.kind !== "dir") return ""
+  return task.worktreePath || task.repo || ""
+}
+
+/**
+ * The one derivation rule: a task with a branch is named by it; a branchless
+ * `dir` task (plain `rove .` opens and scratch shells alike) by its
+ * tail-truncated directory — the stored title is deliberately ignored there,
+ * because dir-task titles are auto-generated noise (`jacksonc-xxxx`) and
+ * existing rows render by this rule with no data migration. A regular task
+ * before its worktree materialises (no branch yet, path not its own) keeps its
+ * title, else the label falls back to the path and finally "scratch" so a row
+ * is never blank.
+ *
+ * `liveBranch` is the caller-resolved HEAD for the rows that own no branch of
+ * their own (see {@link rowLiveBranchPath} and `git-head.ts`); `home` is
+ * injectable so the tildification unit-tests without the real $HOME.
+ */
+export function worktreeRowLabel(
+  task: Task,
+  opts: { readonly liveBranch?: string; readonly home?: string } = {},
+): string {
+  const branch = (opts.liveBranch ?? task.branch) || task.branch
+  if (branch) return branch
+  if (task.kind !== "dir" && task.title) return task.title
+  const path = task.worktreePath || task.repo
+  if (path) {
+    const home = opts.home ?? homedir()
+    const tildified = tildify(path, home)
+    return truncateStart(tildified, PATH_LABEL_MAX)
+  }
+  return task.title || "scratch"
+}

--- a/packages/kobe/src/tui/panes/sidebar/tree-menu.ts
+++ b/packages/kobe/src/tui/panes/sidebar/tree-menu.ts
@@ -186,7 +186,7 @@ export function treeMenuItems(row: TreeRow, ctx: TreeMenuContext = {}): TreeMenu
   // The routine count row is a fold toggle, not a task — there is
   // no task for any verb here to act on, and an entry that does nothing is
   // worse than no entry (the same rule `closeTab` follows above).
-  if (row.kind === "routines") return []
+  if (row.kind === "routines" || row.kind === "machine") return []
   const tabItems: TreeMenuItem[] = [{ action: "open", labelKey: "tasks.menu.openTab", bindingId: "sidebar.select" }]
   if ((ctx.tabCount ?? 0) > 0)
     tabItems.push({ action: "closeTab", labelKey: "tasks.menu.closeTab", bindingId: "chat.tab.close" })

--- a/packages/kobe/src/tui/panes/sidebar/tree-search.ts
+++ b/packages/kobe/src/tui/panes/sidebar/tree-search.ts
@@ -39,6 +39,10 @@ import { type TreeRow, ownerProjectKey, worktreeRowLabel } from "./tree-core"
  */
 function rowHaystacks(row: TreeRow, liveBranch?: (task: Task) => string): readonly string[] {
   if (row.kind === "project") return [row.label]
+  // A machine header is findable by both the name it shows and the alias the
+  // user typed into `rove machine add` — those differ whenever the alias is
+  // shorter than the hostname, which is the reason people pick an alias.
+  if (row.kind === "machine") return [row.label, row.alias]
   // The routine count row carries a translated count, not a name worth
   // matching. It is dropped from a search entirely (see `filterTreeRows`):
   // while searching, the routine tasks it folds are shown DIRECTLY, so the
@@ -94,7 +98,7 @@ export function filterTreeRows(
     if (!matchesRow(q, row, liveBranch)) continue
     selfMatch.add(row.id)
     keep.add(row.id)
-    if (row.kind === "project" || row.kind === "routines") continue
+    if (row.kind === "project" || row.kind === "machine" || row.kind === "routines") continue
     if (row.kind === "tab") keep.add(row.task.id)
     const project = ownerProjectKey(row.task)
     if (project !== null) keep.add(project)
@@ -106,6 +110,13 @@ export function filterTreeRows(
   for (const row of rows) {
     if (row.kind === "project") {
       if (keep.has(row.id)) out.push(row)
+      continue
+    }
+    // Machine headers are decided in a final pass: a header survives only when
+    // something under it did, so a search never leaves a bare host name
+    // standing over nothing.
+    if (row.kind === "machine") {
+      out.push(row)
       continue
     }
     // A search shows every matching routine session directly, so the fold
@@ -120,6 +131,21 @@ export function filterTreeRows(
       continue
     }
     if (underMatchedProject || selfMatch.has(row.task.id) || keep.has(row.id)) out.push(row)
+  }
+  return dropEmptyMachineSections(out)
+}
+
+/** Drop a machine header that no surviving row follows. */
+function dropEmptyMachineSections(rows: readonly TreeRow[]): TreeRow[] {
+  const out: TreeRow[] = []
+  for (let i = 0; i < rows.length; i++) {
+    const row = rows[i]
+    if (!row) continue
+    if (row.kind === "machine") {
+      const next = rows[i + 1]
+      if (!next || next.kind === "machine") continue
+    }
+    out.push(row)
   }
   return out
 }

--- a/packages/kobe/src/types/task.ts
+++ b/packages/kobe/src/types/task.ts
@@ -284,8 +284,36 @@ export interface Task {
    * `prStatus.checkState` comes from asking GitHub.
    */
   readonly report?: TaskWorkerReport
+  /**
+   * Which MACHINE this task came from — stamped by the client that merged
+   * several daemons' task lists (`machines/hub.ts`), never by a daemon: a
+   * daemon has no idea who is looking at it or under what alias.
+   *
+   * ABSENT when only the local daemon is connected, which is the state of
+   * every install with no registered machines. That is deliberate: the field
+   * appearing is what says "more than one machine is in play", so a
+   * single-machine `rove api list` payload is byte-identical to what it was
+   * before machines existed.
+   */
+  readonly origin?: TaskOrigin
   readonly createdAt: string
   readonly updatedAt: string
+}
+
+/** Where a merged task came from. `machineId` is the local alias; `hostLabel`
+ *  is what a row displays (the remote hostname, falling back to the alias). */
+export interface TaskOrigin {
+  readonly machineId: string
+  readonly hostLabel: string
+  /**
+   * The machine is unreachable and this row is its LAST KNOWN state.
+   *
+   * The row survives the disconnect on purpose: a machine whose lid closed
+   * has not stopped having these tasks, and dropping them would erase the
+   * only record of where the work is. So it stays and says it is stale
+   * instead — the one thing a vanished row cannot do.
+   */
+  readonly stale?: boolean
 }
 
 /**

--- a/packages/kobe/test/client/deserialize-task-fields.test.ts
+++ b/packages/kobe/test/client/deserialize-task-fields.test.ts
@@ -33,7 +33,13 @@ type DeepRequired<T> = {
 }
 
 /** Every field the wire can carry, each with a distinguishable value. */
-const FULL: DeepRequired<SerializedTask> = {
+/**
+ * `origin` is excluded on purpose. It is the ONE field on a task that no
+ * daemon ever produces and no store ever keeps: the client stamps it while
+ * merging several machines' task lists (`machines/hub.ts`), so a round-trip
+ * guard demanding it survive would be asserting the opposite of the design.
+ */
+const FULL: DeepRequired<Omit<SerializedTask, "origin">> = {
   id: "01ARZ3NDEKTSV4RRFFQ69G5FAV",
   title: "decode fixture",
   repo: "/repo",

--- a/packages/kobe/test/daemon/serialize-task-fields.test.ts
+++ b/packages/kobe/test/daemon/serialize-task-fields.test.ts
@@ -33,7 +33,13 @@ type DeepRequired<T> = {
 }
 
 /** Every field the wire shape can carry, each with a distinguishable value. */
-const FULL: DeepRequired<SerializedTask> = {
+/**
+ * `origin` is excluded on purpose. It is the ONE field on a task that no
+ * daemon ever produces and no store ever keeps: the client stamps it while
+ * merging several machines' task lists (`machines/hub.ts`), so a round-trip
+ * guard demanding it survive would be asserting the opposite of the design.
+ */
+const FULL: DeepRequired<Omit<SerializedTask, "origin">> = {
   id: "01ARZ3NDEKTSV4RRFFQ69G5FAV",
   title: "wire fixture",
   repo: "/repo",

--- a/packages/kobe/test/machines/discover.test.ts
+++ b/packages/kobe/test/machines/discover.test.ts
@@ -1,0 +1,46 @@
+/**
+ * `parseStatusJson` — the one place a remote `rove daemon status --json` is
+ * read. Everything else in `discover.ts` is an ssh subprocess.
+ */
+
+import { describe, expect, it } from "vitest"
+import { parseStatusJson } from "../../src/machines/discover.ts"
+
+const FULL = JSON.stringify({
+  daemonPid: 900,
+  kobeVersion: "0.9.185",
+  homeDir: "/Users/nahuelchen",
+  socketPath: "/Users/nahuelchen/.rove/daemon.sock",
+  ptySocketPath: "/Users/nahuelchen/.rove/pty.sock",
+  hostname: "Nahuels-Mac-mini.local",
+})
+
+describe("parseStatusJson", () => {
+  it("reads both socket paths and the identity triple", () => {
+    expect(parseStatusJson(FULL)).toEqual({
+      socketPath: "/Users/nahuelchen/.rove/daemon.sock",
+      ptySocketPath: "/Users/nahuelchen/.rove/pty.sock",
+      homeDir: "/Users/nahuelchen",
+      hostname: "Nahuels-Mac-mini.local",
+      kobeVersion: "0.9.185",
+      daemonPid: 900,
+    })
+  })
+
+  it("skips a login banner printed before the JSON", () => {
+    // A non-interactive login that prints anything at all is common enough
+    // that being strict here would read as "Rove is broken on that host".
+    expect(parseStatusJson(`Welcome to narwhal\n${FULL}`)?.hostname).toBe("Nahuels-Mac-mini.local")
+  })
+
+  it("refuses a status without a pty socket — that machine needs upgrading", () => {
+    const old = JSON.stringify({ socketPath: "/s.sock", homeDir: "/h", daemonPid: 1 })
+    expect(parseStatusJson(old)).toBeNull()
+  })
+
+  it("returns null for no daemon, for prose, and for malformed JSON", () => {
+    expect(parseStatusJson("rove daemon: no daemon running at /x/daemon.sock")).toBeNull()
+    expect(parseStatusJson("")).toBeNull()
+    expect(parseStatusJson("{not json")).toBeNull()
+  })
+})

--- a/packages/kobe/test/machines/discover.test.ts
+++ b/packages/kobe/test/machines/discover.test.ts
@@ -4,7 +4,7 @@
  */
 
 import { describe, expect, it } from "vitest"
-import { parseStatusJson } from "../../src/machines/discover.ts"
+import { looksLikeOldStatus, parseStatusJson } from "../../src/machines/discover.ts"
 
 const FULL = JSON.stringify({
   daemonPid: 900,
@@ -42,5 +42,15 @@ describe("parseStatusJson", () => {
     expect(parseStatusJson("rove daemon: no daemon running at /x/daemon.sock")).toBeNull()
     expect(parseStatusJson("")).toBeNull()
     expect(parseStatusJson("{not json")).toBeNull()
+  })
+})
+
+describe("looksLikeOldStatus", () => {
+  it("recognizes a machine whose Rove predates the pty socket field", () => {
+    // This is the difference between "that machine needs upgrading" and "its
+    // daemon would not start" — two remedies, and only one of them works.
+    expect(looksLikeOldStatus(JSON.stringify({ socketPath: "/s.sock", homeDir: "/h" }))).toBe(true)
+    expect(looksLikeOldStatus(FULL)).toBe(false)
+    expect(looksLikeOldStatus("rove daemon: no daemon running")).toBe(false)
   })
 })

--- a/packages/kobe/test/machines/hub-classify.test.ts
+++ b/packages/kobe/test/machines/hub-classify.test.ts
@@ -1,0 +1,32 @@
+/**
+ * How a failed machine handshake reads on its row.
+ *
+ * Tested as a pure classification rather than by downgrading a real machine:
+ * the message shapes below are the two `performInit` actually throws, and a
+ * machine you can only reach over SSH is a poor place to install an old build
+ * on purpose.
+ */
+
+import { describe, expect, it } from "vitest"
+import { classifyHandshakeFailure } from "../../src/machines/hub.ts"
+
+describe("classifyHandshakeFailure", () => {
+  it("calls a protocol-range rejection a mismatch, from either side of the wire", () => {
+    expect(
+      classifyHandshakeFailure(
+        "Rove daemon is protocol v2 (min v2); this client is v5 (min v5). Restart the daemon (`rove daemon restart`) or upgrade Rove.",
+      ),
+    ).toBe("mismatch")
+    expect(classifyHandshakeFailure("daemon is protocol v9 (min v9); this client is v5 (min v2). Upgrade Rove.")).toBe(
+      "mismatch",
+    )
+  })
+
+  it("calls everything else offline", () => {
+    expect(classifyHandshakeFailure("connect ENOENT /x/daemon.sock")).toBe("offline")
+    expect(classifyHandshakeFailure("socket closed before hello")).toBe("offline")
+    // "protocol" without a version is not the protocol check — don't grey a
+    // machine as incompatible on a word.
+    expect(classifyHandshakeFailure("protocol error: bad frame")).toBe("offline")
+  })
+})

--- a/packages/kobe/test/machines/registry.test.ts
+++ b/packages/kobe/test/machines/registry.test.ts
@@ -9,6 +9,8 @@
 import { describe, expect, it } from "vitest"
 import {
   type MachineConfig,
+  type MachineEntry,
+  dedupeMachines,
   duplicateAliasOf,
   isValidMachineAlias,
   parseSshTarget,
@@ -92,5 +94,31 @@ describe("duplicateAliasOf", () => {
 
   it("ignores a machine that has never connected (no identity yet)", () => {
     expect(duplicateAliasOf({ fresh: { host: "h", auth: { kind: "key" } } }, "x", identity)).toBeNull()
+  })
+})
+
+describe("dedupeMachines", () => {
+  const identity = { hostname: "mac-mini", homeDir: "/Users/n", daemonPid: 42 }
+  const entry = (alias: string, over: Partial<MachineEntry> = {}): MachineEntry => ({
+    alias,
+    host: alias,
+    auth: { kind: "key" },
+    ...over,
+  })
+
+  it("keeps the first alias when two name one machine", () => {
+    // The sidebar and `rove api list` share this rule: the two disagreeing is
+    // exactly the bug — one row on screen, every remote task listed twice.
+    const kept = dedupeMachines([
+      entry("narwhal", { identity }),
+      entry("nar2", { identity }),
+      entry("vps", { identity: { ...identity, hostname: "vps" } }),
+    ])
+    expect(kept.map((m) => m.alias)).toEqual(["narwhal", "vps"])
+  })
+
+  it("keeps an entry that has never connected — it may be its own machine", () => {
+    const kept = dedupeMachines([entry("narwhal", { identity }), entry("fresh")])
+    expect(kept.map((m) => m.alias)).toEqual(["narwhal", "fresh"])
   })
 })

--- a/packages/kobe/test/machines/registry.test.ts
+++ b/packages/kobe/test/machines/registry.test.ts
@@ -1,0 +1,96 @@
+/**
+ * The pure halves of the machine registry: how an ssh target is read, what a
+ * usable alias is, and the rule that decides two aliases name one machine.
+ *
+ * No state file is touched — every function here takes its input explicitly,
+ * which is why the identity rule can be tested at all.
+ */
+
+import { describe, expect, it } from "vitest"
+import {
+  type MachineConfig,
+  duplicateAliasOf,
+  isValidMachineAlias,
+  parseSshTarget,
+  sshTargetOf,
+} from "../../src/machines/registry.ts"
+
+describe("parseSshTarget", () => {
+  it("reads a bare host as a host with no user or port", () => {
+    expect(parseSshTarget("narwhal")).toEqual({ host: "narwhal" })
+  })
+
+  it("reads user@host:port", () => {
+    expect(parseSshTarget("nahuel@mac-mini.local:2222")).toEqual({
+      host: "mac-mini.local",
+      user: "nahuel",
+      port: 2222,
+    })
+  })
+
+  it("keeps an unbracketed IPv6 literal whole, and reads a bracketed port", () => {
+    // `::1` split on the last colon would be host `:` on port 1 — a silently
+    // WRONG target. ssh's own rule: brackets are how an IPv6 address carries
+    // a port.
+    expect(parseSshTarget("::1")).toEqual({ host: "::1" })
+    expect(parseSshTarget("fe80::1:2222")).toEqual({ host: "fe80::1:2222" })
+    expect(parseSshTarget("[fe80::1]:2222")).toEqual({ host: "fe80::1", port: 2222 })
+  })
+
+  it("refuses empty, whitespace-bearing and out-of-range input", () => {
+    expect(parseSshTarget("")).toBeNull()
+    expect(parseSshTarget("   ")).toBeNull()
+    expect(parseSshTarget("@host")).toBeNull()
+    expect(parseSshTarget("a b")).toBeNull()
+    expect(parseSshTarget("host:70000")).toBeNull()
+  })
+})
+
+describe("isValidMachineAlias", () => {
+  it("accepts a path-safe name and rejects the reserved local id", () => {
+    expect(isValidMachineAlias("narwhal")).toBe(true)
+    expect(isValidMachineAlias("Nahuels-Mac-mini.local")).toBe(true)
+    expect(isValidMachineAlias("local")).toBe(false)
+  })
+
+  it("rejects anything that would escape its own socket directory", () => {
+    expect(isValidMachineAlias("../etc")).toBe(false)
+    expect(isValidMachineAlias("a/b")).toBe(false)
+    expect(isValidMachineAlias("")).toBe(false)
+  })
+})
+
+describe("sshTargetOf", () => {
+  it("omits the user so ssh_config can supply it", () => {
+    const bare: MachineConfig = { host: "narwhal", auth: { kind: "key" } }
+    expect(sshTargetOf(bare)).toBe("narwhal")
+    expect(sshTargetOf({ ...bare, user: "nahuel" })).toBe("nahuel@narwhal")
+  })
+})
+
+describe("duplicateAliasOf", () => {
+  const identity = { hostname: "mac-mini", homeDir: "/Users/n", daemonPid: 42 }
+  const machines: Record<string, MachineConfig> = {
+    narwhal: { host: "narwhal", auth: { kind: "key" }, identity },
+    other: { host: "vps", auth: { kind: "key" }, identity: { ...identity, hostname: "vps" } },
+  }
+
+  it("finds the alias already naming this machine", () => {
+    expect(duplicateAliasOf(machines, "nar2", identity)).toBe("narwhal")
+  })
+
+  it("never reports an alias as its own duplicate", () => {
+    expect(duplicateAliasOf(machines, "narwhal", identity)).toBeNull()
+  })
+
+  it("needs all three parts to agree — a shared hostname is not a machine", () => {
+    // Two VMs cloned from one image share a hostname; two macs share a homeDir
+    // shape; a pid recycles. Only the triple names one running daemon.
+    expect(duplicateAliasOf(machines, "nar2", { ...identity, daemonPid: 43 })).toBeNull()
+    expect(duplicateAliasOf(machines, "nar2", { ...identity, homeDir: "/Users/other" })).toBeNull()
+  })
+
+  it("ignores a machine that has never connected (no identity yet)", () => {
+    expect(duplicateAliasOf({ fresh: { host: "h", auth: { kind: "key" } } }, "x", identity)).toBeNull()
+  })
+})

--- a/packages/kobe/test/machines/registry.test.ts
+++ b/packages/kobe/test/machines/registry.test.ts
@@ -11,6 +11,7 @@ import {
   type MachineConfig,
   type MachineEntry,
   dedupeMachines,
+  defaultMachineAlias,
   duplicateAliasOf,
   isValidMachineAlias,
   parseSshTarget,
@@ -120,5 +121,33 @@ describe("dedupeMachines", () => {
   it("keeps an entry that has never connected — it may be its own machine", () => {
     const kept = dedupeMachines([entry("narwhal", { identity }), entry("fresh")])
     expect(kept.map((m) => m.alias)).toEqual(["narwhal", "fresh"])
+  })
+})
+
+describe("defaultMachineAlias", () => {
+  it("keeps a bare host — the user already named that machine", () => {
+    // `rove machine add narwhal` should give you a machine called `narwhal`.
+    // They picked that short name in ssh_config; the hostname is one they
+    // never chose, and `Nahuels-Mac-mini.local` fills the sidebar rail.
+    expect(defaultMachineAlias({ typedHost: "narwhal", remoteHostname: "Nahuels-Mac-mini.local" })).toBe("narwhal")
+  })
+
+  it("prefers the remote hostname when the target is addressing, not a name", () => {
+    const remoteHostname = "Nahuels-Mac-mini.local"
+    expect(defaultMachineAlias({ typedHost: "mac.local", typedUser: "nahuel", remoteHostname })).toBe(
+      "Nahuels-Mac-mini",
+    )
+    expect(defaultMachineAlias({ typedHost: "mac.local", port: 2222, remoteHostname })).toBe("Nahuels-Mac-mini")
+    expect(defaultMachineAlias({ typedHost: "192.168.1.5", remoteHostname })).toBe("Nahuels-Mac-mini")
+    expect(defaultMachineAlias({ typedHost: "fe80::1", remoteHostname })).toBe("Nahuels-Mac-mini")
+  })
+
+  it("falls back to the typed host when the machine reported no hostname", () => {
+    // An IP with nothing to fall back to would otherwise become `192`.
+    expect(defaultMachineAlias({ typedHost: "build-box", typedUser: "ci" })).toBe("build-box")
+  })
+
+  it("always yields something usable as a path segment", () => {
+    expect(defaultMachineAlias({ typedHost: "weird host/name" })).toBe("weird-host-name")
   })
 })

--- a/packages/kobe/test/machines/ssh-args.test.ts
+++ b/packages/kobe/test/machines/ssh-args.test.ts
@@ -11,7 +11,14 @@ import { machineSocketDir, machineSshArgs } from "../../src/machines/ssh-args.ts
 const HOME = "/tmp/rove-home"
 const config: MachineConfig = { host: "narwhal", auth: { kind: "key" } }
 
-describe("machineSshArgs", () => {
+/**
+ * POSIX-only. Every assertion below is about unix-socket forwarding, which
+ * OpenSSH on Windows does not have — `startTunnel` reports `unsupported`
+ * there rather than pretending, and the path arithmetic uses `/`.
+ */
+const POSIX = process.platform !== "win32"
+
+describe.skipIf(!POSIX)("machineSshArgs", () => {
   it("multiplexes one connection per machine and fails fast", () => {
     const argv = machineSshArgs("narwhal", config, { home: HOME })
     expect(argv[0]).toBe("ssh")
@@ -30,7 +37,7 @@ describe("machineSshArgs", () => {
   })
 })
 
-describe("machineSocketDir", () => {
+describe.skipIf(!POSIX)("machineSocketDir", () => {
   it("keeps the natural path when it fits", () => {
     expect(machineSocketDir("narwhal", "/Users/x")).toBe("/Users/x/.rove/machines/narwhal")
   })

--- a/packages/kobe/test/machines/ssh-args.test.ts
+++ b/packages/kobe/test/machines/ssh-args.test.ts
@@ -6,7 +6,7 @@
 
 import { describe, expect, it } from "vitest"
 import type { MachineConfig } from "../../src/machines/registry.ts"
-import { localDaemonSocketPath, localPtySocketPath, machineSshArgs, tunnelArgs } from "../../src/machines/ssh-args.ts"
+import { machineSocketDir, machineSshArgs } from "../../src/machines/ssh-args.ts"
 
 const HOME = "/tmp/rove-home"
 const config: MachineConfig = { host: "narwhal", auth: { kind: "key" } }
@@ -30,28 +30,24 @@ describe("machineSshArgs", () => {
   })
 })
 
-describe("tunnelArgs", () => {
-  const argv = tunnelArgs({
-    alias: "narwhal",
-    config,
-    remoteDaemonSocket: "/Users/n/.rove/daemon.sock",
-    remotePtySocket: "/Users/n/.rove/pty.sock",
-    home: HOME,
+describe("machineSocketDir", () => {
+  it("keeps the natural path when it fits", () => {
+    expect(machineSocketDir("narwhal", "/Users/x")).toBe("/Users/x/.rove/machines/narwhal")
   })
 
-  it("forwards both sockets, unix end to unix end", () => {
-    expect(argv).toContain(`${localDaemonSocketPath("narwhal", HOME)}:/Users/n/.rove/daemon.sock`)
-    expect(argv).toContain(`${localPtySocketPath("narwhal", HOME)}:/Users/n/.rove/pty.sock`)
+  it("falls back to a short path when a socket inside it would not fit", () => {
+    // A Rove home inside a worktree already spends most of the ~104-byte
+    // sun_path budget; ssh's own refusal is `ControlPath too long`, which
+    // names neither the machine nor the remedy.
+    const deep = "/Users/someone/.rove/worktrees/kobe-0aff3858ab76/ocelot/.scratch/opentui-visual-5473/home"
+    const dir = machineSocketDir("narwhal", deep)
+    expect(dir).not.toContain(deep)
+    expect(Buffer.byteLength(`${dir}/daemon.sock`)).toBeLessThanOrEqual(100)
   })
 
-  it("exits on a forward that cannot bind", () => {
-    // Without this, ssh stays up looking healthy while the socket it was
-    // supposed to create does not exist — the machine reads as online forever.
-    expect(argv).toContain("ExitOnForwardFailure=yes")
-    expect(argv).toContain("-N")
-  })
-
-  it("keeps the target last, after every flag", () => {
-    expect(argv.at(-1)).toBe("narwhal")
+  it("gives the same fallback every time — a client must find the same socket", () => {
+    const deep = "/Users/someone/.rove/worktrees/kobe-0aff3858ab76/ocelot/.scratch/opentui-visual-5473/home"
+    expect(machineSocketDir("narwhal", deep)).toBe(machineSocketDir("narwhal", deep))
+    expect(machineSocketDir("narwhal", deep)).not.toBe(machineSocketDir("other", deep))
   })
 })

--- a/packages/kobe/test/machines/ssh-args.test.ts
+++ b/packages/kobe/test/machines/ssh-args.test.ts
@@ -1,0 +1,57 @@
+/**
+ * The tunnel's argv. This is the whole transport: if a flag here is wrong, a
+ * machine either never connects or — worse — looks connected while forwarding
+ * nothing.
+ */
+
+import { describe, expect, it } from "vitest"
+import type { MachineConfig } from "../../src/machines/registry.ts"
+import { localDaemonSocketPath, localPtySocketPath, machineSshArgs, tunnelArgs } from "../../src/machines/ssh-args.ts"
+
+const HOME = "/tmp/rove-home"
+const config: MachineConfig = { host: "narwhal", auth: { kind: "key" } }
+
+describe("machineSshArgs", () => {
+  it("multiplexes one connection per machine and fails fast", () => {
+    const argv = machineSshArgs("narwhal", config, { home: HOME })
+    expect(argv[0]).toBe("ssh")
+    expect(argv).toContain("BatchMode=yes")
+    expect(argv).toContain("ControlMaster=auto")
+    expect(argv).toContain(`ControlPath=${HOME}/.rove/machines/narwhal/cm`)
+    expect(argv).toContain("StrictHostKeyChecking=accept-new")
+    expect(argv.at(-1)).toBe("narwhal")
+  })
+
+  it("passes an explicit port and identity file through", () => {
+    const argv = machineSshArgs("m", { ...config, port: 2222, auth: { kind: "key", keyPath: "/k" } }, { home: HOME })
+    expect(argv).toContain("-p")
+    expect(argv[argv.indexOf("-p") + 1]).toBe("2222")
+    expect(argv[argv.indexOf("-i") + 1]).toBe("/k")
+  })
+})
+
+describe("tunnelArgs", () => {
+  const argv = tunnelArgs({
+    alias: "narwhal",
+    config,
+    remoteDaemonSocket: "/Users/n/.rove/daemon.sock",
+    remotePtySocket: "/Users/n/.rove/pty.sock",
+    home: HOME,
+  })
+
+  it("forwards both sockets, unix end to unix end", () => {
+    expect(argv).toContain(`${localDaemonSocketPath("narwhal", HOME)}:/Users/n/.rove/daemon.sock`)
+    expect(argv).toContain(`${localPtySocketPath("narwhal", HOME)}:/Users/n/.rove/pty.sock`)
+  })
+
+  it("exits on a forward that cannot bind", () => {
+    // Without this, ssh stays up looking healthy while the socket it was
+    // supposed to create does not exist — the machine reads as online forever.
+    expect(argv).toContain("ExitOnForwardFailure=yes")
+    expect(argv).toContain("-N")
+  })
+
+  it("keeps the target last, after every flag", () => {
+    expect(argv.at(-1)).toBe("narwhal")
+  })
+})

--- a/packages/kobe/test/machines/tunnel.test.ts
+++ b/packages/kobe/test/machines/tunnel.test.ts
@@ -1,0 +1,85 @@
+/**
+ * The tunnel's lifecycle: when it counts as up, and what it does when ssh dies.
+ *
+ * Driven with an injected spawn and an injected timer, so the reconnect policy
+ * is tested without an ssh binary and without waiting out real backoff.
+ */
+
+import type { ChildProcess } from "node:child_process"
+import { EventEmitter } from "node:events"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import type { MachineConfig } from "../../src/machines/registry.ts"
+import { startTunnel } from "../../src/machines/tunnel.ts"
+
+const config: MachineConfig = { host: "narwhal", auth: { kind: "key" } }
+
+class FakeSsh extends EventEmitter {
+  killed = false
+  kill(): boolean {
+    this.killed = true
+    return true
+  }
+}
+
+function start(spawns: FakeSsh[], retries: Array<() => void>) {
+  return startTunnel({
+    alias: "narwhal",
+    config,
+    remoteDaemonSocket: "/r/daemon.sock",
+    remotePtySocket: "/r/pty.sock",
+    home: "/tmp/rove-tunnel-test",
+    spawnFn: () => {
+      const proc = new FakeSsh()
+      spawns.push(proc)
+      return proc as unknown as ChildProcess
+    },
+    setTimeoutFn: (fn) => {
+      retries.push(fn)
+      return 0
+    },
+  })
+}
+
+beforeEach(() => vi.useFakeTimers())
+afterEach(() => vi.useRealTimers())
+
+describe("startTunnel", () => {
+  it("counts as online only once ssh has outlived a bind failure", () => {
+    // `ssh -N` prints nothing on success, so surviving the window IS the
+    // readiness signal — `ExitOnForwardFailure=yes` makes a failed bind an
+    // immediate exit.
+    const spawns: FakeSsh[] = []
+    const handle = start(spawns, [])
+    expect(handle.state()).toBe("connecting")
+    vi.advanceTimersByTime(800)
+    expect(handle.state()).toBe("online")
+    handle.stop()
+  })
+
+  it("goes offline and schedules a retry when ssh exits", () => {
+    const spawns: FakeSsh[] = []
+    const retries: Array<() => void> = []
+    const handle = start(spawns, retries)
+    vi.advanceTimersByTime(800)
+    const seen: string[] = []
+    handle.onState((state) => seen.push(state))
+    spawns[0]?.emit("exit", 255)
+    expect(handle.state()).toBe("offline")
+    expect(seen).toEqual(["offline"])
+    expect(retries).toHaveLength(1)
+    retries[0]?.()
+    expect(spawns).toHaveLength(2)
+    handle.stop()
+  })
+
+  it("stops retrying once stopped, and kills the child", () => {
+    const spawns: FakeSsh[] = []
+    const retries: Array<() => void> = []
+    const handle = start(spawns, retries)
+    vi.advanceTimersByTime(800)
+    handle.stop()
+    expect(spawns[0]?.killed).toBe(true)
+    spawns[0]?.emit("exit", 0)
+    expect(retries).toHaveLength(0)
+  })
+})

--- a/packages/kobe/test/machines/tunnel.test.ts
+++ b/packages/kobe/test/machines/tunnel.test.ts
@@ -1,85 +1,82 @@
 /**
- * The tunnel's lifecycle: when it counts as up, and what it does when ssh dies.
+ * The tunnel's lifecycle: when a machine counts as up, what happens when its
+ * forward dies, and that a stopped tunnel stops trying.
  *
- * Driven with an injected spawn and an injected timer, so the reconnect policy
+ * Driven with an injected forward + health check + timer, so the retry policy
  * is tested without an ssh binary and without waiting out real backoff.
  */
 
-import type { ChildProcess } from "node:child_process"
-import { EventEmitter } from "node:events"
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { describe, expect, it } from "vitest"
 import type { MachineConfig } from "../../src/machines/registry.ts"
 import { startTunnel } from "../../src/machines/tunnel.ts"
 
 const config: MachineConfig = { host: "narwhal", auth: { kind: "key" } }
 
-class FakeSsh extends EventEmitter {
-  killed = false
-  kill(): boolean {
-    this.killed = true
-    return true
-  }
-}
-
-function start(spawns: FakeSsh[], retries: Array<() => void>) {
-  return startTunnel({
+/** Drives the tunnel with queued answers and a manual clock. */
+function harness(answers: { ensure: boolean[]; check: boolean[] }) {
+  const pending: Array<() => void> = []
+  const ensureCalls: number[] = []
+  const handle = startTunnel({
     alias: "narwhal",
     config,
     remoteDaemonSocket: "/r/daemon.sock",
     remotePtySocket: "/r/pty.sock",
     home: "/tmp/rove-tunnel-test",
-    spawnFn: () => {
-      const proc = new FakeSsh()
-      spawns.push(proc)
-      return proc as unknown as ChildProcess
+    ensureFn: async () => {
+      ensureCalls.push(1)
+      return answers.ensure.shift() ?? false
     },
+    checkFn: async () => answers.check.shift() ?? true,
     setTimeoutFn: (fn) => {
-      retries.push(fn)
+      pending.push(fn)
       return 0
     },
   })
+  /** Run every scheduled callback once, then let their promises settle. */
+  const tick = async (): Promise<void> => {
+    const due = pending.splice(0, pending.length)
+    for (const fn of due) fn()
+    await Promise.resolve()
+    await Promise.resolve()
+    await Promise.resolve()
+  }
+  return { handle, tick, pending, ensureCalls }
 }
 
-beforeEach(() => vi.useFakeTimers())
-afterEach(() => vi.useRealTimers())
-
 describe("startTunnel", () => {
-  it("counts as online only once ssh has outlived a bind failure", () => {
-    // `ssh -N` prints nothing on success, so surviving the window IS the
-    // readiness signal — `ExitOnForwardFailure=yes` makes a failed bind an
-    // immediate exit.
-    const spawns: FakeSsh[] = []
-    const handle = start(spawns, [])
-    expect(handle.state()).toBe("connecting")
-    vi.advanceTimersByTime(800)
-    expect(handle.state()).toBe("online")
-    handle.stop()
+  it("is online once the forward is up", async () => {
+    const h = harness({ ensure: [true], check: [] })
+    expect(h.handle.state()).toBe("connecting")
+    await h.tick()
+    expect(h.handle.state()).toBe("online")
   })
 
-  it("goes offline and schedules a retry when ssh exits", () => {
-    const spawns: FakeSsh[] = []
-    const retries: Array<() => void> = []
-    const handle = start(spawns, retries)
-    vi.advanceTimersByTime(800)
-    const seen: string[] = []
-    handle.onState((state) => seen.push(state))
-    spawns[0]?.emit("exit", 255)
-    expect(handle.state()).toBe("offline")
-    expect(seen).toEqual(["offline"])
-    expect(retries).toHaveLength(1)
-    retries[0]?.()
-    expect(spawns).toHaveLength(2)
-    handle.stop()
+  it("stays offline and keeps retrying while the machine is unreachable", async () => {
+    const h = harness({ ensure: [false, false, true], check: [] })
+    await h.tick()
+    expect(h.handle.state()).toBe("offline")
+    expect(h.pending.length).toBe(1) // a retry is scheduled
+    await h.tick()
+    expect(h.handle.state()).toBe("offline")
+    await h.tick()
+    expect(h.handle.state()).toBe("online")
   })
 
-  it("stops retrying once stopped, and kills the child", () => {
-    const spawns: FakeSsh[] = []
-    const retries: Array<() => void> = []
-    const handle = start(spawns, retries)
-    vi.advanceTimersByTime(800)
-    handle.stop()
-    expect(spawns[0]?.killed).toBe(true)
-    spawns[0]?.emit("exit", 0)
-    expect(retries).toHaveLength(0)
+  it("goes offline when a live forward stops answering, then re-establishes it", async () => {
+    const h = harness({ ensure: [true, true], check: [false] })
+    await h.tick()
+    expect(h.handle.state()).toBe("online")
+    await h.tick() // the health check fires and finds the socket dead
+    expect(h.handle.state()).toBe("online") // re-ensured within the same turn
+    expect(h.ensureCalls.length).toBe(2)
+  })
+
+  it("stops trying once stopped", async () => {
+    const h = harness({ ensure: [false], check: [] })
+    await h.tick()
+    h.handle.stop()
+    const before = h.ensureCalls.length
+    await h.tick()
+    expect(h.ensureCalls.length).toBe(before)
   })
 })

--- a/packages/kobe/test/machines/tunnel.test.ts
+++ b/packages/kobe/test/machines/tunnel.test.ts
@@ -12,6 +12,13 @@ import { startTunnel } from "../../src/machines/tunnel.ts"
 
 const config: MachineConfig = { host: "narwhal", auth: { kind: "key" } }
 
+/**
+ * POSIX-only. Every assertion below is about unix-socket forwarding, which
+ * OpenSSH on Windows does not have — `startTunnel` reports `unsupported`
+ * there rather than pretending, and the path arithmetic uses `/`.
+ */
+const POSIX = process.platform !== "win32"
+
 /** Drives the tunnel with queued answers and a manual clock. */
 function harness(answers: { ensure: boolean[]; check: boolean[] }) {
   const pending: Array<() => void> = []
@@ -43,7 +50,7 @@ function harness(answers: { ensure: boolean[]; check: boolean[] }) {
   return { handle, tick, pending, ensureCalls }
 }
 
-describe("startTunnel", () => {
+describe.skipIf(!POSIX)("startTunnel", () => {
   it("is online once the forward is up", async () => {
     const h = harness({ ensure: [true], check: [] })
     expect(h.handle.state()).toBe("connecting")

--- a/packages/kobe/test/orchestrator/store-codec-roundtrip.test.ts
+++ b/packages/kobe/test/orchestrator/store-codec-roundtrip.test.ts
@@ -43,7 +43,13 @@ type DeepRequired<T> = {
  * is untouched by the status heals — the round-trip must be lossless, so a
  * deliberately-healed fixture would hide a dropped field behind the heal.
  */
-const FULL_TASK: DeepRequired<Task> = {
+/**
+ * `origin` is excluded on purpose. It is the ONE field on a task that no
+ * daemon ever produces and no store ever keeps: the client stamps it while
+ * merging several machines' task lists (`machines/hub.ts`), so a round-trip
+ * guard demanding it survive would be asserting the opposite of the design.
+ */
+const FULL_TASK: DeepRequired<Omit<Task, "origin">> = {
   id: toTaskId("01ARZ3NDEKTSV4RRFFQ69G5FAV"),
   title: "round-trip fixture",
   repo: "/repo",

--- a/packages/kobe/test/tui/sidebar-groups.test.ts
+++ b/packages/kobe/test/tui/sidebar-groups.test.ts
@@ -395,4 +395,25 @@ describe("project identity and labels across machines", () => {
   it("still uses the path tail for a collision on ONE machine", () => {
     expect(sidebarProjectLabel("/work/api", ["/work/api", "/oss/api"])).toBe("work/api")
   })
+
+  it("uses the path tail when the collision is on the same REMOTE machine", () => {
+    // Both checkouts answered `narwhal:kobe` when the machine test came
+    // first — two headers reading as one project, on the very machine whose
+    // name was supposed to be doing the telling-apart.
+    const repos = [
+      { repo: "/Users/n/gihub/kobe", hostLabel: "narwhal" },
+      { repo: "/Users/n/i/kobe", hostLabel: "narwhal" },
+    ]
+    expect(sidebarProjectLabel("/Users/n/gihub/kobe", repos, "narwhal")).toBe("gihub/kobe")
+    expect(sidebarProjectLabel("/Users/n/i/kobe", repos, "narwhal")).toBe("i/kobe")
+  })
+
+  it("puts the host in front of a tail that also repeats across machines", () => {
+    const repos = [
+      { repo: "/a/i/kobe", hostLabel: "narwhal" },
+      { repo: "/b/i/kobe", hostLabel: "narwhal" },
+      { repo: "/c/i/kobe", hostLabel: "vps" },
+    ]
+    expect(sidebarProjectLabel("/a/i/kobe", repos, "narwhal")).toBe("narwhal:i/kobe")
+  })
 })

--- a/packages/kobe/test/tui/sidebar-groups.test.ts
+++ b/packages/kobe/test/tui/sidebar-groups.test.ts
@@ -371,3 +371,28 @@ describe("resolveCursorTarget", () => {
     expect(resolveCursorTarget(null, ids, 9)).toBe(2) // out of range → clamp to last
   })
 })
+
+describe("project identity and labels across machines", () => {
+  it("keys the same path on two machines as two projects", () => {
+    // Without the machine in the key, `~/i/kobe` on the laptop and on the
+    // build box merged into ONE sidebar row carrying both machines' tasks.
+    expect(sidebarProjectKey("/i/kobe", "narwhal")).not.toBe(sidebarProjectKey("/i/kobe"))
+  })
+
+  it("leaves the local key byte-identical to the pre-machines one", () => {
+    expect(sidebarProjectKey("/i/kobe", "local")).toBe(sidebarProjectKey("/i/kobe"))
+  })
+
+  it("disambiguates a cross-machine basename collision by host", () => {
+    const repos = [
+      { repo: "/i/kobe", hostLabel: undefined },
+      { repo: "/i/kobe", hostLabel: "narwhal" },
+    ]
+    expect(sidebarProjectLabel("/i/kobe", repos)).toBe("kobe")
+    expect(sidebarProjectLabel("/i/kobe", repos, "narwhal")).toBe("narwhal:kobe")
+  })
+
+  it("still uses the path tail for a collision on ONE machine", () => {
+    expect(sidebarProjectLabel("/work/api", ["/work/api", "/oss/api"])).toBe("work/api")
+  })
+})

--- a/packages/kobe/test/tui/sidebar-machine-layer.test.ts
+++ b/packages/kobe/test/tui/sidebar-machine-layer.test.ts
@@ -1,0 +1,109 @@
+/**
+ * The machine layer of the sidebar tree.
+ *
+ * The load-bearing test is the FIRST one: an install with no machines must get
+ * back the very array it handed in. Every screenshot, golden and muscle memory
+ * recorded before machines existed depends on that being literally true rather
+ * than merely equal.
+ */
+
+import { describe, expect, it } from "vitest"
+import { applyMachineLayer, machineRowLabel } from "../../src/tui/panes/sidebar/machine-layer.ts"
+import { type TreeRow, buildTreeRows } from "../../src/tui/panes/sidebar/tree-core.ts"
+import { type Task, toTaskId } from "../../src/types/task.ts"
+
+function task(over: Omit<Partial<Task>, "id"> & { id: string; repo: string }): Task {
+  return {
+    title: "t",
+    branch: "",
+    worktreePath: over.repo,
+    kind: "main",
+    status: "active",
+    pinned: false,
+    createdAt: "2026-09-09T00:00:00Z",
+    updatedAt: "2026-09-09T00:00:00Z",
+    ...over,
+    id: toTaskId(over.id),
+  } as Task
+}
+
+const NO_TABS = new Map<string, never[]>()
+
+describe("applyMachineLayer", () => {
+  it("returns the SAME array when no machine is registered", () => {
+    const rows = buildTreeRows({
+      tasks: [task({ id: "01ARZ3NDEKTSV4RRFFQ69G5FAV", repo: "/i/kobe" })],
+      tabsByTask: NO_TABS,
+    })
+    expect(applyMachineLayer(rows, [])).toBe(rows)
+  })
+
+  it("puts a remote machine's projects under a header, indented by one", () => {
+    const tasks = [
+      task({ id: "01ARZ3NDEKTSV4RRFFQ69G5FAV", repo: "/i/kobe" }),
+      task({
+        id: "01ARZ3NDEKTSV4RRFFQ69G5FAW",
+        repo: "/i/kobe",
+        origin: { machineId: "narwhal", hostLabel: "mac-mini" },
+      }),
+    ]
+    const rows = applyMachineLayer(buildTreeRows({ tasks, tabsByTask: NO_TABS }), [
+      { alias: "narwhal", hostLabel: "mac-mini", state: "online", version: "0.9.185" },
+    ])
+    // Local first, at the depth it has always had; then the machine header.
+    expect(rows[0]).toMatchObject({ kind: "project", machineId: "local", depth: 0 })
+    const headerAt = rows.findIndex((row) => row.kind === "machine")
+    expect(headerAt).toBeGreaterThan(0)
+    const under = rows.slice(headerAt + 1)
+    expect(under[0]).toMatchObject({ kind: "project", machineId: "narwhal", depth: 1 })
+    expect(under[1]).toMatchObject({ kind: "worktree", depth: 2 })
+  })
+
+  it("keeps an offline machine's rows instead of dropping them", () => {
+    const tasks = [
+      task({
+        id: "01ARZ3NDEKTSV4RRFFQ69G5FAW",
+        repo: "/i/kobe",
+        origin: { machineId: "narwhal", hostLabel: "mac-mini", stale: true },
+      }),
+    ]
+    const rows = applyMachineLayer(buildTreeRows({ tasks, tabsByTask: NO_TABS }), [
+      { alias: "narwhal", hostLabel: "mac-mini", state: "offline" },
+    ])
+    // A laptop with a closed lid has not stopped having these tasks.
+    expect(rows.filter((row) => row.kind === "worktree")).toHaveLength(1)
+    expect(rows.find((row) => row.kind === "machine")).toMatchObject({ state: "offline" })
+  })
+
+  it("drops rows of a machine that is no longer registered", () => {
+    const tasks = [
+      task({
+        id: "01ARZ3NDEKTSV4RRFFQ69G5FAW",
+        repo: "/i/kobe",
+        origin: { machineId: "gone", hostLabel: "gone" },
+      }),
+    ]
+    const rows: readonly TreeRow[] = applyMachineLayer(buildTreeRows({ tasks, tabsByTask: NO_TABS }), [
+      { alias: "narwhal", hostLabel: "mac-mini", state: "online" },
+    ])
+    // A headerless remote project would read as a local one.
+    expect(rows.filter((row) => row.kind === "project")).toHaveLength(0)
+  })
+})
+
+describe("machineRowLabel", () => {
+  const t = (key: string) => key.split(".").at(-1) ?? key
+
+  it("names the version when online and the state otherwise", () => {
+    expect(machineRowLabel({ alias: "n", hostLabel: "mac-mini", state: "online", version: "0.9.185" }, t)).toBe(
+      "mac-mini · v0.9.185",
+    )
+    expect(machineRowLabel({ alias: "n", hostLabel: "mac-mini", state: "offline" }, t)).toBe("mac-mini · offline")
+  })
+
+  it("marks a protocol mismatch with the version that caused it", () => {
+    expect(machineRowLabel({ alias: "n", hostLabel: "old", state: "mismatch", version: "0.9.100" }, t)).toBe(
+      "old · ⚠ v0.9.100 (mismatch)",
+    )
+  })
+})

--- a/packages/kobe/test/tui/sidebar-tree-menu-items.test.ts
+++ b/packages/kobe/test/tui/sidebar-tree-menu-items.test.ts
@@ -29,7 +29,14 @@ function task(over: Partial<Task> = {}): Task {
   }
 }
 
-const projectRow: TreeRow = { kind: "project", id: "/repos/rove", repo: "/repos/rove", label: "kobe", depth: 0 }
+const projectRow: TreeRow = {
+  kind: "project",
+  machineId: "local",
+  id: "/repos/rove",
+  repo: "/repos/rove",
+  label: "kobe",
+  depth: 0,
+}
 const worktreeRow = (over: Partial<Task> = {}): TreeRow => ({ kind: "worktree", id: "a", task: task(over), depth: 1 })
 const tabRow: TreeRow = { kind: "tab", id: "a::tab-2", task: task(), tab: { id: "tab-2", label: "tab 2" }, depth: 2 }
 

--- a/packages/kobe/test/tui/start-tui.test.ts
+++ b/packages/kobe/test/tui/start-tui.test.ts
@@ -12,7 +12,7 @@ vi.mock("../../src/cli/hook-cmd.ts", () => ({ ensureGlobalKobeHooks: spies.insta
 vi.mock("../../src/cli/reset-gate.ts", () => ({ enforceResetGate: spies.enforceResetGate }))
 vi.mock("../../src/lib/skill-install.ts", () => ({ maybeHintSkillInstall: spies.hintSkillInstall }))
 vi.mock("../../src/tui/lib/outer-terminal-title.ts", () => ({ publishKobeTerminalTitle: spies.publishTitle }))
-vi.mock("../../src/tui-react/workspace/host", () => ({ startWorkspaceHost: spies.startWorkspaceHost }))
+vi.mock("../../src/tui-react/workspace/start-workspace", () => ({ startWorkspaceHost: spies.startWorkspaceHost }))
 
 import { startTui } from "../../src/tui/index"
 

--- a/packages/kobe/test/tui/workspace-task-selection.test.ts
+++ b/packages/kobe/test/tui/workspace-task-selection.test.ts
@@ -31,6 +31,42 @@ function task(id: string, worktreePath: string): Task {
 }
 
 describe("pure-TUI workspace task activation", () => {
+  test("selects a task on another machine without trying to materialize it here", async () => {
+    // The only daemon this process can reach is the local one, which has never
+    // heard of that id — so materializing answered "task not found" for a task
+    // the user was looking at.
+    const ensureWorktree = vi.fn(async () => "/should-not-happen")
+    const selectTask = vi.fn()
+    const reportError = vi.fn()
+    const remote: Task = { ...task("remote-1", ""), origin: { machineId: "narwhal", hostLabel: "narwhal" } }
+
+    const activated = await activateWorkspaceTask(
+      { getTask: () => remote, ensureWorktree, selectTask, focusWorkspace: vi.fn(), reportError },
+      "remote-1",
+    )
+
+    expect(activated).toBe(true)
+    expect(ensureWorktree).not.toHaveBeenCalled()
+    expect(reportError).not.toHaveBeenCalled()
+    expect(selectTask).toHaveBeenCalledWith("remote-1")
+  })
+
+  test("still materializes a LOCAL task that has no worktree yet", async () => {
+    const ensureWorktree = vi.fn(async () => "/worktrees/x")
+    const local: Task = { ...task("local-1", ""), origin: { machineId: "local", hostLabel: "local" } }
+    await activateWorkspaceTask(
+      {
+        getTask: () => local,
+        ensureWorktree,
+        selectTask: vi.fn(),
+        focusWorkspace: vi.fn(),
+        reportError: vi.fn(),
+      },
+      "local-1",
+    )
+    expect(ensureWorktree).toHaveBeenCalledWith("local-1")
+  })
+
   test("materializes and focuses a newly created task before its snapshot renders", async () => {
     const ensureWorktree = vi.fn(async () => "/worktrees/new-task")
     const selectTask = vi.fn()


### PR DESCRIPTION
## Machines — one Rove watching every computer you code on

`rove machine add <ssh-target>` registers another computer running Rove. Its
tasks appear in your sidebar under a row of their own, alongside your local
projects. There is no "switch to that machine" step: every machine is connected
at once, and the tree answers what is running where.

Read-only in this PR (PR 1 of 3). Nothing opens a port and nothing adds
authentication of its own — the remote daemon keeps listening on its private
unix socket and SSH forwards it, so SSH is the transport and the auth.

> Screenshots are real `/harness` captures of the running OpenTUI against a
> real second machine. They are PNGs on the dispatcher's own disk rather than
> attachments, since `gh` cannot upload images:
> `~/.rove/worktrees/kobe-0aff3858ab76/ocelot/.scratch/machines-probe/evidence/`
> Every section below says what its shot shows, so the PR reads without them.

### Sidebar, before and after

Same seeded state (a local `kobe`, a local `frontend`, `machines.narwhal`), two
builds. `origin/main` has no machines feature, so the key is inert there.

| BEFORE — `origin/main` | AFTER — this branch |
| --- | --- |
| `before-sidebar.png` | `after-sidebar.png` |

The AFTER shot has all three label tiers in it at once:

- `kobe` — local, no collision, bare basename.
- `frontend` vs `narwhal:frontend` — collides only across machines, so the
  machine names it. The local one keeps the bare name; it is the one you are
  sitting at.
- `gihub/kobe` vs `i/kobe` — two checkouts on the *same* machine, where the
  machine name would say nothing, so the path does.

### One machine down does not touch another

→ `after-two-machines.png`

`narwhal · v0.9.185` online with its projects; `sleepy · offline` greyed. An
offline machine keeps its rows rather than dropping them — this shot caught
narwhal mid-drop with all 8 of its tasks still on screen:

→ `after-offline.png`

### A remote task's files

→ `after-remote-files.png`

Its worktree path means nothing on this filesystem, so the pane names the
machine instead of listing whatever happens to sit at that path here.

### Registration

```
### rove machine list — nothing registered
No machines registered. Add one with `rove machine add <ssh-target>`.

### rove machine add narwhal --alias narwhal
rove machine: contacting narwhal…
rove machine: narwhal → narwhal (rove 0.9.185 on Nahuels-Mac-mini.local)

### rove machine list
narwhal  narwhal  Nahuels-Mac-mini.local

### state.json machines entry (no plaintext secret)
{
  "narwhal": {
    "host": "narwhal",
    "auth": {
      "kind": "key"
    },
    "identity": {
      "hostname": "Nahuels-Mac-mini.local",
      "homeDir": "/Users/nahuelchen",
      "daemonPid": 19562
    },
    "sockets": {
      "daemon": "/Users/nahuelchen/.rove/daemon.sock",
      "pty": "/Users/nahuelchen/.rove/pty.sock"
    },
    "addedAt": "2026-09-10T03:48:05.695Z"
  }
}
grep -i password over the whole state file -> no match

### forwarded sockets, owner-only
total 0
drwx------@ 5 jacksonc  wheel  160 Sep  9 20:48 .
drwx------@ 3 jacksonc  wheel   96 Sep  9 20:48 ..
srw-------@ 1 jacksonc  wheel    0 Sep  9 20:48 cm
srw-------@ 1 jacksonc  wheel    0 Sep  9 20:48 daemon.sock
srw-------@ 1 jacksonc  wheel    0 Sep  9 20:48 pty.sock
```

### Merged task list — every task carries an origin

```
### rove api list — every task carries an origin
origin.machineId  origin.hostLabel          title                   repo
--------------------------------------------------------------------------------------------------------------
local             local                     kobe                    /private/tmp/rove-mach-ocelot/repos/kobe
local             local                     local probe             /private/tmp/rove-mach-ocelot/repos/kobe
narwhal           Nahuels-Mac-mini.local    nihaoo                  /Users/nahuelchen/gihub/livestates/frontend
narwhal           Nahuels-Mac-mini.local    似乎存在leak问题，我怀疑是反复开关启用了  /Users/nahuelchen/gihub/kobe/
narwhal           Nahuels-Mac-mini.local    Todo tool monitoring a  /Users/nahuelchen/gihub/kobe/
narwhal           Nahuels-Mac-mini.local    kobe                    /Users/nahuelchen/gihub/kobe
narwhal           Nahuels-Mac-mini.local    bug汇报：每次点Chat/Chat wit  /Users/nahuelchen/gihub/livestates/frontend/
narwhal           Nahuels-Mac-mini.local    [Image #1] 修一下这个ui      /Users/nahuelchen/gihub/livestates/frontend/
narwhal           Nahuels-Mac-mini.local    kobe                    /Users/nahuelchen/i/kobe
narwhal           Nahuels-Mac-mini.local    remote probe            /Users/nahuelchen/i/kobe

### the two repos named 'kobe' that now coexist
  local     /private/tmp/rove-mach-ocelot/repos/kobe
  local     /private/tmp/rove-mach-ocelot/repos/kobe
  narwhal   /Users/nahuelchen/gihub/kobe/
  narwhal   /Users/nahuelchen/gihub/kobe/
  narwhal   /Users/nahuelchen/gihub/kobe
  narwhal   /Users/nahuelchen/i/kobe
  narwhal   /Users/nahuelchen/i/kobe
```

### Writes aimed at a remote task are refused, not forwarded

```
remote task (on narwhal): 01M2429QKKH80R8HQY2YG1H170
local  task:              01M24PVSDX1NNQNW4Q17T7CTPW

### a write aimed at the REMOTE task
$ rove api send --task-id 01M2429QKKH80R8HQY2YG1H170 --prompt x
{"error":{"message":"task 01M2429QKKH80R8HQY2YG1H170 lives on machine \"narwhal\". Rove can list it, but acting on a remote task is not supported yet.","code":"NOT_YET_SUPPORTED_REMOTE","taskId":"01M2429QKKH80R8HQY2YG1H170","machineId":"narwhal","hint":"run the command on narwhal itself; remote writes arrive in a later release","nextCommandArgs":["machine","list"]}}
exit=1

### the same verb shape against the LOCAL task still works
$ rove api get-task --task-id 01M24PVSDX1NNQNW4Q17T7CTPW
 -> local probe / running: None

### did the local daemon ever see that remote id?
$ grep -c 01M2429QKKH80R8HQY2YG1H170 <local daemon.log>
0
0
```

The local daemon never sees that id. A bare `TASK_NOT_FOUND` for a task the
user can see in the sidebar reads as data loss; naming the machine says the
task is fine and the command is early.

### One machine under two aliases

```
### the same machine, registered a second time under another alias
$ rove machine add narwhal --alias nar2   (already done)
narwhal  narwhal  Nahuels-Mac-mini.local  same machine as nar2
nar2     narwhal  Nahuels-Mac-mini.local  same machine as narwhal

### the merged list counts that machine ONCE
  tasks per machineId: {'local': 2, 'narwhal': 8}
  "remote probe" rows: 1
```

### Offline and recovery, from the CLI

```
### online: narwhal's tasks are in the list
  narwhal rows: 8

### cut the connection: ssh -O exit narwhal + stop the remote daemon
Exit request sent.
rove daemon: stop requested
20:49:24

### offline: the CLI reports only what it can reach
  narwhal rows: 0  local rows: 2
20:49:26

### the machine comes back: rove daemon start on narwhal
20:52:18
  narwhal rows: 8
20:52:21

  (the forward was re-established on demand — no re-registration, no restart)
srw-------@ 1 jacksonc  wheel    0 Sep  9 20:49 cm
srw-------@ 1 jacksonc  wheel    0 Sep  9 20:49 daemon.sock
srw-------@ 1 jacksonc  wheel    0 Sep  9 20:49 pty.sock
```

Recovery needed no re-registration and no restart — the forward is
re-established on demand over the shared ssh connection.

### Zero-machine regression

The guard the whole feature is built around: an install with no machines must
be what it was.

```
BEFORE = origin/main build (608f6e135)
AFTER  = this branch (568eb7c70), same isolated home, zero machines registered

$ rove machine list
No machines registered. Add one with `rove machine add <ssh-target>`.

$ diff <(BEFORE api list) <(AFTER api list)
  (no output — byte-identical)

$ diff <(BEFORE api inspect) <(AFTER api inspect)
  3c3
  <     "daemonPid": 9551,
  ---
  >     "daemonPid": 9341,
  5c5
  <     "startedAt": "2026-09-10T03:52:34.594Z",
  ---
  >     "startedAt": "2026-09-10T03:52:31.831Z",
  17c17
  <   "at": "2026-09-10T03:52:36.592Z"
  ---
  >   "at": "2026-09-10T03:52:33.936Z"
  ^ only daemonPid / startedAt / the response's own timestamp — per-run values, not fields.
```

The sidebar half of the same guard is `applyMachineLayer` returning the very
array it was handed (identity, not equality) when no machine is registered —
pinned by a test, and by `bun test test/render` staying green.

### Mutation checks

```
### Mutation 1 — drop the machineId prefix from sidebarProjectKey
170:  return path
   × project identity and labels across machines > keys the same path on two machines as two projects 4ms
   × applyMachineLayer > puts a remote machine's projects under a header, indented by one 5ms
 FAIL  test/tui/sidebar-groups.test.ts > project identity and labels across machines > keys the same path on two machines as two projects
 FAIL  test/tui/sidebar-machine-layer.test.ts > applyMachineLayer > puts a remote machine's projects under a header, indented by one
      Tests  2 failed | 37 passed (39)
  (restored)

### Mutation 2 — drop the offline-retention branch from applyMachineLayer
   × applyMachineLayer > keeps an offline machine's rows instead of dropping them 4ms
 FAIL  test/tui/sidebar-machine-layer.test.ts > applyMachineLayer > keeps an offline machine's rows instead of dropping them
      Tests  1 failed | 5 passed (6)
  (restored)

### both restored — suites green again
      Tests  39 passed (39)
```

### What I installed on narwhal

It is not my machine, so: nothing was removed, nothing outside `~/i` and Rove's
own directories was touched, and no `sudo` was used.

- `~/.local/node` — Node 22.20.0 from the official darwin-arm64 tarball.
- One line appended to `~/.zshenv` putting that on `PATH` (needed for
  non-interactive ssh, which is how `machine add` probes).
- `@sma1lboy/rove` globally, first from npm and then this branch's build
  (`npm pack` → `scp` → `npm i -g`), because a machine needs a Rove that
  reports its PTY socket.
- `~/i/kobe` — an empty git repo with one commit, deliberately named `kobe` to
  force the same-name case.
- One Rove task on it, `remote probe`, running `while true; do echo tick; done`.

I did **not** downgrade narwhal to 0.9.100 for the protocol-mismatch check as
the brief suggested. narwhal turned out not to be empty — it carries 8 real
tasks belonging to its owner — and installing a months-old Rove over a live
task index risks their data for a screenshot. The classification is covered by
`classifyHandshakeFailure` and its unit test instead, over the two message
shapes `performInit` actually throws.

### Interfaces PR 2 and PR 3 can build on

- `MachineHub` owns `Map<machineId, RemoteOrchestrator>` and a merged task
  signal. PR 2's pty attach reads `TunnelHandle.ptySocketPath`, which is
  already forwarded and already owner-only.
- `TaskOrigin` (`machineId`, `hostLabel`, `stale`) is on every merged task, so
  `rove api --machine` (PR 2) can route by reading it rather than re-deriving.
- `assertLocalTask` is the single CLI choke point; PR 2 replaces its throw with
  a route to that machine's socket.
- `MachineStatus.state` already carries the vocabulary a PR 3 activity badge
  would hang off, and `machineStateKey` keeps the words translatable.

### What the live run changed

Six things no unit test would have found — the hostname-vs-alias label, the
same-machine repo collision, two forwarding mechanisms fighting for one socket
path, the `sun_path` overrun under a worktree home, a remote task trying to
materialize a worktree locally, and a remote daemon idle-stopping under a
`pane`-role watcher. Each is its own commit with the symptom in the message.

### Alias default

`rove machine add narwhal` gives you a machine called `narwhal`. The short name
in `ssh_config` is one the user chose; the machine's own hostname is one they
never picked, and `Nahuels-Mac-mini.local` fills the sidebar rail — it would
also have been what a disambiguated repo label carried. A target that is
addressing rather than a name (`user@host`, an explicit port, a bare IP) still
takes the remote hostname.

(This changed from the design draft's hostname default after the live run made
the consequence visible. Confirmed with the owner.)

---

coverage-exemption: packages/kobe/src/tui-react/workspace/start-workspace.tsx — process entry point. It opens a daemon socket, attaches the machine hub and owns the PTY registry's teardown; a render test cannot mount it (see docs/HARNESS.md on mounting a real WorkspaceRoot). Its one branch — machines registered or not — is covered by `MachineHub.attach()`'s own tests. It exists as a file only because adding the hub pushed host.tsx past the size cap; the component half it was split from is at 91%.

coverage-exemption: packages/kobe/src/tui/index.tsx — CLI entry point, uncoverable by the render suite. The change here is one line: the dynamic import moved from `workspace/host` to `workspace/start-workspace`.

