### PR TITLE
fix: the effort-level error names every engine that takes one, not just codex

### DIFF
--- a/.changeset/effort-hint-names-all-engines.md
+++ b/.changeset/effort-hint-names-all-engines.md
@@ -1,0 +1,5 @@
+---
+"@sma1lboy/rove": patch
+---
+
+The effort-level error hint no longer names codex as the only engine that takes one. `rove api set-effort` / `add --effort` on an engine that declares no reasoning levels used to answer "Only engines with declared levels accept one (codex today)" — a line hard-coded before pi and OMP shipped their own `off`/`minimal`/`low`/`medium`/`high`/`xhigh`/`max` levels, so it pointed a user away from two engines that would have accepted a level. The hint is now derived from the engine registry and reads "(codex, pi, omp today)", so it stays correct as engines gain or lose levels. The matching `--effort` help text and the Engines doc's reasoning-effort paragraph, which both claimed pi/OMP take Codex's `none` level (they take `minimal` instead), were corrected to spell out the real per-engine lists.

--- a/docs/ENGINES.md
+++ b/docs/ENGINES.md
@@ -81,10 +81,10 @@ it, so Rove assumes you meant it.
 ### Reasoning effort
 
 Codex accepts `none`, `low`, `medium`, `high`, `xhigh`, `max`, passed as
-`-c model_reasoning_effort=<level>`. Pi and OMP take the same levels (plus
-`off`) as `--thinking <level>`. The remaining engines have no effort flag
-Rove can drive; a selected effort is ignored there rather than passed
-through.
+`-c model_reasoning_effort=<level>`. Pi and OMP take `off`, `minimal`, `low`,
+`medium`, `high`, `xhigh`, `max` as `--thinking <level>` — `minimal` in place
+of Codex's `none`, plus `off`. The remaining engines have no effort flag Rove
+can drive; a selected effort is ignored there rather than passed through.
 
 Three places select one:
 

--- a/packages/kobe/src/cli/api/handlers-engines.ts
+++ b/packages/kobe/src/cli/api/handlers-engines.ts
@@ -27,7 +27,7 @@ import {
   sessionProtocol,
 } from "../../engine/engine-presets.ts"
 import { ensurePluginEnginesLoaded } from "../../engine/plugin-engines.ts"
-import { engineEntry } from "../../engine/registry.ts"
+import { engineEntry, vendorsWithEffortLevels } from "../../engine/registry.ts"
 import { type VendorId, coerceVendorId } from "../../types/vendor.ts"
 import { F } from "./flags.ts"
 import { daemonOf, simpleRpc } from "./handler-helpers.ts"
