### PR TITLE
feat: log which code forked each child process, behind an env var

### DIFF
--- a/.changeset/spawn-profile.md
+++ b/.changeset/spawn-profile.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+Find out what Rove is forking. A terminal tab title that flickers between your shell and `git`, a fan that will not settle, an editor a beat behind — all three can mean Rove is spawning child processes far more often than its polls intend, and until now there was no way to tell which poll. `ps` cannot say: a `git` that lives a few milliseconds is caught mid-exec and macOS reports its arguments as `(git)`, so sampling a whole burst yields names and no arguments. `git`'s own `trace2` sees every invocation on the machine but records no parent, so on a machine running several agents it cannot say who asked. Set `ROVE_SPAWN_PROFILE` to a file path and Rove logs one JSON line per child it spawns, naming the code that wanted it, its arguments and the directory it ran in — `jq -r .site` and `sort | uniq -c` then give you a rate per caller. Unset, it costs one boolean test per spawn and touches no disk. See TROUBLESHOOTING for what the normal rates look like.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -155,6 +155,48 @@ The raw logs live under the active Rove home (normally your OS home):
 | `~/.rove/pty.log` | Hosted PTY startup and session-host failures |
 | `~/.rove/client.log` | TUI/pane connection, disconnect, and reconnect diagnostics |
 
+## Rove is spawning more processes than it should
+
+A terminal tab title that flickers between your shell's name and `git`, a fan
+that will not settle, or an editor that feels a beat behind: all three can mean
+Rove is forking child processes far more often than its polls intend. Two
+things Rove does on a timer legitimately fork — the engine walk that answers
+"which engine is live in this tab" runs `ps` every 2 seconds, and the
+worktree-changes chip runs `git status` per worktree, though only when no
+daemon is connected (a connected daemon polls once, centrally, and pushes the
+counts). Anything beyond those two is a bug worth reporting.
+
+`ps` cannot tell you which is which: a `git` that lives a few milliseconds is
+caught mid-exec and macOS reports its arguments as `(git)`. `git`'s own
+`trace2` sees every invocation on the machine but records no parent, so on a
+machine running several agents it cannot say who asked.
+
+Set `ROVE_SPAWN_PROFILE` to a file path and Rove logs one JSON line per child
+it spawns, naming the code that wanted it:
+
+```bash
+ROVE_SPAWN_PROFILE=/tmp/rove-spawns.log rove
+```
+
+Leave it running for 30 seconds of the behaviour you are chasing, then count
+by site:
+
+```console
+$ jq -r .site /tmp/rove-spawns.log | sort | uniq -c | sort -rn
+    14 engine.foregroundWalk
+     6 sidebar.gitHead
+     2 sidebar.worktreeChanges
+```
+
+Divide by your window to get a rate. `engine.foregroundWalk` at roughly one
+every 2 seconds is the design; `sidebar.worktreeChanges` firing steadily while
+a daemon is connected is not, and neither is any site in the tens per second.
+Each line also carries `cwd`, which names the worktree being polled — useful
+when one repo is responsible for all of it. Include the counts in a bug
+report.
+
+Unset, the variable costs one boolean test per spawn and touches no disk.
+
 ## Processes keep running days after their task is gone
 
 Ending a session in Rove ends its whole subtree: the PTY host signals the

--- a/packages/kobe/src/engine/foreground.ts
+++ b/packages/kobe/src/engine/foreground.ts
@@ -18,6 +18,7 @@
  */
 
 import { basename } from "node:path"
+import { recordSpawn } from "../lib/spawn-profile.ts"
 import { loadStateFile } from "../state/store.ts"
 import type { VendorId } from "../types/vendor"
 import { type ProcRow, PsProbeUnavailableError } from "./process-rows.ts"
@@ -271,6 +272,7 @@ export type PsSpawn = () => PsProcess
 export const PS_PROBE_TIMEOUT_MS = 5_000
 
 const bunPsSpawn: PsSpawn = () => {
+  recordSpawn("engine.foregroundWalk", ["ps", "-A", "-o", "pid=,ppid=,args="])
   const proc = Bun.spawn(["ps", "-A", "-o", "pid=,ppid=,args="], { stdout: "pipe", stderr: "ignore" })
   return { text: new Response(proc.stdout).text(), kill: () => proc.kill() }
 }

