### PR TITLE
fix: the engine walk asks about custom presets too

### DIFF
--- a/.changeset/custom-engine-walk.md
+++ b/.changeset/custom-engine-walk.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+A tab running a custom engine no longer reads as a bare shell. The process-tree walk that answers "which engine is live in this tab" only ever asked about engines the registry can name without reading state — the built-ins, the shipped catalog, and plugin engines — so an engine you registered yourself in Settings → Engines was invisible to it. Every consumer reads that silence as a positive "no engine here", so a tab with your engine running in it lost its sidebar state dot, stopped reporting turns, and renamed itself `shell 37` mid-session. The walk now takes a second pass over the launch binaries of your registered presets, and a tab already demoted by an earlier probe is renamed by whatever engine is actually running in it. A built-in found under the same shell still wins: a preset is usually a wrapper (`claudecpa` ends up running claude), and the engine underneath is the one carrying history, status and turn knowledge.

--- a/packages/kobe/src/engine/foreground.ts
+++ b/packages/kobe/src/engine/foreground.ts
@@ -18,6 +18,7 @@
  */
 
 import { basename } from "node:path"
+import { loadStateFile } from "../state/store.ts"
 import type { VendorId } from "../types/vendor"
 import { type ProcRow, PsProbeUnavailableError } from "./process-rows.ts"
 import { engineEntry, identifiableEngineIds } from "./registry"
@@ -126,22 +127,77 @@ export function hasAncestor(rows: readonly ProcRow[], pid: number, ancestorPid: 
 }
 
 /**
- * Breadth-first hunt for an engine among `rootPid`'s descendants —
- * shallowest wins, so a wrapper's engine child is found before that
- * engine's own helper processes (claude spawns `claude bg-pty-host`
- * subprocesses; the session itself is nearer the shell).
+ * Launch binaries of the user's CUSTOM engine presets, keyed by the
+ * executable name a `ps` row would carry.
+ *
+ * {@link vendorFromArgv} deliberately stops at {@link identifiableEngineIds}
+ * — what the registry can name without reading state — so a preset the user
+ * registered themselves (id in `customEngineIds`, command in
+ * `engineCommand.<id>`) was invisible to the walk. Every consumer reads a
+ * null walk as a POSITIVE "no engine here", so a live custom-engine tab lost
+ * its turn detector, its sidebar state dot, and its name: `tabTitleStable`
+ * demoted it to `shell N` while the engine was still running in it.
+ *
+ * Read straight from state.json rather than pushed in at boot because the
+ * walk runs in three processes (TUI probe, daemon activity observer, `api
+ * inspect`) and none of them shares a registration step. One small
+ * `readFileSync` per walk that finds no built-in engine — never per `ps` row.
  */
