### PR TITLE
fix: keep an active task's engine-event feed from being evicted first

### DIFF
--- a/.changeset/engine-event-feed-lru-eviction.md
+++ b/.changeset/engine-event-feed-lru-eviction.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Fix a task's recent-engine-events feed dropping the wrong task once more than 100 tasks have reported activity in one daemon session. The in-memory feed keeps the 100 most recently active tasks and evicts the rest, but it picked the task whose FIRST event was oldest instead of the least-recently-active one — so a task you were still driving could have its feed silently emptied while long-idle tasks kept theirs. Eviction now tracks most-recent activity, so the task being appended to is never the one dropped.

--- a/packages/kobe-daemon/src/daemon/engine-events-log.ts
+++ b/packages/kobe-daemon/src/daemon/engine-events-log.ts
@@ -15,24 +15,30 @@ export interface RecentEngineEvent {
   readonly at: number
 }
 
-const PER_TASK_CAP = 100
-/** ponytail: crude LRU on task count; per-entry eviction if this ever matters. */
-const TASK_CAP = 100
+export const PER_TASK_CAP = 100
+/** Task-count ceiling. Eviction is recency-based (see `append`): the
+ *  least-recently-appended task is dropped, never an active one. */
+export const TASK_CAP = 100
 
 export class EngineEventLog {
   private readonly byTask = new Map<string, RecentEngineEvent[]>()
 
   append(taskId: string, event: RecentEngineEvent): void {
     let list = this.byTask.get(taskId)
-    if (!list) {
-      // Re-inserting moves the task to the Map's tail (newest); evict the head.
-      if (this.byTask.size >= TASK_CAP) {
-        const oldest = this.byTask.keys().next().value
-        if (oldest !== undefined) this.byTask.delete(oldest)
-      }
-      list = []
-      this.byTask.set(taskId, list)
+    if (list) {
+      // Touching an existing task must move it to the Map's tail so the head
+      // stays the least-recently-active task. A `Map` only appends on a NEW
+      // key — `set` on an existing one keeps its original slot — so an
+      // in-place `get`+push leaves insertion order frozen at first-append
+      // (FIFO), and eviction below then drops whichever task was seen first,
+      // even one being appended to right now. Delete + re-set re-keys it.
+      this.byTask.delete(taskId)
+    } else if (this.byTask.size >= TASK_CAP) {
+      const oldest = this.byTask.keys().next().value
+      if (oldest !== undefined) this.byTask.delete(oldest)
     }
+    if (!list) list = []
+    this.byTask.set(taskId, list)
     list.push(event)
     if (list.length > PER_TASK_CAP) list.splice(0, list.length - PER_TASK_CAP)
   }

--- a/packages/kobe/test/daemon/engine-events-log.test.ts
+++ b/packages/kobe/test/daemon/engine-events-log.test.ts
@@ -1,0 +1,64 @@
+import { EngineEventLog, PER_TASK_CAP, TASK_CAP } from "@sma1lboy/kobe-daemon/daemon/engine-events-log"
+import { describe, expect, it } from "vitest"
+
+function event(kind: string, at = Date.now()): { kind: string; at: number } {
+  return { kind, at }
+}
+
+describe("EngineEventLog", () => {
+  it("buffers a task's events newest-last", () => {
+    const log = new EngineEventLog()
+    log.append("t1", event("a"))
+    log.append("t1", event("b"))
+    expect(log.recent("t1").map((e) => e.kind)).toEqual(["a", "b"])
+  })
+
+  it("returns an empty list for a task that has never been seen", () => {
+    expect(new EngineEventLog().recent("nope")).toEqual([])
+  })
+
+  it("caps a single task's buffer at PER_TASK_CAP, dropping the oldest events", () => {
+    const log = new EngineEventLog()
+    for (let i = 0; i < PER_TASK_CAP + 5; i++) log.append("t1", event(`e${i}`))
+    const kinds = log.recent("t1").map((e) => e.kind)
+    expect(kinds).toHaveLength(PER_TASK_CAP)
+    // The five oldest fell off the front; the newest is last.
+    expect(kinds[0]).toBe("e5")
+    expect(kinds.at(-1)).toBe(`e${PER_TASK_CAP + 4}`)
+  })
+
+  it("honours the recent() limit, returning the newest N", () => {
+    const log = new EngineEventLog()
+    for (let i = 0; i < 10; i++) log.append("t1", event(`e${i}`))
+    expect(log.recent("t1", 3).map((e) => e.kind)).toEqual(["e7", "e8", "e9"])
+  })
+
+  it("evicts the least-recently-appended task, never an actively-appended one", () => {
+    const log = new EngineEventLog()
+    // Fill exactly to the ceiling: task-0 .. task-(CAP-1), oldest first.
+    for (let i = 0; i < TASK_CAP; i++) log.append(`task-${i}`, event("seed"))
+
+    // Re-touch task-0 — the one whose FIRST append was oldest. A FIFO-by-first
+    // -seen buffer (the bug) would still evict it next; a recency LRU must not.
+    log.append("task-0", event("active"))
+
+    // A brand-new task pushes the map one over the ceiling, forcing one eviction.
+    log.append("fresh", event("hello"))
+
+    // task-0 survived because it was just touched; its feed is intact.
+    expect(log.recent("task-0").map((e) => e.kind)).toEqual(["seed", "active"])
+    // task-1 — now the least-recently-appended — is the one dropped.
+    expect(log.recent("task-1")).toEqual([])
+    // The newcomer is retained.
+    expect(log.recent("fresh").map((e) => e.kind)).toEqual(["hello"])
+  })
+
+  it("clearTask drops one task's buffer without touching others", () => {
+    const log = new EngineEventLog()
+    log.append("t1", event("a"))
+    log.append("t2", event("b"))
+    log.clearTask("t1")
+    expect(log.recent("t1")).toEqual([])
+    expect(log.recent("t2").map((e) => e.kind)).toEqual(["b"])
+  })
+})


### PR DESCRIPTION
## Direction

Bugs / correctness — a self-found defect where the code contradicts its own documented intent, surfaced by an adversarial read of `kobe-daemon`'s in-memory collectors.

## Problem

`EngineEventLog` (`packages/kobe-daemon/src/daemon/engine-events-log.ts`) backs the per-task recent-engine-events feed (`task.recentEvents` RPC). It keeps at most `TASK_CAP` (100) tasks and evicts the rest, and its comment claimed a recency LRU: *"Re-inserting moves the task to the Map's tail (newest); evict the head."*

But that re-insertion never happened. The existing-task path did `this.byTask.get(taskId)` and pushed into the list **in place** — and a JS `Map` only appends to iteration order on a *new* key; `set` on an existing key keeps its original slot. So the Map's order tracked **first-append order (FIFO)**, not recency. Eviction (`keys().next().value` = oldest-inserted) therefore dropped the task whose *first* event was oldest — which can be the task you are actively driving right now — while long-idle tasks that were first seen later kept their feeds.

Concretely, once 100 tasks have reported activity in one daemon session: touch `task-0` (the oldest first-seen), then let any new task report — `task-0`'s entire feed is silently wiped, even though it was the most-recently-active task. In a product built for many long-running parallel sessions, the `TASK_CAP=100` ceiling is reachable over a day, and the failure picks the worst possible victim.

## Fix

On the existing-task path, `delete` then re-`set` the key so touching a task re-keys it to the Map tail. The head is then a true least-recently-active eviction target, and an active task is never the one dropped. The eviction-when-full check moves to the new-task branch only (an existing task never grows the map). The stale `ponytail` comment on `TASK_CAP` is corrected to describe the actual behavior.

## Verification

- New `packages/kobe/test/daemon/engine-events-log.test.ts` (6 cases): newest-last buffering, empty-for-unseen, the `PER_TASK_CAP` per-task ring cap, the `recent()` limit, `clearTask` isolation, and the eviction regression — an actively-appended task survives a cap-overflow while the least-recently-appended task is the one evicted.
- Confirmed the regression test **fails** against the old logic and **passes** with the fix (temporarily restored the buggy `append` and re-ran).
- `bun run lint`, `bun run typecheck` — both green.
- `test/daemon/engine-events-log.test.ts` and the existing `test/daemon/handlers.test.ts` (29 cases, exercises `EngineEventLog` via `task.recentEvents`) — both green under `KOBE_INCLUDE_SOCKET=1`.
- `bun run changeset:check` — green. Patch changeset added for `@sma1lboy/rove` (the daemon ships bundled inside the published CLI).

## Follow-ups (deliberately out of scope)

- The `TASK_CAP` comment still notes per-entry eviction "if this ever matters" — the count-based ceiling is unchanged here; only which task it drops is fixed.
- The `test/daemon` suite runs under `bun run test:socket` / the release gate rather than the PR `test:fast` gate, matching where the sibling pure-logic daemon tests (`quota-resume`, `attention-inbox`) live.


---
_Generated by [Claude Code](https://claude.ai/code/session_01TdyAX3PbLb2Bg1SkoPfZT8)_