--- a/packages/kobe/src/lib/spawn-profile.ts
+++ b/packages/kobe/src/lib/spawn-profile.ts
@@ -1,0 +1,44 @@
+/**
+ * Env-gated log of every child process a Rove process spawns.
+ *
+ * `ROVE_SPAWN_PROFILE=<path>` turns it on and names a file to append JSON
+ * lines to, one per spawn. Off (the default) every call is a single boolean
+ * test, so the calls can sit in the paths that actually fork.
+ *
+ * What it answers: WHO is forking, how often, and against which directory.
+ * `ps` cannot answer it — a `git` that lives a few milliseconds is caught
+ * mid-exec, and macOS reports its argv as `(git)`; sampling a whole burst
+ * yields names and no arguments. `git`'s own `trace2` sees every invocation
+ * on the machine but records no parent, so on a box running several agents
+ * it cannot say which process asked. The call site can, which is why this
+ * records a site NAME chosen by the caller rather than a stack trace: a
+ * stack through an async poller is a scheduler frame, not the feature that
+ * wanted the data.
+ *
+ * Monkey-patching `node:child_process` was tried first and is a silent
+ * no-op: assigning to the module object succeeds under Bun, and a module
+ * that did `import { spawnSync }` keeps calling the original. An
+ * instrument that reports nothing looks exactly like a quiet system.
+ *
+ * Writes to a FILE, never stdout — stdout belongs to the renderer.
+ */
+
+import { appendFileSync } from "node:fs"
+
+const target = process.env.ROVE_SPAWN_PROFILE
+export const spawnProfileOn = Boolean(target)
+
+/**
+ * Record one spawn. `site` is a stable dotted name for the code that wanted
+ * the child (`sidebar.worktreeChanges`, `engine.foregroundWalk`), NOT the
+ * binary — two callers of `git status` are the thing this has to tell apart.
+ */
+export function recordSpawn(site: string, argv: readonly string[], cwd?: string): void {
+  if (!spawnProfileOn) return
+  try {
+    const row = { t: Date.now(), pid: process.pid, site, argv: argv.slice(0, 12), ...(cwd ? { cwd } : {}) }
+    appendFileSync(target as string, `${JSON.stringify(row)}\n`)
+  } catch {
+    /* profiling must never take the process down */
+  }
+}

--- a/packages/kobe/src/state/repos.ts
+++ b/packages/kobe/src/state/repos.ts
@@ -25,6 +25,7 @@ import { spawnSync } from "node:child_process"
 import { realpathSync } from "node:fs"
 import { pathIdentity, samePath } from "@sma1lboy/kobe-daemon/path-identity"
 import { kvStatePath } from "../env.ts"
+import { recordSpawn } from "../lib/spawn-profile.ts"
 import { type ProjectIntent, type ProjectRejection, projectRejection } from "./project-eligibility.ts"
 import { isRemoteRepoKey, readRemoteRepos } from "./remote-repos.ts"
 import { type StateSnapshot, loadStateFile, patchStateFile, readSavedRepos, updateStateFile } from "./store.ts"