-export function foregroundEngineIn(rows: readonly ProcRow[], rootPid: number): ForegroundEngine | null {
+function customEngineBinaries(): ReadonlyMap<string, VendorId> {
+  const state = loadStateFile()
+  const ids = state.customEngineIds
+  const out = new Map<string, VendorId>()
+  if (!Array.isArray(ids)) return out
+  for (const id of ids) {
+    if (typeof id !== "string" || id.trim().length === 0) continue
+    const command = state[`engineCommand.${id}`]
+    const argv = typeof command === "string" && command.trim().length > 0 ? command.trim().split(/\s+/) : [id]
+    const name = executableNameFromArgv(argv)
+    if (name) out.set(name, id)
+  }
+  return out
+}
+
+/** Shallowest descendant of `rootPid` that `identify` names, or null. */
+function walkDescendants(
+  rows: readonly ProcRow[],
+  rootPid: number,
+  identify: (args: string) => VendorId | null,
+): ForegroundEngine | null {
   const kids = childrenIndex(rows)
   const queue = [...(kids.get(rootPid) ?? [])]
   while (queue.length > 0) {
     const row = queue.shift()
     if (!row) break
-    const vendor = vendorFromArgv(row.args)
+    const vendor = identify(row.args)
     if (vendor) return { vendor, argv: row.args, pid: row.pid }
     queue.push(...(kids.get(row.pid) ?? []))
   }
   return null
+}
+
+/**
+ * Breadth-first hunt for an engine among `rootPid`'s descendants —
+ * shallowest wins, so a wrapper's engine child is found before that
+ * engine's own helper processes (claude spawns `claude bg-pty-host`
+ * subprocesses; the session itself is nearer the shell).
+ *
+ * Custom presets are a SECOND pass, not another arm of the first: a preset
+ * is usually a wrapper around a real engine (`claudecpa` ends up running
+ * claude), and the built-in underneath is the identity that carries adapter
+ * knowledge — history, status-prefix rules, turn hints. Only when the whole
+ * tree names no built-in does the preset's own binary answer.
+ */
+export function foregroundEngineIn(rows: readonly ProcRow[], rootPid: number): ForegroundEngine | null {
+  const builtin = walkDescendants(rows, rootPid, vendorFromArgv)
+  if (builtin) return builtin
+  const custom = customEngineBinaries()
+  if (custom.size === 0) return null
+  return walkDescendants(
+    rows,
+    rootPid,
+    (args) => custom.get(executableNameFromArgv(args.trim().split(/\s+/)) ?? "") ?? null,
+  )
 }
 
 /**

--- a/packages/kobe/src/tui/workspace/terminal-tab-split.ts
+++ b/packages/kobe/src/tui/workspace/terminal-tab-split.ts
@@ -255,7 +255,19 @@ export function tabTitleStable(
   const source = liveTitle?.trim() || tab.lastTitle
   const named = vendor ? stableRecordedTitle(source, vendor) : (source ?? null)
   if (!vendor || engineEntry(vendor).terminalTitle?.ownsStatus !== true) {
-    return tabTitle({ ...tab, lastTitle: named } as TerminalTab, taskVendor)
+    // The resolved vendor still NAMES the tab, exactly as in the
+    // status-owning branch below: a tab running an engine that writes no
+    // title of its own (a custom preset, a contrib CLI) must fall back to
+    // that engine's name, not to `shell N`. Reachable for a `kind:
+    // "command"` tab two ways — a shell the user typed the engine into, and
+    // an engine tab a PAST probe demoted (the walk answered "no engine"
+    // because it had never been asked about custom presets; see
+    // `foreground.ts#customEngineBinaries`) — and in both the live process
+    // is the name. Naming only: no session or resume story is implied.
+    return tabTitle(
+      { ...tab, ...(vendor ? { kind: "engine", vendor } : {}), lastTitle: named } as TerminalTab,
+      taskVendor,
+    )
   }
   // Re-run the normal precedence with the recorded title CLEANED rather than
   // dropped: `stripEngineStatusPrefix` is idempotent, so a title recorded

--- a/packages/kobe/test/engine/foreground.test.ts
+++ b/packages/kobe/test/engine/foreground.test.ts
@@ -1,4 +1,7 @@
-import { afterEach, describe, expect, it } from "vitest"
+import { mkdirSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
 import { clearPluginEngines, registerPluginEngine } from "../../src/engine/contrib-engines.ts"
 import {
   engineProcessIn,
@@ -215,10 +218,10 @@ describe("vendorFromArgv covers every engine the registry can name state-free", 
     expect(foregroundEngineIn(rows, 200)).toBeNull()
   })
 
-  it("a genuinely custom engine stays unnameable here — callers pass its launch argv", () => {
-    // `engineCommand.<id>` lives in state this module must not read, so the
-    // walk cannot name `my-agent`; the delivery gate's `extraLaunch` is how
-    // a caller holding that state asks about it.
+  it("an UNREGISTERED custom binary stays unnameable — callers pass its launch argv", () => {
+    // Nothing in `customEngineIds` claims `my-agent`, so the walk has no
+    // business naming it; the delivery gate's `extraLaunch` is how a caller
+    // holding that launch command asks about it.
     const rows = parsePsSnapshot(`
 10 1 /bin/zsh -l
 11 10 /Users/me/bin/my-agent --serve
@@ -226,5 +229,71 @@ describe("vendorFromArgv covers every engine the registry can name state-free", 
     expect(foregroundEngineIn(rows, 10)).toBeNull()
     expect(engineProcessIn(rows, 10)).toBe(false)
     expect(engineProcessIn(rows, 10, "/Users/me/bin/my-agent")).toBe(true)
+  })
+})
+
+/**
+ * The walk's second pass. Without it a live custom-engine tab reads as a bare
+ * shell everywhere: no turn detector (`targetFor` treats null as a confirmed
+ * shell), no sidebar state dot, and `tabTitleStable` renaming it `shell N`
+ * while the engine is still running in it.
+ */
+describe("custom engine presets in the walk", () => {
+  const home = join(tmpdir(), `rove-foreground-custom-${process.pid}`)
+  // Restored, not just deleted: vitest reuses a worker across FILES, so a
+  // leaked home (pointing at a directory this file removed) silently
+  // re-homes every later suite's state reads.
+  let previousHome: string | undefined
+
+  beforeEach(() => {
+    previousHome = process.env.KOBE_HOME_DIR
+    const dir = join(home, ".config", "rove")
+    mkdirSync(dir, { recursive: true })
+    writeFileSync(
+      join(dir, "state.json"),
+      JSON.stringify({
+        customEngineIds: ["claudecpa", "cluadex"],
+        "engineCommand.claudecpa": "claudecpa",
+        // A preset whose id and BINARY differ — the binary is what `ps` shows.
+        "engineCommand.cluadex": "claudex --yolo",
+      }),
+    )
+    process.env.KOBE_HOME_DIR = home
+  })
+
+  afterEach(() => {
+    rmSync(home, { recursive: true, force: true })
+    if (previousHome === undefined) Reflect.deleteProperty(process.env, "KOBE_HOME_DIR")
+    else process.env.KOBE_HOME_DIR = previousHome
+  })
+
+  it("names a registered preset by the binary its command launches", () => {
+    const rows = parsePsSnapshot(`
+10 1 /bin/zsh -l
+11 10 bun /opt/homebrew/bin/claudecpa
+20 1 /bin/zsh -l
+21 20 /Users/me/.local/bin/claudex --yolo
+`)
+    expect(foregroundEngineIn(rows, 10)?.vendor).toBe("claudecpa")
+    expect(foregroundEngineIn(rows, 20)?.vendor).toBe("cluadex")
+    expect(engineProcessIn(rows, 10)).toBe(true)
+  })
+
+  it("a built-in under the same shell still wins — the preset is the fallback", () => {
+    // `claudecpa`-shaped: the preset's own wrapper plus the real claude it
+    // ends up running. claude carries the adapter knowledge, so it answers.
+    const rows = parsePsSnapshot(`
+10 1 /bin/zsh -l
+11 10 /opt/homebrew/bin/claudecpa
+12 11 /opt/homebrew/bin/claude --model opus
+`)
+    expect(foregroundEngineIn(rows, 10)?.vendor).toBe("claude")
+  })
+
+  it("still answers a confirmed null for a shell running nothing", () => {
+    const rows = parsePsSnapshot(`
+10 1 /bin/zsh -l
+`)
+    expect(foregroundEngineIn(rows, 10)).toBeNull()
   })
 })


### PR DESCRIPTION
## The bug

A tab with a user-registered engine running in it renames itself `shell N`, loses its sidebar state dot, and stops reporting turns — while the engine is still very much alive in the PTY.

Reproduced on 0.9.188 with an engine registered in Settings → Engines. `rove api inspect` on the live session:

```json
{"key":"01M1X18RXQFDQR3TMMRVAAYTKG::tab-37","alive":true,"pid":80067,
 "title":"π > 调研更炫酷的游戏插件","exit":null,"foreground":null}
```

`foreground: null` with `80473 80067 bun /opt/homebrew/bin/omp` sitting right there under pid 80067.

## Root cause

`vendorFromArgv` asks `identifiableEngineIds()` — built-ins, the shipped catalog, plugin engines. A preset the user registered themselves carries its binary in `engineCommand.<id>`, in state the registry deliberately never reads, so the walk was never asked about it. The module's own doc already names this failure shape for contrib engines:

> a running OpenCode answering `null` here is not "no engine", it is this function not having been asked about OpenCode — and every consumer of the walk reads that `null` as a POSITIVE no-engine verdict.

Custom presets were the remaining hole, and all three consumers act on that verdict:

- `demoteExitedEngine` flips the tab to `kind: "command"` → `tabTitle` falls through to `shell N`
- `targetFor` treats `null` as a confirmed bare shell → no turn detector attaches
- the sidebar state dot goes dark

## The fix

**`foreground.ts`** — the walk takes a second pass over the launch binaries of the registered presets, resolved through the same wrapper/path parser the first pass uses (`bun /path/to/x`, `env FOO=1 x`). A second pass rather than another arm of the first: a preset is usually a wrapper around a real engine (`claudecpa` ends up running claude), and the built-in underneath is the identity carrying history, status-prefix rules and turn hints — so it still wins. Only when the whole tree names no built-in does the preset's own binary answer.

State is read in the walk rather than pushed in at boot because the walk runs in three processes — the TUI probe, the daemon activity observer, `api inspect` — and none of them shares a registration step. It costs one small `readFileSync` per walk that finds no built-in engine, never one per `ps` row.

**`terminal-tab-split.ts`** — a tab an earlier probe already demoted is renamed by whatever engine is actually running in it. The status-owning branch below already carried the resolved vendor into the name for exactly this reason ("a shell the user typed `claude` into is named by that engine, not `shell N`"); an engine that writes no title of its own was falling through to `shell N`. Naming only — no session or resume story implied.

## Verification

`test/engine/foreground.test.ts` gains a suite over an isolated home with two presets, one whose id and binary differ. Deleting the second pass turns it red:

```
× custom engine presets in the walk > names a registered preset by the binary its command launches
  → expected undefined to be 'claudecpa'
```

The existing case asserting the old behaviour ("a genuinely custom engine stays unnameable here") is rewritten to the surviving rule: an **unregistered** binary is still honestly `null`, and `extraLaunch` is still how a caller holding that launch command asks about it.

`typecheck` clean; `test/engine`, `test/tui`, `test/tui-react`, `test/cli` green.
