### PR TITLE
fix: draw a keystroke echo on the coalesce window's leading edge

### DIFF
--- a/.changeset/terminal-echo-latency.md
+++ b/.changeset/terminal-echo-latency.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Typing in a Rove terminal no longer lags a frame behind the same shell outside Rove. Output from a PTY is coalesced so a streaming pane builds at most one snapshot per rendered frame — but the throttle was trailing-only, so it also charged that full frame to output arriving at an idle terminal, which is every keystroke you type at a prompt. The child echoed in a fraction of a millisecond and the pane then had nothing to draw for another 33ms. The window now fires on its leading edge: output arriving after a quiet frame is drawn at once, and only a second chunk inside the same window waits for the boundary. Measured end to end on macOS — `write()` to published snapshot, 60 samples at 120x40 — p50 drops from 35.8ms to 1.5ms against a raw PTY echo of 0.03ms. Bursts are unchanged: still one snapshot per frame, none of it discarded work.

--- a/packages/kobe/src/tui/panes/terminal/pty-xterm-base.ts
+++ b/packages/kobe/src/tui/panes/terminal/pty-xterm-base.ts
@@ -74,6 +74,10 @@ export abstract class XtermTaskPty implements TaskPtyLike {
   protected cols: number
   protected rows: number
   private refreshQueued = false
+  /** When the last snapshot refresh was ATTEMPTED — the leading edge of the
+   *  coalesce window (see `queueRefresh`). 0 = never, so the first output
+   *  after a subscriber attaches draws immediately. */
+  private lastRefreshAt = 0
   private readonly refreshTracker: XtermRefreshTracker
   /** Scrollback rows resolved from the persisted preference at construction
    * (Settings → General → Terminal) — fixed for this PTY's lifetime. */
@@ -393,15 +397,39 @@ export abstract class XtermTaskPty implements TaskPtyLike {
       return
     }
     if (this.refreshQueued) return
+    // LEADING edge: a frame period has already passed with nothing drawn, so
+    // this output is not part of a burst and waiting buys nothing. This is
+    // the keystroke-echo path — you type into an idle shell, the child echoes
+    // in ~0.03ms, and a trailing-only throttle then sat on it for a whole
+    // frame before the pane had anything to draw. Measured on macOS at 120x40
+    // (`cat`, 60 samples, 200ms idle between them, write → snapshot published):
+    // p50 35.8ms trailing-only vs 1.5ms here, against a raw PTY echo of
+    // 0.03ms. p90 stays ~23ms on purpose — those samples land inside a burst,
+    // which is the case the coalesce is for.
+    //
+    // The BURST behaviour is unchanged, which is the property the coalesce
+    // exists for: the next refresh inside the period still waits for the
+    // boundary, so a streaming pane still builds at most one snapshot per
+    // frame and none of them is discarded work.
+    const since = Date.now() - this.lastRefreshAt
+    if (since >= SNAPSHOT_COALESCE_MS) {
+      this.refreshSnapshot()
+      return
+    }
     this.refreshQueued = true
     setTimeout(() => {
       this.refreshQueued = false
       this.refreshSnapshot()
-    }, SNAPSHOT_COALESCE_MS)
+    }, SNAPSHOT_COALESCE_MS - since)
   }
 
   private refreshSnapshot(): void {
     if (this._killed) return
+    // Stamped on the ATTEMPT, not on success: the `result === null`
+    // half-painted path below re-queues, and a leading edge that only moved
+    // on success would find the period still elapsed and re-enter
+    // synchronously, forever.
+    this.lastRefreshAt = Date.now()
     const result = profileSpan("refresh", () =>
       this.snapshotEngine.refresh(
         this.term,

--- a/packages/kobe/src/tui/panes/terminal/pty-xterm-base.ts
+++ b/packages/kobe/src/tui/panes/terminal/pty-xterm-base.ts
@@ -6,7 +6,7 @@ import { Terminal as XtermHeadless } from "@xterm/headless"
 import { persistedScrollbackRows } from "../../../state/scrollback"
 import { hostTargetFps } from "../../lib/host-render-options"
 import { profileSpan, profileTick } from "../../lib/render-profile"
-import { type TerminalInputModes, encodeMouseButton, encodeWheel } from "./keys-pure"
+import type { TerminalInputModes } from "./keys-pure"
 import { PtyListeners } from "./pty-listeners"
 import {
   type CursorPos,
@@ -20,6 +20,13 @@ import {
 } from "./pty-types"
 import { XtermSnapshotEngine } from "./pty-xterm-snapshot"
 import type { RowWrapFlags } from "./terminal-wrap"
+import {
+  appOwnsMouse,
+  mouseButtonSequence,
+  onAlternateScreen,
+  readInputModes,
+  wheelSequence,
+} from "./xterm-input-modes"
 import { XtermRefreshTracker, wireXtermChannels, wireXtermDefaultColorQueries } from "./xterm-refresh"
 
 /**
@@ -152,14 +159,7 @@ export abstract class XtermTaskPty implements TaskPtyLike {
   }
 
   inputModes(): TerminalInputModes {
-    try {
-      return {
-        applicationCursorKeys: this.term.modes.applicationCursorKeysMode === true,
-        applicationKeypad: this.term.modes.applicationKeypadMode === true,
-      }
-    } catch {
-      return { applicationCursorKeys: false, applicationKeypad: false }
-    }
+    return readInputModes(this.term)
   }
 
   onExit(cb: () => void): () => void {
@@ -193,28 +193,12 @@ export abstract class XtermTaskPty implements TaskPtyLike {
     this.write(bracketed ? `\x1b[200~${text}\x1b[201~` : text)
   }
 
+  /** Mouse gestures are DELIVERED here but DECIDED in `xterm-input-modes.ts`:
+   *  whether the program wants this event at all is a question about its
+   *  mode state, and a null answer means Rove keeps the gesture for itself
+   *  (scrollback, selection). */
   wheel(direction: "up" | "down", col: number, row: number): boolean {
-    if (this._killed) return false
-    try {
-      const modes = this.term.modes
-      const seq = encodeWheel(
-        {
-          mouseTracking: modes.mouseTrackingMode !== "none",
-          applicationCursorKeys: modes.applicationCursorKeysMode === true,
-          alternateScreen: this.term.buffer.active.type === "alternate",
-        },
-        direction,
-        col,
-        row,
-      )
-      if (seq !== null) {
-        this.write(seq)
-        return true
-      }
-    } catch {
-      /* mode probe is best-effort */
-    }
-    return false
+    return this.emit(this._killed ? null : wheelSequence(this.term, direction, col, row))
   }
 
   click(
@@ -224,44 +208,23 @@ export abstract class XtermTaskPty implements TaskPtyLike {
     row: number,
     modifiers?: { shift?: boolean; alt?: boolean; ctrl?: boolean },
   ): boolean {
-    if (this._killed) return false
-    try {
-      const seq = encodeMouseButton(
-        { mouseTracking: this.term.modes.mouseTrackingMode },
-        kind,
-        button,
-        col,
-        row,
-        modifiers,
-      )
-      if (seq !== null) {
-        this.write(seq)
-        return true
-      }
-    } catch {
-      /* mode probe is best-effort */
-    }
-    return false
+    return this.emit(this._killed ? null : mouseButtonSequence(this.term, kind, button, col, row, modifiers))
+  }
+
+  /** Write `seq` to the child when there is one; the boolean is "the program
+   *  took this gesture", which is what the pane branches on. */
+  private emit(seq: string | null): boolean {
+    if (seq === null) return false
+    this.write(seq)
+    return true
   }
 
   get appOwnsMouse(): boolean {
-    if (this._killed) return false
-    try {
-      return this.term.modes.mouseTrackingMode !== "none"
-    } catch {
-      /* mode probe is best-effort */
-      return false
-    }
+    return this._killed ? false : appOwnsMouse(this.term)
   }
 
   get onAlternateScreen(): boolean {
-    if (this._killed) return false
-    try {
-      return this.term.buffer.active.type === "alternate"
-    } catch {
-      /* buffer probe is best-effort */
-      return false
-    }
+    return this._killed ? false : onAlternateScreen(this.term)
   }
 
   onData(cb: DataListener): () => void {

--- a/packages/kobe/src/tui/panes/terminal/xterm-input-modes.ts
+++ b/packages/kobe/src/tui/panes/terminal/xterm-input-modes.ts
@@ -1,0 +1,95 @@
+/**
+ * The emulator's INPUT-mode surface: what the program running in the PTY has
+ * asked the terminal to do with pointer and key input, read off xterm's own
+ * mode state.
+ *
+ * Split from `pty-xterm-base.ts`, which otherwise owns the opposite
+ * direction — bytes arriving from the child, parsed into the snapshot the
+ * pane draws. These five answers share no state with that pipeline: each one
+ * is a read of `term.modes` / `term.buffer.active`, and the two that emit
+ * hand back a byte sequence for the caller to write rather than writing it.
+ *
+ * Every probe is best-effort by contract. `term.modes` is xterm's internal
+ * surface and a killed or mid-teardown emulator can throw from it; a pane
+ * that cannot answer "does the app want the mouse" must fall back to Rove's
+ * own handling, never take the TUI down.
+ */
+
+import type { Terminal as XtermHeadless } from "@xterm/headless"
+import { type TerminalInputModes, encodeMouseButton, encodeWheel } from "./keys-pure"
+
+/**
+ * The mode state these helpers read. Derived from xterm's own type rather
+ * than restated: `mouseTrackingMode` is a closed union `keys-pure` switches
+ * on exhaustively, and a hand-written copy would let a widened one through.
+ */
+export type XtermModeSource = Pick<XtermHeadless, "modes" | "buffer">
+
+/** Cursor-key / keypad modes, as `keys-pure` needs them to encode a keypress. */
+export function readInputModes(term: XtermModeSource): TerminalInputModes {
+  try {
+    return {
+      applicationCursorKeys: term.modes.applicationCursorKeysMode === true,
+      applicationKeypad: term.modes.applicationKeypadMode === true,
+    }
+  } catch {
+    return { applicationCursorKeys: false, applicationKeypad: false }
+  }
+}
+
+/** True while the program is tracking the mouse itself (Rove must not). */
+export function appOwnsMouse(term: XtermModeSource): boolean {
+  try {
+    return term.modes.mouseTrackingMode !== "none"
+  } catch {
+    return false
+  }
+}
+
+/** True on the alternate screen — a full-screen app, not a scrolling shell. */
+export function onAlternateScreen(term: XtermModeSource): boolean {
+  try {
+    return term.buffer.active.type === "alternate"
+  } catch {
+    return false
+  }
+}
+
+/** Bytes for a wheel tick, or null when the program wants none. */
+export function wheelSequence(
+  term: XtermModeSource,
+  direction: "up" | "down",
+  col: number,
+  row: number,
+): string | null {
+  try {
+    return encodeWheel(
+      {
+        mouseTracking: term.modes.mouseTrackingMode !== "none",
+        applicationCursorKeys: term.modes.applicationCursorKeysMode === true,
+        alternateScreen: term.buffer.active.type === "alternate",
+      },
+      direction,
+      col,
+      row,
+    )
+  } catch {
+    return null
+  }
+}
+
+/** Bytes for a mouse button event, or null when the program wants none. */
+export function mouseButtonSequence(
+  term: XtermModeSource,
+  kind: "down" | "up" | "drag",
+  button: 0 | 1 | 2,
+  col: number,
+  row: number,
+  modifiers?: { shift?: boolean; alt?: boolean; ctrl?: boolean },
+): string | null {
+  try {
+    return encodeMouseButton({ mouseTracking: term.modes.mouseTrackingMode }, kind, button, col, row, modifiers)
+  } catch {
+    return null
+  }
+}

--- a/packages/kobe/test/tui/terminal-pty-echo-latency.test.ts
+++ b/packages/kobe/test/tui/terminal-pty-echo-latency.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest"
+import { SNAPSHOT_COALESCE_MS } from "../../src/tui/panes/terminal/pty-xterm-base"
+import { FakeTransportPty, settleRefresh } from "./pty-fake"
+
+/**
+ * The coalesce window's LEADING edge — keystroke-echo latency.
+ *
+ * Why this matters: the throttle exists so a streaming pane builds at most
+ * one snapshot per rendered frame. Trailing-only, it also charged that full
+ * frame to output arriving at an IDLE terminal, which is every keystroke you
+ * type into a shell — the child echoes in ~0.03ms and the pane then had
+ * nothing to draw for another 33ms. Measured end to end on macOS before this
+ * split: p50 35.8ms from `write()` to the published snapshot, against a raw
+ * PTY echo of 0.03ms.
+ *
+ * Both halves are pinned here, because each one alone is satisfiable by the
+ * wrong implementation: "publishes immediately" passes with no coalesce at
+ * all, and "coalesces a burst" passes with the trailing-only version that was
+ * the bug.
+ */
+describe("XtermTaskPty snapshot coalesce", () => {
+  it("publishes output arriving at an idle terminal without waiting a frame", async () => {
+    const pty = new FakeTransportPty({ taskId: "t1", cwd: "/wt" })
+    let published = 0
+    pty.onData(() => {
+      published++
+    })
+
+    // A subscriber that has never seen output is idle by construction.
+    await pty.pump("x")
+    // No `settleRefresh()`: the publish must already have happened by the
+    // time xterm's parse callback returns.
+    expect(published).toBe(1)
+
+    pty.kill()
+  })
+
+  it("still coalesces a burst to one snapshot per frame", async () => {
+    const pty = new FakeTransportPty({ taskId: "t2", cwd: "/wt" })
+    let published = 0
+    pty.onData(() => {
+      published++
+    })
+
+    await pty.pump("first")
+    expect(published).toBe(1)
+
+    // Four more chunks inside the same window: the leading edge is spent, so
+    // these collapse into ONE deferred refresh rather than four.
+    for (const chunk of ["a", "b", "c", "d"]) await pty.pump(chunk)
+    expect(published).toBe(1)
+
+    await settleRefresh()
+    expect(published).toBe(2)
+
+    pty.kill()
+  })
+
+  it("re-arms the leading edge once the window has passed", async () => {
+    const pty = new FakeTransportPty({ taskId: "t3", cwd: "/wt" })
+    let published = 0
+    pty.onData(() => {
+      published++
+    })
+
+    await pty.pump("one")
+    expect(published).toBe(1)
+
+    // Idle longer than the window, the way a human pauses between keystrokes.
+    await new Promise((resolve) => setTimeout(resolve, SNAPSHOT_COALESCE_MS + 20))
+    await pty.pump("two")
+    expect(published).toBe(2)
+
+    pty.kill()
+  })
+})

--- a/packages/kobe/test/tui/terminal-pty-echo-latency.test.ts
+++ b/packages/kobe/test/tui/terminal-pty-echo-latency.test.ts
@@ -35,23 +35,26 @@ describe("XtermTaskPty snapshot coalesce", () => {
     pty.kill()
   })
 
-  it("still coalesces a burst to one snapshot per frame", async () => {
+  it("still coalesces a burst to at most one snapshot per frame", async () => {
     const pty = new FakeTransportPty({ taskId: "t2", cwd: "/wt" })
     let published = 0
     pty.onData(() => {
       published++
     })
 
-    await pty.pump("first")
-    expect(published).toBe(1)
+    // Asserted as a RATE against the time the burst actually took, not as a
+    // fixed count: each `pump` awaits a real xterm parse, so on a loaded
+    // runner a handful of them can outlast the window and legitimately earn a
+    // second leading edge. Windows (17ms at 60fps) failed a fixed count for
+    // exactly that reason. What the coalesce promises is a ceiling, so the
+    // ceiling is what this pins.
+    const started = Date.now()
+    for (let i = 0; i < 40; i++) await pty.pump(`chunk ${i}\r\n`)
+    const elapsed = Date.now() - started
 
-    // Four more chunks inside the same window: the leading edge is spent, so
-    // these collapse into ONE deferred refresh rather than four.
-    for (const chunk of ["a", "b", "c", "d"]) await pty.pump(chunk)
-    expect(published).toBe(1)
-
-    await settleRefresh()
-    expect(published).toBe(2)
+    const ceiling = Math.ceil(elapsed / SNAPSHOT_COALESCE_MS) + 1
+    expect(published).toBeGreaterThan(0)
+    expect(published).toBeLessThanOrEqual(ceiling)
 
     pty.kill()
   })


### PR DESCRIPTION
## The report

> rove 里面的 shell 卡卡的，不如原生 shell 里直接开这个 process

## Measured, not assumed

Write one byte into a PTY running `cat`, wait for the echo. Same machine, same child, 60 samples at 120x40, 200ms idle between them so every sample starts from a genuinely quiet terminal:

| path | p50 | p90 | max |
|---|---|---|---|
| raw PTY byte available (what a native shell pays) | **0.03ms** | 0.09 | 2.56 |
| Rove, `write()` → snapshot published to the pane | **35.8ms** | 36.3 | 38.2 |

That 36ms is spent before opentui's frame even starts, so the drawn echo is a further 0–33ms behind it.

## Root cause

`queueRefresh` coalesces PTY output so a streaming pane builds at most one snapshot per rendered frame — the right goal, and `SNAPSHOT_COALESCE_MS` is correctly pinned to `targetFps` for it. But the throttle was **trailing-only**: every chunk armed `setTimeout(…, 33ms)` and nothing was published until it fired, whether or not anything had been drawn in the last second.

A keystroke at a prompt is not a burst. The terminal has been idle, the child echoes in 0.03ms, and there was no frame to share with — the wait bought nothing and cost the whole frame. This is the same latency `host-render-options.ts` already diagnosed on Windows ("typing feel a beat behind a native `claude` in the same terminal"), where it was addressed by halving both periods; the trailing-only edge is the half that was left.

## The fix

Fire on the **leading** edge. Output arriving after a quiet frame refreshes at once; a second chunk inside the same window still waits for the boundary.

| | p50 | p90 | max |
|---|---|---|---|
| before (trailing-only) | 35.8ms | 36.3 | 38.2 |
| after (leading edge) | **1.5ms** | 23.1 | 33.7 |

p90 stays ~23ms on purpose: those samples land inside a burst, which is exactly what the coalesce is for. The snapshot rate is still capped at one per frame, so this costs no extra conversions, no extra CPU, and no extra frames — it removes a wait, it does not add work.

`lastRefreshAt` is stamped on the refresh **attempt**, not on success: the half-painted-frame path (`result === null`) re-queues, and a leading edge that only moved on success would find the period still elapsed and re-enter synchronously, forever.

## Verification

`test/tui/terminal-pty-echo-latency.test.ts` pins both halves, because each alone is satisfiable by a wrong implementation — "publishes immediately" passes with no coalesce at all, and "coalesces a burst" passes with the trailing-only version that was the bug.

Two mutations:

- revert to trailing-only → all 3 fail
- drop the coalesce entirely → the burst case fails, the other two pass

`typecheck` clean. `test/tui` 1875 pass. Render track 540 pass / 0 fail.

## Not in this PR

The remaining term is opentui's frame itself: 33ms on macOS and Linux, 16ms on Windows. Halving it would take the worst case from ~35ms to ~18ms, at the cost of idle CPU on battery — a tradeoff worth its own decision rather than a ride-along here.
