### PR TITLE
fix: Windows PowerShell 下打不开会话（静默挂起）

### DIFF
--- a/.changeset/windows-session-opens.md
+++ b/.changeset/windows-session-opens.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Rove on Windows now opens a session from PowerShell instead of hanging silently. Three things on that path were written for one platform only. The session shell was taken from `$SHELL` with a hard-coded `/bin/zsh` fallback, bypassing the resolver that already knows Windows spawns Git for Windows' bash; on Windows that path is not something CreateProcess can run, so the engine tab never came up. The daemon socket connect had no deadline, and the PTY host's address there is a named pipe — libuv waits for an instance that never appears rather than refusing, so the very first probe pending forever and the whole launch sat with no output; it now gives up after five seconds and says what it waited on. And the guard that refuses to restart a PTY host still holding live sessions read the process table through `/bin/ps`, which on Windows is always ENOENT and was folded into a count of zero, making that guard dead code that killed a host and every engine in it; it now reads the Windows table through PowerShell 5.1 and reports "could not read the table" as a refusal instead of a zero.

--- a/packages/kobe-daemon/src/client/index.ts
+++ b/packages/kobe-daemon/src/client/index.ts
@@ -48,6 +48,44 @@ function rpcTimeoutMs(): number {
 }
 
 /**
+ * The daemon's socket never accepted the connection. Distinct from
+ * {@link RpcTimeoutError}, which is a live connection that stopped answering:
+ * here nothing was ever established, so there is no wedge to recover from —
+ * the address is simply not there (or not reachable).
+ *
+ * Without a deadline this is not an error at all, it is a HANG: on Windows the
+ * PTY host's address is a named pipe (`\\\\.\\pipe\\…`, see
+ * `daemon/paths.ts` `windowsPipePath`), and libuv's pipe connect waits for an
+ * instance that never appears instead of failing. Node's `net.connect` exposes
+ * no connect timeout, so the promise stays pending forever and every caller
+ * above it — `ensurePtyHostReachable`'s first probe included — sits silent with
+ * no output to explain itself.
+ */
+export class ConnectTimeoutError extends Error {
+  constructor(socketPath: string, timeoutMs: number) {
+    super(
+      `connecting to ${socketPath} timed out after ${timeoutMs}ms — nothing accepted the connection (daemon or PTY host not listening at that address)`,
+    )
+    this.name = "ConnectTimeoutError"
+  }
+}
+
+/**
+ * Default connect deadline. A local socket connect answers in microseconds;
+ * 5s only ever fires on the hang described above. `ROVE_CONNECT_TIMEOUT_MS`
+ * overrides it (0/negative disables the deadline) — the operator escape hatch
+ * and the test seam, mirroring `rpcTimeoutMs`.
+ */
+function connectTimeoutMs(): number {
+  const raw = readRoveEnv("CONNECT_TIMEOUT_MS")?.trim()
+  if (raw) {
+    const parsed = Number.parseInt(raw, 10)
+    if (Number.isFinite(parsed)) return parsed
+  }
+  return 5_000
+}
+
+/**
  * Single connection-lifecycle hook — fires when the socket transitions from
  * open to closed for ANY reason (daemon died, kernel dropped the socket,
  * manual `forceDisconnect`). The host TUI subscribes to this and prompts
@@ -261,7 +299,23 @@ export class KobeDaemonClient implements DaemonRpcClient {
     return new Promise((resolve, reject) => {
       const socket = connect(this.socketPath)
       this.socket = socket
+      // The connect deadline. Declared ahead of both handlers because each
+      // one clears it; cleared on BOTH other outcomes so a settled socket
+      // never fires it. On expiry the socket is destroyed, so the half-open
+      // handle does not outlive the promise that gave up on it.
+      const timeoutMs = connectTimeoutMs()
+      let timer: ReturnType<typeof setTimeout> | undefined
+      if (timeoutMs > 0) {
+        timer = setTimeout(() => {
+          socket.off("connect", onConnect)
+          socket.off("error", onError)
+          socket.destroy()
+          if (this.socket === socket) this.socket = null
+          reject(new ConnectTimeoutError(this.socketPath, timeoutMs))
+        }, timeoutMs)
+      }
       const onConnect = () => {
+        if (timer) clearTimeout(timer)
         socket.off("error", onError)
         // Post-connect socket errors (EPIPE writing to a peer that's mid-
         // exit, ECONNRESET) must NOT become unhandled 'error' events — an
@@ -272,6 +326,7 @@ export class KobeDaemonClient implements DaemonRpcClient {
         resolve()
       }
       const onError = (err: Error) => {
+        if (timer) clearTimeout(timer)
         socket.off("connect", onConnect)
         if (this.socket === socket) this.socket = null
         reject(err)

--- a/packages/kobe-daemon/src/client/pty-process.ts
+++ b/packages/kobe-daemon/src/client/pty-process.ts
@@ -19,6 +19,7 @@ import { readPidFile } from "../daemon/socket-guard.ts"
 import { resolveKobeSpawn, testDaemonResponds } from "./daemon-process.ts"
 import { spawnDetachedDaemon } from "./detached-spawn.ts"
 import { KobeDaemonClient } from "./index.ts"
+import { windowsPowershellPath } from "./win-detached-launch.ts"
 
 const PTY_HOST_START_ARGS = ["pty-host"] as const
 
@@ -172,24 +173,116 @@ export async function resolveNodePtyHostSpawn(deps: NodePtyHostResolution = {}):
  */
 const BUSY_PTY_HOST_GRACE_MS = 15_000
 
