### PR TITLE
fix(daemon): idle worktrees stop being git-probed every two seconds

### DIFF
--- a/.changeset/quiet-worktrees-stay-quiet.md
+++ b/.changeset/quiet-worktrees-stay-quiet.md
@@ -1,0 +1,9 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Idle worktrees stop being probed with `git` every two seconds. The daemon's
+"which tasks have a working engine?" gate was reading the activity replay,
+which carries known-idle tab entries on purpose — so every task that had ever
+opened a terminal tab counted as busy and skipped the 60s quiet backoff for the
+life of the daemon. The gate now reads the derived task rollup instead.

--- a/packages/kobe-daemon/src/daemon/activity-readers.ts
+++ b/packages/kobe-daemon/src/daemon/activity-readers.ts
@@ -1,0 +1,117 @@
+/**
+ * The READ half of the activity ledger: pure projections of the two maps the
+ * registry writes into the wire payloads consumers read.
+ *
+ * Split out because "what is in the ledger" and "what is working" are not the
+ * same question, and one reader answering both got them confused. The ledger
+ * deliberately keeps known-idle TAB entries — the client holds them as
+ * tombstones, because the sidebar draws ABSENCE as unknown (a dotted ◌), so
+ * "the daemon says this tab is idle" has to stay distinguishable from "the
+ * daemon has never heard of it". A gate that read that replay counted every
+ * task which had ever opened a tab as busy, which pinned the worktree-changes
+ * collector's 2s cadence on worktrees nothing was writing to.
+ *
+ * So each consumer names its own question: {@link workingTaskIds} for a gate,
+ * {@link liveSessions} for per-session telemetry, {@link replaySnapshot} for a
+ * late subscriber's hydration.
+ *
+ * Pure: no timers, no bus, no I/O — the registry owns those.
+ */
+
+import type { EffectiveActivity } from "./activity-arbitrate.ts"
+import type { EngineSessionInfo } from "./activity-reduce.ts"
+import { type RollupCandidate, type RollupTabEntry, deriveTaskActivity, rollupCandidates } from "./activity-rollup.ts"
+import type { EngineActivityDetail, TaskActivityState } from "./contracts.ts"
+import type { ChannelPayloads } from "./protocol.ts"
+
+export type EngineStatePayload = ChannelPayloads["engine-state"]
+
+/** The subset of a ledger entry the wire payload reads. */
+export interface PayloadSource {
+  readonly state: TaskActivityState
+  readonly detail?: EngineActivityDetail
+  readonly session?: EngineSessionInfo
+  readonly at: number
+}
+
+/** One tab's record, as the readers see it. */
+export interface ReadableTabEntry extends RollupTabEntry {
+  readonly effective: EffectiveActivity
+}
+
+/** taskId → tabId → entry. */
+export type TabLedger = ReadonlyMap<string, ReadonlyMap<string, ReadableTabEntry>>
+/** taskId → the task's TAB-LESS hook entry (an engine started outside a kobe tab). */
+export type TablessLedger = ReadonlyMap<string, RollupCandidate>
+
+export function activityPayload(taskId: string, entry: PayloadSource, tabId?: string): EngineStatePayload {
+  return {
+    taskId,
+    ...(tabId ? { tabId } : {}),
+    state: entry.state,
+    ...(entry.detail ? { detail: entry.detail } : {}),
+    ...(entry.session ? { sessionId: entry.session.id } : {}),
+    ...(entry.session?.transcriptPath ? { transcriptPath: entry.session.transcriptPath } : {}),
+    at: entry.at,
+  }
+}
+
+/** Every task with a ledger entry at either level. */
+export function ledgerTaskIds(tabless: TablessLedger, tabs: TabLedger): Set<string> {
+  return new Set([...tabless.keys(), ...tabs.keys()])
+}
+
+/** The derived task-level state, or `undefined` when nothing ever reported. */
+export function taskRollup(taskId: string, tabless: TablessLedger, tabs: TabLedger): RollupCandidate | undefined {
+  return deriveTaskActivity(rollupCandidates(tabless.get(taskId), tabs.get(taskId)))
+}
+
+/**
+ * Tasks whose engine is doing something — the derived rollup, filtered to
+ * non-idle. The rollup already folds every tab (activity-rollup.ts), so one
+ * working tab puts its task here however quiet the siblings are.
+ *
+ * This is what a GATE wants ("is an agent working in there?"), and it is
+ * deliberately NOT {@link replaySnapshot} — see this file's header.
+ */
+export function workingTaskIds(tabless: TablessLedger, tabs: TabLedger): string[] {
+  const out: string[] = []
+  for (const taskId of ledgerTaskIds(tabless, tabs)) {
+    const derived = taskRollup(taskId, tabless, tabs)
+    if (derived && derived.state !== "idle") out.push(taskId)
+  }
+  return out
+}
+
+/**
+ * Every tab holding a live engine SESSION, whatever its state — the
+ * context-usage collector's targets. Idle belongs here: a tab between turns
+ * still has a transcript, and the footer's `ctx N%` must keep rendering.
+ */
+export function liveSessions(tabs: TabLedger): EngineStatePayload[] {
+  const out: EngineStatePayload[] = []
+  for (const [taskId, entries] of tabs) {
+    for (const [tabId, entry] of entries) {
+      if (entry.effective.session) out.push(activityPayload(taskId, entry.effective, tabId))
+    }
+  }
+  return out
+}
+
+/**
+ * The whole `engine-state` replay for a late subscriber: each task's derived
+ * rollup, non-idle only (an idle task has no badge to draw), plus EVERY tab
+ * entry so the client rebuilds its per-tab map too — known-idle ones included,
+ * which is the point and not a missing filter (see this file's header).
+ */
+export function replaySnapshot(tabless: TablessLedger, tabs: TabLedger): EngineStatePayload[] {
+  const out: EngineStatePayload[] = []
+  for (const taskId of ledgerTaskIds(tabless, tabs)) {
+    const derived = taskRollup(taskId, tabless, tabs)
+    if (derived && derived.state !== "idle") out.push(activityPayload(taskId, derived))
+  }
+  for (const [taskId, entries] of tabs) {
+    for (const [tabId, entry] of entries) out.push(activityPayload(taskId, entry.effective, tabId))
+  }
+  return out
+}