@@ -131,7 +131,7 @@ export function assertEngineAcceptsEffort(engine: VendorId, level: string, recov
   if (levels.length === 0) {
     throw new ApiError(`engine ${engine} declares no reasoning effort levels`, "BAD_EFFORT", {
       engine,
-      hint: `Only engines with declared levels accept one (codex today). Check the task's engine with \`get-task\`.`,
+      hint: `Only engines with declared reasoning levels accept one (${vendorsWithEffortLevels().join(", ")} today). Check the task's engine with \`get-task\`.`,
       nextCommandArgs: [...recover],
     })
   }
@@ -179,7 +179,7 @@ export const SET_EFFORT_VERB: VerbSpec = {
   name: "set-effort",
   group: "edit",
   summary:
-    "Set a task's reasoning effort level (takes effect on the next session rebuild). Rejected when the task's engine declares no levels, or does not declare THIS one — the error names the levels it does accept. Codex accepts none/low/medium/high/xhigh/max; claude has none.",
+    "Set a task's reasoning effort level (takes effect on the next session rebuild). Rejected when the task's engine declares no levels, or does not declare THIS one — the error names the levels it does accept. Codex accepts none/low/medium/high/xhigh/max; pi and OMP accept off/minimal/low/medium/high/xhigh/max; claude has none.",
   flags: [
     F.taskId(),
     // Deliberately not an enum: levels are declared PER ENGINE (registry

--- a/packages/kobe/src/cli/api/verbs-create.ts
+++ b/packages/kobe/src/cli/api/verbs-create.ts
@@ -39,7 +39,7 @@ export const CREATE_VERBS: readonly VerbSpec[] = [
         type: "string",
         placeholder: "LEVEL",
         description:
-          "Reasoning effort for the FIRST session, not just later ones. Validated against the engine's declared levels (codex: none/low/medium/high/xhigh/max; claude declares none) — free-form, since a plugin engine may declare its own. With --agents, every engine in the plan must declare it.",
+          "Reasoning effort for the FIRST session, not just later ones. Validated against the engine's declared levels (codex: none/low/medium/high/xhigh/max; pi and OMP: off/minimal/low/medium/high/xhigh/max; claude declares none) — free-form, since a plugin engine may declare its own. With --agents, every engine in the plan must declare it.",
       },
       {
         name: "count",

--- a/packages/kobe/src/engine/registry.ts
+++ b/packages/kobe/src/engine/registry.ts
@@ -418,3 +418,17 @@ export function vendorsWithTurnReader(): readonly VendorId[] {
     .filter((entry) => entry.readTurns)
     .map((entry) => entry.vendor)
 }
+
+/**
+ * Built-in vendors that declare reasoning-effort levels — the ones `set-effort`
+ * / `add --effort` can pin a level on. `assertEngineAcceptsEffort`'s error hint
+ * names these so a user who mis-targeted effort learns which engines would have
+ * taken one. Derived rather than written down for the same reason as the two
+ * helpers above: hard-coding "codex today" in the CLI layer named a single
+ * engine and went stale the moment pi and OMP shipped their own levels.
+ */
+export function vendorsWithEffortLevels(): readonly VendorId[] {
+  return Object.values(BUILTIN_ENGINES)
+    .filter((entry) => (entry.effortLevels?.length ?? 0) > 0)
+    .map((entry) => entry.vendor)
+}

--- a/packages/kobe/test/cli/api-set-effort.test.ts
+++ b/packages/kobe/test/cli/api-set-effort.test.ts
@@ -15,6 +15,7 @@ import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { afterEach, beforeEach, describe, expect, it } from "vitest"
 import { invokeVerb } from "../../src/cli/api-cmd.ts"
+import { ApiError } from "../../src/cli/api/types.ts"
 import { FakeClient, expectApiError, stubRuntime } from "./api-handler-fixtures.ts"
 
 /**
@@ -105,6 +106,21 @@ describe("set-effort", () => {
       /declares no reasoning effort levels/,
     )
     expect(client.requests.map((r) => r.name)).toEqual(["task.get"])
+  })
+
+  it("names every effort-capable engine in the hint, not just codex", async () => {
+    // The hint used to hard-code "(codex today)". pi and OMP declare their own
+    // levels now, so a user who mis-targeted effort must learn they qualify.
+    const client = new FakeClient(taskOf({ vendor: "claude" }))
+    try {
+      await invokeVerb("set-effort", ["--task-id", "t1", "--level", "high"], { client, runtime: stubRuntime() })
+      expect.unreachable("should have thrown")
+    } catch (err) {
+      expect(err).toBeInstanceOf(ApiError)
+      const hint = String((err as ApiError).data?.hint ?? "")
+      expect(hint).toContain("pi")
+      expect(hint).toContain("omp")
+    }
   })
 
   // A preset declaring the codex protocol IS a codex launch, and the TUI

--- a/packages/kobe/test/engine/registry.test.ts
+++ b/packages/kobe/test/engine/registry.test.ts
@@ -19,6 +19,7 @@ import {
   engineEntry,
   getCapabilities,
   supportsStructuredHistory,
+  vendorsWithEffortLevels,
   vendorsWithQuotaProbe,
   vendorsWithTurnReader,
 } from "../../src/engine/registry.ts"
@@ -168,6 +169,21 @@ describe("vendorsWithTurnReader", () => {
 
   it("omits engines with no reader rather than implying they report nothing", () => {
     expect(vendorsWithTurnReader()).not.toContain("kimi")
+  })
+})
+
+describe("vendorsWithEffortLevels", () => {
+  it("lists every engine that declares reasoning levels, so the effort error can name them", () => {
+    // `assertEngineAcceptsEffort`'s hint walks THIS list. Hard-coding "codex
+    // today" in the CLI layer named a single engine and went stale the moment
+    // pi and OMP shipped their own levels.
+    const vendors = vendorsWithEffortLevels()
+    expect([...vendors].sort()).toEqual(["codex", "omp", "pi"])
+    for (const vendor of vendors) expect((engineEntry(vendor).effortLevels?.length ?? 0) > 0).toBe(true)
+  })
+
+  it("omits engines that declare none rather than implying they take a level", () => {
+    expect(vendorsWithEffortLevels()).not.toContain("claude")
   })
 })
 


### PR DESCRIPTION
## Direction

Correctness / UX polish, found by reviewing the effort-picker surface after PRs #989/#990 landed pi and OMP as effort-capable engines. Several user-facing strings that enumerated effort levels were written when Codex was the only engine that took one, and went stale.

## Problem

`rove api set-effort` / `add --effort` on an engine that declares no reasoning levels (e.g. `claude`) throws `BAD_EFFORT` with the hint:

> Only engines with declared levels accept one (**codex today**). Check the task's engine with `get-task`.

That parenthetical was hard-coded before pi and OMP shipped their own `off`/`minimal`/`low`/`medium`/`high`/`xhigh`/`max` levels, so at the exact moment a user has mis-targeted effort, the message points them *away* from two engines that would have accepted a level. The same staleness lived in three more places:

- the `set-effort` verb help ("Codex accepts …; claude has none")
- the `add --effort` flag help ("codex: …; claude declares none")
- `docs/ENGINES.md`'s *Reasoning effort* paragraph, which claimed pi/OMP take "the same levels (plus `off`)" — i.e. Codex's `none` — when they actually take `minimal` in `none`'s place (the doc's own table one screen up already had this right).

## Fix

- Added `vendorsWithEffortLevels()` to `engine/registry.ts`, mirroring the existing `vendorsWithQuotaProbe()` / `vendorsWithTurnReader()` helpers, so the effort-capable set is **derived from the registry** rather than named in the CLI layer. The hint now reads "(codex, pi, omp today)" and stays correct as engines gain or lose levels — matching the repo's "don't hard-code vendor strings in neutral layers" rule.
- Corrected the two verb/flag help strings and the ENGINES.md paragraph to spell out the real per-engine lists.

## Verification

- `bun run lint` and `bun run typecheck` — both green.
- `bun x vitest run test/engine/registry.test.ts test/cli/api-set-effort.test.ts test/cli/api-add-effort.test.ts` — 29 passed. Added a `vendorsWithEffortLevels` test (pins the derived set to `codex/omp/pi`) and a `set-effort` test asserting the hint names pi and omp, so the regression can't creep back.
- Patch changeset included.

## Follow-ups (deliberately out of scope)

- `docs/CLI.md` omits the `machine <verb>` top-level command from its `rove --help` reproduction and its verb-carrying list — a separate docs slice.
- `countPorcelain` counts a pure rename as `+1 added`; unclear whether that's intended aggregate behavior or a defect, so left for a maintainer call rather than changed here.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FxZ2QATbc3UNAm8LXLAw8i)_