-/** Live child processes of `pid` — the pty host's sessions, each a shell
- *  leader. One `ps`; unreadable output counts as zero, which only ever
- *  makes the reap below MORE permissive, never less. */
-async function liveChildCount(pid: number): Promise<number> {
-  try {
-    const proc = spawn("/bin/ps", ["-A", "-o", "ppid="], { stdio: ["ignore", "pipe", "ignore"] })
-    const text = await new Promise<string>((done) => {
-      let out = ""
-      proc.stdout.on("data", (chunk) => {
-        out += String(chunk)
-      })
-      proc.on("close", () => done(out))
-      proc.on("error", () => done(""))
+/**
+ * A child-count probe's whole budget. `ps` answers in ~20ms; a PowerShell
+ * start plus a CIM query is ~0.8s. 5s only ever fires on a stuck process
+ * table, and it is bounded at all because an abandoned probe here would hang
+ * the very recovery path it guards.
+ */
+const CHILD_PROBE_TIMEOUT_MS = 5_000
+
+/** Injectable so the Windows half is testable on a POSIX CI host. */
+export interface ChildProbeDeps {
+  readonly platform?: NodeJS.Platform
+  readonly env?: Readonly<Record<string, string | undefined>>
+  readonly timeoutMs?: number
+  /** Filesystem probe, like {@link NodePtyHostResolution.exists}. */
+  readonly exists?: (path: string) => boolean
+  /** Runs one command to completion, returning stdout. Throws on failure. */
+  readonly run?: (command: readonly string[], timeoutMs: number) => Promise<string>
+}
+
+/**
+ * The process-table read, per platform.
+ *
+ * POSIX is `ps -A -o ppid=`. Windows has NO usable `ps`: the one on PATH is
+ * Git for Windows' Cygwin build, which rejects `-A` and exits 1 with EMPTY
+ * stdout (see `packages/kobe/src/engine/win-process-snapshot.ts`, which
+ * documented the same finding for the foreground probe). `Get-CimInstance
+ * Win32_Process` is the only table that answers there.
+ *
+ * `[Console]::OutputEncoding` is pinned to UTF-8 first: under an OEM codepage
+ * (936 on a Chinese Windows) PowerShell 5.1 writes its stdout in that
+ * codepage, and a UTF-8 read of it is mojibake. The answer here is digits, so
+ * it survives either way — but the pin costs nothing and keeps the two
+ * Windows PowerShell reads in this repo agreeing.
+ *
+ * Exported for tests.
+ */
+export function childProbeCommand(deps: ChildProbeDeps = {}): readonly string[] {
+  const env = deps.env ?? process.env
+  if ((deps.platform ?? process.platform) !== "win32") return ["ps", "-A", "-o", "ppid="]
+  return [
+    windowsPowershellPath(env, deps.exists ?? existsSync),
+    "-NoProfile",
+    "-NonInteractive",
+    "-Command",
+    // One ParentProcessId per line — the SAME shape POSIX `ps -o ppid=`
+    // prints, so one parser reads both. Emitting a count instead would need a
+    // second answer format and a second set of tests for the same number.
+    "[Console]::OutputEncoding=[System.Text.Encoding]::UTF8; " +
+      "Get-CimInstance -ClassName Win32_Process -Property ParentProcessId | " +
+      "Select-Object -ExpandProperty ParentProcessId",
+  ]
+}
+
+/** Run a child to completion by deadline, or throw. Exported for tests. */
+export function runChildProbe(command: readonly string[], timeoutMs: number): Promise<string> {
+  return new Promise((done, fail) => {
+    const proc = spawn(command[0] ?? "", command.slice(1), { stdio: ["ignore", "pipe", "ignore"] })
+    let out = ""
+    const finish = (err: Error | null): void => {
+      clearTimeout(timer)
+      // Kill first: an abandoned probe holding a pipe nobody reads is how a
+      // one-off hang becomes a permanent leak in a long-lived daemon.
+      try {
+        proc.kill()
+      } catch {
+        /* already gone */
+      }
+      if (err) fail(err)
+      else done(out)
+    }
+    const timer = setTimeout(() => finish(new Error(`did not answer within ${timeoutMs}ms`)), timeoutMs)
+    proc.stdout?.on("data", (chunk) => {
+      out += String(chunk)
     })
-    return text.split("\n").filter((row) => Number(row.trim()) === pid).length
+    proc.on("error", (err) => finish(err))
+    proc.on("close", () => finish(null))
+  })
+}
+
+/**
+ * Live child processes of `pid` — the pty host's sessions, each a shell
+ * leader. **`null` means "could not read the process table"**, which is not
+ * the same answer as zero and must never be folded into one.
+ *
+ * It used to be: `/bin/ps`, unreadable output counting as zero. On Windows
+ * `/bin/ps` is always ENOENT, so the count was ALWAYS zero there, and the
+ * refusal below — a live host still holding sessions may not be reaped —
+ * was dead code that silently killed the PTY host and every engine in it.
+ * POSIX cannot answer "zero children" with an empty table either: a healthy
+ * `ps -A` returns hundreds of rows, so NO rows is a failed probe, exactly the
+ * reasoning `engine/foreground.ts` applies to its own snapshot.
+ *
+ * Exported for tests.
+ */
+export async function liveChildCount(pid: number, deps: ChildProbeDeps = {}): Promise<number | null> {
+  const timeoutMs = deps.timeoutMs ?? CHILD_PROBE_TIMEOUT_MS
+  const command = childProbeCommand(deps)
+  const run = deps.run ?? runChildProbe
+  let text: string
+  try {
+    text = await run(command, timeoutMs)
   } catch {
-    return 0
+    return null
   }
+  const rows = text
+    .split("\n")
+    .map((row) => row.trim())
+    .filter((row) => row.length > 0)
+  if (rows.length === 0) return null
+  return rows.filter((row) => Number(row) === pid).length
 }
 
 /**
@@ -224,6 +317,11 @@ export async function ensurePtyHostReachable(): Promise<string> {
     }
     if (isProcessAlive(hostPid)) {
       const sessions = await liveChildCount(hostPid)
+      if (sessions === null) {
+        throw new Error(
+          `rove: the pty host (pid ${hostPid}) is not answering and Rove could not read this machine's process table, so it cannot tell whether the host still holds live sessions — refusing to restart it, which would kill every engine running in them. Inspect it with \`rove api pty-list\`, or kill ${hostPid} yourself once you have accepted losing those sessions.`,
+        )
+      }
       if (sessions > 0) {
         throw new Error(
           `rove: the pty host (pid ${hostPid}) is not answering but still holds ${sessions} live session(s) — refusing to restart it, which would kill every engine running in them. Inspect it with \`rove api pty-list\`, or kill ${hostPid} yourself once you have accepted losing those sessions.`,
@@ -242,7 +340,9 @@ export async function ensurePtyHostReachable(): Promise<string> {
     if (await testDaemonResponds(socketPath)) return socketPath
     await new Promise((resolveTimer) => setTimeout(resolveTimer, 100))
   }
-  throw new Error(`rove: pty host did not start (or stayed wedged) at ${socketPath}`)
+  throw new Error(
+    `rove: pty host did not start (or stayed wedged) at ${socketPath}; check ${defaultPtyHostLogPath()} or run \`rove doctor\``,
+  )
 }
 
 /** Observe sessions before consulting current tasks; never send a captured negative task list. */

--- a/packages/kobe-daemon/src/client/win-detached-launch.ts
+++ b/packages/kobe-daemon/src/client/win-detached-launch.ts
@@ -112,11 +112,17 @@ function quoteWindowsArg(arg: string): string {
   return `${out}${"\\".repeat(backslashes * 2)}"`
 }
 
-/** `powershell.exe` by absolute path — PATH is not guaranteed under a PTY. */
-export function windowsPowershellPath(env: NodeJS.ProcessEnv = process.env): string {
+/** `powershell.exe` by absolute path — PATH is not guaranteed under a PTY.
+ *  `exists` is injectable for the same reason {@link resolveNodePtyHostSpawn}'s
+ *  is: these branches only ever execute on Windows, so a test has to be able
+ *  to answer the disk question without a Windows runner. */
+export function windowsPowershellPath(
+  env: Readonly<Record<string, string | undefined>> = process.env,
+  exists: (path: string) => boolean = existsSync,
+): string {
   const root = env.SystemRoot || env.windir || "C:\\Windows"
   const absolute = join(root, "System32", "WindowsPowerShell", "v1.0", "powershell.exe")
-  return existsSync(absolute) ? absolute : "powershell.exe"
+  return exists(absolute) ? absolute : "powershell.exe"
 }
 
 /** PowerShell's `-EncodedCommand` wants the script as base64 UTF-16LE. */

--- a/packages/kobe/src/cli/api/runtime.ts
+++ b/packages/kobe/src/cli/api/runtime.ts
@@ -6,6 +6,7 @@
  * not this module, so unit tests never open PTY Host or git processes.
  */
 
+import { resolveLoginShell } from "@sma1lboy/kobe-daemon/daemon/platform-shell"
 import type { PtySessionExit } from "@sma1lboy/kobe-daemon/daemon/protocol"
 import { engineLaunchArgv, withPinnedSessionId } from "../../engine/engine-presets.ts"
 
@@ -93,7 +94,7 @@ async function deliverHosted(target: PromptTarget, worktree: string, prompt: str
         // reviving a tab a pty-host restart froze.
         ...(target.respawn
           ? {
-              respawn: () => restoredTabLaunch(target, tabId, worktree, process.env.SHELL?.trim() || "/bin/zsh"),
+              respawn: () => restoredTabLaunch(target, tabId, worktree, resolveLoginShell({ fallback: "/bin/zsh" })),
             }
           : {}),
       })
@@ -121,7 +122,7 @@ async function deliverHosted(target: PromptTarget, worktree: string, prompt: str
     const launch = buildEngineSessionLaunch({
       task: { id: target.id, kind: target.kind, vendor: launchVendor, repo: target.repo },
       worktreePath: worktree,
-      shell: process.env.SHELL?.trim() || "/bin/zsh",
+      shell: resolveLoginShell({ fallback: "/bin/zsh" }),
       argv,
       promptIntent: target.newTask ? { kind: "new-task", prompt } : { kind: "explicit", prompt },
       tabId: newTab,

--- a/packages/kobe/test/client/daemon-connect-timeout.test.ts
+++ b/packages/kobe/test/client/daemon-connect-timeout.test.ts
@@ -1,0 +1,114 @@
+/**
+ * The connect deadline on `KobeDaemonClient.openSocket`.
+ *
+ * `net.connect` has no connect timeout of its own, and the address the PTY
+ * host listens on under Windows is a NAMED PIPE (`\\.\pipe\kobe-…`, see
+ * `daemon/paths.ts` `windowsPipePath`). A pipe whose instances are all taken
+ * does not refuse the connect: libuv parks it in
+ * `WaitNamedPipeW(name, 30000)` and retries for as long as it stays busy
+ * (libuv `src/win/pipe.c`, `pipe_connect_thread_proc`), so the promise is
+ * still pending after 30s — and again after the next 30s. Every caller above
+ * it, `ensurePtyHostReachable`'s first probe included, waits with no output.
+ * That was reported as "rove will not open a session on Windows".
+ *
+ * A POSIX runner cannot produce that hang — a dead unix-socket path answers
+ * ENOENT at once — so the connect is mocked as one that never settles. The
+ * mock is the point: what is under test is that the deadline settles the
+ * promise, not how the OS misbehaves.
+ */
+
+import { ConnectTimeoutError, KobeDaemonClient } from "@sma1lboy/kobe-daemon/client"
+import { probeDaemonSocket } from "@sma1lboy/kobe-daemon/client/daemon-process"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+vi.mock("node:net", async (importActual) => {
+  const actual = await importActual<typeof import("node:net")>()
+  const { EventEmitter } = await import("node:events")
+  return {
+    ...actual,
+    // A socket that emits neither "connect" nor "error": exactly the pending
+    // forever state libuv leaves a busy-pipe connect in.
+    connect: () => {
+      const socket = Object.assign(new EventEmitter(), {
+        destroyed: false,
+        destroy() {
+          this.destroyed = true
+        },
+        end() {
+          this.destroyed = true
+        },
+        write: () => true,
+      })
+      return socket
+    },
+  }
+})
+
+const PIPE = "\\\\.\\pipe\\kobe-test-busy"
+const clients: KobeDaemonClient[] = []
+
+const open = (path = PIPE): KobeDaemonClient => {
+  const client = new KobeDaemonClient(path)
+  clients.push(client)
+  return client
+}
+
+beforeEach(() => {
+  process.env.ROVE_CONNECT_TIMEOUT_MS = "120"
+})
+
+afterEach(() => {
+  process.env.ROVE_CONNECT_TIMEOUT_MS = ""
+  for (const client of clients.splice(0)) client.close()
+})
+
+describe("connect deadline", () => {
+  it("rejects with the address and the budget instead of waiting forever", async () => {
+    const started = Date.now()
+    const err = await open()
+      .connect()
+      .then(
+        () => null,
+        (thrown: unknown) => thrown as Error,
+      )
+
+    expect(err).toBeInstanceOf(ConnectTimeoutError)
+    expect(err?.name).toBe("ConnectTimeoutError")
+    // The message has to say WHAT it waited on and WHERE, or the failure is
+    // indistinguishable from every other connect error.
+    expect(err?.message).toContain(PIPE)
+    expect(err?.message).toContain("120ms")
+    // And it must actually settle in the budget, not after some longer wait.
+    expect(Date.now() - started).toBeLessThan(3_000)
+  })
+
+  it("reports the unreachable host as absent, so the caller stops and spawns one", async () => {
+    // The load-bearing half: the timeout must land in the same `absent`
+    // verdict a refused connect gets, or `ensureDaemonReachable` would treat
+    // a hung address as a wedged daemon and refuse to recover from it.
+    expect(await probeDaemonSocket(PIPE, 500)).toBe("absent")
+  })
+
+  it("keeps a client that gave up reusable — the next connect is not poisoned", async () => {
+    const client = open()
+    await client.connect().catch(() => {})
+    await expect(client.connect()).rejects.toBeInstanceOf(ConnectTimeoutError)
+  })
+
+  it("can be disabled, for an operator who wants the old unbounded wait", async () => {
+    // 0/negative means no deadline, mirroring `ROVE_RPC_TIMEOUT_MS`. Asserted
+    // by a connect that is still pending past the point a deadline would have
+    // fired — never by waiting out a hang.
+    process.env.ROVE_CONNECT_TIMEOUT_MS = "0"
+    const settled = await Promise.race([
+      open()
+        .connect()
+        .then(
+          () => "connected",
+          () => "rejected",
+        ),
+      new Promise<string>((resolve) => setTimeout(() => resolve("pending"), 300)),
+    ])
+    expect(settled).toBe("pending")
+  })
+})

--- a/packages/kobe/test/client/pty-child-probe.test.ts
+++ b/packages/kobe/test/client/pty-child-probe.test.ts
@@ -1,0 +1,119 @@
+/**
+ * The pty host's live-child probe — the guard that decides whether a wedged
+ * host may be reaped.
+ *
+ * Every Windows case injects platform + disk + the child runner, exactly as
+ * `node-pty-host-spawn.test.ts` does: those branches only ever execute on
+ * Windows, so on a POSIX CI host injection is the only reason they are tested
+ * at all. The two real spawns here are `process.execPath`, which is node on
+ * every runner this file lands on.
+ */
+
+import {
+  type ChildProbeDeps,
+  childProbeCommand,
+  liveChildCount,
+  runChildProbe,
+} from "@sma1lboy/kobe-daemon/client/pty-process"
+import { describe, expect, it } from "vitest"
+
+const ENV = { SystemRoot: "C:\\Windows", PATH: "C:\\tools\\bin" }
+/** `node:path` resolves with the HOST's separators, so assertions must not
+ *  care whether the runner produced `C:\Windows\…` or `/Windows/…`. */
+const norm = (path: string) => path.replace(/\\/g, "/").replace(/^[A-Za-z]:/, "")
+const PS = "/Windows/System32/WindowsPowerShell/v1.0/powershell.exe"
+const diskWith = (...present: string[]) => {
+  const set = new Set(present)
+  return (path: string) => set.has(norm(path))
+}
+const win = (over: ChildProbeDeps = {}): ChildProbeDeps => ({ platform: "win32", env: ENV, ...over })
+/** A child runner that answers with a fixed table, recording what it was asked. */
+const table = (out: string, seen: string[][] = []) => {
+  const run = async (command: readonly string[]): Promise<string> => {
+    seen.push([...command])
+    return out
+  }
+  return { run, seen }
+}
+
+describe("childProbeCommand", () => {
+  it("keeps POSIX on `ps`", () => {
+    expect(childProbeCommand({ platform: "linux" })).toEqual(["ps", "-A", "-o", "ppid="])
+    expect(childProbeCommand({ platform: "darwin" })).toEqual(["ps", "-A", "-o", "ppid="])
+  })
+
+  it("reads the Windows table with PowerShell 5.1 by absolute path", () => {
+    const cmd = childProbeCommand(win({ exists: diskWith(PS) }))
+    // Normalised: `node:path` joins with the HOST's separators, so this file
+    // has to be green on a POSIX runner and on a contributor's Windows box.
+    expect(norm(cmd[0] ?? "")).toBe(PS)
+    // NoProfile/NonInteractive: a profile that prompts or an interactive
+    // prompt is a probe that never answers.
+    expect(cmd.slice(1, 3)).toEqual(["-NoProfile", "-NonInteractive"])
+    const script = cmd[cmd.length - 1] ?? ""
+    // 5.1, not 7: no `&&`, no ternaries, no `??`. Get-CimInstance is in 5.1;
+    // the shorter Get-Process has no ParentProcessId at all.
+    expect(script).toContain("Get-CimInstance -ClassName Win32_Process")
+    expect(script).not.toContain("&&")
+    // One ParentProcessId per line — the same shape `ps -o ppid=` prints, so
+    // one parser reads both platforms.
+    expect(script).toContain("Select-Object -ExpandProperty ParentProcessId")
+    // Under an OEM codepage (936 on a Chinese Windows) 5.1 writes its stdout
+    // in that codepage; pinning UTF-8 keeps the read honest.
+    expect(script).toContain("[Console]::OutputEncoding=[System.Text.Encoding]::UTF8")
+  })
+
+  it("falls back to a bare `powershell` when System32 is not where SystemRoot says", () => {
+    expect(childProbeCommand(win({ exists: diskWith() }))[0]).toBe("powershell.exe")
+    // And a machine with no SystemRoot/windir at all still gets one.
+    expect(childProbeCommand(win({ env: {}, exists: diskWith() }))[0]).toBe("powershell.exe")
+  })
+})
+
+describe("liveChildCount", () => {
+  it("counts the rows whose ppid is the host", async () => {
+    const { run } = table(" 1 \n4242\n7\n4242\r\n")
+    expect(await liveChildCount(4242, { platform: "linux", run })).toBe(2)
+    expect(await liveChildCount(999, { platform: "linux", run })).toBe(0)
+  })
+
+  it("answers null — never zero — when the table could not be read", async () => {
+    // The regression this file exists for: `/bin/ps` is ENOENT on Windows, so
+    // the old `catch → 0` made "could not tell" indistinguishable from "host
+    // holds no sessions", and the caller reaped a host with live engines in it.
+    const { run } = table("")
+    expect(await liveChildCount(1, { platform: "linux", run })).toBeNull()
+    expect(
+      await liveChildCount(1, {
+        platform: "linux",
+        run: async () => {
+          throw new Error("ENOENT")
+        },
+      }),
+    ).toBeNull()
+  })
+
+  it("asks Windows for the same number, and reads it with the same parser", async () => {
+    const { run, seen } = table("4242\n8\n")
+    expect(await liveChildCount(4242, win({ run, exists: diskWith(PS) }))).toBe(1)
+    expect(seen[0]?.[0]).toContain("powershell")
+  })
+
+  it("bounds a probe that never answers, and kills the child it gave up on", async () => {
+    // A real child, not a mock: the deadline has to fire against a process
+    // that stays alive, and the abandoned one has to be killed or a long-lived
+    // daemon leaks a probe per recovery attempt.
+    const started = Date.now()
+    await expect(
+      runChildProbe([process.execPath, "-e", "setTimeout(() => {}, 30000)"], 200),
+    ).rejects.toThrow(/did not answer within 200ms/)
+    expect(Date.now() - started).toBeLessThan(5_000)
+  })
+
+  it("reads a real child's stdout to completion", async () => {
+    // The only real spawn of the happy path: `process.execPath` is node on
+    // every runner, so this asserts the accumulate-and-resolve, not the OS.
+    const out = await runChildProbe([process.execPath, "-e", "process.stdout.write('7\\n9\\n')"], 10_000)
+    expect(out.split("\n").filter((row) => row.trim() === "9")).toHaveLength(1)
+  })
+})


### PR DESCRIPTION
## 现象

Windows 11（中文系统，OEM 代码页 936）上用 **Windows PowerShell 5.1**（5.1.26100.9444）启动 rove，**打不开会话**——不是报错，是完全静默挂起，没有任何输出。同一台机器上用 **git bash** 启动则能正常连接、正常进会话。

## 根因

启动路径上有三处只为单一平台写的代码，每一处都不吭声。三者叠加，正好在 PowerShell 宿主下全部命中，在 git bash 宿主下被 `$SHELL` 掩盖：

### 1. 会话 shell 绕过了平台解析器（直接致命）

`packages/kobe/src/cli/api/runtime.ts:97`、`:125`（改动前）：

```ts
shell: process.env.SHELL?.trim() || "/bin/zsh"
```

仓库里已经有 `resolveLoginShell()`（`packages/kobe-daemon/src/daemon/platform-shell.js`），它的模块注释明确写了 Windows 的设计决定：**不给 Windows 造第二套 cmd/PowerShell 方言，而是让它跑 Git for Windows 的 bash**，因为引擎启动契约（`engine/session-launch.ts`）是一整段 POSIX shell 脚本（`trap ':' INT`、`export -p`、`$$`、`kill -TERM`）。它还专门处理了 `$SHELL` 在 Windows 上是 MSYS 路径（`/usr/bin/bash`）、CreateProcess 无法解析的情况（`isWindowsSpawnable`）。

这两处**没走这个解析器**，直接读 `$SHELL`：

- PowerShell 宿主下 `$SHELL` 通常未设置 → 拿到 `/bin/zsh` → CreateProcess 无法启动 → 引擎 tab 起不来。
- git bash 宿主下 `$SHELL` 是 `/usr/bin/bash`（MSYS 路径）。这条能跑通，是因为 Git Bash 自己提供了 POSIX 环境，绕过了 CreateProcess 的限制——**所以「git bash 能开」恰恰是这个 bug 的掩盖条件，不是证据说 Windows 支持没问题。**

### 2. `openSocket()` 没有连接超时（这就是「静默挂起」）

`packages/kobe-daemon/src/client/index.ts:299`（`openSocket()`）。Node 的 `net.connect` 本身不提供 connect timeout。Windows 下 PTY host 监听的地址是 **named pipe**（`\\.\pipe\…`，见 `daemon/paths.ts` 的 `windowsPipePath`），而 libuv 对一个实例被占满的 pipe **不会拒绝连接**，而是停在 `WaitNamedPipeW(name, 30000)` 里反复重试（libuv `src/win/pipe.c`，`pipe_connect_thread_proc`）——promise 30 秒后仍然 pending，再来 30 秒还是 pending。它上面的每一个调用方，包括 `ensurePtyHostReachable` 的第一次探测，就这样无声等着，没有一行输出。POSIX 上不存在这个问题：一个不存在的 unix socket 路径立刻返回 ENOENT。

### 3. 进程表探测硬编码 `/bin/ps`，且把失败折成 0（静默杀会话）

`packages/kobe-daemon/src/client/pty-process.ts:180`（改动前）：

```ts
const proc = spawn("/bin/ps", ["-A", "-o", "ppid="], …)
…
} catch { return 0 }
```

Windows 上 `/bin/ps` 永远 ENOENT，PATH 上那个 `ps` 是 Git for Windows 的 Cygwin 版，不认 `-A`、退出码 1、stdout 为空（同一个发现仓库里 `packages/kobe/src/engine/win-process-snapshot.ts` 已经记录过）。于是「还有活会话的 host 不许重启」这个保护**在 Windows 上是死代码**——永远读到 0，直接 reap 掉 PTY host 和里面所有引擎。

## 修法

没有新增任何 `if (isWindows)` 散点，全部落在已有的抽象层上：

| 文件 | 改动 |
|---|---|
| `packages/kobe/src/cli/api/runtime.ts` | 两处 `process.env.SHELL?.trim() \|\| "/bin/zsh"` → `resolveLoginShell({ fallback: "/bin/zsh" })`。POSIX 行为逐字不变（fallback 保持原值），Windows 交给已有解析器。 |
| `packages/kobe-daemon/src/client/index.ts` | `openSocket()` 加 connect deadline（默认 5s，`ROVE_CONNECT_TIMEOUT_MS` 覆盖，0/负值关闭，形式对齐已有的 `rpcTimeoutMs`），超时抛 `ConnectTimeoutError` 并带上地址；到期销毁 socket，不留半开句柄。这个错误会被 `probeDaemonSocket` 已有的 catch 读成 `absent`，于是走上「地址不在→自己拉起一个 host」的恢复路径，而不是被判成 wedged。 |
| `packages/kobe-daemon/src/client/pty-process.ts` | `liveChildCount` 拆成可注入的 `childProbeCommand` / `runChildProbe` / `liveChildCount`。POSIX 仍是 `ps -A -o ppid=`；Windows 走 PowerShell 5.1 + `Get-CimInstance Win32_Process`，**每行一个 ParentProcessId，和 `ps -o ppid=` 输出同形**，所以两边共用一个解析器、一套测试。探测前钉 `[Console]::OutputEncoding=UTF8`（OEM 936 下 5.1 按代码页写 stdout）。探测有 5s 上限，放弃时先 kill 子进程，避免长命 daemon 每次恢复泄漏一个探测。返回值改成 `number \| null`，**`null` = 读不到进程表**，调用方据此拒绝 reap 并给出可操作的错误，不再折成 0。 |
| `packages/kobe-daemon/src/client/win-detached-launch.ts` | `windowsPowershellPath` 的 `exists` 变成可注入参数；同时 `pty-process.ts` 删掉自己那份重复实现，复用它。 |
| `.changeset/windows-session-opens.md` | changeset-cap 门禁要求。 |

PowerShell 侧刻意只用 5.1 兼容语法：无 `&&`、无 `??`/`?.`、无三元；`Get-CimInstance` 在 5.1 就有（更短的 `Get-Process` 根本没有 `ParentProcessId`）；`-NoProfile -NonInteractive` 防止 profile 弹提示把探测变成永不返回；`powershell.exe` 用绝对路径（`SystemRoot` 推导），因为 PTY 下 PATH 不保证。

## 验证

在 POSIX（macOS）runner 上跑过：

- `bun run typecheck` — 过（4 个包全过）
- `bun run lint`（biome，全仓 1581 文件）— 过
- `bun run changeset:check` — 过
- `node scripts/no-silent-catch.mjs` — 过
- `bash scripts/file-size-check.sh` — 过（改动文件最大 437 行，≤500）
- `vitest run test/client test/lib/platform-shell.test.ts test/cli/api-pane.test.ts test/plugins/pane-command.test.ts` — **22 文件 / 152 测试全过**
- 全量 `test:fast` — 5085 passed / 4 failed；这 4 个失败在 stash 掉本 PR 改动后**同样失败**（`doctor-node-pty` 的 exec bit、`land-*` 的 gpg 签名 / unborn HEAD），是本机环境预存问题，与本 PR 无关

新增测试（Windows 分支靠注入 `platform` / `env` / `exists` / `run`，和仓库里 `node-pty-host-spawn.test.ts` 同样的做法，POSIX CI 上能跑）：

- `packages/kobe/test/client/pty-child-probe.test.ts`（8 个）：POSIX 仍是 `ps`；Windows 命令的绝对路径、`-NoProfile -NonInteractive`、`Get-CimInstance`、无 `&&`、UTF-8 钉死、SystemRoot 缺失时的回退；读不到表返回 `null` 而非 0（就是本 PR 修的回归）；Windows 和 POSIX 走同一个解析器；探测超时用**真实**子进程验证会 fire 且子进程被 kill。
- `packages/kobe/test/client/daemon-connect-timeout.test.ts`（4 个）：mock 一个永不 settle 的 connect（就是 libuv 把 busy pipe 挂住的状态），验证在预算内 reject、消息里带地址和预算、`probeDaemonSocket` 把它判成 `absent`、放弃后 client 仍可复用、`ROVE_CONNECT_TIMEOUT_MS=0` 能关掉 deadline。

## 没验证到的部分

**这个 PR 没有在真 Windows 机器上跑过。** CI 只有 `ubuntu-latest` 和 `macos-14`（`ci.yml` / `nightly.yml` / `release.yml`），没有 windows runner，所以所有 Windows 分支都是静态论证 + 注入式单测，不是实测。需要用户（咸鱼SaltFish）在 Windows PowerShell 5.1 / 中文系统上确认：

1. **主症状是否消失**：PowerShell 下能否正常进会话。若仍失败，请贴 `<KOBE_HOME>/.kobe/daemon.log` 和 PTY host log（本 PR 的错误消息里已经带上了路径）。
2. **是否真的会走到 named pipe 挂起**：根因 2 是对 libuv `WaitNamedPipeW` 行为的静态推断。请确认失败时确实是「静默无任何输出地卡住」，而不是几秒内报错——如果是后者，说明还有另一个我没找到的失败点。
3. **`Get-CimInstance Win32_Process` 在该机器上的开销和权限**：普通用户权限下应可读全表；若被组策略限制（企业环境常见），本 PR 会走 `null` 分支报「读不到进程表，拒绝重启 host」而不是静默杀会话——这个行为是否可接受，需要用户拍板（备选是降级成「读不到就允许 reap」，但那正是原来的 bug）。
4. **代码页 936 下 PowerShell 输出**：本 PR 已钉 `[Console]::OutputEncoding=UTF8`，但没在真 936 环境验证过。
5. **PowerShell 7（pwsh）宿主**：未测。本 PR 只用 5.1 兼容语法，理论上 7 也兼容。
6. **`bun run build`**：sandbox 里 vite 的 bin 没链好，跑不起来（环境问题，非代码问题）。CI 的 build 会覆盖。

## 与 w12 的冲突面

只碰 `cli/api/runtime.ts`、`client/index.ts`、`client/pty-process.ts`、`client/win-detached-launch.ts` 和两个新测试文件，**没有碰 keyboard-hints / i18n 相关文件**。
