### PR TITLE
fix: an unreadable transcript stops re-arming the lapse watchdog forever

### DIFF
--- a/.changeset/bounded-unknown-rearms.md
+++ b/.changeset/bounded-unknown-rearms.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+A tab whose engine transcript stops being readable no longer keeps its running badge forever. The watchdog that catches an engine which never reported finishing works by re-reading the engine's transcript: a recent write means the turn is still going, so it waits again. When it could not read the file at all it also waited again — which is right for a momentary read error and wrong for a transcript that is never coming back, because a deleted worktree or a replaced session answers "could not read" every single time and the badge waits out the life of the daemon. It now gives an unreadable transcript three full waits — half an hour at the default — and then stops believing it, handing the tab back to the observer that watches its terminal directly. Any single successful read resets the count, so a long turn on a healthy transcript keeps its badge exactly as before.

--- a/packages/kobe-daemon/src/daemon/activity-lapse.ts
+++ b/packages/kobe-daemon/src/daemon/activity-lapse.ts
@@ -16,6 +16,29 @@ import {
   activityStillWorking,
 } from "./activity-reduce.ts"
 
+/**
+ * How many CONSECUTIVE "could not read it" probes may re-arm the watchdog
+ * before it retires the claim anyway.
+ *
+ * An unknown probe is the ABSENCE of evidence, not evidence of work. Treating
+ * it as "still working" unconditionally is the second way a `running` claim
+ * outlives its engine: once the transcript stops being readable at all — the
+ * worktree was deleted, the session was replaced, the path moved — every probe
+ * from then on answers unknown, so the watchdog re-arms forever and the badge
+ * never goes out.
+ *
+ * The bound has to be generous, because one unreadable probe really is a
+ * transient filesystem error and idling a mid-turn engine over it is the worse
+ * failure. Three in a row, each a full TTL apart (30 minutes at the default),
+ * is not a hiccup.
+ *
+ * Retiring is not a verdict of "idle", either: it drops the HOOK claim and
+ * lets the observer's own PTY evidence decide the tab, which is the source
+ * that can still see it. So the cost of being wrong here is one poll, not a
+ * wrong badge.
+ */
+export const MAX_UNKNOWN_REARMS = 3
+
 /** Scope key: a task's tab-less entry, or one of its tabs. */
 export interface LapseTarget {
   readonly taskId: string
@@ -53,9 +76,9 @@ export class ActivityLapseWatchdog {
    * heartbeat) instead of retiring. Only a genuinely silent engine (no recent
    * write ⇒ a missed Stop / hung process) lapses.
    */
-  arm(target: LapseTarget, at: number): ReturnType<typeof setTimeout> {
+  arm(target: LapseTarget, at: number, unknowns = 0): ReturnType<typeof setTimeout> {
     const timer = setTimeout(() => {
-      void this.fire(target, at)
+      void this.fire(target, at, unknowns)
     }, this.deps.staleMs)
     timer.unref?.()
     return timer
@@ -78,7 +101,7 @@ export class ActivityLapseWatchdog {
    * same entry identity after the await). A rescheduled lapse is stored back
    * on the live entry, so a later event can cancel it.
    */
-  private async fire(target: LapseTarget, at: number): Promise<void> {
+  private async fire(target: LapseTarget, at: number, unknowns = 0): Promise<void> {
     // Superseded before we even probed (a fresh report swapped the entry).
     const before = this.deps.entryAt(target)
     if (!before || before.at !== at) return
@@ -92,7 +115,15 @@ export class ActivityLapseWatchdog {
     if (cur !== before) return
 
     if (activityStillWorking(live, at, this.deps.now(), this.deps.staleMs)) {
-      cur.lapse = this.arm(target, at)
+      // Count only the probes that said "I don't know". A probe that actually
+      // read a recent write resets the streak, so a long turn on a healthy
+      // transcript re-arms indefinitely exactly as before.
+      const streak = live?.unknown === true ? unknowns + 1 : 0
+      if (streak > MAX_UNKNOWN_REARMS) {
+        this.deps.retire(target)
+        return
+      }
+      cur.lapse = this.arm(target, at, streak)
       return
     }
     this.deps.retire(target)

--- a/packages/kobe-daemon/src/daemon/activity-registry.ts
+++ b/packages/kobe-daemon/src/daemon/activity-registry.ts
@@ -40,6 +40,9 @@ export {
   recomputeTabActivity,
 } from "./activity-arbitrate.ts"
 export { type RollupCandidate, deriveTaskActivity, rollupCandidates } from "./activity-rollup.ts"
+// The watchdog's one policy constant, surfaced here for the same reason as the
+// rest: this file is the module's public entry point.
+export { MAX_UNKNOWN_REARMS } from "./activity-lapse.ts"
 // The read half — pure projections of the ledger below (activity-readers.ts).
 export type { EngineStatePayload } from "./activity-readers.ts"
 

--- a/packages/kobe/test/daemon/activity-liveness.test.ts
+++ b/packages/kobe/test/daemon/activity-liveness.test.ts
@@ -3,6 +3,7 @@ import {
   type ActivityLivenessProbe,
   DaemonActivityRegistry,
   type EngineStatePayload,
+  MAX_UNKNOWN_REARMS,
 } from "@sma1lboy/kobe-daemon/daemon/activity-registry"
 import { DaemonEventBus } from "@sma1lboy/kobe-daemon/daemon/event-bus"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
@@ -258,6 +259,51 @@ describe("activity registry liveness watchdog", () => {
     registry.report("t", "turn-complete", undefined, "tab-1")
     await vi.advanceTimersByTimeAsync(TTL * 2)
     expect(registry.replaySnapshot().every((entry) => entry.state === "turn_complete")).toBe(true)
+  })
+
+  it("stops re-arming once the transcript has been unreadable for MAX_UNKNOWN_REARMS probes", async () => {
+    // The second way a `running` claim outlives its engine. An unknown probe
+    // is the absence of evidence, and the watchdog treated it as evidence of
+    // work — so once the transcript stopped being readable at all (worktree
+    // deleted, session replaced), every probe from then on said unknown and
+    // the claim re-armed forever.
+    registry = new DaemonActivityRegistry(
+      bus,
+      TTL,
+      () => Date.now(),
+      async () => ({ unknown: true }),
+    )
+    registry.report("t", "turn-start")
+
+    // Generous on purpose: one unreadable probe is a filesystem hiccup, and
+    // idling a mid-turn engine over it is the worse failure.
+    await vi.advanceTimersByTimeAsync(TTL * MAX_UNKNOWN_REARMS)
+    expect(states.t).toEqual(["running"])
+
+    // …but it is a bound, not a licence.
+    await vi.advanceTimersByTimeAsync(TTL)
+    expect(states.t).toEqual(["running", "idle"])
+  })
+
+  it("a readable probe resets the unknown streak, so a long healthy turn never lapses", async () => {
+    // The streak counts CONSECUTIVE unknowns. A transcript that flickers
+    // unreadable and comes back is a working engine, and must keep its badge
+    // however long the turn runs.
+    let readable = false
+    registry = new DaemonActivityRegistry(
+      bus,
+      TTL,
+      () => Date.now(),
+      async () => (readable ? { mtimeMs: Date.now() } : { unknown: true }),
+    )
+    registry.report("t", "turn-start")
+    for (let i = 0; i < 4; i++) {
+      await vi.advanceTimersByTimeAsync(TTL * MAX_UNKNOWN_REARMS)
+      readable = true
+      await vi.advanceTimersByTimeAsync(TTL)
+      readable = false
+    }
+    expect(states.t).toEqual(["running"])
   })
 
   it("replaces unknown evidence with a recovered session's own completion", async () => {


### PR DESCRIPTION
The second immortality path in issue #104. The first one (PR #982) was the
observer inventing a fresh `running`; this one is a `running` that was never
allowed to die.

## What was happening

`ActivityLapseWatchdog` exists because a long agent turn emits `turn-start`,
then nothing for many minutes, then `Stop`. A fixed timer would idle a working
engine mid-turn, so instead the watchdog re-reads the engine's transcript when
the timer fires: a recent write means the turn is alive, so wait again.

`activityStillWorking` answered that question with three outcomes, and treated
two of them as "keep waiting":

```ts
if (!live) return false
if (live.unknown) return true          // ← "I could not read it"
```

`unknown` is not evidence of work — it is the absence of evidence. And the
cases that produce it are not momentary: a deleted worktree, a replaced
session, a moved transcript path answer `unknown` on *every* probe from then
on. So the watchdog re-armed forever and the badge stayed `running` for the
life of the daemon.

## The change

The watchdog counts *consecutive* unknowns and stops believing after
`MAX_UNKNOWN_REARMS` (3, so half an hour at the default TTL). Any probe that
actually reads the transcript resets the count to zero.

The bound is deliberately generous, because the two failure modes are not
symmetric: idling a mid-turn engine over one transient filesystem error is
worse than a stale badge lasting another ten minutes.

Retiring is also not a verdict of `idle`. `retireLapsed` drops the **hook**
claim and republishes; the observer's own PTY evidence then decides the tab —
and unlike the transcript, the observer can still see it. So a genuinely
working engine gets its badge back on the next poll rather than losing it.

## Why this is in the watchdog and not in `activityStillWorking`

`activityStillWorking` answers "does this probe say working?" — a pure read of
one probe result. "How many times may I accept *I don't know*" is a policy
about a clock, and the watchdog is the thing that owns clocks. Threading a
streak counter into the pure reducer would have made both files know about the
other's concern.

## Tests

- four consecutive unknown probes retire the claim; the first three do not;
- an unknown streak broken by one readable probe resets, so a long healthy turn
  re-arms indefinitely exactly as before.

Two mutations, two different sites, each caught by its own test:

| mutation | test that goes red |
|---|---|
| delete the `streak > MAX_UNKNOWN_REARMS` bound | `stops re-arming once the transcript has been unreadable…` |
| make the streak never reset (`unknowns + 1` unconditionally) | `a readable probe resets the unknown streak…` |

`MAX_UNKNOWN_REARMS` is re-exported from `activity-registry.ts` rather than
given its own `exports` entry — that file already documents itself as the
module's one public entry point.

## Still open from issue #104

The rollup amplifier behind the repeating chime. My read is that the rollup is
not the thing to change and restamping its `at` on a tier switch would make it
worse — details in #982. The hardening worth doing is in the notifier
(`attentionEdges` should refuse an edge whose `at` predates the last
observation, the way `rove api watch` already does). Separate module, separate
PR.