@@ -60,6 +61,7 @@ export function resolveRepoRoot(absPath: string): string {
   // there is nothing to canonicalize (and no local git repo to ask). Pass it
   // through untouched so it round-trips as the stable savedRepos key.
   if (isRemoteRepoKey(absPath)) return absPath
+  recordSpawn("repos.resolveRepoRoot", ["git", "rev-parse", "--show-toplevel"], absPath)
   const r = spawnSync("git", ["rev-parse", "--show-toplevel"], {
     cwd: absPath,
     encoding: "utf8",
@@ -89,6 +91,7 @@ export function resolveRepoRoot(absPath: string): string {
  */
 export function isGitRepo(absPath: string): boolean {
   if (isRemoteRepoKey(absPath)) return false
+  recordSpawn("repos.isGitRepo", ["git", "rev-parse", "--is-inside-work-tree"], absPath)
   const r = spawnSync("git", ["rev-parse", "--is-inside-work-tree"], {
     cwd: absPath,
     encoding: "utf8",
@@ -122,6 +125,7 @@ export function isValidBranchName(branch: string): boolean {
  */
 export function resolveMainRepoRoot(absPath: string): string {
   if (isRemoteRepoKey(absPath)) return absPath
+  recordSpawn("repos.resolveMainRepoRoot", ["git", "worktree", "list", "--porcelain"], absPath)
   const r = spawnSync("git", ["worktree", "list", "--porcelain"], {
     cwd: absPath,
     encoding: "utf8",

--- a/packages/kobe/src/tui/lib/editor-launch.ts
+++ b/packages/kobe/src/tui/lib/editor-launch.ts
@@ -39,6 +39,7 @@
 
 import { readOnlyGitProcessEnv } from "@/lib/git-env"
 import { quoteShellArg as shellQuote } from "@/lib/shell-command"
+import { recordSpawn } from "@/lib/spawn-profile"
 import { getPersistedString } from "@/state/repos"
 import {
   AUTO_EDITOR_CANDIDATES,
@@ -183,6 +184,7 @@ export async function binaryAvailable(bin: string): Promise<boolean> {
  */
 export async function fileHasDiff(worktree: string, relPath: string): Promise<boolean> {
   try {
+    recordSpawn("tui.fileHasDiff", ["git", "diff", "--quiet", "HEAD", "--", relPath], worktree)
     const proc = Bun.spawn(["git", "diff", "--quiet", "HEAD", "--", relPath], {
       cwd: worktree,
       stdin: "ignore",

--- a/packages/kobe/src/tui/lib/git-snapshot.ts
+++ b/packages/kobe/src/tui/lib/git-snapshot.ts
@@ -20,6 +20,7 @@
 
 import { spawnSync } from "node:child_process"
 import * as fs from "node:fs"
+import { recordSpawn } from "@/lib/spawn-profile"
 import { t } from "@/tui/i18n"
 
 /** Default base ref when the user leaves the branch field blank or HEAD can't be read. */
@@ -84,6 +85,7 @@ function git(
   args: readonly string[],
 ): { status: number; stdout: string; missing: boolean; spawned: boolean } {
   try {
+    recordSpawn("tui.gitSnapshot", ["git", ...args], repo)
     const out = spawnSync("git", args, {
       cwd: repo,
       encoding: "utf-8",

--- a/packages/kobe/src/tui/ops/pr-prompt.ts
+++ b/packages/kobe/src/tui/ops/pr-prompt.ts
@@ -1,6 +1,7 @@
 import { promises as fs } from "node:fs"
 import path from "node:path"
 import { readOnlyGitProcessEnv } from "@/lib/git-env"
+import { recordSpawn } from "@/lib/spawn-profile"
 import { readFirstNonEmptyRepoFile } from "../../lib/repo-config-file.ts"
 import { spawnCapture } from "../lib/background-poll"
 
@@ -40,6 +41,7 @@ async function git(cwd: string, args: readonly string[]): Promise<string | null>
   const controller = new AbortController()
   const timer = setTimeout(() => controller.abort(), GIT_TIMEOUT_MS)
   try {
+    recordSpawn("tui.prPrompt", ["git", ...args], cwd)
     const out = await spawnCapture("git", args, {
       cwd,
       // Read-only inspection (`status`, `rev-parse`, `symbolic-ref`).

--- a/packages/kobe/src/tui/panes/sidebar/git-head.ts
+++ b/packages/kobe/src/tui/panes/sidebar/git-head.ts
@@ -30,6 +30,7 @@
 import { stat } from "node:fs/promises"
 import { join } from "node:path"
 import { readOnlyGitProcessEnv } from "@/lib/git-env"
+import { recordSpawn } from "@/lib/spawn-profile"
 import { createBackgroundPoller, spawnCapture } from "../../lib/background-poll"
 
 /** Kill a ref read that runs longer than this — O(1) commands, tight leash. */
@@ -92,6 +93,7 @@ export async function resolveBranchHead(
   // empty value against a still-valid HEAD fingerprint would permanently
   // blank the branch label, so only the resolved case is cached.
   let resolved = false
+  recordSpawn("sidebar.gitHead", ["git", "symbolic-ref", "--short", "HEAD"], repo)
   const ref = await spawn("git", ["symbolic-ref", "--short", "HEAD"], {
     cwd: repo,
     env: readOnlyGitProcessEnv(),

--- a/packages/kobe/src/tui/panes/sidebar/worktree-changes-poller.ts
+++ b/packages/kobe/src/tui/panes/sidebar/worktree-changes-poller.ts
@@ -33,6 +33,7 @@
  */
 
 import { readOnlyGitProcessEnv } from "@/lib/git-env"
+import { recordSpawn } from "@/lib/spawn-profile"
 import { computeNextAllowedAt, createBackgroundPoller, spawnCapture } from "../../lib/background-poll"
 import { type WorktreeChanges, parsePorcelain, sameWorktreeChanges } from "./worktree-changes"
 
@@ -58,6 +59,7 @@ const poller = createBackgroundPoller<WorktreeChanges | null>({
     // Same flags + lock policy as the sync helper: porcelain v1, and
     // GIT_OPTIONAL_LOCKS=0 so the read never takes .git/index.lock from
     // under the engine's own commits.
+    recordSpawn("sidebar.worktreeChanges", ["git", "status", "--porcelain=v1"], worktreePath)
     const res = await spawnCapture("git", ["status", "--porcelain=v1"], {
       cwd: worktreePath,
       env: readOnlyGitProcessEnv(),

--- a/packages/kobe/src/tui/panes/sidebar/worktree-changes.ts
+++ b/packages/kobe/src/tui/panes/sidebar/worktree-changes.ts
@@ -38,6 +38,7 @@
 import { spawnSync } from "node:child_process"
 import { readOnlyGitProcessEnv } from "@/lib/git-env"
 import { parsePorcelainRows } from "@/lib/git-parsers"
+import { recordSpawn } from "@/lib/spawn-profile"
 
 export interface WorktreeChanges {
   /** Files added, modified, renamed, copied, or untracked. */
@@ -104,6 +105,7 @@ export function pickPushedChanges(
 export function readWorktreeChanges(worktreePath: string): WorktreeChanges | null {
   if (!worktreePath) return null
   try {
+    recordSpawn("sidebar.worktreeChangesSync", ["git", "status", "--porcelain=v1"], worktreePath)
     const out = spawnSync("git", ["status", "--porcelain=v1"], {
       cwd: worktreePath,
       encoding: "utf8",

--- a/packages/kobe/src/worktree/content.ts
+++ b/packages/kobe/src/worktree/content.ts
@@ -11,6 +11,7 @@ import { errorMessage } from "@/lib/error-message"
 import type { ExecResult } from "../exec/exec-host.ts"
 import { execHostForWorktreePath } from "../exec/resolve.ts"
 import { READ_ONLY_GIT_ENV } from "../lib/git-env.ts"
+import { recordSpawn } from "../lib/spawn-profile.ts"
 
 export interface WorktreeGitResult {
   readonly stdout: string
@@ -63,6 +64,7 @@ export async function runWorktreeGit(
       : (controller?.signal ?? options.signal)
   let result: ExecResult
   try {
+    recordSpawn("worktree.content", ["git", ...args], worktreePath)
     result = await exec.run(["git", ...args], {
       cwd: worktreePath,
       env: READ_ONLY_GIT_ENV,

--- a/packages/kobe/test/lib/spawn-profile.test.ts
+++ b/packages/kobe/test/lib/spawn-profile.test.ts
@@ -1,0 +1,77 @@
+import { mkdtempSync, readFileSync } from "node:fs"
+import { existsSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+/**
+ * The spawn profiler's two halves, both of which have to hold or the
+ * instrument is worse than nothing: OFF must touch no disk (these calls sit
+ * in paths that fork several times a second), and ON must actually write —
+ * an instrument that reports nothing is indistinguishable from a quiet
+ * system, which is the failure that sent the last investigation down a
+ * monkey-patch that silently no-opped under Bun.
+ *
+ * `ROVE_SPAWN_PROFILE` is read at MODULE LOAD, so each case resets the module
+ * registry and re-imports with the env already set — importing once and
+ * flipping the variable afterwards would be testing a frozen constant.
+ */
+describe("spawn profile", () => {
+  let dir: string
+  let previous: string | undefined
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "rove-spawn-profile-"))
+    previous = process.env.ROVE_SPAWN_PROFILE
+    vi.resetModules()
+  })
+
+  afterEach(() => {
+    if (previous === undefined) Reflect.deleteProperty(process.env, "ROVE_SPAWN_PROFILE")
+    else process.env.ROVE_SPAWN_PROFILE = previous
+  })
+
+  it("writes one JSON line per spawn, carrying the site, argv and cwd", async () => {
+    const target = join(dir, "spawns.log")
+    process.env.ROVE_SPAWN_PROFILE = target
+    const { recordSpawn, spawnProfileOn } = await import("../../src/lib/spawn-profile.ts")
+    expect(spawnProfileOn).toBe(true)
+
+    recordSpawn("sidebar.worktreeChanges", ["git", "status", "--porcelain=v1"], "/wt/a")
+    recordSpawn("engine.foregroundWalk", ["ps", "-A"])
+
+    const rows = readFileSync(target, "utf8")
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as Record<string, unknown>)
+    expect(rows).toHaveLength(2)
+    expect(rows[0]).toMatchObject({
+      site: "sidebar.worktreeChanges",
+      argv: ["git", "status", "--porcelain=v1"],
+      cwd: "/wt/a",
+      pid: process.pid,
+    })
+    // No cwd passed → the key is absent, not an empty string: "not recorded"
+    // and "spawned in the root" must not read the same in the log.
+    expect(rows[1]).toMatchObject({ site: "engine.foregroundWalk" })
+    expect(rows[1]).not.toHaveProperty("cwd")
+  })
+
+  it("touches no disk when the variable is unset", async () => {
+    Reflect.deleteProperty(process.env, "ROVE_SPAWN_PROFILE")
+    const { recordSpawn, spawnProfileOn } = await import("../../src/lib/spawn-profile.ts")
+    expect(spawnProfileOn).toBe(false)
+
+    recordSpawn("sidebar.worktreeChanges", ["git", "status"], "/wt/a")
+
+    // Nothing was created anywhere under the case's own directory.
+    expect(existsSync(join(dir, "spawns.log"))).toBe(false)
+  })
+
+  it("survives an unwritable target instead of taking the process down", async () => {
+    // A directory where the log file should be: every append throws.
+    process.env.ROVE_SPAWN_PROFILE = dir
+    const { recordSpawn } = await import("../../src/lib/spawn-profile.ts")
+    expect(() => recordSpawn("tui.gitSnapshot", ["git", "status"], "/wt/a")).not.toThrow()
+  })
+})


### PR DESCRIPTION
## Why

A user reported their terminal tab title flickering between `rove (bun)` and `rove (git)`. That is iTerm2 showing the deepest child of the tty, so the flicker means short-lived children — and measuring the TUI process found **~8 per second**, sustained in bursts, against 1.4/s for the daemon and 0 for a bare `sleep` used as a control.

Then the investigation stalled, because nothing available could attribute them:

- **`ps` can't.** A `git` that lives a few milliseconds is caught mid-exec and macOS reports its arguments as `(git)` — hundreds of samples gave names and no arguments, with the processes in state `R+`, so not zombies either.
- **`git trace2` can't.** Enabling it globally does log every invocation on the machine, but it records no parent. On a machine running several agents, `git rev-parse --show-toplevel` at 30/s could not be pinned on anyone — and it turned out not to be the TUI at all (the TUI's cwd is `$HOME`; those calls all ran inside a checkout, i.e. other agents' CLI invocations).
- **Monkey-patching `node:child_process` can't**, and fails *silently*: under Bun the assignment succeeds and a module that did `import { spawnSync }` keeps calling the original. Verified before relying on it:

  ```
  assignment: OK
  victim output: hi
  intercepted: []
  ```

So the process that forks has to say so itself.

## What

`ROVE_SPAWN_PROFILE=<path>` — one JSON line per child, naming the **call site**, its argv and its cwd:

```json
{"t":1789108315070,"pid":92476,"site":"repos.resolveRepoRoot","argv":["git","rev-parse","--show-toplevel"],"cwd":"/Users/…/kobe"}
```

```console
$ jq -r .site /tmp/rove-spawns.log | sort | uniq -c | sort -rn
    14 engine.foregroundWalk
     6 sidebar.gitHead
     2 sidebar.worktreeChanges
```

A site name, not a stack trace: a stack through an async poller is a scheduler frame, not the feature that wanted the data. Two callers of `git status` are exactly the thing this has to tell apart.

Ten spawn sites reachable in the TUI process are instrumented — `repos.{resolveRepoRoot,isGitRepo,resolveMainRepoRoot}`, `sidebar.{gitHead,worktreeChanges,worktreeChangesSync}`, `tui.{gitSnapshot,prPrompt,fileHasDiff}`, `worktree.content`, `engine.foregroundWalk`.

Modelled on the existing `ROVE_RENDER_PROFILE` (`src/tui/lib/render-profile.ts`), which already establishes the pattern: env-gated, file-only, cheap enough to leave in a hot path. Unset, `recordSpawn` is one boolean test and no file is created.

## Verification

Positive and negative control, since an instrument that reports nothing looks exactly like a quiet system:

```console
$ bun -e 'resolveRepoRoot(cwd); isGitRepo(cwd)'                 # OFF
  ls: /tmp/sp.log: No such file or directory
$ ROVE_SPAWN_PROFILE=/tmp/sp.log bun -e '…'                     # ON
  {"site":"repos.resolveRepoRoot","argv":["git","rev-parse","--show-toplevel"],…}
  {"site":"repos.isGitRepo","argv":["git","rev-parse","--is-inside-work-tree"],…}
```

`test/lib/spawn-profile.test.ts` pins both halves plus the failure contract. Two mutations:

- `recordSpawn` returns early even when on → the "writes a line" case fails
- drop the `try`/`catch` → the "survives an unwritable target" case fails

`typecheck` clean; `test:fast` 5133 pass; render track 540 pass / 0 fail.

## Not in this PR

The actual fix for whatever is forking 8/s — this is the instrument that will name it. `docs/TROUBLESHOOTING.md` gains a section with the rates that are by design (`engine.foregroundWalk` every ~2s; `sidebar.worktreeChanges` only when no daemon is connected) so a report can say which site is wrong.
