### PR TITLE
fix: a stopped engine's badge stops re-lighting itself every minute

### DIFF
--- a/.changeset/frozen-title-relight.md
+++ b/.changeset/frozen-title-relight.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+A tab whose engine has stopped no longer keeps re-lighting its activity badge. When an engine dies mid-turn it leaves its last spinner frame in the terminal title, and nothing will ever rewrite it — so the observer that watches PTY titles has to time how long that frame has sat still before it can call the tab idle. It kept that clock in memory alongside the session it was watching, and threw the whole thing away every time a `pty.list` call failed. The next call rebuilt it from scratch with the clock at zero, the frozen frame counted as fresh evidence all over again, and the dot came back on. In one report that happened roughly every ninety seconds for hours, so a stopped engine's badge read `running` essentially forever. The observer now keeps its clocks across a failed call: a session is written off on evidence — its process exited, or a list that actually answered no longer names it — never because the daemon briefly could not look.

--- a/packages/kobe-daemon/src/daemon/activity-observer.ts
+++ b/packages/kobe-daemon/src/daemon/activity-observer.ts
@@ -220,9 +220,18 @@ export function startActivityObserver(
         // positive evidence against hook claims, so only retire what this
         // loop itself asserted: observed-running entries flip to idle
         // (no `correctHookRunningAfterMs` → hook entries stand).
-        for (const [key, track] of tracks) {
+        //
+        // The TRACKS survive the outage. They hold the only clock that can
+        // ever refute a title frame, and a failed RPC is a fact about the
+        // socket, not about the session. Dropping them restarted every
+        // silence clock at `firstSeenAt = now`, so a dead engine's last
+        // spinner glyph — frozen, never re-read as anything else — scored as
+        // fresh evidence again on the very next list and re-lit the dot,
+        // every outage, forever. A track is retired on EVIDENCE (`alive:
+        // false`, or missing from a list that actually answered), never on
+        // our own blindness.
+        for (const track of tracks.values()) {
           activity.observeTab(track.taskId, track.tabId, "rest", {})
-          tracks.delete(key)
         }
         return
       }

--- a/packages/kobe/test/engine/activity-observer.test.ts
+++ b/packages/kobe/test/engine/activity-observer.test.ts
@@ -200,6 +200,50 @@ describe("activity observer", () => {
     expect(w.row("tab-1")?.state).toBe("idle")
   })
 
+  it("a host blip never re-lights a frozen working title (issue #104)", async () => {
+    // The engine died mid-turn: its last OSC title is a spinner frame that
+    // nothing will ever rewrite, and its byte counter is parked. Silence
+    // retires the dot correctly — once. Then `pty.list` failed for a tick
+    // (a per-poll socket connect, under load), the loop dropped every track,
+    // and the reborn track restarted its silence clock at zero: the SAME
+    // frozen frame scored as fresh evidence and re-lit the dot. In prod that
+    // ran every ~90s for hours (57 `seeded running` lines on one tab), so the
+    // badge read running for a stopped engine essentially forever.
+    const w = world({ silenceMs: 60 })
+    const frozen = { key: KEY, alive: true, pid: 42, title: "⠹ 从零构建建筑", totalBytes: 100 }
+    w.state.sessions = [frozen]
+    w.state.engines.set(42, "codex")
+    await waitFor(() => w.row("tab-1")?.state === "running")
+    await waitFor(() => w.row("tab-1")?.state === "idle")
+
+    w.state.sessions = null // the RPC fails — a fact about the socket, not the session
+    await wait(60)
+    w.state.sessions = [frozen] // …and answers again with the very same frame
+
+    // Sampled far finer than the poll: a re-light lasts a full silence
+    // window, so any single flip is caught.
+    const deadline = Date.now() + 180
+    while (Date.now() < deadline) {
+      expect(w.row("tab-1")?.state).toBe("idle")
+      await wait(5)
+    }
+  })
+
+  it("a host blip still lets REAL output re-light the tab", async () => {
+    // The other half of the same clock: keeping the track must not make the
+    // dot un-relightable. Movement after the outage is genuine evidence.
+    const w = world({ silenceMs: 60 })
+    const session = { key: KEY, alive: true, pid: 42, title: "⠹ 从零构建建筑", totalBytes: 100 }
+    w.state.sessions = [session]
+    w.state.engines.set(42, "codex")
+    await waitFor(() => w.row("tab-1")?.state === "idle")
+    w.state.sessions = null
+    await wait(60)
+    w.state.sessions = [session]
+    session.totalBytes += 50
+    await waitFor(() => w.row("tab-1")?.state === "running")
+  })
+
   it("a fresh hook turn after a correction relights the tab (the retire is not permanent)", async () => {
     const w = world()
     w.registry.report(TASK, "turn-start", undefined, "tab-1", { id: "s1" }, "claude")


### PR DESCRIPTION
Closes issue #104.

## What was happening

A tab whose engine had stopped kept re-lighting its activity badge every minute
or two, so the dot never went out. In one report, one tab logged 57
`seeded running` lines over a few hours; four tabs in the same daemon logged
45–47 each.

## Root cause

The observer's two liveness signals — the terminal title and the byte counter —
are **snapshots**. A stopped engine leaves its last spinner frame (`◑`) in the
title and parks its byte counter, and nothing will ever change either again. So
the only thing that can ever refute them is a clock: *how long has this been
frozen*. The loop keeps that clock in a per-session `SessionTrack`
(`firstSeenAt` / `lastActivityAt`).

`listSessions()` opens a fresh socket to the PTY host on every 10s poll. When
that call failed it returned `null`, and the loop **deleted every track**. The
next successful poll rebuilt them from scratch with `firstSeenAt = now`, which
rewinds `silentForMs` to zero — so the same never-changing frame scored as
fresh evidence again and re-lit the dot. Then 30s of silence retired it, the
next failed call wiped the clocks again, and around it went.

The branch already had the *claim* half of this right — its comment says a
failed call "is NOT positive evidence against hook claims" — and then threw
away the state that made that reasoning enforceable.

## Evidence

**1. `working title frame` is structurally unreachable without a track rebirth.**
In the claim chain, `silentForMs === now - lastActivityAt` whenever
`lastActivityAt` is set, so the `live output` branch subsumes the title branch;
the title branch can only fire while `lastActivityAt === null` **and**
`now - firstSeenAt < silenceMs`. That is a newborn track, within its first 30
seconds. The production log has **389** such lines. Each one is a rebirth.

**2. The rebirths are global, not per-tab.** Four different tabs share
near-identical re-light gap statistics (min 56.90s, max 473.67s on all four),
and clustering every re-light into 12s windows puts 354 of the 389
`working title frame` lines — 91% — in windows containing **more than one
tab**. Independent sessions do not flicker in lockstep; a single event wiping
one shared map does. `listed === null` is the only global wipe in the loop.

**3. Live BEFORE/AFTER.** An isolated daemon (own home, own PTY host) running a
fake `claude` that prints one `◑` frame and then sleeps forever — a stopped
engine with a frozen title, still in the tab's foreground so the walk keeps
naming it. `pty.list` outages injected by moving the host socket aside for 25s,
which is the real failure the production daemon hits, not a stub.

### Rig A — does the badge stay out? (1 outage)

|  | `seeded running` | badge after the outage |
|---|---|---|
| **BEFORE** (`origin/main`) | **2** | back to `running` |
| **AFTER** (this branch) | **1** | stays `idle` |

BEFORE, in the isolated daemon's own log:

```
21:22:52  seeded running … (working title frame)   badge on
21:23:56  idle                                     silence window — correct
21:25:57  pty.list socket moved aside              a real failed RPC
21:27:13  socket restored, identical frozen frame
21:27:52  seeded running … (working title frame)   badge back on
```

Nothing about the engine changed between the first and last line — it has been
asleep the whole time. AFTER, the same script against the same fake engine:
one seed at 21:35:46, `idle` from 21:36:51, and 24 consecutive samples across
the six minutes after the host came back — every one of them `idle`, none
`running`.

The remaining `1` is the restart-seeding path issue #16 added, working as
intended: a genuinely first-seen session with a working title frame does light
up. What it no longer does is claim to be first-seen every time an RPC fails.

### Rig B — the chime (3 outages, sibling tab parked on `turn_complete`)

Task-level rollup transitions read off a raw `engine-state` subscriber. Each
`running → turn_complete` is one `pulseSound()`.

|  | `seeded running` | task-level `done` edges |
|---|---|---|
| **BEFORE** | **4** | **4** |
| **AFTER** | **1** | **1** |

BEFORE — one outage in, one chime out, three times over:

```
04:32:00  tab-1 -> running     04:32:30  tab-1 -> idle   TASK -> turn_complete  CHIME 1
04:33:30  tab-1 -> running     04:34:00  tab-1 -> idle   TASK -> turn_complete  CHIME 2
04:35:30  tab-1 -> running     04:36:00  tab-1 -> idle   TASK -> turn_complete  CHIME 3
```

AFTER, across the same three outages: one transition total, the honest one at
startup.

Note for anyone reproducing this: `rove api watch` is the wrong instrument
here. It dedupes on `(task, tab, state, at)`, and the rollup fall-back carries
the sibling's *original* `at`, so every repeat hashes to a key it has already
printed — it reported 1 where the daemon had published 4. The chime path
(`use-attention.ts:123` → `attentionEdges`) diffs state strings and never reads
`at`, so it sees all of them. The two consumers disagree about the same stream,
which is the real argument for teaching the notifier to read `at` rather than
making the rollup restamp it.


## The chime, and why the rollup is not the thing to change

Issue #104's second symptom (the notification sound repeating) rides the same
oscillation: tab A flips to idle, the task-level rollup drops from tier 2
(`running`) to tier 1 and surfaces a sibling tab's hours-old `turn_complete`,
and the cross-task notifier reads that as a fresh `done`.

The issue asks whether `deriveTaskActivity` should restamp `at` when it switches
tiers. It should not, and it would not help: the rising-edge detector
(`notify-state.ts` `attentionEdges`, fed by `use-attention.ts:123`) diffs a
`Map<key, stateString>` and never looks at `at`. The chime fires on the state
string changing, so a fresher timestamp changes nothing. The rollup is also
answering its own question correctly — with nothing running and a sibling
parked on `turn_complete`, `turn_complete` *is* the task's state; that is what
sticky is for.

What is genuinely worth hardening is the notifier: an edge into an attention
state whose underlying `at` is hours old is not news. That needs `at` threaded
into `attentionEdges` and both of its callers, which is a different module and
a different change. Not folded in here — with the oscillation gone, the chimes
stop at the source.

## What is deliberately NOT in this PR

`activity-reduce.ts`'s `activityStillWorking` has `if (live.unknown) return true`,
which issue #104 names as a second immortality path. It is a different one: the
lapse watchdog reads `lapseEntry()`, which returns `.hook` only
(`activity-registry.ts:281-286`), so it never polices the observer's `observed`
slot. That path keeps a **hook**-claimed running alive when a transcript can't
be read. Flipping `unknown` to "not working" would idle a working engine whose
transcript is momentarily unreadable; the right shape is a bounded number of
unknown re-arms, which is its own change with its own tests.

## Tests

Two behavior tests through the real loop + real registry:

- a frozen working title stays idle across an outage and back (this is the bug —
  the assertion samples every 5ms across 180ms, far finer than the poll, so a
  single flip cannot slip through);
- real output after an outage still re-lights the tab (keeping the track must
  not make the dot un-relightable).

Mutation check: restoring the one deleted `tracks.delete(key)` turns the first
test red with `expected 'running' to be 'idle'`; every other test in the file
stays green.
