### PR TITLE
fix: read a remote daemon status past a trailing shell line

### DIFF
--- a/.changeset/machine-status-trailing-noise.md
+++ b/.changeset/machine-status-trailing-noise.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+A machine whose shell prints a line AFTER a command no longer reads as a broken daemon. Registering a remote runs `rove daemon status --json` over ssh and reads the JSON out of the reply, and a non-interactive login prints on the way out as readily as on the way in — an rc-file echo, a "you have mail". Rove already skipped a banner printed BEFORE the JSON, but the parse then ran to the end of the output, so a single trailing line made `JSON.parse` throw and the healthy machine reported "could not read a daemon status" (BAD_STATUS / NO_DAEMON). Rove now extracts just the first brace-balanced object, tolerating noise on both sides, so the status is read whatever the shell prints around it.

--- a/packages/kobe/src/machines/discover.ts
+++ b/packages/kobe/src/machines/discover.ts
@@ -130,12 +130,45 @@ export async function discoverMachine(
   }
 }
 
+/**
+ * The first brace-balanced `{…}` run in a string, or null when there is none.
+ *
+ * A non-interactive `ssh` login prints on BOTH sides of a command's output — a
+ * banner before, a "you have mail" or an rc-file echo after — and the daemon
+ * status is a single JSON object somewhere in the middle. Scanning to the first
+ * `{` skips a leading banner; slicing to its MATCHING `}` is what lets a
+ * trailing line survive too, where a bare `JSON.parse(rest)` throws on it and
+ * reports a healthy machine as "could not read a daemon status". Braces inside
+ * string literals are skipped, so a socket path carrying a `{` cannot unbalance
+ * the scan.
+ */
+function firstJsonObject(text: string): string | null {
+  const start = text.indexOf("{")
+  if (start < 0) return null
+  let depth = 0
+  let inString = false
+  let escaped = false
+  for (let i = start; i < text.length; i++) {
+    const ch = text[i]
+    if (inString) {
+      if (escaped) escaped = false
+      else if (ch === "\\") escaped = true
+      else if (ch === '"') inString = false
+      continue
+    }
+    if (ch === '"') inString = true
+    else if (ch === "{") depth++
+    else if (ch === "}" && --depth === 0) return text.slice(start, i + 1)
+  }
+  return null
+}
+
 /** A status payload that parses but predates `ptySocketPath`. */
 export function looksLikeOldStatus(stdout: string): boolean {
-  const at = stdout.indexOf("{")
-  if (at < 0) return false
+  const json = firstJsonObject(stdout)
+  if (json === null) return false
   try {
-    const raw = JSON.parse(stdout.slice(at)) as Record<string, unknown>
+    const raw = JSON.parse(json) as Record<string, unknown>
     return typeof raw.socketPath === "string" && typeof raw.ptySocketPath !== "string"
   } catch {
     return false
@@ -145,8 +178,9 @@ export function looksLikeOldStatus(stdout: string): boolean {
 /**
  * Pull the status object out of a command's stdout.
  *
- * Tolerant of leading noise (a login banner, an update notice) by scanning for
- * the first `{` — a machine whose shell prints something on every
+ * Tolerant of noise on BOTH sides of the JSON (a login banner or update notice
+ * before, an rc-file echo or "you have mail" after) by extracting the first
+ * brace-balanced object — a machine whose shell prints something on every
  * non-interactive login is common enough that being strict here would read as
  * "Rove is broken on that host". Returns null unless BOTH socket paths are
  * present, so an older remote Rove — which reports `socketPath` but not
@@ -154,11 +188,11 @@ export function looksLikeOldStatus(stdout: string): boolean {
  * that half-forwards.
  */
 export function parseStatusJson(stdout: string): RemoteDaemonStatus | null {
-  const at = stdout.indexOf("{")
-  if (at < 0) return null
+  const json = firstJsonObject(stdout)
+  if (json === null) return null
   let raw: unknown
   try {
-    raw = JSON.parse(stdout.slice(at))
+    raw = JSON.parse(json)
   } catch {
     return null
   }

--- a/packages/kobe/test/machines/discover.test.ts
+++ b/packages/kobe/test/machines/discover.test.ts
@@ -33,6 +33,22 @@ describe("parseStatusJson", () => {
     expect(parseStatusJson(`Welcome to narwhal\n${FULL}`)?.hostname).toBe("Nahuels-Mac-mini.local")
   })
 
+  it("skips an rc-file echo printed after the JSON", () => {
+    // A non-interactive shell prints on the way out as readily as on the way
+    // in ("you have mail", an rc-file echo). A trailing line must not make a
+    // healthy daemon read as "could not read a daemon status".
+    expect(parseStatusJson(`${FULL}\nyou have mail`)?.hostname).toBe("Nahuels-Mac-mini.local")
+  })
+
+  it("extracts the object with noise on both sides", () => {
+    expect(parseStatusJson(`Welcome\n${FULL}\nlogout`)?.socketPath).toBe("/Users/nahuelchen/.rove/daemon.sock")
+  })
+
+  it("is unfazed by a brace inside a socket path", () => {
+    const braced = JSON.stringify({ ...JSON.parse(FULL), socketPath: "/tmp/rove-{1}/daemon.sock" })
+    expect(parseStatusJson(`${braced}\ntrailing`)?.socketPath).toBe("/tmp/rove-{1}/daemon.sock")
+  })
+
   it("refuses a status without a pty socket — that machine needs upgrading", () => {
     const old = JSON.stringify({ socketPath: "/s.sock", homeDir: "/h", daemonPid: 1 })
     expect(parseStatusJson(old)).toBeNull()
@@ -52,5 +68,10 @@ describe("looksLikeOldStatus", () => {
     expect(looksLikeOldStatus(JSON.stringify({ socketPath: "/s.sock", homeDir: "/h" }))).toBe(true)
     expect(looksLikeOldStatus(FULL)).toBe(false)
     expect(looksLikeOldStatus("rove daemon: no daemon running")).toBe(false)
+  })
+
+  it("still recognizes an old status wrapped in shell noise", () => {
+    const old = JSON.stringify({ socketPath: "/s.sock", homeDir: "/h" })
+    expect(looksLikeOldStatus(`motd\n${old}\nlogout`)).toBe(true)
   })
 })


### PR DESCRIPTION
## Direction

Bugs / correctness — a self-found robustness gap in the recent **Machines** feature (`src/machines/discover.ts`), surfaced during a review of the pure-logic layer.

## Problem

Registering a machine runs `rove daemon status --json` over ssh and reads the JSON out of the reply. The parser deliberately tolerates **leading** shell noise (a login banner, an update notice) by scanning to the first `{` — a non-interactive login that prints *something* is common enough that being strict there would read as "Rove is broken on that host". There's even a test for it.

But it then did `JSON.parse(stdout.slice(at))` — parsing everything from the first `{` to end-of-output. `JSON.parse` throws on any **trailing** non-whitespace, and a non-interactive shell prints on the way *out* as readily as on the way *in* (an rc-file echo, a "you have mail", a `logout` line). A single trailing line made the parse throw, and the healthy remote was then reported as `BAD_STATUS` / `NO_DAEMON` ("could not read a daemon status from …") — a broken-looking first run for a headline feature, on a machine that was fine.

Failing input (before): `parseStatusJson('{"socketPath":"…","ptySocketPath":"…",…}\nyou have mail')` → `null`.

## Fix

Extract just the **first brace-balanced `{…}` object** and parse that, tolerating noise on **both** sides. The scan tracks string literals and escapes, so a socket path containing a `{` can't unbalance it. Both readers in the file (`parseStatusJson` and `looksLikeOldStatus`) go through the new helper, so they can't disagree about where the JSON ends. No behavior change for the existing cases — a leading banner, a no-daemon prose line, malformed JSON, and an old status missing `ptySocketPath` all resolve exactly as before.

## Verification

- `bun x vitest run test/machines/discover.test.ts` — 9 passed (4 new: trailing echo, leading+trailing noise, a `{` inside a socket path, and an old status wrapped in shell noise).
- `bun run typecheck` — green.
- `bun run lint` — green.

## Follow-ups

None required. The same "scan to the first `{`, tolerate surrounding noise" pattern appears only in this file, so the fix is fully contained.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JHKeUP2CJ7S9ybSTaCmoZV)_