--- a/packages/kobe-daemon/src/daemon/activity-registry.ts
+++ b/packages/kobe-daemon/src/daemon/activity-registry.ts
@@ -2,16 +2,25 @@ import { type EffectiveActivity, type HookSlot, type ObservedSlot, recomputeTabA
 import { type ActivityDebugSnapshot, buildActivityDebugSnapshot } from "./activity-debug-dump.ts"
 import { ActivityLapseWatchdog, type LapseEntry, type LapseTarget } from "./activity-lapse.ts"
 import {
+  type EngineStatePayload,
+  type PayloadSource,
+  activityPayload,
+  ledgerTaskIds,
+  liveSessions,
+  replaySnapshot,
+  taskRollup,
+  workingTaskIds,
+} from "./activity-readers.ts"
+import {
   type ActivityLivenessProbe,
   type EngineSessionInfo,
   STICKY_STATES,
   reduceActivity,
   resolveEngineStateTtlMs,
 } from "./activity-reduce.ts"
-import { type RollupCandidate, deriveTaskActivity, rollupCandidates } from "./activity-rollup.ts"
+import type { RollupCandidate } from "./activity-rollup.ts"
 import type { EngineActivityDetail, EngineActivityKind, TaskActivityState } from "./contracts.ts"
 import type { DaemonEventBus } from "./event-bus.ts"
-import type { ChannelPayloads } from "./protocol.ts"
 
 // Pure reducer + policy constants/types live in activity-reduce.ts (file-size
 // cap split); re-exported so this stays the one public entry point. The
@@ -31,6 +40,8 @@ export {
   recomputeTabActivity,
 } from "./activity-arbitrate.ts"
 export { type RollupCandidate, deriveTaskActivity, rollupCandidates } from "./activity-rollup.ts"
+// The read half — pure projections of the ledger below (activity-readers.ts).
+export type { EngineStatePayload } from "./activity-readers.ts"
 
 /**
  * A TAB-LESS hook entry: an engine the user started in a shell kobe did not
@@ -71,16 +82,6 @@ interface TabEntry {
 
 /** What `observeTab` did — the caller (activity-observer) logs corrections. */
 export type ObserveTabOutcome = "noop" | "observed-running" | "observed-idle" | "corrected-hook-running"
-
-export type EngineStatePayload = ChannelPayloads["engine-state"]
-
-/** The subset of an entry the wire payload reads. */
-interface PayloadSource {
-  state: TaskActivityState
-  detail?: EngineActivityDetail
-  session?: EngineSessionInfo
-  at: number
-}
 
 /**
  * In-memory, daemon-owned activity registry for hook-driven engine badges.
@@ -223,7 +224,7 @@ export class DaemonActivityRegistry {
 
   /** The derived task-level state, or `undefined` when nothing ever reported. */
   private rollup(taskId: string): RollupCandidate | undefined {
-    return deriveTaskActivity(rollupCandidates(this.activity.get(taskId), this.tabActivity.get(taskId)))
+    return taskRollup(taskId, this.activity, this.tabActivity)
   }
 
   /**
@@ -431,23 +432,22 @@ export class DaemonActivityRegistry {
 
   /** Every task with a ledger entry at either level. */
   private taskIds(): Set<string> {
-    return new Set([...this.activity.keys(), ...this.tabActivity.keys()])
+    return ledgerTaskIds(this.activity, this.tabActivity)
   }
 
-  currentNonIdle(): EngineStatePayload[] {
-    const out: EngineStatePayload[] = []
-    for (const taskId of this.taskIds()) {
-      const derived = this.rollup(taskId)
-      if (derived && derived.state !== "idle") out.push(this.payload(taskId, derived))
-    }
-    // Tab entries ride the same replay so a late subscriber rebuilds its
-    // per-tab map too. Hook-driven entries are only stored non-idle; the
-    // OBSERVED slot includes known-idle ones on purpose — replaying them is
-    // what lets a late client tell "known idle" from "no signal" (unknown).
-    for (const [taskId, tabs] of this.tabActivity) {
-      for (const [tabId, entry] of tabs) out.push(this.payload(taskId, entry.effective, tabId))
-    }
-    return out
+  /** Tasks with a working engine — a GATE, not the replay. See activity-readers.ts. */
+  workingTaskIds(): string[] {
+    return workingTaskIds(this.activity, this.tabActivity)
+  }
+
+  /** Every tab holding a live engine session, idle included. */
+  liveSessions(): EngineStatePayload[] {
+    return liveSessions(this.tabActivity)
+  }
+
+  /** The full `engine-state` replay for a late subscriber. */
+  replaySnapshot(): EngineStatePayload[] {
+    return replaySnapshot(this.activity, this.tabActivity)
   }
 
   /**
@@ -479,14 +479,6 @@ export class DaemonActivityRegistry {
   }
 
   private payload(taskId: string, entry: PayloadSource, tabId?: string): EngineStatePayload {
-    return {
-      taskId,
-      ...(tabId ? { tabId } : {}),
-      state: entry.state,
-      ...(entry.detail ? { detail: entry.detail } : {}),
-      ...(entry.session ? { sessionId: entry.session.id } : {}),
-      ...(entry.session?.transcriptPath ? { transcriptPath: entry.session.transcriptPath } : {}),
-      at: entry.at,
-    }
+    return activityPayload(taskId, entry, tabId)
   }
 }

--- a/packages/kobe-daemon/src/daemon/collectors.ts
+++ b/packages/kobe-daemon/src/daemon/collectors.ts
@@ -210,7 +210,7 @@ export function startDaemonCollectors(
     // Worktrees with a working engine keep the fast cadence — the change
     // probe behind the collector's quiet backoff is blind to nested writes,
     // which is exactly what a working engine produces.
-    activity ? () => activity.currentNonIdle().map((e) => e.taskId) : undefined,
+    activity ? () => activity.workingTaskIds() : undefined,
   )
 
   const stopTranscriptActivityCollector = startTranscriptActivityCollector(
@@ -247,7 +247,7 @@ export function startDaemonCollectors(
     // prStatus rides the task push too.
     () => hasSubscribersFor("task.snapshot"),
     undefined,
-    activity ? () => activity.currentNonIdle().some((e) => e.state !== "idle") : undefined,
+    activity ? () => activity.workingTaskIds().length > 0 : undefined,
   )
 
   // Quota-resume runner: deliberately NOT gated on `hasSubscribers` — its

--- a/packages/kobe-daemon/src/daemon/context-usage-collector.ts
+++ b/packages/kobe-daemon/src/daemon/context-usage-collector.ts
@@ -109,7 +109,7 @@ export class ContextUsageCollector {
   private stopped = false
 
   constructor(
-    private readonly registry: Pick<DaemonActivityRegistry, "currentNonIdle">,
+    private readonly registry: Pick<DaemonActivityRegistry, "liveSessions">,
     private readonly orch: Pick<DaemonOrchestrator, "getTask">,
     private readonly bus: DaemonEventBus,
     private readonly runtime: Pick<DaemonRuntimeAdapter, "readEngineContextUsage">,
@@ -120,7 +120,7 @@ export class ContextUsageCollector {
     if (this.stopped) return
     if (this.options.hasSubscribers && !this.options.hasSubscribers()) return
     try {
-      const targets = contextUsageTargets(this.registry.currentNonIdle(), (id) => this.orch.getTask(id)?.vendor)
+      const targets = contextUsageTargets(this.registry.liveSessions(), (id) => this.orch.getTask(id)?.vendor)
       const live = new Set(targets.map((t) => t.key))
       let pruned = false
       for (const key of [...this.entries.keys()]) {
@@ -200,7 +200,7 @@ export class ContextUsageCollector {
 
 /** Start the production collector on an interval; `tickMs <= 0` disables it. */
 export function startContextUsageCollector(
-  registry: Pick<DaemonActivityRegistry, "currentNonIdle">,
+  registry: Pick<DaemonActivityRegistry, "liveSessions">,
   orch: Pick<DaemonOrchestrator, "getTask">,
   bus: DaemonEventBus,
   runtime: Pick<DaemonRuntimeAdapter, "readEngineContextUsage">,

--- a/packages/kobe-daemon/src/daemon/pr-status-collector.ts
+++ b/packages/kobe-daemon/src/daemon/pr-status-collector.ts
@@ -425,7 +425,7 @@ export async function runPrStatusPass(orch: DaemonOrchestrator, opts: PrStatusPa
  * stale or missing at the exact moment a worker asks whether its PR is green
  * — one mechanism behind "CI is green" being asserted from a local test run.
  *
- * `hasWorkingAgent` is the engine-activity registry (`currentNonIdle()`), fed
+ * `hasWorkingAgent` is the engine-activity registry (`workingTaskIds()`), fed
  * by the ungated `engine.reportEvent` hook path, so it is a free in-memory
  * read that needs no network and no pane. It keeps the gate's point intact —
  * a daemon with no GUI **and** no live engine still polls nobody, which is

--- a/packages/kobe-daemon/src/daemon/subscribe.ts
+++ b/packages/kobe-daemon/src/daemon/subscribe.ts
@@ -72,13 +72,13 @@ export function handleSubscribe(
     if (client.channels && !client.channels.has(event.channel)) continue
     deps.writeEvent(client, event.channel as DaemonEventName, event.payload)
   }
-  // The bus only caches ONE last-value per channel, but `engine-state`
-  // is per-task — so additionally replay EVERY task's current non-idle
-  // activity to this late subscriber (otherwise it'd only learn the most
-  // recently changed task's state). Skip when the client filtered
-  // `engine-state` out.
+  // The bus only caches ONE last-value per channel, but `engine-state` is
+  // per-task — so additionally replay the whole activity snapshot to this
+  // late subscriber (otherwise it'd only learn the most recently changed
+  // task's state). Known-idle TAB entries ride along on purpose; see
+  // `replaySnapshot`. Skip when the client filtered `engine-state` out.
   if (!client.channels || client.channels.has("engine-state")) {
-    for (const payload of deps.activity.currentNonIdle()) {
+    for (const payload of deps.activity.replaySnapshot()) {
       deps.writeEvent(client, "engine-state", payload)
     }
   }

--- a/packages/kobe/test/daemon/activity-liveness.test.ts
+++ b/packages/kobe/test/daemon/activity-liveness.test.ts
@@ -220,7 +220,7 @@ describe("activity registry liveness watchdog", () => {
       { tabId: "tab-1", state: "idle" },
     ])
     // The lapsed tab entry must not linger in the replay set.
-    expect(registry.currentNonIdle().filter((p) => "tabId" in p && p.tabId)).toEqual([])
+    expect(registry.replaySnapshot().filter((p) => "tabId" in p && p.tabId)).toEqual([])
   })
 
   it("keeps an alive per-tab running entry lit across windows (heartbeat)", async () => {
@@ -231,7 +231,7 @@ describe("activity registry liveness watchdog", () => {
     await vi.advanceTimersByTimeAsync(TTL)
     await vi.advanceTimersByTimeAsync(TTL)
 
-    const tabs = registry.currentNonIdle().filter((p) => "tabId" in p && p.tabId)
+    const tabs = registry.replaySnapshot().filter((p) => "tabId" in p && p.tabId)
     expect(tabs).toHaveLength(1)
     expect(tabs[0]?.state).toBe("running")
   })
@@ -244,7 +244,7 @@ describe("activity registry liveness watchdog", () => {
     registry.report("t", "turn-complete", undefined, "tab-1")
     await vi.advanceTimersByTimeAsync(TTL * 3)
 
-    const tabs = registry.currentNonIdle().filter((p) => "tabId" in p && p.tabId)
+    const tabs = registry.replaySnapshot().filter((p) => "tabId" in p && p.tabId)
     expect(tabs).toHaveLength(1)
     expect(tabs[0]?.state).toBe("turn_complete")
   })
@@ -254,10 +254,10 @@ describe("activity registry liveness watchdog", () => {
     registry = new DaemonActivityRegistry(bus, TTL, () => Date.now(), probe)
     registry.report("t", "turn-start", undefined, "tab-1", { id: "own", transcriptPath: "/own" })
     await vi.advanceTimersByTimeAsync(TTL * 3)
-    expect(registry.currentNonIdle().every((entry) => entry.state === "running")).toBe(true)
+    expect(registry.replaySnapshot().every((entry) => entry.state === "running")).toBe(true)
     registry.report("t", "turn-complete", undefined, "tab-1")
     await vi.advanceTimersByTimeAsync(TTL * 2)
-    expect(registry.currentNonIdle().every((entry) => entry.state === "turn_complete")).toBe(true)
+    expect(registry.replaySnapshot().every((entry) => entry.state === "turn_complete")).toBe(true)
   })
 
   it("replaces unknown evidence with a recovered session's own completion", async () => {
@@ -292,10 +292,10 @@ describe("activity registry liveness watchdog", () => {
     registry.report("t", "turn-start", undefined, "tab-1", { id: "new", transcriptPath: "/new" })
     for (const resolve of finish) resolve({ completedAt: 1 })
     await vi.advanceTimersByTimeAsync(0)
-    expect(registry.currentNonIdle()).toEqual(
+    expect(registry.replaySnapshot()).toEqual(
       expect.arrayContaining([expect.objectContaining({ state: "running", sessionId: "new", transcriptPath: "/new" })]),
     )
-    expect(registry.currentNonIdle().some((entry) => entry.state === "idle")).toBe(false)
+    expect(registry.replaySnapshot().some((entry) => entry.state === "idle")).toBe(false)
   })
 
   it.each(["death", "rest"] as const)(
@@ -313,7 +313,7 @@ describe("activity registry liveness watchdog", () => {
       else registry.observeTab("t", "tab-1", "rest", { correctHookRunningAfterMs: 0 })
       expect(vi.getTimerCount()).toBe(0)
       await vi.advanceTimersByTimeAsync(TTL * 2)
-      expect(registry.currentNonIdle().some((entry) => entry.state === "running")).toBe(false)
+      expect(registry.replaySnapshot().some((entry) => entry.state === "running")).toBe(false)
     },
   )
 
@@ -328,7 +328,7 @@ describe("activity registry liveness watchdog", () => {
     registry.report("t", "turn-start", undefined, "tab-2", { id: "two", transcriptPath: "/two" })
     registry.recordEngineDeath("t", "tab-1", { code: 1 }, Date.now())
     await vi.advanceTimersByTimeAsync(TTL)
-    expect(registry.currentNonIdle().find((p) => !p.tabId)).toMatchObject({ state: "running", transcriptPath: "/two" })
+    expect(registry.replaySnapshot().find((p) => !p.tabId)).toMatchObject({ state: "running", transcriptPath: "/two" })
   })
 
   it("never idles after the entry was cleared during the probe await", async () => {

--- a/packages/kobe/test/daemon/activity-rollup-ownership.test.ts
+++ b/packages/kobe/test/daemon/activity-rollup-ownership.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it } from "vitest"
 
 /** The derived task-level rollup, as every production consumer reads it. */
 function rollup(registry: DaemonActivityRegistry) {
-  return registry.currentNonIdle().find((payload) => !payload.tabId)
+  return registry.replaySnapshot().find((payload) => !payload.tabId)
 }
 
 describe("derived task rollup", () => {
@@ -71,7 +71,7 @@ describe("derived task rollup", () => {
       now = 2
       registry.clearTab("t", "tab-1")
       expect(rollup(registry)).toBeUndefined()
-      expect(registry.currentNonIdle()).toEqual([])
+      expect(registry.replaySnapshot()).toEqual([])
     } finally {
       registry.close()
     }
@@ -87,7 +87,7 @@ describe("derived task rollup", () => {
     )
     try {
       expect(registry.observeTab("gone", "tab-1", "working")).toBe("noop")
-      expect(registry.currentNonIdle()).toEqual([])
+      expect(registry.replaySnapshot()).toEqual([])
       expect(registry.observeTab("alive", "tab-1", "working")).toBe("observed-running")
     } finally {
       registry.close()

--- a/packages/kobe/test/daemon/activity-state.test.ts
+++ b/packages/kobe/test/daemon/activity-state.test.ts
@@ -76,7 +76,7 @@ describe("daemon activity state", () => {
     registry.report("task-err", "turn-failed", { failure: "other" })
     registry.report("task-rl", "turn-failed", { failure: "rate_limit" })
 
-    expect(registry.currentNonIdle().map((p) => [p.taskId, p.state])).toEqual([
+    expect(registry.replaySnapshot().map((p) => [p.taskId, p.state])).toEqual([
       ["task-err", "error"],
       ["task-rl", "rate_limited"],
     ])
@@ -90,7 +90,7 @@ describe("daemon activity state", () => {
     registry.report("task-1", "turn-start")
     registry.report("task-2", "awaiting-input", { waiting: "permission" })
 
-    expect(registry.currentNonIdle().map((p) => [p.taskId, p.state])).toEqual([
+    expect(registry.replaySnapshot().map((p) => [p.taskId, p.state])).toEqual([
       ["task-1", "running"],
       ["task-2", "permission_needed"],
     ])
@@ -139,10 +139,10 @@ describe("daemon activity state", () => {
     const registry = new DaemonActivityRegistry(bus, 1_000)
 
     registry.report("task-1", "turn-start")
-    expect(registry.currentNonIdle().map((p) => p.state)).toEqual(["running"])
+    expect(registry.replaySnapshot().map((p) => p.state)).toEqual(["running"])
 
     registry.report("task-1", "turn-interrupted")
-    expect(registry.currentNonIdle()).toEqual([])
+    expect(registry.replaySnapshot()).toEqual([])
 
     registry.close()
   })
@@ -171,14 +171,14 @@ describe("daemon activity state", () => {
       { taskId: "task-1", tabId: undefined, state: "permission_needed" },
     ])
     // Replay carries the task rollup AND the tab entry.
-    expect(registry.currentNonIdle().map((p) => [p.taskId, p.tabId, p.state])).toEqual([
+    expect(registry.replaySnapshot().map((p) => [p.taskId, p.tabId, p.state])).toEqual([
       ["task-1", undefined, "permission_needed"],
       ["task-1", "tab-2", "permission_needed"],
     ])
 
     // A tab's session-end drops its per-tab entry (idle is never stored).
     registry.report("task-1", "session-end", undefined, "tab-2")
-    expect(registry.currentNonIdle()).toEqual([])
+    expect(registry.replaySnapshot()).toEqual([])
 
     // clearTask publishes per-tab idles so subscribers drop tab candidates.
     registry.report("task-1", "turn-start", undefined, "tab-3")
@@ -225,7 +225,7 @@ describe("daemon activity state", () => {
     })
 
     // Replay (late subscriber) carries it too — task rollup + tab entry.
-    const replayed = registry.currentNonIdle()
+    const replayed = registry.replaySnapshot()
     expect(replayed).toHaveLength(2)
     for (const p of replayed) expect((p as { sessionId?: string }).sessionId).toBe("sess-abc")
 
@@ -256,6 +256,55 @@ describe("daemon activity state", () => {
     const last = published.filter((p) => p.tabId).at(-1)
     expect(last?.tabId).toBe("tab-b")
     expect(last?.sessionId).toBeUndefined()
+    registry.close()
+  })
+})
+
+/**
+ * The ledger holds known-idle TAB entries on purpose (the client draws
+ * absence as unknown), so "what is in the ledger" and "what is working" are
+ * different questions. One reader answering both reported every task that had
+ * ever opened a tab as busy — which pinned the worktree-changes collector's
+ * 2 s cadence on worktrees nothing was writing to.
+ */
+describe("activity readers", () => {
+  function world() {
+    let now = 1_000
+    const registry = new DaemonActivityRegistry(new DaemonEventBus(), 60_000, () => now)
+    return {
+      registry,
+      tick(ms: number) {
+        now += ms
+      },
+    }
+  }
+
+  it("a task whose only tab was observed idle is not a working task", () => {
+    const { registry, tick } = world()
+    registry.report("quiet", "turn-start", undefined, "tab-1", { id: "s1", transcriptPath: "/s1" }, "claude")
+    registry.report("busy", "turn-start", undefined, "tab-1", { id: "s2", transcriptPath: "/s2" }, "claude")
+    tick(5_000)
+    expect(registry.observeTab("quiet", "tab-1", "rest", { correctHookRunningAfterMs: 1_000 })).toBe(
+      "corrected-hook-running",
+    )
+
+    expect(registry.workingTaskIds()).toEqual(["busy"])
+    // The entry survives the idle — that is exactly what the old reader
+    // mistook for work.
+    expect(registry.replaySnapshot().filter((p) => p.taskId === "quiet")).toMatchObject([
+      { tabId: "tab-1", state: "idle" },
+    ])
+    registry.close()
+  })
+
+  it("liveSessions keeps an idle tab holding a session, and skips a tab without one", () => {
+    const { registry, tick } = world()
+    registry.report("t", "turn-start", undefined, "with-session", { id: "s1", transcriptPath: "/s1" }, "claude")
+    registry.report("t", "turn-start", undefined, "no-session")
+    tick(5_000)
+    registry.observeTab("t", "with-session", "rest", { correctHookRunningAfterMs: 1_000 })
+
+    expect(registry.liveSessions()).toMatchObject([{ tabId: "with-session", state: "idle", sessionId: "s1" }])
     registry.close()
   })
 })

--- a/packages/kobe/test/daemon/context-usage-collector.test.ts
+++ b/packages/kobe/test/daemon/context-usage-collector.test.ts
@@ -72,7 +72,7 @@ function harness(states: { taskId: string; tabId?: string; sessionId?: string }[
     contextWindowTokens: 100,
   }
   const collector = new ContextUsageCollector(
-    { currentNonIdle: () => live as never },
+    { liveSessions: () => live as never },
     { getTask: () => ({ vendor: "claude" }) as never },
     bus,
     { readEngineContextUsage: async () => value },

--- a/packages/kobe/test/daemon/handlers.test.ts
+++ b/packages/kobe/test/daemon/handlers.test.ts
@@ -134,7 +134,7 @@ describe("daemon handler registry", () => {
 
         expect(activity.debugSnapshot().tabs.t1?.["tab-1"]).toBeUndefined()
         // …and the task row follows: nothing is left to be running.
-        expect(activity.currentNonIdle()).toEqual([])
+        expect(activity.replaySnapshot()).toEqual([])
       } finally {
         activity.close()
       }

--- a/packages/kobe/test/engine/activity-observer.test.ts
+++ b/packages/kobe/test/engine/activity-observer.test.ts
@@ -236,7 +236,7 @@ describe("activity observer", () => {
     await waitFor(() => w.row("tab-1")?.state === "idle")
     // Late subscriber: replay must carry the known-idle fact for tab-1 —
     // and nothing for tab-9, which stays unknown.
-    const replay = w.registry.currentNonIdle()
+    const replay = w.registry.replaySnapshot()
     expect(replay.some((p) => p.tabId === "tab-1" && p.state === "idle")).toBe(true)
     expect(replay.some((p) => p.tabId === "tab-9")).toBe(false)
   })

--- a/packages/kobe/test/engine/activity-pipeline.test.ts
+++ b/packages/kobe/test/engine/activity-pipeline.test.ts
@@ -70,7 +70,7 @@ function rowAfterClaudeHook(event: string, payload: Record<string, unknown>) {
     // 5. Client side: RemoteOrchestrator accumulates non-idle states into
     //    TaskEngineState — which is exactly what the registry's derived
     //    rollup replays, so an idle task is simply absent here.
-    const published = registry.currentNonIdle().find((p) => p.taskId === "task-1" && !p.tabId)
+    const published = registry.replaySnapshot().find((p) => p.taskId === "task-1" && !p.tabId)
     const activity: TaskEngineState | undefined = published
       ? { state: published.state, detail: published.detail, at: published.at }
       : undefined

--- a/packages/kobe/test/golden/running-status.test.ts
+++ b/packages/kobe/test/golden/running-status.test.ts
@@ -281,7 +281,7 @@ describe("golden: session events → sidebar running state", () => {
     h.registry.report(TASK_ID, "turn-start", undefined, "tab-1", { id: "s1" }, "claude")
     // A fresh client attaches: no live events, only the subscribe-time replay.
     const late = h.makeClient()
-    for (const payload of h.registry.currentNonIdle()) {
+    for (const payload of h.registry.replaySnapshot()) {
       handleOrchestratorEvent("engine-state", payload, late.signals)
     }
     expect(late.row("tab-1").loading).toBe(true)


### PR DESCRIPTION
## The defect

`ActivityRegistry.currentNonIdle()` returned two different kinds of thing concatenated: per-task rollups filtered to non-idle, and **every** per-tab entry with no state filter. Three of its four callers wanted a filter it did not apply.

`collectors.ts` fed `currentNonIdle().map(e => e.taskId)` into the worktree-changes collector as `activeTaskIds` → `busyPaths()` → the `busy` flag, which is the escape hatch from the 60s quiet backoff. Because the ledger keeps known-idle **tab** entries forever, every task that had ever opened a terminal tab was permanently "busy".

## What changed

The one conflated reader is split into three, each named for the question its callers ask, extracted into `activity-readers.ts` (registry: 534 → 483 lines):

- `workingTaskIds()` — the derived rollup filtered to non-idle. Feeds the worktree-changes gate and the PR-status gate. The rollup already folds every tab, so the redundant `.some(e => e.state !== "idle")` re-filter at the PR call site is gone.
- `liveSessions()` — every tab holding a session, idle included. Feeds the context-usage collector, whose `ctx N%` must keep rendering between turns.
- `replaySnapshot()` — the subscribe hydration, unchanged in behavior, now honestly named.

**One deliberate divergence from the brief.** The brief asked for the subscribe replay to be filtered to non-idle too. It must not be: the client keeps idle tab entries as tombstones (`remote-orchestrator-events.ts`, "an idle entry is KEPT as a tombstone") because the sidebar draws absence as UNKNOWN (a dotted ◌). Filtering would make a late subscriber render ◌ for tabs the daemon knows are idle, and `activity-observer.test.ts` already asserts the known-idle replay. So the replay keeps its behavior and gets an honest name plus a comment saying why; only the two gates changed.

## Behavioural measurement — live daemon, isolated home

Isolated `KOBE_HOME_DIR` / `KOBE_DAEMON_SOCKET_PATH` / `KOBE_PTY_SOCKET_PATH`, six seeded tasks with real git worktrees, six real hosted PTY sessions (a plain `sleep`, no engine — which is what makes the activity observer write the observed-idle tab entries this is about), and exactly one task driven to `running` via `rove api engine-report`. `git` shimmed on the daemon's PATH to a counter that `exec`s the real `/usr/bin/git`. BEFORE differs from AFTER by exactly one line: the gate reads `replaySnapshot().map(e => e.taskId)` (the old `currentNonIdle` body) instead of `workingTaskIds()`.

| worktree | activity state | BEFORE (`git status` spawns / 60s) | AFTER |
|---|---|---|---|
| w1 | running engine | 28 | 28 |
| w2 | observed idle tab | 28 | 1 |
| w3 | observed idle tab | 28 | 1 |
| w4 | observed idle tab | 28 | 1 |
| w5 | observed idle tab | 28 | 1 |
| w6 | observed idle tab | 28 | 1 |
| **total** | | **168** | **33** |

The working worktree keeps its exact 2s cadence; the five idle ones fall to the 60s safety poll. Production at the time this was filed had 9 idle tasks of 14.

The command that produced each row (label is `BEFORE` / `AFTER`; the script is `.scratch/nonidle/probe.sh`, gitignored, and prints its isolated home as its first line):

```
./.scratch/nonidle/probe.sh AFTER 60
```

which inlines every path into one invocation:

```
env -u ROVE_HOME_DIR -u KOBE_DAEMON_SOCKET_PATH -u KOBE_PTY_SOCKET_PATH \
    KOBE_HOME_DIR="$BASE/home" KOBE_DAEMON_SOCKET_PATH="$BASE/d.sock" \
    KOBE_PTY_SOCKET_PATH="$BASE/p.sock" ROVE_DAEMON_IDLE_GRACE_MS=600000 \
    PATH="$BASE/shim:$PATH" \
    bun packages/kobe/src/cli/rove.ts daemon start
```

and counts with `awk -F'\t' '{n=split($1,p,"/"); c[p[n]]++} END{for(k in c) print k, c[k]}' "$BASE/git.log"`.
Nothing was written to `/Users/jacksonc/.rove/` — verified after each run with `find ~/.rove -maxdepth 2 -newermt '-90 minutes' -not -path '*/worktrees/*'` (empty) and `grep -c PROBE ~/.rove/tasks.json` (0).

## Verification

- `bun run test:fast` — 505 files, 5023 passed
- `bun test test/render` — 523 passed
- `KOBE_INCLUDE_SOCKET=1 bun run test:socket` — 114 files, 919 passed
- `bun run lint` (repo root), `bun run typecheck` — clean
- Mutation-checked: dropping the idle filter in `workingTaskIds`, and adding one to `liveSessions`, each turn the two new unit tests red.
- Changeset: patch.

Refers to task "`currentNonIdle()` answers a different question than 3 of its 4 callers ask" (…KN2SM4).
